### PR TITLE
Add Waveshare board support helpers

### DIFF
--- a/esp32/include/hal.hpp
+++ b/esp32/include/hal.hpp
@@ -175,8 +175,7 @@ constexpr bool TFT_INVERT = true;
 
 /**
  * @brief WAVESHARE ESP32-S3 1.75 AMOLED pin definition
- * CORRECTED from official schematic - See:
- * .agent/workflows/WAVESHARE_HARDWARE.md
+ * Corrected from official schematic. See WAVESHARE_HARDWARE.md.
  */
 #ifdef WAVESHARE_AMOLED_175
 // I2C Bus (Shared by AXP2101, CST9217, TCA9554, RTC, IMU)
@@ -200,13 +199,13 @@ constexpr uint8_t TFT_QSPI_RST = GPIO_NUM_39;
 
 // Touch Pins (CST9217 on shared I2C bus)
 constexpr uint8_t TCH_I2C_SDA = GPIO_NUM_15;
-constexpr uint8_t TCH_I2C_SCL = GPIO_NUM_14; // CORRECTED: Same as main I2C bus
+constexpr uint8_t TCH_I2C_SCL = GPIO_NUM_14; // Same as main I2C bus
 constexpr uint8_t TCH_I2C_INT = GPIO_NUM_21;
 // NOTE: Touch Reset is controlled by TCA9554 I/O Expander (0x20), NOT a GPIO!
 // Do NOT use GPIO 20 - it is USB D+ and will break serial monitor.
 constexpr uint8_t TCH_I2C_ADDR = 0x5A; // CST9217 Address (verified)
 
-// SD Card (SPI) - CORRECTED from schematic
+// SD Card (SPI) - verified from schematic
 // NO CONFLICT with Touch - completely separate pins
 constexpr uint8_t SD_CS = GPIO_NUM_41;
 constexpr uint8_t SD_MOSI = GPIO_NUM_1;

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -14,42 +14,11 @@
 
 // Include HAL for pin definitions
 #include "../../include/hal.hpp"
+#include "waveshare_board.hpp"
 
 // Define Global Variables declared extern in hal.hpp
 uint8_t GPS_TX = GPIO_NUM_43;
 uint8_t GPS_RX = GPIO_NUM_44;
-
-// Display Pins (CO5300 QSPI Driver) - Defined as extern const in hal.hpp but
-// initialized here? No, they are extern const in hal.hpp, so we need to define
-// them if they aren't constexpr. But wait, in hal.hpp they were constexpr
-// before, then I changed them to extern?? Let me check hal.hpp content from
-// previous view. In step 758 I changed GPS_TX/RX to extern. I didn't change
-// others. The others are 'constexpr' in hal.hpp (Step 717). So they don't need
-// definition. ONLY GPS_TX and GPS_RX need definition because I changed them to
-// extern. And checking linker error from Step 754: undefined reference to
-// `SD_CS`, `SD_MOSI`, `SD_MISO`, `SD_CLK`. This means they ARE extern in
-// hal.hpp? Let me re-read hal.hpp (Step 717). I changed 'extern const ...' to
-// 'constexpr ...' for 'TFT_QSPI_*', 'TCH_*', 'SD_*'. So they are constexpr.
-// Linker shouldn't fail unless code takes their address or ODR use. Wait,
-// libraries use them. 'storage.cpp' uses 'SD_CS'. If 'constexpr' is in header,
-// it should be fine. BUT, 'storage.cpp' might be compiled against 'hal.hpp'
-// where they are 'extern'? No, platformio rebuilds all. The linker error
-// 'undefined reference to SD_CS' implies it expects a symbol. This happens if
-// 'constexpr' is not used (i.e. ifdef logical flow) OR if ODR used. Ah,
-// SD.begin(SD_CS) takes uint8_t which is by value. Maybe 'storage.cpp' is not
-// seeing the 'constexpr' definition? Maybe 'storage.cpp' includes 'hal.hpp' but
-// the macro 'WAVESHARE_AMOLED_175' is NOT defined for 'storage.cpp'? This is
-// the likely culprit! 'storage.cpp' is in a library. Does it receive
-// '-DWAVESHARE_AMOLED_175'? In platformio.ini: 'build_flags =
-// -DWAVESHARE_AMOLED_175'. These flags are global. So 'storage.cpp' should see
-// it. Wait, look at linker error again. undefined reference to `GPS_TX`,
-// `GPS_RX`, `SD_CS`... If they are constexpr, they are internal linkage. If
-// 'storage.cpp' sees `constexpr uint8_t SD_CS = 21;`, it uses 21. Why undefined
-// reference? Maybe 'hal.hpp' has `extern const uint8_t SD_CS;` ? I need to be
-// 100% sure what hal.hpp contains now. I will check hal.hpp content again.
-
-// Assume I will only define GPS_TX/RX for now.
-// Display: change to extern.
 
 // ============================================================================
 // DISPLAY CONFIGURATION (Arduino_GFX)
@@ -114,15 +83,14 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
 
 // ============================================================================
 // TOUCH DRIVER (CST9217) - WITH TCA9554 RESET AND I2C BUS RECOVERY
-// See: .agent/workflows/WAVESHARE_HARDWARE.md
+// See WAVESHARE_HARDWARE.md.
 // ============================================================================
 
-#define CST9217_ADDRESS 0x5A
-#define TCA9554_ADDR 0x20
+constexpr uint8_t TCA9554_ADDR = waveshare_board::TCA9554_ADDR;
 #define TCA9554_OUTPUT_REG 0x01
 #define TCA9554_CONFIG_REG 0x03
 #define TCA9554_TOUCH_RST_BIT 0
-#define CST9217_INT_PIN 21
+constexpr uint8_t CST9217_INT_PIN = TCH_I2C_INT;
 #define CST9217_REG_DATA 0xD000
 #define CST9217_ACK 0xAB
 #define CST9217_DATA_LENGTH 10

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
@@ -9,6 +9,7 @@
 // Use Arduino_GFX for CO5300 AMOLED (like working esp32 project)
 #include <Arduino_GFX_Library.h>
 #include <lvgl.h>
+#include "waveshare_board.hpp"
 
 // Display dimensions
 #define SCREEN_WIDTH  466
@@ -26,7 +27,7 @@ extern volatile uint32_t lastDisplayFlushDurationUs;
 extern volatile uint32_t maxDisplayFlushDurationUs;
 
 // Touch handling (CST9217)
-#define CST9217_ADDRESS 0x5A
+constexpr uint8_t CST9217_ADDRESS = waveshare_board::CST9217_ADDR;
 extern bool touchPressed;
 extern uint16_t touchX, touchY;
 

--- a/esp32/lib/storage/storage.cpp
+++ b/esp32/lib/storage/storage.cpp
@@ -72,7 +72,7 @@ esp_err_t Storage::initSD() {
   // Waveshare 1.75" AMOLED: Use DEDICATED HSPI bus to avoid conflict with
   // QSPI display. The default SPI (FSPI) shares resources with the display.
   // NOTE: Use HSPI constant, not SPI3_HOST (which fails with "out of range")
-  // See: .agent/workflows/WAVESHARE_HARDWARE.md
+  // See WAVESHARE_HARDWARE.md.
   // Verified working pins: CS=41, MOSI=1, MISO=3, SCK=2
 
   Serial.println("Initializing SD Card (HSPI mode)...");

--- a/esp32/lib/waveshare_board/waveshare_board.cpp
+++ b/esp32/lib/waveshare_board/waveshare_board.cpp
@@ -1,0 +1,87 @@
+/**
+ * @file waveshare_board.cpp
+ * @brief Waveshare ESP32-S3 Touch AMOLED 1.75 board helpers.
+ */
+
+#include "waveshare_board.hpp"
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include <Wire.h>
+#include <hal.hpp>
+
+namespace waveshare_board {
+
+void recoverI2CBus() {
+  // Must run before Wire.begin() so stuck slaves can release SDA.
+  log_i("Performing I2C bus recovery...");
+
+  pinMode(I2C_SDA_PIN, INPUT_PULLUP);
+  pinMode(I2C_SCL_PIN, OUTPUT);
+
+  int clockCount = 0;
+  for (int i = 0; i < 9; i++) {
+    digitalWrite(I2C_SCL_PIN, LOW);
+    delayMicroseconds(5);
+    digitalWrite(I2C_SCL_PIN, HIGH);
+    delayMicroseconds(5);
+    clockCount++;
+
+    if (digitalRead(I2C_SDA_PIN) == HIGH) {
+      break;
+    }
+  }
+
+  pinMode(I2C_SDA_PIN, OUTPUT);
+  digitalWrite(I2C_SDA_PIN, LOW);
+  delayMicroseconds(5);
+  digitalWrite(I2C_SCL_PIN, HIGH);
+  delayMicroseconds(5);
+  digitalWrite(I2C_SDA_PIN, HIGH);
+  delayMicroseconds(5);
+
+  log_i("I2C bus recovery done (%d clocks)", clockCount);
+}
+
+static void writeAxp2101(uint8_t reg, uint8_t value) {
+  Wire.beginTransmission(AXP2101_ADDR);
+  Wire.write(reg);
+  Wire.write(value);
+  Wire.endTransmission();
+}
+
+void enablePowerRails() {
+  Serial.println("Enabling display power via AXP2101...");
+  Wire.beginTransmission(AXP2101_ADDR);
+  if (Wire.endTransmission() == 0) {
+    Serial.println("✓ AXP2101 found!");
+
+    writeAxp2101(AXP2101_DLDO1_REG, AXP2101_LDO_3V3);
+    writeAxp2101(AXP2101_DLDO1_REG, AXP2101_LDO_3V3_ENABLED);
+
+    constexpr uint8_t ldoRegs[] = {
+        AXP2101_ALDO1_REG, AXP2101_ALDO2_REG, AXP2101_ALDO3_REG,
+        AXP2101_ALDO4_REG, AXP2101_BLDO1_REG, AXP2101_BLDO2_REG};
+
+    Serial.println("Resetting Peripheral Power...");
+    for (uint8_t reg : ldoRegs) {
+      writeAxp2101(reg, AXP2101_LDO_3V3);
+    }
+    delay(500);
+
+    Serial.println("Enabling Peripheral Power...");
+    for (uint8_t reg : ldoRegs) {
+      writeAxp2101(reg, AXP2101_LDO_3V3);
+      writeAxp2101(reg, AXP2101_LDO_3V3_ENABLED);
+    }
+
+    delay(500);
+    Serial.println("✓ AXP2101 display power enabled");
+  } else {
+    Serial.println("✗ AXP2101 not found - display may not work!");
+  }
+}
+
+} // namespace waveshare_board
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/lib/waveshare_board/waveshare_board.hpp
+++ b/esp32/lib/waveshare_board/waveshare_board.hpp
@@ -1,0 +1,36 @@
+/**
+ * @file waveshare_board.hpp
+ * @brief Waveshare ESP32-S3 Touch AMOLED 1.75 board helpers.
+ */
+
+#pragma once
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include <Arduino.h>
+
+namespace waveshare_board {
+
+constexpr uint8_t AXP2101_ADDR = 0x34;
+constexpr uint8_t TCA9554_ADDR = 0x20;
+constexpr uint8_t CST9217_ADDR = 0x5A;
+constexpr uint8_t PCF85063_ADDR = 0x51;
+constexpr uint8_t QMI8658_ADDR_PRIMARY = 0x6B;
+constexpr uint8_t QMI8658_ADDR_FALLBACK = 0x6A;
+
+constexpr uint8_t AXP2101_DLDO1_REG = 0x90;
+constexpr uint8_t AXP2101_ALDO1_REG = 0x92;
+constexpr uint8_t AXP2101_ALDO2_REG = 0x93;
+constexpr uint8_t AXP2101_ALDO3_REG = 0x94;
+constexpr uint8_t AXP2101_ALDO4_REG = 0x95;
+constexpr uint8_t AXP2101_BLDO1_REG = 0x96;
+constexpr uint8_t AXP2101_BLDO2_REG = 0x97;
+constexpr uint8_t AXP2101_LDO_3V3 = 0x1C;
+constexpr uint8_t AXP2101_LDO_3V3_ENABLED = 0x9C;
+
+void recoverI2CBus();
+void enablePowerRails();
+
+} // namespace waveshare_board
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -204,8 +204,7 @@ build_flags =
   -DBOARD_HAS_PSRAM
   -DARDUINO_USB_MODE=1
   -DARDUINO_USB_CDC_ON_BOOT=1
-  ; SD Card uses SDMMC 1-bit mode (native interface - more reliable than SPI)
-  ; Pins: CLK=14, CMD=17, D0=16 (per Waveshare wiki)
+  ; SD Card uses dedicated HSPI. Verified pins: CS=41, MOSI=1, MISO=3, SCK=2.
   -DDEFAULT_LAT=35.16755
   -DDEFAULT_LON=136.89451
   -Wno-error=return-type  ; Disable error for missing return statements (NeoGPS compatibility)

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -67,6 +67,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "waitingScr.hpp"
 #ifdef WAVESHARE_AMOLED_175
 #include "WAVESHARE_AMOLED_175.hpp"
+#include "waveshare_board.hpp"
 #endif
 
 extern Storage storage;
@@ -209,42 +210,7 @@ void setup() {
                 esp_reset_reason());
 
 #ifdef WAVESHARE_AMOLED_175
-  // =========================================================
-  // I2C Bus Recovery - CRITICAL for stuck bus
-  // Must run BEFORE any other I2C/SD operations
-  // =========================================================
-  log_i("Performing I2C bus recovery...");
-
-  // Configure pins as GPIO for manual control (Wire not started yet)
-  pinMode(I2C_SDA_PIN, INPUT_PULLUP);
-  pinMode(I2C_SCL_PIN, OUTPUT);
-
-  // Clock SCL up to 9 times while monitoring SDA
-  // This releases any slave holding SDA low
-  int clockCount = 0;
-  for (int i = 0; i < 9; i++) {
-    digitalWrite(I2C_SCL_PIN, LOW);
-    delayMicroseconds(5);
-    digitalWrite(I2C_SCL_PIN, HIGH);
-    delayMicroseconds(5);
-    clockCount++;
-
-    // If SDA is released (high), we might be done
-    if (digitalRead(I2C_SDA_PIN) == HIGH) {
-      break;
-    }
-  }
-
-  // Generate STOP condition: SDA low-to-high while SCL high
-  pinMode(I2C_SDA_PIN, OUTPUT);
-  digitalWrite(I2C_SDA_PIN, LOW);
-  delayMicroseconds(5);
-  digitalWrite(I2C_SCL_PIN, HIGH);
-  delayMicroseconds(5);
-  digitalWrite(I2C_SDA_PIN, HIGH);
-  delayMicroseconds(5);
-
-  log_i("I2C bus recovery done (%d clocks)", clockCount);
+  waveshare_board::recoverI2CBus();
 #endif
 #ifdef POWER_SAVE
   pinMode(BOARD_BOOT_PIN, INPUT_PULLUP);
@@ -278,60 +244,7 @@ void setup() {
   Wire.begin();
 
 #ifdef WAVESHARE_AMOLED_175
-  // Initialize AXP2101 Power Management - CRITICAL for display power!
-  Serial.println("Enabling display power via AXP2101...");
-  Wire.beginTransmission(0x34); // AXP2101 I2C address
-  if (Wire.endTransmission() == 0) {
-    Serial.println("✓ AXP2101 found!");
-
-    // Enable DLDO1 output (3.3V for display) - exact same as working demo
-    Wire.beginTransmission(0x34);
-    Wire.write(0x90); // DLDO1 voltage setting register
-    Wire.write(0x1C); // Set to 3.3V
-    Wire.endTransmission();
-
-    Wire.beginTransmission(0x34);
-    Wire.write(0x90); // Enable DLDO1
-    Wire.write(0x9C); // Enable bit + 3.3V
-    Wire.endTransmission();
-
-    // Enable other LDOs (ALDO1-4, BLDO1-2) to ensure SD Card and other
-    // peripherals are powered Register map typically: 0x92=ALDO1, 0x93=ALDO2,
-    // 0x94=ALDO3, 0x95=ALDO4, 0x96=BLDO1, 0x97=BLDO2
-
-    uint8_t ldo_regs[] = {0x92, 0x93, 0x94, 0x95, 0x96, 0x97};
-
-    // 1. Turn OFF all peripheral LDOs to force reset
-    Serial.println("Resetting Peripheral Power...");
-    for (uint8_t reg : ldo_regs) {
-      Wire.beginTransmission(0x34);
-      Wire.write(reg);
-      Wire.write(0x1C); // Disable (Bit 7=0) + Voltage 3.3V (Just in case)
-      Wire.endTransmission();
-    }
-    delay(500); // Wait for capacitors to discharge
-
-    // 2. Turn ON all peripheral LDOs
-    Serial.println("Enabling Peripheral Power...");
-    for (uint8_t reg : ldo_regs) {
-      Wire.beginTransmission(0x34);
-      Wire.write(reg);
-      Wire.write(0x1C); // Set to 3.3V
-      Wire.endTransmission();
-
-      Wire.beginTransmission(0x34);
-      Wire.write(reg);
-      Wire.write(0x9C); // Enable (Bit 7=1) + 3.3V
-      Wire.endTransmission();
-    }
-
-    delay(500); // Wait for power to stabilize (Longer delay)
-    Serial.println("✓ AXP2101 display power enabled");
-    // I2C Bus kept enabled for Touch Controller and Power Management
-
-  } else {
-    Serial.println("✗ AXP2101 not found - display may not work!");
-  }
+  waveshare_board::enablePowerRails();
 #endif
 
 #ifdef BME280


### PR DESCRIPTION
## Summary

- Add a `waveshare_board` helper module for Waveshare-specific I2C constants, pre-`Wire.begin()` bus recovery, and the existing AXP2101 rail enable sequence.
- Replace the inline Waveshare boot-time I2C recovery and AXP2101 writes in `main.cpp` with named helpers while preserving the known-good sequence and timings.
- Point active CST9217/TCA9554 touch address usage at the board constants and fix stale Waveshare hardware comments, including the SD card PlatformIO comment.

## Why

PR8 is the low-risk board-support cleanup before deeper hardware-native integrations. It keeps runtime behavior equivalent, but moves verified Waveshare hardware details into a smaller, named surface so later PMU, RTC, touch, and IMU work does not keep spreading raw addresses and boot sequencing through unrelated code.

## Validation

- `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- `git diff --check`
- Uploaded successfully with `pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101`
- Captured a reset boot log from the connected board on `/dev/cu.usbmodem2101`.

Connected-device smoke test passed:

- AXP2101 was found and display/peripheral rails were enabled.
- Arduino_GFX display initialized successfully.
- SD mounted on HSPI pins: `CS=41`, `MOSI=1`, `MISO=3`, `SCK=2`.
- LVGL display and touch drivers registered.
- BLE started and advertised as `BikeComputer`.
- TCA9554 was initially missed, then retried and recovered with `TCA9554 found - resetting touch controller`.
- `SYS` heartbeats continued through 30 seconds with no reboot loop.

## Notes

Known baseline symptoms are still present and are intentionally left for later I2C/touch PRs: GPIO21 stayed `HIGH(idle)`, CST9217 fallback reads sometimes returned `FF FF FF FF FF FF FF`, intermittent `ESP_ERR_INVALID_STATE` appeared from `Wire.requestFrom()`, and USB CDC logging reported host timeout warnings.

One earlier post-upload reset showed a transient NimBLE/BT interrupt allocation stack-canary panic before auto-rebooting cleanly. Subsequent reset testing did not reproduce it and reached stable BLE advertising. This PR does not touch BLE, so this is noted as residual hardware smoke-test context rather than a blocker.
