### PR TITLE
PR10: Integrate Waveshare AXP2101 PMU

### DIFF
--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -1,0 +1,745 @@
+# Waveshare Hardware-Native Implementation Plan
+
+This plan covers follow-up firmware work for the Waveshare ESP32-S3 Touch
+AMOLED 1.75 board based on the verified hardware reference in
+`WAVESHARE_HARDWARE.md`.
+
+The work should be split into small PRs. These changes touch boot sequencing,
+power rails, shared I2C behavior, display addressing, input handling, storage,
+and new hardware devices. Keeping them separate makes hardware regressions
+easier to bisect and keeps review focused.
+
+## Current Baseline
+
+Already implemented:
+
+- Correct shared I2C pins: SDA `GPIO15`, SCL `GPIO14`.
+- Correct CO5300 QSPI display pins.
+- Correct CST9217 touch address and TCA9554 P0 reset path.
+- Correct SD card SPI pins: CS `GPIO41`, MOSI `GPIO1`, MISO `GPIO3`, SCK
+  `GPIO2`.
+- SD card isolated on HSPI instead of the display QSPI path.
+- Boot-time I2C bus recovery.
+- Boot-time AXP2101 rail enable sequence.
+- Full-screen LVGL buffer in PSRAM to avoid AMOLED partial-update artifacts.
+
+Known remaining gaps:
+
+- AXP2101 is handled with raw boot-time writes instead of a real PMU module.
+- I2C recovery is boot-only and not shared by all I2C clients.
+- PCF85063 RTC is detected but unused.
+- QMI8658 IMU is detected but unused.
+- CO5300 90-degree rotation still has a green-edge/window artifact.
+- CST9217 touch correctly treats GPIO21 as an active-low hint plus throttled
+  polling fallback; the next work should measure and centralize that policy, not
+  make GPIO21 the only source of truth.
+- Storage debug logging and SPI speed are not tuned for production use.
+- Audio should be treated as a later bring-up track. The official schematic
+  exposes codec/audio nets, but the local hardware reference says ES8311 was
+  not detected in the reference scan.
+
+## PR Strategy
+
+Use a stacked sequence, not one large PR.
+
+Recommended order:
+
+1. PR 8: Board support cleanup.
+2. PR 10: AXP2101 PMU integration.
+3. PR 11: Shared I2C resilience.
+4. PR 12: CST9217 touch hint/fallback optimization.
+5. PR 13: CO5300 display window and rotation fix.
+6. PR 14: PCF85063 RTC integration.
+7. PR 15: QMI8658 IMU integration.
+8. PR 16: SD and map I/O tuning.
+
+GitHub PR #9 is unrelated to this hardware-native sequence, so the AXP2101 PMU
+work is numbered as PR 10 in this plan.
+
+Only combine changes when they are mechanically related and low risk. In
+practice, PR 8 may include small comments/build cleanup, but PRs 10-16 should
+remain separate.
+
+GPS is intentionally excluded from this sequence because this hardware model
+does not have GPS populated. Audio is also excluded from the core sequence: it
+needs separate codec-enable and I2S bring-up after the board basics are stable.
+
+## Researched Answers
+
+Internet research against the official Waveshare docs/schematic and vendor
+datasheets narrows several questions:
+
+- This board model should be treated as no-GPS hardware. Do not spend a PR on
+  UART GPS bring-up for this target.
+- The AXP2101 rail names are visible in the official schematic. Known nets
+  include `VCC3V3`, `VCC-RTC`, `A3V3`, `CPUSLDO`, `DCDC1-5`, `ALDO1-4`, and
+  `BLDO1-2`. The first PMU PR should preserve the current broad rail-enable
+  behavior, then add readback and named rail helpers before any rail is turned
+  off aggressively.
+- The AXP2101 datasheet exposes battery/charger state and ADC-style telemetry,
+  including battery voltage, VBUS/VSYS readings, charging status, and fuel-gauge
+  percentage registers. PMU integration can use these instead of ESP32 ADC
+  battery estimation once register reads are confirmed on the board.
+- The PCF85063 RTC is shown as powered from the AXP2101-backed RTC rail. That
+  supports the RTC integration plan, but retention across full power removal
+  still needs a real board test.
+- The QMI8658 datasheet allows `0x6A` or `0x6B` depending on the address pin;
+  the Waveshare schematic points to `0x6B` for this board. Treat `0x6B` as the
+  primary address and keep `0x6A` as a fallback/probe only.
+- QMI8658 supports standard/fast I2C modes, so `100 kHz` and `400 kHz` are both
+  plausible from the IMU side. Board-level stability still decides the final
+  bus speed because AXP2101, CST9217, TCA9554, PCF85063, and QMI8658 share the
+  bus.
+- PR #6/PR #7 bring-up found `100 kHz` I2C plus bus recovery/backoff and
+  throttled touch reads to be the stable baseline on Arduino Core 3.x.
+- PR #6/PR #7 confirmed CO5300 0-degree mode is clean, 90-degree mode works for
+  map/touch but can show a thin green edge, and explicit Arduino_CO5300
+  constructor offsets made the edge worse. Preserve driver defaults until
+  CASET/PASET experiments are isolated in the display PR.
+- PR #6/PR #7 confirmed a 32 GB SDHC card works at the current 4 MHz SPI
+  setting on HSPI. Treat 4 MHz/32 GB SDHC as the known-good storage baseline.
+- `pio device monitor` can fail in non-interactive PTYs on this setup; use the
+  pyserial reset/capture workflow documented in `AGENTS.md` when serial monitor
+  capture is unreliable.
+- Audio is not blocked purely by unknown pins: the official schematic includes
+  codec/audio control and I2S nets. It should remain a separate later bring-up
+  because codec enable, I2C detection, and exact I2S mapping need focused
+  validation.
+
+Research sources:
+
+- Merged PR #6 bring-up notes:
+  `https://github.com/seichris/esp32-bike-computer/pull/6`
+- Waveshare product docs:
+  `https://docs.waveshare.com/ESP32-S3-Touch-AMOLED-1.75`
+- Waveshare schematic PDF:
+  `https://files.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75/ESP32-S3-Touch-AMOLED-1.75.pdf`
+- AXP2101 datasheet:
+  `https://files.waveshare.com/wiki/common/X-power-AXP2101_SWcharge_V1.0.pdf`
+- QMI8658C datasheet:
+  `https://qstcorp.com/upload/pdf/202202/QMI8658C%20datasheet%20rev%200.9.pdf`
+- PCF85063A datasheet:
+  `https://www.nxp.com/docs/en/data-sheet/PCF85063A.pdf`
+
+## Live Baseline: 2026-07-01
+
+Connected-device baseline on Chris's Mac:
+
+- `pio run -e WAVESHARE_AMOLED_175` succeeded.
+- Upload succeeded over ESP32-S3 USB CDC/JTAG. The board appeared as
+  `/dev/cu.usbmodem101` before upload and `/dev/cu.usbmodem2101` after replug.
+- Upload detected ESP32-S3, 16 MB flash, and 8 MB embedded PSRAM.
+- After upload, the board temporarily disappeared from macOS USB enumeration
+  until manually unplugged/replugged.
+- Serial capture via pyserial on `/dev/cu.usbmodem2101` reached the expected
+  boot path:
+  - AXP2101 found.
+  - Peripheral power reset/enabled.
+  - Arduino_GFX display initialized.
+  - SD mounted on HSPI with pins `CS=41`, `MOSI=1`, `MISO=3`, `SCK=2`.
+  - SD root listed `.Spotlight-V100`, `.fseventsd`, `MAP`, `WPT`, `VECTMAP`,
+    `TRK`, and `.Trashes`.
+  - LVGL initialized with full-screen PSRAM buffer.
+  - Touch driver registered.
+  - BLE server started and advertised as `BikeComputer`.
+  - Runtime stayed on the waiting screen with periodic `SYS` heartbeats.
+
+Live symptoms observed:
+
+- First touch initialization attempt reported `TCA9554 not found`, then a later
+  attempt found TCA9554 and reset touch successfully.
+- Touch interrupt stayed `HIGH(idle)` during capture.
+- Touch fallback reads periodically returned `FF FF FF FF FF FF FF` with no ACK.
+- Intermittent Arduino Core 3.x I2C failures appeared as
+  `ESP_ERR_INVALID_STATE` from `Wire.requestFrom()`.
+- USB CDC logging periodically reported `HWCDC write failed due to waiting USB
+  Host - timeout`; boot and runtime still progressed.
+
+## PR 10 Connected-Device Findings: 2026-07-01
+
+Validated on branch `axp2101-pmu-integration` with the Waveshare board on
+`/dev/cu.usbmodem2101`:
+
+- Upload works normally once the board is out of BOOT/download mode.
+- App boot reaches `SPI_FAST_FLASH_BOOT` and stays alive on the waiting screen.
+- AXP2101 is found at `0x34`.
+- AXP2101 status registers read as `status1=0x20`, `status2=0x15` on USB:
+  VBUS good, battery absent, current direction standby, charge status
+  `5`/not charging.
+- PMU enable register `0x90` readback works:
+  - baseline reset `0x1C`
+  - baseline on `0x9C`
+  - final peripheral/display enable `0x9C`
+- AXP2101 voltage registers `0x93` through `0x97` read back as `0x1C`.
+- AXP2101 voltage register `0x92` / ALDO1 did not reliably read back `0x1C`;
+  captures saw `0x15` and `0x1F`, with one Arduino Core I2C
+  `ESP_ERR_INVALID_STATE`. Because final enable register `0x90` verified and
+  display, SD, touch, LVGL, and BLE all initialized, PR 10 treats voltage
+  readback mismatches as warnings while still requiring final enable readback.
+- Display initialization succeeded and the loading/waiting UI appeared.
+- SD mounted on HSPI using `CS=41`, `MOSI=1`, `MISO=3`, `SCK=2`.
+- LVGL initialized with the full-screen PSRAM buffer.
+- TCA9554 touch reset succeeded in the final captures.
+- BLE advertised as `BikeComputer`.
+- Touch fallback still occasionally logs no-ACK/raw idle bytes and
+  `ESP_ERR_INVALID_STATE`; this remains PR 11 shared-I2C work, not a PMU
+  blocker.
+- `WAVESHARE_AMOLED_175` does not define `POWER_SAVE`, so the BOOT short-press
+  light-sleep and long-press deep-sleep UI handlers are not reachable in the
+  normal Waveshare firmware. PR 10 test builds that enabled `POWER_SAVE` built
+  and flashed, but repeatedly reproduced an IPC task stack-canary panic during
+  Bluetooth interrupt allocation. After one test build did reach the waiting
+  screen, short-press and long-press BOOT tests did not trigger any visible
+  sleep/shutdown transition; the display stayed on the `Bike Computer. Start
+  the app...` screen and serial capture produced no PMU/sleep/shutdown logs.
+  Do not enable `POWER_SAVE` for Waveshare in PR 10; sleep/wake needs a focused
+  follow-up with Bluetooth stack sizing/startup order reviewed and explicit
+  GPIO0/button instrumentation.
+- Final pre-merge test on the normal `WAVESHARE_AMOLED_175` firmware built and
+  uploaded successfully on 2026-07-01. The first reset capture immediately after
+  flashing hit one IPC task stack-canary panic during NimBLE initialization, then
+  the automatic reboot reached the waiting screen and stayed alive through the
+  25-second heartbeat. Three subsequent explicit USB reset captures were clean:
+  no panic, PMU enable `0x90` readback `0x9C`, display ready, SD mounted, LVGL
+  initialized, BLE advertising, TCA9554 touch reset found, and SYS heartbeats
+  through 20 seconds.
+- Real USB power-removal/reconnect was tested by watching `/dev/cu.usbmodem*`
+  disappear, waiting for reconnect, and capturing serial boot without asserting
+  RTS/DTR. The reconnect boot was clean through 30 seconds: AXP2101 was found,
+  all voltage registers `0x92` through `0x97` read back `0x1C`, PMU enable
+  `0x90` read back `0x9C`, display initialized, SD mounted, LVGL initialized,
+  BLE advertised, TCA9554 reset succeeded, and SYS heartbeats continued through
+  30 seconds. Touch still showed intermittent idle-read I2C errors, which remain
+  PR 11 scope.
+- Battery-only cold boot was visually confirmed by unplugging USB and powering
+  the board from battery only. The board reached the expected screen. This was
+  not serial-captured because connecting USB would add VBUS and change the PMU
+  state being tested.
+- After the final `POWER_SAVE` long-press test, the temporary firmware stayed on
+  the waiting screen and serial reset could not enter the uploader
+  (`Failed to connect to ESP32-S3: No serial data received`). Normal firmware
+  restoration may require manually entering BOOT/download mode if the board is
+  left on a `POWER_SAVE` test image.
+- Normal PR 10 firmware was restored after manually entering BOOT/download mode.
+  The upload completed and verified successfully. A follow-up pyserial capture
+  still reset the chip into `DOWNLOAD(USB/UART0)`, so final visual boot
+  verification should use a plain USB-C unplug/replug without holding BOOT
+  instead of another serial-reset capture.
+
+Implementation status:
+
+- Implemented `esp32/lib/waveshare_board/axp2101.hpp` and `.cpp`.
+- `waveshare_board::enablePowerRails()` now delegates to the AXP2101 helper
+  instead of raw register writes.
+- AXP2101 register writes now include retry and readback logging.
+- PMU status readback logs VBUS/battery/charge state during setup.
+- Voltage register readback mismatches are warning-only; final enable register
+  readback remains required.
+- Waveshare `Power::powerOffPeripherals()` and `Power::deviceSuspend()` now call
+  the AXP2101 helper for display/peripheral rail control when compiled for
+  `WAVESHARE_AMOLED_175`.
+- `POWER_SAVE` remains disabled for `WAVESHARE_AMOLED_175`; sleep and deep
+  sleep validation are deferred.
+- Latest local verification before opening PR 10:
+  - `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`
+    passed on 2026-07-01.
+  - `git diff --check` passed on 2026-07-01.
+  - Normal firmware upload passed after manual BOOT/download mode; final
+    no-BOOT visual boot confirmation is the remaining device-side check because
+    serial reset can force `DOWNLOAD(USB/UART0)` on this setup.
+
+Implications:
+
+- The PR #6/PR #7 touch/I2C conclusions remain current on the connected device.
+- PR 8 can proceed without more hardware discovery, as long as it preserves
+  boot behavior.
+- PR 11 should include a post-boot I2C recovery path, retry policy, and counters
+  because TCA9554 can be missed during early touch init and later become
+  reachable.
+- PR 12 should keep GPIO21 as a hint plus fallback polling; do not make it the
+  only touch trigger.
+- PR 16 should gate SD root listing behind debug output because normal boot logs
+  currently include macOS metadata entries from the SD card.
+- BOOT-button sleep/shutdown should not be treated as validated for PR 10. The
+  PMU helper functions compile, but the user-facing sleep/shutdown route is
+  currently disabled for the Waveshare env, and a temporary `POWER_SAVE` build
+  did not visibly react to short or long BOOT presses while on the waiting
+  screen.
+- The one post-flash NimBLE panic should be tracked as Bluetooth startup
+  robustness work. It was not reproduced in three immediate follow-up USB reset
+  captures, so it is not treated as a PR 10 PMU regression by itself.
+
+## Remaining Test Questions
+
+These still need bench validation:
+
+- Which AXP2101 rails can be turned off safely without losing touch, SD, RTC,
+  IMU, or display resume behavior?
+- Does PCF85063 RTC time survive full battery/USB removal on this assembled
+  board?
+- Is GPIO21 reliable across multiple boards/firmware states as a hint, and what
+  fallback polling cadence gives the best latency/I2C-load tradeoff?
+- Is any I2C clock above the known-good `100 kHz` stable under real touch, PMU,
+  RTC, and IMU traffic?
+- Is the CO5300 controller address space effectively 480x480 with a centered
+  466x466 active window, and do rotation-specific CASET/PASET offsets fix the
+  green edge?
+- Which SD cards and capacities should be part of the mount/speed test matrix?
+
+Hard answers from `WAVESHARE_HARDWARE.md` that should not be reopened unless
+new schematic evidence appears:
+
+- Shared I2C is `GPIO15` SDA and `GPIO14` SCL.
+- Touch reset is TCA9554 P0 at I2C address `0x20`; never use GPIO20.
+- CST9217 touch is at `0x5A`.
+- AXP2101 PMU is at `0x34`.
+- PCF85063 RTC is at `0x51`.
+- SD card is SPI on CS `GPIO41`, MOSI `GPIO1`, MISO `GPIO3`, SCK `GPIO2`.
+- SD and touch do not have a pin conflict.
+- CO5300 QSPI display pins are CS `GPIO12`, CLK `GPIO38`, D0-D3
+  `GPIO4`/`GPIO5`/`GPIO6`/`GPIO7`, reset `GPIO39`.
+
+## PR 8: Board Support Cleanup
+
+Goal: centralize Waveshare-specific board primitives without changing runtime
+behavior.
+
+Scope:
+
+- Add a small Waveshare board module, for example:
+  - `esp32/lib/waveshare_board/waveshare_board.hpp`
+  - `esp32/lib/waveshare_board/waveshare_board.cpp`
+- Move boot-time I2C recovery out of `esp32/src/main.cpp`.
+- Move raw AXP2101 boot rail writes behind named functions, even if the first
+  implementation still writes the same registers.
+- Define named constants for:
+  - `AXP2101_ADDR = 0x34`
+  - `TCA9554_ADDR = 0x20`
+  - `CST9217_ADDR = 0x5A`
+  - `PCF85063_ADDR = 0x51`
+  - `QMI8658_ADDR_PRIMARY = 0x6B`
+  - `QMI8658_ADDR_FALLBACK = 0x6A`
+- Replace stale comments that point to `.agent/workflows/WAVESHARE_HARDWARE.md`
+  with `WAVESHARE_HARDWARE.md`.
+- Fix stale `platformio.ini` comments that still describe SDMMC pins for this
+  board.
+
+Out of scope:
+
+- Changing PMU behavior.
+- Changing touch polling behavior.
+- Changing display rotation or LVGL buffer mode.
+
+Validation:
+
+- `cd esp32 && pio run`
+- Cold boot on USB.
+- Capture serial boot log and compare against the 2026-07-01 live baseline.
+- Confirm display powers on.
+- Confirm touch still works.
+- Confirm SD card still mounts.
+- Confirm expected I2C devices are still visible if scanner/debug output is
+  enabled.
+
+Acceptance criteria:
+
+- `main.cpp` no longer owns Waveshare low-level boot details.
+- Hardware behavior matches the current baseline.
+- No new feature flags are required to boot the Waveshare env.
+
+## PR 10: AXP2101 PMU Integration
+
+Goal: treat the AXP2101 as the board PMU rather than a one-time display power
+enable sequence.
+
+Scope:
+
+- Add a dedicated AXP2101 helper module or class.
+- Implement named rail setup functions:
+  - `begin()`
+  - `enableDisplayRails()`
+  - `enablePeripheralRails()`
+  - `setDisplayPower(bool enabled)`
+  - `setPeripheralPower(bool enabled)`
+  - `restoreDefaultRails()`
+- Preserve the currently working rail values until the board schematic/register
+  map has been verified.
+- Add register readback after writes so boot logs can show whether requested
+  rail states actually latched.
+- Add battery/charge status primitives if the AXP2101 register map is confirmed:
+  - battery present
+  - charging/discharging
+  - VBUS present
+  - battery voltage if supported/configured
+- Update `Power::deviceSuspend()` and `Power::deviceShutdown()` to use PMU
+  rail control where safe.
+
+Out of scope:
+
+- Aggressive low-power tuning.
+- Wake-on-motion.
+- RTC alarm wake.
+
+Validation:
+
+- Required before merging PR 10:
+  - Build `WAVESHARE_AMOLED_175`.
+  - Upload to the connected board over USB CDC/JTAG.
+  - Reset/capture serial boot on USB.
+  - Confirm AXP2101 is found at `0x34`.
+  - Confirm PMU enable register `0x90` reaches/readbacks `0x9C`.
+  - Confirm display, LVGL, SD, touch reset, and BLE still initialize.
+- Explicitly deferred from PR 10:
+  - Full low-voltage/brownout behavior under battery load. Real USB
+    power-removal/reconnect passed, and USB reset coverage is enough for PR 10.
+  - Display off/on cycle from user-facing sleep; `POWER_SAVE` is disabled for
+    `WAVESHARE_AMOLED_175`.
+  - Light sleep and wake by BOOT button; enabling `POWER_SAVE` for testing
+    reproduced an IPC stack-canary panic during Bluetooth interrupt allocation,
+    and short BOOT press did not produce a visible/logged sleep transition.
+  - Deep sleep and wake by BOOT button; same `POWER_SAVE` blocker as light
+    sleep, and long BOOT press left the device on the waiting screen with no
+    visible shutdown warning.
+
+Acceptance criteria:
+
+- PMU writes are named and read back.
+- Display and peripherals can be powered down through board-specific code.
+- Existing boot stability is not worse than baseline.
+
+## PR 11: Shared I2C Resilience
+
+Goal: make the known I2C instability manageable for all devices on the shared
+bus, not just touch.
+
+Scope:
+
+- Add a shared I2C helper for Waveshare:
+  - bus recovery
+  - transaction retry
+  - transaction timeout handling
+  - optional device probe
+  - optional debug scan
+- Use helper functions for AXP2101, TCA9554, CST9217, PCF85063, and QMI8658
+  access.
+- Keep polling/logging rate limited to avoid making bus contention worse.
+- Add counters for:
+  - recovery attempts
+  - failed transactions
+  - recovered transactions
+  - detected missing devices
+- Make `100 kHz` the explicit default I2C speed because that was the stable
+  bring-up baseline from PR #6/PR #7.
+- Consider `Wire.setClock()` experiments behind a single board constant only
+  after shared recovery/counters exist. Validate `200 kHz` and `400 kHz` on
+  hardware before changing the default.
+
+Out of scope:
+
+- Rewriting each device driver completely.
+- Changing touch UX.
+- Adding RTC/IMU features.
+
+Validation:
+
+- Long idle run with touch enabled.
+- Repeated map pan/touch gestures.
+- Repeated suspend/wake.
+- Run with I2C scan/debug enabled and confirm no phantom-device storm.
+- Confirm failures recover without requiring device reset.
+
+Acceptance criteria:
+
+- I2C recovery is callable after boot.
+- Touch failures no longer permanently wedge the bus.
+- PMU and touch code share the same transaction policy.
+
+## PR 12: CST9217 Touch Hint/Fallback Optimization
+
+Goal: reduce shared I2C load while preserving the PR #6/PR #7 finding that
+GPIO21 is a useful active-low hint, not a perfect sole source of truth.
+
+Scope:
+
+- Move CST9217/TCA9554 constants out of the panel implementation into board or
+  touch-specific headers.
+- Configure GPIO21 as active-low hint input.
+- Track hint edge or level state without doing I2C work inside the ISR.
+- Read touch packets promptly after hint activity.
+- Keep a throttled polling fallback because observed states can stay idle even
+  when touch data exists.
+- Tune polling cadence around:
+  - idle/no-touch state
+  - active touch state
+  - recent touch release confirmation
+  - repeated I2C failures/backoff
+- Keep current coordinate validation and glitch filtering.
+- Keep TCA9554 P0 reset path and never use GPIO20.
+
+Out of scope:
+
+- Multi-touch gestures unless packet format is verified.
+- UI gesture redesign.
+
+Validation:
+
+- Tap.
+- Drag/pan map.
+- Long press.
+- No-touch idle for at least 10 minutes.
+- Repeated suspend/wake.
+- Confirm no phantom touches at corners.
+- Compare I2C transaction count before/after if counters exist from PR 11.
+
+Acceptance criteria:
+
+- Normal touch interaction uses GPIO21 as a hint where it works.
+- Boards or firmware states with unreliable GPIO21 behavior remain usable
+  through fallback.
+- I2C traffic decreases during idle.
+
+## PR 13: CO5300 Display Window And Rotation Fix
+
+Goal: resolve the 90-degree green-edge artifact and make the 466x466 active
+window explicit.
+
+Scope:
+
+- Isolate CO5300 panel setup behind a small board-local wrapper.
+- Preserve the current Arduino_CO5300 constructor defaults as the baseline,
+  because explicit constructor offsets made the 90-degree green-edge artifact
+  worse during PR #6/PR #7 bring-up.
+- Test whether the physical controller address space is 480x480 with a centered
+  466x466 active area.
+- Experiment with CASET/PASET offsets per rotation rather than raw MADCTL alone.
+- Add a hardware test mode or simple helper that draws:
+  - full black
+  - full white
+  - red/green/blue fills
+  - 1 px border
+  - corner markers
+- Keep LVGL full-screen PSRAM buffer and full render mode unless measurement
+  proves another mode is stable.
+
+Out of scope:
+
+- Replacing Arduino_GFX entirely.
+- Changing map renderer behavior.
+- Re-enabling unsupported 180/270 rotations unless verified.
+
+Validation:
+
+- 0-degree fill tests.
+- 90-degree fill tests.
+- LVGL full-screen invalidation.
+- Map render in both supported orientations.
+- Touch coordinate alignment in both supported orientations.
+- No green strip or stale pixels after repeated redraws.
+
+Acceptance criteria:
+
+- Active display window is documented in code.
+- 90-degree mode either has no green edge or is explicitly disabled until a
+  verified fix exists.
+- Touch transform matches final display rotation behavior.
+
+## PR 14: PCF85063 RTC Integration
+
+Goal: use the onboard RTC for real time before BLE/iOS time is available.
+
+Scope:
+
+- Add a small PCF85063 driver.
+- Probe RTC at `0x51`.
+- Read current RTC time on boot.
+- Sync RTC from trusted time sources:
+  - iOS app time over BLE
+  - BLE-injected location timestamp if available
+- Store time validity/source in logs.
+- Use RTC time for:
+  - boot timestamps
+  - ride start/resume before BLE/iOS location arrives
+  - GPX metadata when phone-provided time is unavailable
+
+Out of scope:
+
+- RTC alarm wake unless PMU/sleep behavior is already stable.
+- Timezone UI changes.
+
+Validation:
+
+- Boot after prior RTC sync with phone disconnected.
+- Boot after full power removal if backup battery/rail supports RTC.
+- iOS/BLE time updates RTC.
+- Invalid RTC values are rejected safely.
+
+Acceptance criteria:
+
+- System can start with sane time before BLE/iOS.
+- RTC sync does not disturb other I2C devices.
+- Logs show RTC status and source.
+
+## PR 15: QMI8658 IMU Integration
+
+Goal: bring up the onboard IMU safely, then decide which product behaviors are
+worth enabling.
+
+Scope:
+
+- Add QMI8658 probe for primary address `0x6B`, with `0x6A` as fallback.
+- Implement basic readout:
+  - accelerometer
+  - gyroscope
+  - chip ID/status if available
+- Add sample-rate and range configuration.
+- Add debug logging behind a flag or rate limit.
+- Characterize board orientation and axis signs.
+- Add optional derived signals:
+  - device orientation
+  - motion/no-motion
+  - rough vibration level
+
+Out of scope for first IMU PR:
+
+- Course-up fusion with BLE/iOS location heading.
+- Wake-on-motion.
+- Ride auto-start/stop.
+
+Follow-up candidates:
+
+- Wake-on-motion after PMU/sleep is stable.
+- BLE/iOS heading smoothing at low speed.
+- Auto pause/resume based on sustained motion state.
+- Crash/impact detection if sensor data is reliable.
+
+Validation:
+
+- Static board reports stable gravity vector.
+- Rotating board changes expected axes.
+- Sensor read loop does not degrade touch.
+- Long run does not increase I2C failures.
+
+Acceptance criteria:
+
+- IMU is detected and sampled reliably.
+- Axis orientation is documented.
+- No user-facing navigation behavior depends on IMU until the signal is proven.
+
+## PR 16: SD And Map I/O Tuning
+
+Goal: improve storage startup and map load performance without destabilizing SD
+mounting.
+
+Scope:
+
+- Remove or gate normal boot root-directory listing.
+- Add timing around:
+  - SD mount
+  - map file open
+  - map block read
+  - vector parse
+  - canvas draw
+- Test SD SPI frequencies:
+  - 4 MHz baseline
+  - 8 MHz
+  - 12 MHz
+  - 16 MHz
+- Keep HSPI isolation from the CO5300 QSPI display.
+- Keep 32 GB SDHC at 4 MHz as the known-good baseline from PR #6/PR #7.
+- Add map-block cache/read-ahead only after measurements show I/O is a real
+  bottleneck.
+
+Out of scope:
+
+- Filesystem format migration.
+- Large map pipeline changes.
+- Display renderer rewrites.
+
+Validation:
+
+- Mount the known-good 32 GB SDHC card first, then test additional cards if
+  available.
+- Load known map tiles repeatedly.
+- Pan map across tile boundaries.
+- Long ride simulation with route overlay.
+- Confirm no display corruption during SD reads.
+
+Acceptance criteria:
+
+- Boot logs are quieter.
+- Chosen SPI frequency is documented with test result.
+- Map I/O timing is visible enough to guide future optimization.
+
+## Cross-Cutting Rules
+
+- Do not touch `IceNav-v3/` unless a task explicitly targets the vendored
+  reference.
+- Preserve full-screen LVGL buffer plus full render mode until the CO5300
+  artifact work proves a safer alternative.
+- Never configure GPIO20 as touch reset; it is USB D+.
+- Keep SD on the verified SPI pins and isolated from display QSPI.
+- Keep all hardware-feature changes guarded by `WAVESHARE_AMOLED_175`.
+- Do not add a UART GPS implementation for this no-GPS Waveshare model.
+- Prefer named device helpers over raw `Wire` writes in application code.
+- Add debug counters before making behavioral tuning decisions.
+
+## Suggested Milestones
+
+Milestone 1: stable board layer
+
+- PR 8 board support cleanup.
+- PR 10 PMU integration.
+- PR 11 shared I2C resilience.
+
+Milestone 2: input and display polish
+
+- PR 12 touch hint/fallback optimization.
+- PR 13 CO5300 window/rotation fix.
+
+Milestone 3: onboard sensors
+
+- PR 14 RTC integration.
+- PR 15 IMU integration.
+
+Milestone 4: performance tuning
+
+- PR 16 SD and map I/O tuning.
+
+## Hardware Test Checklist
+
+Run this checklist for every PR that changes boot, PMU, I2C, display, touch, or
+storage behavior:
+
+- Build: `cd esp32 && pio run`.
+- USB cold boot.
+- Battery cold boot if battery is connected.
+- Display powers on.
+- Touch tap works.
+- Touch drag works.
+- SD card mounts.
+- Map loads from SD or FFat fallback behaves as expected.
+- BLE still advertises/connects.
+- Suspend/wake still works if the PR touches power.
+- Serial logs do not show repeated I2C invalid-state storms.
+
+## PR Grouping Decision
+
+Do not put all improvements in one PR.
+
+Safe to combine:
+
+- PR 8 with nonfunctional comments/build cleanup.
+
+Keep separate:
+
+- PMU integration and I2C resilience.
+- Touch hint/fallback changes and display rotation changes.
+- RTC and IMU support.
+- Storage tuning and map renderer changes.
+
+Reasoning:
+
+- PMU and I2C bugs can look identical during hardware testing.
+- Display and touch regressions need isolated visual/input validation.
+- RTC and IMU are independent devices with separate failure modes.
+- Storage performance tuning should be measurement-driven and easy to revert.

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -8,6 +8,10 @@
 
 #include "power.hpp"
 
+#ifdef WAVESHARE_AMOLED_175
+#include "axp2101.hpp"
+#endif
+
 extern const uint8_t BOARD_BOOT_PIN;
 
 /**
@@ -87,6 +91,10 @@ void Power::powerOffPeripherals() {
     gfx->fillScreen(0x0000);
   }
 #endif
+#ifdef WAVESHARE_AMOLED_175
+  waveshare_board::axp2101::setDisplayPower(false);
+  waveshare_board::axp2101::setPeripheralPower(false);
+#endif
   SPI.end();
   Wire.end();
 }
@@ -108,7 +116,14 @@ void Power::deviceSuspend() {
   lv_refr_now(display);
   if (gfx)
     gfx->displayOff();
+#ifdef WAVESHARE_AMOLED_175
+  waveshare_board::axp2101::setDisplayPower(false);
+#endif
   powerLightSleep();
+#ifdef WAVESHARE_AMOLED_175
+  waveshare_board::axp2101::setDisplayPower(true);
+  delay(50);
+#endif
   if (gfx) {
     gfx->displayOn();
     gfx->setBrightness(255);

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -1,0 +1,213 @@
+/**
+ * @file axp2101.cpp
+ * @brief AXP2101 PMU helpers for the Waveshare ESP32-S3 Touch AMOLED 1.75.
+ */
+
+#include "axp2101.hpp"
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include "waveshare_board.hpp"
+#include <Wire.h>
+
+namespace waveshare_board::axp2101 {
+
+namespace {
+
+bool pmuAvailable = false;
+
+constexpr uint8_t AXP2101_STATUS1_REG = 0x00;
+constexpr uint8_t AXP2101_STATUS2_REG = 0x01;
+constexpr uint8_t AXP2101_VBUS_GOOD_MASK = 0x20;
+constexpr uint8_t AXP2101_BATTERY_PRESENT_MASK = 0x08;
+constexpr uint8_t AXP2101_BATTERY_CURRENT_DIRECTION_SHIFT = 5;
+constexpr uint8_t AXP2101_BATTERY_CURRENT_DIRECTION_MASK = 0x03;
+constexpr uint8_t AXP2101_SYSTEM_ON_MASK = 0x10;
+constexpr uint8_t AXP2101_VINDPM_ACTIVE_MASK = 0x08;
+constexpr uint8_t AXP2101_CHARGING_STATUS_MASK = 0x07;
+
+constexpr uint8_t peripheralRailRegs[] = {
+    AXP2101_ALDO1_VOLTAGE_REG, AXP2101_ALDO2_VOLTAGE_REG,
+    AXP2101_ALDO3_VOLTAGE_REG, AXP2101_ALDO4_VOLTAGE_REG,
+    AXP2101_BLDO1_VOLTAGE_REG, AXP2101_BLDO2_VOLTAGE_REG};
+
+bool writeRegisterChecked(const char *label, uint8_t reg, uint8_t value,
+                          uint8_t readbackMask = 0xFF) {
+  uint8_t readback = 0;
+  for (uint8_t attempt = 0; attempt < 2; attempt++) {
+    if (!writeRegister(reg, value)) {
+      Serial.printf("AXP2101: %s write failed reg=0x%02X value=0x%02X\n",
+                    label, reg, value);
+      return false;
+    }
+
+    delay(5);
+    if (!readRegister(reg, readback)) {
+      Serial.printf("AXP2101: %s readback failed reg=0x%02X expected=0x%02X\n",
+                    label, reg, value);
+      continue;
+    }
+
+    bool ok = (readback & readbackMask) == (value & readbackMask);
+    Serial.printf("AXP2101: %s reg=0x%02X value=0x%02X read=0x%02X mask=0x%02X %s\n",
+                  label, reg, value, readback, readbackMask,
+                  ok ? "ok" : "mismatch");
+    if (ok) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+uint8_t currentLdoEnableValue(uint8_t fallback) {
+  uint8_t value = fallback;
+  readRegister(AXP2101_LDO_ENABLE_REG, value);
+  return value;
+}
+
+} // namespace
+
+bool begin() {
+  Wire.beginTransmission(AXP2101_ADDR);
+  pmuAvailable = Wire.endTransmission() == 0;
+  return pmuAvailable;
+}
+
+bool isAvailable() { return pmuAvailable; }
+
+bool readRegister(uint8_t reg, uint8_t &value) {
+  for (uint8_t attempt = 0; attempt < 3; attempt++) {
+    Wire.beginTransmission(AXP2101_ADDR);
+    Wire.write(reg);
+    if (Wire.endTransmission() != 0) {
+      delay(2);
+      continue;
+    }
+
+    if (Wire.requestFrom(AXP2101_ADDR, static_cast<uint8_t>(1)) == 1) {
+      value = Wire.read();
+      return true;
+    }
+    delay(2);
+  }
+
+  return false;
+}
+
+bool writeRegister(uint8_t reg, uint8_t value) {
+  for (uint8_t attempt = 0; attempt < 2; attempt++) {
+    Wire.beginTransmission(AXP2101_ADDR);
+    Wire.write(reg);
+    Wire.write(value);
+    if (Wire.endTransmission() == 0) {
+      return true;
+    }
+    delay(2);
+  }
+  return false;
+}
+
+bool readPowerStatus(PowerStatus &status) {
+  if (!readRegister(AXP2101_STATUS1_REG, status.status1) ||
+      !readRegister(AXP2101_STATUS2_REG, status.status2)) {
+    return false;
+  }
+
+  status.vbusGood = (status.status1 & AXP2101_VBUS_GOOD_MASK) != 0;
+  status.batteryPresent =
+      (status.status1 & AXP2101_BATTERY_PRESENT_MASK) != 0;
+  status.batteryCurrentDirection =
+      (status.status2 >> AXP2101_BATTERY_CURRENT_DIRECTION_SHIFT) &
+      AXP2101_BATTERY_CURRENT_DIRECTION_MASK;
+  status.systemOn = (status.status2 & AXP2101_SYSTEM_ON_MASK) != 0;
+  status.vindpmActive = (status.status2 & AXP2101_VINDPM_ACTIVE_MASK) != 0;
+  status.chargingStatus = status.status2 & AXP2101_CHARGING_STATUS_MASK;
+  return true;
+}
+
+bool setDisplayPower(bool enabled) {
+  uint8_t value = currentLdoEnableValue(AXP2101_KNOWN_GOOD_LDO_ENABLES);
+  if (enabled) {
+    value |= AXP2101_DISPLAY_ENABLE_MASK;
+  } else {
+    value &= ~AXP2101_DISPLAY_ENABLE_MASK;
+  }
+  return writeRegisterChecked(enabled ? "display on" : "display off",
+                              AXP2101_LDO_ENABLE_REG, value);
+}
+
+bool enableDisplayRails() { return setDisplayPower(true); }
+
+bool setPeripheralPower(bool enabled) {
+  uint8_t value = currentLdoEnableValue(
+      enabled ? AXP2101_KNOWN_GOOD_LDO_ENABLES
+              : AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK);
+  if (enabled) {
+    value |= AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK;
+  } else {
+    value &= ~AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK;
+  }
+  return writeRegisterChecked(enabled ? "peripheral on" : "peripheral off",
+                              AXP2101_LDO_ENABLE_REG, value);
+}
+
+bool enablePeripheralRails() {
+  bool voltageOk = true;
+  for (uint8_t reg : peripheralRailRegs) {
+    voltageOk = writeRegisterChecked("peripheral 3v3", reg,
+                                     AXP2101_LDO_VOLTAGE_3V3,
+                                     AXP2101_LDO_VOLTAGE_MASK) &&
+                voltageOk;
+  }
+
+  if (!voltageOk) {
+    Serial.println("AXP2101: peripheral voltage readback warning");
+  }
+
+  return writeRegisterChecked("peripheral on", AXP2101_LDO_ENABLE_REG,
+                              AXP2101_KNOWN_GOOD_LDO_ENABLES);
+}
+
+bool restoreDefaultRails() {
+  Serial.println("Enabling display power via AXP2101...");
+  if (!begin()) {
+    Serial.println("AXP2101 not found - display may not work!");
+    return false;
+  }
+
+  Serial.println("AXP2101 found!");
+
+  bool ok = writeRegisterChecked("ldo baseline reset", AXP2101_LDO_ENABLE_REG,
+                                 AXP2101_KNOWN_GOOD_LDO_RESET);
+  ok = writeRegisterChecked("ldo baseline on", AXP2101_LDO_ENABLE_REG,
+                            AXP2101_KNOWN_GOOD_LDO_ENABLES) &&
+       ok;
+
+  PowerStatus status;
+  if (readPowerStatus(status)) {
+    Serial.printf("AXP2101: status1=0x%02X status2=0x%02X vbus=%s battery=%s "
+                  "currentDir=%u charge=%u\n",
+                  status.status1, status.status2,
+                  status.vbusGood ? "good" : "not-good",
+                  status.batteryPresent ? "present" : "absent",
+                  status.batteryCurrentDirection, status.chargingStatus);
+  } else {
+    Serial.println("AXP2101: status read failed");
+  }
+
+  Serial.println("Configuring Peripheral Power...");
+  ok = enablePeripheralRails() && ok;
+
+  delay(500);
+  if (ok) {
+    Serial.println("AXP2101 display power enabled");
+  } else {
+    Serial.println("! AXP2101 rail setup completed with readback errors");
+  }
+  return ok;
+}
+
+} // namespace waveshare_board::axp2101
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -1,0 +1,39 @@
+/**
+ * @file axp2101.hpp
+ * @brief AXP2101 PMU helpers for the Waveshare ESP32-S3 Touch AMOLED 1.75.
+ */
+
+#pragma once
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include <Arduino.h>
+
+namespace waveshare_board::axp2101 {
+
+struct PowerStatus {
+  uint8_t status1 = 0;
+  uint8_t status2 = 0;
+  bool vbusGood = false;
+  bool batteryPresent = false;
+  uint8_t batteryCurrentDirection = 0;
+  bool systemOn = false;
+  bool vindpmActive = false;
+  uint8_t chargingStatus = 0;
+};
+
+bool begin();
+bool isAvailable();
+bool readRegister(uint8_t reg, uint8_t &value);
+bool writeRegister(uint8_t reg, uint8_t value);
+bool readPowerStatus(PowerStatus &status);
+
+bool enableDisplayRails();
+bool enablePeripheralRails();
+bool setDisplayPower(bool enabled);
+bool setPeripheralPower(bool enabled);
+bool restoreDefaultRails();
+
+} // namespace waveshare_board::axp2101
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/lib/waveshare_board/waveshare_board.cpp
+++ b/esp32/lib/waveshare_board/waveshare_board.cpp
@@ -7,6 +7,7 @@
 
 #ifdef WAVESHARE_AMOLED_175
 
+#include "axp2101.hpp"
 #include <Wire.h>
 #include <hal.hpp>
 
@@ -43,43 +44,8 @@ void recoverI2CBus() {
   log_i("I2C bus recovery done (%d clocks)", clockCount);
 }
 
-static void writeAxp2101(uint8_t reg, uint8_t value) {
-  Wire.beginTransmission(AXP2101_ADDR);
-  Wire.write(reg);
-  Wire.write(value);
-  Wire.endTransmission();
-}
-
 void enablePowerRails() {
-  Serial.println("Enabling display power via AXP2101...");
-  Wire.beginTransmission(AXP2101_ADDR);
-  if (Wire.endTransmission() == 0) {
-    Serial.println("✓ AXP2101 found!");
-
-    writeAxp2101(AXP2101_DLDO1_REG, AXP2101_LDO_3V3);
-    writeAxp2101(AXP2101_DLDO1_REG, AXP2101_LDO_3V3_ENABLED);
-
-    constexpr uint8_t ldoRegs[] = {
-        AXP2101_ALDO1_REG, AXP2101_ALDO2_REG, AXP2101_ALDO3_REG,
-        AXP2101_ALDO4_REG, AXP2101_BLDO1_REG, AXP2101_BLDO2_REG};
-
-    Serial.println("Resetting Peripheral Power...");
-    for (uint8_t reg : ldoRegs) {
-      writeAxp2101(reg, AXP2101_LDO_3V3);
-    }
-    delay(500);
-
-    Serial.println("Enabling Peripheral Power...");
-    for (uint8_t reg : ldoRegs) {
-      writeAxp2101(reg, AXP2101_LDO_3V3);
-      writeAxp2101(reg, AXP2101_LDO_3V3_ENABLED);
-    }
-
-    delay(500);
-    Serial.println("✓ AXP2101 display power enabled");
-  } else {
-    Serial.println("✗ AXP2101 not found - display may not work!");
-  }
+  axp2101::restoreDefaultRails();
 }
 
 } // namespace waveshare_board

--- a/esp32/lib/waveshare_board/waveshare_board.hpp
+++ b/esp32/lib/waveshare_board/waveshare_board.hpp
@@ -18,15 +18,19 @@ constexpr uint8_t PCF85063_ADDR = 0x51;
 constexpr uint8_t QMI8658_ADDR_PRIMARY = 0x6B;
 constexpr uint8_t QMI8658_ADDR_FALLBACK = 0x6A;
 
-constexpr uint8_t AXP2101_DLDO1_REG = 0x90;
-constexpr uint8_t AXP2101_ALDO1_REG = 0x92;
-constexpr uint8_t AXP2101_ALDO2_REG = 0x93;
-constexpr uint8_t AXP2101_ALDO3_REG = 0x94;
-constexpr uint8_t AXP2101_ALDO4_REG = 0x95;
-constexpr uint8_t AXP2101_BLDO1_REG = 0x96;
-constexpr uint8_t AXP2101_BLDO2_REG = 0x97;
-constexpr uint8_t AXP2101_LDO_3V3 = 0x1C;
-constexpr uint8_t AXP2101_LDO_3V3_ENABLED = 0x9C;
+constexpr uint8_t AXP2101_LDO_ENABLE_REG = 0x90;
+constexpr uint8_t AXP2101_ALDO1_VOLTAGE_REG = 0x92;
+constexpr uint8_t AXP2101_ALDO2_VOLTAGE_REG = 0x93;
+constexpr uint8_t AXP2101_ALDO3_VOLTAGE_REG = 0x94;
+constexpr uint8_t AXP2101_ALDO4_VOLTAGE_REG = 0x95;
+constexpr uint8_t AXP2101_BLDO1_VOLTAGE_REG = 0x96;
+constexpr uint8_t AXP2101_BLDO2_VOLTAGE_REG = 0x97;
+constexpr uint8_t AXP2101_LDO_VOLTAGE_3V3 = 0x1C;
+constexpr uint8_t AXP2101_LDO_VOLTAGE_MASK = 0x1F;
+constexpr uint8_t AXP2101_DISPLAY_ENABLE_MASK = 0x80;
+constexpr uint8_t AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK = 0x1C;
+constexpr uint8_t AXP2101_KNOWN_GOOD_LDO_ENABLES = 0x9C;
+constexpr uint8_t AXP2101_KNOWN_GOOD_LDO_RESET = 0x1C;
 
 void recoverI2CBus();
 void enablePowerRails();


### PR DESCRIPTION
## Summary

- Add a dedicated Waveshare AXP2101 PMU helper with named rail controls, retries, readbacks, and USB/battery/charge status logging.
- Route Waveshare boot rail setup through the helper instead of raw register writes.
- Wire Waveshare display/peripheral PMU rail control into existing power-off and suspend paths without enabling `POWER_SAVE` for this board.
- Add/update the hardware-native implementation plan, including PR renumbering: GitHub PR #9 is unrelated, so this AXP2101 work is PR10.

## Hardware Notes

- Normal `WAVESHARE_AMOLED_175` firmware built, uploaded, and booted through PMU/display/SD/LVGL/touch/BLE checks during connected-device testing.
- Real USB power removal/reconnect passed.
- Battery-only cold boot was visually confirmed.
- Final plain USB-C unplug/replug without holding BOOT showed the `Bike Computer. Start the app...` waiting screen again.
- Temporary `POWER_SAVE` test builds are not mergeable: they reproduced NimBLE startup stack-canary panics, and BOOT short/long presses did not visibly enter sleep/shutdown.
- Final normal firmware restoration required manual BOOT/download mode after a temporary `POWER_SAVE` test image. Serial reset can force `DOWNLOAD(USB/UART0)` on this setup, so visual boot checks should use plain USB-C replug without BOOT.

## Validation

- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`
- `git diff --check`
- Device upload: `pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101` passed after manually entering BOOT/download mode.
- Device visual reboot: plain unplug/replug without BOOT returned to the Bike Computer waiting screen.

## Deferred

- User-facing light sleep / deep sleep on Waveshare remains out of scope because `POWER_SAVE` is disabled for this environment and the temporary test build was unstable.
- Shared I2C recovery/counters remain PR11 scope.
