### PR TITLE
PR11: Add Waveshare shared I2C resilience

### DIFF
--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -251,7 +251,7 @@ Implementation status:
 Implications:
 
 - The PR #6/PR #7 touch/I2C conclusions remain current on the connected device.
-- PR 8 can proceed without more hardware discovery, as long as it preserves
+- PR 11 can proceed without more hardware discovery, as long as it preserves
   boot behavior.
 - PR 11 should include a post-boot I2C recovery path, retry policy, and counters
   because TCA9554 can be missed during early touch init and later become
@@ -412,6 +412,41 @@ Acceptance criteria:
 Goal: make the known I2C instability manageable for all devices on the shared
 bus, not just touch.
 
+Implementation status:
+
+- In progress on branch `shared-i2c-resilience`, based on merged PR 10 commit
+  `b853488`.
+- Added a Waveshare-only shared I2C helper with explicit `100 kHz` default
+  clock, `50 ms` transaction timeout, retry wrappers, post-boot bus recovery,
+  optional probe/debug-scan helpers, and counters for failed transactions,
+  recovery attempts, recovered transactions, and missing devices.
+- Migrated current Waveshare AXP2101, TCA9554, and CST9217 register access to
+  the shared helper.
+- PCF85063 and QMI8658 do not yet have production accessors in the firmware;
+  they should use the shared helper when PR 14 and PR 15 add RTC/IMU drivers,
+  rather than adding unused reads in PR 11.
+- Local build passed on 2026-07-01:
+  `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`.
+- Connected-device upload passed four times on 2026-07-01 without manually
+  entering BOOT/download mode:
+  `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101`.
+- First passive serial capture after PR 11 boot showed AXP2101, display, SD,
+  LVGL, BLE advertising, and TCA9554 touch reset initialized successfully
+  through a 30-second idle run. It also showed recurring Arduino Core
+  `ESP_ERR_INVALID_STATE` touch-read failures while the firmware kept running;
+  those failures are now measurable through the PR 11 I2C counters.
+- A later passive serial capture saw the USB CDC device re-enumerate/drop with
+  `Device not configured`. Treat serial-capture resets as a local USB CDC
+  testing caveat, and use plain unplug/replug visual boot confirmation as the
+  final practical check before merging.
+- Final connected-device check after unplug/replug and reflashing the review-loop
+  build passed on 2026-07-01. The device reached the waiting screen and stayed
+  running through a 35-second passive serial capture. The `SYS:` heartbeat now
+  reports I2C counters on the same line, ending at
+  `i2c[fail=8 recover=8 recovered=8 missing=0]`; this confirms the known
+  Arduino Core touch-read failures are counted and the bus recovers during
+  normal idle operation.
+
 Scope:
 
 - Add a shared I2C helper for Waveshare:
@@ -420,8 +455,9 @@ Scope:
   - transaction timeout handling
   - optional device probe
   - optional debug scan
-- Use helper functions for AXP2101, TCA9554, CST9217, PCF85063, and QMI8658
-  access.
+- Use helper functions for current AXP2101, TCA9554, and CST9217 access.
+- Keep PCF85063 and QMI8658 on the same helper path when their RTC/IMU drivers
+  are added.
 - Keep polling/logging rate limited to avoid making bus contention worse.
 - Add counters for:
   - recovery attempts

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -10,10 +10,10 @@
 
 #include <cstring>
 #include <Preferences.h>
-#include <Wire.h>
 
 // Include HAL for pin definitions
 #include "../../include/hal.hpp"
+#include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
 
 // Define Global Variables declared extern in hal.hpp
@@ -124,22 +124,8 @@ static bool isValidTouchCoordinate(uint16_t x, uint16_t y) {
 }
 
 static bool readCst9217Register(uint16_t reg, uint8_t *data, uint8_t len) {
-  Wire.beginTransmission(CST9217_ADDRESS);
-  Wire.write(reg >> 8);
-  Wire.write(reg & 0xFF);
-  if (Wire.endTransmission(false) != 0) {
-    return false;
-  }
-
-  delay(2);
-  if (Wire.requestFrom(CST9217_ADDRESS, len, (uint8_t)true) != len) {
-    return false;
-  }
-
-  for (uint8_t i = 0; i < len; i++) {
-    data[i] = Wire.read();
-  }
-  return true;
+  return waveshare_board::i2c::readRegister16(CST9217_ADDRESS, reg, data, len,
+                                              "CST9217");
 }
 
 static void logTouchPacket(const char *label, const uint8_t *data,
@@ -224,26 +210,22 @@ static void noteTouchReadFailure(const char *reason, uint32_t now) {
 }
 
 // TCA9554 helper functions
-static void tca9554SetPin(uint8_t pin, bool level) {
+static bool tca9554SetPin(uint8_t pin, bool level) {
   if (level) {
     tca9554OutputShadow |= (1 << pin);
   } else {
     tca9554OutputShadow &= ~(1 << pin);
   }
 
-  Wire.beginTransmission(TCA9554_ADDR);
-  Wire.write(TCA9554_OUTPUT_REG);
-  Wire.write(tca9554OutputShadow);
-  Wire.endTransmission();
+  return waveshare_board::i2c::writeRegister8(
+      TCA9554_ADDR, TCA9554_OUTPUT_REG, tca9554OutputShadow, "TCA9554");
 }
 
-static void tca9554ConfigureOutput(uint8_t pin) {
+static bool tca9554ConfigureOutput(uint8_t pin) {
   tca9554ConfigShadow &= ~(1 << pin); // Clear bit = Output
 
-  Wire.beginTransmission(TCA9554_ADDR);
-  Wire.write(TCA9554_CONFIG_REG);
-  Wire.write(tca9554ConfigShadow);
-  Wire.endTransmission();
+  return waveshare_board::i2c::writeRegister8(
+      TCA9554_ADDR, TCA9554_CONFIG_REG, tca9554ConfigShadow, "TCA9554");
 }
 
 void initTouchController() {
@@ -257,16 +239,18 @@ void initTouchController() {
   lastTouchInitAttemptMs = now;
 
   // Check for TCA9554 and reset touch controller
-  Wire.beginTransmission(TCA9554_ADDR);
-  if (Wire.endTransmission() == 0) {
+  if (waveshare_board::i2c::probe(TCA9554_ADDR, "TCA9554")) {
     Serial.println("✓ TCA9554 found - resetting touch controller");
     pinMode(CST9217_INT_PIN, INPUT_PULLUP);
-    tca9554ConfigureOutput(TCA9554_TOUCH_RST_BIT);
-    tca9554SetPin(TCA9554_TOUCH_RST_BIT, false); // RST low
+    bool resetOk = tca9554ConfigureOutput(TCA9554_TOUCH_RST_BIT);
+    resetOk = tca9554SetPin(TCA9554_TOUCH_RST_BIT, false) && resetOk; // RST low
     delay(20);
-    tca9554SetPin(TCA9554_TOUCH_RST_BIT, true); // RST high
+    resetOk = tca9554SetPin(TCA9554_TOUCH_RST_BIT, true) && resetOk; // RST high
     delay(100); // Wait for touch controller to boot
-    touchInitialized = true;
+    touchInitialized = resetOk;
+    if (!resetOk) {
+      Serial.println("Touch reset failed through TCA9554");
+    }
   } else {
     Serial.println("✗ TCA9554 not found - touch may not work");
   }

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -7,8 +7,8 @@
 
 #ifdef WAVESHARE_AMOLED_175
 
+#include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
-#include <Wire.h>
 
 namespace waveshare_board::axp2101 {
 
@@ -69,43 +69,18 @@ uint8_t currentLdoEnableValue(uint8_t fallback) {
 } // namespace
 
 bool begin() {
-  Wire.beginTransmission(AXP2101_ADDR);
-  pmuAvailable = Wire.endTransmission() == 0;
+  pmuAvailable = i2c::probe(AXP2101_ADDR, "AXP2101");
   return pmuAvailable;
 }
 
 bool isAvailable() { return pmuAvailable; }
 
 bool readRegister(uint8_t reg, uint8_t &value) {
-  for (uint8_t attempt = 0; attempt < 3; attempt++) {
-    Wire.beginTransmission(AXP2101_ADDR);
-    Wire.write(reg);
-    if (Wire.endTransmission() != 0) {
-      delay(2);
-      continue;
-    }
-
-    if (Wire.requestFrom(AXP2101_ADDR, static_cast<uint8_t>(1)) == 1) {
-      value = Wire.read();
-      return true;
-    }
-    delay(2);
-  }
-
-  return false;
+  return i2c::readRegister8(AXP2101_ADDR, reg, value, "AXP2101");
 }
 
 bool writeRegister(uint8_t reg, uint8_t value) {
-  for (uint8_t attempt = 0; attempt < 2; attempt++) {
-    Wire.beginTransmission(AXP2101_ADDR);
-    Wire.write(reg);
-    Wire.write(value);
-    if (Wire.endTransmission() == 0) {
-      return true;
-    }
-    delay(2);
-  }
-  return false;
+  return i2c::writeRegister8(AXP2101_ADDR, reg, value, "AXP2101");
 }
 
 bool readPowerStatus(PowerStatus &status) {

--- a/esp32/lib/waveshare_board/i2c_bus.cpp
+++ b/esp32/lib/waveshare_board/i2c_bus.cpp
@@ -1,0 +1,173 @@
+/**
+ * @file i2c_bus.cpp
+ * @brief Shared I2C helpers for the Waveshare ESP32-S3 Touch AMOLED 1.75.
+ */
+
+#include "i2c_bus.hpp"
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include "waveshare_board.hpp"
+#include <Wire.h>
+#include <hal.hpp>
+
+namespace waveshare_board::i2c {
+
+namespace {
+
+Stats i2cStats;
+bool busConfigured = false;
+uint32_t activeClockHz = DEFAULT_CLOCK_HZ;
+uint32_t lastFailureLogMs = 0;
+
+void logFailure(const char *label, const char *operation, uint8_t address) {
+  uint32_t now = millis();
+  if (now - lastFailureLogMs < 5000) {
+    return;
+  }
+
+  Serial.printf("Waveshare I2C: %s failed addr=0x%02X label=%s failures=%u "
+                "recoveries=%u recovered=%u missing=%u\n",
+                operation, address, label ? label : "-",
+                i2cStats.failedTransactions, i2cStats.recoveryAttempts,
+                i2cStats.recoveredTransactions, i2cStats.missingDevices);
+  lastFailureLogMs = now;
+}
+
+void recoverAfterFailure() {
+  i2cStats.recoveryAttempts++;
+  if (busConfigured) {
+    Wire.end();
+  }
+  waveshare_board::recoverI2CBus();
+  if (busConfigured) {
+    Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
+    Wire.begin();
+    Wire.setClock(activeClockHz);
+    Wire.setTimeOut(DEFAULT_TIMEOUT_MS);
+  }
+}
+
+template <typename Fn>
+bool withRetries(uint8_t address, const char *label, const char *operation,
+                 uint8_t attempts, Fn &&fn) {
+  if (attempts == 0) {
+    attempts = 1;
+  }
+
+  for (uint8_t attempt = 0; attempt < attempts; attempt++) {
+    if (fn()) {
+      if (attempt > 0) {
+        i2cStats.recoveredTransactions++;
+      }
+      return true;
+    }
+
+    i2cStats.failedTransactions++;
+    recoverAfterFailure();
+    if (attempt + 1 < attempts) {
+      delay(2);
+    }
+  }
+
+  logFailure(label, operation, address);
+  return false;
+}
+
+} // namespace
+
+void configureBus(uint32_t clockHz) {
+  activeClockHz = clockHz;
+  Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
+  Wire.begin();
+  Wire.setClock(activeClockHz);
+  Wire.setTimeOut(DEFAULT_TIMEOUT_MS);
+  busConfigured = true;
+  Serial.printf("Waveshare I2C: configured SDA=%u SCL=%u clock=%lu Hz timeout=%u ms\n",
+                I2C_SDA_PIN, I2C_SCL_PIN,
+                static_cast<unsigned long>(activeClockHz), DEFAULT_TIMEOUT_MS);
+}
+
+const Stats &stats() { return i2cStats; }
+
+void debugScan(Stream &out, uint8_t firstAddress, uint8_t lastAddress) {
+  out.println("Waveshare I2C scan:");
+  for (uint16_t address = firstAddress; address <= lastAddress; address++) {
+    Wire.beginTransmission(address);
+    if (Wire.endTransmission() == 0) {
+      out.printf("  found 0x%02X\n", address);
+    }
+  }
+}
+
+bool probe(uint8_t address, const char *label, uint8_t attempts) {
+  bool ok = withRetries(address, label, "probe", attempts, [address]() {
+    Wire.beginTransmission(address);
+    return Wire.endTransmission() == 0;
+  });
+  if (!ok) {
+    i2cStats.missingDevices++;
+  }
+  return ok;
+}
+
+bool writeRegister8(uint8_t address, uint8_t reg, uint8_t value,
+                    const char *label, uint8_t attempts) {
+  return withRetries(address, label, "write8", attempts,
+                     [address, reg, value]() {
+                       Wire.beginTransmission(address);
+                       Wire.write(reg);
+                       Wire.write(value);
+                       return Wire.endTransmission() == 0;
+                     });
+}
+
+bool readRegister8(uint8_t address, uint8_t reg, uint8_t &value,
+                   const char *label, uint8_t attempts) {
+  return withRetries(address, label, "read8", attempts, [address, reg, &value]() {
+    Wire.beginTransmission(address);
+    Wire.write(reg);
+    if (Wire.endTransmission() != 0) {
+      return false;
+    }
+
+    if (Wire.requestFrom(address, static_cast<uint8_t>(1)) != 1) {
+      return false;
+    }
+
+    value = Wire.read();
+    return true;
+  });
+}
+
+bool readRegister16(uint8_t address, uint16_t reg, uint8_t *data, uint8_t len,
+                    const char *label, uint8_t attempts) {
+  if (data == nullptr || len == 0) {
+    return false;
+  }
+
+  return withRetries(address, label, "read16", attempts,
+                     [address, reg, data, len]() {
+                       Wire.beginTransmission(address);
+                       Wire.write(reg >> 8);
+                       Wire.write(reg & 0xFF);
+                       if (Wire.endTransmission(false) != 0) {
+                         return false;
+                       }
+
+                       delay(2);
+                       if (Wire.requestFrom(address, len,
+                                            static_cast<uint8_t>(true)) != len) {
+                         return false;
+                       }
+
+                       for (uint8_t i = 0; i < len; i++) {
+                         data[i] = Wire.read();
+                       }
+                       return true;
+                     });
+}
+
+} // namespace waveshare_board::i2c
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/lib/waveshare_board/i2c_bus.hpp
+++ b/esp32/lib/waveshare_board/i2c_bus.hpp
@@ -1,0 +1,40 @@
+/**
+ * @file i2c_bus.hpp
+ * @brief Shared I2C helpers for the Waveshare ESP32-S3 Touch AMOLED 1.75.
+ */
+
+#pragma once
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include <Arduino.h>
+
+namespace waveshare_board::i2c {
+
+constexpr uint32_t DEFAULT_CLOCK_HZ = 100000;
+constexpr uint16_t DEFAULT_TIMEOUT_MS = 50;
+
+struct Stats {
+  uint32_t recoveryAttempts = 0;
+  uint32_t failedTransactions = 0;
+  uint32_t recoveredTransactions = 0;
+  uint32_t missingDevices = 0;
+};
+
+void configureBus(uint32_t clockHz = DEFAULT_CLOCK_HZ);
+const Stats &stats();
+void debugScan(Stream &out = Serial, uint8_t firstAddress = 0x08,
+               uint8_t lastAddress = 0x77);
+
+bool probe(uint8_t address, const char *label = nullptr,
+           uint8_t attempts = 2);
+bool writeRegister8(uint8_t address, uint8_t reg, uint8_t value,
+                    const char *label = nullptr, uint8_t attempts = 2);
+bool readRegister8(uint8_t address, uint8_t reg, uint8_t &value,
+                   const char *label = nullptr, uint8_t attempts = 3);
+bool readRegister16(uint8_t address, uint16_t reg, uint8_t *data, uint8_t len,
+                    const char *label = nullptr, uint8_t attempts = 3);
+
+} // namespace waveshare_board::i2c
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -67,6 +67,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "waitingScr.hpp"
 #ifdef WAVESHARE_AMOLED_175
 #include "WAVESHARE_AMOLED_175.hpp"
+#include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
 #endif
 
@@ -142,6 +143,9 @@ static void logSystemDebugHeartbeat() {
   lastLogMs = now;
 
   BLEDebugStats bleStats = bleNavServer.getDebugStats();
+#ifdef WAVESHARE_AMOLED_175
+  const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
+#endif
   const char *screenName = "unknown";
   lv_obj_t *activeScreen = lv_scr_act();
   if (activeScreen == waitingScreen) {
@@ -150,6 +154,45 @@ static void logSystemDebugHeartbeat() {
     screenName = "main";
   }
 
+#ifdef WAVESHARE_AMOLED_175
+  Serial.printf("SYS: up=%lus heap=%lu psram=%lu screen=%s tile=%s "
+                "waitRefresh=%d gpsFromApp=%d pendingMap=%d lat=%.6f "
+                "lon=%.6f heading=%u routePts=%u mapFound=%d mapBlocks=%u "
+                "mapFlags[pos=%d redraw=%d follow=%d vector=%d zoom=%u] "
+                "ui[loop=%lu maxGapMs=%lu lvgl=%lu lastLvglMs=%lu "
+                "lvglUs=%lu/%lu flush=%lu lastFlushMs=%lu flushUs=%lu/%lu] "
+                "ble[conn=%d auth=%d nav=%lu route=%lu gps=%lu settings=%lu] "
+                "i2c[fail=%lu recover=%lu recovered=%lu missing=%lu]\n",
+                (unsigned long)(now / 1000),
+                (unsigned long)ESP.getFreeHeap(),
+                (unsigned long)ESP.getFreePsram(), screenName,
+                debugTileName(activeTile), waitScreenRefresh,
+                gpsReceivedFromApp, pendingTransitionToMap,
+                gps.gpsData.latitude, gps.gpsData.longitude,
+                (unsigned)gps.gpsData.heading,
+                (unsigned)routeOverlay.getPointCount(),
+                mapView.debugIsMapFound(),
+                (unsigned)mapView.debugCachedBlockCount(), mapView.isPosMoved,
+                mapView.redrawMap, mapView.followGps, mapSet.vectorMap, zoom,
+                (unsigned long)loopCount, (unsigned long)maxLoopGapMs,
+                (unsigned long)lvglHandlerCount,
+                (unsigned long)lastLvglHandlerMs,
+                (unsigned long)lastLvglHandlerDurationUs,
+                (unsigned long)maxLvglHandlerDurationUs,
+                (unsigned long)displayFlushCount,
+                (unsigned long)lastDisplayFlushMs,
+                (unsigned long)lastDisplayFlushDurationUs,
+                (unsigned long)maxDisplayFlushDurationUs,
+                bleStats.connected, bleStats.authenticated,
+                (unsigned long)bleStats.navPacketCount,
+                (unsigned long)bleStats.routePacketCount,
+                (unsigned long)bleStats.gpsPacketCount,
+                (unsigned long)bleStats.settingsPacketCount,
+                (unsigned long)i2cStats.failedTransactions,
+                (unsigned long)i2cStats.recoveryAttempts,
+                (unsigned long)i2cStats.recoveredTransactions,
+                (unsigned long)i2cStats.missingDevices);
+#else
   Serial.printf("SYS: up=%lus heap=%lu psram=%lu screen=%s tile=%s "
                 "waitRefresh=%d gpsFromApp=%d pendingMap=%d lat=%.6f "
                 "lon=%.6f heading=%u routePts=%u mapFound=%d mapBlocks=%u "
@@ -168,28 +211,17 @@ static void logSystemDebugHeartbeat() {
                 mapView.debugIsMapFound(),
                 (unsigned)mapView.debugCachedBlockCount(), mapView.isPosMoved,
                 mapView.redrawMap, mapView.followGps, mapSet.vectorMap, zoom,
-#ifdef WAVESHARE_AMOLED_175
-                (unsigned long)loopCount, (unsigned long)maxLoopGapMs,
-                (unsigned long)lvglHandlerCount,
-                (unsigned long)lastLvglHandlerMs,
-                (unsigned long)lastLvglHandlerDurationUs,
-                (unsigned long)maxLvglHandlerDurationUs,
-                (unsigned long)displayFlushCount,
-                (unsigned long)lastDisplayFlushMs,
-                (unsigned long)lastDisplayFlushDurationUs,
-                (unsigned long)maxDisplayFlushDurationUs,
-#else
                 (unsigned long)loopCount, (unsigned long)maxLoopGapMs,
                 (unsigned long)lvglHandlerCount,
                 (unsigned long)lastLvglHandlerMs,
                 (unsigned long)lastLvglHandlerDurationUs,
                 (unsigned long)maxLvglHandlerDurationUs, 0UL, 0UL, 0UL, 0UL,
-#endif
                 bleStats.connected, bleStats.authenticated,
                 (unsigned long)bleStats.navPacketCount,
                 (unsigned long)bleStats.routePacketCount,
                 (unsigned long)bleStats.gpsPacketCount,
                 (unsigned long)bleStats.settingsPacketCount);
+#endif
 }
 
 /**
@@ -240,8 +272,12 @@ void setup() {
   digitalWrite(SD_CS, HIGH);
 #endif
 
+#ifdef WAVESHARE_AMOLED_175
+  waveshare_board::i2c::configureBus();
+#else
   Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
   Wire.begin();
+#endif
 
 #ifdef WAVESHARE_AMOLED_175
   waveshare_board::enablePowerRails();


### PR DESCRIPTION
## Summary
- Add a Waveshare-only shared I2C helper with explicit 100 kHz clock, 50 ms timeout, retries, post-boot bus recovery, optional probe/debug scan helpers, and counters.
- Route current Waveshare AXP2101, TCA9554, and CST9217 I2C access through the shared helper.
- Add I2C recovery counters to the Waveshare `SYS:` heartbeat and update the hardware-native implementation/status doc.

## Validation
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`
- `git diff --check`
- Flashed to connected Waveshare board on `/dev/cu.usbmodem2101` without manual BOOT/download mode.
- Passive 35s serial capture reached the waiting screen with AXP2101, display, SD, LVGL, BLE, and touch reset initialized.
- Final heartbeat included same-line counters: `i2c[fail=8 recover=8 recovered=8 missing=0]`, confirming known Arduino Core touch-read failures are counted and recovered during idle operation.

## Notes
- PCF85063 and QMI8658 do not yet have production accessors in firmware; their future PRs should use this shared helper instead of adding unused reads here.
