### PR TITLE
Optimize Waveshare touch hint fallback

### DIFF
--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -497,8 +497,8 @@ GPIO21 is a useful active-low hint, not a perfect sole source of truth.
 
 Implementation status:
 
-- In progress on branch `touch-hint-fallback-optimization`, based on merged
-  PR 11.
+- Implemented on branch `touch-hint-fallback-optimization` in PR 12, based on
+  merged PR 11.
 - Added `esp32/lib/waveshare_board/touch.hpp` for CST9217/TCA9554 registers,
   dimensions, GPIO21 hint pin, and touch polling/backoff timing constants.
 - Panel touch code now tracks GPIO21 active-low hint level and edges without

--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -495,6 +495,48 @@ Acceptance criteria:
 Goal: reduce shared I2C load while preserving the PR #6/PR #7 finding that
 GPIO21 is a useful active-low hint, not a perfect sole source of truth.
 
+Implementation status:
+
+- In progress on branch `touch-hint-fallback-optimization`, based on merged
+  PR 11.
+- Added `esp32/lib/waveshare_board/touch.hpp` for CST9217/TCA9554 registers,
+  dimensions, GPIO21 hint pin, and touch polling/backoff timing constants.
+- Panel touch code now tracks GPIO21 active-low hint level and edges without
+  doing I2C work from an ISR.
+- Active hint edges can bypass current backoff and trigger an immediate read;
+  active/recent hints keep a fast read cadence.
+- Idle fallback polling is still present for boards or states where GPIO21
+  remains high despite available CST9217 data, but the idle cadence is slower
+  than PR 11 to reduce shared I2C load.
+- Repeated idle I2C failures now use a bounded increasing retry backoff.
+- Dormant non-Arduino_GFX touch config no longer points reset at GPIO20 and uses
+  the correct shared I2C SCL pin.
+
+Device validation on 2026-07-01:
+
+- Built and flashed successfully to the connected Waveshare board on
+  `/dev/cu.usbmodem2101`.
+- Boot stayed healthy after flash: AXP2101 display power, Arduino_GFX display,
+  SD card, LVGL, BLE advertising, and TCA9554 touch reset all initialized.
+- 45-second no-touch serial capture stayed up without reboot or I2C wedge.
+  CST9217 reads still intermittently returned `ESP_ERR_INVALID_STATE`, but PR 11
+  I2C recovery kept the bus usable. The latest periodic `SYS` line during that
+  capture showed `i2c[fail=5 recover=5 recovered=5]`, followed by two additional
+  read errors before the capture ended.
+- Tap, drag, and long-press testing produced valid CST9217 touch packets and
+  `Touch: press`/`Touch: release` events on the device.
+- During tap, drag, and long-press testing, GPIO21 remained `HIGH(idle)`.
+  Therefore this hardware/firmware state must keep fallback reads; GPIO21 cannot
+  be used as the sole touch readiness source on this unit.
+- The fallback path read valid points such as `(204,297)` and `(285,279)` while
+  the hint line stayed idle, confirming the fallback path remains necessary and
+  functional.
+- 10-minute no-touch idle summary capture stayed alive to `SYS: up=599s` with
+  zero touch press/release events and zero GPIO21 `LOW(active)` observations.
+  The capture saw 76 Arduino Wire `ESP_ERR_INVALID_STATE` lines, but no runtime
+  reboot, phantom touch, or visible bus wedge. The only reset lines were the
+  expected USB serial reset banner from opening the capture.
+
 Scope:
 
 - Move CST9217/TCA9554 constants out of the panel implementation into board or

--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -536,6 +536,15 @@ Device validation on 2026-07-01:
   The capture saw 76 Arduino Wire `ESP_ERR_INVALID_STATE` lines, but no runtime
   reboot, phantom touch, or visible bus wedge. The only reset lines were the
   expected USB serial reset banner from opening the capture.
+- Integrated iPhone navigation smoke test passed. The iPhone connected over BLE,
+  sent settings, GPS, route geometry, and navigation instructions; the ESP32
+  transitioned to the main map screen with route overlay active. Touch tap/drag
+  activity continued to produce valid CST9217 press/release packets while the map
+  redrew and BLE stayed connected/authenticated. GPIO21 still remained
+  `HIGH(idle)`, so the fallback path remains required under navigation load too.
+  The final heartbeat stayed on `screen=main` with `routePts=25`,
+  `ble[conn=1 auth=1 nav=2 route=1 gps=1 settings=7]`, and recovering I2C
+  counters (`i2c[fail=11 recover=11 recovered=10 missing=0]`).
 
 Scope:
 

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -14,6 +14,7 @@
 // Include HAL for pin definitions
 #include "../../include/hal.hpp"
 #include "i2c_bus.hpp"
+#include "touch.hpp"
 #include "waveshare_board.hpp"
 
 // Define Global Variables declared extern in hal.hpp
@@ -86,18 +87,10 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
 // See WAVESHARE_HARDWARE.md.
 // ============================================================================
 
-constexpr uint8_t TCA9554_ADDR = waveshare_board::TCA9554_ADDR;
-#define TCA9554_OUTPUT_REG 0x01
-#define TCA9554_CONFIG_REG 0x03
-#define TCA9554_TOUCH_RST_BIT 0
-constexpr uint8_t CST9217_INT_PIN = TCH_I2C_INT;
-#define CST9217_REG_DATA 0xD000
-#define CST9217_ACK 0xAB
-#define CST9217_DATA_LENGTH 10
-
 bool touchPressed = false;
 uint16_t touchX = 0, touchY = 0;
 static bool touchInitialized = false;
+static bool touchHintConfigured = false;
 static uint32_t lastTouchInitAttemptMs = 0;
 static uint32_t lastTouchReadMs = 0;
 static uint32_t touchBackoffUntilMs = 0;
@@ -106,26 +99,22 @@ static uint32_t lastTouchDebugLogMs = 0;
 static uint32_t lastTouchRawLogMs = 0;
 static uint32_t touchFastPollUntilMs = 0;
 static uint32_t lastValidTouchMs = 0;
+static uint32_t lastTouchHintActiveMs = 0;
+static uint32_t lastTouchHintChangeMs = 0;
 static uint8_t consecutiveTouchReadFailures = 0;
 static uint8_t tca9554OutputShadow = 0xFF;
 static uint8_t tca9554ConfigShadow = 0xFF;
-static bool lastTouchInterruptActive = false;
-static bool touchInterruptStateKnown = false;
-
-constexpr uint32_t TOUCH_ACTIVE_READ_INTERVAL_MS = 25;
-constexpr uint32_t TOUCH_FAST_FALLBACK_READ_INTERVAL_MS = 25;
-constexpr uint32_t TOUCH_IDLE_FALLBACK_READ_INTERVAL_MS = 250;
-constexpr uint32_t TOUCH_FAST_POLL_WINDOW_MS = 700;
-constexpr uint32_t TOUCH_ACTIVE_FAILURE_GRACE_MS = 600;
-constexpr uint32_t TOUCH_IDLE_FAILURE_RETRY_MS = 75;
+static bool lastTouchHintActive = false;
+static bool touchHintStateKnown = false;
 
 static bool isValidTouchCoordinate(uint16_t x, uint16_t y) {
-  return x < 466 && y < 466;
+  return x < waveshare_board::touch::ACTIVE_WIDTH &&
+         y < waveshare_board::touch::ACTIVE_HEIGHT;
 }
 
 static bool readCst9217Register(uint16_t reg, uint8_t *data, uint8_t len) {
-  return waveshare_board::i2c::readRegister16(CST9217_ADDRESS, reg, data, len,
-                                              "CST9217");
+  return waveshare_board::i2c::readRegister16(
+      waveshare_board::touch::CST9217_ADDR, reg, data, len, "CST9217");
 }
 
 static void logTouchPacket(const char *label, const uint8_t *data,
@@ -160,22 +149,80 @@ static void setTouchPressed(bool pressed) {
   touchPressed = pressed;
 }
 
-static bool isTouchInterruptActive() {
-  // CST touch controllers use an active-low interrupt line.
-  return digitalRead(CST9217_INT_PIN) == LOW;
+static void configureTouchHintPin() {
+  if (touchHintConfigured) {
+    return;
+  }
+
+  pinMode(waveshare_board::touch::CST9217_INT_PIN, INPUT_PULLUP);
+  touchHintConfigured = true;
 }
 
-static void logTouchInterruptState(bool active, uint32_t now) {
-  bool changed = !touchInterruptStateKnown || active != lastTouchInterruptActive;
+static bool isTouchHintActive() {
+  configureTouchHintPin();
+  return digitalRead(waveshare_board::touch::CST9217_INT_PIN) == LOW;
+}
+
+static bool updateTouchHintState(bool active, uint32_t now) {
+  bool changed = !touchHintStateKnown || active != lastTouchHintActive;
   bool heartbeat = now - lastTouchDebugLogMs > 10000;
 
-  if (changed || heartbeat) {
-    Serial.printf("Touch debug: init=%d int=%s pressed=%d\n", touchInitialized,
-                  active ? "LOW(active)" : "HIGH(idle)", touchPressed);
-    lastTouchDebugLogMs = now;
-    lastTouchInterruptActive = active;
-    touchInterruptStateKnown = true;
+  if (active) {
+    lastTouchHintActiveMs = now;
   }
+  if (changed) {
+    lastTouchHintChangeMs = now;
+    if (active) {
+      touchFastPollUntilMs =
+          now + waveshare_board::touch::HINT_FAST_POLL_WINDOW_MS;
+    }
+  }
+
+  if (changed || heartbeat) {
+    uint32_t msSinceHintChange =
+        lastTouchHintChangeMs == 0 ? 0 : now - lastTouchHintChangeMs;
+    Serial.printf("Touch debug: init=%d int=%s pressed=%d hint_age_ms=%lu\n",
+                  touchInitialized, active ? "LOW(active)" : "HIGH(idle)",
+                  touchPressed, static_cast<unsigned long>(msSinceHintChange));
+    lastTouchDebugLogMs = now;
+    lastTouchHintActive = active;
+    touchHintStateKnown = true;
+  }
+
+  return changed;
+}
+
+static uint32_t idleFailureRetryMs() {
+  uint32_t retryMs = waveshare_board::touch::IDLE_FAILURE_BASE_RETRY_MS;
+  if (consecutiveTouchReadFailures > 1) {
+    retryMs += static_cast<uint32_t>(consecutiveTouchReadFailures - 1) * 75;
+  }
+  if (retryMs > waveshare_board::touch::IDLE_FAILURE_MAX_RETRY_MS) {
+    retryMs = waveshare_board::touch::IDLE_FAILURE_MAX_RETRY_MS;
+  }
+  return retryMs;
+}
+
+static uint32_t touchReadInterval(bool hintActive, bool hintChanged,
+                                  uint32_t now) {
+  if (hintChanged && hintActive) {
+    return 0;
+  }
+  if (hintActive) {
+    return waveshare_board::touch::HINT_ACTIVE_READ_INTERVAL_MS;
+  }
+  if (touchPressed) {
+    return waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
+  }
+  if (lastTouchHintActiveMs != 0 &&
+      now - lastTouchHintActiveMs <
+          waveshare_board::touch::HINT_FAST_POLL_WINDOW_MS) {
+    return waveshare_board::touch::RECENT_HINT_READ_INTERVAL_MS;
+  }
+  if (now < touchFastPollUntilMs) {
+    return waveshare_board::touch::FAST_FALLBACK_READ_INTERVAL_MS;
+  }
+  return waveshare_board::touch::IDLE_FALLBACK_READ_INTERVAL_MS;
 }
 
 static void noteTouchReadFailure(const char *reason, uint32_t now) {
@@ -187,13 +234,15 @@ static void noteTouchReadFailure(const char *reason, uint32_t now) {
     lastTouchErrorLogMs = now;
   }
 
-  if (touchPressed && now - lastValidTouchMs < TOUCH_ACTIVE_FAILURE_GRACE_MS) {
-    touchBackoffUntilMs = now + TOUCH_ACTIVE_READ_INTERVAL_MS;
+  if (touchPressed &&
+      now - lastValidTouchMs < waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+    touchBackoffUntilMs =
+        now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
     return;
   }
 
   if (!touchPressed) {
-    touchBackoffUntilMs = now + TOUCH_IDLE_FAILURE_RETRY_MS;
+    touchBackoffUntilMs = now + idleFailureRetryMs();
     if (consecutiveTouchReadFailures > 20) {
       consecutiveTouchReadFailures = 0;
     }
@@ -204,7 +253,7 @@ static void noteTouchReadFailure(const char *reason, uint32_t now) {
   touchBackoffUntilMs = now + 250;
   if (consecutiveTouchReadFailures >= 5) {
     touchInitialized = false;
-    touchBackoffUntilMs = now + 1200;
+    touchBackoffUntilMs = now + waveshare_board::touch::REINIT_BACKOFF_MS;
     consecutiveTouchReadFailures = 0;
   }
 }
@@ -218,14 +267,16 @@ static bool tca9554SetPin(uint8_t pin, bool level) {
   }
 
   return waveshare_board::i2c::writeRegister8(
-      TCA9554_ADDR, TCA9554_OUTPUT_REG, tca9554OutputShadow, "TCA9554");
+      waveshare_board::TCA9554_ADDR, waveshare_board::touch::TCA9554_OUTPUT_REG,
+      tca9554OutputShadow, "TCA9554");
 }
 
 static bool tca9554ConfigureOutput(uint8_t pin) {
   tca9554ConfigShadow &= ~(1 << pin); // Clear bit = Output
 
   return waveshare_board::i2c::writeRegister8(
-      TCA9554_ADDR, TCA9554_CONFIG_REG, tca9554ConfigShadow, "TCA9554");
+      waveshare_board::TCA9554_ADDR, waveshare_board::touch::TCA9554_CONFIG_REG,
+      tca9554ConfigShadow, "TCA9554");
 }
 
 void initTouchController() {
@@ -237,15 +288,20 @@ void initTouchController() {
     return;
   }
   lastTouchInitAttemptMs = now;
+  configureTouchHintPin();
 
   // Check for TCA9554 and reset touch controller
-  if (waveshare_board::i2c::probe(TCA9554_ADDR, "TCA9554")) {
+  if (waveshare_board::i2c::probe(waveshare_board::TCA9554_ADDR, "TCA9554")) {
     Serial.println("✓ TCA9554 found - resetting touch controller");
-    pinMode(CST9217_INT_PIN, INPUT_PULLUP);
-    bool resetOk = tca9554ConfigureOutput(TCA9554_TOUCH_RST_BIT);
-    resetOk = tca9554SetPin(TCA9554_TOUCH_RST_BIT, false) && resetOk; // RST low
+    bool resetOk =
+        tca9554ConfigureOutput(waveshare_board::touch::TCA9554_TOUCH_RST_BIT);
+    resetOk =
+        tca9554SetPin(waveshare_board::touch::TCA9554_TOUCH_RST_BIT, false) &&
+        resetOk; // RST low
     delay(20);
-    resetOk = tca9554SetPin(TCA9554_TOUCH_RST_BIT, true) && resetOk; // RST high
+    resetOk =
+        tca9554SetPin(waveshare_board::touch::TCA9554_TOUCH_RST_BIT, true) &&
+        resetOk; // RST high
     delay(100); // Wait for touch controller to boot
     touchInitialized = resetOk;
     if (!resetOk) {
@@ -258,9 +314,12 @@ void initTouchController() {
 
 void readTouch() {
   uint32_t now = millis();
+  bool touchHintActive = isTouchHintActive();
+  bool touchHintChanged = updateTouchHintState(touchHintActive, now);
 
-  if (now < touchBackoffUntilMs) {
-    if (touchPressed && now - lastValidTouchMs < TOUCH_ACTIVE_FAILURE_GRACE_MS) {
+  if (now < touchBackoffUntilMs && !(touchHintChanged && touchHintActive)) {
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
       return;
     }
     setTouchPressed(false);
@@ -276,32 +335,28 @@ void readTouch() {
     }
   }
 
-  bool touchInterruptActive = isTouchInterruptActive();
-  logTouchInterruptState(touchInterruptActive, now);
-  // GPIO21 is useful when it works, but on some Waveshare units it stays idle
-  // even while CST9217 has touch data. Keep a slow polling fallback so touch
-  // remains usable without hammering the shared I2C bus.
-  uint32_t readInterval = touchInterruptActive ? TOUCH_ACTIVE_READ_INTERVAL_MS
-                               : (touchPressed || now < touchFastPollUntilMs)
-                                     ? TOUCH_FAST_FALLBACK_READ_INTERVAL_MS
-                                     : TOUCH_IDLE_FALLBACK_READ_INTERVAL_MS;
+  uint32_t readInterval =
+      touchReadInterval(touchHintActive, touchHintChanged, now);
   if (now - lastTouchReadMs < readInterval) {
     return;
   }
   lastTouchReadMs = now;
 
-  uint8_t data[CST9217_DATA_LENGTH] = {0};
-  if (!readCst9217Register(CST9217_REG_DATA, data, sizeof(data))) {
+  uint8_t data[waveshare_board::touch::CST9217_DATA_LENGTH] = {0};
+  if (!readCst9217Register(waveshare_board::touch::CST9217_DATA_REG, data,
+                           sizeof(data))) {
     noteTouchReadFailure("data read", now);
     return;
   }
   consecutiveTouchReadFailures = 0;
 
-  if (data[6] != CST9217_ACK) {
+  if (data[6] != waveshare_board::touch::CST9217_ACK) {
     logTouchPacket("ignored-no-ack", data, sizeof(data), 0, 0,
-                   touchInterruptActive, now);
-    if (touchPressed && now - lastValidTouchMs < TOUCH_ACTIVE_FAILURE_GRACE_MS) {
-      touchBackoffUntilMs = now + TOUCH_ACTIVE_READ_INTERVAL_MS;
+                   touchHintActive, now);
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+      touchBackoffUntilMs =
+          now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
       return;
     }
     setTouchPressed(false);
@@ -310,8 +365,10 @@ void readTouch() {
 
   uint8_t points = data[5] & 0x7F;
   if (points == 0) {
-    if (touchPressed && now - lastValidTouchMs < TOUCH_ACTIVE_FAILURE_GRACE_MS) {
-      touchBackoffUntilMs = now + TOUCH_ACTIVE_READ_INTERVAL_MS;
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+      touchBackoffUntilMs =
+          now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
       return;
     }
     setTouchPressed(false);
@@ -323,9 +380,11 @@ void readTouch() {
   uint16_t rawY = (data[2] << 4) | (data[3] & 0x0F);
   if (status != 0x00 && status != 0x06) {
     logTouchPacket("ignored-status", data, sizeof(data), rawX, rawY,
-                   touchInterruptActive, now);
-    if (touchPressed && now - lastValidTouchMs < TOUCH_ACTIVE_FAILURE_GRACE_MS) {
-      touchBackoffUntilMs = now + TOUCH_ACTIVE_READ_INTERVAL_MS;
+                   touchHintActive, now);
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+      touchBackoffUntilMs =
+          now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
       return;
     }
     setTouchPressed(false);
@@ -333,7 +392,7 @@ void readTouch() {
   }
   if (!isValidTouchCoordinate(rawX, rawY)) {
     logTouchPacket("ignored-invalid", data, sizeof(data), rawX, rawY,
-                   touchInterruptActive, now);
+                   touchHintActive, now);
     setTouchPressed(false);
     return;
   }
@@ -341,12 +400,12 @@ void readTouch() {
   bool moved = rawX != touchX || rawY != touchY;
   if (status == 0x00 && !touchPressed) {
     logTouchPacket("ignored-stale-start", data, sizeof(data), rawX, rawY,
-                   touchInterruptActive, now);
+                   touchHintActive, now);
     setTouchPressed(false);
     return;
   }
   if (status == 0x00 && !moved &&
-      now - lastValidTouchMs >= TOUCH_ACTIVE_FAILURE_GRACE_MS) {
+      now - lastValidTouchMs >= waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
     setTouchPressed(false);
     return;
   }
@@ -356,15 +415,16 @@ void readTouch() {
   if (status == 0x06 || moved) {
     lastValidTouchMs = now;
   }
-  touchFastPollUntilMs = now + TOUCH_FAST_POLL_WINDOW_MS;
+  touchFastPollUntilMs =
+      now + waveshare_board::touch::TOUCH_FAST_POLL_WINDOW_MS;
   logTouchPacket(status == 0x06 ? "point" : "point-status0", data,
-                 sizeof(data), touchX, touchY, touchInterruptActive, now);
+                 sizeof(data), touchX, touchY, touchHintActive, now);
 
   // Clamp to screen bounds
-  if (touchX >= 466)
-    touchX = 465;
-  if (touchY >= 466)
-    touchY = 465;
+  if (touchX >= waveshare_board::touch::ACTIVE_WIDTH)
+    touchX = waveshare_board::touch::MAX_X;
+  if (touchY >= waveshare_board::touch::ACTIVE_HEIGHT)
+    touchY = waveshare_board::touch::MAX_Y;
 
   setTouchPressed(true);
 }
@@ -380,14 +440,14 @@ void my_touchpad_read(lv_indev_t *indev_driver, lv_indev_data_t *data) {
     switch (displayRotation) {
     case 1: // 90° CCW: swap X/Y and flip new X
       rotatedX = touchY;
-      rotatedY = 465 - touchX;
+      rotatedY = waveshare_board::touch::MAX_Y - touchX;
       break;
     case 2: // 180°: flip both
-      rotatedX = 465 - touchX;
-      rotatedY = 465 - touchY;
+      rotatedX = waveshare_board::touch::MAX_X - touchX;
+      rotatedY = waveshare_board::touch::MAX_Y - touchY;
       break;
     case 3: // 270° CCW: swap X/Y and flip new Y
-      rotatedX = 465 - touchY;
+      rotatedX = waveshare_board::touch::MAX_X - touchY;
       rotatedY = touchX;
       break;
     }

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
@@ -9,7 +9,6 @@
 // Use Arduino_GFX for CO5300 AMOLED (like working esp32 project)
 #include <Arduino_GFX_Library.h>
 #include <lvgl.h>
-#include "waveshare_board.hpp"
 
 // Display dimensions
 #define SCREEN_WIDTH  466
@@ -27,7 +26,6 @@ extern volatile uint32_t lastDisplayFlushDurationUs;
 extern volatile uint32_t maxDisplayFlushDurationUs;
 
 // Touch handling (CST9217)
-constexpr uint8_t CST9217_ADDRESS = waveshare_board::CST9217_ADDR;
 extern bool touchPressed;
 extern uint16_t touchX, touchY;
 
@@ -97,13 +95,13 @@ class LGFX : public lgfx::LGFX_Device {
        cfg.y_min      = 0;
        cfg.y_max      = 465;  // 466px height
        cfg.pin_int    = 21;
-       cfg.pin_rst    = 20;
+       cfg.pin_rst    = -1; // Reset is TCA9554 P0; never drive GPIO20.
        cfg.bus_shared = true;
        cfg.i2c_port   = 0; // I2C Port 0
        cfg.i2c_addr   = 0x5A;  // CST9217 address (not CST816S)
        cfg.pin_sda    = 15;
-       cfg.pin_scl    = 16;
-       cfg.freq       = 400000;
+       cfg.pin_scl    = 14;
+       cfg.freq       = 100000;
 
        _touch_instance.config(cfg);
        _panel_instance.setTouch(&_touch_instance);

--- a/esp32/lib/waveshare_board/touch.hpp
+++ b/esp32/lib/waveshare_board/touch.hpp
@@ -1,0 +1,45 @@
+/**
+ * @file touch.hpp
+ * @brief CST9217/TCA9554 touch constants for the Waveshare board.
+ */
+
+#pragma once
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include "waveshare_board.hpp"
+#include <Arduino.h>
+#include <hal.hpp>
+
+namespace waveshare_board::touch {
+
+constexpr uint8_t TCA9554_OUTPUT_REG = 0x01;
+constexpr uint8_t TCA9554_CONFIG_REG = 0x03;
+constexpr uint8_t TCA9554_TOUCH_RST_BIT = 0;
+
+constexpr uint8_t CST9217_ADDR = waveshare_board::CST9217_ADDR;
+constexpr uint8_t CST9217_INT_PIN = TCH_I2C_INT;
+constexpr uint16_t CST9217_DATA_REG = 0xD000;
+constexpr uint8_t CST9217_ACK = 0xAB;
+constexpr uint8_t CST9217_DATA_LENGTH = 10;
+
+constexpr uint16_t ACTIVE_WIDTH = 466;
+constexpr uint16_t ACTIVE_HEIGHT = 466;
+constexpr uint16_t MAX_X = ACTIVE_WIDTH - 1;
+constexpr uint16_t MAX_Y = ACTIVE_HEIGHT - 1;
+
+constexpr uint32_t HINT_ACTIVE_READ_INTERVAL_MS = 20;
+constexpr uint32_t ACTIVE_READ_INTERVAL_MS = 25;
+constexpr uint32_t RECENT_HINT_READ_INTERVAL_MS = 25;
+constexpr uint32_t FAST_FALLBACK_READ_INTERVAL_MS = 40;
+constexpr uint32_t IDLE_FALLBACK_READ_INTERVAL_MS = 400;
+constexpr uint32_t HINT_FAST_POLL_WINDOW_MS = 700;
+constexpr uint32_t TOUCH_FAST_POLL_WINDOW_MS = 700;
+constexpr uint32_t ACTIVE_FAILURE_GRACE_MS = 600;
+constexpr uint32_t IDLE_FAILURE_BASE_RETRY_MS = 100;
+constexpr uint32_t IDLE_FAILURE_MAX_RETRY_MS = 700;
+constexpr uint32_t REINIT_BACKOFF_MS = 1200;
+
+} // namespace waveshare_board::touch
+
+#endif // WAVESHARE_AMOLED_175


### PR DESCRIPTION
## Summary
- move CST9217/TCA9554 touch constants into a Waveshare touch header
- track GPIO21 as an active-low touch hint without doing I2C work in an ISR
- keep a slower fallback polling path for boards where GPIO21 stays idle while CST9217 data is available
- add bounded idle read-failure retry backoff and fix the dormant LovyanGFX touch config to avoid GPIO20 reset
- update the hardware-native implementation/status doc with PR12 device findings

## Device validation
- Built and flashed `WAVESHARE_AMOLED_175` to `/dev/cu.usbmodem2101`.
- Boot stayed healthy after flash: AXP2101 display power, Arduino_GFX display, SD card, LVGL, BLE advertising, and TCA9554 touch reset initialized.
- Tap, drag, and long-press on the connected board produced valid CST9217 touch packets and `Touch: press` / `Touch: release` events.
- GPIO21 remained `HIGH(idle)` during tap, drag, and long-press testing, confirming fallback reads are still required on this unit.
- 10-minute no-touch summary capture stayed alive to `SYS: up=599s`, with zero touch press/release events and zero GPIO21 `LOW(active)` observations.
- iPhone navigation smoke test passed: the iPhone connected over BLE, sent settings/GPS/route/nav data, the ESP32 moved to `screen=main` with `routePts=25`, drag worked on-device, BLE stayed connected/authenticated, and touch continued to work while the route overlay redrew. GPIO21 still stayed `HIGH(idle)` under navigation load.

## Checks
- `git diff --check`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101`