### PR TITLE
Fix Waveshare CO5300 display window

### DIFF
--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -499,6 +499,7 @@ Implementation status:
 
 - Implemented on branch `touch-hint-fallback-optimization` in PR 12, based on
   merged PR 11.
+- Merged into `main` on 2026-07-01 before starting PR 13.
 - Added `esp32/lib/waveshare_board/touch.hpp` for CST9217/TCA9554 registers,
   dimensions, GPIO21 hint pin, and touch polling/backoff timing constants.
 - Panel touch code now tracks GPIO21 active-low hint level and edges without
@@ -590,15 +591,126 @@ Acceptance criteria:
 Goal: resolve the 90-degree green-edge artifact and make the 466x466 active
 window explicit.
 
+Implementation status:
+
+- In progress on branch `co5300-window-rotation-fix`, based on merged PR 12.
+- Re-read `WAVESHARE_HARDWARE.md` and followed its official links. The Waveshare
+  wiki confirms this model is a 466x466 CO5300 AMOLED.
+- Researched the official Waveshare demo repository. Every Arduino display/LVGL
+  demo instantiates `Arduino_CO5300` as `466x466` with constructor offsets
+  `6,0,0,0`.
+- Researched the official Waveshare ESP-IDF BSP. It applies the same effective
+  gap with `esp_lcd_panel_set_gap(panel_handle, 0x06, 0)`.
+- Found an ESPHome report for this exact 466x466 CO5300 Waveshare model where a
+  missing 6-pixel gap produced a green-line/wrap artifact. That matches our
+  symptoms better than the earlier centered-window hypothesis.
+- Rejected the earlier `480x480` controller plus centered `466x466` active
+  window assumption. The board-local constants now model the vendor baseline:
+  logical/active `466x466`, constructor gap `6,0,0,0`, and named MADCTL
+  constants for the still-experimental hardware-rotation path.
+- Updated the normal CO5300 constructor to match Waveshare's Arduino demos:
+  `Arduino_CO5300(..., 466, 466, 6, 0, 0, 0)`.
+- Normal Waveshare firmware now clamps unsupported display rotations to `0`.
+  Rotation `1`/90-degree requests are also clamped to `0` unless the build sets
+  `WAVESHARE_ENABLE_EXPERIMENTAL_90_ROTATION`, because the last verified 90
+  degree path had a green-edge artifact.
+- BLE map-setting writes and startup NVS loads apply the same Waveshare rotation
+  clamp, so an iPhone setting or stale saved value cannot leave normal firmware
+  using the known-bad 90-degree display path.
+- Added `WAVESHARE_AMOLED_175_DISPLAY_TEST`, which now draws vendor-baseline
+  black/white/red/green/blue fills plus a `466x466` border and corner markers at
+  0 degrees before LVGL starts. The default diagnostic no longer enables the raw
+  90-degree path.
+- Preserved the full-screen LVGL PSRAM buffer/full render strategy.
+
+Device validation on 2026-07-01 and 2026-07-02:
+
+- Earlier pre-vendor diagnostic display-test build/upload to
+  `/dev/cu.usbmodem2101` passed. That diagnostic exercised guessed offsets and
+  raw 90-degree MADCTL rotation before we found the official 6-pixel gap.
+- User-provided photos `/Users/chris/Downloads/IMG_8885.jpg` and
+  `/Users/chris/Downloads/IMG_8886.jpg` show solid green and blue fill passes
+  without an obvious thin green-edge band or stale-pixel strip. The square
+  active area remains visibly clipped by the round lens/bezel, which is expected
+  for a `466x466` active window under the circular cover.
+- The same photos show the visible black margin is not symmetric: the green
+  fill has the margin mostly on the left, while the blue/rotated state shows
+  margins at the top and bottom. That suggests the current MADCTL-only rotation
+  changes the coordinate scan direction without applying the matching
+  per-rotation CASET/PASET active-window offsets.
+- User-provided photos `/Users/chris/Downloads/IMG_8892.jpg`,
+  `/Users/chris/Downloads/IMG_8893.jpg`, and
+  `/Users/chris/Downloads/IMG_8894.jpg` show that the guessed-offset diagnostic
+  remained slightly rotated/clipped in different positions. Combined with the
+  vendor research, this confirms the guessed `0/7/14` offset test was the wrong
+  direction.
+- The square active area also appeared slightly rotated clockwise relative to
+  the USB-C connector/case during the experimental diagnostic. Later regression
+  checks showed the same slight clockwise skew on older project firmware and on
+  Waveshare's official factory firmware, so this is treated as physical
+  panel/lens/case alignment rather than a PR 13 firmware regression.
+- After the vendor-baseline patch, `git diff --check` passed.
+- After the vendor-baseline patch, normal firmware build passed:
+  `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`.
+- After the vendor-baseline patch, display-test build passed:
+  `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175_DISPLAY_TEST`.
+- Normal vendor-baseline firmware upload to `/dev/cu.usbmodem2101` passed:
+  `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101`.
+- Serial reset capture confirmed the normal firmware logs
+  `CO5300: logical=466x466 active=466x466 constructorGap=(6,0,0,0) rotation=0
+  experimental90=0`.
+- First post-upload serial reset capture hit one BLE startup reboot:
+  `Stack canary watchpoint triggered (ipc0)` while ESP-IDF Bluetooth interrupt
+  allocation was running. The decoded backtrace pointed into ESP-IDF/BT
+  interrupt allocation (`btdm_intr_alloc`/`esp_intr_alloc`) and not display,
+  LVGL, or the new constructor path. The automatic reboot then reached BLE
+  advertising and heartbeat logs.
+- A second 25-second reset capture did not reproduce the BLE reboot. It reached
+  SD init, LVGL init, touch reset, BLE advertising, waiting screen, and repeated
+  heartbeat logs with the vendor display geometry.
+- Exact historical firmware checks:
+  - PR 12 merge commit `d52cb85` was flashed from a detached temp worktree and
+    still showed the slight clockwise skew.
+  - PR 11 merge commit `3fb1f6a` was flashed from a detached temp worktree and
+    still showed the slight clockwise skew. Device readback of the app partition
+    matched the PR 11 firmware SHA-256 exactly:
+    `393f093daaa3982231634c4d9cdd7ce6a91a4f3f3fe4680edb79019f64b55305`.
+  - PR 10 merge commit `b853488` was flashed from a detached temp worktree and
+    still showed the slight clockwise skew.
+- Waveshare's official factory image
+  `/tmp/waveshare-esp32-s3-touch-amoled-175/Firmware/ESP32-S3-Touch-AMOLED-1.75-FactoryOnly.bin`
+  was flashed at `0x0` and verified by esptool. The factory UI also showed the
+  same slight clockwise skew. This confirms the angular skew is not caused by
+  PR 13, PR 12, PR 11, or PR 10.
+- Reflashing PR 13 normal firmware after the factory image confirmed the vendor
+  display geometry in serial logs:
+  `CO5300: logical=466x466 active=466x466 constructorGap=(6,0,0,0) rotation=0
+  experimental90=0`. A physical unplug/replug restored stable PMU/touch-expander
+  detection after the factory-image test.
+- PR 13 `WAVESHARE_AMOLED_175_DISPLAY_TEST` was flashed again on 2026-07-02.
+  The user confirmed the red/green/blue color-rotation diagnostic no longer
+  showed clipping. That is the final display-window validation: the vendor
+  `466x466` geometry plus 6-pixel X gap removes the observed address-window
+  clipping/wrap issue. The remaining slight angular skew is hardware alignment.
+- Normal PR 13 firmware was restored after the display-test run on 2026-07-02.
+  Upload completed with esptool hash verification. A reset serial capture
+  reached AXP2101 power setup, CO5300 vendor-window init, SD mount, LVGL init,
+  BLE advertising, TCA9554 touch reset, and waiting-screen heartbeats. The
+  final capture showed the known recoverable Arduino I2C touch-read failure once
+  after startup (`i2c[fail=1 recover=1 recovered=1 missing=0]`), with no reboot
+  or display regression.
+- PR 13 should keep 90-degree hardware rotation disabled and leave software
+  rotation as a later, separate experiment if the product still needs a rotated
+  UI.
+
 Scope:
 
 - Isolate CO5300 panel setup behind a small board-local wrapper.
-- Preserve the current Arduino_CO5300 constructor defaults as the baseline,
-  because explicit constructor offsets made the 90-degree green-edge artifact
-  worse during PR #6/PR #7 bring-up.
-- Test whether the physical controller address space is 480x480 with a centered
-  466x466 active area.
-- Experiment with CASET/PASET offsets per rotation rather than raw MADCTL alone.
+- Use Waveshare's official Arduino/ESP-IDF display geometry as the baseline:
+  466x466 with a 6-pixel X gap.
+- Keep raw 90-degree MADCTL rotation behind an explicit experimental build flag.
+- Defer software rotation as a follow-up if the product still needs portrait or
+  landscape switching after the baseline is stable.
 - Add a hardware test mode or simple helper that draws:
   - full black
   - full white
@@ -617,10 +729,10 @@ Out of scope:
 Validation:
 
 - 0-degree fill tests.
-- 90-degree fill tests.
+- 90-degree fill tests only in an explicit experimental build.
 - LVGL full-screen invalidation.
-- Map render in both supported orientations.
-- Touch coordinate alignment in both supported orientations.
+- Map render in the normal supported orientation.
+- Touch coordinate alignment in the normal supported orientation.
 - No green strip or stale pixels after repeated redraws.
 
 Acceptance criteria:

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -9,6 +9,9 @@
 #include "../gps/gps.hpp"
 #include "../gui/src/waitingScr.hpp"
 #include "../route_overlay/route_overlay.hpp"
+#ifdef WAVESHARE_AMOLED_175
+#include "../waveshare_board/display.hpp"
+#endif
 #include <NimBLEDevice.h>
 #include <Preferences.h>
 #include <algorithm>
@@ -46,6 +49,28 @@ static bool unauthTimeoutDisconnectRequested = false;
 // Route geometry debouncing - skip redundant parses
 static uint32_t lastRouteHash = 0;
 static size_t lastRouteLen = 0;
+
+static uint8_t sanitizeMapDisplayRotation(uint8_t requestedRotation,
+                                          const char *source) {
+#ifdef WAVESHARE_AMOLED_175
+  if (requestedRotation > waveshare_board::display::MAX_SUPPORTED_ROTATION) {
+    Serial.printf("BLE Settings: %s displayRotation %u unsupported, clamping "
+                  "to 0\n",
+                  source, requestedRotation);
+    return waveshare_board::display::ROTATION_0;
+  }
+  if (requestedRotation == waveshare_board::display::ROTATION_90 &&
+      !waveshare_board::display::EXPERIMENTAL_90_ROTATION_ENABLED) {
+    Serial.printf("BLE Settings: %s displayRotation 1 disabled on Waveshare "
+                  "until CO5300 window is verified; using 0\n",
+                  source);
+    return waveshare_board::display::ROTATION_0;
+  }
+#else
+  (void)source;
+#endif
+  return requestedRotation;
+}
 
 /**
  * @brief Parse navigation instruction data
@@ -365,6 +390,8 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
   case 4:
     mapRenderSettings.displayRotation =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)3);
+    mapRenderSettings.displayRotation =
+        sanitizeMapDisplayRotation(mapRenderSettings.displayRotation, "write");
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("rotation", mapRenderSettings.displayRotation);
     settingsPrefs.end();
@@ -590,7 +617,8 @@ static void loadSettingsFromNVS() {
   mapRenderSettings.minPolygonSize = prefs.getUChar("minPolySize", 0);
   mapRenderSettings.detailLevel = prefs.getUChar("detailLevel", 2);
   mapRenderSettings.routeLineWidth = prefs.getUChar("routeWidth", 4);
-  mapRenderSettings.displayRotation = prefs.getUChar("rotation", 0);
+  mapRenderSettings.displayRotation =
+      sanitizeMapDisplayRotation(prefs.getUChar("rotation", 0), "NVS");
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
   mapRenderSettings.zoomLevel = prefs.getUChar("zoomLevel", 4);
   mapRenderSettings.visibilityMask = prefs.getUInt("visMask", 0xFFFFFFFF);

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -13,6 +13,7 @@
 
 // Include HAL for pin definitions
 #include "../../include/hal.hpp"
+#include "display.hpp"
 #include "i2c_bus.hpp"
 #include "touch.hpp"
 #include "waveshare_board.hpp"
@@ -34,12 +35,23 @@ Arduino_ESP32QSPI *bus = new Arduino_ESP32QSPI(12, // CS
                                                7   // D3
 );
 
-// CO5300 Display Driver - Use minimal constructor (works for 0° mode)
-// Note: Explicit offsets caused green edges, so use defaults
+// CO5300 Display Driver. Match Waveshare's Arduino demos and ESP-IDF BSP:
+// the exposed panel is 466x466 with a 6 px column gap.
 Arduino_CO5300 *gfx = new Arduino_CO5300(bus,
                                          39, // RST
-                                         0   // Rotation
-);
+                                         0,  // Rotation
+                                         waveshare_board::display::
+                                             LOGICAL_WIDTH,
+                                         waveshare_board::display::
+                                             LOGICAL_HEIGHT,
+                                         waveshare_board::display::
+                                             ARDUINO_CO5300_COL_OFFSET1,
+                                         waveshare_board::display::
+                                             ARDUINO_CO5300_ROW_OFFSET1,
+                                         waveshare_board::display::
+                                             ARDUINO_CO5300_COL_OFFSET2,
+                                         waveshare_board::display::
+                                             ARDUINO_CO5300_ROW_OFFSET2);
 
 // ============================================================================
 // LVGL 9 DISPLAY BUFFER
@@ -53,6 +65,100 @@ volatile uint32_t displayFlushCount = 0;
 volatile uint32_t lastDisplayFlushMs = 0;
 volatile uint32_t lastDisplayFlushDurationUs = 0;
 volatile uint32_t maxDisplayFlushDurationUs = 0;
+
+static uint8_t sanitizeDisplayRotation(uint8_t requestedRotation) {
+  using namespace waveshare_board::display;
+
+  if (requestedRotation > MAX_SUPPORTED_ROTATION) {
+    Serial.printf("CO5300: unsupported display rotation %u, using 0\n",
+                  requestedRotation);
+    return ROTATION_0;
+  }
+
+  if (requestedRotation == ROTATION_90 && !EXPERIMENTAL_90_ROTATION_ENABLED) {
+    Serial.println("CO5300: 90-degree display rotation disabled until the "
+                   "active window is verified; using 0");
+    return ROTATION_0;
+  }
+
+  return requestedRotation;
+}
+
+static void writeCo5300Madctl(uint8_t madctl) {
+  gfx->startWrite();
+  bus->writeC8D8(waveshare_board::display::CO5300_MADCTL, madctl);
+  gfx->endWrite();
+}
+
+static void applyCo5300Rotation(uint8_t rotation) {
+  using namespace waveshare_board::display;
+
+  Serial.printf("CO5300: logical=%ux%u active=%ux%u constructorGap=(%u,%u,%u,%u) "
+                "rotation=%u experimental90=%d\n",
+                LOGICAL_WIDTH, LOGICAL_HEIGHT, ACTIVE_WIDTH, ACTIVE_HEIGHT,
+                ARDUINO_CO5300_COL_OFFSET1, ARDUINO_CO5300_ROW_OFFSET1,
+                ARDUINO_CO5300_COL_OFFSET2, ARDUINO_CO5300_ROW_OFFSET2,
+                rotation, EXPERIMENTAL_90_ROTATION_ENABLED ? 1 : 0);
+
+  switch (rotation) {
+  case ROTATION_90:
+    Serial.printf("CO5300: applying experimental MADCTL 0x%02X for 90-degree "
+                  "rotation\n",
+                  CO5300_MADCTL_ROTATION_90);
+    writeCo5300Madctl(CO5300_MADCTL_ROTATION_90);
+    break;
+  case ROTATION_0:
+  default:
+    gfx->setRotation(0);
+    break;
+  }
+}
+
+#ifdef WAVESHARE_DISPLAY_TEST
+static void drawVendorWindowMarker(uint8_t rotation, uint16_t fillColor,
+                                   uint16_t borderColor) {
+  using namespace waveshare_board::display;
+
+  gfx->fillScreen(0x0000);
+  gfx->fillRect(0, 0, ACTIVE_WIDTH, ACTIVE_HEIGHT, fillColor);
+  gfx->drawRect(0, 0, ACTIVE_WIDTH, ACTIVE_HEIGHT, borderColor);
+  gfx->drawRect(1, 1, ACTIVE_WIDTH - 2, ACTIVE_HEIGHT - 2, borderColor);
+  gfx->drawFastHLine(0, ACTIVE_HEIGHT / 2, ACTIVE_WIDTH, 0x8410);
+  gfx->drawFastVLine(ACTIVE_WIDTH / 2, 0, ACTIVE_HEIGHT, 0x8410);
+  gfx->fillRect(0, 0, 24, 24, 0xF800);
+  gfx->fillRect(ACTIVE_WIDTH - 24, 0, 24, 24, 0x07E0);
+  gfx->fillRect(0, ACTIVE_HEIGHT - 24, 24, 24, 0x001F);
+  gfx->fillRect(ACTIVE_WIDTH - 24, ACTIVE_HEIGHT - 24, 24, 24, 0xFFE0);
+  Serial.printf("CO5300 display test: rotation=%u vendorGap=(%u,%u,%u,%u) "
+                "active=%ux%u fill=0x%04X\n",
+                rotation, ARDUINO_CO5300_COL_OFFSET1,
+                ARDUINO_CO5300_ROW_OFFSET1, ARDUINO_CO5300_COL_OFFSET2,
+                ARDUINO_CO5300_ROW_OFFSET2, ACTIVE_WIDTH, ACTIVE_HEIGHT,
+                fillColor);
+}
+
+static void drawDisplayTestPatternForRotation(uint8_t rotation) {
+  using namespace waveshare_board::display;
+
+  applyCo5300Rotation(rotation);
+  const uint16_t fills[] = {0x0000, 0xFFFF, 0xF800, 0x07E0, 0x001F};
+  for (uint16_t fill : fills) {
+    drawVendorWindowMarker(rotation, fill, 0xFFFF);
+    delay(2500);
+  }
+}
+
+static void drawDisplayTestPatterns(uint8_t appliedRotation) {
+  using namespace waveshare_board::display;
+
+  drawDisplayTestPatternForRotation(ROTATION_0);
+  if (EXPERIMENTAL_90_ROTATION_ENABLED) {
+    drawDisplayTestPatternForRotation(ROTATION_90);
+  }
+  applyCo5300Rotation(appliedRotation);
+  gfx->fillScreen(0x0000);
+}
+#endif
 
 // ============================================================================
 // LVGL 9 DISPLAY FLUSH CALLBACK
@@ -472,10 +578,12 @@ void setupDisplay() {
   // Load rotation from NVS (default to 0 if not set)
   Preferences prefs;
   prefs.begin("mapSettings", true); // read-only
-  uint8_t rotation = prefs.getUChar("rotation", 0);
+  uint8_t requestedRotation = prefs.getUChar("rotation", 0);
   prefs.end();
+  uint8_t rotation = sanitizeDisplayRotation(requestedRotation);
   displayRotation = rotation; // Store globally for touch coordinate rotation
-  Serial.printf("Loaded rotation from NVS: %d\n", rotation);
+  Serial.printf("Loaded rotation from NVS: requested=%u applied=%u\n",
+                requestedRotation, rotation);
 
   // ============================================================================
   // DISPLAY ROTATION VIA RAW MADCTL COMMAND
@@ -484,8 +592,10 @@ void setupDisplay() {
   // - Standard panels use: 0x80=MY, 0x40=MX, 0x20=MV (row/col exchange)
   // - CO5300 uses different bits: 0x02=X_FLIP, 0x05=Y_FLIP, 0x20=MV
   //
-  // IMPORTANT: CO5300 hardware only supports 0° and 90° rotation!
-  // 180° and 270° attempts all resulted in mirroring or wrong direction.
+  // IMPORTANT: current board bring-up only verified 0° for normal firmware.
+  // A 90° MADCTL path exists behind WAVESHARE_ENABLE_EXPERIMENTAL_90_ROTATION
+  // for hardware testing. 180° and 270° attempts all resulted in mirroring or
+  // wrong direction.
   //
   // === 180° ROTATION ATTEMPTS (all failed): ===
   // - 0x07 (X_FLIP + Y_FLIP): shows 0° mirrored
@@ -502,45 +612,40 @@ void setupDisplay() {
   // ============================================================================
   // KNOWN ISSUE: 90° ROTATION HAS GREEN EDGE AT BOTTOM
   // ============================================================================
-  // When 90° rotation is enabled, a thin green strip appears at the bottom
-  // of the display. The map and touch work correctly, but this visual artifact
-  // persists during all map operations.
+  // When 90° rotation is enabled experimentally, a thin green strip appears at
+  // the bottom of the display. The map and touch work correctly, but this visual
+  // artifact persists during all map operations.
   //
   // === WHAT WE TRIED TO FIX THE GREEN EDGE (all failed): ===
   // 1. fillScreen(BLACK) after MADCTL - still shows green
   // 2. fillScreen(BLACK) after rotation in LVGL setup - still shows green
   // 3. Explicit constructor with 466x466 dimensions and 7px offsets
-  //    (center in 480x480 panel) - made it worse, added green to 0° mode too
+  //    (a rejected centered-window guess) - made the artifact move around
   // 4. Various MADCTL bit combinations - didn't help
+  // 5. Full-screen diagnostic fills with guessed 0/7/14 offsets - remained
+  //    clipped/skewed in user photos
   //
-  // === POSSIBLE ROOT CAUSES (for future investigation): ===
-  // - CO5300 panel is 480x480, we use 466x466 window
+  // === CURRENT BASELINE AND FUTURE INVESTIGATION: ===
+  // - Waveshare's Arduino examples use 466x466 with constructor gap 6,0,0,0.
+  // - Waveshare's ESP-IDF BSP applies esp_lcd_panel_set_gap(..., 0x06, 0).
   // - When MV (row/col swap) is set, the address window offsets may not
   //   adjust correctly in the Arduino_CO5300 driver
-  // - The driver's writeAddrWindow() adds _xStart/_yStart offsets which
-  //   may not be correct for rotated mode
-  // - LVGL or map buffer may not be fully covering the rotated display area
+  // - LVGL software rotation may be a better follow-up than raw MADCTL.
   //
   // === POTENTIAL FIXES TO TRY IN FUTURE: ===
-  // - Modify Arduino_CO5300 driver to handle rotation offsets properly
-  // - Send custom CASET/PASET commands after MADCTL to adjust window
   // - Use LVGL's software rotation (lv_display_set_rotation) with proper
   //   render mode configuration
-  // - Investigate if the green is from uninitialized PSRAM buffer
+  // - Modify Arduino_CO5300 driver only if software rotation is too slow.
   //
-  // For now, the iOS app still offers 90° rotation option with this known
-  // visual artifact (green strip at bottom). Touch and map work correctly.
+  // For now, normal Waveshare firmware clamps 90° requests back to 0° so the
+  // shipped build does not expose the known artifact. Use
+  // WAVESHARE_AMOLED_175_DISPLAY_TEST to inspect 0° and the experimental 90°
+  // path on hardware before enabling it in normal firmware.
   // ============================================================================
   //
-  if (rotation == 1) {
-    // 90° CCW - MV + X_FLIP (rotation works, touch works, but green edge issue)
-    uint8_t madctl = 0x20 | 0x02; // MV + X_FLIP = 0x22
-    Serial.printf("Sending raw MADCTL: 0x%02X for 90° rotation\n", madctl);
-    gfx->startWrite();
-    bus->writeC8D8(0x36, madctl);
-    gfx->endWrite();
-    // Clear display RAM with new rotation coordinate system
-    gfx->fillScreen(0x0000); // BLACK - important to clear after rotation!
+  applyCo5300Rotation(rotation);
+  if (rotation == waveshare_board::display::ROTATION_90) {
+    gfx->fillScreen(0x0000); // Clear with the experimental rotation applied.
   }
   // Note: rotation values 2 (180°) and 3 (270°) are not supported by CO5300
   // The iOS app only offers 0° and 90° options
@@ -551,6 +656,10 @@ void setupDisplay() {
   delay(50);
   gfx->setBrightness(255); // Maximum brightness 0-255
   delay(50);
+
+#ifdef WAVESHARE_DISPLAY_TEST
+  drawDisplayTestPatterns(rotation);
+#endif
 
   // Clear screen for LVGL
   gfx->fillScreen(0x0000); // BLACK

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.hpp
@@ -7,12 +7,13 @@
 
 #ifdef USE_ARDUINO_GFX
 // Use Arduino_GFX for CO5300 AMOLED (like working esp32 project)
+#include "display.hpp"
 #include <Arduino_GFX_Library.h>
 #include <lvgl.h>
 
 // Display dimensions
-#define SCREEN_WIDTH  466
-#define SCREEN_HEIGHT 466
+#define SCREEN_WIDTH waveshare_board::display::ACTIVE_WIDTH
+#define SCREEN_HEIGHT waveshare_board::display::ACTIVE_HEIGHT
 
 // Arduino_GFX instances
 extern Arduino_ESP32QSPI *bus;

--- a/esp32/lib/waveshare_board/display.hpp
+++ b/esp32/lib/waveshare_board/display.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file display.hpp
+ * @brief CO5300 display constants for the Waveshare AMOLED board.
+ */
+
+#pragma once
+
+#include <Arduino.h>
+
+namespace waveshare_board::display {
+
+constexpr uint16_t LOGICAL_WIDTH = 466;
+constexpr uint16_t LOGICAL_HEIGHT = 466;
+constexpr uint16_t ACTIVE_WIDTH = 466;
+constexpr uint16_t ACTIVE_HEIGHT = 466;
+
+// Vendor Waveshare Arduino examples use:
+// Arduino_CO5300(..., 466, 466, 6, 0, 0, 0)
+// The ESP-IDF BSP applies the same effective panel gap with
+// esp_lcd_panel_set_gap(panel_handle, 6, 0).
+constexpr uint8_t ARDUINO_CO5300_COL_OFFSET1 = 6;
+constexpr uint8_t ARDUINO_CO5300_ROW_OFFSET1 = 0;
+constexpr uint8_t ARDUINO_CO5300_COL_OFFSET2 = 0;
+constexpr uint8_t ARDUINO_CO5300_ROW_OFFSET2 = 0;
+
+constexpr uint8_t ROTATION_0 = 0;
+constexpr uint8_t ROTATION_90 = 1;
+constexpr uint8_t MAX_SUPPORTED_ROTATION = ROTATION_90;
+
+constexpr uint8_t CO5300_CASET = 0x2A;
+constexpr uint8_t CO5300_PASET = 0x2B;
+constexpr uint8_t CO5300_MADCTL = 0x36;
+constexpr uint8_t CO5300_MADCTL_MV = 0x20;
+constexpr uint8_t CO5300_MADCTL_X_FLIP = 0x02;
+constexpr uint8_t CO5300_MADCTL_RGB = 0x00;
+constexpr uint8_t CO5300_MADCTL_ROTATION_0 = CO5300_MADCTL_RGB;
+constexpr uint8_t CO5300_MADCTL_ROTATION_90 =
+    CO5300_MADCTL_RGB | CO5300_MADCTL_MV | CO5300_MADCTL_X_FLIP;
+
+#ifdef WAVESHARE_ENABLE_EXPERIMENTAL_90_ROTATION
+constexpr bool EXPERIMENTAL_90_ROTATION_ENABLED = true;
+#else
+constexpr bool EXPERIMENTAL_90_ROTATION_ENABLED = false;
+#endif
+
+} // namespace waveshare_board::display

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -228,6 +228,12 @@ build_flags =
   ; but we define a default here just in case.
   -DTFT_BL=-1
 
+[env:WAVESHARE_AMOLED_175_DISPLAY_TEST]
+extends = env:WAVESHARE_AMOLED_175
+build_flags =
+  ${env:WAVESHARE_AMOLED_175.build_flags}
+  -DWAVESHARE_DISPLAY_TEST=1
+
 ; ==========================================
 ; Simple display test environment
 ; ==========================================


### PR DESCRIPTION
## Summary

- Match the Waveshare CO5300 vendor display geometry: 466x466 active/logical size with the 6 px X gap used by Waveshare's Arduino examples and ESP-IDF BSP.
- Clamp unsupported Waveshare display rotations back to 0 in normal firmware, including BLE/NVS map settings, so the known 90-degree green-edge path is not selected accidentally.
- Add a Waveshare display constants header and a `WAVESHARE_AMOLED_175_DISPLAY_TEST` target for fill/border/corner diagnostics.
- Update the hardware-native implementation plan with the PR13 research, device validation, official factory firmware comparison, and final status.

## Hardware Findings

- The slight clockwise screen skew is present on PR10, PR11, PR12, PR13, and Waveshare's official factory firmware, so it is treated as physical panel/lens/case alignment rather than a firmware regression.
- The PR13 display-test color rotation no longer shows clipping or opposite-edge wrap, which validates the vendor 466x466 + 6 px gap baseline.
- Normal PR13 firmware was restored after diagnostics and booted through PMU, display, SD, LVGL, BLE advertising, TCA9554 touch reset, and waiting-screen heartbeats.

## Validation

- `git diff --check`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-313 /tmp/esp32-bike-pio-313/bin/pio run -e WAVESHARE_AMOLED_175_DISPLAY_TEST`
- Uploaded normal PR13 firmware to `/dev/cu.usbmodem2101` with esptool hash verification.
- Captured reset boot log confirming `CO5300: logical=466x466 active=466x466 constructorGap=(6,0,0,0) rotation=0 experimental90=0`.
- Flashed `WAVESHARE_AMOLED_175_DISPLAY_TEST`; user confirmed the color rotation has no clipping.
- Flashed Waveshare official factory image and confirmed it shows the same slight clockwise skew as project firmware.
