### PR TITLE
Add QMI8658 IMU diagnostics

### DIFF
--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -155,7 +155,7 @@ When scanning the I2C bus, you should find:
 | Touch | ✅ Working | CST9217 @ 0x5A, TCA9554 reset, coordinate mirroring |
 | SD Card | ✅ Working | **Pins verified: CS=41, MOSI=1, MISO=3, SCK=2** (32GB SDHC tested) |
 | RTC | ✅ Integrated | PCF85063 @ 0x51; PR14 driver added, BLE sync + warm-reset restore verified; full USB power removal loses RTC on current board (`battery=absent`) |
-| IMU | ✅ Detected | QMI8658 @ 0x6A and 0x6B (not integrated yet) |
+| IMU | ✅ Diagnostic | QMI8658 @ 0x6B primary / 0x6A fallback; PR15 detects/configures it and samples accel/gyro for diagnostics only |
 | I/O Expander | ✅ Working | TCA9554 @ 0x20 (controls touch reset) |
 | Audio | ⏳ Untested | ES8311 not detected in scan |
 | GPS | ⏳ Untested | UART on 43/44 |

--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -31,7 +31,9 @@ Known remaining gaps:
   retention are verified. Full USB power removal does not retain RTC time on
   the current board because AXP2101 reports `battery=absent` and the PCF85063
   voltage-low flag is set after replug.
-- QMI8658 IMU is detected but unused.
+- QMI8658 IMU integration is in progress in PR 15. The first pass detects,
+  configures, and samples the sensor at low rate for diagnostics only;
+  navigation behavior does not depend on it.
 - CO5300 90-degree rotation still has a green-edge/window artifact.
 - CST9217 touch correctly treats GPIO21 as an active-low hint plus throttled
   polling fallback; the next work should measure and centralize that policy, not
@@ -851,6 +853,62 @@ Acceptance criteria:
 Goal: bring up the onboard IMU safely, then decide which product behaviors are
 worth enabling.
 
+Implementation status:
+
+- In progress on branch `qmi8658-imu-integration`.
+- Added a Waveshare-local QMI8658 helper that:
+  - probes primary address `0x6B`, then fallback `0x6A`
+  - validates `WHO_AM_I == 0x05`
+  - records revision/address/configuration status
+  - configures accelerometer to `8g @ 125 Hz`
+  - configures gyroscope to `512 dps @ 112 Hz`
+  - enables accel + gyro via `CTRL7`
+  - reads accel and gyro registers through the shared I2C helper
+- Added a 2 Hz background sample path from the main loop. This is diagnostic
+  only and does not change map, heading, ride, sleep, or navigation behavior.
+- Added derived diagnostic fields:
+  - acceleration magnitude
+  - rough gyro vibration magnitude
+  - rough moving/no-moving flag
+  - preliminary dominant-axis orientation label
+- Added a compact `IMU:` heartbeat before the rate-limited `SYS` heartbeat:
+  `present`, `configured`, latest-sample validity, address, sample count,
+  failed reads, latest accel/gyro values, acceleration magnitude, vibration
+  magnitude, orientation label, and moving flag.
+- Added optional `WAVESHARE_IMU_DEBUG_LOG` build flag for direct QMI8658 sample
+  logs and successful raw register diagnostics. Normal builds keep the sensor
+  visible through the compact `IMU:` heartbeat and keep raw diagnostics for
+  failure cases.
+- Axis orientation was checked on the connected board. The coarse orientation
+  labels match the physical device positions, and product behavior can use this
+  mapping later if we add an IMU-dependent feature.
+- Connected-device notes from PR 15 bring-up:
+  - QMI8658 identifies at `0x6B` with `WHO_AM_I=0x05` and `REVISION=0x7C`
+    after a soft reset.
+  - The Waveshare Arduino SensorLib also expects `WHO_AM_I=0x05`; the earlier
+    observed `0x26` was resolved by matching SensorLib's reset-before-ID order.
+  - A 17-byte timestamp/temp/accel/gyro burst read at 10 Hz caused frequent I2C
+    recovery, so PR 15 narrowed sampling to separate 6-byte accel and gyro reads
+    at 2 Hz.
+  - STOP-style block reads matched SensorLib source shape but caused repeated
+    `i2cRead()` invalid-state failures in this firmware; the shared repeated
+    start helper was safer on the connected board.
+  - The final read path uses repeated-start register reads locally for the
+    QMI8658. STOP-style reads and read/modify/write config preserved stale or
+    garbage bytes after `CTRL1.ADDR_AI` was enabled.
+  - Final connected-device capture showed `CTRL1=0x40`, `CTRL2=0x26`,
+    `CTRL3=0x56`, `CTRL7=0x03`, `STATUS0=0x03`, no zero samples, no IMU read
+    failures, and a static gravity vector around `956 mg`.
+  - Orientation capture showed stable axis signs:
+    - face-down: roughly `+X small`, `+Y small`, `-Z`
+    - right-edge-up: roughly `+X`, `+Y small`, `-Z partial`
+    - left-edge-up: roughly `-X`, `+Y small`, `-Z partial`
+    - USB-up: roughly `+Y`
+    - USB-down: roughly `-Y`
+    - face-up: roughly `+Z`
+  - During the 90-second orientation capture the IMU stayed at `valid=1`,
+    `zero=0`, and `fail=0`.
+
 Scope:
 
 - Add QMI8658 probe for primary address `0x6B`, with `0x6A` as fallback.
@@ -881,15 +939,21 @@ Follow-up candidates:
 
 Validation:
 
-- Static board reports stable gravity vector.
-- Rotating board changes expected axes.
-- Sensor read loop does not degrade touch.
-- Long run does not increase I2C failures.
+- Build the Waveshare firmware.
+- Flash to the connected board and confirm `QMI8658: found`.
+- Static board reports a stable gravity vector near `1000 mg` in the final
+  connected-device capture.
+- Rotating board changes expected axes and the coarse orientation labels match
+  physical device positions.
+- Touch still works while the low-rate sensor read loop is active.
+- Long run should not increase I2C failures materially versus the PR14 baseline;
+  17-byte burst reads failed this, while the reduced 2 Hz path is much safer.
 
 Acceptance criteria:
 
-- IMU is detected and sampled reliably.
-- Axis orientation is documented.
+- IMU is detected and configured reliably.
+- IMU sampling is stable enough for diagnostics.
+- Axis orientation is documented after connected-device testing.
 - No user-facing navigation behavior depends on IMU until the signal is proven.
 
 ## PR 16: SD And Map I/O Tuning

--- a/esp32/lib/waveshare_board/qmi8658.cpp
+++ b/esp32/lib/waveshare_board/qmi8658.cpp
@@ -1,0 +1,401 @@
+/**
+ * @file qmi8658.cpp
+ * @brief QMI8658 IMU helper for the Waveshare AMOLED board.
+ */
+
+#include "qmi8658.hpp"
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include "i2c_bus.hpp"
+#include "waveshare_board.hpp"
+#include <math.h>
+
+namespace waveshare_board::imu {
+
+namespace {
+
+constexpr uint8_t REG_WHO_AM_I = 0x00;
+constexpr uint8_t REG_REVISION = 0x01;
+constexpr uint8_t REG_CTRL1 = 0x02;
+constexpr uint8_t REG_CTRL2 = 0x03;
+constexpr uint8_t REG_CTRL3 = 0x04;
+constexpr uint8_t REG_CTRL5 = 0x06;
+constexpr uint8_t REG_CTRL7 = 0x08;
+constexpr uint8_t REG_STATUS_INT = 0x2D;
+constexpr uint8_t REG_STATUS0 = 0x2E;
+constexpr uint8_t REG_STATUS1 = 0x2F;
+constexpr uint8_t REG_TIMESTAMP_L = 0x30;
+constexpr uint8_t REG_AX_L = 0x35;
+constexpr uint8_t REG_GX_L = 0x3B;
+constexpr uint8_t REG_RST_RESULT = 0x4D;
+constexpr uint8_t REG_RESET = 0x60;
+
+constexpr uint8_t EXPECTED_WHO_AM_I = 0x05;
+constexpr uint8_t RESET_VALUE = 0xB0;
+constexpr uint8_t RST_RESULT_OK = 0x80;
+constexpr uint8_t CTRL1_LITTLE_ENDIAN_AUTO_INC = 0x40;
+constexpr uint8_t CTRL2_ACCEL_8G_125HZ = 0x26;
+constexpr uint8_t CTRL3_GYRO_512DPS_112HZ = 0x56;
+constexpr uint8_t CTRL7_ENABLE_ACCEL_GYRO = 0x03;
+constexpr uint8_t CTRL7_DISABLE_SENSORS = 0x00;
+
+constexpr float ACCEL_LSB_PER_G = 4096.0f;
+constexpr float GYRO_LSB_PER_DPS = 64.0f;
+constexpr uint32_t SAMPLE_INTERVAL_MS = 500;
+constexpr float MOVING_GYRO_THRESHOLD_DPS = 20.0f;
+constexpr float MOVING_ACCEL_DELTA_MG = 180.0f;
+constexpr float ORIENTATION_THRESHOLD_MG = 650.0f;
+
+Status imuStatus;
+Sample latestSample;
+uint32_t lastPollMs = 0;
+uint32_t lastDiagLogMs = 0;
+
+int16_t readInt16Le(const uint8_t *data) {
+  return static_cast<int16_t>((static_cast<uint16_t>(data[1]) << 8) | data[0]);
+}
+
+bool write8(uint8_t reg, uint8_t value, const char *label) {
+  return i2c::writeRegister8(imuStatus.address, reg, value, label, 3);
+}
+
+bool read8(uint8_t reg, uint8_t &value, const char *label) {
+  return i2c::readRegisterBlock8(imuStatus.address, reg, &value, 1, label, 3);
+}
+
+bool readSequentialBytes(uint8_t firstReg, uint8_t *data, uint8_t len,
+                         const char *label) {
+  if (data == nullptr || len == 0) {
+    return false;
+  }
+  for (uint8_t i = 0; i < len; i++) {
+    if (!read8(firstReg + i, data[i], label)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+void logRawDiagnostic(const char *reason) {
+  if (!imuStatus.present || imuStatus.address == 0) {
+    return;
+  }
+
+  uint8_t regs[12] = {};
+  const bool regsOk = readSequentialBytes(REG_WHO_AM_I, regs, sizeof(regs),
+                                          "QMI8658 diag regs");
+  uint8_t status[3] = {};
+  const bool statusOk = readSequentialBytes(REG_STATUS_INT, status,
+                                            sizeof(status),
+                                            "QMI8658 diag status");
+  uint8_t data[12] = {};
+  const bool dataOk = readSequentialBytes(REG_AX_L, data, sizeof(data),
+                                          "QMI8658 diag data");
+  uint8_t timestamp[3] = {};
+  const bool timestampOk = readSequentialBytes(REG_TIMESTAMP_L, timestamp,
+                                               sizeof(timestamp),
+                                               "QMI8658 diag ts");
+
+  Serial.printf("QMI8658 diag: reason=%s regsOk=%d who=0x%02X rev=0x%02X "
+                "ctrl1=0x%02X ctrl2=0x%02X ctrl3=0x%02X ctrl5=0x%02X "
+                "ctrl7=0x%02X statusOk=%d int=0x%02X st0=0x%02X st1=0x%02X "
+                "tsOk=%d ts=%02X%02X%02X dataOk=%d "
+                "acc=%02X %02X %02X %02X %02X %02X "
+                "gyro=%02X %02X %02X %02X %02X %02X samples=%lu zero=%lu "
+                "fail=%lu\n",
+                reason ? reason : "-", regsOk, regs[REG_WHO_AM_I],
+                regs[REG_REVISION], regs[REG_CTRL1], regs[REG_CTRL2],
+                regs[REG_CTRL3], regs[REG_CTRL5], regs[REG_CTRL7], statusOk,
+                status[0], status[1], status[2], timestampOk, timestamp[2],
+                timestamp[1], timestamp[0], dataOk, data[0], data[1], data[2],
+                data[3], data[4], data[5], data[6], data[7], data[8], data[9],
+                data[10], data[11],
+                static_cast<unsigned long>(imuStatus.sampleCount),
+                static_cast<unsigned long>(imuStatus.zeroSamples),
+                static_cast<unsigned long>(imuStatus.failedReads));
+}
+
+bool softReset(uint8_t address) {
+  if (!i2c::writeRegister8(address, REG_RESET, RESET_VALUE, "QMI8658 reset",
+                           3)) {
+    return false;
+  }
+
+  const uint32_t startMs = millis();
+  uint8_t resetResult = 0;
+  while (millis() - startMs < 250) {
+    delay(10);
+    if (i2c::readRegister8(address, REG_RST_RESULT, resetResult,
+                           "QMI8658 reset result", 1) &&
+        resetResult == RST_RESULT_OK) {
+      return true;
+    }
+  }
+
+  Serial.printf("QMI8658: reset result timeout addr=0x%02X last=0x%02X\n",
+                address, resetResult);
+  return false;
+}
+
+bool detectAddress(uint8_t address, uint8_t &whoAmI, uint8_t &revision) {
+  if (!i2c::probe(address, "QMI8658", 2)) {
+    return false;
+  }
+
+  if (!softReset(address)) {
+    return false;
+  }
+
+  if (!i2c::readRegister8(address, REG_WHO_AM_I, whoAmI, "QMI8658 whoami", 3)) {
+    return false;
+  }
+
+  if (whoAmI != EXPECTED_WHO_AM_I) {
+    Serial.printf("QMI8658: ignoring addr=0x%02X unexpected whoami=0x%02X\n",
+                  address, whoAmI);
+    return false;
+  }
+
+  if (!i2c::readRegister8(address, REG_REVISION, revision, "QMI8658 revision",
+                          3)) {
+    revision = 0;
+  }
+
+  return true;
+}
+
+Orientation classifyOrientation(const Sample &sample) {
+  const float ax = sample.accelMg[0];
+  const float ay = sample.accelMg[1];
+  const float az = sample.accelMg[2];
+  const float absX = fabsf(ax);
+  const float absY = fabsf(ay);
+  const float absZ = fabsf(az);
+
+  if (absX < ORIENTATION_THRESHOLD_MG && absY < ORIENTATION_THRESHOLD_MG &&
+      absZ < ORIENTATION_THRESHOLD_MG) {
+    return Orientation::Unknown;
+  }
+
+  if (absZ >= absX && absZ >= absY) {
+    return az >= 0.0f ? Orientation::FaceUp : Orientation::FaceDown;
+  }
+  if (absX >= absY) {
+    return ax >= 0.0f ? Orientation::RightEdgeUp : Orientation::LeftEdgeUp;
+  }
+  return ay >= 0.0f ? Orientation::UsbUp : Orientation::UsbDown;
+}
+
+void updateDerivedState(const Sample &sample) {
+  const float ax = sample.accelMg[0];
+  const float ay = sample.accelMg[1];
+  const float az = sample.accelMg[2];
+  const float gx = sample.gyroDps[0];
+  const float gy = sample.gyroDps[1];
+  const float gz = sample.gyroDps[2];
+
+  imuStatus.accelMagnitudeMg = sqrtf(ax * ax + ay * ay + az * az);
+  imuStatus.vibrationDps = sqrtf(gx * gx + gy * gy + gz * gz);
+  const bool accelMagnitudeLooksCalibrated = imuStatus.accelMagnitudeMg > 700.0f;
+  imuStatus.moving = imuStatus.vibrationDps > MOVING_GYRO_THRESHOLD_DPS ||
+                     (accelMagnitudeLooksCalibrated &&
+                      fabsf(imuStatus.accelMagnitudeMg - 1000.0f) >
+                          MOVING_ACCEL_DELTA_MG);
+  imuStatus.orientation = classifyOrientation(sample);
+}
+
+bool configureSensor() {
+  for (uint8_t attempt = 1; attempt <= 3; attempt++) {
+    bool writeOk = write8(REG_CTRL7, CTRL7_DISABLE_SENSORS,
+                          "QMI8658 disable sensors");
+    delay(10);
+    writeOk = writeOk &&
+              write8(REG_CTRL1, CTRL1_LITTLE_ENDIAN_AUTO_INC, "QMI8658 ctrl1");
+    delay(10);
+    writeOk = writeOk &&
+              write8(REG_CTRL2, CTRL2_ACCEL_8G_125HZ, "QMI8658 accel config");
+    delay(10);
+    writeOk = writeOk &&
+              write8(REG_CTRL3, CTRL3_GYRO_512DPS_112HZ,
+                     "QMI8658 gyro config");
+    delay(10);
+    writeOk = writeOk &&
+              write8(REG_CTRL7, CTRL7_ENABLE_ACCEL_GYRO, "QMI8658 enable");
+    delay(50);
+
+    uint8_t ctrl1 = 0;
+    uint8_t ctrl2 = 0;
+    uint8_t ctrl3 = 0;
+    uint8_t ctrl7 = 0;
+    const bool readbackOk =
+        read8(REG_CTRL1, ctrl1, "QMI8658 ctrl1 readback") &&
+        read8(REG_CTRL2, ctrl2, "QMI8658 ctrl2 readback") &&
+        read8(REG_CTRL3, ctrl3, "QMI8658 ctrl3 readback") &&
+        read8(REG_CTRL7, ctrl7, "QMI8658 ctrl7 readback");
+    if (writeOk && readbackOk && ctrl1 == CTRL1_LITTLE_ENDIAN_AUTO_INC &&
+        ctrl2 == CTRL2_ACCEL_8G_125HZ && ctrl3 == CTRL3_GYRO_512DPS_112HZ &&
+        (ctrl7 & CTRL7_ENABLE_ACCEL_GYRO) == CTRL7_ENABLE_ACCEL_GYRO) {
+      return true;
+    }
+
+    Serial.printf("QMI8658: config attempt %u failed write=%d read=%d "
+                  "ctrl1=0x%02X ctrl2=0x%02X ctrl3=0x%02X ctrl7=0x%02X\n",
+                  attempt, writeOk, readbackOk, ctrl1, ctrl2, ctrl3, ctrl7);
+  }
+  logRawDiagnostic("config-failed");
+  return false;
+}
+
+} // namespace
+
+const Status &status() { return imuStatus; }
+
+const Sample &lastSample() { return latestSample; }
+
+const char *orientationName(Orientation orientation) {
+  switch (orientation) {
+  case Orientation::FaceUp:
+    return "face-up";
+  case Orientation::FaceDown:
+    return "face-down";
+  case Orientation::LeftEdgeUp:
+    return "left-edge-up";
+  case Orientation::RightEdgeUp:
+    return "right-edge-up";
+  case Orientation::UsbUp:
+    return "usb-up";
+  case Orientation::UsbDown:
+    return "usb-down";
+  case Orientation::Unknown:
+  default:
+    return "unknown";
+  }
+}
+
+bool begin() {
+  imuStatus = Status{};
+  latestSample = Sample{};
+
+  uint8_t whoAmI = 0;
+  uint8_t revision = 0;
+  uint8_t address = waveshare_board::QMI8658_ADDR_PRIMARY;
+  if (!detectAddress(address, whoAmI, revision)) {
+    address = waveshare_board::QMI8658_ADDR_FALLBACK;
+    if (!detectAddress(address, whoAmI, revision)) {
+      Serial.println("QMI8658: not found");
+      return false;
+    }
+  }
+
+  imuStatus.present = true;
+  imuStatus.address = address;
+  imuStatus.whoAmI = whoAmI;
+  imuStatus.revision = revision;
+
+  if (!configureSensor()) {
+    Serial.printf("QMI8658: failed to configure addr=0x%02X\n", address);
+    return false;
+  }
+
+  imuStatus.configured = true;
+  Serial.printf("QMI8658: found addr=0x%02X whoami=0x%02X rev=0x%02X "
+                "accel=8g@125Hz gyro=512dps@112Hz\n",
+                imuStatus.address, imuStatus.whoAmI, imuStatus.revision);
+#ifdef WAVESHARE_IMU_DEBUG_LOG
+  logRawDiagnostic("configured");
+#endif
+  return true;
+}
+
+bool readSample(Sample &sample) {
+  if (!imuStatus.configured) {
+    return false;
+  }
+
+  uint8_t accelRegs[6] = {};
+  if (!readSequentialBytes(REG_AX_L, accelRegs, sizeof(accelRegs),
+                           "QMI8658 accel")) {
+    imuStatus.dataValid = false;
+    imuStatus.failedReads++;
+    return false;
+  }
+
+  uint8_t gyroRegs[6] = {};
+  if (!readSequentialBytes(REG_GX_L, gyroRegs, sizeof(gyroRegs),
+                           "QMI8658 gyro")) {
+    imuStatus.dataValid = false;
+    imuStatus.failedReads++;
+    return false;
+  }
+
+  const int16_t ax = readInt16Le(accelRegs);
+  const int16_t ay = readInt16Le(accelRegs + 2);
+  const int16_t az = readInt16Le(accelRegs + 4);
+  const int16_t gx = readInt16Le(gyroRegs);
+  const int16_t gy = readInt16Le(gyroRegs + 2);
+  const int16_t gz = readInt16Le(gyroRegs + 4);
+  const bool allZero = ax == 0 && ay == 0 && az == 0 && gx == 0 && gy == 0 &&
+                       gz == 0;
+
+  sample.accelMg[0] = (static_cast<float>(ax) * 1000.0f) / ACCEL_LSB_PER_G;
+  sample.accelMg[1] = (static_cast<float>(ay) * 1000.0f) / ACCEL_LSB_PER_G;
+  sample.accelMg[2] = (static_cast<float>(az) * 1000.0f) / ACCEL_LSB_PER_G;
+  sample.gyroDps[0] = static_cast<float>(gx) / GYRO_LSB_PER_DPS;
+  sample.gyroDps[1] = static_cast<float>(gy) / GYRO_LSB_PER_DPS;
+  sample.gyroDps[2] = static_cast<float>(gz) / GYRO_LSB_PER_DPS;
+  sample.sampledAtMs = millis();
+  sample.timestamp = sample.sampledAtMs;
+
+  latestSample = sample;
+  imuStatus.sampleCount++;
+  imuStatus.dataValid = !allZero;
+  if (allZero) {
+    imuStatus.zeroSamples++;
+  }
+  imuStatus.lastSampleMs = sample.sampledAtMs;
+  updateDerivedState(sample);
+  return true;
+}
+
+void process() {
+  if (!imuStatus.configured) {
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (now - lastPollMs < SAMPLE_INTERVAL_MS) {
+    return;
+  }
+  lastPollMs = now;
+
+  Sample sample;
+  if (!readSample(sample)) {
+    return;
+  }
+
+  if (!imuStatus.dataValid && imuStatus.zeroSamples > 0 &&
+      (imuStatus.zeroSamples <= 3 || now - lastDiagLogMs >= 5000)) {
+    lastDiagLogMs = now;
+    logRawDiagnostic("zero-sample");
+  }
+
+#ifdef WAVESHARE_IMU_DEBUG_LOG
+  static uint32_t lastLogMs = 0;
+  if (now - lastLogMs >= 5000) {
+    lastLogMs = now;
+    Serial.printf("QMI8658: accel[mg]=%.0f,%.0f,%.0f gyro[dps]=%.1f,%.1f,%.1f "
+                  "temp=%.1f orient=%s moving=%d samples=%lu failures=%lu\n",
+                  sample.accelMg[0], sample.accelMg[1], sample.accelMg[2],
+                  sample.gyroDps[0], sample.gyroDps[1], sample.gyroDps[2],
+                  sample.temperatureC, orientationName(imuStatus.orientation),
+                  imuStatus.moving,
+                  static_cast<unsigned long>(imuStatus.sampleCount),
+                  static_cast<unsigned long>(imuStatus.failedReads));
+  }
+#endif
+}
+
+} // namespace waveshare_board::imu
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/lib/waveshare_board/qmi8658.hpp
+++ b/esp32/lib/waveshare_board/qmi8658.hpp
@@ -1,0 +1,58 @@
+/**
+ * @file qmi8658.hpp
+ * @brief QMI8658 IMU helper for the Waveshare AMOLED board.
+ */
+
+#pragma once
+
+#ifdef WAVESHARE_AMOLED_175
+
+#include <Arduino.h>
+
+namespace waveshare_board::imu {
+
+enum class Orientation : uint8_t {
+  Unknown,
+  FaceUp,
+  FaceDown,
+  LeftEdgeUp,
+  RightEdgeUp,
+  UsbUp,
+  UsbDown,
+};
+
+struct Sample {
+  float accelMg[3] = {0.0f, 0.0f, 0.0f};
+  float gyroDps[3] = {0.0f, 0.0f, 0.0f};
+  float temperatureC = 0.0f;
+  uint32_t timestamp = 0;
+  uint32_t sampledAtMs = 0;
+};
+
+struct Status {
+  bool present = false;
+  bool configured = false;
+  bool dataValid = false;
+  uint8_t address = 0;
+  uint8_t whoAmI = 0;
+  uint8_t revision = 0;
+  uint32_t sampleCount = 0;
+  uint32_t failedReads = 0;
+  uint32_t zeroSamples = 0;
+  uint32_t lastSampleMs = 0;
+  float accelMagnitudeMg = 0.0f;
+  float vibrationDps = 0.0f;
+  bool moving = false;
+  Orientation orientation = Orientation::Unknown;
+};
+
+bool begin();
+void process();
+bool readSample(Sample &sample);
+const Status &status();
+const Sample &lastSample();
+const char *orientationName(Orientation orientation);
+
+} // namespace waveshare_board::imu
+
+#endif // WAVESHARE_AMOLED_175

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -208,6 +208,9 @@ build_flags =
   ; identity and makes iOS see a fresh peripheral after each firmware boot.
   ; Keep disabled for normal reconnect behavior.
   ; -DBLE_DEV_RANDOM_IDENTITY=1
+  ; Optional QMI8658 sample logging; normal builds expose IMU state through the
+  ; compact rate-limited IMU heartbeat instead.
+  ; -DWAVESHARE_IMU_DEBUG_LOG=1
   ; SD Card uses dedicated HSPI. Verified pins: CS=41, MOSI=1, MISO=3, SCK=2.
   -DDEFAULT_LAT=35.16755
   -DDEFAULT_LON=136.89451

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -69,6 +69,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "WAVESHARE_AMOLED_175.hpp"
 #include "i2c_bus.hpp"
 #include "pcf85063.hpp"
+#include "qmi8658.hpp"
 #include "waveshare_board.hpp"
 #endif
 
@@ -148,6 +149,10 @@ static void logSystemDebugHeartbeat() {
   const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
   const waveshare_board::rtc::Status &rtcStatus =
       waveshare_board::rtc::status();
+  const waveshare_board::imu::Status &imuStatus =
+      waveshare_board::imu::status();
+  const waveshare_board::imu::Sample &imuSample =
+      waveshare_board::imu::lastSample();
 #endif
   const char *screenName = "unknown";
   lv_obj_t *activeScreen = lv_scr_act();
@@ -158,6 +163,21 @@ static void logSystemDebugHeartbeat() {
   }
 
 #ifdef WAVESHARE_AMOLED_175
+  Serial.printf("IMU: p=%d cfg=%d valid=%d addr=0x%02X n=%lu zero=%lu fail=%lu "
+                "a=%.0f,%.0f,%.0f g=%.1f,%.1f,%.1f mag=%.0f vib=%.1f "
+                "orient=%s moving=%d\n",
+                imuStatus.present, imuStatus.configured, imuStatus.dataValid,
+                imuStatus.address,
+                (unsigned long)imuStatus.sampleCount,
+                (unsigned long)imuStatus.zeroSamples,
+                (unsigned long)imuStatus.failedReads, imuSample.accelMg[0],
+                imuSample.accelMg[1], imuSample.accelMg[2],
+                imuSample.gyroDps[0], imuSample.gyroDps[1],
+                imuSample.gyroDps[2], imuStatus.accelMagnitudeMg,
+                imuStatus.vibrationDps,
+                waveshare_board::imu::orientationName(imuStatus.orientation),
+                imuStatus.moving);
+
   Serial.printf("SYS: up=%lus heap=%lu psram=%lu screen=%s tile=%s "
                 "waitRefresh=%d gpsFromApp=%d pendingMap=%d lat=%.6f "
                 "lon=%.6f heading=%u routePts=%u mapFound=%d mapBlocks=%u "
@@ -289,6 +309,7 @@ void setup() {
 #ifdef WAVESHARE_AMOLED_175
   waveshare_board::enablePowerRails();
   waveshare_board::rtc::restoreSystemTimeFromRtc();
+  waveshare_board::imu::begin();
 #endif
 
 #ifdef BME280
@@ -414,6 +435,10 @@ void loop() {
 
   // Process BLE events
   bleNavServer.process();
+
+#ifdef WAVESHARE_AMOLED_175
+  waveshare_board::imu::process();
+#endif
 
   // Check if we need to transition from waiting screen to map
   checkPendingMapTransition();


### PR DESCRIPTION
## Summary

- Add a Waveshare-local QMI8658 IMU helper for detection, reset, configuration, and low-rate accel/gyro diagnostics.
- Hook IMU initialization into the Waveshare boot path and add a compact `IMU:` serial heartbeat.
- Document the PR15 implementation status, connected-device findings, and measured orientation axis signs.

## Notes

This is diagnostic-only. Navigation, map, ride, sleep, and heading behavior do not depend on IMU data yet.

Connected-device testing found the QMI8658 at `0x6B` with `WHO_AM_I=0x05` and `REVISION=0x7C`. The stable read path uses local repeated-start single-register reads because earlier burst and STOP-style reads caused invalid-state I2C failures on this board.

## Validation

- `git diff --check`
- `pio run -e WAVESHARE_AMOLED_175`
- Flashed/tested on connected Waveshare board during bring-up
- 90-second orientation capture: all coarse orientations matched physical positions, `valid=1`, `zero=0`, `fail=0`
