### PR TITLE
Instrument Waveshare SD map IO timing

### DIFF
--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -153,7 +153,7 @@ When scanning the I2C bus, you should find:
 |---|---|---|
 | Display | ✅ Working | CO5300 QSPI via Arduino_GFX |
 | Touch | ✅ Working | CST9217 @ 0x5A, TCA9554 reset, coordinate mirroring |
-| SD Card | ✅ Working | **Pins verified: CS=41, MOSI=1, MISO=3, SCK=2** (32GB SDHC tested) |
+| SD Card | ✅ Working | **Pins verified: CS=41, MOSI=1, MISO=3, SCK=2** (32GB SDHC tested); PR16 keeps 4 MHz default and adds mount/map I/O timings plus configurable frequency testing |
 | RTC | ✅ Integrated | PCF85063 @ 0x51; PR14 driver added, BLE sync + warm-reset restore verified; full USB power removal loses RTC on current board (`battery=absent`) |
 | IMU | ✅ Diagnostic | QMI8658 @ 0x6B primary / 0x6A fallback; PR15 detects/configures it and samples accel/gyro for diagnostics only |
 | I/O Expander | ✅ Working | TCA9554 @ 0x20 (controls touch reset) |

--- a/docs/waveshare-hardware-native-implementation-plan.md
+++ b/docs/waveshare-hardware-native-implementation-plan.md
@@ -961,6 +961,52 @@ Acceptance criteria:
 Goal: improve storage startup and map load performance without destabilizing SD
 mounting.
 
+Implementation status:
+
+- In progress on branch `sd-map-io-timing`.
+- Normal Waveshare SD boot no longer prints temporary macro-debug lines or lists
+  the SD root directory by default.
+- Root listing is now opt-in via `WAVESHARE_SD_LIST_ROOT`.
+- Waveshare SD SPI frequency is configurable via `WAVESHARE_SD_SPI_FREQ_HZ`;
+  the default remains the PR 6/PR 7 known-good `4 MHz` baseline.
+- Added concise `SDIO:` timing for SD mount, including bus, frequency, pins,
+  card type, card size, success/failure, and elapsed time.
+- Added concise `MAPIO:` timing for:
+  - map block open/stat/read
+  - binary and ASCII vector parse/grid build
+  - map-block cache hits, loads, evictions, and elapsed time
+  - canvas fill/draw timing per block
+  - full vector generation, route overlay, and display invalidation
+- `MAPIO:` timing is opt-in via `WAVESHARE_MAPIO_TIMING_LOG` after review found
+  unconditional redraw logs could trigger USB CDC write timeouts during normal
+  app-driven map use. Low-volume `SDIO:` mount timing remains always visible.
+- No map-block cache/read-ahead behavior was changed; PR 16 is instrumentation
+  and boot-log cleanup first.
+- Default `4 MHz` Waveshare firmware build passes locally.
+- Default `4 MHz` firmware flashed to the connected board. Boot capture showed
+  `SDIO: mount ok=1 elapsedMs=19 freq=4000000 type=SDHC sizeMB=30436` and no
+  normal root-directory listing.
+- App-driven map loads were captured from the connected iPhone app against the
+  same 32 GB SDHC card and the same Shanghai `4_14.fmb` map block:
+  - `4 MHz`: mount `19 ms`, read `395 ms`, parse/grid `74 ms`, block load
+    `476 ms`, first map generation `507 ms`, cached redraws about `28-30 ms`.
+  - `8 MHz`: mount `18 ms`, read `213 ms`, parse/grid `74 ms`, block load
+    `292 ms`, first map generation `321 ms`, cached redraws about `28-29 ms`.
+  - `12 MHz`: mount `17 ms`, read `159 ms`, parse/grid `74 ms`, block load
+    `237 ms`, first map generation `265 ms`, cached redraws about `28 ms`.
+  - `16 MHz`: mount `16 ms`, read `123 ms`, parse/grid `74 ms`, block load
+    `200-209 ms`, first map generation `229-237 ms`, cached redraws about
+    `28 ms`.
+- The 16 MHz test was stable across reset/app-driven map load in this bench
+  run, but source still keeps `4 MHz` as the default until faster SD SPI is
+  proven across cold boots, repeated real map loads, and more cards.
+- After frequency testing, the connected board was flashed back to the restored
+  default firmware and confirmed `freq=4000000`, SD mount `19 ms`, block load
+  `477 ms`, and first map generation `513 ms`.
+- A 90 second pan/block-boundary capture did not force a second map block load:
+  GPS stayed fixed on the same block with `mapBlocks=1`. Boundary loading still
+  needs a route/location test that crosses a block edge.
+
 Scope:
 
 - Remove or gate normal boot root-directory listing.
@@ -988,12 +1034,20 @@ Out of scope:
 
 Validation:
 
-- Mount the known-good 32 GB SDHC card first, then test additional cards if
-  available.
-- Load known map tiles repeatedly.
-- Pan map across tile boundaries.
-- Long ride simulation with route overlay.
-- Confirm no display corruption during SD reads.
+- Done: mount the known-good 32 GB SDHC card first.
+- Done: build default `4 MHz` firmware.
+- Done: flash default `4 MHz` firmware and capture `SDIO:` / `MAPIO:` timings.
+- Done: rebuild/flash with `WAVESHARE_SD_SPI_FREQ_HZ` set to `8000000`,
+  `12000000`, and `16000000`.
+- Done: load the known Shanghai vector map block repeatedly from the iPhone app
+  path and confirm cached redraw timing.
+- Keep `4 MHz` unless a faster setting is stable across cold boots, repeated
+  map loads, and more than the current single known-good SD card.
+- Still needed: pan or route across map-block boundaries and capture a second
+  `MAPIO: block ok=1` load from a different file path.
+- Still needed: longer ride simulation with route overlay.
+- Still needed: explicit visual confirmation that display output remains clean
+  during repeated SD reads.
 
 Acceptance criteria:
 

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -14,6 +14,16 @@ extern Gps gps;
 extern std::vector<wayPoint> trackData;
 const char *TAG PROGMEM = "Maps";
 
+#ifdef WAVESHARE_MAPIO_TIMING_LOG
+#define MAPIO_LOG(...) Serial.printf(__VA_ARGS__)
+#define MAPIO_TIME_MS() millis()
+#else
+#define MAPIO_LOG(...)                                                        \
+  do {                                                                        \
+  } while (0)
+#define MAPIO_TIME_MS() 0
+#endif
+
 #include "../../gui/src/mainScr.hpp"
 #include "../../route_overlay/route_overlay.hpp"
 #include <esp_heap_caps.h>
@@ -393,11 +403,13 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
   ESP_LOGI(TAG, "readMapBlock: %s", fileName.c_str());
   char str[30];
   MapBlock *mblock = new MapBlock();
+  const uint32_t blockStartMs = MAPIO_TIME_MS();
 
   // Try Binary first (.fmb) then ASCII (.fmp)
   std::string filePath = fileName.c_str() + std::string(".fmb");
   bool isBinary = true;
 
+  const uint32_t openStartMs = MAPIO_TIME_MS();
   int fd = ::open(filePath.c_str(), O_RDONLY);
 
   if (fd < 0) {
@@ -405,9 +417,12 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     isBinary = false;
     fd = ::open(filePath.c_str(), O_RDONLY);
   }
+  const uint32_t openMs = MAPIO_TIME_MS() - openStartMs;
 
   if (fd < 0) {
     ESP_LOGE(TAG, "Failed to open file: %s", filePath.c_str());
+    MAPIO_LOG("MAPIO: block-open ok=0 base=%s openMs=%lu\n", fileName.c_str(),
+              (unsigned long)openMs);
     Maps::isMapFound = false;
     mblock->inView = false;
     return mblock;
@@ -416,13 +431,18 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
              isBinary ? "Binary" : "ASCII");
     // Get file size
     struct stat st;
+    const uint32_t statStartMs = MAPIO_TIME_MS();
     if (fstat(fd, &st) != 0) {
       ESP_LOGE(TAG, "Failed to get file size: %s", filePath.c_str());
       ::close(fd);
+      MAPIO_LOG("MAPIO: block-stat ok=0 file=%s openMs=%lu statMs=%lu\n",
+                filePath.c_str(), (unsigned long)openMs,
+                (unsigned long)(MAPIO_TIME_MS() - statStartMs));
       Maps::isMapFound = false;
       mblock->inView = false;
       return mblock;
     }
+    const uint32_t statMs = MAPIO_TIME_MS() - statStartMs;
     size_t fileSize = st.st_size;
 
 #ifdef BOARD_HAS_PSRAM
@@ -439,20 +459,38 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
       return mblock;
     }
 
+    const uint32_t readStartMs = MAPIO_TIME_MS();
     ssize_t bytesRead = ::read(fd, file, fileSize);
     ::close(fd);
+    const uint32_t readMs = MAPIO_TIME_MS() - readStartMs;
 
     if (bytesRead != (ssize_t)fileSize) {
       ESP_LOGE(TAG, "Failed to read file completely: got %d of %u bytes",
                bytesRead, fileSize);
+      MAPIO_LOG("MAPIO: block-read ok=0 file=%s size=%u got=%d "
+                "openMs=%lu statMs=%lu readMs=%lu\n",
+                filePath.c_str(), (unsigned)fileSize, (int)bytesRead,
+                (unsigned long)openMs, (unsigned long)statMs,
+                (unsigned long)readMs);
       free(file);
       Maps::isMapFound = false;
       return mblock;
     }
 
     if (isBinary) {
+      const uint32_t parseStartMs = MAPIO_TIME_MS();
       delete mblock; // readMapBlockBinary creates a new one
       mblock = readMapBlockBinary(file, fileSize);
+      const uint32_t parseGridMs = MAPIO_TIME_MS() - parseStartMs;
+      MAPIO_LOG("MAPIO: block ok=1 file=%s format=binary size=%u "
+                "openMs=%lu statMs=%lu readMs=%lu parseGridMs=%lu "
+                "totalMs=%lu polygons=%u lines=%u\n",
+                filePath.c_str(), (unsigned)fileSize, (unsigned long)openMs,
+                (unsigned long)statMs, (unsigned long)readMs,
+                (unsigned long)parseGridMs,
+                (unsigned long)(MAPIO_TIME_MS() - blockStartMs),
+                (unsigned)mblock->polygons.size(),
+                (unsigned)mblock->polylines.size());
       free(file);
       return mblock;
     }
@@ -462,6 +500,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
 
     uint32_t line = 0;
     Maps::idx = 0;
+    const uint32_t parseStartMs = MAPIO_TIME_MS();
 
     // read polygons
     Maps::parseStrUntil(file, ':', str);
@@ -573,7 +612,19 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     // File descriptor was already closed via ::close(fd) after reading
     free(file);
     // Build spatial grid for polygon culling optimization
+    const uint32_t gridStartMs = MAPIO_TIME_MS();
     buildPolygonGrid(mblock);
+    const uint32_t gridMs = MAPIO_TIME_MS() - gridStartMs;
+    MAPIO_LOG("MAPIO: block ok=1 file=%s format=ascii size=%u openMs=%lu "
+              "statMs=%lu readMs=%lu parseMs=%lu gridMs=%lu totalMs=%lu "
+              "polygons=%u lines=%u\n",
+              filePath.c_str(), (unsigned)fileSize, (unsigned long)openMs,
+              (unsigned long)statMs, (unsigned long)readMs,
+              (unsigned long)(gridStartMs - parseStartMs),
+              (unsigned long)gridMs,
+              (unsigned long)(MAPIO_TIME_MS() - blockStartMs),
+              (unsigned)mblock->polygons.size(),
+              (unsigned)mblock->polylines.size());
     return mblock;
   }
 }
@@ -583,6 +634,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
  * Supports both v1 (legacy) and v2 (with typeId) formats
  */
 Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
+  const uint32_t parseStartMs = MAPIO_TIME_MS();
   MapBlock *mblock = new MapBlock();
   size_t offset = 0;
 
@@ -679,7 +731,16 @@ Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
 
   Maps::isMapFound = true;
   // Build spatial grid for polygon culling optimization
+  const uint32_t gridStartMs = MAPIO_TIME_MS();
   buildPolygonGrid(mblock);
+  const uint32_t gridMs = MAPIO_TIME_MS() - gridStartMs;
+  MAPIO_LOG("MAPIO: vector-parse format=binary size=%u version=%u "
+            "polygons=%u lines=%u parseMs=%lu gridMs=%lu totalMs=%lu\n",
+            (unsigned)fileSize, version, (unsigned)mblock->polygons.size(),
+            (unsigned)mblock->polylines.size(),
+            (unsigned long)(gridStartMs - parseStartMs),
+            (unsigned long)gridMs,
+            (unsigned long)(MAPIO_TIME_MS() - parseStartMs));
   return mblock;
 }
 
@@ -891,6 +952,10 @@ void Maps::drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
  */
 void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
   ESP_LOGI(TAG, "getMapBlocks %i", millis());
+  const uint32_t blocksStartMs = MAPIO_TIME_MS();
+  uint16_t cacheHits = 0;
+  uint16_t loadedBlocks = 0;
+  uint16_t evictedBlocks = 0;
   for (MapBlock *block : memCache.blocks) {
     block->inView = false;
   }
@@ -935,8 +1000,10 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
       }
     }
 
-    if (found)
+    if (found) {
+      cacheHits++;
       continue;
+    }
 
     ESP_LOGI(TAG, "getMapBlocks loading missing: offset(%d, %d)", req.x, req.y);
 
@@ -963,6 +1030,7 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
                    (*it)->offset.y);
           delete *it;
           memCache.blocks.erase(it);
+          evictedBlocks++;
           evicted = true;
           break;
         }
@@ -973,6 +1041,7 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
         ESP_LOGW(TAG, "Cache full and all blocks inView! Evicting front.");
         delete memCache.blocks.front();
         memCache.blocks.erase(memCache.blocks.begin());
+        evictedBlocks++;
       }
     }
 
@@ -981,6 +1050,7 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
       newBlock->inView = true;
       newBlock->offset = req;
       memCache.blocks.push_back(newBlock);
+      loadedBlocks++;
 
       ESP_LOGI(TAG, "Block loaded: %p, offset(%d, %d)", newBlock, req.x, req.y);
       ESP_LOGI(TAG, "FreeHeap: %d", (int)esp_get_free_heap_size());
@@ -988,6 +1058,12 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
   }
 
   ESP_LOGI(TAG, "memCache size: %i %i", memCache.blocks.size(), millis());
+  MAPIO_LOG("MAPIO: blocks required=%u cacheHit=%u loaded=%u evicted=%u "
+            "cache=%u elapsedMs=%lu\n",
+            (unsigned)requiredOffsets.size(), (unsigned)cacheHits,
+            (unsigned)loadedBlocks, (unsigned)evictedBlocks,
+            (unsigned)memCache.blocks.size(),
+            (unsigned long)(MAPIO_TIME_MS() - blocksStartMs));
 }
 
 /**
@@ -1001,7 +1077,10 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
 void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
                          lv_obj_t *canvas, uint8_t zoom, double rotation) {
   Polygon newPolygon;
+  const uint32_t drawStartMs = MAPIO_TIME_MS();
+  const uint32_t fillStartMs = MAPIO_TIME_MS();
   lv_canvas_fill_bg(canvas, lv_color_hex(BACKGROUND_COLOR), LV_OPA_COVER);
+  const uint32_t fillMs = MAPIO_TIME_MS() - fillStartMs;
 
   // Calculate rotation from passed argument
   double cosA = cos(rotation);
@@ -1021,6 +1100,9 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
     log_w("readVectorMap: No map data found for this location!");
     // VISUAL DEBUG: Fill with BLUE to confirm we are here
     lv_canvas_fill_bg(canvas, lv_color_make(0x00, 0x00, 0xFF), LV_OPA_COVER);
+    MAPIO_LOG("MAPIO: canvas-draw ok=0 blocks=%u fillMs=%lu totalMs=%lu\n",
+              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
+              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
     return;
   }
 
@@ -1045,6 +1127,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           mblock->offset; // screen boundaries with features coordinates
 
       ////// Polygons - Grid-based spatial culling for performance
+      const uint32_t polygonStartMs = millis();
       int poly_total = mblock->polygons.size();
       int poly_drawn = 0;
       int poly_checked = 0;
@@ -1159,8 +1242,9 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       }
       Serial.printf("[Maps] Block polygons: Total=%d, Checked=%d, Drawn=%d\n",
                     poly_total, poly_checked, poly_drawn);
-      log_i("Block polygons done %i ms", millis() - blockTime);
-      blockTime = millis();
+      const uint32_t polygonMs = millis() - polygonStartMs;
+      log_i("Block polygons done %i ms", polygonMs);
+      const uint32_t lineStartMs = millis();
 
       ////// Lines
       // Removed lv_draw_line usage to fix crash
@@ -1210,7 +1294,15 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           p1 = p2;
         }
       }
-      ESP_LOGI(TAG, "Block lines done %i ms", millis() - blockTime);
+      const uint32_t lineMs = millis() - lineStartMs;
+      ESP_LOGI(TAG, "Block lines done %i ms", lineMs);
+      MAPIO_LOG("MAPIO: draw-block offset=%d,%d polygons=%d "
+                "checked=%d drawn=%d lines=%u polygonMs=%lu lineMs=%lu "
+                "totalMs=%lu\n",
+                mblock->offset.x, mblock->offset.y, poly_total, poly_checked,
+                poly_drawn, (unsigned)mblock->polylines.size(),
+                (unsigned long)polygonMs, (unsigned long)lineMs,
+                (unsigned long)(MAPIO_TIME_MS() - blockTime));
     }
     ESP_LOGI(TAG, "Total %i ms", millis() - totalTime);
 
@@ -1261,9 +1353,15 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
         uint16_t x, y, x2, y2;
       }
     }
+    MAPIO_LOG("MAPIO: canvas-draw ok=1 blocks=%u fillMs=%lu totalMs=%lu\n",
+              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
+              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
   } else {
     Maps::isMapFound = false;
     lv_canvas_fill_bg(canvas, lv_color_hex(TFT_BLACK), LV_OPA_COVER);
+    MAPIO_LOG("MAPIO: canvas-draw ok=0 blocks=%u fillMs=%lu totalMs=%lu\n",
+              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
+              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
     //    Maps::showNoMap(map);
     //    ESP_LOGE(TAG, "Map doesn't exist");
   }
@@ -1811,6 +1909,7 @@ void Maps::generateRenderMap(uint8_t zoom) {
  * @brief Display Map (Stub for Vector Maps/Arduino_GFX)
  */
 void Maps::displayMap() {
+  const uint32_t displayStartMs = MAPIO_TIME_MS();
   if (Maps::canvasMap)
     lv_obj_invalidate(Maps::canvasMap);
 
@@ -1880,6 +1979,9 @@ void Maps::displayMap() {
     }
     lv_obj_move_foreground(Maps::canvasArrow);
   }
+  MAPIO_LOG("MAPIO: display invalidateMs=%lu hasCanvas=%d hasArrow=%d\n",
+            (unsigned long)(MAPIO_TIME_MS() - displayStartMs),
+            Maps::canvasMap != nullptr, Maps::canvasArrow != nullptr);
 }
 
 /**
@@ -1888,6 +1990,7 @@ void Maps::displayMap() {
  * @param zoom -> Zoom Level
  */
 void Maps::generateVectorMap(uint8_t zoom) {
+  const uint32_t generateStartMs = MAPIO_TIME_MS();
   Maps::mapTileSize = Maps::vectorMapTileSize;
   Maps::zoomLevel = zoom;
 
@@ -1905,7 +2008,9 @@ void Maps::generateVectorMap(uint8_t zoom) {
   Maps::viewPort.setCenter(Maps::point);
 
   // Get Map Blocks
+  const uint32_t blocksStartMs = MAPIO_TIME_MS();
   Maps::getMapBlocks(Maps::viewPort.bbox, Maps::memCache);
+  const uint32_t blocksMs = MAPIO_TIME_MS() - blocksStartMs;
 
   ESP_LOGI(TAG,
            "generateVectorMap: zoom=%d center(%d, %d) bbox[(%d, %d), (%d, %d)]",
@@ -1914,10 +2019,13 @@ void Maps::generateVectorMap(uint8_t zoom) {
            Maps::viewPort.bbox.max.x, Maps::viewPort.bbox.max.y);
 
   // Read Vector Map to Canvas (Pass calculated rotation)
+  const uint32_t drawStartMs = MAPIO_TIME_MS();
   Maps::readVectorMap(Maps::viewPort, Maps::memCache, Maps::canvasMap, zoom,
                       rotationRad);
+  const uint32_t drawMs = MAPIO_TIME_MS() - drawStartMs;
 
   // Draw route overlay from iOS navigation (if available)
+  const uint32_t routeStartMs = MAPIO_TIME_MS();
   ESP_LOGI(TAG, "Checking for route overlay: hasRoute=%d",
            routeOverlay.hasRoute());
   if (routeOverlay.hasRoute()) {
@@ -1939,6 +2047,13 @@ void Maps::generateVectorMap(uint8_t zoom) {
   } else {
     ESP_LOGI(TAG, "No route overlay to draw (no route data)");
   }
+  const uint32_t routeMs = MAPIO_TIME_MS() - routeStartMs;
+  MAPIO_LOG("MAPIO: generate zoom=%u blocksMs=%lu drawMs=%lu "
+            "routeMs=%lu totalMs=%lu cache=%u hasRoute=%d\n",
+            zoom, (unsigned long)blocksMs, (unsigned long)drawMs,
+            (unsigned long)routeMs,
+            (unsigned long)(MAPIO_TIME_MS() - generateStartMs),
+            (unsigned)Maps::memCache.blocks.size(), routeOverlay.hasRoute());
   // NOTE: isPosMoved flag is now cleared in updateMap() after display,
   // not here, to allow queued BLE updates to trigger new regenerations
 }

--- a/esp32/lib/storage/storage.cpp
+++ b/esp32/lib/storage/storage.cpp
@@ -30,6 +30,10 @@
 static const char *TAG = "Storage";
 
 namespace {
+#ifndef WAVESHARE_SD_SPI_FREQ_HZ
+#define WAVESHARE_SD_SPI_FREQ_HZ 4000000
+#endif
+
 std::string formatSize(uint64_t size) {
   static const char *suffixes[] = {"B", "KB", "MB", "GB", "TB"};
   int order = 0;
@@ -55,28 +59,17 @@ Storage::Storage() : isSdLoaded(false), card(nullptr) {}
  * @brief SD Card init with DMA using ESP-IDF
  */
 esp_err_t Storage::initSD() {
-  Serial.println("DEBUG: initSD() ENTRY");
 #ifdef WAVESHARE_AMOLED_175
-  Serial.println("DEBUG: Macro WAVESHARE_AMOLED_175 is DEFINED");
-#else
-  Serial.println("DEBUG: Macro WAVESHARE_AMOLED_175 is NOT defined");
-#endif
-
-#ifdef SPI_SHARED
-  Serial.println("DEBUG: Macro SPI_SHARED is DEFINED");
-#else
-  Serial.println("DEBUG: Macro SPI_SHARED is NOT defined");
-#endif
-
-#ifdef WAVESHARE_AMOLED_175
+  const uint32_t mountStartMs = millis();
   // Waveshare 1.75" AMOLED: Use DEDICATED HSPI bus to avoid conflict with
   // QSPI display. The default SPI (FSPI) shares resources with the display.
   // NOTE: Use HSPI constant, not SPI3_HOST (which fails with "out of range")
   // See WAVESHARE_HARDWARE.md.
   // Verified working pins: CS=41, MOSI=1, MISO=3, SCK=2
 
-  Serial.println("Initializing SD Card (HSPI mode)...");
-  Serial.printf("Pins: CS=%d, MOSI=%d, MISO=%d, SCK=%d\n", SD_CS, SD_MOSI,
+  Serial.printf("SDIO: init bus=HSPI freq=%luHz pins[cs=%d mosi=%d miso=%d "
+                "sck=%d]\n",
+                (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ, SD_CS, SD_MOSI,
                 SD_MISO, SD_CLK);
 
   // Explicitly set CS as output and deselect before SPI init
@@ -87,8 +80,11 @@ esp_err_t Storage::initSD() {
   static SPIClass hspi(HSPI);
   hspi.begin(SD_CLK, SD_MISO, SD_MOSI, SD_CS);
 
-  if (!SD.begin(SD_CS, hspi, 4000000, "/sdcard")) {
+  if (!SD.begin(SD_CS, hspi, WAVESHARE_SD_SPI_FREQ_HZ, "/sdcard")) {
     ESP_LOGE(TAG, "SD Card Mount Failed - check card insertion and format");
+    Serial.printf("SDIO: mount ok=0 elapsedMs=%lu freq=%lu\n",
+                  (unsigned long)(millis() - mountStartMs),
+                  (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ);
     isSdLoaded = false;
     return ESP_FAIL;
   }
@@ -96,6 +92,9 @@ esp_err_t Storage::initSD() {
   uint8_t cardType = SD.cardType();
   if (cardType == CARD_NONE) {
     ESP_LOGE(TAG, "No SD card detected");
+    Serial.printf("SDIO: mount ok=0 elapsedMs=%lu freq=%lu card=none\n",
+                  (unsigned long)(millis() - mountStartMs),
+                  (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ);
     isSdLoaded = false;
     return ESP_FAIL;
   }
@@ -110,9 +109,13 @@ esp_err_t Storage::initSD() {
 
   ESP_LOGI(TAG, "SD Card Type: %s, Size: %lluMB", typeStr,
            SD.cardSize() / (1024 * 1024));
+  Serial.printf("SDIO: mount ok=1 elapsedMs=%lu freq=%lu type=%s sizeMB=%llu\n",
+                (unsigned long)(millis() - mountStartMs),
+                (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ, typeStr,
+                SD.cardSize() / (1024 * 1024));
 
-  // Debug: List root directory
-  Serial.println("Listing SD Card Root:");
+#ifdef WAVESHARE_SD_LIST_ROOT
+  Serial.println("SDIO: root listing enabled");
   File root = SD.open("/");
   if (root) {
     File file = root.openNextFile();
@@ -126,6 +129,7 @@ esp_err_t Storage::initSD() {
     }
     root.close();
   }
+#endif
 
   isSdLoaded = true;
   return ESP_OK;
@@ -248,6 +252,7 @@ esp_err_t Storage::initSPIFFS() {
   size_t used = FFat.usedBytes();
   ESP_LOGI(TAG, "FFat Mounted at /sdcard. Total: %d, Used: %d", total, used);
 
+#ifdef WAVESHARE_SD_LIST_ROOT
   // Debug: List files (flat, no recursion to avoid file handle exhaustion)
   File root = FFat.open("/");
   if (root) {
@@ -263,6 +268,7 @@ esp_err_t Storage::initSPIFFS() {
     }
     root.close();
   }
+#endif
 
   return ESP_OK;
 }

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -212,6 +212,13 @@ build_flags =
   ; compact rate-limited IMU heartbeat instead.
   ; -DWAVESHARE_IMU_DEBUG_LOG=1
   ; SD Card uses dedicated HSPI. Verified pins: CS=41, MOSI=1, MISO=3, SCK=2.
+  ; SD SPI tuning defaults to the PR6/PR7 known-good 4 MHz baseline.
+  ; Test candidates: 8000000, 12000000, 16000000.
+  ; -DWAVESHARE_SD_SPI_FREQ_HZ=4000000
+  ; Map I/O timing is verbose; enable only for targeted SD/map profiling.
+  ; -DWAVESHARE_MAPIO_TIMING_LOG=1
+  ; Root directory listing is noisy and disabled by default.
+  ; -DWAVESHARE_SD_LIST_ROOT=1
   -DDEFAULT_LAT=35.16755
   -DDEFAULT_LON=136.89451
   -Wno-error=return-type  ; Disable error for missing return statements (NeoGPS compatibility)


### PR DESCRIPTION
## Summary
- gate noisy SD root listings behind `WAVESHARE_SD_LIST_ROOT`
- add configurable Waveshare SD SPI frequency with the known-good 4 MHz default
- add concise SD mount timing and opt-in map I/O timing via `WAVESHARE_MAPIO_TIMING_LOG`
- document PR16 implementation status, SD frequency measurements, and remaining hardware validation

## Hardware results
- 4 MHz: mount 19 ms, read ~395 ms, block ~476/477 ms, first generation ~507/513 ms
- 8 MHz: mount 18 ms, read 213 ms, block 292 ms, first generation 321 ms
- 12 MHz: mount 17 ms, read 159 ms, block 237 ms, first generation 265 ms
- 16 MHz: mount 16 ms, read 123 ms, block 200-209 ms, first generation 229-237 ms
- source still defaults to 4 MHz until faster SPI is proven across cold boots, repeated real map loads, and more cards

## Review notes
- Deep review found unconditional `MAPIO:` redraw logs could add serial pressure during normal map use.
- Fixed by making `MAPIO:` timing opt-in only; low-volume `SDIO:` mount timing remains always visible.

## Tests
- `git diff --check`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-314 /tmp/esp32-bike-pio-314/bin/pio run -e WAVESHARE_AMOLED_175`
- instrumented build with `WAVESHARE_MAPIO_TIMING_LOG=1`
- connected Waveshare board SD/map timing captures at 4, 8, 12, and 16 MHz
