### PR TITLE
Fix PCF85063 RTC sync reliability

### DIFF
--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -191,11 +191,19 @@ Full USB power-removal/replug without a battery was tested. On replug, AXP2101
 reported `battery=absent`, the PCF85063 voltage-low flag was set, and the RTC
 time was correctly rejected.
 
-Battery-connected testing later showed `battery=present`, but RTC sync still
-failed readback because the year byte remained `0x07` while the other time
-fields updated. Example invalid register dump for a 2026 timestamp:
-`44 49 04 02 04 07 07`. Treat RTC retention as not validated until the
-PCF85063 year-byte write/readback issue is fixed.
+Battery-connected testing later showed `battery=present`. The first driver
+version sometimes left the year byte at `0x07` while the other time fields
+updated. The fixed path stops the divider while writing time, explicitly writes
+the year register, and retries sync/readback and boot restore around transient
+shared-I2C failures.
+
+Verified after the fix:
+- BLE/iPhone timestamp sync succeeds after retry.
+- Warm reset restores system time from RTC before BLE reconnect.
+- A first boot read can still fail due to shared-I2C instability, so restore
+  must keep retrying before declaring RTC time invalid.
+- Full USB-removal retention with battery connected still needs a final
+  unplug/replug validation after this fix.
 
 ### 7. IMU (QMI8658)
 
@@ -269,7 +277,7 @@ When scanning the I2C bus, you should find:
 | Display | ✅ Working | CO5300 QSPI via Arduino_GFX; vendor 466x466 + 6px X gap; 90-degree hardware rotation disabled |
 | Touch | ✅ Working | CST9217 @ 0x5A, TCA9554 P0 reset, GPIO21 hint + throttled fallback polling |
 | SD Card | ✅ Working | Pins verified: CS=41, MOSI=1, MISO=3, SCK=2; 32 GB SDHC tested; 4 MHz default |
-| RTC | ⚠️ Partial | PCF85063 @ 0x51 detected; invalid/voltage-low values rejected; battery-connected testing found year byte stuck at `0x07`, so sync/retention need a driver fix |
+| RTC | ✅ Integrated | PCF85063 @ 0x51; invalid/voltage-low values rejected; BLE sync and warm-reset restore verified with battery present; full USB-removal retention still needs final battery retest |
 | IMU | ✅ Diagnostic | QMI8658 @ 0x6B primary / 0x6A fallback; low-rate diagnostic accel/gyro sampling only |
 | I/O Expander | ✅ Working | TCA9554 @ 0x20 controls touch reset; can be missed early but recovered by shared I2C retry/recovery |
 | Audio | ⏳ Untested | ES8311 not detected in scan; treat as separate future bring-up |

--- a/esp32/lib/waveshare_board/pcf85063.cpp
+++ b/esp32/lib/waveshare_board/pcf85063.cpp
@@ -17,7 +17,9 @@ namespace {
 
 constexpr uint8_t REG_CONTROL_1 = 0x00;
 constexpr uint8_t REG_SECONDS = 0x04;
+constexpr uint8_t REG_YEARS = 0x0A;
 constexpr uint8_t CONTROL_1_STOP_BIT = 0x20;
+constexpr uint8_t CONTROL_1_EXT_TEST_BIT = 0x80;
 constexpr uint8_t SECONDS_VL_BIT = 0x80;
 constexpr int64_t MIN_VALID_UNIX_TIME = 1704067200; // 2024-01-01T00:00:00Z
 constexpr int64_t MAX_VALID_UNIX_TIME = 4102444800; // 2100-01-01T00:00:00Z
@@ -118,6 +120,47 @@ void logUtcTime(const char *prefix, time_t unixTime) {
   Serial.printf("PCF85063: %s %s\n", prefix, buffer);
 }
 
+bool setStopBit(bool stopped) {
+  uint8_t control1 = 0;
+  if (!i2c::readRegister8(waveshare_board::PCF85063_ADDR, REG_CONTROL_1,
+                          control1, "PCF85063 ctrl1")) {
+    return false;
+  }
+
+  uint8_t next = control1 & ~CONTROL_1_EXT_TEST_BIT;
+  if (stopped) {
+    next |= CONTROL_1_STOP_BIT;
+  } else {
+    next &= ~CONTROL_1_STOP_BIT;
+  }
+
+  if (next == control1) {
+    return true;
+  }
+
+  return i2c::writeRegister8(waveshare_board::PCF85063_ADDR, REG_CONTROL_1,
+                             next,
+                             stopped ? "PCF85063 stop" : "PCF85063 start", 3);
+}
+
+bool writeRtcRegisters(const uint8_t regs[7]) {
+  bool stopped = setStopBit(true);
+  bool wroteTime =
+      stopped &&
+      i2c::writeRegisterBlock8(waveshare_board::PCF85063_ADDR, REG_SECONDS,
+                               regs, 7, "PCF85063 time set", 3);
+  if (wroteTime) {
+    // Defensive write for the final calendar byte. The connected Waveshare
+    // board accepted seconds through month while leaving year at 0x07 unless
+    // the year register was written explicitly.
+    wroteTime = i2c::writeRegister8(waveshare_board::PCF85063_ADDR, REG_YEARS,
+                                    regs[6], "PCF85063 year set", 3);
+  }
+  bool restarted = setStopBit(false);
+
+  return stopped && wroteTime && restarted;
+}
+
 } // namespace
 
 const char *sourceName(TimeSource source) {
@@ -162,7 +205,22 @@ bool restoreSystemTimeFromRtc() {
   }
 
   time_t rtcTime = 0;
-  if (!readRtcUnixTime(rtcTime)) {
+  constexpr uint8_t RESTORE_ATTEMPTS = 3;
+  bool restored = false;
+  for (uint8_t attempt = 1; attempt <= RESTORE_ATTEMPTS; attempt++) {
+    if (readRtcUnixTime(rtcTime)) {
+      restored = true;
+      break;
+    }
+
+    if (attempt < RESTORE_ATTEMPTS) {
+      Serial.printf("PCF85063: restore read attempt %u/%u failed\n", attempt,
+                    RESTORE_ATTEMPTS);
+      delay(20);
+    }
+  }
+
+  if (!restored) {
     rtcStatus.timeValid = false;
     rtcStatus.source = TimeSource::Unknown;
     rtcStatus.unixTime = 0;
@@ -203,31 +261,40 @@ bool syncFromUnixTime(time_t unixTime, const char *source) {
       decToBcd(static_cast<uint8_t>((utc.tm_year + 1900) - 2000)),
   };
 
-  if (!i2c::writeRegisterBlock8(waveshare_board::PCF85063_ADDR, REG_SECONDS,
-                                regs, sizeof(regs), "PCF85063 time set", 3)) {
-    Serial.printf("PCF85063: failed to sync from %s\n",
-                  source ? source : "unknown");
-    return false;
+  constexpr uint8_t SYNC_ATTEMPTS = 3;
+  for (uint8_t attempt = 1; attempt <= SYNC_ATTEMPTS; attempt++) {
+    if (!writeRtcRegisters(regs)) {
+      Serial.printf("PCF85063: sync write attempt %u/%u failed from %s\n",
+                    attempt, SYNC_ATTEMPTS, source ? source : "unknown");
+      delay(20);
+      continue;
+    }
+
+    delay(20);
+    time_t readBack = 0;
+    if (readRtcUnixTime(readBack) &&
+        llabs(static_cast<long long>(readBack) -
+              static_cast<long long>(unixTime)) <= 2) {
+      setSystemTime(unixTime);
+      rtcStatus.timeValid = true;
+      rtcStatus.source = TimeSource::BLE;
+      rtcStatus.unixTime = unixTime;
+      char logPrefix[80];
+      snprintf(logPrefix, sizeof(logPrefix), "synced RTC from %s:",
+               source ? source : "unknown");
+      logUtcTime(logPrefix, unixTime);
+      return true;
+    }
+
+    Serial.printf("PCF85063: sync readback attempt %u/%u failed from %s\n",
+                  attempt, SYNC_ATTEMPTS, source ? source : "unknown");
+    delay(20);
   }
 
-  delay(5);
-  time_t readBack = 0;
-  if (!readRtcUnixTime(readBack) || llabs(static_cast<long long>(readBack) -
-                                         static_cast<long long>(unixTime)) > 2) {
-    Serial.printf("PCF85063: failed %s readback after sync\n",
-                  source ? source : "unknown");
-    return false;
-  }
-
-  setSystemTime(unixTime);
-  rtcStatus.timeValid = true;
-  rtcStatus.source = TimeSource::BLE;
-  rtcStatus.unixTime = unixTime;
-  char logPrefix[80];
-  snprintf(logPrefix, sizeof(logPrefix), "synced RTC from %s:",
-           source ? source : "unknown");
-  logUtcTime(logPrefix, unixTime);
-  return true;
+  setStopBit(false);
+  Serial.printf("PCF85063: failed %s readback after sync\n",
+                source ? source : "unknown");
+  return false;
 }
 
 } // namespace waveshare_board::rtc


### PR DESCRIPTION
## Summary
- stop the PCF85063 divider while writing time, matching the datasheet/Linux driver set-time shape
- explicitly write the year register after the calendar block write to fix the observed stale `0x07` year byte
- retry full RTC sync/readback and boot restore reads around transient shared-I2C failures
- update the Waveshare hardware notes with the fixed RTC behavior and remaining full USB-removal battery retest

Closes #22.

## Device validation
- Build/upload passed for `WAVESHARE_AMOLED_175` on `/dev/cu.usbmodem2101`.
- Battery was connected and AXP2101 reported `battery=present`.
- BLE/iPhone RTC sync initially hit shared-I2C failures, then succeeded via retry:
  `PCF85063: synced RTC from BLE GPS timestamp: 2026-07-02T05:03:56Z`.
- Warm reset restore initially hit one invalid/corrupt read, then succeeded via retry before BLE sync:
  `PCF85063: restored system time from RTC: 2026-07-02T05:03:56Z`.
- Heartbeat after restore showed `rtc[present=1 valid=1 source=rtc ...]`.

## Tests
- `git diff --check`
- `PLATFORMIO_CORE_DIR=/tmp/esp32-bike-pio-core-314 /tmp/esp32-bike-pio-314/bin/pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodem2101`
- connected-device BLE sync and warm-reset restore captures
