### PR TITLE
Add Waveshare 2.06 firmware support

### DIFF
--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -87,7 +87,7 @@ and a 3.7 V lithium battery header.
 | QSPI D3 / `LCD_SDIO3` / `QSPI_SI3` | GPIO 7 | Vendor `pin_config.h` |
 | Reset / `LCD_RESET` | GPIO 8 | Direct GPIO reset; differs from 1.75" GPIO39 |
 | TE / `LCD_TE` | GPIO 13 | Schematic net; not required by HelloWorld |
-| Panel power enable / `DSI_PWR_EN` | GPIO 39 | Schematic net; needs app integration testing |
+| Panel power enable / `DSI_PWR_EN` | GPIO 39 | Schematic net; current Arduino_GFX app path works without driving it directly |
 
 Vendor Arduino constructor baseline:
 
@@ -105,17 +105,18 @@ constructor gap `(22,0,0,0)`, rotation `0`.
 Connected-device display findings on 2026-07-02:
 - The board enumerated as ESP32-S3 USB CDC/JTAG on `/dev/cu.usbmodem2101`
   with VID:PID `303A:1001`.
-- A full app-linked display probe booted and wrote fills but the display stayed
-  black, even after preserving the AXP rails and forcing the suspected display
-  enable bit.
 - A standalone vendor-shaped HelloWorld test using registry Arduino_GFX `1.6.6`
   reported `gfx->begin() ok` and wrote continuous color fills.
 - A second standalone test using Waveshare's bundled Arduino_GFX `1.6.0`
   also reported `gfx->begin() ok`; after full USB/battery power removal and
   USB-only replug, the physical display visibly cycled colors.
-- Therefore the 2.06 panel, QSPI pinout, reset pin, and baseline Arduino_GFX
-  constructor are confirmed. The remaining black-screen issue is in this repo's
-  app integration path, not in the hardware baseline.
+- The full app-linked display probe now visibly cycles white/red/green/blue
+  after matching the vendor init order: bring up CO5300 display first, then
+  configure the shared I2C/PMU stack.
+- The full bike firmware boots on 2.06, initializes LVGL, advertises BLE,
+  connects to the iPhone app, renders the SD-card map, and supports map drag.
+- Therefore the 2.06 panel, QSPI pinout, reset pin, baseline Arduino_GFX
+  constructor, and current repo app integration path are confirmed.
 
 ### Touch (FT3168)
 
@@ -131,6 +132,13 @@ The vendor Arduino LVGL examples use `Arduino_DriveBus` and construct
 `Arduino_FT3x68` at `FT3168_DEVICE_ADDRESS`; our firmware should treat this as
 an FT3168/FT3x68 family I2C touch controller rather than CST9217.
 
+Connected-device touch findings:
+- Direct GPIO9 reset and FT3168 I2C address `0x38` are confirmed.
+- Idle FT3168 reads can produce Arduino Core 3.x I2C invalid-state errors.
+  The app path gates normal reads on the GPIO38 touch interrupt and observed
+  `i2c[fail=0 recover=0]` over idle serial captures.
+- Map dragging works in the full bike firmware on the 2.06 board.
+
 ### SD Card
 
 | Signal | GPIO | Notes |
@@ -143,6 +151,12 @@ an FT3168/FT3x68 family I2C touch controller rather than CST9217.
 The vendor macro names look SDMMC-like, but the published Arduino examples use
 these as explicit card pins and the schematic labels the nets `MOSI`, `MISO`,
 `SCK`, and `SDCS`.
+
+Connected-device SD findings:
+- The full bike firmware reads the SD card on `CS=17, MOSI=1, MISO=3, SCK=2`
+  and renders the offline map on the 2.06 board.
+- Keep the SD bus isolated on HSPI, as on the 1.75 board, because the display
+  uses its own QSPI bus.
 
 ### RTC And IMU
 
@@ -214,13 +228,13 @@ card, and factory firmware.
 | Feature | Status | Notes |
 |---|---|---|
 | Standalone display baseline | Verified | Vendor-shaped HelloWorld and color-cycle tests work after full power removal/replug |
-| App display integration | In progress | App-linked probe writes fills but can leave panel black; isolate differences from standalone baseline |
-| Touch | Pinout/address known | FT3168 pins known; expected address `0x38`; app behavior still needs connected-device validation |
-| SD Card | Pinout known | CS differs from 1.75"; card mount/read still needs device validation |
-| RTC | Pinout/address known | PCF85063 expected at `0x51`; retention behavior needs board/battery validation |
-| IMU | Pinout/address known | QMI8658 expected at `0x6B`; axis/sign tests need validation on 2.06 |
+| App display integration | Verified | Full app boots after display-first init, BLE advertises/connects, LVGL flushes normally |
+| Touch | Verified | FT3168 direct reset/address confirmed; map dragging works; idle reads are interrupt-gated |
+| SD Card | Verified | SD map renders from `CS=17, MOSI=1, MISO=3, SCK=2` |
+| RTC | Partially verified | PCF85063 found at `0x51`; retention behavior still needs battery-backed power-removal validation |
+| IMU | Partially verified | QMI8658 found at `0x6B` and reports motion; axis/sign tests still need validation on 2.06 |
 | Audio | Vendor demo exists | ES8311/ES7210/I2S pins known; repo audio support not implemented |
-| Power / Battery | PMU present | AXP2101 status readable; exact display/panel power integration still under investigation |
+| Power / Battery | Partially verified | AXP2101 status readable; current app preserves rails during boot; deeper sleep/rail shutdown still needs testing |
 
 ## 2.06 Bring-up Rules
 

--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -1,14 +1,246 @@
-# Waveshare ESP32-S3 Touch AMOLED 1.75" Hardware Reference
+# Waveshare ESP32-S3 Touch AMOLED Hardware Reference
 
-This document contains the definitive hardware pinout for the Waveshare ESP32-S3-Touch-AMOLED-1.75 board, extracted directly from the official schematic.
+This document contains hardware pinouts and bring-up notes for the Waveshare
+ESP32-S3 Touch AMOLED boards supported by this repo.
+
+The 1.75" notes are the most thoroughly app-verified path and were extracted
+from the official schematic. The 2.06" notes combine Waveshare's public
+product/wiki pages, GitHub demo source, downloadable schematic/datasheets, and
+the first connected-device bring-up tests on Chris's Mac.
 
 Official links:
 - https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262
 - https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75
+- https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm
+- https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-2.06
+- https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-2.06
 
 ---
 
-## Core Components
+# ESP32-S3-Touch-AMOLED-2.06 Hardware Reference
+
+## Source Links And Downloadable References
+
+Primary product and project pages:
+- Product page: https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm
+- Wiki: https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-2.06
+- GitHub demo repository: https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-2.06
+
+Linked PDFs and component references from the Waveshare wiki:
+- Schematic: https://files.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-2.06/ESP32-S3-Touch-AMOLED-2.06.pdf
+- Dimensional drawing: https://files.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-2.06/Esp32-s3-touch-amoled-2_06_dimensions.pdf
+- ESP32-S3 datasheet: https://files.waveshare.com/wiki/common/Esp32-s3_datasheet_en.pdf
+- ESP32-S3 technical reference manual: https://files.waveshare.com/wiki/common/esp32-s3_technical_reference_manual_en.pdf
+- QMI8658C datasheet: https://files.waveshare.com/wiki/common/QMI8658C.pdf
+- PCF85063A datasheet: https://files.waveshare.com/wiki/common/PCF85063A.pdf
+- AXP2101 datasheet: https://files.waveshare.com/wiki/common/X-power-AXP2101_SWcharge_V1.0.pdf
+- ES8311 datasheet: https://files.waveshare.com/wiki/common/ES8311.DS.pdf
+- ES8311 user guide: https://files.waveshare.com/wiki/common/ES8311%20User%20Guide.pdf
+- FT3168 datasheet: https://files.waveshare.com/wiki/common/FT3168.pdf
+- ES7210 datasheet: https://files.waveshare.com/wiki/common/ES7210-datasheet.pdf
+
+Local reference clone used during bring-up:
+- `/tmp/waveshare-amoled-206`
+- Schematic PDF: `/tmp/waveshare-amoled-206/Schematic/ESP32-S3-Touch-AMOLED-2.06-Schematic-V1.0.pdf`
+- Arduino pin macros: `/tmp/waveshare-amoled-206/examples/Arduino-v3.2.0/libraries/Mylibrary/pin_config.h`
+- Display smoke test: `/tmp/waveshare-amoled-206/examples/Arduino-v3.2.0/examples/01_HelloWorld/01_HelloWorld.ino`
+
+## 2.06 Core Components
+
+| Component | IC / Part | Bus | Address / Notes |
+|---|---|---|---|
+| MCU | ESP32-S3R8 | internal | Dual-core LX7 up to 240 MHz; 8 MB PSRAM; external 32 MB flash |
+| Display Driver | CO5300 | QSPI | 2.06" AMOLED, 410x502, 16.7M colors |
+| Touch Controller | FT3168 | I2C | Vendor `FT3168_DEVICE_ADDRESS` is `0x38`; docs describe 10 kHz-400 kHz I2C support |
+| Power Management | AXP2101 | I2C | PMU, charging, battery management, multiple output rails |
+| RTC | PCF85063ATL | I2C | Address `0x51`; RTC rail is powered through AXP2101/battery path |
+| IMU | QMI8658C | I2C | Schematic ties SDO/SAO low, so expected address is `0x6B` |
+| Audio Codec | ES8311 | I2C/I2S | Audio codec used by vendor `08_ES8311` demo |
+| Audio ADC / Mic Front End | ES7210 | I2S/TDM | Product page advertises dual digital microphone array; schematic includes ES7210 |
+| SD Card Slot | TF / microSD | SPI-style pins | Vendor pin macros use `CLK=2`, `CMD/MOSI=1`, `DATA/MISO=3`, `CS=17` |
+| Battery Header | MX1.25 3.7 V LiPo | PMU | Product page has battery-included and no-battery variants |
+| Buttons | PWR, BOOT | GPIO / PMU | BOOT is GPIO0; PWR drives PMU power key path |
+
+Waveshare documents this as a watch-shaped development board for wearable
+prototyping. The product page and wiki both describe onboard Wi-Fi/BLE 5, a
+Type-C connector, reserved I2C/UART/USB pads, TF card, IMU, RTC, audio, PMU,
+and a 3.7 V lithium battery header.
+
+## 2.06 Pin Assignments
+
+### Shared I2C Bus
+
+| Signal | GPIO | Devices |
+|---|---:|---|
+| SDA | GPIO 15 | AXP2101, FT3168, PCF85063, QMI8658, ES8311/ES7210 control |
+| SCL | GPIO 14 | AXP2101, FT3168, PCF85063, QMI8658, ES8311/ES7210 control |
+
+### Display (CO5300 QSPI AMOLED)
+
+| Signal | GPIO | Source / Notes |
+|---|---:|---|
+| QSPI CS / `LCD_CS` | GPIO 12 | Vendor `pin_config.h` and schematic |
+| QSPI CLK / `LCD_SCLK` | GPIO 11 | Differs from 1.75" GPIO38 |
+| QSPI D0 / `LCD_SDIO0` / `QSPI_SIO0` | GPIO 4 | Vendor `pin_config.h` |
+| QSPI D1 / `LCD_SDIO1` / `QSPI_SI1` | GPIO 5 | Vendor `pin_config.h` |
+| QSPI D2 / `LCD_SDIO2` / `QSPI_SI2` | GPIO 6 | Vendor `pin_config.h` |
+| QSPI D3 / `LCD_SDIO3` / `QSPI_SI3` | GPIO 7 | Vendor `pin_config.h` |
+| Reset / `LCD_RESET` | GPIO 8 | Direct GPIO reset; differs from 1.75" GPIO39 |
+| TE / `LCD_TE` | GPIO 13 | Schematic net; not required by HelloWorld |
+| Panel power enable / `DSI_PWR_EN` | GPIO 39 | Schematic net; needs app integration testing |
+
+Vendor Arduino constructor baseline:
+
+```cpp
+Arduino_DataBus *bus = new Arduino_ESP32QSPI(
+  LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
+
+Arduino_GFX *gfx = new Arduino_CO5300(
+  bus, LCD_RESET, 0, LCD_WIDTH, LCD_HEIGHT, 22, 0, 0, 0);
+```
+
+The known-good dimensions and gap are `LCD_WIDTH=410`, `LCD_HEIGHT=502`,
+constructor gap `(22,0,0,0)`, rotation `0`.
+
+Connected-device display findings on 2026-07-02:
+- The board enumerated as ESP32-S3 USB CDC/JTAG on `/dev/cu.usbmodem2101`
+  with VID:PID `303A:1001`.
+- A full app-linked display probe booted and wrote fills but the display stayed
+  black, even after preserving the AXP rails and forcing the suspected display
+  enable bit.
+- A standalone vendor-shaped HelloWorld test using registry Arduino_GFX `1.6.6`
+  reported `gfx->begin() ok` and wrote continuous color fills.
+- A second standalone test using Waveshare's bundled Arduino_GFX `1.6.0`
+  also reported `gfx->begin() ok`; after full USB/battery power removal and
+  USB-only replug, the physical display visibly cycled colors.
+- Therefore the 2.06 panel, QSPI pinout, reset pin, and baseline Arduino_GFX
+  constructor are confirmed. The remaining black-screen issue is in this repo's
+  app integration path, not in the hardware baseline.
+
+### Touch (FT3168)
+
+| Signal / Field | GPIO / Value | Notes |
+|---|---:|---|
+| I2C SDA | GPIO 15 | Shared I2C bus |
+| I2C SCL | GPIO 14 | Shared I2C bus |
+| I2C address | `0x38` | Vendor `Arduino_DriveBus` constant |
+| INT / `TP_INT` | GPIO 38 | Direct interrupt GPIO |
+| RST / `TP_RESET` | GPIO 9 | Direct reset GPIO; no TCA9554 on 2.06 path |
+
+The vendor Arduino LVGL examples use `Arduino_DriveBus` and construct
+`Arduino_FT3x68` at `FT3168_DEVICE_ADDRESS`; our firmware should treat this as
+an FT3168/FT3x68 family I2C touch controller rather than CST9217.
+
+### SD Card
+
+| Signal | GPIO | Notes |
+|---|---:|---|
+| CS / `SDMMC_CS` / `SDCS` | GPIO 17 | Differs from 1.75" GPIO41 |
+| MOSI / `SDMMC_CMD` | GPIO 1 | Vendor macro calls this `SDMMC_CMD` |
+| MISO / `SDMMC_DATA` | GPIO 3 | Vendor macro calls this `SDMMC_DATA` |
+| SCK / `SDMMC_CLK` | GPIO 2 | Shared numbering with 1.75" SCK |
+
+The vendor macro names look SDMMC-like, but the published Arduino examples use
+these as explicit card pins and the schematic labels the nets `MOSI`, `MISO`,
+`SCK`, and `SDCS`.
+
+### RTC And IMU
+
+| Device | Signal | GPIO / Address | Notes |
+|---|---|---:|---|
+| PCF85063ATL | I2C SDA/SCL | GPIO15/GPIO14 | Expected address `0x51` |
+| PCF85063ATL | `RTC_INT` | GPIO21 | Schematic net; app does not currently use this IRQ |
+| QMI8658C | I2C SDA/SCL | GPIO15/GPIO14 | Schematic SDO/SAO low; expected address `0x6B` |
+| QMI8658C | `QMI_INT1` | GPIO18 | Schematic interrupt net |
+| QMI8658C | `QMI_INT2` | not routed for current firmware | Appears as test-point/internal schematic net |
+
+### Audio
+
+| Signal / Function | GPIO / Device | Notes |
+|---|---:|---|
+| I2S MCLK | GPIO 41 | Vendor `08_ES8311` passes this as first `i2s.setPins()` arg |
+| I2S SCLK / BCLK | GPIO 45 | Vendor `08_ES8311` |
+| I2S LRCK / WS | GPIO 40 | Vendor `08_ES8311` |
+| I2S ASDOUT / speaker data out | GPIO 42 | Vendor `08_ES8311` |
+| I2S DSDIN / mic data in | GPIO 16 | Vendor `08_ES8311` |
+| PA control | GPIO 46 | Vendor `08_ES8311` drives this high before codec init |
+| Codec | ES8311 | I2C control plus I2S audio |
+| Mic ADC/front-end | ES7210 | Schematic and product page; not yet brought up here |
+
+Audio is still a separate bring-up track for this repo. Note that GPIO41 is an
+audio MCLK pin on 2.06, while GPIO41 was SD CS on 1.75.
+
+### Buttons, External Pads, And Power
+
+| Function | GPIO / Net | Notes |
+|---|---:|---|
+| BOOT | GPIO0 | Standard ESP32-S3 boot strap / user button |
+| PWR | PMU `PWRON` path | Side power key; not the same behavior as BOOT |
+| UART | U0TXD/U0RXD | Exposed as reserved UART pads per product page/schematic |
+| USB | USB_P/USB_N and reserved USB pads | Type-C connector plus pads |
+| I2C pads | GPIO15/GPIO14 | Shared with onboard devices |
+| Motor | `MOTOR` schematic net | Present in schematic; not implemented |
+| Battery | 3.7 V MX1.25 LiPo header | Product page offers battery-included and battery-not-included variants |
+
+## 2.06 Software Baseline
+
+Waveshare's Arduino wiki path requires Espressif Arduino core `>=3.2.0`.
+The wiki library table names:
+- GFX Library for Arduino `1.6.0`
+- LVGL `9.3.0`
+- SensorLib `0.3.1`
+- XPowersLib `0.2.6` in the wiki table, while the cloned repo currently
+  contains XPowersLib `0.3.0`
+- Arduino_DriveBus for touch
+- `Mylibrary/pin_config.h` for board pin macros
+
+Waveshare's Arduino demos:
+- `01_HelloWorld`: CO5300 display/GFX smoke test; this is the known-good panel
+  baseline we flashed successfully.
+- `02_GFX_AsciiTable`: display character table.
+- `03_LVGL_PCF85063_simpleTime`: RTC with LVGL.
+- `04_LVGL_QMI8658_ui`: IMU line chart.
+- `05_LVGL_AXP2101_ADC_Data`: PMU/ADC status.
+- `06_LVGL_Arduino_v9`: LVGL plus touch through Arduino_DriveBus.
+- `07_LVGL_SD_Test`: TF card file listing/display.
+- `08_ES8311`: ES8311 audio echo/playback.
+
+Waveshare's ESP-IDF demos include AXP2101, LVGL, esp-brookesia, an IMU
+immersive block demo, microphone spectrum analyzer, video playback from TF
+card, and factory firmware.
+
+## 2.06 Current Repo Status
+
+| Feature | Status | Notes |
+|---|---|---|
+| Standalone display baseline | Verified | Vendor-shaped HelloWorld and color-cycle tests work after full power removal/replug |
+| App display integration | In progress | App-linked probe writes fills but can leave panel black; isolate differences from standalone baseline |
+| Touch | Pinout/address known | FT3168 pins known; expected address `0x38`; app behavior still needs connected-device validation |
+| SD Card | Pinout known | CS differs from 1.75"; card mount/read still needs device validation |
+| RTC | Pinout/address known | PCF85063 expected at `0x51`; retention behavior needs board/battery validation |
+| IMU | Pinout/address known | QMI8658 expected at `0x6B`; axis/sign tests need validation on 2.06 |
+| Audio | Vendor demo exists | ES8311/ES7210/I2S pins known; repo audio support not implemented |
+| Power / Battery | PMU present | AXP2101 status readable; exact display/panel power integration still under investigation |
+
+## 2.06 Bring-up Rules
+
+- Keep `WAVESHARE_AMOLED_206` separate from `WAVESHARE_AMOLED_175`; the boards
+  are not pin-compatible.
+- Do not copy the 1.75" TCA9554/CST9217 reset path to the 2.06. Touch reset is
+  direct GPIO9.
+- Do not copy 1.75" display CLK/RST pins. 2.06 uses CLK GPIO11 and reset GPIO8.
+- Do not use 1.75" SD CS GPIO41. 2.06 SD CS is GPIO17; GPIO41 is audio MCLK.
+- If the display is black, first flash the standalone vendor-shaped HelloWorld
+  or color-cycle test before debugging app code. The verified baseline is
+  CO5300 `410x502`, gap `(22,0,0,0)`, rotation `0`, QSPI pins
+  `CS=12, SCLK=11, D0=4, D1=5, D2=6, D3=7`, reset `8`.
+- A full USB and battery power removal can matter after failed experiments; the
+  verified standalone display test became visible after power removal and
+  USB-only replug.
+
+---
+
+## ESP32-S3-Touch-AMOLED-1.75 Core Components
 
 | Component | IC | Bus | Address / Notes |
 |---|---|---|---|
@@ -23,7 +255,7 @@ Official links:
 
 ---
 
-## Pin Assignments
+## ESP32-S3-Touch-AMOLED-1.75 Pin Assignments
 
 ### I2C Bus (Shared by AXP2101, CST9217, TCA9554, RTC, IMU)
 

--- a/WAVESHARE_HARDWARE.md
+++ b/WAVESHARE_HARDWARE.md
@@ -229,6 +229,7 @@ card, and factory firmware.
 |---|---|---|
 | Standalone display baseline | Verified | Vendor-shaped HelloWorld and color-cycle tests work after full power removal/replug |
 | App display integration | Verified | Full app boots after display-first init, BLE advertises/connects, LVGL flushes normally |
+| Panel-specific UI | Implemented | 2.06 keeps the shared map path but uses board-specific GUI geometry and a lower map anchor to show more route ahead on the taller panel |
 | Touch | Verified | FT3168 direct reset/address confirmed; map dragging works; idle reads are interrupt-gated |
 | SD Card | Verified | SD map renders from `CS=17, MOSI=1, MISO=3, SCK=2` |
 | RTC | Partially verified | PCF85063 found at `0x51`; retention behavior still needs battery-backed power-removal validation |

--- a/esp32/include/hal.hpp
+++ b/esp32/include/hal.hpp
@@ -174,10 +174,10 @@ extern const uint8_t SD_CLK = GPIO_NUM_12;
 constexpr bool TFT_INVERT = true;
 
 /**
- * @brief WAVESHARE ESP32-S3 1.75 AMOLED pin definition
- * Corrected from official schematic. See WAVESHARE_HARDWARE.md.
+ * @brief WAVESHARE ESP32-S3 AMOLED pin definitions.
+ * Corrected from official Waveshare schematics/examples.
  */
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 // I2C Bus (Shared by AXP2101, CST9217, TCA9554, RTC, IMU)
 #define I2C_SDA_PIN GPIO_NUM_15
 #define I2C_SCL_PIN GPIO_NUM_14
@@ -190,25 +190,39 @@ constexpr uint8_t BOARD_BOOT_PIN = GPIO_NUM_0;
 
 // Display Pins (CO5300 QSPI Driver)
 constexpr uint8_t TFT_QSPI_CS = GPIO_NUM_12;
+#ifdef WAVESHARE_AMOLED_206
+constexpr uint8_t TFT_QSPI_CLK = GPIO_NUM_11;
+constexpr uint8_t TFT_QSPI_RST = GPIO_NUM_8;
+#else
 constexpr uint8_t TFT_QSPI_CLK = GPIO_NUM_38;
+constexpr uint8_t TFT_QSPI_RST = GPIO_NUM_39;
+#endif
 constexpr uint8_t TFT_QSPI_D0 = GPIO_NUM_4;
 constexpr uint8_t TFT_QSPI_D1 = GPIO_NUM_5;
 constexpr uint8_t TFT_QSPI_D2 = GPIO_NUM_6;
 constexpr uint8_t TFT_QSPI_D3 = GPIO_NUM_7;
-constexpr uint8_t TFT_QSPI_RST = GPIO_NUM_39;
 
-// Touch Pins (CST9217 on shared I2C bus)
+// Touch Pins on shared I2C bus.
 constexpr uint8_t TCH_I2C_SDA = GPIO_NUM_15;
 constexpr uint8_t TCH_I2C_SCL = GPIO_NUM_14; // Same as main I2C bus
+#ifdef WAVESHARE_AMOLED_206
+constexpr uint8_t TCH_I2C_INT = GPIO_NUM_38;
+constexpr uint8_t TCH_I2C_RST = GPIO_NUM_9;
+constexpr uint8_t TCH_I2C_ADDR = 0x38; // FT3168 Address
+#else
 constexpr uint8_t TCH_I2C_INT = GPIO_NUM_21;
 // NOTE: Touch Reset is controlled by TCA9554 I/O Expander (0x20), NOT a GPIO!
 // Do NOT use GPIO 20 - it is USB D+ and will break serial monitor.
 constexpr uint8_t TCH_I2C_ADDR = 0x5A; // CST9217 Address (verified)
+#endif
 
-// SD Card (SPI) - verified from schematic
-// NO CONFLICT with Touch - completely separate pins
+// SD Card (SPI) - verified from Waveshare schematics/examples.
+#ifdef WAVESHARE_AMOLED_206
+constexpr uint8_t SD_CS = GPIO_NUM_17;
+#else
 constexpr uint8_t SD_CS = GPIO_NUM_41;
+#endif
 constexpr uint8_t SD_MOSI = GPIO_NUM_1;
 constexpr uint8_t SD_MISO = GPIO_NUM_3;
 constexpr uint8_t SD_CLK = GPIO_NUM_2;
-#endif
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -9,7 +9,7 @@
 #include "../gps/gps.hpp"
 #include "../gui/src/waitingScr.hpp"
 #include "../route_overlay/route_overlay.hpp"
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "../waveshare_board/display.hpp"
 #include "../waveshare_board/pcf85063.hpp"
 #endif
@@ -52,7 +52,7 @@ static bool unauthTimeoutDisconnectRequested = false;
 // Route geometry debouncing - skip redundant parses
 static uint32_t lastRouteHash = 0;
 static size_t lastRouteLen = 0;
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 static uint32_t lastBleRtcSyncMs = 0;
 constexpr uint32_t BLE_RTC_SYNC_INTERVAL_MS = 10UL * 60UL * 1000UL;
 #endif
@@ -149,7 +149,7 @@ static void initBleIdentityAndSecurity(const char *deviceName) {
 
 static uint8_t sanitizeMapDisplayRotation(uint8_t requestedRotation,
                                           const char *source) {
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   if (requestedRotation > waveshare_board::display::MAX_SUPPORTED_ROTATION) {
     Serial.printf("BLE Settings: %s displayRotation %u unsupported, clamping "
                   "to 0\n",
@@ -436,7 +436,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
     gps.gpsData.heading = headingVal;
   }
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   bool rtcTimestampSynced = false;
   if (len >= 14) {
     uint32_t unixTime = 0;
@@ -460,7 +460,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
       "BLE: %s GPS position received: lat=%ld lon=%ld heading=%u rtcSync=%d\n",
       source == nullptr ? "unknown" : source, (long)lat, (long)lon,
       (unsigned)gps.gpsData.heading,
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
       rtcTimestampSynced
 #else
       0

--- a/esp32/lib/gui/src/guiLayout.hpp
+++ b/esp32/lib/gui/src/guiLayout.hpp
@@ -17,6 +17,7 @@ constexpr uint8_t MAP_TOOLBAR_OFFSET = 92;
 constexpr uint8_t MAP_TOOLBAR_SPACE = 54;
 constexpr uint8_t MAP_TOOLBAR_INSET = 12;
 constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 30;
+constexpr int8_t MAP_DRAG_DELTA_SIGN = -1;
 #elif defined(LARGE_SCREEN)
 constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 100;
 constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
@@ -25,6 +26,7 @@ constexpr uint8_t MAP_TOOLBAR_OFFSET = 100;
 constexpr uint8_t MAP_TOOLBAR_SPACE = 60;
 constexpr uint8_t MAP_TOOLBAR_INSET = 10;
 constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 24;
+constexpr int8_t MAP_DRAG_DELTA_SIGN = 1;
 #else
 constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 100;
 constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
@@ -33,6 +35,7 @@ constexpr uint8_t MAP_TOOLBAR_OFFSET = 80;
 constexpr uint8_t MAP_TOOLBAR_SPACE = 50;
 constexpr uint8_t MAP_TOOLBAR_INSET = 10;
 constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 24;
+constexpr int8_t MAP_DRAG_DELTA_SIGN = 1;
 #endif
 
 inline uint16_t mapViewportHeight(uint16_t screenHeight) {
@@ -48,6 +51,10 @@ inline int16_t mapAnchorX(uint16_t width) {
 
 inline int16_t mapAnchorY(uint16_t height) {
   return (height * MAP_ANCHOR_Y_PERCENT) / 100;
+}
+
+inline int16_t mapDragDelta(int16_t delta) {
+  return delta * MAP_DRAG_DELTA_SIGN;
 }
 
 } // namespace gui_layout

--- a/esp32/lib/gui/src/guiLayout.hpp
+++ b/esp32/lib/gui/src/guiLayout.hpp
@@ -1,0 +1,53 @@
+/**
+ * @file guiLayout.hpp
+ * @brief Board-specific GUI geometry that keeps shared UI code portable.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+namespace gui_layout {
+
+#if defined(WAVESHARE_AMOLED_206)
+constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 72;
+constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
+constexpr uint8_t MAP_ANCHOR_Y_PERCENT = 58;
+constexpr uint8_t MAP_TOOLBAR_OFFSET = 92;
+constexpr uint8_t MAP_TOOLBAR_SPACE = 54;
+constexpr uint8_t MAP_TOOLBAR_INSET = 12;
+constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 30;
+#elif defined(LARGE_SCREEN)
+constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 100;
+constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
+constexpr uint8_t MAP_ANCHOR_Y_PERCENT = 50;
+constexpr uint8_t MAP_TOOLBAR_OFFSET = 100;
+constexpr uint8_t MAP_TOOLBAR_SPACE = 60;
+constexpr uint8_t MAP_TOOLBAR_INSET = 10;
+constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 24;
+#else
+constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 100;
+constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
+constexpr uint8_t MAP_ANCHOR_Y_PERCENT = 50;
+constexpr uint8_t MAP_TOOLBAR_OFFSET = 80;
+constexpr uint8_t MAP_TOOLBAR_SPACE = 50;
+constexpr uint8_t MAP_TOOLBAR_INSET = 10;
+constexpr uint8_t MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN = 24;
+#endif
+
+inline uint16_t mapViewportHeight(uint16_t screenHeight) {
+  if (screenHeight <= MAP_NONFULLSCREEN_RESERVED_HEIGHT) {
+    return screenHeight;
+  }
+  return screenHeight - MAP_NONFULLSCREEN_RESERVED_HEIGHT;
+}
+
+inline int16_t mapAnchorX(uint16_t width) {
+  return (width * MAP_ANCHOR_X_PERCENT) / 100;
+}
+
+inline int16_t mapAnchorY(uint16_t height) {
+  return (height * MAP_ANCHOR_Y_PERCENT) / 100;
+}
+
+} // namespace gui_layout

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -514,8 +514,8 @@ void scrollMapEvent(lv_event_t *event) {
       if (abs(dx) > SCROLL_THRESHOLD || abs(dy) > SCROLL_THRESHOLD) {
         log_i("PRESSING: p(%d,%d) last(%d,%d) -> dx=%d dy=%d", p.x, p.y, last_x,
               last_y, dx, dy);
-        pendingDx += dx;
-        pendingDy += dy;
+        pendingDx += gui_layout::mapDragDelta(dx);
+        pendingDy += gui_layout::mapDragDelta(dy);
         last_x = p.x;
         last_y = p.y;
         pressStartTime = 0;
@@ -535,8 +535,8 @@ void scrollMapEvent(lv_event_t *event) {
         const int SCROLL_THRESHOLD = 5;
         if (abs(dx) <= MAX_JUMP && abs(dy) <= MAX_JUMP &&
             (abs(dx) > SCROLL_THRESHOLD || abs(dy) > SCROLL_THRESHOLD)) {
-          pendingDx += dx;
-          pendingDy += dy;
+          pendingDx += gui_layout::mapDragDelta(dx);
+          pendingDy += gui_layout::mapDragDelta(dy);
         }
         flushDragMovement(true);
       }

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -8,6 +8,7 @@
 
 #include "mainScr.hpp"
 #include "../../ble_navigation/ble_navigation.hpp" // Access mapRenderSettings
+#include "guiLayout.hpp"
 // #include "../../compass/compass.hpp"
 
 bool isMainScreen = false; // Flag to indicate main screen is selected
@@ -26,14 +27,20 @@ extern Compass compass;
 extern Gps gps;
 extern wayPoint loadWpt;
 
-#ifdef LARGE_SCREEN
-uint8_t toolBarOffset = 100;
-uint8_t toolBarSpace = 60;
-#endif
-#ifndef LARGE_SCREEN
-uint8_t toolBarOffset = 80;
-uint8_t toolBarSpace = 50;
-#endif
+uint8_t toolBarOffset = gui_layout::MAP_TOOLBAR_OFFSET;
+uint8_t toolBarSpace = gui_layout::MAP_TOOLBAR_SPACE;
+
+static void positionMapToolbarButtons(uint16_t mapHeight) {
+  if (!btnFullScreen || !btnZoomOut || !btnZoomIn) {
+    return;
+  }
+
+  const uint8_t inset = gui_layout::MAP_TOOLBAR_INSET;
+  lv_obj_set_pos(btnFullScreen, inset, mapHeight - toolBarOffset);
+  lv_obj_set_pos(btnZoomOut, inset, mapHeight - (toolBarOffset + toolBarSpace));
+  lv_obj_set_pos(btnZoomIn, inset,
+                 mapHeight - (toolBarOffset + (2 * toolBarSpace)));
+}
 
 lv_obj_t *tilesScreen;
 lv_obj_t *compassTile;
@@ -45,6 +52,16 @@ lv_obj_t *btnZoomIn;
 lv_obj_t *btnZoomOut;
 
 Maps mapView;
+
+static int16_t mapInteractionAnchorX() {
+  return gui_layout::mapAnchorX(mapView.mapScrWidth);
+}
+
+static int16_t mapInteractionAnchorY() {
+  const uint16_t mapHeight =
+      mapSet.mapFullScreen ? mapView.mapScrFull : mapView.mapScrHeight;
+  return gui_layout::mapAnchorY(mapHeight);
+}
 
 /**
  * @brief Trigger map redraw (called by BLE when route geometry is received)
@@ -359,19 +376,10 @@ void mapToolBarEvent(lv_event_t *event) {
   canScrollMap = !canScrollMap;
 
   if (!mapSet.mapFullScreen) {
-    lv_obj_set_pos(btnFullScreen, 10, mapView.mapScrHeight - toolBarOffset);
-    lv_obj_set_pos(btnZoomOut, 10,
-                   mapView.mapScrHeight - (toolBarOffset + toolBarSpace));
-    lv_obj_set_pos(btnZoomIn, 10,
-                   mapView.mapScrHeight - (toolBarOffset + (2 * toolBarSpace)));
+    positionMapToolbarButtons(mapView.mapScrHeight);
   } else {
-    lv_obj_set_pos(btnFullScreen, 10,
-                   mapView.mapScrFull - (toolBarOffset + 24));
-    lv_obj_set_pos(btnZoomOut, 10,
-                   mapView.mapScrFull - (toolBarOffset + toolBarSpace + 24));
-    lv_obj_set_pos(btnZoomIn, 10,
-                   mapView.mapScrFull -
-                       (toolBarOffset + (2 * toolBarSpace) + 24));
+    positionMapToolbarButtons(
+        mapView.mapScrFull - gui_layout::MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN);
   }
 
   if (!showMapToolBar) {
@@ -539,11 +547,12 @@ void scrollMapEvent(lv_event_t *event) {
           millis() - pressStartTime < 300) {
         int totalMove = abs(p.x - pressStartX) + abs(p.y - pressStartY);
         if (totalMove < 30) {
-          // GPS indicator is always at center when followGps is true
+          // GPS indicator is at the board-specific map anchor when followGps
+          // is true.
           // When followGps is false, it could be anywhere - use center area
           // anyway since user expects to tap the center indicator
-          int centerX = mapView.mapScrWidth / 2;
-          int centerY = mapView.mapScrHeight / 2;
+          int centerX = mapInteractionAnchorX();
+          int centerY = mapInteractionAnchorY();
           int distX = abs(p.x - centerX);
           int distY = abs(p.y - centerY);
           log_i("SHORT TAP CHECK: pos(%d,%d) center(%d,%d) dist(%d,%d)", p.x,
@@ -583,11 +592,7 @@ void fullScreenEvent(lv_event_t *event) {
   mapSet.mapFullScreen = !mapSet.mapFullScreen;
 
   if (!mapSet.mapFullScreen) {
-    lv_obj_set_pos(btnFullScreen, 10, mapView.mapScrHeight - toolBarOffset);
-    lv_obj_set_pos(btnZoomOut, 10,
-                   mapView.mapScrHeight - (toolBarOffset + toolBarSpace));
-    lv_obj_set_pos(btnZoomIn, 10,
-                   mapView.mapScrHeight - (toolBarOffset + (2 * toolBarSpace)));
+    positionMapToolbarButtons(mapView.mapScrHeight);
 
     if (isBarOpen)
       lv_obj_clear_flag(buttonBar, LV_OBJ_FLAG_HIDDEN);
@@ -598,13 +603,8 @@ void fullScreenEvent(lv_event_t *event) {
     lv_obj_clear_flag(notifyBarHour, LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(notifyBarIcons, LV_OBJ_FLAG_HIDDEN);
   } else {
-    lv_obj_set_pos(btnFullScreen, 10,
-                   mapView.mapScrFull - (toolBarOffset + 24));
-    lv_obj_set_pos(btnZoomOut, 10,
-                   mapView.mapScrFull - (toolBarOffset + toolBarSpace + 24));
-    lv_obj_set_pos(btnZoomIn, 10,
-                   mapView.mapScrFull -
-                       (toolBarOffset + (2 * toolBarSpace) + 24));
+    positionMapToolbarButtons(
+        mapView.mapScrFull - gui_layout::MAP_TOOLBAR_FULLSCREEN_BOTTOM_MARGIN);
     lv_obj_add_flag(buttonBar, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(menuBtn, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(notifyBarHour, LV_OBJ_FLAG_HIDDEN);

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -8,6 +8,7 @@
  */
 
 #include "maps.hpp"
+#include "../../gui/src/guiLayout.hpp"
 // #include "../../compass/compass.hpp"
 extern Gps gps;
 // extern Storage storage;
@@ -80,6 +81,14 @@ static inline bool isTypeVisible(uint8_t typeId,
 static void *bufMapTemp = nullptr;
 static void *bufMapIcon = nullptr;
 static void *bufArrow = nullptr;
+
+static int16_t mapAnchorXForWidth(uint16_t width) {
+  return gui_layout::mapAnchorX(width);
+}
+
+static int16_t mapAnchorYForHeight(uint16_t height) {
+  return gui_layout::mapAnchorY(height);
+}
 
 extern Point16::Point16(char *coordsPair) {
   char *next;
@@ -1086,11 +1095,16 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   double cosA = cos(rotation);
   double sinA = sin(rotation);
 
-  // BUGFIX: Use actual canvas dimensions, not mapScrHeight which may differ
-  // from canvas height in fullscreen mode
+  // Use the actual canvas dimensions, not mapScrHeight which may differ from
+  // canvas height in fullscreen mode. The anchor may be board-specific: 1.75
+  // stays centered; 2.06 shifts down to show more route ahead on the tall panel.
   lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
-  int16_t halfW = draw_buf ? draw_buf->header.w / 2 : Maps::mapScrWidth / 2;
-  int16_t halfH = draw_buf ? draw_buf->header.h / 2 : Maps::mapScrHeight / 2;
+  int16_t screenAnchorX =
+      mapAnchorXForWidth(draw_buf ? draw_buf->header.w : Maps::mapScrWidth);
+  int16_t screenAnchorY = mapAnchorYForHeight(
+      draw_buf ? draw_buf->header.h
+               : (mapSet.mapFullScreen ? Maps::mapScrFull
+                                        : Maps::mapScrHeight));
 
   uint32_t totalTime = millis();
   log_i("readVectorMap: Draw start. isMapFound=%d, Blocks=%d", Maps::isMapFound,
@@ -1167,8 +1181,8 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
         double ry = dx * sinA + dy * cosA;
 
         // 3. Translate to screen center
-        int16_t sx = round(rx) + halfW;
-        int16_t sy = round(ry) + halfH;
+        int16_t sx = round(rx) + screenAnchorX;
+        int16_t sy = round(ry) + screenAnchorY;
 
         return Point16(sx, sy);
       };
@@ -1281,8 +1295,8 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           }
           double rx = dx * cosA - dy * sinA;
           double ry = dx * sinA + dy * cosA;
-          int16_t sx = round(rx) + halfW;
-          int16_t sy = round(ry) + halfH;
+          int16_t sx = round(rx) + screenAnchorX;
+          int16_t sy = round(ry) + screenAnchorY;
           return Point16(sx, sy);
         };
 
@@ -1916,15 +1930,18 @@ void Maps::displayMap() {
   // Update Arrow Position
   if (Maps::canvasArrow) {
     uint16_t h = mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
+    const int16_t anchorX = mapAnchorXForWidth(Maps::mapScrWidth);
+    const int16_t anchorY = mapAnchorYForHeight(h);
     int16_t x, y;
 
     if (Maps::followGps) {
-      // Center of screen when following GPS (48x48 icon, so offset by -24)
-      x = Maps::mapScrWidth / 2 - 24;
-      y = h / 2 - 24;
+      // Board-specific map anchor when following GPS (48x48 icon, so offset
+      // by -24). The 1.75 stays centered; the 2.06 anchor is lower.
+      x = anchorX - 24;
+      y = anchorY - 24;
       lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       lv_obj_set_pos(Maps::canvasArrow, x, y);
-      ESP_LOGI(TAG, "GPS indicator: followGps mode, center screen pos(%d,%d)",
+      ESP_LOGI(TAG, "GPS indicator: followGps mode, anchor screen pos(%d,%d)",
                x, y);
     } else {
       // Calculate position relative to viewport center
@@ -1957,8 +1974,8 @@ void Maps::displayMap() {
 
       // 3. Translate to screen center (centered on arrow)
       // 48x48 icon, so offset by -24
-      x = (round(rx) + Maps::mapScrWidth / 2) - 24;
-      y = (round(ry) + h / 2) - 24;
+      x = (round(rx) + anchorX) - 24;
+      y = (round(ry) + anchorY) - 24;
 
       ESP_LOGI(TAG,
                "GPS indicator: gps(%.6f,%.6f) -> mercator(%d,%d) -> "
@@ -2041,7 +2058,9 @@ void Maps::generateVectorMap(uint8_t zoom) {
         mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
     routeOverlay.drawRoute(Maps::canvasMap, Maps::viewPort.center.x,
                            Maps::viewPort.center.y, zoom, Maps::mapScrWidth,
-                           canvasHeight, rotationRad);
+                           canvasHeight, rotationRad,
+                           mapAnchorXForWidth(Maps::mapScrWidth),
+                           mapAnchorYForHeight(canvasHeight));
     ESP_LOGI(TAG, "Route overlay draw complete (rotation=%.2f rad, canvasH=%d)",
              rotationRad, canvasHeight);
   } else {

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -1,7 +1,7 @@
 /**
  * @file WAVESHARE_AMOLED_175.cpp
- * @brief Waveshare 1.75 AMOLED (CO5300) implementation for IceNav using
- * Arduino_GFX
+ * @brief Waveshare AMOLED (CO5300) implementation for IceNav using Arduino_GFX.
+ * Shared by the 1.75 and 2.06 variants.
  */
 
 #include "WAVESHARE_AMOLED_175.hpp"
@@ -26,19 +26,19 @@ uint8_t GPS_RX = GPIO_NUM_44;
 // DISPLAY CONFIGURATION (Arduino_GFX)
 // ============================================================================
 
-// QSPI Bus for CO5300 - matches working esp32 project
-Arduino_ESP32QSPI *bus = new Arduino_ESP32QSPI(12, // CS
-                                               38, // SCK
-                                               4,  // D0
-                                               5,  // D1
-                                               6,  // D2
-                                               7   // D3
+// QSPI Bus for CO5300.
+Arduino_ESP32QSPI *bus = new Arduino_ESP32QSPI(TFT_QSPI_CS,  // CS
+                                               TFT_QSPI_CLK, // SCK
+                                               TFT_QSPI_D0,  // D0
+                                               TFT_QSPI_D1,  // D1
+                                               TFT_QSPI_D2,  // D2
+                                               TFT_QSPI_D3   // D3
 );
 
-// CO5300 Display Driver. Match Waveshare's Arduino demos and ESP-IDF BSP:
-// the exposed panel is 466x466 with a 6 px column gap.
+// CO5300 Display Driver. Match the vendor dimensions and panel gap for the
+// selected Waveshare AMOLED variant.
 Arduino_CO5300 *gfx = new Arduino_CO5300(bus,
-                                         39, // RST
+                                         TFT_QSPI_RST, // RST
                                          0,  // Rotation
                                          waveshare_board::display::
                                              LOGICAL_WIDTH,
@@ -156,7 +156,11 @@ static void drawDisplayTestPatterns(uint8_t appliedRotation) {
     drawDisplayTestPatternForRotation(ROTATION_90);
   }
   applyCo5300Rotation(appliedRotation);
+#ifdef WAVESHARE_DISPLAY_PROBE
+  drawVendorWindowMarker(appliedRotation, 0x001F, 0xFFFF);
+#else
   gfx->fillScreen(0x0000);
+#endif
 }
 #endif
 
@@ -189,12 +193,225 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
 }
 
 // ============================================================================
-// TOUCH DRIVER (CST9217) - WITH TCA9554 RESET AND I2C BUS RECOVERY
-// See WAVESHARE_HARDWARE.md.
+// TOUCH DRIVER
+// 1.75: CST9217 reset through TCA9554. 2.06: FT3168 direct reset GPIO.
 // ============================================================================
 
 bool touchPressed = false;
 uint16_t touchX = 0, touchY = 0;
+
+#ifdef WAVESHARE_AMOLED_206
+
+static bool touchInitialized = false;
+static bool touchHintConfigured = false;
+static uint32_t lastTouchInitAttemptMs = 0;
+static uint32_t lastTouchReadMs = 0;
+static uint32_t touchBackoffUntilMs = 0;
+static uint32_t lastTouchErrorLogMs = 0;
+static uint32_t lastTouchDebugLogMs = 0;
+static uint32_t lastValidTouchMs = 0;
+static uint32_t touchFastPollUntilMs = 0;
+static bool lastTouchHintActive = false;
+static bool touchHintStateKnown = false;
+static uint8_t consecutiveTouchReadFailures = 0;
+
+static bool isValidTouchCoordinate(uint16_t x, uint16_t y) {
+  return x < waveshare_board::touch::ACTIVE_WIDTH &&
+         y < waveshare_board::touch::ACTIVE_HEIGHT;
+}
+
+static void setTouchPressed(bool pressed) {
+  if (pressed != touchPressed) {
+    if (pressed) {
+      Serial.printf("Touch: press x=%u y=%u\n", touchX, touchY);
+    } else {
+      Serial.println("Touch: release");
+    }
+  }
+  touchPressed = pressed;
+}
+
+static void configureTouchHintPin() {
+  if (touchHintConfigured) {
+    return;
+  }
+  pinMode(waveshare_board::touch::FT3168_INT_PIN, INPUT_PULLUP);
+  touchHintConfigured = true;
+}
+
+static bool isTouchHintActive() {
+  configureTouchHintPin();
+  return digitalRead(waveshare_board::touch::FT3168_INT_PIN) == LOW;
+}
+
+static void updateTouchHintState(bool active, uint32_t now) {
+  bool changed = !touchHintStateKnown || active != lastTouchHintActive;
+  bool heartbeat = now - lastTouchDebugLogMs > 10000;
+  if (changed || heartbeat) {
+    Serial.printf("Touch debug: init=%d ft3168_int=%s pressed=%d\n",
+                  touchInitialized, active ? "LOW(active)" : "HIGH(idle)",
+                  touchPressed);
+    lastTouchDebugLogMs = now;
+  }
+  lastTouchHintActive = active;
+  touchHintStateKnown = true;
+  if (changed && active) {
+    touchFastPollUntilMs =
+        now + waveshare_board::touch::HINT_FAST_POLL_WINDOW_MS;
+  }
+}
+
+static uint32_t touchReadInterval(bool hintActive, uint32_t now) {
+  if (hintActive) {
+    return waveshare_board::touch::HINT_ACTIVE_READ_INTERVAL_MS;
+  }
+  if (touchPressed) {
+    return waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
+  }
+  if (now < touchFastPollUntilMs) {
+    return waveshare_board::touch::FAST_FALLBACK_READ_INTERVAL_MS;
+  }
+  return waveshare_board::touch::IDLE_FALLBACK_READ_INTERVAL_MS;
+}
+
+static void noteTouchReadFailure(const char *reason, uint32_t now) {
+  consecutiveTouchReadFailures++;
+  if (now - lastTouchErrorLogMs > 5000) {
+    Serial.printf("Touch read failed: %s (failures=%u)\n", reason,
+                  consecutiveTouchReadFailures);
+    lastTouchErrorLogMs = now;
+  }
+  if (touchPressed &&
+      now - lastValidTouchMs < waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+    touchBackoffUntilMs =
+        now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
+    return;
+  }
+  setTouchPressed(false);
+  touchBackoffUntilMs = now + 250;
+  if (consecutiveTouchReadFailures >= 5) {
+    touchInitialized = false;
+    touchBackoffUntilMs = now + waveshare_board::touch::REINIT_BACKOFF_MS;
+    consecutiveTouchReadFailures = 0;
+  }
+}
+
+void initTouchController() {
+  if (touchInitialized) {
+    return;
+  }
+
+  uint32_t now = millis();
+  if (lastTouchInitAttemptMs != 0 && now - lastTouchInitAttemptMs < 5000) {
+    return;
+  }
+  lastTouchInitAttemptMs = now;
+  configureTouchHintPin();
+
+  pinMode(waveshare_board::touch::FT3168_RST_PIN, OUTPUT);
+  digitalWrite(waveshare_board::touch::FT3168_RST_PIN, HIGH);
+  delay(1);
+  digitalWrite(waveshare_board::touch::FT3168_RST_PIN, LOW);
+  delay(20);
+  digitalWrite(waveshare_board::touch::FT3168_RST_PIN, HIGH);
+  delay(50);
+
+  if (!waveshare_board::i2c::probe(waveshare_board::touch::FT3168_ADDR,
+                                   "FT3168", 3)) {
+    Serial.println("FT3168: not found");
+    return;
+  }
+
+  uint8_t deviceId = 0;
+  if (waveshare_board::i2c::readRegister8(
+          waveshare_board::touch::FT3168_ADDR,
+          waveshare_board::touch::FT3168_DEVICE_ID_REG, deviceId, "FT3168")) {
+    Serial.printf("FT3168: found deviceId=0x%02X\n", deviceId);
+  } else {
+    Serial.println("FT3168: found");
+  }
+
+  waveshare_board::i2c::writeRegister8(
+      waveshare_board::touch::FT3168_ADDR,
+      waveshare_board::touch::FT3168_POWER_MODE_REG,
+      waveshare_board::touch::FT3168_MONITOR_MODE, "FT3168 power", 3);
+  touchInitialized = true;
+}
+
+void readTouch() {
+  uint32_t now = millis();
+  bool touchHintActive = isTouchHintActive();
+  updateTouchHintState(touchHintActive, now);
+
+  if (now < touchBackoffUntilMs) {
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+      return;
+    }
+    setTouchPressed(false);
+    return;
+  }
+
+  if (!touchInitialized) {
+    initTouchController();
+    if (!touchInitialized) {
+      setTouchPressed(false);
+      return;
+    }
+  }
+
+  if (!touchHintActive && !touchPressed && now >= touchFastPollUntilMs) {
+    setTouchPressed(false);
+    return;
+  }
+
+  if (now - lastTouchReadMs < touchReadInterval(touchHintActive, now)) {
+    return;
+  }
+  lastTouchReadMs = now;
+
+  uint8_t data[waveshare_board::touch::FT3168_TOUCH_DATA_LENGTH] = {0};
+  if (!waveshare_board::i2c::readRegisterBlock8(
+          waveshare_board::touch::FT3168_ADDR,
+          waveshare_board::touch::FT3168_FINGER_REG, data, sizeof(data),
+          "FT3168 touch")) {
+    noteTouchReadFailure("data read", now);
+    return;
+  }
+  consecutiveTouchReadFailures = 0;
+
+  uint8_t points = data[0] & 0x0F;
+  if (points == 0) {
+    if (touchPressed && now - lastValidTouchMs <
+                            waveshare_board::touch::ACTIVE_FAILURE_GRACE_MS) {
+      touchBackoffUntilMs =
+          now + waveshare_board::touch::ACTIVE_READ_INTERVAL_MS;
+      return;
+    }
+    setTouchPressed(false);
+    return;
+  }
+
+  uint16_t rawX = ((data[1] & 0x0F) << 8) | data[2];
+  uint16_t rawY = ((data[3] & 0x0F) << 8) | data[4];
+  if (!isValidTouchCoordinate(rawX, rawY)) {
+    Serial.printf("Touch raw: ignored-invalid raw=(%u,%u) bytes=%02X %02X "
+                  "%02X %02X %02X\n",
+                  rawX, rawY, data[0], data[1], data[2], data[3], data[4]);
+    setTouchPressed(false);
+    return;
+  }
+
+  touchX = rawX;
+  touchY = rawY;
+  lastValidTouchMs = now;
+  touchFastPollUntilMs =
+      now + waveshare_board::touch::TOUCH_FAST_POLL_WINDOW_MS;
+  setTouchPressed(true);
+}
+
+#else
+
 static bool touchInitialized = false;
 static bool touchHintConfigured = false;
 static uint32_t lastTouchInitAttemptMs = 0;
@@ -534,6 +751,8 @@ void readTouch() {
 
   setTouchPressed(true);
 }
+
+#endif // WAVESHARE_AMOLED_206
 
 void my_touchpad_read(lv_indev_t *indev_driver, lv_indev_data_t *data) {
   readTouch();

--- a/esp32/lib/panel/panelSelect.hpp
+++ b/esp32/lib/panel/panelSelect.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#if defined(WAVESHARE_AMOLED_175)
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "WAVESHARE_AMOLED_175.hpp"
 #else
 #error "No Panel defined!"

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -8,7 +8,7 @@
 
 #include "power.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "axp2101.hpp"
 #endif
 
@@ -91,7 +91,7 @@ void Power::powerOffPeripherals() {
     gfx->fillScreen(0x0000);
   }
 #endif
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(false);
   waveshare_board::axp2101::setPeripheralPower(false);
 #endif
@@ -116,11 +116,11 @@ void Power::deviceSuspend() {
   lv_refr_now(display);
   if (gfx)
     gfx->displayOff();
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(false);
 #endif
   powerLightSleep();
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(true);
   delay(50);
 #endif

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -85,7 +85,10 @@ void RouteOverlay::clear() {
 #endif
 
 int16_t RouteOverlay::geoToScreenX(int32_t lonMicro, int32_t centerMercatorX,
-                                   uint8_t zoom, int16_t screenWidth) {
+                                   uint8_t zoom, int16_t screenWidth,
+                                   int16_t anchorX) {
+  (void)screenWidth;
+
   // Convert microdegrees to degrees
   double lon = lonMicro / 1000000.0;
 
@@ -100,14 +103,14 @@ int16_t RouteOverlay::geoToScreenX(int32_t lonMicro, int32_t centerMercatorX,
   int16_t screenX;
   if (zoom == 0) {
     screenX =
-        (int16_t)(round((worldX - centerWorldX) * 2.0) + (screenWidth / 2.0));
+        (int16_t)(round((worldX - centerWorldX) * 2.0) + anchorX);
   } else if (zoom == 1) {
     screenX =
-        (int16_t)(round((worldX - centerWorldX) * 1.5) + (screenWidth / 2.0));
+        (int16_t)(round((worldX - centerWorldX) * 1.5) + anchorX);
   } else {
     int divisor = zoom - 1;
-    screenX = (int16_t)(round((worldX - centerWorldX) / divisor) +
-                        (screenWidth / 2.0));
+    screenX =
+        (int16_t)(round((worldX - centerWorldX) / divisor) + anchorX);
   }
 
   return screenX;
@@ -115,7 +118,10 @@ int16_t RouteOverlay::geoToScreenX(int32_t lonMicro, int32_t centerMercatorX,
 
 int16_t RouteOverlay::geoToScreenY(int32_t latMicro, int32_t centerMercatorY,
                                    uint8_t zoom, int16_t screenHeight,
-                                   int16_t screenWidth) {
+                                   int16_t screenWidth, int16_t anchorY) {
+  (void)screenHeight;
+  (void)screenWidth;
+
   // Convert microdegrees to degrees
   double lat = latMicro / 1000000.0;
 
@@ -128,14 +134,14 @@ int16_t RouteOverlay::geoToScreenY(int32_t latMicro, int32_t centerMercatorY,
   int16_t screenY;
   if (zoom == 0) {
     screenY =
-        (int16_t)(round(-(worldY - centerWorldY) * 2.0) + (screenHeight / 2.0));
+        (int16_t)(round(-(worldY - centerWorldY) * 2.0) + anchorY);
   } else if (zoom == 1) {
     screenY =
-        (int16_t)(round(-(worldY - centerWorldY) * 1.5) + (screenHeight / 2.0));
+        (int16_t)(round(-(worldY - centerWorldY) * 1.5) + anchorY);
   } else {
     int divisor = zoom - 1;
-    screenY = (int16_t)(round(-(worldY - centerWorldY) / divisor) +
-                        (screenHeight / 2.0));
+    screenY =
+        (int16_t)(round(-(worldY - centerWorldY) / divisor) + anchorY);
   }
 
   return screenY;
@@ -209,7 +215,11 @@ void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
 void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
                              int32_t centerMercatorY, uint8_t zoom,
                              uint16_t mapScrWidth, uint16_t mapScrHeight,
-                             double rotationRad) {
+                             double rotationRad, int16_t anchorX,
+                             int16_t anchorY) {
+  (void)mapScrWidth;
+  (void)mapScrHeight;
+
   if (points.size() < 2) {
     Serial.println("RouteOverlay: Not enough points to draw (need >= 2)");
     return; // Need at least 2 points to draw a line
@@ -232,6 +242,12 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
   int32_t bufH = draw_buf->header.h;
   uint32_t stride =
       draw_buf->header.stride / 2; // stride is in bytes, we need pixels
+  if (anchorX < 0) {
+    anchorX = bufW / 2;
+  }
+  if (anchorY < 0) {
+    anchorY = bufH / 2;
+  }
 
   Serial.printf("RouteOverlay: Canvas buffer W=%d H=%d stride=%d\n", bufW, bufH,
                 stride);
@@ -239,32 +255,33 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
   // Pre-calculate rotation values
   double cosA = cos(rotationRad);
   double sinA = sin(rotationRad);
-  int16_t halfW = bufW / 2;
-  int16_t halfH = bufH / 2;
 
   int drawnCount = 0;
   // Draw route segments
   for (size_t i = 0; i < points.size() - 1; i++) {
     // Convert geographic coordinates to screen pixels
-    int16_t x1 = geoToScreenX(points[i].lon, centerMercatorX, zoom, bufW);
-    int16_t y1 = geoToScreenY(points[i].lat, centerMercatorY, zoom, bufH, bufW);
-    int16_t x2 = geoToScreenX(points[i + 1].lon, centerMercatorX, zoom, bufW);
-    int16_t y2 =
-        geoToScreenY(points[i + 1].lat, centerMercatorY, zoom, bufH, bufW);
+    int16_t x1 =
+        geoToScreenX(points[i].lon, centerMercatorX, zoom, bufW, anchorX);
+    int16_t y1 = geoToScreenY(points[i].lat, centerMercatorY, zoom, bufH, bufW,
+                              anchorY);
+    int16_t x2 =
+        geoToScreenX(points[i + 1].lon, centerMercatorX, zoom, bufW, anchorX);
+    int16_t y2 = geoToScreenY(points[i + 1].lat, centerMercatorY, zoom, bufH,
+                              bufW, anchorY);
 
     // Apply rotation transform if rotationRad is non-zero
     if (rotationRad != 0.0) {
       // Transform point 1
-      double dx1 = x1 - halfW;
-      double dy1 = y1 - halfH;
-      x1 = (int16_t)(dx1 * cosA - dy1 * sinA + halfW);
-      y1 = (int16_t)(dx1 * sinA + dy1 * cosA + halfH);
+      double dx1 = x1 - anchorX;
+      double dy1 = y1 - anchorY;
+      x1 = (int16_t)(dx1 * cosA - dy1 * sinA + anchorX);
+      y1 = (int16_t)(dx1 * sinA + dy1 * cosA + anchorY);
 
       // Transform point 2
-      double dx2 = x2 - halfW;
-      double dy2 = y2 - halfH;
-      x2 = (int16_t)(dx2 * cosA - dy2 * sinA + halfW);
-      y2 = (int16_t)(dx2 * sinA + dy2 * cosA + halfH);
+      double dx2 = x2 - anchorX;
+      double dy2 = y2 - anchorY;
+      x2 = (int16_t)(dx2 * cosA - dy2 * sinA + anchorX);
+      y2 = (int16_t)(dx2 * sinA + dy2 * cosA + anchorY);
     }
 
     // LOGGING: Debug Center Offset for the first segment
@@ -272,7 +289,7 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
       ESP_LOGI(
           "RouteOverlay",
           "DEBUG_OFFSET: Center(%d,%d) StartPixel(%d,%d) Diff(%d,%d) Rot(%.2f)",
-          halfW, halfH, x1, y1, x1 - halfW, y1 - halfH, rotationRad);
+          anchorX, anchorY, x1, y1, x1 - anchorX, y1 - anchorY, rotationRad);
     }
 
     // Log first few segments for debugging

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -56,7 +56,8 @@ public:
    */
   void drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
                  int32_t centerMercatorY, uint8_t zoom, uint16_t mapScrWidth,
-                 uint16_t mapScrHeight, double rotationRad = 0.0);
+                 uint16_t mapScrHeight, double rotationRad = 0.0,
+                 int16_t anchorX = -1, int16_t anchorY = -1);
 
   /**
    * @brief Clear all route points
@@ -84,13 +85,14 @@ private:
    * @brief Convert longitude to screen X coordinate
    */
   int16_t geoToScreenX(int32_t lon, int32_t centerLon, uint8_t zoom,
-                       int16_t screenWidth);
+                       int16_t screenWidth, int16_t anchorX);
 
   /**
    * @brief Convert latitude to screen Y coordinate
    */
   int16_t geoToScreenY(int32_t lat, int32_t centerLat, uint8_t zoom,
-                       int16_t screenHeight, int16_t screenWidth);
+                       int16_t screenHeight, int16_t screenWidth,
+                       int16_t anchorY);
 
   /**
    * @brief Draw a single line segment with thickness

--- a/esp32/lib/settings/settings.cpp
+++ b/esp32/lib/settings/settings.cpp
@@ -64,6 +64,78 @@ extern Compass compass;
 extern Gps gps;
 bool calculateDST = false; // Calculate DST flag
 
+static uint16_t defaultCompassX() {
+  return (TFT_WIDTH / 2) - (100 * scale);
+}
+
+static uint16_t defaultCompassY() {
+#ifdef WAVESHARE_AMOLED_206
+  return 112;
+#else
+  return 80;
+#endif
+}
+
+static uint16_t defaultCoordX() {
+  return (TFT_WIDTH / 2) - (90 * scale);
+}
+
+static uint16_t defaultCoordY() {
+#ifdef WAVESHARE_AMOLED_206
+  return 42;
+#else
+  return 30;
+#endif
+}
+
+static uint16_t defaultAltitudeX() {
+#ifdef WAVESHARE_AMOLED_206
+  return 12;
+#else
+  return 8;
+#endif
+}
+
+static uint16_t defaultAltitudeY() {
+#ifdef WAVESHARE_AMOLED_206
+  return TFT_HEIGHT - 148;
+#else
+  return TFT_HEIGHT - 170;
+#endif
+}
+
+static uint16_t defaultSpeedX() {
+#ifdef WAVESHARE_AMOLED_206
+  return 12;
+#else
+  return 1;
+#endif
+}
+
+static uint16_t defaultSpeedY() {
+#ifdef WAVESHARE_AMOLED_206
+  return TFT_HEIGHT - 104;
+#else
+  return TFT_HEIGHT - 130;
+#endif
+}
+
+static uint16_t defaultSunX() {
+#ifdef WAVESHARE_AMOLED_206
+  return TFT_WIDTH - 92;
+#else
+  return 170;
+#endif
+}
+
+static uint16_t defaultSunY() {
+#ifdef WAVESHARE_AMOLED_206
+  return TFT_HEIGHT - 154;
+#else
+  return TFT_HEIGHT - 170;
+#endif
+}
+
 /**
  * @brief Load stored preferences
  *
@@ -87,16 +159,16 @@ void loadPreferences() {
   mapSet.showMapScale = cfg.getBool(PKEYS::KMAP_SCALE, true);
   gpsBaud = cfg.getShort(PKEYS::KGPS_SPEED, 4);
   gpsUpdate = cfg.getShort(PKEYS::KGPS_RATE, 3);
-  compassPosX = cfg.getInt(PKEYS::KCOMP_X, (TFT_WIDTH / 2) - (100 * scale));
-  compassPosY = cfg.getInt(PKEYS::KCOMP_Y, 80);
-  coordPosX = cfg.getInt(PKEYS::KCOORD_X, (TFT_WIDTH / 2) - (90 * scale));
-  coordPosY = cfg.getInt(PKEYS::KCOORD_Y, 30);
-  altitudePosX = cfg.getInt(PKEYS::KALTITUDE_X, 8);
-  altitudePosY = cfg.getInt(PKEYS::KALTITUDE_Y, TFT_HEIGHT - 170);
-  speedPosX = cfg.getInt(PKEYS::KSPEED_X, 1);
-  speedPosY = cfg.getInt(PKEYS::KSPEED_Y, TFT_HEIGHT - 130);
-  sunPosX = cfg.getInt(PKEYS::KSUN_X, 170);
-  sunPosY = cfg.getInt(PKEYS::KSUN_Y, TFT_HEIGHT - 170);
+  compassPosX = cfg.getInt(PKEYS::KCOMP_X, defaultCompassX());
+  compassPosY = cfg.getInt(PKEYS::KCOMP_Y, defaultCompassY());
+  coordPosX = cfg.getInt(PKEYS::KCOORD_X, defaultCoordX());
+  coordPosY = cfg.getInt(PKEYS::KCOORD_Y, defaultCoordY());
+  altitudePosX = cfg.getInt(PKEYS::KALTITUDE_X, defaultAltitudeX());
+  altitudePosY = cfg.getInt(PKEYS::KALTITUDE_Y, defaultAltitudeY());
+  speedPosX = cfg.getInt(PKEYS::KSPEED_X, defaultSpeedX());
+  speedPosY = cfg.getInt(PKEYS::KSPEED_Y, defaultSpeedY());
+  sunPosX = cfg.getInt(PKEYS::KSUN_X, defaultSunX());
+  sunPosY = cfg.getInt(PKEYS::KSUN_Y, defaultSunY());
   defBright = cfg.getUInt(PKEYS::KDEF_BRIGT, 254);
   if (mapSet.vectorMap) {
     minZoom = 1;

--- a/esp32/lib/storage/storage.cpp
+++ b/esp32/lib/storage/storage.cpp
@@ -61,11 +61,10 @@ Storage::Storage() : isSdLoaded(false), card(nullptr) {}
 esp_err_t Storage::initSD() {
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   const uint32_t mountStartMs = millis();
-  // Waveshare 1.75" AMOLED: Use DEDICATED HSPI bus to avoid conflict with
+  // Waveshare AMOLED boards: use dedicated HSPI to avoid conflict with the
   // QSPI display. The default SPI (FSPI) shares resources with the display.
   // NOTE: Use HSPI constant, not SPI3_HOST (which fails with "out of range")
-  // See WAVESHARE_HARDWARE.md.
-  // Verified working pins: CS=41, MOSI=1, MISO=3, SCK=2
+  // See WAVESHARE_HARDWARE.md for variant-specific CS pins.
 
   Serial.printf("SDIO: init bus=HSPI freq=%luHz pins[cs=%d mosi=%d miso=%d "
                 "sck=%d]\n",

--- a/esp32/lib/storage/storage.cpp
+++ b/esp32/lib/storage/storage.cpp
@@ -59,7 +59,7 @@ Storage::Storage() : isSdLoaded(false), card(nullptr) {}
  * @brief SD Card init with DMA using ESP-IDF
  */
 esp_err_t Storage::initSD() {
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   const uint32_t mountStartMs = millis();
   // Waveshare 1.75" AMOLED: Use DEDICATED HSPI bus to avoid conflict with
   // QSPI display. The default SPI (FSPI) shares resources with the display.
@@ -346,7 +346,7 @@ bool Storage::getSdLoaded() const { return isSdLoaded; }
  * @return FILE* Pointer to the opened file
  */
 FILE *Storage::open(const char *path, const char *mode) {
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   // Reconfigure SPI bus before SD access - QSPI display operations may have
   // altered SPI state. This ensures the SD card SPI is properly configured.
   SPI.begin(SD_CLK, SD_MISO, SD_MOSI, SD_CS);

--- a/esp32/lib/storage/storage.hpp
+++ b/esp32/lib/storage/storage.hpp
@@ -28,7 +28,7 @@
 #include "SD_MMC.h"
 #endif
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "Arduino.h"
 #include "SD_MMC.h"
 #endif

--- a/esp32/lib/tft/tft.cpp
+++ b/esp32/lib/tft/tft.cpp
@@ -148,7 +148,7 @@ void initTFT()
   tft.fillScreen(TFT_BLACK);
 
   #ifdef TOUCH_INPUT
-    #ifndef WAVESHARE_AMOLED_175
+    #if !defined(WAVESHARE_AMOLED_175) && !defined(WAVESHARE_AMOLED_206)
       touchCalibrate();
     #endif
   #endif

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -5,7 +5,7 @@
 
 #include "axp2101.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
@@ -103,6 +103,9 @@ bool readPowerStatus(PowerStatus &status) {
 
 bool setDisplayPower(bool enabled) {
   uint8_t value = currentLdoEnableValue(AXP2101_KNOWN_GOOD_LDO_ENABLES);
+  Serial.printf("AXP2101: display power request enabled=%d currentLdo=0x%02X "
+                "mask=0x%02X\n",
+                enabled ? 1 : 0, value, AXP2101_DISPLAY_ENABLE_MASK);
   if (enabled) {
     value |= AXP2101_DISPLAY_ENABLE_MASK;
   } else {
@@ -153,6 +156,33 @@ bool restoreDefaultRails() {
 
   Serial.println("AXP2101 found!");
 
+#ifdef WAVESHARE_AMOLED_206
+  // Waveshare's 2.06 Arduino display examples do not program AXP2101 rails
+  // before gfx->begin(). Preserve the PMU state during bring-up instead of
+  // reusing the 1.75 board's known-good LDO mask and voltage sequence.
+  PowerStatus status;
+  if (readPowerStatus(status)) {
+    uint8_t ldoEnable = 0;
+    bool ldoReadOk = readRegister(AXP2101_LDO_ENABLE_REG, ldoEnable);
+    Serial.printf("AXP2101: 2.06 safe mode preserving rails; status1=0x%02X "
+                  "status2=0x%02X vbus=%s battery=%s currentDir=%u "
+                  "charge=%u ldo=0x%02X ldoRead=%d\n",
+                  status.status1, status.status2,
+                  status.vbusGood ? "good" : "not-good",
+                  status.batteryPresent ? "present" : "absent",
+                  status.batteryCurrentDirection, status.chargingStatus,
+                  ldoEnable, ldoReadOk ? 1 : 0);
+  } else {
+    Serial.println("AXP2101: 2.06 safe mode status read failed");
+  }
+
+#ifdef WAVESHARE_206_FORCE_AXP_DISPLAY
+  Serial.println("AXP2101: 2.06 forcing display rail by explicit build flag");
+  return enableDisplayRails();
+#else
+  return true;
+#endif
+#else
   bool ok = writeRegisterChecked("ldo baseline reset", AXP2101_LDO_ENABLE_REG,
                                  AXP2101_KNOWN_GOOD_LDO_RESET);
   ok = writeRegisterChecked("ldo baseline on", AXP2101_LDO_ENABLE_REG,
@@ -181,8 +211,9 @@ bool restoreDefaultRails() {
     Serial.println("! AXP2101 rail setup completed with readback errors");
   }
   return ok;
+#endif
 }
 
 } // namespace waveshare_board::axp2101
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include <Arduino.h>
 
@@ -36,4 +36,4 @@ bool restoreDefaultRails();
 
 } // namespace waveshare_board::axp2101
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/display.hpp
+++ b/esp32/lib/waveshare_board/display.hpp
@@ -9,16 +9,29 @@
 
 namespace waveshare_board::display {
 
+#ifdef WAVESHARE_AMOLED_206
+constexpr uint16_t LOGICAL_WIDTH = 410;
+constexpr uint16_t LOGICAL_HEIGHT = 502;
+constexpr uint16_t ACTIVE_WIDTH = 410;
+constexpr uint16_t ACTIVE_HEIGHT = 502;
+#else
 constexpr uint16_t LOGICAL_WIDTH = 466;
 constexpr uint16_t LOGICAL_HEIGHT = 466;
 constexpr uint16_t ACTIVE_WIDTH = 466;
 constexpr uint16_t ACTIVE_HEIGHT = 466;
+#endif
 
+#ifdef WAVESHARE_AMOLED_206
+// Waveshare's 2.06 Arduino examples use:
+// Arduino_CO5300(..., 410, 502, 22, 0, 0, 0)
+constexpr uint8_t ARDUINO_CO5300_COL_OFFSET1 = 22;
+#else
 // Vendor Waveshare Arduino examples use:
 // Arduino_CO5300(..., 466, 466, 6, 0, 0, 0)
 // The ESP-IDF BSP applies the same effective panel gap with
 // esp_lcd_panel_set_gap(panel_handle, 6, 0).
 constexpr uint8_t ARDUINO_CO5300_COL_OFFSET1 = 6;
+#endif
 constexpr uint8_t ARDUINO_CO5300_ROW_OFFSET1 = 0;
 constexpr uint8_t ARDUINO_CO5300_COL_OFFSET2 = 0;
 constexpr uint8_t ARDUINO_CO5300_ROW_OFFSET2 = 0;

--- a/esp32/lib/waveshare_board/i2c_bus.cpp
+++ b/esp32/lib/waveshare_board/i2c_bus.cpp
@@ -5,7 +5,7 @@
 
 #include "i2c_bus.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "waveshare_board.hpp"
 #include <Wire.h>
@@ -258,4 +258,4 @@ bool readRegister16(uint8_t address, uint16_t reg, uint8_t *data, uint8_t len,
 
 } // namespace waveshare_board::i2c
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/i2c_bus.hpp
+++ b/esp32/lib/waveshare_board/i2c_bus.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include <Arduino.h>
 
@@ -43,4 +43,4 @@ bool readRegister16(uint8_t address, uint16_t reg, uint8_t *data, uint8_t len,
 
 } // namespace waveshare_board::i2c
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/pcf85063.cpp
+++ b/esp32/lib/waveshare_board/pcf85063.cpp
@@ -5,7 +5,7 @@
 
 #include "pcf85063.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
@@ -299,4 +299,4 @@ bool syncFromUnixTime(time_t unixTime, const char *source) {
 
 } // namespace waveshare_board::rtc
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/pcf85063.hpp
+++ b/esp32/lib/waveshare_board/pcf85063.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include <Arduino.h>
 #include <time.h>
@@ -33,4 +33,4 @@ const char *sourceName(TimeSource source);
 
 } // namespace waveshare_board::rtc
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/qmi8658.cpp
+++ b/esp32/lib/waveshare_board/qmi8658.cpp
@@ -5,7 +5,7 @@
 
 #include "qmi8658.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "i2c_bus.hpp"
 #include "waveshare_board.hpp"
@@ -398,4 +398,4 @@ void process() {
 
 } // namespace waveshare_board::imu
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/qmi8658.hpp
+++ b/esp32/lib/waveshare_board/qmi8658.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include <Arduino.h>
 
@@ -55,4 +55,4 @@ const char *orientationName(Orientation orientation);
 
 } // namespace waveshare_board::imu
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/touch.hpp
+++ b/esp32/lib/waveshare_board/touch.hpp
@@ -1,11 +1,11 @@
 /**
  * @file touch.hpp
- * @brief CST9217/TCA9554 touch constants for the Waveshare board.
+ * @brief Touch constants for Waveshare AMOLED boards.
  */
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "waveshare_board.hpp"
 #include <Arduino.h>
@@ -18,13 +18,26 @@ constexpr uint8_t TCA9554_CONFIG_REG = 0x03;
 constexpr uint8_t TCA9554_TOUCH_RST_BIT = 0;
 
 constexpr uint8_t CST9217_ADDR = waveshare_board::CST9217_ADDR;
+constexpr uint8_t FT3168_ADDR = waveshare_board::FT3168_ADDR;
 constexpr uint8_t CST9217_INT_PIN = TCH_I2C_INT;
 constexpr uint16_t CST9217_DATA_REG = 0xD000;
 constexpr uint8_t CST9217_ACK = 0xAB;
 constexpr uint8_t CST9217_DATA_LENGTH = 10;
 
+#ifdef WAVESHARE_AMOLED_206
+constexpr uint8_t FT3168_INT_PIN = TCH_I2C_INT;
+constexpr uint8_t FT3168_RST_PIN = TCH_I2C_RST;
+constexpr uint8_t FT3168_FINGER_REG = 0x02;
+constexpr uint8_t FT3168_TOUCH_DATA_LENGTH = 5;
+constexpr uint8_t FT3168_POWER_MODE_REG = 0xA5;
+constexpr uint8_t FT3168_MONITOR_MODE = 0x01;
+constexpr uint8_t FT3168_DEVICE_ID_REG = 0xA0;
+constexpr uint16_t ACTIVE_WIDTH = 410;
+constexpr uint16_t ACTIVE_HEIGHT = 502;
+#else
 constexpr uint16_t ACTIVE_WIDTH = 466;
 constexpr uint16_t ACTIVE_HEIGHT = 466;
+#endif
 constexpr uint16_t MAX_X = ACTIVE_WIDTH - 1;
 constexpr uint16_t MAX_Y = ACTIVE_HEIGHT - 1;
 
@@ -42,4 +55,4 @@ constexpr uint32_t REINIT_BACKOFF_MS = 1200;
 
 } // namespace waveshare_board::touch
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/waveshare_board.cpp
+++ b/esp32/lib/waveshare_board/waveshare_board.cpp
@@ -5,7 +5,7 @@
 
 #include "waveshare_board.hpp"
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "axp2101.hpp"
 #include <Wire.h>
@@ -50,4 +50,4 @@ void enablePowerRails() {
 
 } // namespace waveshare_board
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/waveshare_board/waveshare_board.hpp
+++ b/esp32/lib/waveshare_board/waveshare_board.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include <Arduino.h>
 
@@ -14,6 +14,7 @@ namespace waveshare_board {
 constexpr uint8_t AXP2101_ADDR = 0x34;
 constexpr uint8_t TCA9554_ADDR = 0x20;
 constexpr uint8_t CST9217_ADDR = 0x5A;
+constexpr uint8_t FT3168_ADDR = 0x38;
 constexpr uint8_t PCF85063_ADDR = 0x51;
 constexpr uint8_t QMI8658_ADDR_PRIMARY = 0x6B;
 constexpr uint8_t QMI8658_ADDR_FALLBACK = 0x6A;
@@ -37,4 +38,4 @@ void enablePowerRails();
 
 } // namespace waveshare_board
 
-#endif // WAVESHARE_AMOLED_175
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -164,7 +164,7 @@ build_flags =
   -DSPI_SHARED
   -DTFT_BL=45
 
-[env:WAVESHARE_AMOLED_175]
+[waveshare_amoled_common]
 board = esp32-s3-devkitc-1
 board_build.mcu = esp32s3
 ; This board uses 8MB/16MB Flash and OPI PSRAM
@@ -198,7 +198,6 @@ lib_deps =
   h2zero/NimBLE-Arduino@^1.4.1
 
 build_flags =
-  -DWAVESHARE_AMOLED_175
   -I include  ; Add global include directory to path
   -DUSE_ARDUINO_GFX  ; Use Arduino_GFX instead of LovyanGFX for CO5300
   -DBOARD_HAS_PSRAM
@@ -242,11 +241,43 @@ build_flags =
   ; but we define a default here just in case.
   -DTFT_BL=-1
 
+[env:WAVESHARE_AMOLED_175]
+extends = waveshare_amoled_common
+build_flags =
+  ${waveshare_amoled_common.build_flags}
+  -DWAVESHARE_AMOLED_175
+
 [env:WAVESHARE_AMOLED_175_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_175
 build_flags =
   ${env:WAVESHARE_AMOLED_175.build_flags}
   -DWAVESHARE_DISPLAY_TEST=1
+
+[env:WAVESHARE_AMOLED_206]
+extends = waveshare_amoled_common
+build_flags =
+  ${waveshare_amoled_common.build_flags}
+  -DWAVESHARE_AMOLED_206
+
+[env:WAVESHARE_AMOLED_206_DISPLAY_TEST]
+extends = env:WAVESHARE_AMOLED_206
+build_flags =
+  ${env:WAVESHARE_AMOLED_206.build_flags}
+  -DWAVESHARE_DISPLAY_TEST=1
+  -DWAVESHARE_DISPLAY_PROBE=1
+
+[env:WAVESHARE_AMOLED_206_VENDOR_HELLO]
+extends = waveshare_amoled_common
+lib_deps =
+  moononournation/GFX Library for Arduino @ ^1.6.0
+build_src_filter =
+  -<*>
+  +<../waveshare_206_hello.cpp>
+build_flags =
+  -DBOARD_HAS_PSRAM
+  -DARDUINO_USB_MODE=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+  -DCORE_DEBUG_LEVEL=3
 
 ; ==========================================
 ; Simple display test environment

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -62,6 +62,7 @@ extern xSemaphoreHandle gpsMutex;
 
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
+#include "guiLayout.hpp"
 #include "mainScr.hpp"
 #include "route_overlay.hpp"
 #include "waitingScr.hpp"
@@ -369,7 +370,8 @@ void setup() {
 
   createGpxFolders();
 
-  mapView.initMap(TFT_HEIGHT - 100, TFT_WIDTH, TFT_HEIGHT);
+  mapView.initMap(gui_layout::mapViewportHeight(TFT_HEIGHT), TFT_WIDTH,
+                  TFT_HEIGHT);
 
   loadPreferences();
   gps.init();

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -65,7 +65,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "mainScr.hpp"
 #include "route_overlay.hpp"
 #include "waitingScr.hpp"
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "WAVESHARE_AMOLED_175.hpp"
 #include "i2c_bus.hpp"
 #include "pcf85063.hpp"
@@ -145,7 +145,7 @@ static void logSystemDebugHeartbeat() {
   lastLogMs = now;
 
   BLEDebugStats bleStats = bleNavServer.getDebugStats();
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
   const waveshare_board::rtc::Status &rtcStatus =
       waveshare_board::rtc::status();
@@ -162,7 +162,7 @@ static void logSystemDebugHeartbeat() {
     screenName = "main";
   }
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   Serial.printf("IMU: p=%d cfg=%d valid=%d addr=0x%02X n=%lu zero=%lu fail=%lu "
                 "a=%.0f,%.0f,%.0f g=%.1f,%.1f,%.1f mag=%.0f vib=%.1f "
                 "orient=%s moving=%d\n",
@@ -299,17 +299,35 @@ void setup() {
   digitalWrite(SD_CS, HIGH);
 #endif
 
-#ifdef WAVESHARE_AMOLED_175
+#ifdef WAVESHARE_AMOLED_206
+  // The 2.06 vendor demos bring the CO5300 up before touching the PMU/I2C
+  // stack. Keep that order so display recovery stays close to the proven
+  // HelloWorld baseline.
+  initTFT();
+#ifdef WAVESHARE_DISPLAY_PROBE
+  Serial.println("Waveshare 2.06 display probe complete; holding before I2C/PMU/SD/LVGL/BLE/touch init");
+  while (true) {
+    delay(1000);
+  }
+#endif
+  waveshare_board::recoverI2CBus();
+#endif
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::i2c::configureBus();
 #else
   Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
   Wire.begin();
 #endif
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::enablePowerRails();
+#ifdef WAVESHARE_DISPLAY_PROBE
+  Serial.println("Waveshare display probe: skipping RTC and IMU init");
+#else
   waveshare_board::rtc::restoreSystemTimeFromRtc();
   waveshare_board::imu::begin();
+#endif
 #endif
 
 #ifdef BME280
@@ -330,7 +348,16 @@ void setup() {
   // The QSPI display init can disrupt SPI bus settings.
   // By initializing display first, the SPI buses are settled
   // before we configure the SD card.
+#ifndef WAVESHARE_AMOLED_206
   initTFT();
+
+#ifdef WAVESHARE_DISPLAY_PROBE
+  Serial.println("Waveshare display probe complete; holding before SD/LVGL/BLE/touch init");
+  while (true) {
+    delay(1000);
+  }
+#endif
+#endif
 
   // Now initialize SD card after display is fully configured
   esp_err_t sdResult = storage.initSD();
@@ -436,7 +463,7 @@ void loop() {
   // Process BLE events
   bleNavServer.process();
 
-#ifdef WAVESHARE_AMOLED_175
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::imu::process();
 #endif
 

--- a/esp32/waveshare_206_hello.cpp
+++ b/esp32/waveshare_206_hello.cpp
@@ -1,0 +1,89 @@
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+
+#if ARDUINO_USB_CDC_ON_BOOT
+#define TEST_SERIAL Serial
+#else
+#include "HWCDC.h"
+HWCDC USBSerial;
+#define TEST_SERIAL USBSerial
+#endif
+
+namespace {
+constexpr int LCD_SDIO0 = 4;
+constexpr int LCD_SDIO1 = 5;
+constexpr int LCD_SDIO2 = 6;
+constexpr int LCD_SDIO3 = 7;
+constexpr int LCD_SCLK = 11;
+constexpr int LCD_CS = 12;
+constexpr int LCD_RESET = 8;
+constexpr int LCD_WIDTH = 410;
+constexpr int LCD_HEIGHT = 502;
+constexpr uint16_t COLOR_BLACK = 0x0000;
+constexpr uint16_t COLOR_WHITE = 0xFFFF;
+constexpr uint16_t COLOR_RED = 0xF800;
+constexpr uint16_t COLOR_GREEN = 0x07E0;
+constexpr uint16_t COLOR_BLUE = 0x001F;
+constexpr uint16_t COLOR_YELLOW = 0xFFE0;
+
+Arduino_DataBus *bus = new Arduino_ESP32QSPI(
+    LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2, LCD_SDIO3);
+
+Arduino_GFX *gfx = new Arduino_CO5300(bus, LCD_RESET, 0, LCD_WIDTH, LCD_HEIGHT,
+                                      22, 0, 0, 0);
+} // namespace
+
+void setup() {
+  TEST_SERIAL.begin(115200);
+  delay(1500);
+  TEST_SERIAL.println("Waveshare 2.06 vendor-shaped HelloWorld display test");
+  TEST_SERIAL.printf("pins cs=%d sclk=%d d0=%d d1=%d d2=%d d3=%d rst=%d\n",
+                     LCD_CS, LCD_SCLK, LCD_SDIO0, LCD_SDIO1, LCD_SDIO2,
+                     LCD_SDIO3, LCD_RESET);
+  TEST_SERIAL.printf("panel %dx%d gap=(22,0,0,0)\n", LCD_WIDTH, LCD_HEIGHT);
+
+#ifdef GFX_EXTRA_PRE_INIT
+  GFX_EXTRA_PRE_INIT();
+#endif
+
+  if (!gfx->begin()) {
+    TEST_SERIAL.println("gfx->begin() failed");
+  } else {
+    TEST_SERIAL.println("gfx->begin() ok");
+  }
+
+  gfx->fillScreen(COLOR_WHITE);
+  gfx->setCursor(10, 10);
+  gfx->setTextColor(COLOR_RED);
+  gfx->setTextSize(3);
+  gfx->println("Hello");
+  gfx->setCursor(10, 50);
+  gfx->setTextColor(COLOR_BLUE);
+  gfx->println("2.06");
+  TEST_SERIAL.println("white fill + text written");
+}
+
+void loop() {
+  static uint32_t last = 0;
+  if (millis() - last < 1000) {
+    return;
+  }
+  last = millis();
+
+  static uint8_t colorIndex = 0;
+  static constexpr uint16_t colors[] = {
+      COLOR_WHITE, COLOR_RED, COLOR_GREEN, COLOR_BLUE, COLOR_YELLOW};
+  uint16_t color = colors[colorIndex % (sizeof(colors) / sizeof(colors[0]))];
+  colorIndex++;
+
+  gfx->fillScreen(color);
+  gfx->drawRect(0, 0, gfx->width(), gfx->height(), COLOR_BLACK);
+  gfx->drawFastHLine(0, gfx->height() / 2, gfx->width(), COLOR_BLACK);
+  gfx->drawFastVLine(gfx->width() / 2, 0, gfx->height(), COLOR_BLACK);
+  gfx->setCursor(10, 10);
+  gfx->setTextColor(COLOR_BLACK);
+  gfx->setTextSize(3);
+  gfx->printf("0x%04X", color);
+  TEST_SERIAL.printf("fill 0x%04X width=%d height=%d\n", color, gfx->width(),
+                     gfx->height());
+}


### PR DESCRIPTION
## Summary
- document the Waveshare ESP32-S3-Touch-AMOLED-2.06 hardware reference
- add PlatformIO targets for `WAVESHARE_AMOLED_206`, display probe, and a vendor-shaped recovery display sketch
- generalize the Waveshare CO5300, I2C, PMU, RTC, IMU, SD, BLE, storage, and touch paths for the 2.06 variant
- keep the 2.06 boot path conservative by bringing up the display before PMU/I2C-dependent subsystems and preserving AXP2101 rails
- add FT3168 touch support with idle interrupt gating to avoid repeated idle I2C failures
- add board-specific GUI geometry so the 2.06 map uses a lower navigation anchor on the taller panel while the 1.75 path stays centered

## Validation
- `cd esp32 && pio run -e WAVESHARE_AMOLED_206_DISPLAY_TEST`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_206`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_206_VENDOR_HELLO`
- after layout tuning: `cd esp32 && pio run -e WAVESHARE_AMOLED_206`
- after layout tuning: `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- flashed `WAVESHARE_AMOLED_206_DISPLAY_TEST` to `/dev/cu.usbmodem2101`; display cycled white/red/green/blue
- flashed `WAVESHARE_AMOLED_206`; serial showed display, AXP2101, PCF85063, QMI8658, LVGL, BLE advertising, and stable idle `i2c[fail=0 recover=0]`
- on-device confirmation: iPhone app connects, SD map renders, and map dragging works on the 2.06 device

## Notes
- RTC voltage-low remains expected when the backup rail has no retained state.
- The standalone vendor-shaped display sketch is included as a known-good recovery target for cautious 2.06 bring-up.
- The 2.06 UI tuning is compile-time gated through board-specific layout constants; 1.75 keeps the centered map anchor.