### PR TITLE
Use route bearing for course-up map rotation

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -53,6 +53,10 @@ DeltaLon: Int16 microdegrees
 Coordinates are WGS-84. The iOS app converts Apple Maps route coordinates from
 GCJ-02 to WGS-84 before writing route geometry so it aligns with OSM map blocks.
 
+A zero-length route geometry packet clears the route overlay on the ESP32. The
+iOS app sends this when navigation stops so stale route geometry is not used for
+route-overlay rendering or Course Up rotation.
+
 ## GPS Position (`2A72`)
 
 Little-endian binary packet:

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -386,8 +386,20 @@ static bool hasPrefix(const std::string &value, const char *prefix) {
 
 static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                                        const char *source) {
-  if (data == nullptr || len == 0) {
-    Serial.printf("BLE: Rejected %s route geometry: empty payload\n",
+  if (len == 0) {
+    lastRouteHash = 0;
+    lastRouteLen = 0;
+    Serial.printf("BLE: %s route geometry cleared\n",
+                  source == nullptr ? "unknown" : source);
+    bleDebugStats.routePacketCount++;
+    bleDebugStats.lastRoutePacketMs = millis();
+    routeOverlay.clear();
+    triggerMapRedraw();
+    return;
+  }
+
+  if (data == nullptr) {
+    Serial.printf("BLE: Rejected %s route geometry: null payload\n",
                   source == nullptr ? "unknown" : source);
     return;
   }

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -8,6 +8,7 @@
 
 #include "mainScr.hpp"
 #include "../../ble_navigation/ble_navigation.hpp" // Access mapRenderSettings
+#include "../../route_overlay/route_overlay.hpp"
 #include "guiLayout.hpp"
 // #include "../../compass/compass.hpp"
 
@@ -61,6 +62,15 @@ static int16_t mapInteractionAnchorY() {
   const uint16_t mapHeight =
       mapSet.mapFullScreen ? mapView.mapScrFull : mapView.mapScrHeight;
   return gui_layout::mapAnchorY(mapHeight);
+}
+
+static uint16_t currentCourseUpHeading() {
+  uint16_t routeHeading = 0;
+  if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
+                               routeHeading)) {
+    return routeHeading;
+  }
+  return gps.gpsData.heading;
 }
 
 /**
@@ -228,7 +238,7 @@ void updateMainScreen(lv_timer_t *t) {
 #endif
       // Track last heading for Course-Up auto-rotation
       static uint16_t lastHeading = 0;
-      uint16_t currentHeading = gps.gpsData.heading;
+      uint16_t currentHeading = currentCourseUpHeading();
 
       // In Course-Up mode, redraw map when heading changes significantly (> 5
       // degrees)

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -2014,8 +2014,21 @@ void Maps::generateVectorMap(uint8_t zoom) {
   // CRITICAL: Update Rotation ONCE per generation frame to ensure map and route
   // align
   if (rotationMode == ROT_COURSE_UP) {
-    // Use negative heading to rotate map so heading points UP
-    rotationRad = -DEG2RAD(gps.gpsData.heading);
+    uint16_t courseUpHeading = gps.gpsData.heading;
+    const char *courseUpSource = "gps";
+    uint16_t routeHeading = 0;
+    if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
+                                 routeHeading)) {
+      courseUpHeading = routeHeading;
+      courseUpSource = "route";
+    }
+
+    // Use negative heading to rotate map so the selected navigation/course
+    // direction points up.
+    rotationRad = -DEG2RAD(courseUpHeading);
+    ESP_LOGI(TAG, "Course-Up: heading=%u source=%s gpsHeading=%u",
+             (unsigned)courseUpHeading, courseUpSource,
+             (unsigned)gps.gpsData.heading);
   } else {
     rotationRad = 0;
   }

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -11,6 +11,7 @@
 #include "../../utils/src/gpsMath.hpp"
 #include <Arduino.h>
 #include <algorithm>
+#include <cfloat>
 #include <cmath>
 #include <cstring>
 
@@ -78,6 +79,57 @@ void RouteOverlay::parseRouteData(const uint8_t *data, size_t len) {
 void RouteOverlay::clear() {
   points.clear();
   Serial.println("Route overlay cleared");
+}
+
+bool RouteOverlay::headingNear(double lat, double lon,
+                               uint16_t &headingDeg) const {
+  if (points.size() < 2) {
+    return false;
+  }
+
+  const double cosLat = cos(DEG2RAD(lat));
+  double bestDistanceSq = DBL_MAX;
+  size_t bestSegment = 0;
+
+  for (size_t i = 0; i + 1 < points.size(); i++) {
+    const double lat1 = points[i].lat / 1000000.0;
+    const double lon1 = points[i].lon / 1000000.0;
+    const double lat2 = points[i + 1].lat / 1000000.0;
+    const double lon2 = points[i + 1].lon / 1000000.0;
+
+    const double x1 = (lon1 - lon) * cosLat;
+    const double y1 = lat1 - lat;
+    const double x2 = (lon2 - lon) * cosLat;
+    const double y2 = lat2 - lat;
+    const double segX = x2 - x1;
+    const double segY = y2 - y1;
+    const double segLenSq = (segX * segX) + (segY * segY);
+    if (segLenSq <= 0.0) {
+      continue;
+    }
+
+    double t = -((x1 * segX) + (y1 * segY)) / segLenSq;
+    t = std::max(0.0, std::min(1.0, t));
+    const double closestX = x1 + (segX * t);
+    const double closestY = y1 + (segY * t);
+    const double distanceSq = (closestX * closestX) + (closestY * closestY);
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      bestSegment = i;
+    }
+  }
+
+  if (bestDistanceSq == DBL_MAX) {
+    return false;
+  }
+
+  const double segmentHeading =
+      calcCourse(points[bestSegment].lat / 1000000.0,
+                 points[bestSegment].lon / 1000000.0,
+                 points[bestSegment + 1].lat / 1000000.0,
+                 points[bestSegment + 1].lon / 1000000.0);
+  headingDeg = static_cast<uint16_t>(round(segmentHeading)) % 360;
+  return true;
 }
 
 #ifndef DEG2RAD

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -75,6 +75,16 @@ public:
    */
   size_t getPointCount() const { return points.size(); }
 
+  /**
+   * @brief Estimate route bearing near a current GPS position.
+   *
+   * @param lat Current latitude in degrees
+   * @param lon Current longitude in degrees
+   * @param headingDeg Output route segment bearing in degrees, 0-359
+   * @return true when a usable route segment was found
+   */
+  bool headingNear(double lat, double lon, uint16_t &headingDeg) const;
+
 private:
   std::vector<GeoPoint, PsramAllocator<GeoPoint>> points;
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -361,6 +361,11 @@ class BLEManager: NSObject, ObservableObject {
         sendFallbackMapPacket(fallback, label: "route geometry")
     }
 
+    /// Clear route geometry on ESP32.
+    func clearRouteGeometry() {
+        sendRouteGeometry(Data())
+    }
+
     /// Send GPS position to ESP32.
     /// Format: [Lat:4][Lon:4][Heading:2][UnixTime:4] with WGS-84 microdegrees.
     func sendGPSPosition(lat: Double, lon: Double, heading: Double = 0) {

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -331,12 +331,22 @@ class NavigationEngine: NSObject, ObservableObject {
     private func resendCurrentRouteGeometry() {
         guard isNavigating, let route = currentRoute, route.polyline.pointCount > 0 else { return }
 
-        var startCoordinate = CLLocationCoordinate2D()
-        route.polyline.getCoordinates(&startCoordinate, range: NSRange(location: 0, length: 1))
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
-        sendRouteGeometryIfNeeded(currentLocation: CLLocation(latitude: startCoordinate.latitude,
-                                                              longitude: startCoordinate.longitude))
+        sendRouteGeometryIfNeeded(currentLocation: routeGeometryResendLocation(for: route))
+    }
+
+    private func routeGeometryResendLocation(for route: MKRoute) -> CLLocation {
+        if let lastDeviceGpsLocation {
+            if lastDeviceGpsLocation.convertFromMapKitRoute {
+                return lastDeviceGpsLocation.location
+            }
+            return CoordinateConverter.mapKitRouteLocation(fromGPSLocation: lastDeviceGpsLocation.location)
+        }
+
+        var startCoordinate = CLLocationCoordinate2D()
+        route.polyline.getCoordinates(&startCoordinate, range: NSRange(location: 0, length: 1))
+        return CLLocation(latitude: startCoordinate.latitude, longitude: startCoordinate.longitude)
     }
 
     private func resendCurrentDeviceGpsPosition() {

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -56,10 +56,14 @@ class NavigationEngine: NSObject, ObservableObject {
             .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isReady in
-                guard isReady else { return }
-                self?.resendCurrentDeviceGpsPosition()
-                self?.resendCurrentRouteGeometry()
-                self?.resendCurrentNavigationState()
+                guard isReady, let self else { return }
+                guard self.isNavigating else {
+                    self.bleManager?.clearRouteGeometry()
+                    return
+                }
+                self.resendCurrentDeviceGpsPosition()
+                self.resendCurrentRouteGeometry()
+                self.resendCurrentNavigationState()
             }
             .store(in: &cancellables)
     }
@@ -99,6 +103,7 @@ class NavigationEngine: NSObject, ObservableObject {
     
     /// Stop navigation
     func stopNavigation() {
+        bleManager?.clearRouteGeometry()
         isNavigating = false
         currentRoute = nil
         currentStepIndex = 0
@@ -107,6 +112,8 @@ class NavigationEngine: NSObject, ObservableObject {
         initialNavigationLocation = nil
         lastDeviceGpsLocation = nil
         hasAcceptedLiveLocation = false
+        lastSentGeometryHash = 0
+        lastGeometrySendTime = .distantPast
         stopSimulation()
         print("Navigation stopped")
     }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift
@@ -47,19 +47,7 @@ class CoordinateConverter {
             wgsLon += (lon - gcj.lon)
         }
         
-        // Apply manual calibration
-        return applyCalibration(lat: wgsLat, lon: wgsLon)
-    }
-    
-    /// Apply manual calibration nudge to WGS-84 coordinates
-    /// Used to correct specific map tile offsets (e.g. ~50m offset in Shanghai)
-    static func applyCalibration(lat: Double, lon: Double) -> (lat: Double, lon: Double) {
-        if !isInChina(lat: lat, lon: lon) {
-             return (lat, lon)
-        }
-        // Standard calibration: +80m North, 0m East/West (China only)
-        // User confirmed this provides correct alignment in North-Up mode.
-        return (lat + 0.00080, lon + 0.0)
+        return (wgsLat, wgsLon)
     }
     
     /// Convert CLLocationCoordinate2D from GCJ-02 to WGS-84

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -91,6 +91,7 @@ struct NavigationProtocolTests {
     static func main() {
         testIconMapping()
         testRouteEndpointExtraction()
+        testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
         testSourceEndpointSelection()
         testRouteInitialLocationUsesResolvedSource()
         testRouteTransportTypes()
@@ -132,6 +133,18 @@ struct NavigationProtocolTests {
 
         let emptyPolyline = MKPolyline()
         assert(RoutePolylineEndpoint.location(for: emptyPolyline) == nil, "empty polyline has no endpoint")
+    }
+
+    static func testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge() {
+        let wgs = CLLocationCoordinate2D(latitude: 31.2304, longitude: 121.4737)
+        let gcj = CoordinateConverter.wgs84ToGCJ02(coordinate: wgs)
+        let converted = CoordinateConverter.gcj02ToWGS84(coordinate: gcj)
+
+        assert(
+            CLLocation(latitude: converted.latitude, longitude: converted.longitude)
+                .distance(from: CLLocation(latitude: wgs.latitude, longitude: wgs.longitude)) < 2,
+            "GCJ route inverse should return WGS without a fixed calibration offset"
+        )
     }
 
     static func testSourceEndpointSelection() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -26,6 +26,7 @@ func assertCoordinate(
 
 final class TestBLEManager: BLEManager {
     var sentPackets: [String] = []
+    var sentRouteGeometry: [Data] = []
 
     override func centralManagerDidUpdateState(_ central: CBCentralManager) {
         // Keep CoreBluetooth startup callbacks from changing test-controlled state.
@@ -38,6 +39,14 @@ final class TestBLEManager: BLEManager {
 
         sentPackets.append(data)
         return true
+    }
+
+    override func sendRouteGeometry(_ data: Data) {
+        guard isConnected, isNavigationReady else {
+            return
+        }
+
+        sentRouteGeometry.append(data)
     }
 }
 
@@ -92,6 +101,7 @@ struct NavigationProtocolTests {
         testIconMapping()
         testRouteEndpointExtraction()
         testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
+        testNonChinaCoordinatesPassThroughUnchanged()
         testSourceEndpointSelection()
         testRouteInitialLocationUsesResolvedSource()
         testRouteTransportTypes()
@@ -103,6 +113,9 @@ struct NavigationProtocolTests {
         testBLEManagerPersistsNewMapSettings()
         testNavigationSendTrackerReadinessRetry()
         testNavigationEngineResendsWhenBLEBecomesReady()
+        testNavigationEngineResendsRouteGeometryNearLastLocation()
+        testNavigationEngineClearsRouteGeometryOnStop()
+        testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         print("NavigationProtocolTests passed")
     }
@@ -145,6 +158,19 @@ struct NavigationProtocolTests {
                 .distance(from: CLLocation(latitude: wgs.latitude, longitude: wgs.longitude)) < 2,
             "GCJ route inverse should return WGS without a fixed calibration offset"
         )
+    }
+
+    static func testNonChinaCoordinatesPassThroughUnchanged() {
+        let coordinate = CLLocationCoordinate2D(latitude: 37.7749, longitude: -122.4194)
+
+        assertCoordinate(CoordinateConverter.wgs84ToGCJ02(coordinate: coordinate),
+                         latitude: coordinate.latitude,
+                         longitude: coordinate.longitude,
+                         "non-China WGS->GCJ should pass through")
+        assertCoordinate(CoordinateConverter.gcj02ToWGS84(coordinate: coordinate),
+                         latitude: coordinate.latitude,
+                         longitude: coordinate.longitude,
+                         "non-China GCJ->WGS should pass through")
     }
 
     static func testSourceEndpointSelection() {
@@ -361,6 +387,76 @@ struct NavigationProtocolTests {
         assertEqual(String(fields[2]), "Turn left onto Test Road", "resent packet keeps current instruction")
     }
 
+    static func testNavigationEngineResendsRouteGeometryNearLastLocation() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0020, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0030, longitude: -122.0000)
+        ]
+        let route = TestRoute(instructions: "Continue", coordinates: coordinates)
+        engine.startNavigation(with: route)
+        engine.processExternalLocation(CLLocation(latitude: coordinates[2].latitude,
+                                                  longitude: coordinates[2].longitude))
+        manager.sentRouteGeometry.removeAll()
+
+        manager.isNavigationReady = false
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        manager.isNavigationReady = true
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        assertEqual(manager.sentRouteGeometry.count, 1, "navigation readiness should resend route geometry")
+        guard let firstCoordinate = routeStartCoordinate(from: manager.sentRouteGeometry[0]) else {
+            assert(false, "route geometry should include a start coordinate")
+            return
+        }
+        assertCoordinate(firstCoordinate,
+                         latitude: coordinates[2].latitude,
+                         longitude: coordinates[2].longitude,
+                         "route geometry resend should use the latest device location window")
+    }
+
+    static func testNavigationEngineClearsRouteGeometryOnStop() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000)
+        ]
+        let route = TestRoute(instructions: "Continue", coordinates: coordinates)
+        engine.startNavigation(with: route)
+        manager.sentRouteGeometry.removeAll()
+
+        engine.stopNavigation()
+
+        assertEqual(manager.sentRouteGeometry, [Data()], "stop navigation should clear route geometry")
+    }
+
+    static func testNavigationEngineClearsRouteGeometryWhenReadyAndIdle() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        manager.isNavigationReady = true
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        assertEqual(manager.sentRouteGeometry, [Data()], "idle readiness should clear route geometry")
+    }
+
     static func testNavigationEngineIgnoresLiveLocationFarFromRouteStart() {
         let manager = TestBLEManager()
         manager.isConnected = true
@@ -383,5 +479,23 @@ struct NavigationProtocolTests {
         engine.processExternalLocation(unrelatedDeviceLocation)
 
         assertEqual(manager.sentPackets.count, 1, "far live GPS should not overwrite a route started from another source")
+    }
+
+    static func routeStartCoordinate(from data: Data) -> CLLocationCoordinate2D? {
+        guard data.count >= 8 else { return nil }
+
+        let latBits = UInt32(data[0]) |
+            (UInt32(data[1]) << 8) |
+            (UInt32(data[2]) << 16) |
+            (UInt32(data[3]) << 24)
+        let lonBits = UInt32(data[4]) |
+            (UInt32(data[5]) << 8) |
+            (UInt32(data[6]) << 16) |
+            (UInt32(data[7]) << 24)
+        let lat = Int32(bitPattern: latBits)
+        let lon = Int32(bitPattern: lonBits)
+
+        return CLLocationCoordinate2D(latitude: Double(lat) / 1_000_000,
+                                      longitude: Double(lon) / 1_000_000)
     }
 }


### PR DESCRIPTION
## Summary
- derive a route-segment bearing from the current sliding route geometry window
- use that route bearing for Course Up / blue map rotation when a route is loaded
- keep GPS course as the fallback when no route geometry is available
- use the same route-preferred heading for Course Up redraw detection
- clear ESP32 route geometry when navigation stops or the app reconnects idle, so stale routes cannot keep driving Course Up rotation
- resend route geometry from the latest known device location after BLE reconnect instead of jumping back to the route start
- remove the hardcoded China route-calibration nudge so MapKit GCJ-02 routes convert cleanly to WGS-84 for the ESP32 OSM map

## Validation
- `git diff --check`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_206`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- `cd ios-app && swiftc BikeComputer/BikeComputer/Models/AppModels.swift BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift BikeComputer/BikeComputer/Managers/BLEManager.swift BikeComputer/BikeComputer/Managers/NavigationEngine.swift BikeComputerTests/NavigationProtocolTests.swift -o /tmp/NavigationProtocolTests && /tmp/NavigationProtocolTests`
- `cd ios-app && xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'platform=iOS,id=00008140-001055643C81401C' build`
- installed the updated dev app on the connected iPhone with `xcrun devicectl device install app`
- on-device China navigation test: route overlay now aligns with the road/GPS dot

## Notes
- A zero-length route geometry write now means “clear route” in the BLE protocol.
- Free-ride/map-only Course Up behavior falls back to the iPhone GPS course once no route geometry is available.
- Outside mainland China, coordinate conversion functions return the original WGS-84 coordinates unchanged.
- The first 2.06 PlatformIO build attempt failed after linking with a missing pioarduino helper file while another environment was building in parallel; rerunning `WAVESHARE_AMOLED_206` alone succeeded.
