### PR TITLE
Add ride telemetry device screen

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -66,13 +66,18 @@ Lat: Int32 microdegrees
 Lon: Int32 microdegrees
 Heading: UInt16 degrees, 0...359
 UnixTime: UInt32 seconds since 1970-01-01T00:00:00Z (optional)
+Speed: UInt16 centimeters/second, 0xFFFF invalid (optional)
+Altitude: Int16 meters (optional)
+DistanceTraveled: UInt32 meters (optional)
+ElapsedTime: UInt32 seconds (optional)
+RouteRemaining: UInt32 meters, 0xFFFFFFFF invalid (optional)
 ```
 
 Live CoreLocation coordinates are sent as WGS-84. Simulated or MapKit route
 coordinates are converted from GCJ-02 to WGS-84 before writing. Firmware accepts
-the original 8-byte lat/lon payload, the 10-byte lat/lon/heading payload, and
-the 14-byte payload with Unix time. The Waveshare firmware uses the optional
-Unix time to sync the onboard PCF85063 RTC.
+the original 8-byte lat/lon payload, the 10-byte lat/lon/heading payload, the
+14-byte payload with Unix time, and the extended 30-byte telemetry payload. The
+Waveshare firmware uses the optional Unix time to sync the onboard PCF85063 RTC.
 
 ## Map Settings (`2A73`)
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -454,6 +454,41 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
     gps.gpsData.heading = headingVal;
   }
 
+  if (len >= 16) {
+    uint16_t speedCmps;
+    memcpy(&speedCmps, data + 14, sizeof(speedCmps));
+    if (speedCmps != 0xFFFF) {
+      gps.gpsData.speed = (uint16_t)((speedCmps * 36U + 500U) / 1000U);
+    }
+  }
+
+  if (len >= 18) {
+    int16_t altitudeMeters;
+    memcpy(&altitudeMeters, data + 16, sizeof(altitudeMeters));
+    gps.gpsData.altitude = altitudeMeters;
+  }
+
+  if (len >= 22) {
+    uint32_t distanceMeters;
+    memcpy(&distanceMeters, data + 18, sizeof(distanceMeters));
+    gps.gpsData.distanceTraveled = distanceMeters;
+  }
+
+  if (len >= 26) {
+    uint32_t elapsedSeconds;
+    memcpy(&elapsedSeconds, data + 22, sizeof(elapsedSeconds));
+    gps.gpsData.elapsedSeconds = elapsedSeconds;
+  }
+
+  if (len >= 30) {
+    uint32_t routeRemainingMeters;
+    memcpy(&routeRemainingMeters, data + 26, sizeof(routeRemainingMeters));
+    gps.gpsData.hasRouteRemaining = routeRemainingMeters != 0xFFFFFFFF;
+    if (gps.gpsData.hasRouteRemaining) {
+      gps.gpsData.routeRemaining = routeRemainingMeters;
+    }
+  }
+
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   bool rtcTimestampSynced = false;
   if (len >= 14) {

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -459,6 +459,8 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
     memcpy(&speedCmps, data + 14, sizeof(speedCmps));
     if (speedCmps != 0xFFFF) {
       gps.gpsData.speed = (uint16_t)((speedCmps * 36U + 500U) / 1000U);
+    } else {
+      gps.gpsData.speed = 0;
     }
   }
 

--- a/esp32/lib/gps/gps.hpp
+++ b/esp32/lib/gps/gps.hpp
@@ -74,6 +74,10 @@ public:
     uint8_t fixMode;
     int16_t altitude;
     uint16_t speed;
+    uint32_t distanceTraveled;
+    uint32_t elapsedSeconds;
+    uint32_t routeRemaining;
+    bool hasRouteRemaining;
     double latitude;
     double longitude;
     uint16_t heading;

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -46,6 +46,7 @@ static void positionMapToolbarButtons(uint16_t mapHeight) {
 lv_obj_t *tilesScreen;
 lv_obj_t *compassTile;
 lv_obj_t *navTile;
+lv_obj_t *rideStatsTile;
 lv_obj_t *mapTile;
 lv_obj_t *satTrackTile;
 lv_obj_t *btnFullScreen;
@@ -286,6 +287,10 @@ void updateMainScreen(lv_timer_t *t) {
 
     case NAV:
       lv_obj_send_event(navTile, LV_EVENT_VALUE_CHANGED, NULL);
+      break;
+
+    case RIDESTATS:
+      lv_obj_send_event(rideStatsTile, LV_EVENT_VALUE_CHANGED, NULL);
       break;
 
     case SATTRACK:
@@ -722,35 +727,60 @@ void updateNavEvent(lv_event_t *event) {
   lv_img_set_angle(arrowNav, arrowAngle);
 }
 
-static void showNavigationScreen(bool showNavigation) {
-  if (!mapTile || !navTile) {
+static void showMainTile(tileName tile) {
+  if (!mapTile || !navTile || !rideStatsTile) {
     return;
   }
 
-  if (showNavigation) {
-    activeTile = NAV;
-    canScrollMap = false;
-    lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
+
+  activeTile = tile;
+  canScrollMap = tile == MAP;
+
+  switch (tile) {
+  case NAV:
     lv_obj_clear_flag(navTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_send_event(navTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to navigation instruction screen");
-  } else {
-    activeTile = MAP;
-    canScrollMap = true;
-    lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
+    break;
+  case RIDESTATS:
+    lv_obj_clear_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_send_event(rideStatsTile, LV_EVENT_VALUE_CHANGED, NULL);
+    log_i("UI: switched to ride telemetry screen");
+    break;
+  case MAP:
+  default:
     lv_obj_clear_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
     mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to map screen");
+    break;
+  }
+}
+
+void showNextMainScreen() {
+  switch (activeTile) {
+  case MAP:
+    showMainTile(NAV);
+    break;
+  case NAV:
+    showMainTile(RIDESTATS);
+    break;
+  case RIDESTATS:
+  default:
+    showMainTile(MAP);
+    break;
   }
 }
 
 void toggleNavigationScreen() {
-  if (!isMainScreen || !mainScreen || !mapTile || !navTile) {
+  if (!isMainScreen || !mainScreen || !mapTile || !navTile || !rideStatsTile) {
     return;
   }
 
-  showNavigationScreen(activeTile == MAP);
+  showNextMainScreen();
 }
 
 /**
@@ -777,6 +807,16 @@ void createMainScr() {
   navigationScr(navTile);
   lv_obj_add_event_cb(navTile, updateNavEvent, LV_EVENT_VALUE_CHANGED, NULL);
   lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
+
+  rideStatsTile = lv_obj_create(mainScreen);
+  lv_obj_remove_style_all(rideStatsTile);
+  lv_obj_set_size(rideStatsTile, TFT_WIDTH, TFT_HEIGHT);
+  lv_obj_set_pos(rideStatsTile, 0, 0);
+  lv_obj_clear_flag(rideStatsTile, LV_OBJ_FLAG_SCROLLABLE);
+  rideTelemetryScr(rideStatsTile);
+  lv_obj_add_event_cb(rideStatsTile, updateRideTelemetryEvent,
+                      LV_EVENT_VALUE_CHANGED, NULL);
+  lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
 
   // Set tilesScreen to same as mapTile for compatibility
   tilesScreen = mapTile;

--- a/esp32/lib/gui/src/mainScr.hpp
+++ b/esp32/lib/gui/src/mainScr.hpp
@@ -16,6 +16,7 @@
 #endif
 #include "globalGuiDef.h"
 #include "navScr.hpp"
+#include "rideTelemetryScr.hpp"
 #include "satInfoScr.hpp"
 #include "widgets.hpp"
 
@@ -37,6 +38,7 @@ enum tileName {
   MAP,
   NAV,
   SATTRACK,
+  RIDESTATS,
 };
 
 /**
@@ -45,6 +47,7 @@ enum tileName {
  */
 extern lv_obj_t *compassTile;
 extern lv_obj_t *navTile;
+extern lv_obj_t *rideStatsTile;
 extern lv_obj_t *mapTile;
 extern lv_obj_t *satTrackTile;
 extern lv_obj_t *tilesScreen;
@@ -75,6 +78,7 @@ void fullScreenEvent(lv_event_t *event);
 void zoomOutEvent(lv_event_t *event);
 void zoomInEvent(lv_event_t *event);
 void updateNavEvent(lv_event_t *event);
+void showNextMainScreen();
 
 void createMainScr();
 void toggleNavigationScreen();

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -1,0 +1,118 @@
+/**
+ * @file rideTelemetryScr.cpp
+ * @brief LVGL ride telemetry screen
+ */
+
+#include "rideTelemetryScr.hpp"
+#include "gps.hpp"
+#include <cstdio>
+
+extern Gps gps;
+
+lv_obj_t *rideSpeedValue;
+lv_obj_t *rideAltitudeValue;
+lv_obj_t *rideDistanceValue;
+lv_obj_t *rideElapsedValue;
+lv_obj_t *rideRouteRemainingValue;
+
+static lv_obj_t *createMetricLabel(lv_obj_t *screen, const char *title,
+                                   lv_coord_t x, lv_coord_t y) {
+  lv_obj_t *titleLabel = lv_label_create(screen);
+  lv_obj_set_style_text_font(titleLabel, fontOptions, 0);
+  lv_obj_set_style_text_color(titleLabel, lv_color_hex(0xAAAAAA), 0);
+  lv_label_set_text_static(titleLabel, title);
+  lv_obj_set_pos(titleLabel, x, y);
+
+  lv_obj_t *valueLabel = lv_label_create(screen);
+  lv_obj_set_style_text_font(valueLabel, fontLargeMedium, 0);
+  lv_obj_set_style_text_color(valueLabel, lv_color_white(), 0);
+  lv_label_set_text_static(valueLabel, "--");
+  lv_obj_set_pos(valueLabel, x, y + 28);
+  return valueLabel;
+}
+
+static void formatElapsed(uint32_t elapsedSeconds, char *buffer,
+                          size_t bufferSize) {
+  const uint32_t hours = elapsedSeconds / 3600;
+  const uint32_t minutes = (elapsedSeconds / 60) % 60;
+  const uint32_t seconds = elapsedSeconds % 60;
+
+  if (hours > 0) {
+    snprintf(buffer, bufferSize, "%lu:%02lu:%02lu", (unsigned long)hours,
+             (unsigned long)minutes, (unsigned long)seconds);
+  } else {
+    snprintf(buffer, bufferSize, "%02lu:%02lu", (unsigned long)minutes,
+             (unsigned long)seconds);
+  }
+}
+
+static void setDistanceLabel(lv_obj_t *label, uint32_t meters) {
+  if (meters >= 10000) {
+    lv_label_set_text_fmt(label, "%lu km", (unsigned long)(meters / 1000));
+  } else if (meters >= 1000) {
+    lv_label_set_text_fmt(label, "%.1f km", meters / 1000.0f);
+  } else {
+    lv_label_set_text_fmt(label, "%lu m", (unsigned long)meters);
+  }
+}
+
+void rideTelemetryScr(_lv_obj_t *screen) {
+  lv_obj_set_style_bg_color(screen, lv_color_black(), 0);
+  lv_obj_set_style_bg_opa(screen, LV_OPA_COVER, 0);
+
+  lv_obj_t *title = lv_label_create(screen);
+  lv_obj_set_style_text_font(title, fontOptions, 0);
+  lv_obj_set_style_text_color(title, lv_color_hex(0xAAAAAA), 0);
+  lv_label_set_text_static(title, "Ride stats");
+  lv_obj_align(title, LV_ALIGN_TOP_MID, 0, 18);
+
+  rideSpeedValue = lv_label_create(screen);
+  lv_obj_set_style_text_font(rideSpeedValue, fontVeryLarge, 0);
+  lv_obj_set_style_text_color(rideSpeedValue, lv_color_white(), 0);
+  lv_obj_set_style_text_align(rideSpeedValue, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_text_static(rideSpeedValue, "0");
+  lv_obj_set_width(rideSpeedValue, TFT_WIDTH);
+  lv_obj_align(rideSpeedValue, LV_ALIGN_TOP_MID, 0, 52);
+
+  lv_obj_t *speedUnit = lv_label_create(screen);
+  lv_obj_set_style_text_font(speedUnit, fontOptions, 0);
+  lv_obj_set_style_text_color(speedUnit, lv_color_hex(0xAAAAAA), 0);
+  lv_label_set_text_static(speedUnit, "km/h");
+  lv_obj_align(speedUnit, LV_ALIGN_TOP_MID, 0, 118);
+
+  const lv_coord_t leftX = 34;
+  const lv_coord_t rightX = TFT_WIDTH / 2 + 14;
+  rideAltitudeValue = createMetricLabel(screen, "Altitude", leftX, 170);
+  rideDistanceValue = createMetricLabel(screen, "Distance", rightX, 170);
+  rideElapsedValue = createMetricLabel(screen, "Elapsed", leftX, 270);
+  rideRouteRemainingValue =
+      createMetricLabel(screen, "Route left", rightX, 270);
+}
+
+void updateRideTelemetryEvent(lv_event_t *event) {
+  if (rideSpeedValue) {
+    lv_label_set_text_fmt(rideSpeedValue, "%u", gps.gpsData.speed);
+  }
+
+  if (rideAltitudeValue) {
+    lv_label_set_text_fmt(rideAltitudeValue, "%d m", gps.gpsData.altitude);
+  }
+
+  if (rideDistanceValue) {
+    setDistanceLabel(rideDistanceValue, gps.gpsData.distanceTraveled);
+  }
+
+  if (rideElapsedValue) {
+    char elapsed[16];
+    formatElapsed(gps.gpsData.elapsedSeconds, elapsed, sizeof(elapsed));
+    lv_label_set_text(rideElapsedValue, elapsed);
+  }
+
+  if (rideRouteRemainingValue) {
+    if (gps.gpsData.hasRouteRemaining) {
+      setDistanceLabel(rideRouteRemainingValue, gps.gpsData.routeRemaining);
+    } else {
+      lv_label_set_text_static(rideRouteRemainingValue, "--");
+    }
+  }
+}

--- a/esp32/lib/gui/src/rideTelemetryScr.hpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.hpp
@@ -1,0 +1,17 @@
+/**
+ * @file rideTelemetryScr.hpp
+ * @brief LVGL ride telemetry screen
+ */
+
+#pragma once
+
+#include "globalGuiDef.h"
+
+extern lv_obj_t *rideSpeedValue;
+extern lv_obj_t *rideAltitudeValue;
+extern lv_obj_t *rideDistanceValue;
+extern lv_obj_t *rideElapsedValue;
+extern lv_obj_t *rideRouteRemainingValue;
+
+void rideTelemetryScr(_lv_obj_t *screen);
+void updateRideTelemetryEvent(lv_event_t *event);

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -110,7 +110,7 @@ static void processWaveshareBootButton() {
 
   const uint32_t pressDurationMs = now - pressStartMs;
   if (pressDurationMs > 0 && pressDurationMs <= SHORT_PRESS_MAX_MS) {
-    log_i("Waveshare BOOT short press: toggling navigation screen");
+    log_i("Waveshare BOOT short press: cycling main screen");
     toggleNavigationScreen();
   }
 }
@@ -169,6 +169,8 @@ static const char *debugTileName(uint8_t tile) {
     return "NAV";
   case SATTRACK:
     return "SATTRACK";
+  case RIDESTATS:
+    return "RIDESTATS";
   default:
     return "UNKNOWN";
   }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -402,9 +402,18 @@ class BLEManager: NSObject, ObservableObject {
         sendRouteGeometry(Data())
     }
 
-    /// Send GPS position to ESP32.
-    /// Format: [Lat:4][Lon:4][Heading:2][UnixTime:4] with WGS-84 microdegrees.
-    func sendGPSPosition(lat: Double, lon: Double, heading: Double = 0) {
+    /// Send GPS position and optional ride telemetry to ESP32.
+    /// Format: [Lat:4][Lon:4][Heading:2][UnixTime:4][SpeedCmps:2][Altitude:2][Distance:4][Elapsed:4][RouteRemaining:4].
+    func sendGPSPosition(
+        lat: Double,
+        lon: Double,
+        heading: Double = 0,
+        speedMetersPerSecond: Double? = nil,
+        altitudeMeters: Double? = nil,
+        distanceTraveledMeters: Double? = nil,
+        elapsedSeconds: TimeInterval? = nil,
+        routeRemainingMeters: Double? = nil
+    ) {
         guard let peripheral = connectedPeripheral,
               isConnected,
               isNavigationReady else {
@@ -416,10 +425,30 @@ class BLEManager: NSObject, ObservableObject {
         let lonInt = Int32(lon * 1_000_000)
         let headingDeg: UInt16 = heading >= 0 ? UInt16(min(heading, 359)) : 0
         let unixTime = UInt32(Date().timeIntervalSince1970)
+        let speedCmps: UInt16 = {
+            guard let speedMetersPerSecond, speedMetersPerSecond >= 0 else {
+                return UInt16.max
+            }
+            return UInt16(min((speedMetersPerSecond * 100).rounded(), Double(UInt16.max - 1)))
+        }()
+        let altitudeInt = Int16(max(min((altitudeMeters ?? 0).rounded(), Double(Int16.max)), Double(Int16.min)))
+        let distanceInt = UInt32(max(min((distanceTraveledMeters ?? 0).rounded(), Double(UInt32.max)), 0))
+        let elapsedInt = UInt32(max(min((elapsedSeconds ?? 0).rounded(), Double(UInt32.max)), 0))
+        let routeRemainingInt: UInt32 = {
+            guard let routeRemainingMeters, routeRemainingMeters >= 0 else {
+                return UInt32.max
+            }
+            return UInt32(max(min(routeRemainingMeters.rounded(), Double(UInt32.max - 1)), 0))
+        }()
         withUnsafeBytes(of: latInt.littleEndian) { data.append(contentsOf: $0) }
         withUnsafeBytes(of: lonInt.littleEndian) { data.append(contentsOf: $0) }
         withUnsafeBytes(of: headingDeg.littleEndian) { data.append(contentsOf: $0) }
         withUnsafeBytes(of: unixTime.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: speedCmps.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: altitudeInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: distanceInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: elapsedInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: routeRemainingInt.littleEndian) { data.append(contentsOf: $0) }
 
         if let characteristic = gpsPositionCharacteristic {
             peripheral.writeValue(data, for: characteristic, type: .withoutResponse)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -420,35 +420,16 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        var data = Data()
-        let latInt = Int32(lat * 1_000_000)
-        let lonInt = Int32(lon * 1_000_000)
-        let headingDeg: UInt16 = heading >= 0 ? UInt16(min(heading, 359)) : 0
-        let unixTime = UInt32(Date().timeIntervalSince1970)
-        let speedCmps: UInt16 = {
-            guard let speedMetersPerSecond, speedMetersPerSecond >= 0 else {
-                return UInt16.max
-            }
-            return UInt16(min((speedMetersPerSecond * 100).rounded(), Double(UInt16.max - 1)))
-        }()
-        let altitudeInt = Int16(max(min((altitudeMeters ?? 0).rounded(), Double(Int16.max)), Double(Int16.min)))
-        let distanceInt = UInt32(max(min((distanceTraveledMeters ?? 0).rounded(), Double(UInt32.max)), 0))
-        let elapsedInt = UInt32(max(min((elapsedSeconds ?? 0).rounded(), Double(UInt32.max)), 0))
-        let routeRemainingInt: UInt32 = {
-            guard let routeRemainingMeters, routeRemainingMeters >= 0 else {
-                return UInt32.max
-            }
-            return UInt32(max(min(routeRemainingMeters.rounded(), Double(UInt32.max - 1)), 0))
-        }()
-        withUnsafeBytes(of: latInt.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: lonInt.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: headingDeg.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: unixTime.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: speedCmps.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: altitudeInt.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: distanceInt.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: elapsedInt.littleEndian) { data.append(contentsOf: $0) }
-        withUnsafeBytes(of: routeRemainingInt.littleEndian) { data.append(contentsOf: $0) }
+        let data = DeviceGPSPacketBuilder.data(
+            lat: lat,
+            lon: lon,
+            heading: heading,
+            speedMetersPerSecond: speedMetersPerSecond,
+            altitudeMeters: altitudeMeters,
+            distanceTraveledMeters: distanceTraveledMeters,
+            elapsedSeconds: elapsedSeconds,
+            routeRemainingMeters: routeRemainingMeters
+        )
 
         if let characteristic = gpsPositionCharacteristic {
             peripheral.writeValue(data, for: characteristic, type: .withoutResponse)

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -399,50 +399,10 @@ class NavigationEngine: NSObject, ObservableObject {
         lastRideLocation = gpsLocation
 
         if isNavigating, let route = currentRoute, let routeLocation {
-            lastRouteRemainingMeters = routeRemainingDistance(from: routeLocation, in: route)
+            lastRouteRemainingMeters = RouteProgress.remainingDistance(from: routeLocation, in: route)
         } else {
             lastRouteRemainingMeters = nil
         }
-    }
-
-    private func routeRemainingDistance(from location: CLLocation, in route: MKRoute) -> CLLocationDistance? {
-        let polyline = route.polyline
-        let pointCount = polyline.pointCount
-        guard pointCount > 1 else { return nil }
-
-        let routePoints = polyline.points()
-        let target = MKMapPoint(location.coordinate)
-        var totalDistance: CLLocationDistance = 0
-        var closestDistance = Double.greatestFiniteMagnitude
-        var closestDistanceAlongRoute: CLLocationDistance = 0
-
-        for index in 0..<(pointCount - 1) {
-            let start = routePoints[index]
-            let end = routePoints[index + 1]
-            let dx = end.x - start.x
-            let dy = end.y - start.y
-            let segmentLengthSquared = dx * dx + dy * dy
-            let segmentLength = start.distance(to: end)
-
-            if segmentLengthSquared > 0 {
-                let rawProjection = ((target.x - start.x) * dx + (target.y - start.y) * dy) / segmentLengthSquared
-                let projection = min(max(rawProjection, 0), 1)
-                let projected = MKMapPoint(x: start.x + projection * dx, y: start.y + projection * dy)
-                let distanceToSegment = target.distance(to: projected)
-                if distanceToSegment < closestDistance {
-                    closestDistance = distanceToSegment
-                    closestDistanceAlongRoute = totalDistance + start.distance(to: projected)
-                }
-            }
-
-            totalDistance += segmentLength
-        }
-
-        guard totalDistance > 0 else { return nil }
-
-        let routeDistance = route.distance > 0 ? route.distance : totalDistance
-        let scaledDistanceAlongRoute = (closestDistanceAlongRoute / totalDistance) * routeDistance
-        return max(routeDistance - scaledDistanceAlongRoute, 0)
     }
     
     /// Extract clean instruction text from MKRoute.Step

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -33,6 +33,10 @@ class NavigationEngine: NSObject, ObservableObject {
     private var geometrySendInterval: TimeInterval = 2.0
     private var lastGeometrySendTime: Date = .distantPast
     private let geometryWindowSize: Int = 30
+    private var rideStartDate: Date?
+    private var rideDistanceMeters: CLLocationDistance = 0
+    private var lastRideLocation: CLLocation?
+    private var lastRouteRemainingMeters: CLLocationDistance?
     
     // Simulation state
     private var simulationTimer: Timer?
@@ -70,10 +74,16 @@ class NavigationEngine: NSObject, ObservableObject {
 
     func processExternalLocation(_ location: CLLocation) {
         guard !isSimulationMode else { return }
-        sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
         let routeLocation = CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location)
-        guard shouldAcceptLiveLocation(routeLocation) else { return }
-        processLocation(routeLocation)
+        let acceptedRouteLocation: CLLocation?
+        if shouldAcceptLiveLocation(routeLocation) {
+            processLocation(routeLocation)
+            acceptedRouteLocation = routeLocation
+        } else {
+            acceptedRouteLocation = nil
+        }
+        updateRideTelemetry(gpsLocation: location, routeLocation: acceptedRouteLocation)
+        sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
     }
     
     /// Start navigation with a given route
@@ -89,15 +99,17 @@ class NavigationEngine: NSObject, ObservableObject {
         hasAcceptedLiveLocation = initialLocation == nil
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
+        resetRideTelemetry(startingAt: initialLocation)
         
         print("Navigation started with \(route.steps.count) steps (Test Mode: \(isTestMode))")
         
         if isTestMode {
             startSimulation()
         } else if let initialLocation {
-            sendDeviceGpsPosition(initialLocation, convertFromMapKitRoute: true)
             sendRouteGeometryIfNeeded(currentLocation: initialLocation)
             processLocation(initialLocation)
+            updateRideTelemetry(gpsLocation: initialLocation, routeLocation: initialLocation)
+            sendDeviceGpsPosition(initialLocation, convertFromMapKitRoute: true)
         }
     }
     
@@ -114,6 +126,7 @@ class NavigationEngine: NSObject, ObservableObject {
         hasAcceptedLiveLocation = false
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
+        resetRideTelemetry(startingAt: nil)
         stopSimulation()
         print("Navigation stopped")
     }
@@ -167,11 +180,20 @@ class NavigationEngine: NSObject, ObservableObject {
         if let position = interpolatePositionAlongRoute(progress: simulationProgress) {
             simulatedPosition = position
             
-            let location = CLLocation(latitude: position.latitude, longitude: position.longitude)
-            sendDeviceGpsPosition(location, convertFromMapKitRoute: true)
-            
+            let location = CLLocation(
+                coordinate: position,
+                altitude: 0,
+                horizontalAccuracy: 5,
+                verticalAccuracy: -1,
+                course: -1,
+                speed: simulationSpeed,
+                timestamp: now
+            )
+
             // Also process location for navigation instructions
             processLocation(location)
+            updateRideTelemetry(gpsLocation: location, routeLocation: location)
+            sendDeviceGpsPosition(location, convertFromMapKitRoute: true)
         }
     }
     
@@ -355,6 +377,73 @@ class NavigationEngine: NSObject, ObservableObject {
         sendDeviceGpsPosition(lastDeviceGpsLocation.location,
                               convertFromMapKitRoute: lastDeviceGpsLocation.convertFromMapKitRoute)
     }
+
+    private func resetRideTelemetry(startingAt location: CLLocation?) {
+        rideStartDate = location == nil ? nil : Date()
+        rideDistanceMeters = 0
+        lastRideLocation = location
+        lastRouteRemainingMeters = nil
+    }
+
+    private func updateRideTelemetry(gpsLocation: CLLocation, routeLocation: CLLocation?) {
+        if rideStartDate == nil {
+            rideStartDate = Date()
+        }
+
+        if let lastRideLocation {
+            let distanceIncrement = gpsLocation.distance(from: lastRideLocation)
+            if distanceIncrement >= 0 && distanceIncrement < 100 {
+                rideDistanceMeters += distanceIncrement
+            }
+        }
+        lastRideLocation = gpsLocation
+
+        if isNavigating, let route = currentRoute, let routeLocation {
+            lastRouteRemainingMeters = routeRemainingDistance(from: routeLocation, in: route)
+        } else {
+            lastRouteRemainingMeters = nil
+        }
+    }
+
+    private func routeRemainingDistance(from location: CLLocation, in route: MKRoute) -> CLLocationDistance? {
+        let polyline = route.polyline
+        let pointCount = polyline.pointCount
+        guard pointCount > 1 else { return nil }
+
+        let routePoints = polyline.points()
+        let target = MKMapPoint(location.coordinate)
+        var totalDistance: CLLocationDistance = 0
+        var closestDistance = Double.greatestFiniteMagnitude
+        var closestDistanceAlongRoute: CLLocationDistance = 0
+
+        for index in 0..<(pointCount - 1) {
+            let start = routePoints[index]
+            let end = routePoints[index + 1]
+            let dx = end.x - start.x
+            let dy = end.y - start.y
+            let segmentLengthSquared = dx * dx + dy * dy
+            let segmentLength = start.distance(to: end)
+
+            if segmentLengthSquared > 0 {
+                let rawProjection = ((target.x - start.x) * dx + (target.y - start.y) * dy) / segmentLengthSquared
+                let projection = min(max(rawProjection, 0), 1)
+                let projected = MKMapPoint(x: start.x + projection * dx, y: start.y + projection * dy)
+                let distanceToSegment = target.distance(to: projected)
+                if distanceToSegment < closestDistance {
+                    closestDistance = distanceToSegment
+                    closestDistanceAlongRoute = totalDistance + start.distance(to: projected)
+                }
+            }
+
+            totalDistance += segmentLength
+        }
+
+        guard totalDistance > 0 else { return nil }
+
+        let routeDistance = route.distance > 0 ? route.distance : totalDistance
+        let scaledDistanceAlongRoute = (closestDistanceAlongRoute / totalDistance) * routeDistance
+        return max(routeDistance - scaledDistanceAlongRoute, 0)
+    }
     
     /// Extract clean instruction text from MKRoute.Step
     private func extractInstruction(from step: MKRoute.Step) -> String {
@@ -409,7 +498,12 @@ class NavigationEngine: NSObject, ObservableObject {
         let heading = location.course >= 0 ? location.course : 0
         bleManager?.sendGPSPosition(lat: wgsCoordinate.latitude,
                                     lon: wgsCoordinate.longitude,
-                                    heading: heading)
+                                    heading: heading,
+                                    speedMetersPerSecond: location.speed,
+                                    altitudeMeters: location.altitude,
+                                    distanceTraveledMeters: rideDistanceMeters,
+                                    elapsedSeconds: rideStartDate.map { Date().timeIntervalSince($0) },
+                                    routeRemainingMeters: lastRouteRemainingMeters)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -35,6 +35,48 @@ enum RoutePolylineEndpoint {
     }
 }
 
+enum RouteProgress {
+    static func remainingDistance(from location: CLLocation, in route: MKRoute) -> CLLocationDistance? {
+        let polyline = route.polyline
+        let pointCount = polyline.pointCount
+        guard pointCount > 1 else { return nil }
+
+        let routePoints = polyline.points()
+        let target = MKMapPoint(location.coordinate)
+        var totalDistance: CLLocationDistance = 0
+        var closestDistance = Double.greatestFiniteMagnitude
+        var closestDistanceAlongRoute: CLLocationDistance = 0
+
+        for index in 0..<(pointCount - 1) {
+            let start = routePoints[index]
+            let end = routePoints[index + 1]
+            let dx = end.x - start.x
+            let dy = end.y - start.y
+            let segmentLengthSquared = dx * dx + dy * dy
+            let segmentLength = start.distance(to: end)
+
+            if segmentLengthSquared > 0 {
+                let rawProjection = ((target.x - start.x) * dx + (target.y - start.y) * dy) / segmentLengthSquared
+                let projection = min(max(rawProjection, 0), 1)
+                let projected = MKMapPoint(x: start.x + projection * dx, y: start.y + projection * dy)
+                let distanceToSegment = target.distance(to: projected)
+                if distanceToSegment < closestDistance {
+                    closestDistance = distanceToSegment
+                    closestDistanceAlongRoute = totalDistance + start.distance(to: projected)
+                }
+            }
+
+            totalDistance += segmentLength
+        }
+
+        guard totalDistance > 0 else { return nil }
+
+        let routeDistance = route.distance > 0 ? route.distance : totalDistance
+        let scaledDistanceAlongRoute = (closestDistanceAlongRoute / totalDistance) * routeDistance
+        return max(routeDistance - scaledDistanceAlongRoute, 0)
+    }
+}
+
 enum RouteEndpointSelection {
     static func sourceEndpoint(hasSelectedSource: Bool, sourceAddress: String) -> RouteEndpoint {
         hasSelectedSource ? .query(sourceAddress) : .currentLocation
@@ -49,6 +91,54 @@ enum RouteInitialLocation {
 
 enum RouteTransportTypes {
     static let cycling = MKDirectionsTransportType(rawValue: 1 << 3)
+}
+
+enum DeviceGPSPacketBuilder {
+    static let invalidSpeedCmps = UInt16.max
+    static let invalidRouteRemainingMeters = UInt32.max
+
+    static func data(
+        lat: Double,
+        lon: Double,
+        heading: Double = 0,
+        unixTime: UInt32 = UInt32(Date().timeIntervalSince1970),
+        speedMetersPerSecond: Double? = nil,
+        altitudeMeters: Double? = nil,
+        distanceTraveledMeters: Double? = nil,
+        elapsedSeconds: TimeInterval? = nil,
+        routeRemainingMeters: Double? = nil
+    ) -> Data {
+        var data = Data()
+        let latInt = Int32(lat * 1_000_000)
+        let lonInt = Int32(lon * 1_000_000)
+        let headingDeg: UInt16 = heading >= 0 ? UInt16(min(heading, 359)) : 0
+        let speedCmps: UInt16 = {
+            guard let speedMetersPerSecond, speedMetersPerSecond >= 0 else {
+                return invalidSpeedCmps
+            }
+            return UInt16(min((speedMetersPerSecond * 100).rounded(), Double(UInt16.max - 1)))
+        }()
+        let altitudeInt = Int16(max(min((altitudeMeters ?? 0).rounded(), Double(Int16.max)), Double(Int16.min)))
+        let distanceInt = UInt32(max(min((distanceTraveledMeters ?? 0).rounded(), Double(UInt32.max)), 0))
+        let elapsedInt = UInt32(max(min((elapsedSeconds ?? 0).rounded(), Double(UInt32.max)), 0))
+        let routeRemainingInt: UInt32 = {
+            guard let routeRemainingMeters, routeRemainingMeters >= 0 else {
+                return invalidRouteRemainingMeters
+            }
+            return UInt32(max(min(routeRemainingMeters.rounded(), Double(UInt32.max - 1)), 0))
+        }()
+
+        withUnsafeBytes(of: latInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: lonInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: headingDeg.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: unixTime.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: speedCmps.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: altitudeInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: distanceInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: elapsedInt.littleEndian) { data.append(contentsOf: $0) }
+        withUnsafeBytes(of: routeRemainingInt.littleEndian) { data.append(contentsOf: $0) }
+        return data
+    }
 }
 
 enum NavigationPacketBuilder {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -14,6 +14,25 @@ func assertEqual<T: Equatable>(_ actual: T, _ expected: T, _ message: String) {
     assert(actual == expected, "\(message): expected \(expected), got \(actual)")
 }
 
+func readUInt16LE(_ data: Data, offset: Int) -> UInt16 {
+    UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+}
+
+func readInt16LE(_ data: Data, offset: Int) -> Int16 {
+    Int16(bitPattern: readUInt16LE(data, offset: offset))
+}
+
+func readUInt32LE(_ data: Data, offset: Int) -> UInt32 {
+    UInt32(data[offset]) |
+        (UInt32(data[offset + 1]) << 8) |
+        (UInt32(data[offset + 2]) << 16) |
+        (UInt32(data[offset + 3]) << 24)
+}
+
+func readInt32LE(_ data: Data, offset: Int) -> Int32 {
+    Int32(bitPattern: readUInt32LE(data, offset: offset))
+}
+
 func assertCoordinate(
     _ actual: CLLocationCoordinate2D,
     latitude expectedLatitude: CLLocationDegrees,
@@ -77,8 +96,10 @@ final class TestRoute: MKRoute {
     init(instructions: String, coordinates: [CLLocationCoordinate2D]) {
         self.storedSteps = [TestRouteStep(instructions: instructions, coordinates: coordinates)]
         self.storedPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
-        self.storedDistance = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
-            .distance(from: CLLocation(latitude: coordinates[1].latitude, longitude: coordinates[1].longitude))
+        self.storedDistance = zip(coordinates, coordinates.dropFirst()).reduce(0) { distance, pair in
+            distance + CLLocation(latitude: pair.0.latitude, longitude: pair.0.longitude)
+                .distance(from: CLLocation(latitude: pair.1.latitude, longitude: pair.1.longitude))
+        }
         super.init()
     }
 
@@ -100,11 +121,13 @@ struct NavigationProtocolTests {
     static func main() {
         testIconMapping()
         testRouteEndpointExtraction()
+        testRouteRemainingDistance()
         testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
         testNonChinaCoordinatesPassThroughUnchanged()
         testSourceEndpointSelection()
         testRouteInitialLocationUsesResolvedSource()
         testRouteTransportTypes()
+        testDeviceGPSPacketBuilder()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
         testBLEPairingAuthenticator()
@@ -146,6 +169,27 @@ struct NavigationProtocolTests {
 
         let emptyPolyline = MKPolyline()
         assert(RoutePolylineEndpoint.location(for: emptyPolyline) == nil, "empty polyline has no endpoint")
+    }
+
+    static func testRouteRemainingDistance() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0020, longitude: -122.0000)
+        ]
+        let route = TestRoute(instructions: "Continue", coordinates: coordinates)
+        let totalDistance = route.distance
+
+        let start = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
+        let halfway = CLLocation(latitude: 37.0010, longitude: -122.0000)
+        let finish = CLLocation(latitude: coordinates[2].latitude, longitude: coordinates[2].longitude)
+
+        assert(abs((RouteProgress.remainingDistance(from: start, in: route) ?? -1) - totalDistance) < 1, "route remaining starts at full route distance")
+        assert(abs((RouteProgress.remainingDistance(from: halfway, in: route) ?? -1) - totalDistance / 2) < 2, "route remaining tracks progress along route")
+        assert(abs(RouteProgress.remainingDistance(from: finish, in: route) ?? -1) < 1, "route remaining reaches zero at route end")
+
+        let offRouteNearHalfway = CLLocation(latitude: 37.0010, longitude: -122.0005)
+        assert(abs((RouteProgress.remainingDistance(from: offRouteNearHalfway, in: route) ?? -1) - totalDistance / 2) < 2, "route remaining projects nearby locations onto closest segment")
     }
 
     static func testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge() {
@@ -197,6 +241,35 @@ struct NavigationProtocolTests {
 
     static func testRouteTransportTypes() {
         assertEqual(RouteTransportTypes.cycling.rawValue, 8, "cycling transport uses MapKit raw option")
+    }
+
+    static func testDeviceGPSPacketBuilder() {
+        let data = DeviceGPSPacketBuilder.data(
+            lat: 37.123456,
+            lon: -122.654321,
+            heading: 361,
+            unixTime: 1_234_567_890,
+            speedMetersPerSecond: 5.55,
+            altitudeMeters: 42.4,
+            distanceTraveledMeters: 1234.4,
+            elapsedSeconds: 65.2,
+            routeRemainingMeters: 9876.5
+        )
+
+        assertEqual(data.count, 30, "extended GPS packet has expected byte length")
+        assertEqual(readInt32LE(data, offset: 0), 37_123_456, "GPS packet stores latitude microdegrees")
+        assertEqual(readInt32LE(data, offset: 4), -122_654_321, "GPS packet stores longitude microdegrees")
+        assertEqual(readUInt16LE(data, offset: 8), 359, "GPS packet clamps heading")
+        assertEqual(readUInt32LE(data, offset: 10), 1_234_567_890, "GPS packet stores Unix time")
+        assertEqual(readUInt16LE(data, offset: 14), 555, "GPS packet stores speed in centimeters per second")
+        assertEqual(readInt16LE(data, offset: 16), 42, "GPS packet stores altitude in meters")
+        assertEqual(readUInt32LE(data, offset: 18), 1234, "GPS packet stores distance traveled in meters")
+        assertEqual(readUInt32LE(data, offset: 22), 65, "GPS packet stores elapsed seconds")
+        assertEqual(readUInt32LE(data, offset: 26), 9877, "GPS packet stores rounded route remaining meters")
+
+        let invalidData = DeviceGPSPacketBuilder.data(lat: 0, lon: 0, unixTime: 0)
+        assertEqual(readUInt16LE(invalidData, offset: 14), DeviceGPSPacketBuilder.invalidSpeedCmps, "missing speed uses invalid sentinel")
+        assertEqual(readUInt32LE(invalidData, offset: 26), DeviceGPSPacketBuilder.invalidRouteRemainingMeters, "missing route remaining uses invalid sentinel")
     }
 
     static func testNavigationPacketBuilder() {


### PR DESCRIPTION
## Summary
- extend the existing GPS BLE packet with optional speed, altitude, distance, elapsed time, and route remaining fields
- add a third ESP32 device screen for ride telemetry and cycle BOOT button navigation through map, maneuver, and ride stats
- estimate route distance remaining from the current location along the active Apple Maps route

## Validation
- `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.5' build`

No firmware was flashed.
