### PR TITLE
Add map-first iOS navigation UI

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -14,107 +14,31 @@ struct ContentView: View {
     
     @StateObject private var coordinator = BikeComputerCoordinator()
     
-    @State private var showingRouteInput = false
     @State private var sourceAddress = ""
     @State private var destinationAddress = ""
-    @State private var transportType: MKDirectionsTransportType = RouteTransportTypes.cycling
     @State private var showingSettings = false
+    @State private var isSearchPanelExpanded = false
     
     var body: some View {
-        NavigationView {
-            VStack(spacing: 15) {
-                // BLE Connection Status + Settings
-                HStack {
-                    ConnectionStatusView(
-                        isConnected: coordinator.isConnected,
-                        signalStrength: coordinator.signalStrength,
-                        onReconnect: { coordinator.reconnect() }
-                    )
-                    
-                    Button(action: { showingSettings = true }) {
-                        Image(systemName: "gearshape.fill")
-                            .font(.title3)
-                            .foregroundColor(.secondary)
-                    }
-                    .padding(.trailing, 30)
-                }
-                
-                // Main Content Views
-                if coordinator.isNavigating {
-                    // Swipeable view: map | navigation+workout
-                    TabView(selection: $coordinator.selectedView) {
-                        mapView
-                            .tag(0)
+        GeometryReader { proxy in
+            ZStack {
+                mapView
+                    .ignoresSafeArea()
 
-                        CombinedNavigationWorkoutView(coordinator: coordinator)
-                            .tag(1)
-                    }
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
-                    .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
-                    .frame(height: 550)
-                } else if coordinator.routeCalculation.isCalculating {
-                    CalculationStatusView(status: coordinator.routeCalculation.status)
-                } else {
-                    // Swipeable view: map | workout
-                    TabView(selection: $coordinator.selectedView) {
-                        mapView
-                            .tag(0)
+                VStack(spacing: 0) {
+                    topOverlay
 
-                        WorkoutOnlyView(coordinator: coordinator)
-                            .tag(1)
+                    if coordinator.isNavigating {
+                        navigationInstructionBanner
+                            .padding(.horizontal, 14)
+                            .padding(.top, 8)
                     }
-                    .tabViewStyle(PageTabViewStyle(indexDisplayMode: .automatic))
-                    .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
-                    .frame(height: 550)
+
+                    Spacer()
+
+                    bottomOverlay(maxHeight: proxy.size.height * 0.68)
                 }
-                
-                // Bottom Controls
-                VStack(spacing: 15) {
-                    if !coordinator.isNavigating {
-                        // Search bar for destination
-                        Button(action: {
-                            showingRouteInput = true
-                        }) {
-                            HStack {
-                                Image(systemName: "magnifyingglass")
-                                    .foregroundColor(.secondary)
-                                Text("Search for a destination")
-                                    .foregroundColor(.secondary)
-                                Spacer()
-                            }
-                            .padding()
-                            .background(Color(.systemGray6))
-                            .cornerRadius(12)
-                        }
-                    } else {
-                        Button(action: {
-                            coordinator.stopNavigation()
-                        }) {
-                            Label("Stop Navigation", systemImage: "stop.fill")
-                                .font(.headline)
-                                .foregroundColor(.white)
-                                .frame(maxWidth: .infinity)
-                                .padding()
-                                .background(Color.red)
-                                .cornerRadius(12)
-                        }
-                    }
-                }
-                .padding(.horizontal, 30)
-                .padding(.bottom, 0)
-            }
-            .navigationBarHidden(true)
-            .fullScreenCover(isPresented: $showingRouteInput) {
-                RouteInputView(
-                    sourceAddress: $sourceAddress,
-                    destinationAddress: $destinationAddress,
-                    currentAddress: coordinator.currentAddress,
-                    currentLocation: coordinator.currentLocation,
-                    onStartNavigation: { source, destination, transport, isTestMode in
-                        transportType = transport
-                        coordinator.startNavigation(from: source, to: destination, transportType: transport, isTestMode: isTestMode)
-                    }
-                )
+                .ignoresSafeArea(.container, edges: .bottom)
             }
             .alert("Navigation Error", isPresented: $coordinator.alert.isShowing) {
                 Button("OK", role: .cancel) { }
@@ -127,9 +51,79 @@ struct ContentView: View {
             }
         }
         .onChange(of: coordinator.selectedView) { newValue in
-            // Notify coordinator of view change
             coordinator.updateSelectedView(newValue)
         }
+    }
+
+    private var topOverlay: some View {
+        HStack(alignment: .center, spacing: 12) {
+            ConnectionStatusView(
+                isConnected: coordinator.isConnected,
+                onReconnect: { coordinator.reconnect() }
+            )
+
+            Button(action: { showingSettings = true }) {
+                Image(systemName: "gearshape.fill")
+                    .font(.title3)
+                    .foregroundColor(.primary)
+                    .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Settings")
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 8)
+        .zIndex(10)
+    }
+
+    @ViewBuilder
+    private func bottomOverlay(maxHeight: CGFloat) -> some View {
+        VStack(spacing: 12) {
+            if coordinator.routeCalculation.isCalculating {
+                CalculationStatusView(status: coordinator.routeCalculation.status)
+                    .padding(.horizontal, 18)
+            } else if coordinator.isNavigating {
+                navigationControlPanel
+            } else {
+                RouteSearchPanel(
+                    sourceAddress: $sourceAddress,
+                    destinationAddress: $destinationAddress,
+                    isExpanded: $isSearchPanelExpanded,
+                    currentAddress: coordinator.currentAddress,
+                    currentLocation: coordinator.currentLocation,
+                    maxExpandedHeight: maxHeight,
+                    onStartNavigation: { source, destination, transport, isTestMode in
+                        isSearchPanelExpanded = false
+                        coordinator.startNavigation(from: source, to: destination, transportType: transport, isTestMode: isTestMode)
+                    }
+                )
+                .padding(.horizontal, 12)
+            }
+        }
+        .padding(.bottom, 12)
+        .animation(.spring(response: 0.34, dampingFraction: 0.88), value: isSearchPanelExpanded)
+        .animation(.easeInOut(duration: 0.2), value: coordinator.routeCalculation.isCalculating)
+        .animation(.easeInOut(duration: 0.2), value: coordinator.isNavigating)
+    }
+
+    private var navigationControlPanel: some View {
+        NavigationMetricsPanel(
+            arrivalDate: coordinator.expectedArrivalDate,
+            remainingTime: coordinator.routeRemainingTime,
+            remainingDistance: coordinator.routeRemainingDistance,
+            onStopNavigation: { coordinator.stopNavigation() }
+        )
+        .padding(.horizontal, 12)
+    }
+
+    private var navigationInstructionBanner: some View {
+        NavigationInstructionBanner(
+            iconID: coordinator.currentIconID,
+            distanceToManeuver: coordinator.distanceToManeuver,
+            instruction: coordinator.currentInstruction
+        )
     }
     
     // MARK: - Map View
@@ -140,12 +134,16 @@ struct ContentView: View {
             route: coordinator.currentRoute,
             simulatedPosition: coordinator.simulatedPosition,
             isSimulationMode: coordinator.isSimulationMode,
+            isNavigating: coordinator.isNavigating,
+            onMapTapped: {
+                if isSearchPanelExpanded {
+                    isSearchPanelExpanded = false
+                }
+            },
             onDestinationSelected: coordinator.isNavigating ? nil : { coordinate, mapLocation in
                 coordinator.handleDestinationSelection(coordinate: coordinate, mapLocation: mapLocation)
             }
         )
-        .cornerRadius(20)
-        .padding(.horizontal, 30)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -18,6 +18,48 @@ struct NavigationWriteEndpoint {
     let write: (Data) -> Void
 }
 
+enum DeviceBLEProtocol {
+    static let serviceUUIDString = "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800"
+    static let navigationCharacteristicUUIDString = "2A6E"
+    static let authCharacteristicUUIDString = "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1002"
+    static let routeGeometryCharacteristicUUIDString = "2A6F"
+    static let gpsPositionCharacteristicUUIDString = "2A72"
+    static let settingsCharacteristicUUIDString = "2A73"
+    static let deviceInformationServiceUUIDString = "180A"
+    static let modelNumberCharacteristicUUIDString = "2A24"
+    static let firmwareRevisionCharacteristicUUIDString = "2A26"
+    static let hardwareRevisionCharacteristicUUIDString = "2A27"
+    static let manufacturerNameCharacteristicUUIDString = "2A29"
+
+    static let routeGeometryFallbackPrefix = "MAPR"
+    static let gpsPositionFallbackPrefix = "GPSP"
+    static let settingsFallbackPrefix = "MSET"
+
+    static let brightnessSettingID: UInt8 = 12
+
+    static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
+    static var navigationCharacteristicUUID: CBUUID { CBUUID(string: navigationCharacteristicUUIDString) }
+    static var authCharacteristicUUID: CBUUID { CBUUID(string: authCharacteristicUUIDString) }
+    static var routeGeometryCharacteristicUUID: CBUUID { CBUUID(string: routeGeometryCharacteristicUUIDString) }
+    static var gpsPositionCharacteristicUUID: CBUUID { CBUUID(string: gpsPositionCharacteristicUUIDString) }
+    static var settingsCharacteristicUUID: CBUUID { CBUUID(string: settingsCharacteristicUUIDString) }
+    static var deviceInformationServiceUUID: CBUUID { CBUUID(string: deviceInformationServiceUUIDString) }
+    static var modelNumberCharacteristicUUID: CBUUID { CBUUID(string: modelNumberCharacteristicUUIDString) }
+    static var firmwareRevisionCharacteristicUUID: CBUUID { CBUUID(string: firmwareRevisionCharacteristicUUIDString) }
+    static var hardwareRevisionCharacteristicUUID: CBUUID { CBUUID(string: hardwareRevisionCharacteristicUUIDString) }
+    static var manufacturerNameCharacteristicUUID: CBUUID { CBUUID(string: manufacturerNameCharacteristicUUIDString) }
+
+    static func hardwareLabel(model: String?, hardware: String?) -> String {
+        if let model, !model.isEmpty {
+            return model
+        }
+        if let hardware, !hardware.isEmpty {
+            return hardware
+        }
+        return ""
+    }
+}
+
 enum BLEPairingAuthenticator {
     private static let key = SymmetricKey(data: Data("BikeComputer BLE v1 local pairing key".utf8))
 
@@ -117,6 +159,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var isNavigationReady: Bool = false
     @Published var supportsDeviceSettings: Bool = false
     @Published var peripheralName: String = ""
+    @Published var hardwareLabel: String = ""
     @Published var signalStrength: Int = 0
     @Published var centralStateDescription: String = "unknown"
     @Published var trustedPeripheralDescription: String = "none"
@@ -132,6 +175,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up  // 0-3: 0°, 90°, 180°, 270°
     @Published var zoomLevel: Int = 2 // 0-4: 0=super-zoom, 1=closest, 4=farthest
     @Published var tapToSwitchScreens: Bool = false
+    @Published var deviceBrightnessPercent: Double = 100
     
     // Feature Visibility
     @Published var showBuildings: Bool = true
@@ -146,12 +190,17 @@ class BLEManager: NSObject, ObservableObject {
     @Published var showCurrentPosition: Bool = true
     
     // MARK: - BLE UUIDs (matching ESP32)
-    private let serviceUUID = CBUUID(string: "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800")
-    private let characteristicUUID = CBUUID(string: "2A6E")    // Navigation Data Characteristic
-    private let authCharacteristicUUID = CBUUID(string: "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1002")
-    private let routeGeometryCharacteristicUUID = CBUUID(string: "2A6F")
-    private let gpsPositionCharacteristicUUID = CBUUID(string: "2A72")
-    private let settingsCharacteristicUUID = CBUUID(string: "2A73")
+    private let serviceUUID = DeviceBLEProtocol.serviceUUID
+    private let characteristicUUID = DeviceBLEProtocol.navigationCharacteristicUUID
+    private let authCharacteristicUUID = DeviceBLEProtocol.authCharacteristicUUID
+    private let routeGeometryCharacteristicUUID = DeviceBLEProtocol.routeGeometryCharacteristicUUID
+    private let gpsPositionCharacteristicUUID = DeviceBLEProtocol.gpsPositionCharacteristicUUID
+    private let settingsCharacteristicUUID = DeviceBLEProtocol.settingsCharacteristicUUID
+    private let deviceInformationServiceUUID = DeviceBLEProtocol.deviceInformationServiceUUID
+    private let modelNumberCharacteristicUUID = DeviceBLEProtocol.modelNumberCharacteristicUUID
+    private let firmwareRevisionCharacteristicUUID = DeviceBLEProtocol.firmwareRevisionCharacteristicUUID
+    private let hardwareRevisionCharacteristicUUID = DeviceBLEProtocol.hardwareRevisionCharacteristicUUID
+    private let manufacturerNameCharacteristicUUID = DeviceBLEProtocol.manufacturerNameCharacteristicUUID
     
     // MARK: - Private Properties
     private var centralManager: CBCentralManager!
@@ -161,6 +210,7 @@ class BLEManager: NSObject, ObservableObject {
     private var routeGeometryCharacteristic: CBCharacteristic?
     private var gpsPositionCharacteristic: CBCharacteristic?
     private var settingsCharacteristic: CBCharacteristic?
+    private var deviceInformation: [CBUUID: String] = [:]
     private var navigationWriteEndpoint: NavigationWriteEndpoint?
     private var navigationWriteQueue = NavigationWriteQueue(maxCount: 16)
     private var isConnecting: Bool = false
@@ -208,6 +258,7 @@ class BLEManager: NSObject, ObservableObject {
         static let resetMapRotationModeToNorthUp = "mapSettings.resetMapRotationModeToNorthUp.v1"
         static let zoomLevel = "mapSettings.zoomLevel"
         static let tapToSwitchScreens = "deviceSettings.tapToSwitchScreens"
+        static let deviceBrightnessPercent = "deviceSettings.brightnessPercent"
         static let showBuildings = "mapSettings.showBuildings"
         static let showGreenSpace = "mapSettings.showGreenSpace"
         static let showPaths = "mapSettings.showPaths"
@@ -250,6 +301,7 @@ class BLEManager: NSObject, ObservableObject {
         }
         zoomLevel = defaults.object(forKey: SettingsKeys.zoomLevel) as? Int ?? 2
         tapToSwitchScreens = defaults.object(forKey: SettingsKeys.tapToSwitchScreens) as? Bool ?? false
+        deviceBrightnessPercent = defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
         showBuildings = defaults.object(forKey: SettingsKeys.showBuildings) as? Bool ?? true
         let legacyNature = defaults.object(forKey: SettingsKeys.legacyShowNature) as? Bool ?? true
         let legacyMinorRoads = defaults.object(forKey: SettingsKeys.legacyShowMinorRoads) as? Bool ?? true
@@ -281,6 +333,7 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(mapRotationMode, forKey: SettingsKeys.mapRotationMode)
         defaults.set(zoomLevel, forKey: SettingsKeys.zoomLevel)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
+        defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
         defaults.set(showBuildings, forKey: SettingsKeys.showBuildings)
         defaults.set(showGreenSpace, forKey: SettingsKeys.showGreenSpace)
         defaults.set(showPaths, forKey: SettingsKeys.showPaths)
@@ -402,7 +455,7 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        var fallback = Data("MAPR".utf8)
+        var fallback = Data(DeviceBLEProtocol.routeGeometryFallbackPrefix.utf8)
         fallback.append(data)
         guard fallback.count <= maxLength else {
             log("Cannot send geometry: \(data.count) bytes exceeds write limit \(maxLength)")
@@ -453,7 +506,7 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        var fallback = Data("GPSP".utf8)
+        var fallback = Data(DeviceBLEProtocol.gpsPositionFallbackPrefix.utf8)
         fallback.append(data)
         guard fallback.count <= peripheral.maximumWriteValueLength(for: .withoutResponse) else {
             log("Cannot send GPS position fallback: write limit exceeded")
@@ -480,7 +533,7 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        var fallback = Data("MSET".utf8)
+        var fallback = Data(DeviceBLEProtocol.settingsFallbackPrefix.utf8)
         fallback.append(data)
         guard fallback.count <= (navigationWriteEndpoint?.maximumWriteLength ?? 0) else {
             log("Cannot send fallback setting: write limit exceeded")
@@ -849,6 +902,7 @@ class BLEManager: NSObject, ObservableObject {
         sendSetting(id: 6, value: Int32(mapRotationMode))
         sendSetting(id: 7, value: Int32(zoomLevel))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
+        sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(deviceBrightnessPercent))
     }
 
     private func sendOrQueueClientProof(_ proofData: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic) {
@@ -1037,7 +1091,7 @@ extension BLEManager: CBCentralManagerDelegate {
         resetReconnectionState()
         
         // Discover services
-        peripheral.discoverServices([serviceUUID])
+        peripheral.discoverServices([serviceUUID, deviceInformationServiceUUID])
     }
     
     func centralManager(_ central: CBCentralManager, 
@@ -1052,6 +1106,8 @@ extension BLEManager: CBCentralManagerDelegate {
         isConnected = false
         isConnecting = false
         supportsDeviceSettings = false
+        hardwareLabel = ""
+        deviceInformation.removeAll()
         connectedPeripheral = nil
         navigationCharacteristic = nil
         authCharacteristic = nil
@@ -1155,6 +1211,15 @@ extension BLEManager: CBPeripheralDelegate {
                 log("Discovering all BikeComputer service characteristics")
                 peripheral.discoverCharacteristics(nil, for: service)
             }
+            if service.uuid == deviceInformationServiceUUID {
+                log("Discovering Device Information characteristics")
+                peripheral.discoverCharacteristics([
+                    modelNumberCharacteristicUUID,
+                    firmwareRevisionCharacteristicUUID,
+                    hardwareRevisionCharacteristicUUID,
+                    manufacturerNameCharacteristicUUID
+                ], for: service)
+            }
         }
     }
     
@@ -1170,6 +1235,12 @@ extension BLEManager: CBPeripheralDelegate {
         
         for characteristic in characteristics {
             log("Discovered characteristic: \(characteristic.uuid) props=\(characteristic.properties.debugDescription)")
+
+            if service.uuid == deviceInformationServiceUUID,
+               characteristic.properties.contains(.read) {
+                peripheral.readValue(for: characteristic)
+                continue
+            }
             
             if characteristic.uuid == characteristicUUID {
                 guard characteristic.properties.contains(.writeWithoutResponse) else {
@@ -1271,10 +1342,29 @@ extension BLEManager: CBPeripheralDelegate {
             handleAuthResponse(data, peripheral: peripheral, characteristic: characteristic)
             return
         }
+
+        if [modelNumberCharacteristicUUID,
+            firmwareRevisionCharacteristicUUID,
+            hardwareRevisionCharacteristicUUID,
+            manufacturerNameCharacteristicUUID].contains(characteristic.uuid),
+           let value = String(data: data.trimmedTrailingNullsAndWhitespace, encoding: .utf8),
+           !value.isEmpty {
+            deviceInformation[characteristic.uuid] = value
+            updateHardwareLabel()
+            log("Device information \(characteristic.uuid): \(value)")
+            return
+        }
         
         if let string = String(data: data, encoding: .utf8) {
             log("Received from ESP32: \(string)")
         }
+    }
+
+    private func updateHardwareLabel() {
+        hardwareLabel = DeviceBLEProtocol.hardwareLabel(
+            model: deviceInformation[modelNumberCharacteristicUUID],
+            hardware: deviceInformation[hardwareRevisionCharacteristicUUID]
+        )
     }
     
     func peripheral(_ peripheral: CBPeripheral, 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -28,6 +28,7 @@ class BikeComputerCoordinator: ObservableObject {
     // BLE Connection
     @Published var isConnected: Bool = false
     @Published var peripheralName: String = ""
+    @Published var hardwareLabel: String = ""
     @Published var signalStrength: Int = 0
 
     // Navigation
@@ -38,6 +39,9 @@ class BikeComputerCoordinator: ObservableObject {
     @Published var currentRoute: MKRoute?
     @Published var isSimulationMode: Bool = false
     @Published var simulatedPosition: CLLocationCoordinate2D?
+    @Published var routeRemainingDistance: CLLocationDistance?
+    @Published var routeRemainingTime: TimeInterval?
+    @Published var expectedArrivalDate: Date?
 
     // Workout
     @Published var isWorkoutActive: Bool = false
@@ -87,6 +91,9 @@ class BikeComputerCoordinator: ObservableObject {
         bleManager.$peripheralName
             .assign(to: &$peripheralName)
 
+        bleManager.$hardwareLabel
+            .assign(to: &$hardwareLabel)
+
         bleManager.$signalStrength
             .assign(to: &$signalStrength)
 
@@ -113,6 +120,15 @@ class BikeComputerCoordinator: ObservableObject {
 
         navEngine.$currentIconID
             .assign(to: &$currentIconID)
+
+        navEngine.$routeRemainingDistance
+            .assign(to: &$routeRemainingDistance)
+
+        navEngine.$routeRemainingTime
+            .assign(to: &$routeRemainingTime)
+
+        navEngine.$expectedArrivalDate
+            .assign(to: &$expectedArrivalDate)
 
         // Bind health kit manager state
         healthKitManager.$isAuthorized

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -20,6 +20,9 @@ class NavigationEngine: NSObject, ObservableObject {
     @Published var isNavigating: Bool = false
     @Published var isSimulationMode: Bool = false
     @Published var simulatedPosition: CLLocationCoordinate2D?
+    @Published var routeRemainingDistance: CLLocationDistance?
+    @Published var routeRemainingTime: TimeInterval?
+    @Published var expectedArrivalDate: Date?
     
     // MARK: - Private Properties
     private var currentRoute: MKRoute?
@@ -33,6 +36,8 @@ class NavigationEngine: NSObject, ObservableObject {
     private var geometrySendInterval: TimeInterval = 2.0
     private var lastGeometrySendTime: Date = .distantPast
     private let geometryWindowSize: Int = 30
+    private let idleGpsSyncInterval: TimeInterval = 10 * 60
+    private var lastIdleGpsSyncTime: Date = .distantPast
     private var rideStartDate: Date?
     private var rideDistanceMeters: CLLocationDistance = 0
     private var lastRideLocation: CLLocation?
@@ -83,7 +88,12 @@ class NavigationEngine: NSObject, ObservableObject {
             acceptedRouteLocation = nil
         }
         updateRideTelemetry(gpsLocation: location, routeLocation: acceptedRouteLocation)
-        sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
+        if isNavigating {
+            sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
+        } else {
+            lastDeviceGpsLocation = (location, false)
+            sendIdleDeviceTimeSyncIfNeeded(location)
+        }
     }
     
     /// Start navigation with a given route
@@ -100,6 +110,7 @@ class NavigationEngine: NSObject, ObservableObject {
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
         resetRideTelemetry(startingAt: initialLocation)
+        updateNavigationSummary(route: route, remainingDistance: route.distance)
         
         print("Navigation started with \(route.steps.count) steps (Test Mode: \(isTestMode))")
         
@@ -126,6 +137,10 @@ class NavigationEngine: NSObject, ObservableObject {
         hasAcceptedLiveLocation = false
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
+        lastIdleGpsSyncTime = .distantPast
+        routeRemainingDistance = nil
+        routeRemainingTime = nil
+        expectedArrivalDate = nil
         resetRideTelemetry(startingAt: nil)
         stopSimulation()
         print("Navigation stopped")
@@ -378,6 +393,15 @@ class NavigationEngine: NSObject, ObservableObject {
                               convertFromMapKitRoute: lastDeviceGpsLocation.convertFromMapKitRoute)
     }
 
+    private func sendIdleDeviceTimeSyncIfNeeded(_ location: CLLocation) {
+        let now = Date()
+        guard now.timeIntervalSince(lastIdleGpsSyncTime) >= idleGpsSyncInterval else { return }
+        guard let bleManager, bleManager.isConnected, bleManager.isNavigationReady else { return }
+
+        sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
+        lastIdleGpsSyncTime = now
+    }
+
     private func resetRideTelemetry(startingAt location: CLLocation?) {
         rideStartDate = location == nil ? nil : Date()
         rideDistanceMeters = 0
@@ -399,10 +423,30 @@ class NavigationEngine: NSObject, ObservableObject {
         lastRideLocation = gpsLocation
 
         if isNavigating, let route = currentRoute, let routeLocation {
-            lastRouteRemainingMeters = RouteProgress.remainingDistance(from: routeLocation, in: route)
+            let remaining = RouteProgress.remainingDistance(from: routeLocation, in: route)
+            lastRouteRemainingMeters = remaining
+            if let remaining {
+                updateNavigationSummary(route: route, remainingDistance: remaining)
+            }
         } else {
             lastRouteRemainingMeters = nil
         }
+    }
+
+    private func updateNavigationSummary(route: MKRoute, remainingDistance: CLLocationDistance) {
+        let clampedDistance = min(max(remainingDistance, 0), max(route.distance, 0))
+        routeRemainingDistance = clampedDistance
+
+        guard route.distance > 0, route.expectedTravelTime > 0 else {
+            routeRemainingTime = nil
+            expectedArrivalDate = nil
+            return
+        }
+
+        let fractionRemaining = clampedDistance / route.distance
+        let remainingTime = max(route.expectedTravelTime * fractionRemaining, 0)
+        routeRemainingTime = remainingTime
+        expectedArrivalDate = Date().addingTimeInterval(remainingTime)
     }
     
     /// Extract clean instruction text from MKRoute.Step

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -11,54 +11,30 @@ import SwiftUI
 
 struct ConnectionStatusView: View {
     let isConnected: Bool
-    let signalStrength: Int
     let onReconnect: () -> Void
     
     var body: some View {
-        HStack(spacing: 8) {
-            // Status Light
-            Image(systemName: "circle.fill")
-                .font(.caption)
-                .foregroundColor(isConnected ? .green : .red)
-                .shadow(color: isConnected ? .green.opacity(0.5) : .red.opacity(0.5), 
-                       radius: 4)
-            
-            // "BikeComputer" Label
-            Text("BikeComputer")
-                .font(.caption)
-                .foregroundColor(.secondary)
-                    
-            // Signal Info
-            if isConnected && signalStrength != 0 {
-                Text("•")
+        Button(action: onReconnect) {
+            HStack(spacing: 8) {
+                Image(systemName: "circle.fill")
                     .font(.caption)
-                    .foregroundColor(.secondary.opacity(0.5))
-                
-                Image(systemName: SignalIcon.icon(for: signalStrength))
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    
-                Text("\(signalStrength) dBm")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-            }
+                    .foregroundColor(isConnected ? .green : .red)
+                    .shadow(
+                        color: isConnected ? .green.opacity(0.5) : .red.opacity(0.5),
+                        radius: 4
+                    )
 
-            // Reconnect Button (only shown when not connected)
-            if !isConnected {
-                Button(action: onReconnect) {
-                    Label("Reconnect", systemImage: "antenna.radiowaves.left.and.right")
-                        .font(.caption)
-                        .foregroundColor(.blue)
-                }
+                Text("BikeComputer")
+                    .font(.caption)
+                    .foregroundColor(.primary)
+                    .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
             }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
-        .padding()
-        .frame(maxWidth: .infinity)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(Color(.systemGray6))
-        )
-        .padding(.horizontal, 30)
+        .buttonStyle(.plain)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .accessibilityLabel(isConnected ? "BikeComputer connected" : "Reconnect BikeComputer")
     }
 }
 
@@ -84,7 +60,9 @@ struct CalculationStatusView: View {
                     .padding(.horizontal)
             }
         }
-        .frame(height: 550)
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
     }
 }
 
@@ -130,4 +108,3 @@ enum SignalIcon {
         }
     }
 }
-

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -28,6 +28,8 @@ struct MapViewContainer: UIViewRepresentable {
     let route: MKRoute?
     let simulatedPosition: CLLocationCoordinate2D?
     let isSimulationMode: Bool
+    let isNavigating: Bool
+    let onMapTapped: (() -> Void)?
     let onDestinationSelected: ((CLLocationCoordinate2D, CLLocation?) -> Void)?
     
     func makeUIView(context: Context) -> MKMapView {
@@ -37,8 +39,9 @@ struct MapViewContainer: UIViewRepresentable {
         mapView.userTrackingMode = .follow
         
         // Configure map appearance
-        mapView.showsCompass = true
+        mapView.showsCompass = false
         mapView.showsScale = true
+        context.coordinator.installMapControls(on: mapView)
         
         // Add long press gesture recognizer
         let longPress = UILongPressGestureRecognizer(
@@ -47,8 +50,17 @@ struct MapViewContainer: UIViewRepresentable {
         )
         longPress.minimumPressDuration = 0.5
         mapView.addGestureRecognizer(longPress)
+
+        let tap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.handleTap(_:))
+        )
+        tap.cancelsTouchesInView = false
+        tap.delegate = context.coordinator
+        mapView.addGestureRecognizer(tap)
         
         // Store the callback in coordinator
+        context.coordinator.onMapTapped = onMapTapped
         context.coordinator.onDestinationSelected = onDestinationSelected
         
         return mapView
@@ -57,6 +69,9 @@ struct MapViewContainer: UIViewRepresentable {
     func updateUIView(_ uiView: MKMapView, context: Context) {
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
+        context.coordinator.onMapTapped = onMapTapped
+        context.coordinator.onDestinationSelected = onDestinationSelected
+        context.coordinator.updateControlVisibility(isNavigating: isNavigating)
         
         // Only set initial region once if not already set
         if let location = location, 
@@ -83,14 +98,19 @@ struct MapViewContainer: UIViewRepresentable {
         
         // Update route overlay
         if let route = route, context.coordinator.lastRoute !== route {
-            // Disable user tracking when showing route
-            uiView.userTrackingMode = .none
-            
             // Remove old overlays
             uiView.removeOverlays(uiView.overlays)
             
             // Add new route overlay
             uiView.addOverlay(route.polyline, level: .aboveRoads)
+            context.coordinator.configureRouteCamera(
+                mapView: uiView,
+                route: route,
+                location: location,
+                simulatedPosition: simulatedPosition,
+                isSimulationMode: isSimulationMode,
+                isNavigating: isNavigating
+            )
             
             // Handle simulated position annotation
             // Remove existing one
@@ -115,6 +135,7 @@ struct MapViewContainer: UIViewRepresentable {
             uiView.userTrackingMode = .follow
             uiView.showsUserLocation = true 
             context.coordinator.hasSetInitialRegion = false
+            context.coordinator.resetNavigationCamera()
         }
         
         // Update simulated position
@@ -125,6 +146,11 @@ struct MapViewContainer: UIViewRepresentable {
             if uiView.showsUserLocation {
                 uiView.showsUserLocation = false
             }
+            context.coordinator.updateNavigationCamera(
+                mapView: uiView,
+                coordinate: simPos,
+                animated: true
+            )
             
             // Update or add annotation
             if let annotation = existingSimAnnotations.first as? SimulatedPositionAnnotation {
@@ -143,6 +169,11 @@ struct MapViewContainer: UIViewRepresentable {
             if !uiView.showsUserLocation {
                 uiView.showsUserLocation = true
             }
+            if isNavigating && uiView.userTrackingMode != .followWithHeading {
+                uiView.setUserTrackingMode(.followWithHeading, animated: true)
+            } else if !isNavigating && uiView.userTrackingMode == .followWithHeading {
+                uiView.setUserTrackingMode(.follow, animated: true)
+            }
             // Remove sim annotation if present
             if !existingSimAnnotations.isEmpty {
                 uiView.removeAnnotations(existingSimAnnotations)
@@ -154,15 +185,113 @@ struct MapViewContainer: UIViewRepresentable {
         Coordinator()
     }
     
-    class Coordinator: NSObject, MKMapViewDelegate {
+    class Coordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDelegate {
         var lastRoute: MKRoute?
         var mapView: MKMapView?
+        var onMapTapped: (() -> Void)?
         var onDestinationSelected: ((CLLocationCoordinate2D, CLLocation?) -> Void)?
         var hasSetInitialRegion = false
+        private var compassButton: MKCompassButton?
+        private var trackingButton: MKUserTrackingButton?
+        private var lastNavigationCoordinate: CLLocationCoordinate2D?
+        private var lastNavigationHeading: CLLocationDirection = 0
+
+        func installMapControls(on mapView: MKMapView) {
+            guard compassButton == nil else { return }
+
+            let compass = MKCompassButton(mapView: mapView)
+            compass.compassVisibility = .adaptive
+            compass.translatesAutoresizingMaskIntoConstraints = false
+            mapView.addSubview(compass)
+
+            let tracking = MKUserTrackingButton(mapView: mapView)
+            tracking.translatesAutoresizingMaskIntoConstraints = false
+            mapView.addSubview(tracking)
+
+            NSLayoutConstraint.activate([
+                compass.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 18),
+                compass.topAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.topAnchor, constant: 220),
+
+                tracking.trailingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.trailingAnchor, constant: -18),
+                tracking.topAnchor.constraint(equalTo: compass.topAnchor)
+            ])
+
+            compassButton = compass
+            trackingButton = tracking
+        }
+
+        func updateControlVisibility(isNavigating: Bool) {
+            compassButton?.compassVisibility = isNavigating ? .visible : .adaptive
+            trackingButton?.isHidden = !isNavigating
+        }
+
+        func configureRouteCamera(
+            mapView: MKMapView,
+            route: MKRoute,
+            location: CLLocation?,
+            simulatedPosition: CLLocationCoordinate2D?,
+            isSimulationMode: Bool,
+            isNavigating: Bool
+        ) {
+            guard isNavigating else {
+                mapView.setVisibleMapRect(
+                    route.polyline.boundingMapRect,
+                    edgePadding: UIEdgeInsets(top: 140, left: 48, bottom: 160, right: 48),
+                    animated: true
+                )
+                return
+            }
+
+            if isSimulationMode, let simulatedPosition {
+                updateNavigationCamera(mapView: mapView, coordinate: simulatedPosition, animated: false)
+            } else {
+                mapView.setUserTrackingMode(.followWithHeading, animated: true)
+            }
+        }
+
+        func updateNavigationCamera(
+            mapView: MKMapView,
+            coordinate: CLLocationCoordinate2D,
+            animated: Bool
+        ) {
+            if let previous = lastNavigationCoordinate {
+                let distance = MKMapPoint(previous).distance(to: MKMapPoint(coordinate))
+                if distance > 2 {
+                    lastNavigationHeading = bearing(from: previous, to: coordinate)
+                }
+            }
+
+            lastNavigationCoordinate = coordinate
+            let camera = MKMapCamera(
+                lookingAtCenter: coordinate,
+                fromDistance: 520,
+                pitch: 58,
+                heading: lastNavigationHeading
+            )
+            mapView.setCamera(camera, animated: animated)
+        }
+
+        func resetNavigationCamera() {
+            lastNavigationCoordinate = nil
+            lastNavigationHeading = 0
+        }
+
+        @objc func handleTap(_ gestureRecognizer: UITapGestureRecognizer) {
+            guard gestureRecognizer.state == .ended else { return }
+            onMapTapped?()
+        }
+
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            true
+        }
         
         @objc func handleLongPress(_ gestureRecognizer: UILongPressGestureRecognizer) {
             guard gestureRecognizer.state == .began,
-                  let mapView = mapView else { return }
+                  let mapView = mapView,
+                  onDestinationSelected != nil else { return }
             
             // Disable user tracking mode to allow free map movement
             mapView.userTrackingMode = .none
@@ -184,6 +313,18 @@ struct MapViewContainer: UIViewRepresentable {
             
             // Show the callout
             mapView.selectAnnotation(annotation, animated: true)
+        }
+
+        private func bearing(from start: CLLocationCoordinate2D, to end: CLLocationCoordinate2D) -> CLLocationDirection {
+            let startLat = start.latitude * .pi / 180
+            let startLon = start.longitude * .pi / 180
+            let endLat = end.latitude * .pi / 180
+            let endLon = end.longitude * .pi / 180
+            let deltaLon = endLon - startLon
+            let y = sin(deltaLon) * cos(endLat)
+            let x = cos(startLat) * sin(endLat) - sin(startLat) * cos(endLat) * cos(deltaLon)
+            let degrees = atan2(y, x) * 180 / .pi
+            return degrees >= 0 ? degrees : degrees + 360
         }
         
         func mapView(_ mapView: MKMapView, rendererFor overlay: MKOverlay) -> MKOverlayRenderer {

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import CoreLocation
 
 struct NavigationDetailsView: View {
     let iconID: Int
@@ -44,6 +45,226 @@ struct NavigationDetailsView: View {
                 .padding(.horizontal)
                 .lineLimit(isCompact ? 2 : nil)
         }
+    }
+}
+
+struct MapNavigationInstructionCard: View {
+    let iconID: Int
+    let distanceToManeuver: Int
+    let instruction: String
+    let onStopNavigation: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(alignment: .center, spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(Color.blue)
+                        .frame(width: 48, height: 48)
+
+                    Image(systemName: NavigationIcon.icon(for: iconID))
+                        .font(.system(size: 24, weight: .bold))
+                        .foregroundColor(.white)
+                }
+                .accessibilityHidden(true)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(formattedDistance)
+                        .font(.system(size: 28, weight: .bold, design: .rounded))
+                        .foregroundColor(.primary)
+
+                    Text(instruction)
+                        .font(.subheadline)
+                        .fontWeight(.medium)
+                        .foregroundColor(.primary)
+                        .lineLimit(2)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Spacer(minLength: 8)
+
+                Button(action: onStopNavigation) {
+                    Text("End")
+                        .font(.headline)
+                        .foregroundColor(.red)
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 10)
+                        .background(Color(.secondarySystemBackground), in: Capsule())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("End navigation")
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+        }
+        .frame(maxWidth: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+    }
+
+    private var formattedDistance: String {
+        if distanceToManeuver >= 1000 {
+            return String(format: "%.1f km", Double(distanceToManeuver) / 1000)
+        }
+
+        return "\(distanceToManeuver) m"
+    }
+}
+
+struct NavigationInstructionBanner: View {
+    let iconID: Int
+    let distanceToManeuver: Int
+    let instruction: String
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 18) {
+            Image(systemName: NavigationIcon.icon(for: iconID))
+                .font(.system(size: 58, weight: .bold))
+                .foregroundColor(.white)
+                .frame(width: 70, height: 70)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 6) {
+                Text(formattedDistance)
+                    .font(.system(size: 38, weight: .bold, design: .rounded))
+                    .foregroundColor(.white)
+                    .minimumScaleFactor(0.78)
+
+                Text(instruction)
+                    .font(.system(size: 28, weight: .semibold, design: .rounded))
+                    .foregroundColor(.white.opacity(0.72))
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(nil)
+                    .minimumScaleFactor(0.72)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .layoutPriority(1)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 24)
+        .padding(.vertical, 18)
+        .background(
+            RoundedRectangle(cornerRadius: 30, style: .continuous)
+                .fill(Color.black.opacity(0.66))
+        )
+        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var formattedDistance: String {
+        NavigationFormatters.distance(distanceToManeuver)
+    }
+}
+
+struct NavigationMetricsPanel: View {
+    let arrivalDate: Date?
+    let remainingTime: TimeInterval?
+    let remainingDistance: CLLocationDistance?
+    let onStopNavigation: () -> Void
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(alignment: .center, spacing: 0) {
+                NavigationMetricColumn(value: formattedArrival, label: "arrival")
+                NavigationMetricColumn(value: formattedTime, label: timeUnit)
+                NavigationMetricColumn(value: formattedDistance, label: distanceUnit)
+            }
+            .padding(.horizontal, 12)
+            .padding(.top, 18)
+
+            Button(action: onStopNavigation) {
+                Text("End")
+                    .font(.headline)
+                    .foregroundColor(.red)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .background(Color(.secondarySystemBackground), in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .padding(.horizontal, 18)
+            .padding(.bottom, 14)
+            .accessibilityLabel("End navigation")
+        }
+        .frame(maxWidth: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 32, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 32, style: .continuous)
+                .stroke(Color.white.opacity(0.35), lineWidth: 1)
+        )
+        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+    }
+
+    private var formattedArrival: String {
+        guard let arrivalDate else { return "--" }
+        return NavigationFormatters.arrivalTime.string(from: arrivalDate)
+    }
+
+    private var formattedTime: String {
+        guard let remainingTime else { return "--" }
+        if remainingTime >= 60 * 60 {
+            let hours = Int(remainingTime / 3600)
+            let minutes = Int((remainingTime.truncatingRemainder(dividingBy: 3600)) / 60)
+            return minutes > 0 ? "\(hours)h \(minutes)" : "\(hours)h"
+        }
+        return "\(max(Int(ceil(remainingTime / 60)), 1))"
+    }
+
+    private var timeUnit: String {
+        guard let remainingTime, remainingTime >= 60 * 60 else { return "min" }
+        return "time"
+    }
+
+    private var formattedDistance: String {
+        guard let remainingDistance else { return "--" }
+        if remainingDistance >= 1000 {
+            return String(format: "%.1f", remainingDistance / 1000)
+        }
+        return "\(Int(max(remainingDistance.rounded(), 0)))"
+    }
+
+    private var distanceUnit: String {
+        guard let remainingDistance, remainingDistance < 1000 else { return "km" }
+        return "m"
+    }
+}
+
+private struct NavigationMetricColumn: View {
+    let value: String
+    let label: String
+
+    var body: some View {
+        VStack(spacing: 2) {
+            Text(value)
+                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+
+            Text(label)
+                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private enum NavigationFormatters {
+    static let arrivalTime: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        formatter.dateStyle = .none
+        return formatter
+    }()
+
+    static func distance(_ meters: Int) -> String {
+        if meters >= 1000 {
+            return String(format: "%.1f km", Double(meters) / 1000)
+        }
+
+        return "\(max(meters, 0)) m"
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
@@ -42,6 +42,441 @@ class AddressSearchCompleter: NSObject, ObservableObject, MKLocalSearchCompleter
     }
 }
 
+// MARK: - Route Search Panel
+
+private enum RouteSearchPanelField: Hashable {
+    case destination
+    case source
+}
+
+struct RouteSearchPanel: View {
+    @Binding var sourceAddress: String
+    @Binding var destinationAddress: String
+    @Binding var isExpanded: Bool
+
+    let currentAddress: String
+    let currentLocation: CLLocation?
+    let maxExpandedHeight: CGFloat
+    var onStartNavigation: (RouteEndpoint, RouteEndpoint, MKDirectionsTransportType, Bool) -> Void
+
+    @StateObject private var destinationCompleter = AddressSearchCompleter()
+    @StateObject private var sourceCompleter = AddressSearchCompleter()
+
+    @FocusState private var focusedField: RouteSearchPanelField?
+
+    @State private var hasSelectedDestination = false
+    @State private var isSelectingFromSuggestion = false
+    @State private var isEditingSource = false
+    @State private var hasSelectedSource = false
+    @State private var isTestMode = false
+    @State private var selectedTransportType: MKDirectionsTransportType = RouteTransportTypes.cycling
+    @State private var recentDestinationSearches: [String] = []
+
+    private let recentDestinationSearchesKey = "routeInput.recentDestinationSearches"
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Capsule()
+                .fill(Color.secondary.opacity(0.35))
+                .frame(width: 38, height: 5)
+                .padding(.top, 8)
+                .padding(.bottom, 10)
+
+            if isExpanded {
+                expandedContent
+            } else {
+                collapsedSearchButton
+            }
+        }
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
+        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+        .frame(maxHeight: isExpanded ? maxExpandedHeight : nil, alignment: .bottom)
+        .onAppear {
+            recentDestinationSearches = loadRecentDestinationSearches()
+            updateSearchRegions()
+        }
+        .onChange(of: currentLocation) { _ in
+            updateSearchRegions()
+        }
+        .onChange(of: isExpanded) { expanded in
+            if expanded {
+                DispatchQueue.main.async {
+                    focusedField = .destination
+                }
+            } else {
+                focusedField = nil
+                resetTransientState()
+            }
+        }
+    }
+
+    private var collapsedSearchButton: some View {
+        Button(action: expandForDestinationSearch) {
+            HStack(spacing: 12) {
+                Image(systemName: "magnifyingglass")
+                    .foregroundColor(.secondary)
+
+                Text(destinationAddress.isEmpty ? "Search for a destination" : destinationAddress)
+                    .foregroundColor(destinationAddress.isEmpty ? .secondary : .primary)
+                    .lineLimit(1)
+
+                Spacer()
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Search for a destination")
+    }
+
+    private var expandedContent: some View {
+        VStack(spacing: 12) {
+            destinationSearchField
+
+            if hasSelectedDestination {
+                sourcePicker
+                transportControls
+                testModeToggle
+            }
+
+            searchResults
+
+            if hasSelectedDestination && !isEditingSource {
+                goButton
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.bottom, 14)
+    }
+
+    private var destinationSearchField: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.secondary)
+
+            TextField("Search for a destination", text: $destinationAddress)
+                .textContentType(.fullStreetAddress)
+                .focused($focusedField, equals: .destination)
+                .onTapGesture {
+                    expandForDestinationSearch()
+                }
+                .onChange(of: destinationAddress) { newValue in
+                    if isSelectingFromSuggestion {
+                        isSelectingFromSuggestion = false
+                        return
+                    }
+
+                    destinationCompleter.search(query: newValue)
+                    if hasSelectedDestination {
+                        hasSelectedDestination = false
+                    }
+                }
+
+            if !destinationAddress.isEmpty {
+                Button(action: clearDestination) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear destination")
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+        .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    @ViewBuilder
+    private var sourcePicker: some View {
+        if isEditingSource {
+            HStack(spacing: 12) {
+                Image(systemName: "location.fill")
+                    .foregroundColor(.blue)
+
+                TextField("Search start location", text: $sourceAddress)
+                    .focused($focusedField, equals: .source)
+                    .onChange(of: sourceAddress) { newValue in
+                        if isSelectingFromSuggestion {
+                            isSelectingFromSuggestion = false
+                            return
+                        }
+                        sourceCompleter.search(query: newValue)
+                    }
+
+                Button("Cancel") {
+                    isEditingSource = false
+                    focusedField = nil
+                    if sourceAddress.isEmpty {
+                        sourceAddress = currentAddress
+                        hasSelectedSource = false
+                    }
+                }
+                .font(.caption)
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        } else {
+            Button(action: {
+                isEditingSource = true
+                if sourceAddress.isEmpty || (!hasSelectedSource && sourceAddress != currentAddress) {
+                    sourceAddress = currentAddress
+                }
+                focusedField = .source
+            }) {
+                HStack(spacing: 12) {
+                    Image(systemName: "location.fill")
+                        .foregroundColor(.blue)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(hasSelectedSource ? "Start Location" : "Your Location")
+                            .foregroundColor(.primary)
+                            .font(.body)
+
+                        Text(hasSelectedSource ? sourceAddress : currentAddress)
+                            .foregroundColor(.secondary)
+                            .font(.caption)
+                            .lineLimit(1)
+                    }
+
+                    Spacer()
+
+                    Image(systemName: "pencil")
+                        .foregroundColor(.secondary)
+                        .font(.caption)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+                .background(Color(.secondarySystemBackground), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private var transportControls: some View {
+        HStack(spacing: 10) {
+            TransportButton(
+                icon: "bicycle",
+                label: "Bike",
+                isSelected: selectedTransportType == RouteTransportTypes.cycling,
+                action: { selectedTransportType = RouteTransportTypes.cycling }
+            )
+
+            TransportButton(
+                icon: "car.fill",
+                label: "Drive",
+                isSelected: selectedTransportType == .automobile,
+                action: { selectedTransportType = .automobile }
+            )
+
+            TransportButton(
+                icon: "figure.walk",
+                label: "Walk",
+                isSelected: selectedTransportType == .walking,
+                action: { selectedTransportType = .walking }
+            )
+        }
+    }
+
+    private var testModeToggle: some View {
+        Toggle(isOn: $isTestMode) {
+            Label("Test Mode", systemImage: "testtube.2")
+                .foregroundColor(.primary)
+        }
+        .tint(.orange)
+    }
+
+    @ViewBuilder
+    private var searchResults: some View {
+        if isEditingSource {
+            if !sourceCompleter.suggestions.isEmpty {
+                suggestionsScroll(for: sourceCompleter.suggestions) { suggestion in
+                    let fullAddress = formattedAddress(for: suggestion)
+                    isSelectingFromSuggestion = true
+                    sourceAddress = fullAddress
+                    hasSelectedSource = true
+                    isEditingSource = false
+                    focusedField = nil
+                }
+            } else {
+                Spacer(minLength: 0)
+            }
+        } else if !hasSelectedDestination && !destinationCompleter.suggestions.isEmpty {
+            suggestionsScroll(for: destinationCompleter.suggestions) { suggestion in
+                let fullAddress = formattedAddress(for: suggestion)
+                isSelectingFromSuggestion = true
+                destinationAddress = fullAddress
+                hasSelectedDestination = true
+                focusedField = nil
+                saveRecentDestinationSearch(fullAddress)
+            }
+        } else if shouldShowRecentDestinationSearches {
+            recentDestinationScroll
+        } else {
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var recentDestinationScroll: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Recent Searches")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 4)
+                .padding(.bottom, 6)
+
+            ScrollView {
+                LazyVStack(spacing: 0) {
+                    ForEach(recentDestinationSearches, id: \.self) { search in
+                        Button(action: {
+                            isSelectingFromSuggestion = true
+                            destinationAddress = search
+                            hasSelectedDestination = true
+                            focusedField = nil
+                            saveRecentDestinationSearch(search)
+                        }) {
+                            HStack(spacing: 12) {
+                                Image(systemName: "clock.arrow.circlepath")
+                                    .foregroundColor(.secondary)
+
+                                Text(search)
+                                    .font(.body)
+                                    .foregroundColor(.primary)
+                                    .lineLimit(2)
+
+                                Spacer()
+                            }
+                            .padding(.vertical, 12)
+                        }
+                        .buttonStyle(.plain)
+
+                        Divider()
+                    }
+                }
+            }
+            .frame(maxHeight: 260)
+        }
+    }
+
+    private var goButton: some View {
+        Button(action: {
+            let sourceEndpoint = RouteEndpointSelection.sourceEndpoint(
+                hasSelectedSource: hasSelectedSource,
+                sourceAddress: sourceAddress
+            )
+            saveRecentDestinationSearch(destinationAddress)
+            onStartNavigation(sourceEndpoint, .query(destinationAddress), selectedTransportType, isTestMode)
+        }) {
+            Text(isTestMode ? "Go (Test)" : "Go")
+                .font(.headline)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .padding()
+                .background(isTestMode ? Color.orange : Color.blue, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func suggestionsScroll(
+        for suggestions: [MKLocalSearchCompletion],
+        onSelect: @escaping (MKLocalSearchCompletion) -> Void
+    ) -> some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                ForEach(suggestions, id: \.self) { suggestion in
+                    Button(action: {
+                        onSelect(suggestion)
+                    }) {
+                        HStack(spacing: 12) {
+                            Image(systemName: "mappin.circle.fill")
+                                .foregroundColor(.secondary)
+
+                            VStack(alignment: .leading, spacing: 4) {
+                                Text(suggestion.title)
+                                    .font(.body)
+                                    .foregroundColor(.primary)
+                                    .lineLimit(1)
+
+                                if !suggestion.subtitle.isEmpty {
+                                    Text(suggestion.subtitle)
+                                        .font(.caption)
+                                        .foregroundColor(.secondary)
+                                        .lineLimit(1)
+                                }
+                            }
+
+                            Spacer()
+                        }
+                        .padding(.vertical, 12)
+                    }
+                    .buttonStyle(.plain)
+
+                    Divider()
+                }
+            }
+        }
+        .frame(maxHeight: 300)
+    }
+
+    private var shouldShowRecentDestinationSearches: Bool {
+        !hasSelectedDestination &&
+        destinationAddress.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty &&
+        !recentDestinationSearches.isEmpty
+    }
+
+    private func expandForDestinationSearch() {
+        isExpanded = true
+        focusedField = .destination
+    }
+
+    private func clearDestination() {
+        destinationAddress = ""
+        destinationCompleter.search(query: "")
+        hasSelectedDestination = false
+        focusedField = .destination
+    }
+
+    private func formattedAddress(for suggestion: MKLocalSearchCompletion) -> String {
+        suggestion.subtitle.isEmpty ? suggestion.title : "\(suggestion.title), \(suggestion.subtitle)"
+    }
+
+    private func updateSearchRegions() {
+        guard let location = currentLocation else { return }
+
+        let region = MKCoordinateRegion(
+            center: location.coordinate,
+            latitudinalMeters: 50000,
+            longitudinalMeters: 50000
+        )
+        destinationCompleter.updateRegion(region)
+        sourceCompleter.updateRegion(region)
+    }
+
+    private func resetTransientState() {
+        isEditingSource = false
+        hasSelectedSource = false
+        hasSelectedDestination = false
+        destinationAddress = ""
+        sourceAddress = ""
+    }
+
+    private func loadRecentDestinationSearches() -> [String] {
+        UserDefaults.standard.stringArray(forKey: recentDestinationSearchesKey) ?? []
+    }
+
+    private func saveRecentDestinationSearch(_ search: String) {
+        let normalized = search.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return }
+
+        var searches = loadRecentDestinationSearches()
+        searches.removeAll { $0.caseInsensitiveCompare(normalized) == .orderedSame }
+        searches.insert(normalized, at: 0)
+        searches = Array(searches.prefix(5))
+        UserDefaults.standard.set(searches, forKey: recentDestinationSearchesKey)
+        recentDestinationSearches = searches
+    }
+}
+
 // MARK: - Route Input View
 
 struct RouteInputView: View {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -14,21 +14,11 @@ struct SettingsView: View {
     var body: some View {
         NavigationView {
             Form {
-                Section(header: Text("Connection")) {
-                    HStack {
-                        Text("ESP32")
-                        Spacer()
-                        Text(bleManager.isConnected ? "Connected" : "Disconnected")
-                            .foregroundColor(bleManager.isConnected ? .green : .red)
-                    }
-                    HStack {
-                        Text("Device Settings")
-                        Spacer()
-                        Text(bleManager.supportsDeviceSettings ? "Available" : "Unavailable")
-                            .foregroundColor(bleManager.supportsDeviceSettings ? .green : .secondary)
-                    }
-                }
-                
+                connectionSummary
+                    .listRowBackground(Color.clear)
+                    .listRowSeparator(.hidden)
+                    .listRowInsets(EdgeInsets(top: 12, leading: 20, bottom: 8, trailing: 20))
+
                 Section(header: Text("Map Rendering"), footer: Text("Feature toggles control map categories; polygon size filters tiny filled areas.")) {
                     VStack(alignment: .leading) {
                         HStack {
@@ -185,6 +175,19 @@ struct SettingsView: View {
                 .disabled(!bleManager.supportsDeviceSettings)
                 
                 Section(header: Text("Device")) {
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Brightness")
+                            Spacer()
+                            Text("\(Int(bleManager.deviceBrightnessPercent))%")
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: $bleManager.deviceBrightnessPercent, in: 5...100, step: 5)
+                            .onChange(of: bleManager.deviceBrightnessPercent) { newValue in
+                                bleManager.sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(newValue))
+                            }
+                    }
+
                     Button(action: {
                         bleManager.sendSetting(id: 5, value: 1) // Reboot command
                     }) {
@@ -256,6 +259,31 @@ struct SettingsView: View {
             .navigationTitle("Map Settings")
             .navigationBarTitleDisplayMode(.inline)
         }
+    }
+
+    private var connectionSummary: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("Bike Computer")
+                .font(.body)
+
+            Spacer()
+
+            Text(connectionStatusText)
+                .font(.subheadline)
+                .foregroundColor(bleManager.isConnected ? .green : .red)
+        }
+    }
+
+    private var connectionStatusText: String {
+        guard bleManager.isConnected else {
+            return "Disconnected"
+        }
+
+        if bleManager.signalStrength != 0 {
+            return "Connected \(bleManager.signalStrength) dBm"
+        }
+
+        return "Connected"
     }
 }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -130,9 +130,12 @@ struct NavigationProtocolTests {
         testDeviceGPSPacketBuilder()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
+        testDeviceBLEProtocolConstants()
+        testHardwareLabelPreference()
         testBLEPairingAuthenticator()
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
+        testBLEManagerSendsBrightnessFallbackSetting()
         testBLEManagerPersistsNewMapSettings()
         testNavigationSendTrackerReadinessRetry()
         testNavigationEngineResendsWhenBLEBecomesReady()
@@ -331,6 +334,30 @@ struct NavigationProtocolTests {
         assertEqual(queue.count, 0, "queue is empty after flush")
     }
 
+    static func testDeviceBLEProtocolConstants() {
+        assertEqual(DeviceBLEProtocol.serviceUUIDString, "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800", "service UUID must stay firmware-compatible")
+        assertEqual(DeviceBLEProtocol.navigationCharacteristicUUIDString, "2A6E", "navigation characteristic UUID must stay firmware-compatible")
+        assertEqual(DeviceBLEProtocol.routeGeometryCharacteristicUUIDString, "2A6F", "route characteristic UUID must stay firmware-compatible")
+        assertEqual(DeviceBLEProtocol.gpsPositionCharacteristicUUIDString, "2A72", "GPS characteristic UUID must stay firmware-compatible")
+        assertEqual(DeviceBLEProtocol.settingsCharacteristicUUIDString, "2A73", "settings characteristic UUID must stay firmware-compatible")
+        assertEqual(DeviceBLEProtocol.routeGeometryFallbackPrefix, "MAPR", "route fallback remains framed over navigation writes")
+        assertEqual(DeviceBLEProtocol.gpsPositionFallbackPrefix, "GPSP", "GPS fallback remains framed over navigation writes")
+        assertEqual(DeviceBLEProtocol.settingsFallbackPrefix, "MSET", "settings fallback remains framed over navigation writes")
+        assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
+    }
+
+    static func testHardwareLabelPreference() {
+        assertEqual(DeviceBLEProtocol.hardwareLabel(model: "BikeComputer-XIAO", hardware: "nRF52840"),
+                    "BikeComputer-XIAO",
+                    "model number is the preferred hardware label")
+        assertEqual(DeviceBLEProtocol.hardwareLabel(model: nil, hardware: "XIAO nRF52840"),
+                    "XIAO nRF52840",
+                    "hardware revision is used when model is absent")
+        assertEqual(DeviceBLEProtocol.hardwareLabel(model: "", hardware: ""),
+                    "",
+                    "missing device information produces no hardware label")
+    }
+
     static func testBLEPairingAuthenticator() {
         let nonce = "00112233445566778899aabbccddeeff"
         let serverProof = "a88fdf1fe1bc0381314cc68820d92cb8da4942cb49ba2062d7f7750cd1f7eb4b"
@@ -389,7 +416,9 @@ struct NavigationProtocolTests {
 
         assertEqual(sentPackets.count, 1, "settings without a dedicated characteristic should use fallback navigation writes")
         let packet = sentPackets[0]
-        assertEqual(String(data: packet.prefix(4), encoding: .utf8), "MSET", "fallback settings packet uses MSET prefix")
+        assertEqual(String(data: packet.prefix(4), encoding: .utf8),
+                    DeviceBLEProtocol.settingsFallbackPrefix,
+                    "fallback settings packet uses MSET prefix")
         assertEqual(packet[4], 8, "fallback settings packet includes setting id")
         let valueBytes = Array(packet[5..<9])
         let value = Int32(valueBytes[0])
@@ -397,6 +426,40 @@ struct NavigationProtocolTests {
             | (Int32(valueBytes[2]) << 16)
             | (Int32(valueBytes[3]) << 24)
         assertEqual(value, 7, "fallback settings packet includes little-endian value")
+    }
+
+    static func testBLEManagerSendsBrightnessFallbackSetting() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.deviceBrightnessPercent = 65
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(manager.deviceBrightnessPercent))
+
+        assertEqual(sentPackets.count, 1, "brightness without a dedicated characteristic should use fallback navigation writes")
+        let packet = sentPackets[0]
+        assertEqual(String(data: packet.prefix(4), encoding: .utf8), DeviceBLEProtocol.settingsFallbackPrefix, "brightness fallback uses MSET prefix")
+        assertEqual(packet[4], DeviceBLEProtocol.brightnessSettingID, "brightness fallback uses setting ID 12")
+        let valueBytes = Array(packet[5..<9])
+        let value = Int32(valueBytes[0])
+            | (Int32(valueBytes[1]) << 8)
+            | (Int32(valueBytes[2]) << 16)
+            | (Int32(valueBytes[3]) << 24)
+        assertEqual(value, 65, "brightness fallback includes little-endian percent")
+
+        let reloaded = BLEManager()
+        assertEqual(Int(reloaded.deviceBrightnessPercent), 65, "brightness setting persists for UI display")
+        defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
     }
 
     static func testBLEManagerPersistsNewMapSettings() {

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -2,6 +2,20 @@
 
 iOS companion application for the [IceNav-v3 ESP32 Bike Computer](../IceNav-v3). This app handles route planning and transmits navigation data via Bluetooth Low Energy (BLE).
 
+## Local Tests
+
+Run the standalone navigation/BLE protocol tests from the repository root:
+
+```sh
+ios-app/scripts/run-navigation-tests.sh
+```
+
+These tests compile the testable app helpers with `xcrun swiftc` and cover route
+math, BLE packet builders, BLE authentication vectors, fallback `2A6E` framed
+writes, and XIAO-compatible UUID/settings constants. The Xcode project currently
+has only the app target, so the `BikeComputer` scheme does not run these tests
+through Xcode's test action.
+
 ## 🛠 Testing with a Real iPhone
 
 To test the app on a physical device and share it with others, follow these steps:

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REPO_DIR="$(cd "${IOS_DIR}/.." && pwd)"
+OUT="${TMPDIR:-/tmp}/open-bike-navigation-tests"
+
+cd "${REPO_DIR}"
+
+xcrun swiftc \
+  -o "${OUT}" \
+  ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
+  ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
+  ios-app/BikeComputerTests/NavigationProtocolTests.swift
+
+"${OUT}"


### PR DESCRIPTION
## Summary
- rework the iPhone start screen around a full-screen MapKit map with transparent top controls
- add an Apple Maps-style expanding search drawer with inline suggestions/recent searches and map-tap collapse
- add active navigation overlays with a wrapped maneuver banner, ETA/min/km panel, MapKit heading-follow camera, and native compass/tracking controls
- simplify settings/connection presentation and keep iOS BLE settings constants/test coverage aligned

## Validation
- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'platform=iOS,id=00008140-001055643C81401C' -derivedDataPath /tmp/BikeComputerIOSOnlyDerivedData build`
- `xcrun devicectl device install app --device FDDF471D-DA2E-5C12-86B7-021BB570A821 /tmp/BikeComputerIOSOnlyDerivedData/Build/Products/Debug-iphoneos/BikeComputer.app`
- `xcrun devicectl device process launch --device FDDF471D-DA2E-5C12-86B7-021BB570A821 LetItRide.BikeComputer`
