### PR TITLE
Refresh README and contribution docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,167 @@
+# Contributing
+
+Open Source Bike Computer is an iOS-driven bike computer: the phone plans the
+route, records workout metrics, and streams navigation, GPS, route geometry,
+map settings, and ride telemetry to a small handlebar display over BLE.
+
+## Repo layout
+
+- `esp32/` - ESP32-S3 Waveshare firmware using PlatformIO, Arduino, LVGL,
+  Arduino_GFX, NimBLE, SD map rendering, BLE navigation, and board helpers.
+- `xiao-nrf52840/` - lower-power Seeed XIAO nRF52840 + Round Display firmware
+  target using PlatformIO, Seeed_GFX, Bluefruit BLE, serial simulation, native
+  protocol tests, and hardware-evidence checkers.
+- `ios-app/` - iOS companion app using SwiftUI, MapKit, CoreBluetooth,
+  CoreLocation, and HealthKit.
+- `OSM_Extract/` - Dockerized OpenStreetMap extraction tools that generate
+  vector map blocks (`.fmb` / `.fmp`) from PBF files. This is modified from
+  [aresta/OSM_Extract](https://github.com/aresta/OSM_Extract).
+- `docs/` - protocol and implementation notes. The current BLE source of truth
+  is [docs/ble-protocol.md](docs/ble-protocol.md).
+- `hardware/` and [WAVESHARE_HARDWARE.md](WAVESHARE_HARDWARE.md) - board
+  bring-up notes, pinouts, power/enclosure records, and hardware validation
+  evidence.
+
+## Development flow
+
+Prerequisites:
+
+- PlatformIO CLI (`pio`) or VS Code with the PlatformIO extension.
+- Xcode for the iOS app.
+- A USB-C data cable and the correct serial port for the connected board.
+
+List connected ports on macOS:
+
+```sh
+pio device list
+ls /dev/cu.usbmodem*
+```
+
+Build the default Waveshare ESP32-S3 1.75 firmware:
+
+```sh
+cd esp32
+pio run -e WAVESHARE_AMOLED_175
+```
+
+Build the Waveshare ESP32-S3 2.06 firmware:
+
+```sh
+cd esp32
+pio run -e WAVESHARE_AMOLED_206
+```
+
+Upload ESP32 firmware:
+
+```sh
+cd esp32
+pio run -e WAVESHARE_AMOLED_175 -t upload
+```
+
+If upload fails, hold BOOT (`GPIO0`) while reconnecting USB, then retry. For the
+2.06 board, use `-e WAVESHARE_AMOLED_206`.
+
+View ESP32 serial logs:
+
+```sh
+cd esp32
+pio device monitor -b 115200
+```
+
+Build the XIAO nRF52840 Round Display firmware:
+
+```sh
+cd xiao-nrf52840
+pio run -e xiao_nrf52840_round
+```
+
+Upload only after verifying the connected USB device is the XIAO nRF52840, not a
+Waveshare ESP32-S3:
+
+```sh
+cd xiao-nrf52840
+pio run -e xiao_nrf52840_round -t upload --upload-port /dev/cu.usbmodemXXXX
+```
+
+If upload fails, double-tap reset on the XIAO to enter the bootloader and retry
+against the bootloader serial port.
+
+Run the portable XIAO/native protocol tests:
+
+```sh
+cd xiao-nrf52840
+pio test -e native_protocol
+python3 -m unittest discover -s tools -p 'test_*.py'
+```
+
+Run the iOS navigation/BLE protocol tests from the repo root:
+
+```sh
+ios-app/scripts/run-navigation-tests.sh
+```
+
+Run the iOS app by opening:
+
+```text
+ios-app/BikeComputer/BikeComputer.xcodeproj
+```
+
+For physical iPhone setup, developer trust, and sharing notes, see
+[ios-app/README.md](ios-app/README.md).
+
+## Hardware notes
+
+Supported display targets:
+
+- [Waveshare ESP32-S3-Touch-AMOLED-1.75](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262)
+- [Waveshare ESP32-S3-Touch-AMOLED-2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm)
+- [Seeed Studio XIAO nRF52840](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html)
+  + [1.28" Round Touch Display for XIAO](https://www.seeedstudio.com/1-28-Round-Touch-Display-for-Seeed-Studio-XIAO-ESP32.html),
+  tracked in [PR #31](https://github.com/seichris/open-bike-computer/pull/31).
+
+Definitive Waveshare pinouts and known quirks live in
+[WAVESHARE_HARDWARE.md](WAVESHARE_HARDWARE.md). Important reminders:
+
+- The 1.75 and 2.06 Waveshare boards both use CO5300 AMOLED displays, but they
+  do not share the same display, touch, or SD pinout. Keep
+  `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` changes separate.
+- Waveshare 1.75 display power is controlled through AXP2101, touch reset is
+  via TCA9554 P0, and SD uses `CS=41, MOSI=1, MISO=3, SCK=2`.
+- Waveshare 2.06 uses direct FT3168 touch reset on `GPIO9`, display clock on
+  `GPIO11`, display reset on `GPIO8`, and SD `CS=17`.
+- The XIAO target is intentionally separate from `esp32/` because it uses a
+  different MCU, BLE stack, display library, memory budget, and power model.
+
+Hardware validation records live under `hardware/`. For XIAO work, use the
+serial simulation and evidence-checker flow in
+[xiao-nrf52840/README.md](xiao-nrf52840/README.md) before treating a hardware
+run as validated.
+
+## BLE protocol
+
+The iOS app discovers the bike computer by the BikeComputer service UUID
+`9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800`. ESP32 firmware advertises as
+`BikeComputer`; the XIAO target may advertise as `BikeComputer-XIAO` while using
+the same service contract.
+
+All navigation, GPS, route, and settings writes require the local authenticated
+session described in [docs/ble-protocol.md](docs/ble-protocol.md).
+
+Current characteristics:
+
+| UUID | Direction | Purpose |
+| --- | --- | --- |
+| `2A6E` | iOS -> device | UTF-8 navigation instruction, `IconID|DistanceMeters|Instruction` |
+| `9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1002` | bidirectional | Local auth handshake |
+| `2A6F` | iOS -> device | Binary route geometry |
+| `2A72` | iOS -> device | GPS position, heading, time, and optional ride telemetry |
+| `2A73` | iOS -> device | Runtime map/display settings |
+
+When iOS has an older cached GATT table, the app falls back to framed binary
+writes over authenticated `2A6E` using `MAPR`, `GPSP`, and `MSET` frame
+prefixes. Keep new device firmware compatible with both the direct
+characteristics and the fallback framing path.
+
+Before changing BLE formats, update the shared builders/parsers, iOS protocol
+tests, ESP32 firmware, XIAO native tests, and [docs/ble-protocol.md](docs/ble-protocol.md)
+in the same change.

--- a/OFFLINE_MAPS.md
+++ b/OFFLINE_MAPS.md
@@ -1,0 +1,70 @@
+# Offline Maps
+
+Use the `OSM_Extract` toolchain to generate OpenStreetMap vector blocks for the
+device map renderer. The recommended path is the provided Docker environment,
+which includes `osmium`, `ogr2ogr`, and the required Python dependencies.
+
+## 1. Download a PBF extract
+
+Use BBBike Extract in PBF format: https://extract.bbbike.org/
+
+Save the resulting file to:
+
+```text
+OSM_Extract/pbf/<your-area>.osm.pbf
+```
+
+## 2. Run the extractor in Docker
+
+```sh
+cd OSM_Extract
+docker compose run --rm tools bash
+```
+
+If you have an older Docker install, use `docker-compose` instead of
+`docker compose`.
+
+Inside the container:
+
+```sh
+cd /scripts
+
+# Get the file's bounding box and copy values into the vars below.
+osmium fileinfo -g header.box /pbf/<your-area>.osm.pbf
+
+min_lon=...
+min_lat=...
+max_lon=...
+max_lat=...
+
+# Generates: /maps/<your-area>_lines.geojson and /maps/<your-area>_polygons.geojson
+./pbf_to_geojson.sh "$min_lon" "$min_lat" "$max_lon" "$max_lat" "/pbf/<your-area>.osm.pbf" "/maps/<your-area>"
+
+# Generates a folder tree of vector blocks under /maps/<output-name>/
+./extract_features.py "$min_lon" "$min_lat" "$max_lon" "$max_lat" "/maps/<your-area>" "/maps/<output-name>"
+```
+
+Outputs on the host machine:
+
+```text
+OSM_Extract/maps/<output-name>/
+```
+
+The output folder contains generated `.fmb` / `.fmp` vector map blocks.
+
+Config knobs:
+
+- Feature selection: `OSM_Extract/conf/conf_extract.yaml`
+- Styling: `OSM_Extract/conf/conf_styles.yaml`
+
+## 3. Copy maps to SD card
+
+Copy the generated map folders to the SD card under:
+
+```text
+/VECTMAP/<output-name>/
+```
+
+The ESP32 firmware reads `.fmb` blocks from this layout for offline map
+rendering. The XIAO nRF52840 target has an experimental map-lite probe/render
+path that uses the same folder structure for hardware go/no-go testing.

--- a/README.md
+++ b/README.md
@@ -2,138 +2,28 @@
 
 # Open Source Bike Computer
 
-Navigate your bike rides with a compact ESP32 display, for ~$30.
+Navigate your bike rides with a ~$30 open source bike computer.
 
-- **Device**: [Waveshare ESP32-S3-Touch-AMOLED-1.75](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262)
-- **iOS app**: Route planning + workout metrics; sends navigation + telemetry to the device over BLE.
+- **Paired iOS app**: Plan routes, record workout metrics, and stream turn-by-turn navigation, GPS, map settings, and ride telemetry to the handlebar display over BLE.
+- **Supported hardware**:
+  - [Waveshare ESP32-S3-Touch-AMOLED-1.75](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262)
+  - [Waveshare ESP32-S3-Touch-AMOLED-2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm)
+  - [Seeed Studio XIAO nRF52840](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html) + [1.28" Round Touch Display for XIAO](https://www.seeedstudio.com/1-28-Round-Touch-Display-for-Seeed-Studio-XIAO-ESP32.html) via [PR #31](https://github.com/seichris/open-bike-computer/pull/31)
 
-We used [IceNav-v3](https://github.com/jgauchia/IceNav-v3) as a reference for this project. If you want a **self-contained** ESP32 GPS navigator with **offline OSM maps** (no phone required), IceNav-v3 is highly recommended.
+The firmware, iOS app, and hardware notes are open source, so you can tailor the
+device to your rides. See [CONTRIBUTING.md](CONTRIBUTING.md) to build on this
+codebase.
 
-## Repo layout
+The iOS app needs an internet connection for route planning. For a fully
+offline, phone-free setup, flash [IceNav-v3](https://github.com/jgauchia/IceNav-v3)
+on a GPS-equipped board like the
+[Waveshare ESP32-S3-Touch-AMOLED-1.75 with GPS](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31264).
 
-- `esp32/` — firmware (PlatformIO + Arduino + LVGL + NimBLE).
-- `ios-app/` — iOS companion app (SwiftUI + MapKit + CoreBluetooth + HealthKit).
-- `OSM_Extract/` — tools to generate vector map blocks (`.fmb` / `.fmp`) from OpenStreetMap PBF. Modified from [this repo](https://github.com/aresta/OSM_Extract).
+## Contributing
 
-## Development flow
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the repo layout, build and test flow, supported-hardware notes, and the current BLE protocol overview.
 
-### 1) Flash ESP32 firmware
+## Offline maps
 
-Prereqs:
-- PlatformIO CLI (`pio`) or VS Code + PlatformIO extension
-- USB-C data cable
-
-Build + upload:
-```bash
-cd esp32
-pio run -t upload
-```
-
-If upload fails, force bootloader mode: **hold BOOT (GPIO0)** while re-plugging the USB cable, then retry.
-
-### 2) Find the device port (macOS)
-
-PlatformIO:
-```bash
-pio device list
-```
-
-Or directly:
-```bash
-ls /dev/cu.usbmodem*
-```
-
-### 3) View serial logs (macOS)
-
-PlatformIO monitor:
-```bash
-cd esp32
-pio device monitor -b 115200
-```
-
-Or with `screen`:
-```bash
-screen /dev/cu.usbmodem1101 115200
-```
-
-### 4) Run the iOS app
-
-Open the Xcode project:
-- `ios-app/BikeComputer/BikeComputer.xcodeproj`
-
-For “run on a real iPhone / trust the developer / sharing to others”, see:
-- `ios-app/README.md`
-
-## BLE protocol (current)
-
-- Peripheral name: `BikeComputer`
-- Service UUID: `1819`
-- Characteristic UUID: `2A6E` (write without response)
-- Payload (UTF-8): `IconID|DistanceMeters|Instruction`
-  - Example: `2|150|Turn Left onto Main St`
-  - Icon IDs: `1` straight, `2` left, `3` right, `4` u-turn.
-
-## Create a new offline map (OSM_Extract)
-
-The recommended path is using the provided Docker toolchain (includes `osmium` + `ogr2ogr` + Python deps).
-
-### 1) Download a PBF extract
-
-Use BBBike Extract (PBF format): https://extract.bbbike.org/
-
-Save the resulting file to:
-- `OSM_Extract/pbf/<your-area>.osm.pbf`
-
-### 2) Run the extractor in Docker
-
-```bash
-cd OSM_Extract
-docker compose run --rm tools bash
-```
-
-(If you have an older Docker install, use `docker-compose` instead of `docker compose`.)
-
-Inside the container:
-```bash
-cd /scripts
-
-# Get the file's bounding box (copy values into the vars below)
-osmium fileinfo -g header.box /pbf/<your-area>.osm.pbf
-
-min_lon=...
-min_lat=...
-max_lon=...
-max_lat=...
-
-# Generates: /maps/<your-area>_lines.geojson + /maps/<your-area>_polygons.geojson
-./pbf_to_geojson.sh "$min_lon" "$min_lat" "$max_lon" "$max_lat" "/pbf/<your-area>.osm.pbf" "/maps/<your-area>"
-
-# Generates folder tree of vector blocks under /maps/<output-name>/
-./extract_features.py "$min_lon" "$min_lat" "$max_lon" "$max_lat" "/maps/<your-area>" "/maps/<output-name>"
-```
-
-Outputs on the host machine:
-- `OSM_Extract/maps/<output-name>/` (folder tree of `*.fmb` / `*.fmp`)
-
-Config knobs:
-- feature selection: `OSM_Extract/conf/conf_extract.yaml`
-- styling: `OSM_Extract/conf/conf_styles.yaml`
-
-### 3) Copy maps to SD card
-
-For the upstream `IceNav-v3` project, these typically go under `VECTMAP/` on the SD card (excluding `test_imgs/`).
-
-For the firmware in `esp32/` today, SD support is still basic (it lists files and reads test files), but the same folder structure will be used when the vector map renderer lands.
-
-## Hardware notes
-
-Definitive pinout + known quirks live in:
-- `WAVESHARE_HARDWARE.md`
-- Official board links:
-  - https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262
-  - https://www.waveshare.com/wiki/ESP32-S3-Touch-AMOLED-1.75
-
-Highlights:
-- display power must be enabled via **AXP2101** (I2C `0x34`)
-- touch reset is via **TCA9554 P0** (I2C `0x20`) — **do not** toggle GPIO20 (USB D+)
-- SD is SPI on `CS=41, MOSI=1, MISO=3, SCK=2` (uses HSPI in `esp32/src/main.cpp`)
+See [OFFLINE_MAPS.md](OFFLINE_MAPS.md) to generate OpenStreetMap vector blocks
+for SD-card map rendering.


### PR DESCRIPTION
## Summary

- Refresh the root README with the shorter project pitch, paired iOS app wording, current supported hardware links, and offline-device guidance.
- Move contribution-facing repo layout, development flow, hardware notes, and BLE protocol overview into CONTRIBUTING.md.
- Move OSM_Extract offline map generation instructions into OFFLINE_MAPS.md.

## Validation

- git diff --check -- README.md CONTRIBUTING.md OFFLINE_MAPS.md
- Verified local documentation link targets exist in the branch worktree.
