### PR TITLE
Add map guidance screen

### DIFF
--- a/xiao-nrf52840/lib/display_round/display_round.cpp
+++ b/xiao-nrf52840/lib/display_round/display_round.cpp
@@ -184,7 +184,8 @@ void DisplayRound::drawCenteredPositionMarker(bool courseUp) {
 }
 
 void DisplayRound::drawNavigationGuidanceOverlay(uint8_t iconId,
-                                                 uint16_t distanceMeters) {
+                                                 uint16_t distanceMeters,
+                                                 bool active) {
   if (!frameActive) {
     return;
   }
@@ -197,6 +198,17 @@ void DisplayRound::drawNavigationGuidanceOverlay(uint8_t iconId,
   const int16_t panelHeight = height - panelY;
   tft.fillRect(0, panelY, width, panelHeight, GUIDANCE_PANEL_COLOR);
   tft.drawFastHLine(0, panelY, width, GUIDANCE_DIM_COLOR);
+
+  if (!active) {
+    tft.setTextDatum(TC_DATUM);
+    tft.setTextColor(TFT_WHITE, GUIDANCE_PANEL_COLOR);
+    tft.setTextSize(3);
+    tft.drawString("Map", width / 2, panelY + 18);
+    tft.setTextSize(2);
+    tft.setTextColor(GUIDANCE_DIM_COLOR, GUIDANCE_PANEL_COLOR);
+    tft.drawString("Ready", width / 2, panelY + 52);
+    return;
+  }
 
   drawManeuverArrow(iconId, 50, panelY + 45, TFT_WHITE);
 
@@ -219,7 +231,8 @@ void DisplayRound::drawNavigationGuidanceOverlay(uint8_t iconId,
   tft.drawString(unit, 104, panelY + 58);
 }
 
-void DisplayRound::endMapFrame(const char *label, uint32_t elapsedMs) {
+void DisplayRound::endMapFrame(const char *label, uint32_t elapsedMs,
+                               bool keepStatusOverlay) {
   Serial.print("DisplayRound: map frame ");
   Serial.print(label == nullptr ? "preview" : label);
   Serial.print(" lines=");
@@ -227,7 +240,7 @@ void DisplayRound::endMapFrame(const char *label, uint32_t elapsedMs) {
   Serial.print(" elapsed_ms=");
   Serial.println(elapsedMs);
   frameActive = false;
-  statusOverlayPending = true;
+  statusOverlayPending = keepStatusOverlay;
 }
 
 } // namespace xiao_round

--- a/xiao-nrf52840/lib/display_round/display_round.cpp
+++ b/xiao-nrf52840/lib/display_round/display_round.cpp
@@ -13,6 +13,8 @@ constexpr uint16_t PRIMARY_TEXT_COLOR = TFT_WHITE;
 constexpr uint16_t SECONDARY_TEXT_COLOR = TFT_CYAN;
 constexpr uint16_t STATUS_PANEL_COLOR = 0x0008;
 constexpr uint16_t ACCENT_COLOR = TFT_GREEN;
+constexpr uint16_t GUIDANCE_PANEL_COLOR = 0x0000;
+constexpr uint16_t GUIDANCE_DIM_COLOR = 0x4208;
 
 TFT_eSPI tft;
 
@@ -45,6 +47,44 @@ void drawStatusPanel(const char *line1, const char *line2, bool overlay) {
                                                  : BACKGROUND_COLOR);
   tft.drawString(line2 == nullptr ? "" : line2, DisplayRound::width / 2,
                  overlay ? DisplayRound::height - 28 : 128);
+}
+
+void drawThickLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2,
+                   uint16_t color, int16_t thickness) {
+  const bool mostlyVertical = abs(y2 - y1) >= abs(x2 - x1);
+  const int16_t half = thickness / 2;
+  for (int16_t offset = -half; offset <= half; offset++) {
+    if (mostlyVertical) {
+      tft.drawLine(x1 + offset, y1, x2 + offset, y2, color);
+    } else {
+      tft.drawLine(x1, y1 + offset, x2, y2 + offset, color);
+    }
+  }
+}
+
+void drawManeuverArrow(uint8_t iconId, int16_t x, int16_t y, uint16_t color) {
+  switch (iconId) {
+  case 2:
+    drawThickLine(x + 18, y + 28, x + 18, y + 4, color, 6);
+    drawThickLine(x + 18, y + 4, x - 18, y + 4, color, 6);
+    tft.fillTriangle(x - 26, y + 4, x - 12, y - 6, x - 12, y + 14, color);
+    break;
+  case 3:
+    drawThickLine(x - 18, y + 28, x - 18, y + 4, color, 6);
+    drawThickLine(x - 18, y + 4, x + 18, y + 4, color, 6);
+    tft.fillTriangle(x + 26, y + 4, x + 12, y - 6, x + 12, y + 14, color);
+    break;
+  case 4:
+    drawThickLine(x + 18, y + 28, x + 18, y - 6, color, 6);
+    drawThickLine(x + 18, y - 6, x - 12, y - 6, color, 6);
+    drawThickLine(x - 12, y - 6, x - 12, y + 16, color, 6);
+    tft.fillTriangle(x - 12, y + 26, x - 22, y + 12, x - 2, y + 12, color);
+    break;
+  default:
+    drawThickLine(x, y + 26, x, y - 12, color, 6);
+    tft.fillTriangle(x, y - 24, x - 12, y - 6, x + 12, y - 6, color);
+    break;
+  }
 }
 
 } // namespace
@@ -119,6 +159,64 @@ void DisplayRound::drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2,
       tft.drawLine(x1, y1, x2, y2, color);
     }
   }
+}
+
+void DisplayRound::drawCenteredPositionMarker(bool courseUp) {
+  if (!frameActive) {
+    return;
+  }
+  frameLineCount += 4;
+  if (!initialized) {
+    return;
+  }
+
+  const int16_t centerX = width / 2;
+  const int16_t centerY = height / 2;
+  if (courseUp) {
+    tft.fillTriangle(centerX, centerY - 15, centerX - 11, centerY + 12,
+                     centerX + 11, centerY + 12, TFT_WHITE);
+    tft.drawTriangle(centerX, centerY - 15, centerX - 11, centerY + 12,
+                     centerX + 11, centerY + 12, TFT_BLACK);
+  } else {
+    tft.fillCircle(centerX, centerY, 5, TFT_WHITE);
+    tft.drawCircle(centerX, centerY, 7, TFT_BLACK);
+  }
+}
+
+void DisplayRound::drawNavigationGuidanceOverlay(uint8_t iconId,
+                                                 uint16_t distanceMeters) {
+  if (!frameActive) {
+    return;
+  }
+  frameLineCount += 12;
+  if (!initialized) {
+    return;
+  }
+
+  const int16_t panelY = (height * 2) / 3;
+  const int16_t panelHeight = height - panelY;
+  tft.fillRect(0, panelY, width, panelHeight, GUIDANCE_PANEL_COLOR);
+  tft.drawFastHLine(0, panelY, width, GUIDANCE_DIM_COLOR);
+
+  drawManeuverArrow(iconId, 50, panelY + 45, TFT_WHITE);
+
+  char value[12];
+  char unit[4];
+  if (distanceMeters >= 1000) {
+    snprintf(value, sizeof(value), "%u.%u", distanceMeters / 1000,
+             (distanceMeters % 1000) / 100);
+    snprintf(unit, sizeof(unit), "km");
+  } else {
+    snprintf(value, sizeof(value), "%u", distanceMeters);
+    snprintf(unit, sizeof(unit), "m");
+  }
+
+  tft.setTextDatum(TL_DATUM);
+  tft.setTextColor(TFT_WHITE, GUIDANCE_PANEL_COLOR);
+  tft.setTextSize(5);
+  tft.drawString(value, 100, panelY + 14);
+  tft.setTextSize(2);
+  tft.drawString(unit, 104, panelY + 58);
 }
 
 void DisplayRound::endMapFrame(const char *label, uint32_t elapsedMs) {

--- a/xiao-nrf52840/lib/display_round/display_round.hpp
+++ b/xiao-nrf52840/lib/display_round/display_round.hpp
@@ -17,8 +17,10 @@ public:
   void drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2,
                 uint16_t color);
   void drawCenteredPositionMarker(bool courseUp);
-  void drawNavigationGuidanceOverlay(uint8_t iconId, uint16_t distanceMeters);
-  void endMapFrame(const char *label, uint32_t elapsedMs);
+  void drawNavigationGuidanceOverlay(uint8_t iconId, uint16_t distanceMeters,
+                                     bool active);
+  void endMapFrame(const char *label, uint32_t elapsedMs,
+                   bool keepStatusOverlay = true);
 
 private:
   uint8_t brightnessPercent = 100;

--- a/xiao-nrf52840/lib/display_round/display_round.hpp
+++ b/xiao-nrf52840/lib/display_round/display_round.hpp
@@ -16,6 +16,8 @@ public:
   void beginMapFrame();
   void drawLine(int16_t x1, int16_t y1, int16_t x2, int16_t y2,
                 uint16_t color);
+  void drawCenteredPositionMarker(bool courseUp);
+  void drawNavigationGuidanceOverlay(uint8_t iconId, uint16_t distanceMeters);
   void endMapFrame(const char *label, uint32_t elapsedMs);
 
 private:

--- a/xiao-nrf52840/lib/map_lite/map_lite.cpp
+++ b/xiao-nrf52840/lib/map_lite/map_lite.cpp
@@ -179,6 +179,11 @@ bool MapLite::printDirectory(const char *path, uint8_t maxEntries) {
 }
 
 bool MapLite::renderLastProbePreview(DisplayRound &display, uint32_t nowMs) {
+  return renderLastProbePreview(display, nowMs, MapRenderViewport{});
+}
+
+bool MapLite::renderLastProbePreview(DisplayRound &display, uint32_t nowMs,
+                                     const MapRenderViewport &viewport) {
   if (!currentStatus.hasProbe || !currentStatus.lastResult.found ||
       currentStatus.lastResult.path[0] == '\0' ||
       currentStatus.lastResult.decision != MapLiteDecision::Candidate) {
@@ -186,7 +191,8 @@ bool MapLite::renderLastProbePreview(DisplayRound &display, uint32_t nowMs) {
   }
   if (currentStatus.lastRenderedProbeCount == currentStatus.probeCount &&
       currentStatus.lastRenderAtMs != 0 &&
-      nowMs - currentStatus.lastRenderAtMs < MAP_LITE_RENDER_MIN_INTERVAL_MS) {
+      nowMs - currentStatus.lastRenderAtMs < MAP_LITE_RENDER_MIN_INTERVAL_MS &&
+      !viewport.centered) {
     return false;
   }
 
@@ -205,7 +211,8 @@ bool MapLite::renderLastProbePreview(DisplayRound &display, uint32_t nowMs) {
     if (header.headerValid && skipPolygonRecords(file, header)) {
       valid = renderPolylineRecords(file, display, header, featureCount,
                                     segmentCount, skippedSegmentCount,
-                                    budgetExceeded);
+                                    budgetExceeded,
+                                    viewport.centered ? &viewport : nullptr);
     }
     file.close();
   }
@@ -372,12 +379,51 @@ bool MapLite::skipPolygonRecords(SdFile &file,
   return true;
 }
 
+bool centeredPointToScreen(const MapRenderViewport &viewport,
+                           int32_t blockOriginX, int32_t blockOriginY,
+                           int16_t localX, int16_t localY, int16_t &screenX,
+                           int16_t &screenY, double &rotatedX,
+                           double &rotatedY) {
+  double dx = static_cast<double>(blockOriginX + localX -
+                                  viewport.centerMapMetersX);
+  double dy = static_cast<double>(blockOriginY + localY -
+                                  viewport.centerMapMetersY);
+  if (viewport.courseUp) {
+    const double radians =
+        static_cast<double>(viewport.headingDegrees) * 0.017453292519943295;
+    const double sinHeading = sin(radians);
+    const double cosHeading = cos(radians);
+    const double courseX = (dx * cosHeading) - (dy * sinHeading);
+    const double courseY = (dx * sinHeading) + (dy * cosHeading);
+    dx = courseX;
+    dy = courseY;
+  }
+
+  rotatedX = dx;
+  rotatedY = dy;
+  const double center = (DisplayRound::width - 1) / 2.0;
+  const double scale = center / viewport.radiusMeters;
+  auto clampScreen = [](int32_t value) -> int16_t {
+    if (value < 0) {
+      return 0;
+    }
+    if (value >= DisplayRound::width) {
+      return DisplayRound::width - 1;
+    }
+    return static_cast<int16_t>(value);
+  };
+  screenX = clampScreen(static_cast<int32_t>(center + (dx * scale) + 0.5));
+  screenY = clampScreen(static_cast<int32_t>(center - (dy * scale) + 0.5));
+  return fabs(dx) <= viewport.radiusMeters || fabs(dy) <= viewport.radiusMeters;
+}
+
 bool MapLite::renderPolylineRecords(SdFile &file, DisplayRound &display,
                                     const MapBlockProbeResult &result,
                                     uint16_t &featureCount,
                                     uint16_t &segmentCount,
                                     uint16_t &skippedSegmentCount,
-                                    bool &budgetExceeded) {
+                                    bool &budgetExceeded,
+                                    const MapRenderViewport *viewport) {
   uint16_t polylineCount = 0;
   if (!readU16(file, polylineCount)) {
     return false;
@@ -413,6 +459,12 @@ bool MapLite::renderPolylineRecords(SdFile &file, DisplayRound &display,
       return false;
     }
     bool featureDrewSegment = false;
+    const int32_t blockOriginX =
+        map_lite_core::blockCoordForMapMeters(currentStatus.lastMapMetersX) *
+        map_lite_core::MAPBLOCK_SIZE_METERS;
+    const int32_t blockOriginY =
+        map_lite_core::blockCoordForMapMeters(currentStatus.lastMapMetersY) *
+        map_lite_core::MAPBLOCK_SIZE_METERS;
     for (uint16_t pointIndex = 1; pointIndex < pointCount; pointIndex++) {
       int16_t currentX = 0;
       int16_t currentY = 0;
@@ -421,13 +473,43 @@ bool MapLite::renderPolylineRecords(SdFile &file, DisplayRound &display,
       }
       if (featureCount < map_lite_core::RENDER_FEATURE_BUDGET &&
           segmentCount < map_lite_core::RENDER_SEGMENT_BUDGET) {
-        display.drawLine(map_lite_core::localMapCoordToScreen(previousX, false),
-                         map_lite_core::localMapCoordToScreen(previousY, true),
-                         map_lite_core::localMapCoordToScreen(currentX, false),
-                         map_lite_core::localMapCoordToScreen(currentY, true),
-                         color);
-        segmentCount++;
-        featureDrewSegment = true;
+        int16_t previousScreenX = 0;
+        int16_t previousScreenY = 0;
+        int16_t currentScreenX = 0;
+        int16_t currentScreenY = 0;
+        bool shouldDraw = true;
+        if (viewport != nullptr) {
+          double previousRotatedX = 0.0;
+          double previousRotatedY = 0.0;
+          double currentRotatedX = 0.0;
+          double currentRotatedY = 0.0;
+          centeredPointToScreen(*viewport, blockOriginX, blockOriginY,
+                                previousX, previousY, previousScreenX,
+                                previousScreenY, previousRotatedX,
+                                previousRotatedY);
+          centeredPointToScreen(*viewport, blockOriginX, blockOriginY,
+                                currentX, currentY, currentScreenX,
+                                currentScreenY, currentRotatedX,
+                                currentRotatedY);
+          shouldDraw =
+              !((fabs(previousRotatedX) > viewport->radiusMeters &&
+                 fabs(currentRotatedX) > viewport->radiusMeters &&
+                 ((previousRotatedX < 0.0) == (currentRotatedX < 0.0))) ||
+                (fabs(previousRotatedY) > viewport->radiusMeters &&
+                 fabs(currentRotatedY) > viewport->radiusMeters &&
+                 ((previousRotatedY < 0.0) == (currentRotatedY < 0.0))));
+        } else {
+          previousScreenX = map_lite_core::localMapCoordToScreen(previousX, false);
+          previousScreenY = map_lite_core::localMapCoordToScreen(previousY, true);
+          currentScreenX = map_lite_core::localMapCoordToScreen(currentX, false);
+          currentScreenY = map_lite_core::localMapCoordToScreen(currentY, true);
+        }
+        if (shouldDraw) {
+          display.drawLine(previousScreenX, previousScreenY, currentScreenX,
+                           currentScreenY, color);
+          segmentCount++;
+          featureDrewSegment = true;
+        }
       } else {
         skippedSegmentCount++;
         budgetExceeded = true;

--- a/xiao-nrf52840/lib/map_lite/map_lite.hpp
+++ b/xiao-nrf52840/lib/map_lite/map_lite.hpp
@@ -55,6 +55,15 @@ struct MapLiteStatus {
   MapBlockProbeResult lastResult;
 };
 
+struct MapRenderViewport {
+  bool centered = false;
+  int32_t centerMapMetersX = 0;
+  int32_t centerMapMetersY = 0;
+  uint16_t headingDegrees = 0;
+  bool courseUp = false;
+  double radiusMeters = 500.0;
+};
+
 class MapLite {
 public:
   bool begin();
@@ -62,6 +71,8 @@ public:
   bool updateForGps(int32_t latMicrodegrees, int32_t lonMicrodegrees,
                     uint32_t nowMs);
   bool renderLastProbePreview(DisplayRound &display, uint32_t nowMs);
+  bool renderLastProbePreview(DisplayRound &display, uint32_t nowMs,
+                              const MapRenderViewport &viewport);
   bool printDirectory(const char *path = "/", uint8_t maxEntries = 24);
   bool isReady() const { return sdReady; }
   MapLiteStatus status() const;
@@ -82,7 +93,8 @@ private:
                              const MapBlockProbeResult &result,
                              uint16_t &featureCount, uint16_t &segmentCount,
                              uint16_t &skippedSegmentCount,
-                             bool &budgetExceeded);
+                             bool &budgetExceeded,
+                             const MapRenderViewport *viewport);
   bool readHeader(SdFile &file, MapBlockProbeResult &result);
   bool scanFeatures(SdFile &file, MapBlockProbeResult &result);
 

--- a/xiao-nrf52840/lib/ui_round/ui_round.cpp
+++ b/xiao-nrf52840/lib/ui_round/ui_round.cpp
@@ -318,10 +318,12 @@ void RoundUi::drawMapGuidancePage(const BLENavigationServer &bleServer,
   const bike_ble::GpsPosition &gps = bleServer.currentGps();
   const BLEDebugStats stats = bleServer.getDebugStats();
   const bool hasGps = gpsLooksValid(gps, stats);
-  const bool hasNavigation =
-      route.loaded || nav.distanceMeters > 0 || nav.instruction[0] != '\0';
+  const bool isNavigating = route.loaded;
+  const bool hasManeuver =
+      isNavigating &&
+      (nav.iconId != 0 || nav.distanceMeters > 0 || nav.instruction[0] != '\0');
   const uint16_t orientationHeading =
-      hasNavigation ? routeHeadingNearGps(route, gps) : 0;
+      isNavigating ? routeHeadingNearGps(route, gps) : 0;
 
   bool mapRendered = false;
   uint16_t routeSegments = 0;
@@ -340,7 +342,7 @@ void RoundUi::drawMapGuidancePage(const BLENavigationServer &bleServer,
         viewport.centerMapMetersX = centerMapMetersX;
         viewport.centerMapMetersY = centerMapMetersY;
         viewport.headingDegrees = orientationHeading;
-        viewport.courseUp = hasNavigation;
+        viewport.courseUp = isNavigating;
         mapRendered =
             mapLite.renderLastProbePreview(*display, frameStartMs, viewport);
       }
@@ -348,11 +350,11 @@ void RoundUi::drawMapGuidancePage(const BLENavigationServer &bleServer,
       mapRendered = mapLite.renderLastProbePreview(*display, frameStartMs);
     }
     routeSegments =
-        drawRoutePreview(route, gps, stats, orientationHeading, hasNavigation,
+        drawRoutePreview(route, gps, stats, orientationHeading, isNavigating,
                          false);
-    display->drawCenteredPositionMarker(hasNavigation);
+    display->drawCenteredPositionMarker(isNavigating);
     display->drawNavigationGuidanceOverlay(nav.iconId, nav.distanceMeters,
-                                           hasNavigation);
+                                           hasManeuver);
     display->endMapFrame(mapRendered ? "guidance-map" : "guidance-preview",
                          millis() - frameStartMs, false);
   }

--- a/xiao-nrf52840/lib/ui_round/ui_round.cpp
+++ b/xiao-nrf52840/lib/ui_round/ui_round.cpp
@@ -351,9 +351,10 @@ void RoundUi::drawMapGuidancePage(const BLENavigationServer &bleServer,
         drawRoutePreview(route, gps, stats, orientationHeading, hasNavigation,
                          false);
     display->drawCenteredPositionMarker(hasNavigation);
-    display->drawNavigationGuidanceOverlay(nav.iconId, nav.distanceMeters);
+    display->drawNavigationGuidanceOverlay(nav.iconId, nav.distanceMeters,
+                                           hasNavigation);
     display->endMapFrame(mapRendered ? "guidance-map" : "guidance-preview",
-                         millis() - frameStartMs);
+                         millis() - frameStartMs, false);
   }
 
   Serial.print("RoundUi: guidance map=");

--- a/xiao-nrf52840/lib/ui_round/ui_round.cpp
+++ b/xiao-nrf52840/lib/ui_round/ui_round.cpp
@@ -18,6 +18,7 @@ constexpr uint16_t ROUTE_PREVIEW_SEGMENT_BUDGET = 96;
 constexpr uint16_t ROUTE_COLOR_RGB565 = 0x001F;
 constexpr uint16_t POSITION_COLOR_RGB565 = 0xF800;
 constexpr uint8_t BRIGHTNESS_GESTURE_STEP_PERCENT = 5;
+constexpr uint8_t ROUND_PAGE_COUNT = 5;
 
 double degreesToRadians(double degrees) { return degrees * 0.017453292519943295; }
 
@@ -118,6 +119,9 @@ void RoundUi::update(BLENavigationServer &bleServer, PowerManager &powerManager,
   case RoundPage::Route:
     drawRoutePage(bleServer, mapLite);
     break;
+  case RoundPage::MapGuidance:
+    drawMapGuidancePage(bleServer, mapLite);
+    break;
   case RoundPage::Settings:
     drawSettingsPage(bleServer, powerManager);
     break;
@@ -129,14 +133,17 @@ void RoundUi::update(BLENavigationServer &bleServer, PowerManager &powerManager,
 }
 
 void RoundUi::nextPage() {
-  page = static_cast<RoundPage>((static_cast<uint8_t>(page) + 1) % 4);
+  page = static_cast<RoundPage>((static_cast<uint8_t>(page) + 1) %
+                                ROUND_PAGE_COUNT);
   lastRenderMs = 0;
   Serial.print("RoundUi: page=");
   Serial.println(pageName());
 }
 
 void RoundUi::previousPage() {
-  page = static_cast<RoundPage>((static_cast<uint8_t>(page) + 3) % 4);
+  page = static_cast<RoundPage>((static_cast<uint8_t>(page) +
+                                 ROUND_PAGE_COUNT - 1) %
+                                ROUND_PAGE_COUNT);
   lastRenderMs = 0;
   Serial.print("RoundUi: page=");
   Serial.println(pageName());
@@ -287,7 +294,7 @@ void RoundUi::drawRoutePage(const BLENavigationServer &bleServer,
     const uint32_t frameStartMs = millis();
     display->beginMapFrame();
     mapRendered = mapLite.renderLastProbePreview(*display, frameStartMs);
-    routeSegments = drawRoutePreview(route, gps, stats);
+    routeSegments = drawRoutePreview(route, gps, stats, 0, false, true);
     display->endMapFrame(mapRendered ? "route-map" : "route-preview",
                          millis() - frameStartMs);
   }
@@ -302,6 +309,59 @@ void RoundUi::drawRoutePage(const BLENavigationServer &bleServer,
                : 0UL,
            mapRendered ? "Y" : "N");
   display->drawStatus(line1, line2);
+}
+
+void RoundUi::drawMapGuidancePage(const BLENavigationServer &bleServer,
+                                  MapLite &mapLite) {
+  const bike_ble::NavigationData &nav = bleServer.currentNavigation();
+  const bike_ble::RouteSummary &route = bleServer.currentRoute();
+  const bike_ble::GpsPosition &gps = bleServer.currentGps();
+  const BLEDebugStats stats = bleServer.getDebugStats();
+  const bool hasGps = gpsLooksValid(gps, stats);
+  const bool hasNavigation =
+      route.loaded || nav.distanceMeters > 0 || nav.instruction[0] != '\0';
+  const uint16_t orientationHeading =
+      hasNavigation ? routeHeadingNearGps(route, gps) : 0;
+
+  bool mapRendered = false;
+  uint16_t routeSegments = 0;
+  if (display != nullptr) {
+    const uint32_t frameStartMs = millis();
+    display->beginMapFrame();
+    if (hasGps) {
+      int32_t centerMapMetersX = 0;
+      int32_t centerMapMetersY = 0;
+      if (map_lite_core::gpsToMapMeters(gps.latMicrodegrees,
+                                         gps.lonMicrodegrees,
+                                         centerMapMetersX,
+                                         centerMapMetersY)) {
+        MapRenderViewport viewport;
+        viewport.centered = true;
+        viewport.centerMapMetersX = centerMapMetersX;
+        viewport.centerMapMetersY = centerMapMetersY;
+        viewport.headingDegrees = orientationHeading;
+        viewport.courseUp = hasNavigation;
+        mapRendered =
+            mapLite.renderLastProbePreview(*display, frameStartMs, viewport);
+      }
+    } else {
+      mapRendered = mapLite.renderLastProbePreview(*display, frameStartMs);
+    }
+    routeSegments =
+        drawRoutePreview(route, gps, stats, orientationHeading, hasNavigation,
+                         false);
+    display->drawCenteredPositionMarker(hasNavigation);
+    display->drawNavigationGuidanceOverlay(nav.iconId, nav.distanceMeters);
+    display->endMapFrame(mapRendered ? "guidance-map" : "guidance-preview",
+                         millis() - frameStartMs);
+  }
+
+  Serial.print("RoundUi: guidance map=");
+  Serial.print(mapRendered ? "Y" : "N");
+  Serial.print(" route_segments=");
+  Serial.print(routeSegments);
+  Serial.print(" heading=");
+  Serial.println(orientationHeading);
 }
 
 void RoundUi::drawSettingsPage(const BLENavigationServer &bleServer,
@@ -323,7 +383,9 @@ void RoundUi::drawSettingsPage(const BLENavigationServer &bleServer,
 
 uint16_t RoundUi::drawRoutePreview(const bike_ble::RouteSummary &route,
                                    const bike_ble::GpsPosition &gps,
-                                   const BLEDebugStats &stats) {
+                                   const BLEDebugStats &stats,
+                                   uint16_t orientationHeading, bool courseUp,
+                                   bool drawMarker) {
   if (display == nullptr || route.storedPointCount < 2) {
     return 0;
   }
@@ -335,6 +397,9 @@ uint16_t RoundUi::drawRoutePreview(const bike_ble::RouteSummary &route,
       centerOnGps ? gps.lonMicrodegrees : route.points[0].lonMicrodegrees;
   const double cosLat =
       cos(degreesToRadians(static_cast<double>(centerLat) / 1000000.0));
+  const double headingRadians = degreesToRadians(orientationHeading);
+  const double sinHeading = sin(headingRadians);
+  const double cosHeading = cos(headingRadians);
   uint16_t drawnSegments = 0;
 
   for (uint16_t i = 0; i + 1 < route.storedPointCount &&
@@ -342,14 +407,24 @@ uint16_t RoundUi::drawRoutePreview(const bike_ble::RouteSummary &route,
        i++) {
     const bike_ble::RoutePoint &a = route.points[i];
     const bike_ble::RoutePoint &b = route.points[i + 1];
-    const double ax = static_cast<double>(a.lonMicrodegrees - centerLon) *
-                      METERS_PER_MICRODEGREE_LAT * cosLat;
-    const double ay = static_cast<double>(a.latMicrodegrees - centerLat) *
-                      METERS_PER_MICRODEGREE_LAT;
-    const double bx = static_cast<double>(b.lonMicrodegrees - centerLon) *
-                      METERS_PER_MICRODEGREE_LAT * cosLat;
-    const double by = static_cast<double>(b.latMicrodegrees - centerLat) *
-                      METERS_PER_MICRODEGREE_LAT;
+    double ax = static_cast<double>(a.lonMicrodegrees - centerLon) *
+                METERS_PER_MICRODEGREE_LAT * cosLat;
+    double ay = static_cast<double>(a.latMicrodegrees - centerLat) *
+                METERS_PER_MICRODEGREE_LAT;
+    double bx = static_cast<double>(b.lonMicrodegrees - centerLon) *
+                METERS_PER_MICRODEGREE_LAT * cosLat;
+    double by = static_cast<double>(b.latMicrodegrees - centerLat) *
+                METERS_PER_MICRODEGREE_LAT;
+    if (courseUp) {
+      const double rotatedAx = (ax * cosHeading) - (ay * sinHeading);
+      const double rotatedAy = (ax * sinHeading) + (ay * cosHeading);
+      const double rotatedBx = (bx * cosHeading) - (by * sinHeading);
+      const double rotatedBy = (bx * sinHeading) + (by * cosHeading);
+      ax = rotatedAx;
+      ay = rotatedAy;
+      bx = rotatedBx;
+      by = rotatedBy;
+    }
 
     if ((fabs(ax) > ROUTE_PREVIEW_RADIUS_METERS &&
          fabs(bx) > ROUTE_PREVIEW_RADIUS_METERS &&
@@ -367,7 +442,7 @@ uint16_t RoundUi::drawRoutePreview(const bike_ble::RouteSummary &route,
     drawnSegments++;
   }
 
-  if (centerOnGps) {
+  if (centerOnGps && drawMarker) {
     const int16_t center = DisplayRound::width / 2;
     display->drawLine(center - 4, center, center + 4, center,
                       POSITION_COLOR_RGB565);
@@ -471,6 +546,8 @@ const char *RoundUi::pageName() const {
     return "navigation";
   case RoundPage::Route:
     return "route";
+  case RoundPage::MapGuidance:
+    return "map-guidance";
   case RoundPage::Settings:
     return "settings";
   }

--- a/xiao-nrf52840/lib/ui_round/ui_round.hpp
+++ b/xiao-nrf52840/lib/ui_round/ui_round.hpp
@@ -13,7 +13,8 @@ enum class RoundPage : uint8_t {
   Ride = 0,
   Navigation = 1,
   Route = 2,
-  Settings = 3,
+  MapGuidance = 3,
+  Settings = 4,
 };
 
 enum class TouchGesture : uint8_t {
@@ -46,11 +47,15 @@ private:
                     const PowerManager &powerManager);
   void drawNavigationPage(const BLENavigationServer &bleServer);
   void drawRoutePage(const BLENavigationServer &bleServer, MapLite &mapLite);
+  void drawMapGuidancePage(const BLENavigationServer &bleServer,
+                           MapLite &mapLite);
   void drawSettingsPage(const BLENavigationServer &bleServer,
                         const PowerManager &powerManager);
   uint16_t drawRoutePreview(const bike_ble::RouteSummary &route,
                             const bike_ble::GpsPosition &gps,
-                            const BLEDebugStats &stats);
+                            const BLEDebugStats &stats,
+                            uint16_t orientationHeading, bool courseUp,
+                            bool drawMarker);
   uint16_t speedKmhX10(const bike_ble::GpsPosition &gps);
   uint16_t routeHeadingNearGps(const bike_ble::RouteSummary &route,
                                const bike_ble::GpsPosition &gps) const;


### PR DESCRIPTION
## What changed

- Adds a new XIAO round display page, `MapGuidance`, to the tap-switched screen cycle.
- Renders the map centered on the current GPS position with north-up behavior when idle and course-up behavior while navigation data is active.
- Adds a bottom-third guidance overlay with a maneuver arrow and formatted distance in meters or kilometers.
- Draws a centered dot while idle and a centered direction arrow while navigating.

## Validation

- `pio run -d xiao-nrf52840 -e xiao_nrf52840_round`
- `pio test -d xiao-nrf52840 -e native_protocol`
