### PR TITLE
Add configurable device screens

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -101,7 +101,10 @@ Current setting IDs:
 | `8` | Visibility mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/tracks, bit 3 major roads, bit 4 local streets, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker |
 | `9` | Street line width boost | `0...24` px added to known road/path line style widths; legacy unknown lines are boosted when their stored style width is at least 3px; final rendered width is capped at 24px |
 | `10` | Current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a white dot when no route is loaded and a white arrow while navigating. |
-| `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device between map, navigation instruction, and ride stats screens. Map drags and long presses are ignored by this shortcut. |
+| `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device through the enabled main screens. Map drags and long presses are ignored by this shortcut. |
+| `12` | Device brightness | `5...100` percent on supported hardware |
+| `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation. Invalid or empty masks fall back to all supported screens. |
+| `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation. Invalid or disabled defaults fall back to Map if enabled, otherwise the first enabled screen. |
 
 Feature visibility toggles are authoritative for their classes. Detail level
 controls small-area density without overriding the visibility mask: high uses

--- a/docs/device-screen-selection-implementation-plan.md
+++ b/docs/device-screen-selection-implementation-plan.md
@@ -1,0 +1,328 @@
+# Device Screen Selection Implementation Plan
+
+## Goal
+
+Allow the iOS app to configure which main screens are available on the ESP32
+device and which screen is shown by default when the main UI starts.
+
+Current device screens on `main`:
+
+- Map
+- Navigation instruction
+- Ride stats
+- Map guidance
+
+The firmware should still be usable without iOS configuration. If no setting has
+been received, the current behavior should remain equivalent to enabling all
+screens and starting on Map.
+
+## User-Facing Behavior
+
+In the iOS app settings, add a Device Screens section with:
+
+- A toggle for each device screen.
+- A default screen picker containing only enabled screens.
+
+Rules:
+
+- At least one screen must remain enabled.
+- If the current default screen is disabled, select the first enabled screen.
+- If a saved/default screen is invalid on firmware, fall back to Map if enabled,
+  otherwise the first enabled screen.
+- Cycling on the device should skip disabled screens.
+- Direct device controls that currently call `toggleNavigationScreen()` should
+  use the same enabled-screen cycle.
+
+## BLE Protocol
+
+Reuse the existing `2A73` map/settings characteristic and `MSET` fallback path.
+
+Add setting IDs:
+
+| ID | Meaning | Range |
+| --- | --- | --- |
+| `12` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map Guidance |
+| `13` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map Guidance |
+
+Do not use the firmware `tileName` enum values directly in the BLE protocol.
+That enum has legacy values and may change for internal compatibility. Define a
+small stable protocol enum for screen settings on both iOS and firmware.
+
+Recommended defaults:
+
+```text
+enabledScreensMask = 0b1111
+defaultScreen = 0
+```
+
+## Firmware Plan
+
+### 1. Add Stable Screen Setting Types
+
+In the ESP32 firmware, add stable protocol constants near the BLE settings code:
+
+```cpp
+enum DeviceScreenSetting : uint8_t {
+  DEVICE_SCREEN_MAP = 0,
+  DEVICE_SCREEN_NAVIGATION = 1,
+  DEVICE_SCREEN_RIDE_STATS = 2,
+  DEVICE_SCREEN_MAP_GUIDANCE = 3,
+};
+```
+
+Add helpers to translate from this protocol enum to `tileName`.
+
+### 2. Extend Persisted Settings
+
+Add fields to the settings structure used by `ble_navigation`:
+
+```cpp
+uint8_t enabledScreensMask = 0x0F;
+uint8_t defaultScreen = DEVICE_SCREEN_MAP;
+```
+
+Persist in NVS under the existing `mapSettings` namespace, for example:
+
+- `screenMask`
+- `defaultScreen`
+
+When loading:
+
+- Clamp `enabledScreensMask` to supported bits.
+- If the result is zero, reset to all supported screens.
+- Clamp or validate `defaultScreen`.
+- If default is not enabled, choose a fallback.
+
+### 3. Handle Setting IDs 12 and 13
+
+Extend `applyMapSetting`:
+
+- ID `12`: update `enabledScreensMask`, persist, and if the active screen is no
+  longer enabled, switch to the configured fallback.
+- ID `13`: update `defaultScreen`, persist after validation, and optionally
+  switch immediately only if product wants live preview. Initial implementation
+  should persist only and leave the current active screen unchanged.
+
+Validation must not allow zero enabled screens.
+
+### 4. Centralize Screen Selection Helpers
+
+In `mainScr.cpp`, add helpers such as:
+
+```cpp
+static tileName tileForDeviceScreen(uint8_t screen);
+static uint8_t deviceScreenForTile(tileName tile);
+static bool isScreenEnabled(tileName tile);
+static tileName fallbackScreen();
+static tileName nextEnabledScreen(tileName current);
+```
+
+Use these helpers from:
+
+- `showNextMainScreen()`
+- `toggleNavigationScreen()`
+- setting ID `12` live active-screen correction
+- startup/default screen selection
+
+Keep existing behavior for unsupported screens like `COMPASS` and `SATTRACK`.
+They should not become part of this iOS-configurable main cycle unless product
+explicitly adds them later.
+
+### 5. Apply Default Screen on Startup
+
+The startup path currently forces Map in `loadMainScreen()`/`createMainScr()`.
+Change it so after the main screen exists and map sprites are created, firmware
+calls the same `showMainTile(defaultTile)` path used by runtime cycling.
+
+Be careful with map sprite creation:
+
+- The map canvas is parented to `mapTile`.
+- Map-backed screens are Map and Map Guidance.
+- If the default is Navigation or Ride Stats, the map canvas can still exist but
+  the visible tile should be the configured default.
+
+### 6. Preserve Map Guidance Semantics
+
+The Map Guidance screen must keep its current invariants:
+
+- Dragging disabled.
+- `followGps` forced true.
+- North-up when no route is loaded.
+- Course-up when route geometry exists.
+- Bottom navigation overlay visible only in Map Guidance mode.
+
+Enabled-screen cycling must not bypass those entry actions; it should call
+`showMainTile(MAP_GUIDANCE)` rather than mutating `activeTile` directly.
+
+## iOS Plan
+
+### 1. Add Screen Setting Model
+
+In `BLEManager`, add stable values matching the BLE protocol, not firmware enum
+values:
+
+```swift
+enum DeviceScreen: Int, CaseIterable, Identifiable {
+    case map = 0
+    case navigation = 1
+    case rideStats = 2
+    case mapGuidance = 3
+}
+```
+
+Add published properties:
+
+```swift
+@Published var enabledDeviceScreens: Set<DeviceScreen>
+@Published var defaultDeviceScreen: DeviceScreen
+```
+
+If a `Set` binding becomes awkward in SwiftUI/UserDefaults, store the mask as an
+`Int` internally and expose small helpers:
+
+```swift
+func isDeviceScreenEnabled(_ screen: DeviceScreen) -> Bool
+func setDeviceScreen(_ screen: DeviceScreen, enabled: Bool)
+```
+
+### 2. Persist iOS Defaults
+
+Add UserDefaults keys:
+
+- `deviceSettings.enabledScreensMask`
+- `deviceSettings.defaultScreen`
+
+Defaults:
+
+- enabled mask `0x0F`
+- default `.map`
+
+When loading or saving, apply the same validation as firmware:
+
+- At least one enabled screen.
+- Default must be enabled.
+- Unknown bits ignored.
+
+### 3. Send BLE Settings
+
+Add:
+
+```swift
+func sendEnabledScreensMask()
+func sendDefaultDeviceScreen()
+```
+
+These should call:
+
+```swift
+sendSetting(id: 12, value: Int32(mask))
+sendSetting(id: 13, value: Int32(defaultScreen.rawValue))
+```
+
+Because `sendSetting` already saves settings and handles unsupported BLE state,
+the new controls inherit the existing offline/local-save behavior.
+
+### 4. Settings UI
+
+Add a `Device Screens` section near the existing Screen Navigation section:
+
+- Toggle rows:
+  - Map
+  - Navigation
+  - Ride Stats
+  - Map Guidance
+- Picker:
+  - Default Screen
+
+UI validation:
+
+- Disable the last enabled screen's toggle, or re-enable it immediately if the
+  user tries to turn it off.
+- Picker options should include enabled screens only.
+- If toggling off the current default, update default before sending settings.
+
+Send order when a toggle changes:
+
+1. Update local mask and default fallback.
+2. Send enabled mask.
+3. If default changed, send default screen.
+
+### 5. Optional Copy
+
+Use concise names:
+
+- `Map`
+- `Navigation`
+- `Ride Stats`
+- `Map Guidance`
+
+Avoid explaining the screens inline. The surrounding settings page already uses
+short operational labels.
+
+## Documentation Updates
+
+Update `docs/ble-protocol.md`:
+
+- Add setting IDs `12` and `13`.
+- Document bit mapping and stable screen enum.
+- State that firmware falls back to Map or first enabled screen if settings are
+  invalid.
+
+## Test Plan
+
+### Firmware
+
+Add native/unit coverage where practical for pure helpers:
+
+- `enabledScreensMask = 0` normalizes to all supported screens.
+- disabled current screen falls back to an enabled screen.
+- `showNextMainScreen()` skips disabled screens.
+- single enabled screen cycles to itself.
+- default screen disabled falls back deterministically.
+- protocol screen IDs translate correctly to `tileName`.
+
+If the current ESP32 code does not expose testable pure helpers, put the mask
+normalization and next-screen logic in a small helper module to avoid LVGL in
+unit tests.
+
+Run:
+
+```sh
+pio run -d esp32 -e WAVESHARE_AMOLED_175
+```
+
+### iOS
+
+Extend `NavigationProtocolTests` or add focused BLEManager settings tests:
+
+- screen mask persists across `BLEManager` reloads.
+- default screen persists across reloads.
+- disabling default changes default to first enabled screen.
+- last enabled screen cannot produce a zero mask.
+- setting IDs `12` and `13` are sent with expected values.
+
+Run the existing iOS test command used by CI.
+
+### Manual Device Checks
+
+With a paired device:
+
+1. Enable all screens, set default Map, reboot device. Verify Map appears.
+2. Disable Navigation, cycle screens. Verify Navigation is skipped.
+3. Enable only Map Guidance, cycle screens. Verify it stays on Map Guidance.
+4. Set default Ride Stats, reboot. Verify Ride Stats appears.
+5. Disable current default. Verify app selects a new default and device remains
+   on a valid screen.
+6. Start and stop navigation while Map Guidance is enabled. Verify stale turn
+   instructions do not remain after route clear.
+
+## Rollout Notes
+
+- Old firmware will ignore setting IDs `12` and `13`; the iOS app should still
+  save them locally.
+- New firmware with old iOS defaults to all screens and Map startup.
+- Keep the stable BLE screen enum separate from `tileName` to avoid protocol
+  breakage if internal screen ordering changes.
+- Do not remove `tapToSwitchScreens`; it remains the control for whether short
+  taps cycle screens at all. The new mask only controls which screens are in the
+  cycle and startup default.

--- a/docs/device-screen-selection-implementation-plan.md
+++ b/docs/device-screen-selection-implementation-plan.md
@@ -10,7 +10,7 @@ Current device screens on `main`:
 - Map
 - Navigation instruction
 - Ride stats
-- Map guidance
+- Map + Navigation
 
 The firmware should still be usable without iOS configuration. If no setting has
 been received, the current behavior should remain equivalent to enabling all
@@ -41,8 +41,8 @@ Add setting IDs:
 
 | ID | Meaning | Range |
 | --- | --- | --- |
-| `12` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map Guidance |
-| `13` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map Guidance |
+| `12` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation |
+| `13` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation |
 
 Do not use the firmware `tileName` enum values directly in the BLE protocol.
 That enum has legacy values and may change for internal compatibility. Define a
@@ -66,11 +66,13 @@ enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
   DEVICE_SCREEN_NAVIGATION = 1,
   DEVICE_SCREEN_RIDE_STATS = 2,
-  DEVICE_SCREEN_MAP_GUIDANCE = 3,
+  DEVICE_SCREEN_MAP_PLUS_NAVIGATION = 3,
 };
 ```
 
-Add helpers to translate from this protocol enum to `tileName`.
+Add helpers to translate from this protocol enum to `tileName`. The current
+firmware tile may still be named `MAP_GUIDANCE`; keep that internal name if it
+reduces churn, but expose the user-facing label as Map + Navigation.
 
 ### 2. Extend Persisted Settings
 
@@ -137,22 +139,23 @@ calls the same `showMainTile(defaultTile)` path used by runtime cycling.
 Be careful with map sprite creation:
 
 - The map canvas is parented to `mapTile`.
-- Map-backed screens are Map and Map Guidance.
+- Map-backed screens are Map and Map + Navigation.
 - If the default is Navigation or Ride Stats, the map canvas can still exist but
   the visible tile should be the configured default.
 
-### 6. Preserve Map Guidance Semantics
+### 6. Preserve Map + Navigation Semantics
 
-The Map Guidance screen must keep its current invariants:
+The Map + Navigation screen must keep its current invariants:
 
 - Dragging disabled.
 - `followGps` forced true.
 - North-up when no route is loaded.
 - Course-up when route geometry exists.
-- Bottom navigation overlay visible only in Map Guidance mode.
+- Bottom navigation overlay visible only in Map + Navigation mode.
 
 Enabled-screen cycling must not bypass those entry actions; it should call
-`showMainTile(MAP_GUIDANCE)` rather than mutating `activeTile` directly.
+the mapped `showMainTile(...)` target rather than mutating `activeTile`
+directly.
 
 ## iOS Plan
 
@@ -166,7 +169,7 @@ enum DeviceScreen: Int, CaseIterable, Identifiable {
     case map = 0
     case navigation = 1
     case rideStats = 2
-    case mapGuidance = 3
+    case mapPlusNavigation = 3
 }
 ```
 
@@ -230,7 +233,7 @@ Add a `Device Screens` section near the existing Screen Navigation section:
   - Map
   - Navigation
   - Ride Stats
-  - Map Guidance
+  - Map + Navigation
 - Picker:
   - Default Screen
 
@@ -254,7 +257,7 @@ Use concise names:
 - `Map`
 - `Navigation`
 - `Ride Stats`
-- `Map Guidance`
+- `Map + Navigation`
 
 Avoid explaining the screens inline. The surrounding settings page already uses
 short operational labels.
@@ -309,12 +312,13 @@ With a paired device:
 
 1. Enable all screens, set default Map, reboot device. Verify Map appears.
 2. Disable Navigation, cycle screens. Verify Navigation is skipped.
-3. Enable only Map Guidance, cycle screens. Verify it stays on Map Guidance.
+3. Enable only Map + Navigation, cycle screens. Verify it stays on
+   Map + Navigation.
 4. Set default Ride Stats, reboot. Verify Ride Stats appears.
 5. Disable current default. Verify app selects a new default and device remains
    on a valid screen.
-6. Start and stop navigation while Map Guidance is enabled. Verify stale turn
-   instructions do not remain after route clear.
+6. Start and stop navigation while Map + Navigation is enabled. Verify stale
+   turn instructions do not remain after route clear.
 
 ## Rollout Notes
 

--- a/docs/device-screen-selection-implementation-plan.md
+++ b/docs/device-screen-selection-implementation-plan.md
@@ -41,8 +41,11 @@ Add setting IDs:
 
 | ID | Meaning | Range |
 | --- | --- | --- |
-| `12` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation |
-| `13` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation |
+| `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation |
+| `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation |
+
+Setting ID `12` is already used by device brightness in the iOS app, so screen
+selection starts at `13`.
 
 Do not use the firmware `tileName` enum values directly in the BLE protocol.
 That enum has legacy values and may change for internal compatibility. Define a
@@ -95,13 +98,13 @@ When loading:
 - Clamp or validate `defaultScreen`.
 - If default is not enabled, choose a fallback.
 
-### 3. Handle Setting IDs 12 and 13
+### 3. Handle Setting IDs 13 and 14
 
 Extend `applyMapSetting`:
 
-- ID `12`: update `enabledScreensMask`, persist, and if the active screen is no
+- ID `13`: update `enabledScreensMask`, persist, and if the active screen is no
   longer enabled, switch to the configured fallback.
-- ID `13`: update `defaultScreen`, persist after validation, and optionally
+- ID `14`: update `defaultScreen`, persist after validation, and optionally
   switch immediately only if product wants live preview. Initial implementation
   should persist only and leave the current active screen unchanged.
 
@@ -123,7 +126,7 @@ Use these helpers from:
 
 - `showNextMainScreen()`
 - `toggleNavigationScreen()`
-- setting ID `12` live active-screen correction
+- setting ID `13` live active-screen correction
 - startup/default screen selection
 
 Keep existing behavior for unsupported screens like `COMPASS` and `SATTRACK`.
@@ -218,8 +221,8 @@ func sendDefaultDeviceScreen()
 These should call:
 
 ```swift
-sendSetting(id: 12, value: Int32(mask))
-sendSetting(id: 13, value: Int32(defaultScreen.rawValue))
+sendSetting(id: 13, value: Int32(mask))
+sendSetting(id: 14, value: Int32(defaultScreen.rawValue))
 ```
 
 Because `sendSetting` already saves settings and handles unsupported BLE state,
@@ -266,7 +269,7 @@ short operational labels.
 
 Update `docs/ble-protocol.md`:
 
-- Add setting IDs `12` and `13`.
+- Add setting IDs `13` and `14`.
 - Document bit mapping and stable screen enum.
 - State that firmware falls back to Map or first enabled screen if settings are
   invalid.
@@ -302,7 +305,7 @@ Extend `NavigationProtocolTests` or add focused BLEManager settings tests:
 - default screen persists across reloads.
 - disabling default changes default to first enabled screen.
 - last enabled screen cannot produce a zero mask.
-- setting IDs `12` and `13` are sent with expected values.
+- setting IDs `13` and `14` are sent with expected values.
 
 Run the existing iOS test command used by CI.
 
@@ -322,7 +325,7 @@ With a paired device:
 
 ## Rollout Notes
 
-- Old firmware will ignore setting IDs `12` and `13`; the iOS app should still
+- Old firmware will ignore setting IDs `13` and `14`; the iOS app should still
   save them locally.
 - New firmware with old iOS defaults to all screens and Map startup.
 - Keep the stable BLE screen enum separate from `tileName` to avoid protocol

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -29,6 +29,7 @@ BLENavigationServer bleNavServer;
 
 // Forward declaration of map redraw trigger
 extern void triggerMapRedraw();
+extern void applyDeviceScreenSettings();
 
 // NavigationData struct is now in ble_navigation.hpp
 
@@ -53,6 +54,36 @@ NavigationData getCurrentNavigationData() { return currentNavData; }
 
 bool hasCurrentNavigationData() {
   return currentNavData.distance > 0 || currentNavData.instruction[0] != '\0';
+}
+
+static uint8_t deviceScreenBit(uint8_t screen) {
+  return (screen <= DEVICE_SCREEN_MAP_PLUS_NAVIGATION) ? (1 << screen) : 0;
+}
+
+static uint8_t normalizedEnabledScreensMask(int32_t rawMask) {
+  uint8_t mask = (uint8_t)rawMask & DEVICE_SCREEN_SUPPORTED_MASK;
+  return mask == 0 ? DEVICE_SCREEN_SUPPORTED_MASK : mask;
+}
+
+static uint8_t normalizedDefaultScreen(int32_t rawDefault,
+                                       uint8_t enabledScreensMask) {
+  uint8_t defaultScreen =
+      rawDefault >= 0 && rawDefault <= DEVICE_SCREEN_MAP_PLUS_NAVIGATION
+          ? (uint8_t)rawDefault
+          : (uint8_t)DEVICE_SCREEN_MAP;
+  if (enabledScreensMask & deviceScreenBit(defaultScreen)) {
+    return defaultScreen;
+  }
+  if (enabledScreensMask & deviceScreenBit(DEVICE_SCREEN_MAP)) {
+    return DEVICE_SCREEN_MAP;
+  }
+  for (uint8_t screen = DEVICE_SCREEN_MAP;
+       screen <= DEVICE_SCREEN_MAP_PLUS_NAVIGATION; screen++) {
+    if (enabledScreensMask & deviceScreenBit(screen)) {
+      return screen;
+    }
+  }
+  return DEVICE_SCREEN_MAP;
 }
 
 static void clearCurrentNavigationData() {
@@ -621,6 +652,28 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     Serial.printf("BLE Settings: tapToSwitchScreens = %d (saved)\n",
                   mapRenderSettings.tapToSwitchScreens);
     break;
+  case 13:
+    mapRenderSettings.enabledScreensMask =
+        normalizedEnabledScreensMask(settingValue);
+    mapRenderSettings.defaultScreen = normalizedDefaultScreen(
+        mapRenderSettings.defaultScreen, mapRenderSettings.enabledScreensMask);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar("screenMask", mapRenderSettings.enabledScreensMask);
+    settingsPrefs.putUChar("defaultScreen", mapRenderSettings.defaultScreen);
+    settingsPrefs.end();
+    applyDeviceScreenSettings();
+    Serial.printf("BLE Settings: enabledScreensMask = 0x%02X (saved)\n",
+                  mapRenderSettings.enabledScreensMask);
+    break;
+  case 14:
+    mapRenderSettings.defaultScreen = normalizedDefaultScreen(
+        settingValue, mapRenderSettings.enabledScreensMask);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar("defaultScreen", mapRenderSettings.defaultScreen);
+    settingsPrefs.end();
+    Serial.printf("BLE Settings: defaultScreen = %d (saved)\n",
+                  mapRenderSettings.defaultScreen);
+    break;
   case 4:
     mapRenderSettings.displayRotation =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)3);
@@ -859,19 +912,28 @@ static void loadSettingsFromNVS() {
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
   mapRenderSettings.zoomLevel = prefs.getUChar("zoomLevel", 4);
   mapRenderSettings.tapToSwitchScreens = prefs.getUChar("tapSwitch", 0);
+  mapRenderSettings.enabledScreensMask =
+      normalizedEnabledScreensMask(prefs.getUChar("screenMask",
+                                                 DEVICE_SCREEN_SUPPORTED_MASK));
+  mapRenderSettings.defaultScreen = normalizedDefaultScreen(
+      prefs.getUChar("defaultScreen", DEVICE_SCREEN_MAP),
+      mapRenderSettings.enabledScreensMask);
   mapRenderSettings.visibilityMask = prefs.getUInt("visMask", 0xFFFFFFFF);
 
   prefs.end();
 
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
                 "detailLevel=%d, routeWidth=%d, streetBoost=%d, "
-                "markerScale=%d, rotation=%d, tapSwitch=%d\n",
+                "markerScale=%d, rotation=%d, tapSwitch=%d, "
+                "screenMask=0x%02X, defaultScreen=%d\n",
                 mapRenderSettings.minPolygonSize, mapRenderSettings.detailLevel,
                 mapRenderSettings.routeLineWidth,
                 mapRenderSettings.streetLineWidthBoost,
                 mapRenderSettings.positionMarkerScale,
                 mapRenderSettings.displayRotation,
-                mapRenderSettings.tapToSwitchScreens);
+                mapRenderSettings.tapToSwitchScreens,
+                mapRenderSettings.enabledScreensMask,
+                mapRenderSettings.defaultScreen);
 }
 
 void BLENavigationServer::init(const char *deviceName) {
@@ -1007,4 +1069,8 @@ BLEDebugStats BLENavigationServer::getDebugStats() const {
 __attribute__((weak)) void triggerMapRedraw() {
   // Default implementation - will be overridden by mainScr.cpp
   Serial.println("BLE: triggerMapRedraw called (default - no map linked)");
+}
+
+__attribute__((weak)) void applyDeviceScreenSettings() {
+  // Default implementation - will be overridden by mainScr.cpp
 }

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -32,8 +32,20 @@ struct NavigationData {
  * @brief Map rendering settings (configurable via BLE from iOS app)
  * Settings IDs: 1=minPolygonSize, 2=detailLevel, 3=routeLineWidth,
  * 4=displayRotation, 6=mapRotationMode, 7=zoomLevel, 8=visibilityMask,
- * 9=streetLineWidthBoost, 10=positionMarkerScale, 11=tapToSwitchScreens
+ * 9=streetLineWidthBoost, 10=positionMarkerScale, 11=tapToSwitchScreens,
+ * 13=enabledScreensMask, 14=defaultScreen
  */
+enum DeviceScreenSetting : uint8_t {
+  DEVICE_SCREEN_MAP = 0,
+  DEVICE_SCREEN_NAVIGATION = 1,
+  DEVICE_SCREEN_RIDE_STATS = 2,
+  DEVICE_SCREEN_MAP_PLUS_NAVIGATION = 3,
+};
+
+static constexpr uint8_t DEVICE_SCREEN_SUPPORTED_MASK =
+    (1 << DEVICE_SCREEN_MAP) | (1 << DEVICE_SCREEN_NAVIGATION) |
+    (1 << DEVICE_SCREEN_RIDE_STATS) | (1 << DEVICE_SCREEN_MAP_PLUS_NAVIGATION);
+
 struct MapRenderSettings {
   uint8_t minPolygonSize = 0; // 0-50: Skip polygons smaller than N pixels²
   uint8_t detailLevel = 2;    // 0=Low, 1=Med, 2=High
@@ -45,6 +57,9 @@ struct MapRenderSettings {
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
   uint8_t zoomLevel = 2;       // 0-5: Zoom level (0=super, 2=default)
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
+  uint8_t enabledScreensMask =
+      DEVICE_SCREEN_SUPPORTED_MASK; // Bits follow DeviceScreenSetting
+  uint8_t defaultScreen = DEVICE_SCREEN_MAP; // DeviceScreenSetting value
   uint32_t visibilityMask =
       0xFFFFFFFF; // Bits: 0 buildings, 1 green, 2 paths, 3 major roads,
                   // 4 local streets, 5 water, 6 rail, 7 other areas,

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -85,6 +85,86 @@ static bool isMapBackedTile(uint8_t tile) {
   return tile == MAP || tile == MAP_GUIDANCE;
 }
 
+static uint8_t normalizedEnabledScreensMask() {
+  const uint8_t mask =
+      mapRenderSettings.enabledScreensMask & DEVICE_SCREEN_SUPPORTED_MASK;
+  return mask == 0 ? DEVICE_SCREEN_SUPPORTED_MASK : mask;
+}
+
+static uint8_t deviceScreenBit(uint8_t screen) {
+  return (screen <= DEVICE_SCREEN_MAP_PLUS_NAVIGATION) ? (1 << screen) : 0;
+}
+
+static tileName tileForDeviceScreen(uint8_t screen) {
+  switch (screen) {
+  case DEVICE_SCREEN_NAVIGATION:
+    return NAV;
+  case DEVICE_SCREEN_RIDE_STATS:
+    return RIDESTATS;
+  case DEVICE_SCREEN_MAP_PLUS_NAVIGATION:
+    return MAP_GUIDANCE;
+  case DEVICE_SCREEN_MAP:
+  default:
+    return MAP;
+  }
+}
+
+static uint8_t deviceScreenForTile(tileName tile) {
+  switch (tile) {
+  case NAV:
+    return DEVICE_SCREEN_NAVIGATION;
+  case RIDESTATS:
+    return DEVICE_SCREEN_RIDE_STATS;
+  case MAP_GUIDANCE:
+    return DEVICE_SCREEN_MAP_PLUS_NAVIGATION;
+  case MAP:
+  default:
+    return DEVICE_SCREEN_MAP;
+  }
+}
+
+static bool isScreenEnabled(tileName tile) {
+  return (normalizedEnabledScreensMask() &
+          deviceScreenBit(deviceScreenForTile(tile))) != 0;
+}
+
+static uint8_t normalizedDefaultDeviceScreen() {
+  const uint8_t mask = normalizedEnabledScreensMask();
+  uint8_t defaultScreen = mapRenderSettings.defaultScreen;
+  if (defaultScreen > DEVICE_SCREEN_MAP_PLUS_NAVIGATION) {
+    defaultScreen = DEVICE_SCREEN_MAP;
+  }
+  if (mask & deviceScreenBit(defaultScreen)) {
+    return defaultScreen;
+  }
+  if (mask & deviceScreenBit(DEVICE_SCREEN_MAP)) {
+    return DEVICE_SCREEN_MAP;
+  }
+  for (uint8_t screen = DEVICE_SCREEN_MAP;
+       screen <= DEVICE_SCREEN_MAP_PLUS_NAVIGATION; screen++) {
+    if (mask & deviceScreenBit(screen)) {
+      return screen;
+    }
+  }
+  return DEVICE_SCREEN_MAP;
+}
+
+static tileName configuredDefaultTile() {
+  return tileForDeviceScreen(normalizedDefaultDeviceScreen());
+}
+
+static tileName nextEnabledTile(tileName current) {
+  const uint8_t currentScreen = deviceScreenForTile(current);
+  for (uint8_t offset = 1; offset <= 4; offset++) {
+    const uint8_t screen = (currentScreen + offset) % 4;
+    tileName candidate = tileForDeviceScreen(screen);
+    if (isScreenEnabled(candidate)) {
+      return candidate;
+    }
+  }
+  return configuredDefaultTile();
+}
+
 static bool isGuidanceNavigating() { return routeOverlay.hasRoute(); }
 
 static int16_t navigationArrowAngle(uint8_t iconID) {
@@ -916,20 +996,19 @@ static void showMainTile(tileName tile) {
 }
 
 void showNextMainScreen() {
-  switch (activeTile) {
-  case MAP:
-    showMainTile(NAV);
-    break;
-  case NAV:
-    showMainTile(RIDESTATS);
-    break;
-  case RIDESTATS:
-    showMainTile(MAP_GUIDANCE);
-    break;
-  case MAP_GUIDANCE:
-  default:
-    showMainTile(MAP);
-    break;
+  showMainTile(nextEnabledTile((tileName)activeTile));
+}
+
+void showConfiguredDefaultMainScreen() { showMainTile(configuredDefaultTile()); }
+
+void applyDeviceScreenSettings() {
+  if (!isMainScreen || !mainScreen || !mapTile || !navTile || !rideStatsTile ||
+      !mapGuidanceOverlay) {
+    return;
+  }
+
+  if (!isScreenEnabled((tileName)activeTile)) {
+    showMainTile(configuredDefaultTile());
   }
 }
 

--- a/esp32/lib/gui/src/mainScr.hpp
+++ b/esp32/lib/gui/src/mainScr.hpp
@@ -83,3 +83,5 @@ void showNextMainScreen();
 
 void createMainScr();
 void toggleNavigationScreen();
+void showConfiguredDefaultMainScreen();
+void applyDeviceScreenSettings();

--- a/esp32/lib/lvgl/src/lvglSetup.cpp
+++ b/esp32/lib/lvgl/src/lvglSetup.cpp
@@ -461,4 +461,6 @@ void loadMainScreen() {
   // Trigger display update
   if (mapView.redrawMap)
     mapView.displayMap();
+
+  showConfiguredDefaultMainScreen();
 }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -36,6 +36,8 @@ enum DeviceBLEProtocol {
     static let settingsFallbackPrefix = "MSET"
 
     static let brightnessSettingID: UInt8 = 12
+    static let enabledScreensSettingID: UInt8 = 13
+    static let defaultScreenSettingID: UInt8 = 14
 
     static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
     static var navigationCharacteristicUUID: CBUUID { CBUUID(string: navigationCharacteristicUUIDString) }
@@ -57,6 +59,50 @@ enum DeviceBLEProtocol {
             return hardware
         }
         return ""
+    }
+}
+
+enum DeviceScreen: Int, CaseIterable, Identifiable {
+    case map = 0
+    case navigation = 1
+    case rideStats = 2
+    case mapPlusNavigation = 3
+
+    var id: Int { rawValue }
+    var bit: Int { 1 << rawValue }
+
+    var title: String {
+        switch self {
+        case .map:
+            return "Map"
+        case .navigation:
+            return "Navigation"
+        case .rideStats:
+            return "Ride Stats"
+        case .mapPlusNavigation:
+            return "Map + Navigation"
+        }
+    }
+
+    static var allScreensMask: Int {
+        allCases.reduce(0) { $0 | $1.bit }
+    }
+
+    static func normalizedMask(_ rawMask: Int) -> Int {
+        let mask = rawMask & allScreensMask
+        return mask == 0 ? allScreensMask : mask
+    }
+
+    static func fallbackDefault(for rawDefault: Int, mask rawMask: Int) -> DeviceScreen {
+        let mask = normalizedMask(rawMask)
+        let candidate = DeviceScreen(rawValue: rawDefault) ?? .map
+        if mask & candidate.bit != 0 {
+            return candidate
+        }
+        if mask & DeviceScreen.map.bit != 0 {
+            return .map
+        }
+        return allCases.first { mask & $0.bit != 0 } ?? .map
     }
 }
 
@@ -175,6 +221,8 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up  // 0-3: 0°, 90°, 180°, 270°
     @Published var zoomLevel: Int = 2 // 0-4: 0=super-zoom, 1=closest, 4=farthest
     @Published var tapToSwitchScreens: Bool = false
+    @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
+    @Published var defaultDeviceScreen: DeviceScreen = .map
     @Published var deviceBrightnessPercent: Double = 100
     
     // Feature Visibility
@@ -258,6 +306,8 @@ class BLEManager: NSObject, ObservableObject {
         static let resetMapRotationModeToNorthUp = "mapSettings.resetMapRotationModeToNorthUp.v1"
         static let zoomLevel = "mapSettings.zoomLevel"
         static let tapToSwitchScreens = "deviceSettings.tapToSwitchScreens"
+        static let enabledDeviceScreensMask = "deviceSettings.enabledScreensMask"
+        static let defaultDeviceScreen = "deviceSettings.defaultScreen"
         static let deviceBrightnessPercent = "deviceSettings.brightnessPercent"
         static let showBuildings = "mapSettings.showBuildings"
         static let showGreenSpace = "mapSettings.showGreenSpace"
@@ -301,6 +351,13 @@ class BLEManager: NSObject, ObservableObject {
         }
         zoomLevel = defaults.object(forKey: SettingsKeys.zoomLevel) as? Int ?? 2
         tapToSwitchScreens = defaults.object(forKey: SettingsKeys.tapToSwitchScreens) as? Bool ?? false
+        enabledDeviceScreensMask = DeviceScreen.normalizedMask(
+            defaults.object(forKey: SettingsKeys.enabledDeviceScreensMask) as? Int ?? DeviceScreen.allScreensMask
+        )
+        defaultDeviceScreen = DeviceScreen.fallbackDefault(
+            for: defaults.object(forKey: SettingsKeys.defaultDeviceScreen) as? Int ?? DeviceScreen.map.rawValue,
+            mask: enabledDeviceScreensMask
+        )
         deviceBrightnessPercent = defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
         showBuildings = defaults.object(forKey: SettingsKeys.showBuildings) as? Bool ?? true
         let legacyNature = defaults.object(forKey: SettingsKeys.legacyShowNature) as? Bool ?? true
@@ -333,6 +390,13 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(mapRotationMode, forKey: SettingsKeys.mapRotationMode)
         defaults.set(zoomLevel, forKey: SettingsKeys.zoomLevel)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
+        enabledDeviceScreensMask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
+        defaultDeviceScreen = DeviceScreen.fallbackDefault(
+            for: defaultDeviceScreen.rawValue,
+            mask: enabledDeviceScreensMask
+        )
+        defaults.set(enabledDeviceScreensMask, forKey: SettingsKeys.enabledDeviceScreensMask)
+        defaults.set(defaultDeviceScreen.rawValue, forKey: SettingsKeys.defaultDeviceScreen)
         defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
         defaults.set(showBuildings, forKey: SettingsKeys.showBuildings)
         defaults.set(showGreenSpace, forKey: SettingsKeys.showGreenSpace)
@@ -557,6 +621,60 @@ class BLEManager: NSObject, ObservableObject {
         if showCurrentPosition { mask |= (1 << 9) }
         
         sendSetting(id: 8, value: mask)
+    }
+
+    func isDeviceScreenEnabled(_ screen: DeviceScreen) -> Bool {
+        DeviceScreen.normalizedMask(enabledDeviceScreensMask) & screen.bit != 0
+    }
+
+    func isOnlyEnabledDeviceScreen(_ screen: DeviceScreen) -> Bool {
+        guard isDeviceScreenEnabled(screen) else { return false }
+        return DeviceScreen.allCases.filter { isDeviceScreenEnabled($0) }.count == 1
+    }
+
+    func setDeviceScreen(_ screen: DeviceScreen, enabled: Bool) {
+        var mask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
+        if enabled {
+            mask |= screen.bit
+        } else {
+            let candidateMask = mask & ~screen.bit
+            guard candidateMask != 0 else { return }
+            mask = candidateMask
+        }
+
+        let oldDefault = defaultDeviceScreen
+        enabledDeviceScreensMask = DeviceScreen.normalizedMask(mask)
+        defaultDeviceScreen = DeviceScreen.fallbackDefault(
+            for: defaultDeviceScreen.rawValue,
+            mask: enabledDeviceScreensMask
+        )
+        sendEnabledDeviceScreensMask()
+        if defaultDeviceScreen != oldDefault {
+            sendDefaultDeviceScreen()
+        }
+    }
+
+    var enabledDeviceScreens: [DeviceScreen] {
+        DeviceScreen.allCases.filter { isDeviceScreenEnabled($0) }
+    }
+
+    func sendEnabledDeviceScreensMask() {
+        enabledDeviceScreensMask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
+        defaultDeviceScreen = DeviceScreen.fallbackDefault(
+            for: defaultDeviceScreen.rawValue,
+            mask: enabledDeviceScreensMask
+        )
+        sendSetting(id: DeviceBLEProtocol.enabledScreensSettingID,
+                    value: Int32(enabledDeviceScreensMask))
+    }
+
+    func sendDefaultDeviceScreen() {
+        defaultDeviceScreen = DeviceScreen.fallbackDefault(
+            for: defaultDeviceScreen.rawValue,
+            mask: enabledDeviceScreensMask
+        )
+        sendSetting(id: DeviceBLEProtocol.defaultScreenSettingID,
+                    value: Int32(defaultDeviceScreen.rawValue))
     }
 
     func sendDebugNavigationPacket() {
@@ -902,6 +1020,8 @@ class BLEManager: NSObject, ObservableObject {
         sendSetting(id: 6, value: Int32(mapRotationMode))
         sendSetting(id: 7, value: Int32(zoomLevel))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
+        sendEnabledDeviceScreensMask()
+        sendDefaultDeviceScreen()
         sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(deviceBrightnessPercent))
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -124,6 +124,26 @@ struct SettingsView: View {
                         }
                 }
                 .disabled(!bleManager.supportsDeviceSettings)
+
+                Section(header: Text("Device Screens")) {
+                    ForEach(DeviceScreen.allCases) { screen in
+                        Toggle(screen.title, isOn: Binding(
+                            get: { bleManager.isDeviceScreenEnabled(screen) },
+                            set: { bleManager.setDeviceScreen(screen, enabled: $0) }
+                        ))
+                        .disabled(bleManager.isOnlyEnabledDeviceScreen(screen))
+                    }
+
+                    Picker("Default Screen", selection: $bleManager.defaultDeviceScreen) {
+                        ForEach(bleManager.enabledDeviceScreens) { screen in
+                            Text(screen.title).tag(screen)
+                        }
+                    }
+                    .onChange(of: bleManager.defaultDeviceScreen) { _ in
+                        bleManager.sendDefaultDeviceScreen()
+                    }
+                }
+                .disabled(!bleManager.supportsDeviceSettings)
                 
                 Section(header: Text("Zoom Level"), footer: Text("0 = Super Zoom, 5 = Farthest")) {
                     Picker("Zoom", selection: $bleManager.zoomLevel) {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -131,11 +131,13 @@ struct NavigationProtocolTests {
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
         testDeviceBLEProtocolConstants()
+        testDeviceScreenValidation()
         testHardwareLabelPreference()
         testBLEPairingAuthenticator()
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
         testBLEManagerSendsBrightnessFallbackSetting()
+        testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
         testNavigationSendTrackerReadinessRetry()
         testNavigationEngineResendsWhenBLEBecomesReady()
@@ -344,6 +346,29 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.gpsPositionFallbackPrefix, "GPSP", "GPS fallback remains framed over navigation writes")
         assertEqual(DeviceBLEProtocol.settingsFallbackPrefix, "MSET", "settings fallback remains framed over navigation writes")
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
+        assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
+        assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
+        assertEqual(DeviceScreen.map.rawValue, 0, "Map screen protocol value stays stable")
+        assertEqual(DeviceScreen.navigation.rawValue, 1, "Navigation screen protocol value stays stable")
+        assertEqual(DeviceScreen.rideStats.rawValue, 2, "Ride Stats screen protocol value stays stable")
+        assertEqual(DeviceScreen.mapPlusNavigation.rawValue, 3, "Map + Navigation screen protocol value stays stable")
+        assertEqual(DeviceScreen.mapPlusNavigation.title, "Map + Navigation", "combined map/navigation screen keeps user-facing label")
+        assertEqual(DeviceScreen.allScreensMask, 0x0F, "all supported device screens use the low four mask bits")
+    }
+
+    static func testDeviceScreenValidation() {
+        assertEqual(DeviceScreen.normalizedMask(0), DeviceScreen.allScreensMask, "zero screen mask falls back to all screens")
+        assertEqual(DeviceScreen.normalizedMask(0xFF), DeviceScreen.allScreensMask, "unknown screen mask bits are ignored")
+
+        let rideStatsOnly = DeviceScreen.rideStats.bit
+        assertEqual(DeviceScreen.fallbackDefault(for: DeviceScreen.mapPlusNavigation.rawValue, mask: rideStatsOnly),
+                    .rideStats,
+                    "disabled default falls back to the first enabled non-map screen")
+
+        let mapAndStats = DeviceScreen.map.bit | DeviceScreen.rideStats.bit
+        assertEqual(DeviceScreen.fallbackDefault(for: DeviceScreen.navigation.rawValue, mask: mapAndStats),
+                    .map,
+                    "disabled default prefers Map when Map is enabled")
     }
 
     static func testHardwareLabelPreference() {
@@ -462,19 +487,59 @@ struct NavigationProtocolTests {
         defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
     }
 
+    static func testBLEManagerSendsDeviceScreenSettings() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.enabledDeviceScreensMask = DeviceScreen.map.bit | DeviceScreen.mapPlusNavigation.bit
+        manager.defaultDeviceScreen = .mapPlusNavigation
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendEnabledDeviceScreensMask()
+        manager.sendDefaultDeviceScreen()
+
+        assertEqual(sentPackets.count, 2, "device screen settings should send mask and default packets")
+        assertEqual(String(data: sentPackets[0].prefix(4), encoding: .utf8), DeviceBLEProtocol.settingsFallbackPrefix, "screen mask fallback uses MSET prefix")
+        assertEqual(sentPackets[0][4], DeviceBLEProtocol.enabledScreensSettingID, "screen mask uses setting ID 13")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5),
+                    Int32(DeviceScreen.map.bit | DeviceScreen.mapPlusNavigation.bit),
+                    "screen mask fallback includes little-endian mask")
+        assertEqual(sentPackets[1][4], DeviceBLEProtocol.defaultScreenSettingID, "default screen uses setting ID 14")
+        assertEqual(readInt32LE(sentPackets[1], offset: 5),
+                    Int32(DeviceScreen.mapPlusNavigation.rawValue),
+                    "default screen fallback includes little-endian screen value")
+    }
+
     static func testBLEManagerPersistsNewMapSettings() {
         let defaults = UserDefaults.standard
-        let keys = ["mapSettings.mapRotationMode", "mapSettings.zoomLevel"]
+        let keys = [
+            "mapSettings.mapRotationMode",
+            "mapSettings.zoomLevel",
+            "deviceSettings.enabledScreensMask",
+            "deviceSettings.defaultScreen"
+        ]
         keys.forEach { defaults.removeObject(forKey: $0) }
 
         let manager = BLEManager()
         manager.mapRotationMode = 1
         manager.zoomLevel = 5
+        manager.enabledDeviceScreensMask = DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit
+        manager.defaultDeviceScreen = .mapPlusNavigation
         manager.saveSettings()
 
         let reloaded = BLEManager()
         assertEqual(reloaded.mapRotationMode, 1, "map rotation mode should persist across BLEManager reloads")
         assertEqual(reloaded.zoomLevel, 5, "zoom level should persist across BLEManager reloads")
+        assertEqual(reloaded.enabledDeviceScreensMask,
+                    DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit,
+                    "enabled device screens should persist across BLEManager reloads")
+        assertEqual(reloaded.defaultDeviceScreen, .mapPlusNavigation, "default device screen should persist across BLEManager reloads")
 
         keys.forEach { defaults.removeObject(forKey: $0) }
     }


### PR DESCRIPTION
## Summary
- add iOS Device Screens settings for enabled screens and startup default
- persist and send screen mask/default over BLE setting IDs 13 and 14
- make ESP32 startup/cycling honor the configured screen set, including Map + Navigation
- document the BLE protocol and implementation details

## Tests
- ios-app/scripts/run-navigation-tests.sh
- xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' build
- pio run -d esp32 -e WAVESHARE_AMOLED_175