### PR TITLE
Plan firmware OTA over device transfer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
             BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
             BikeComputer/BikeComputer/Managers/BLEManager.swift \
+            BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
             BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
             BikeComputer/BikeComputer/Managers/OfflineMapManager.swift \
             BikeComputer/BikeComputer/Models/OfflineMapServiceConfig.swift \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,7 @@ jobs:
             BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
             BikeComputer/BikeComputer/Managers/BLEManager.swift \
             BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
+            BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift \
             BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
             BikeComputer/BikeComputer/Managers/OfflineMapManager.swift \
             BikeComputer/BikeComputer/Models/OfflineMapServiceConfig.swift \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,14 @@ on:
 
 jobs:
   esp32:
-    name: ESP32
+    name: ESP32 (${{ matrix.target }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - WAVESHARE_AMOLED_175
+          - WAVESHARE_AMOLED_206
     defaults:
       run:
         working-directory: esp32
@@ -19,7 +25,7 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
-        run: pio run -e WAVESHARE_AMOLED_175
+        run: pio run -e "${{ matrix.target }}"
 
   ios:
     name: iOS

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -1,0 +1,97 @@
+name: Firmware Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - WAVESHARE_AMOLED_175
+          - WAVESHARE_AMOLED_206
+    defaults:
+      run:
+        working-directory: esp32
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PlatformIO
+        run: python -m pip install --upgrade platformio
+      - name: Build firmware
+        run: pio run -e "${{ matrix.target }}"
+      - name: Stage firmware image
+        run: |
+          mkdir -p dist
+          cp ".pio/build/${{ matrix.target }}/firmware.bin" "dist/${{ matrix.target }}.bin"
+          shasum -a 256 "dist/${{ matrix.target }}.bin"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.target }}
+          path: esp32/dist/${{ matrix.target }}.bin
+          if-no-files-found: error
+
+  publish:
+    name: Publish Firmware
+    runs-on: ubuntu-latest
+    needs: build
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    env:
+      GH_TOKEN: ${{ github.token }}
+      FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY: ${{ secrets.FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install manifest dependencies
+        run: python -m pip install --upgrade cryptography
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+      - name: Generate signed manifests
+        run: |
+          set -euo pipefail
+          if [ -z "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" ]; then
+            echo "FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY is required" >&2
+            exit 1
+          fi
+          mkdir -p release-assets public/firmware
+          find dist -name '*.bin' -exec cp {} release-assets/ \;
+          for target in WAVESHARE_AMOLED_175 WAVESHARE_AMOLED_206; do
+            python tools/firmware_manifest.py \
+              --firmware "release-assets/${target}.bin" \
+              --target "${target}" \
+              --repository "${{ github.repository }}" \
+              --tag "${GITHUB_REF_NAME}" \
+              --git-sha "${GITHUB_SHA::12}" \
+              --private-key-base64 "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" \
+              --output "public/firmware/${target}/manifest.json"
+            cp "public/firmware/${target}/manifest.json" "release-assets/${target}.manifest.json"
+          done
+      - name: Publish GitHub release assets
+        run: |
+          set -euo pipefail
+          if ! gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
+            gh release create "${GITHUB_REF_NAME}" --title "${GITHUB_REF_NAME}" --generate-notes
+          fi
+          gh release upload "${GITHUB_REF_NAME}" release-assets/* --clobber
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -71,6 +71,7 @@ jobs:
             exit 1
           fi
           mkdir -p release-assets public/firmware
+          git_sha="$(git rev-parse --short=12 HEAD)"
           find dist -name '*.bin' -exec cp {} release-assets/ \;
           for target in WAVESHARE_AMOLED_175 WAVESHARE_AMOLED_206; do
             python tools/firmware_manifest.py \
@@ -78,7 +79,7 @@ jobs:
               --target "${target}" \
               --repository "${{ github.repository }}" \
               --tag "${GITHUB_REF_NAME}" \
-              --git-sha "${GITHUB_SHA::12}" \
+              --git-sha "${git_sha}" \
               --private-key-base64 "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" \
               --output "public/firmware/${target}/manifest.json"
             cp "public/firmware/${target}/manifest.json" "release-assets/${target}.manifest.json"

--- a/docs/firmware-ota-hardware-validation.md
+++ b/docs/firmware-ota-hardware-validation.md
@@ -1,0 +1,134 @@
+# Firmware OTA Hardware Validation
+
+Use this checklist after the firmware OTA branch is installed on the iPhone app
+and the ESP32 device. These tests are the remaining proof that cannot be covered
+by local builds or CI.
+
+## Preconditions
+
+- iPhone has the branch build installed.
+- Device is running firmware built from this branch.
+- GitHub Pages has a signed target manifest for the device target:
+  - `WAVESHARE_AMOLED_175`
+  - `WAVESHARE_AMOLED_206`
+- GitHub Release has the matching target `.bin` asset.
+- Device has enough battery or external power.
+- USB flashing remains available as recovery.
+
+Record before each test:
+
+- Device model.
+- Current firmware target/version/build shown in Developer Settings.
+- Manifest target/version/build shown by Check Latest.
+- Whether Developer Downgrade is enabled.
+- Result and any device/app error message.
+
+## Test 1: Foreground Update
+
+1. Open the iPhone app.
+2. Connect to the device over BLE.
+3. Open Developer Settings.
+4. Tap Refresh Device.
+5. Tap Check Latest.
+6. Verify the manifest target matches the connected device target.
+7. Tap Install Update and keep the app foregrounded.
+8. Wait for download, SoftAP transfer, finalize, reboot, and BLE reconnect.
+
+Pass criteria:
+
+- App reports firmware update installed.
+- Device reconnects without manual BLE repair.
+- Developer Settings shows the new version/build.
+- Device remains usable after reboot.
+
+## Test 2: Retry After Interrupted Upload
+
+1. Start Install Update.
+2. During upload, interrupt the transfer by locking the iPhone, disabling Wi-Fi,
+   or moving out of range.
+3. Confirm the app reports failure or unknown status.
+4. Reconnect to the device.
+5. Refresh Device and confirm the old firmware is still running.
+6. Run Install Update again without interruption.
+
+Pass criteria:
+
+- Interrupted upload does not boot partial firmware.
+- Retry starts from a full-image upload, not a partial resume.
+- Retry can complete successfully.
+
+## Test 3: Wrong Target Rejection
+
+Run once for each cross-target direction when both devices or test manifests are
+available:
+
+- 1.75 device with a 2.06 manifest/image.
+- 2.06 device with a 1.75 manifest/image.
+
+Pass criteria:
+
+- iOS refuses to offer or install the mismatched target.
+- If the request reaches the device, ESP32 returns `target_mismatch`.
+- Running firmware target/version/build remains unchanged.
+
+## Test 4: Hash Mismatch Rejection
+
+Use a test-only manifest or asset where the signed manifest SHA-256 does not
+match the downloaded image.
+
+Pass criteria:
+
+- iOS rejects the image before upload with download hash mismatch, or ESP32
+  rejects it with `sha256_mismatch`.
+- Running firmware target/version/build remains unchanged.
+
+## Test 5: Developer Downgrade
+
+1. Publish or point the manifest URL at an older signed build for the same
+   target.
+2. Disable Developer Downgrade.
+3. Tap Check Latest and verify install is blocked.
+4. Enable Developer Downgrade.
+5. Install the older signed build.
+
+Pass criteria:
+
+- Downgrade is blocked while the toggle is off.
+- Downgrade succeeds only when the toggle is on.
+- Target and signature checks still apply.
+
+## Test 6: SD Card Independence
+
+Run the foreground update on a 1.75 device:
+
+- once with SD card inserted.
+- once without SD card inserted.
+
+Pass criteria:
+
+- Firmware update does not depend on map storage being available.
+- Existing map transfer behavior still reports SD-card availability correctly.
+
+## Test 7: USB Recovery
+
+After all normal OTA tests pass, verify the fallback path still works:
+
+1. Flash known-good firmware over USB.
+2. Boot the device.
+3. Confirm BLE reconnects and Developer Settings reports the flashed build.
+
+Pass criteria:
+
+- USB flashing can recover the device.
+- BLE identity/reconnect behavior remains acceptable after USB flash.
+
+## Completion
+
+Firmware OTA hardware validation is complete when:
+
+- Foreground update succeeds on each supported target.
+- Cross-target firmware is rejected in both directions.
+- Interrupted upload leaves the old firmware active and retry succeeds.
+- Hash mismatch is rejected.
+- Developer downgrade policy behaves as configured.
+- USB recovery is confirmed.

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -10,6 +10,41 @@ The long-term design is to generalize the PR38 map-transfer plumbing into a
 shared device-transfer layer, then implement map transfer and firmware OTA as
 separate protocols on top of that layer.
 
+## Implementation Status
+
+Status as of 2026-07-09:
+
+- Implemented the shared ESP32/iOS device-transfer layer and migrated map
+  upload setup onto it.
+- Implemented firmware-specific BLE transfer mode, local HTTP endpoints,
+  inactive-partition OTA write/finalize, SHA-256 validation, target/build
+  checks, developer downgrade allowance, reboot, and BLE reconnect
+  verification.
+- Implemented firmware metadata generation and BLE status reporting, including
+  target, semantic version, build number, git SHA, build timestamp, and updater
+  protocol version.
+- Implemented iOS manifest fetching, P-256 signature verification, image
+  download/hash verification, SoftAP upload, finalize, pending update
+  persistence, post-reboot version/build/git SHA verification, Settings UI, and
+  developer downgrade toggle.
+- Implemented GitHub Actions CI builds for both Waveshare targets and tagged
+  release builds that publish target-specific `.bin` files plus signed
+  manifests.
+- Enabled GitHub Pages for workflow deployments so tagged releases can publish
+  stable latest-manifest URLs under `/firmware/<target>/manifest.json`.
+- Validated foreground OTA on `WAVESHARE_AMOLED_206`: the iPhone installed
+  release `v0.2.4`, the ESP32 rebooted into `0.2.4 (88)`, BLE reconnected, and
+  the map UI returned without the prior BLE-startup crash.
+
+Remaining before promoting beyond developer validation:
+
+- Run the full hardware checklist on `WAVESHARE_AMOLED_175`, including with and
+  without an SD card.
+- Validate interrupted upload retry, wrong-target rejection, hash mismatch
+  rejection, developer downgrade, and USB recovery on real hardware.
+- Keep firmware update entry points developer-scoped until the above failure
+  path tests pass repeatedly.
+
 ## Design Principles
 
 - Keep internet access, GitHub release downloads, TLS, and large-file caching on
@@ -323,27 +358,27 @@ long-term trust boundary.
 
 ## ESP32 Implementation Tasks
 
-1. Add firmware version/build metadata constants and BLE status reporting.
-2. Add `device_transfer` shared server/lifecycle layer.
-3. Move map-transfer Wi-Fi/HTTP lifecycle into `device_transfer` while keeping
+- [x] Add firmware version/build metadata constants and BLE status reporting.
+- [x] Add `device_transfer` shared server/lifecycle layer.
+- [x] Move map-transfer Wi-Fi/HTTP lifecycle into `device_transfer` while keeping
    map-specific endpoints and installer behavior intact.
-4. Add generic BLE transfer commands and keep `MTRN`/`MSTS` compatibility.
-5. Add `firmware_update` OTA state machine using ESP-IDF OTA APIs.
-6. Add `/firmware-update/status`, `/begin`, `/image`, `/finalize`, and
+- [x] Add generic BLE transfer commands and keep `MTRN`/`MSTS` compatibility.
+- [x] Add `firmware_update` OTA state machine using ESP-IDF OTA APIs.
+- [x] Add `/firmware-update/status`, `/begin`, `/image`, `/finalize`, and
    `/cancel` endpoints.
-7. Add SHA-256 streaming verification, target/build checks, and
+- [x] Add SHA-256 streaming verification, target/build checks, and
    developer-controlled downgrade allowance.
-8. Enable boot validation and rollback handling:
+- [x] Enable boot validation and rollback handling:
    - mark the new app valid only after core boot checks pass.
    - report pending/rollback state over BLE.
-9. Add serial logs with stable error codes for every OTA failure path.
+- [x] Add serial logs with stable error codes for OTA failure paths.
 
 ## iOS Implementation Tasks
 
-1. Add `DeviceTransferManager` and `DeviceTransferSession`.
-2. Refactor offline map transfer to use the shared manager.
-3. Add `FirmwareReleaseManifest` model and signature/hash verification.
-4. Add `FirmwareUpdateManager`:
+- [x] Add `DeviceTransferManager` and `DeviceTransferSession`.
+- [x] Refactor offline map transfer to use the shared manager.
+- [x] Add `FirmwareReleaseManifest` model and signature/hash verification.
+- [x] Add `FirmwareUpdateManager`:
    - check latest manifest.
    - compare against connected device metadata.
    - download firmware with progress.
@@ -351,27 +386,27 @@ long-term trust boundary.
    - enter firmware transfer mode.
    - upload image over local HTTP.
    - finalize and wait for BLE reconnect.
-5. Add Settings UI for:
+- [x] Add Settings UI for:
    - current firmware version/build.
    - available update.
    - update progress.
    - post-reboot success/failure.
-6. Add a developer-only downgrade toggle or action. Downgrade must still require
+- [x] Add a developer-only downgrade toggle or action. Downgrade must still require
    a signed, target-matched release image.
-7. Persist update state so the app can resume status checks after foregrounding
+- [x] Persist update state so the app can resume status checks after foregrounding
    or device reboot.
 
 ## GitHub Actions Tasks
 
-1. Add an ESP32 firmware build workflow for:
+- [x] Add an ESP32 firmware build workflow for:
    - `WAVESHARE_AMOLED_175`
    - `WAVESHARE_AMOLED_206`
-2. Build on PRs to catch compile regressions.
-3. Build on version tags and upload target-specific `.bin` release assets.
-4. Generate SHA-256 metadata.
-5. Sign target-specific manifests.
-6. Publish/update target-specific GitHub Pages manifests.
-7. Keep release artifacts target-specific and avoid ambiguous asset names.
+- [x] Build on PRs to catch compile regressions.
+- [x] Build on version tags and upload target-specific `.bin` release assets.
+- [x] Generate SHA-256 metadata.
+- [x] Sign target-specific manifests.
+- [x] Publish/update target-specific GitHub Pages manifests.
+- [x] Keep release artifacts target-specific and avoid ambiguous asset names.
 
 ## Validation Plan
 
@@ -387,6 +422,8 @@ long-term trust boundary.
 
 - Existing map transfer still works after the shared transfer refactor.
 - Firmware update succeeds from iPhone over ESP32 SoftAP.
+  - `WAVESHARE_AMOLED_206` foreground update passed on 2026-07-09 with
+    release `v0.2.4`.
 - Interrupted upload leaves the device on the old firmware.
 - Hash mismatch is rejected and old firmware remains active.
 - Wrong target image is rejected.

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -397,6 +397,10 @@ long-term trust boundary.
 
 ### Hardware Tests
 
+Run the detailed checklist in
+[`firmware-ota-hardware-validation.md`](firmware-ota-hardware-validation.md)
+before promoting OTA beyond developer validation.
+
 - Waveshare ESP32-S3 AMOLED 1.75 with SD card inserted.
 - Waveshare ESP32-S3 AMOLED 1.75 without SD card inserted.
 - Waveshare ESP32-S3 AMOLED 2.06 with target-matched firmware.

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -306,9 +306,11 @@ Minimum acceptable security:
 - ESP32 verifies target, size, SHA-256, and signature before finalization.
 - ESP32 refuses cross-target images.
 
-Preferred signing:
+Manifest signing:
 
-- Generate an Ed25519 signing key for release manifests.
+- Generate a P-256 signing key for release manifests. P-256 is used here because
+  it is supported by both Python `cryptography` in GitHub Actions and Apple's
+  CryptoKit verifier in the iOS app.
 - Store the public key in firmware and iOS.
 - Store the private key only in GitHub Actions secrets or an offline release
   process.

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -1,0 +1,382 @@
+# Firmware OTA Transfer Implementation Plan
+
+## Goal
+
+Add a production-ready firmware update path where the iPhone app downloads a
+signed firmware release, transfers it to the ESP32 over the existing local
+device Wi-Fi path, and the ESP32 installs it through the inactive OTA partition.
+
+The long-term design is to generalize the PR38 map-transfer plumbing into a
+shared device-transfer layer, then implement map transfer and firmware OTA as
+separate protocols on top of that layer.
+
+## Design Principles
+
+- Keep internet access, GitHub release downloads, TLS, and large-file caching on
+  iOS.
+- Keep ESP32 update installation local, deterministic, and boot-safe.
+- Use BLE only for authenticated control/status. Use Wi-Fi/HTTP for bulk data.
+- Reuse the existing ESP32 SoftAP/iOS join flow, but do not reuse the map
+  upload endpoint for firmware writes.
+- Treat firmware as security-sensitive: verify integrity before upload and
+  before boot, and prefer signed release metadata over unsigned hashes.
+- Preserve USB flashing as the recovery path for bootloader, partition-table,
+  or unrecoverable application failures.
+
+## Current Baseline
+
+PR38 established the right transfer shape for large payloads:
+
+- iOS sends authenticated BLE commands to enter/exit transfer mode and request
+  status.
+- ESP32 starts a temporary SoftAP when needed and exposes a local HTTP server.
+- iOS joins the device network with `NEHotspotConfiguration`.
+- Maps upload through local HTTP session endpoints, then activate asynchronously.
+- Map installation validates staged files before publishing them to the active
+  SD-card layout.
+
+Firmware OTA should share the transfer-mode lifecycle and Wi-Fi join logic, but
+must use a firmware-specific HTTP API that streams into the inactive OTA app
+partition instead of staging files on SD.
+
+## Target User Flow
+
+1. iOS checks the firmware update manifest from GitHub Pages or another stable
+   HTTPS endpoint.
+2. iOS compares the manifest target/version/build against the connected device
+   status reported over BLE.
+3. iOS downloads the firmware image from GitHub Releases.
+4. iOS verifies the downloaded image against the signed manifest.
+5. User confirms update in the app.
+6. iOS sends an authenticated BLE command to enter firmware-transfer mode.
+7. ESP32 enables the shared local transfer server and reports `baseUrl`, SSID,
+   firmware status, and a short-lived session token.
+8. iOS joins the device SoftAP if needed.
+9. iOS uploads the firmware image over local HTTP.
+10. ESP32 writes the image to the inactive OTA partition and verifies it.
+11. iOS asks ESP32 to finalize the update.
+12. ESP32 marks the new app partition bootable and reboots.
+13. New firmware performs boot health checks and marks the image valid.
+14. iOS reconnects over BLE and reports success or rollback state.
+
+## Shared Device Transfer Layer
+
+Create a reusable transfer service instead of keeping transfer logic named only
+for maps.
+
+### ESP32
+
+Add `esp32/lib/device_transfer/`:
+
+- Owns Wi-Fi mode transitions, temporary SoftAP lifecycle, HTTP server lifecycle,
+  shared status, and last-error reporting.
+- Supports transfer modes:
+  - `none`
+  - `map`
+  - `firmware`
+- Generates a short-lived session token when transfer mode starts.
+- Exposes common status JSON:
+
+```json
+{
+  "enabled": true,
+  "mode": "firmware",
+  "baseUrl": "http://192.168.4.1:8080",
+  "apSsid": "BikeComputer-Transfer",
+  "sessionToken": "opaque-short-lived-token",
+  "lastError": null
+}
+```
+
+Map transfer can continue to serve `/map-transfer/...`; firmware OTA gets its
+own `/firmware-update/...` endpoints. The shared layer routes requests by path
+to the active feature handler.
+
+### iOS
+
+Add a `DeviceTransferManager`:
+
+- Sends BLE transfer commands.
+- Waits for transfer status.
+- Joins the ESP32 SoftAP.
+- Verifies local HTTP reachability.
+- Owns common timeout/error handling.
+- Provides `DeviceTransferSession` with `baseURL`, `mode`, and session token.
+
+Refactor `OfflineMapManager` to use `DeviceTransferManager` for setup/teardown,
+while leaving map packaging and map activation in the map-specific code.
+
+## BLE Protocol Additions
+
+Extend the authenticated BLE control/status channel with generic transfer
+commands while preserving map compatibility during migration.
+
+Recommended commands:
+
+| Prefix | Direction | Payload | Meaning |
+| --- | --- | --- | --- |
+| `DTRN` | iOS -> ESP32 | `enter|map` | Enter map transfer mode. |
+| `DTRN` | iOS -> ESP32 | `enter|firmware` | Enter firmware update transfer mode. |
+| `DTRN` | iOS -> ESP32 | `exit` | Exit any active transfer mode. |
+| `DSTS` | iOS -> ESP32 | empty | Request generic transfer status. |
+| `DSTS` | ESP32 -> iOS | UTF-8 JSON | Generic transfer status notification. |
+
+Keep `MTRN`/`MSTS` as aliases for map transfer until the iOS and ESP32 releases
+using the generic protocol are broadly installed.
+
+Firmware status should include:
+
+```json
+{
+  "deviceVersion": "0.3.0",
+  "build": 42,
+  "target": "WAVESHARE_AMOLED_175",
+  "otaState": "valid",
+  "runningPartition": "ota_0",
+  "nextPartition": "ota_1",
+  "firmwareUpdate": {
+    "status": "idle",
+    "receivedBytes": 0,
+    "totalBytes": 0,
+    "sha256": null,
+    "error": null
+  }
+}
+```
+
+## Firmware HTTP API
+
+Use a firmware-specific API. Do not put firmware bytes into map staging paths.
+
+### `GET /firmware-update/status`
+
+Returns current OTA state:
+
+```json
+{
+  "status": "idle",
+  "target": "WAVESHARE_AMOLED_175",
+  "runningVersion": "0.3.0",
+  "runningBuild": 42,
+  "runningPartition": "ota_0",
+  "inactivePartition": "ota_1",
+  "maxImageBytes": 3145728,
+  "receivedBytes": 0,
+  "totalBytes": 0,
+  "sha256": null,
+  "lastError": null
+}
+```
+
+### `POST /firmware-update/begin`
+
+Body:
+
+```json
+{
+  "version": "0.4.0",
+  "build": 43,
+  "target": "WAVESHARE_AMOLED_175",
+  "size": 2178944,
+  "sha256": "hex",
+  "manifestSignature": "base64",
+  "releaseUrl": "https://github.com/..."
+}
+```
+
+Behavior:
+
+- Validate target, version/build policy, size, and signature.
+- Ensure image fits the inactive OTA partition.
+- Initialize OTA writer with `esp_ota_begin`.
+- Move status to `receiving`.
+
+### `PUT /firmware-update/image`
+
+Uploads the firmware image body.
+
+Recommended v1 behavior:
+
+- Accept one full-image upload with `Content-Length`.
+- Stream request body directly into `esp_ota_write`.
+- Compute SHA-256 while streaming.
+- Reject unexpected size or hash mismatch.
+- Move status to `received` when complete.
+
+Full retry is acceptable for v1 because the firmware image should be small
+enough to transfer quickly over local Wi-Fi. Add chunk offset resume later only
+if field testing shows it is needed.
+
+### `POST /firmware-update/finalize`
+
+Behavior:
+
+- Call `esp_ota_end`.
+- Verify image descriptor target/version compatibility.
+- Mark the inactive partition bootable with `esp_ota_set_boot_partition`.
+- Return `202 Accepted`.
+- Reboot after a short delay so iOS receives the response.
+
+### `POST /firmware-update/cancel`
+
+Abort an in-progress upload, call OTA cleanup, and return status to `idle`.
+
+## Firmware Image Metadata
+
+Embed firmware identity in the app image:
+
+- target/environment, for example `WAVESHARE_AMOLED_175`
+- semantic version
+- monotonically increasing build number
+- git SHA
+- build timestamp
+- protocol version
+
+Expose this over BLE status so iOS can decide whether an update applies.
+
+## Release Hosting
+
+Use GitHub-native release hosting:
+
+- GitHub Actions builds firmware on tags and pull requests.
+- Tagged builds attach `WAVESHARE_AMOLED_175.bin` to GitHub Releases.
+- The workflow computes SHA-256 and signs the manifest.
+- GitHub Pages hosts the latest manifest at a stable HTTPS URL.
+
+Example manifest:
+
+```json
+{
+  "schemaVersion": 1,
+  "target": "WAVESHARE_AMOLED_175",
+  "version": "0.4.0",
+  "build": 43,
+  "gitSha": "abc123",
+  "size": 2178944,
+  "sha256": "hex",
+  "url": "https://github.com/seichris/open-bike-computer/releases/download/v0.4.0/WAVESHARE_AMOLED_175.bin",
+  "minUpdaterProtocol": 1,
+  "signature": "base64"
+}
+```
+
+iOS should verify the signature before offering the update. ESP32 should verify
+the same manifest fields and image hash before finalizing the OTA write.
+
+## Security Model
+
+Minimum acceptable security:
+
+- BLE transfer commands require the existing authenticated session.
+- Firmware transfer mode returns a short-lived session token.
+- Every firmware HTTP request includes `X-BikeComputer-Transfer-Token`.
+- iOS verifies the signed manifest before upload.
+- ESP32 verifies target, size, SHA-256, and signature before finalization.
+- ESP32 refuses cross-target images.
+
+Preferred signing:
+
+- Generate an Ed25519 signing key for release manifests.
+- Store the public key in firmware and iOS.
+- Store the private key only in GitHub Actions secrets or an offline release
+  process.
+
+Do not rely on obscured GitHub URLs, local AP isolation, or SHA-256 alone as the
+long-term trust boundary.
+
+## ESP32 Implementation Tasks
+
+1. Add firmware version/build metadata constants and BLE status reporting.
+2. Add `device_transfer` shared server/lifecycle layer.
+3. Move map-transfer Wi-Fi/HTTP lifecycle into `device_transfer` while keeping
+   map-specific endpoints and installer behavior intact.
+4. Add generic BLE transfer commands and keep `MTRN`/`MSTS` compatibility.
+5. Add `firmware_update` OTA state machine using ESP-IDF OTA APIs.
+6. Add `/firmware-update/status`, `/begin`, `/image`, `/finalize`, and
+   `/cancel` endpoints.
+7. Add SHA-256 streaming verification and target/build checks.
+8. Enable boot validation and rollback handling:
+   - mark the new app valid only after core boot checks pass.
+   - report pending/rollback state over BLE.
+9. Add serial logs with stable error codes for every OTA failure path.
+
+## iOS Implementation Tasks
+
+1. Add `DeviceTransferManager` and `DeviceTransferSession`.
+2. Refactor offline map transfer to use the shared manager.
+3. Add `FirmwareReleaseManifest` model and signature/hash verification.
+4. Add `FirmwareUpdateManager`:
+   - check latest manifest.
+   - compare against connected device metadata.
+   - download firmware with progress.
+   - verify downloaded image.
+   - enter firmware transfer mode.
+   - upload image over local HTTP.
+   - finalize and wait for BLE reconnect.
+5. Add Settings UI for:
+   - current firmware version/build.
+   - available update.
+   - update progress.
+   - post-reboot success/failure.
+6. Persist update state so the app can resume status checks after foregrounding
+   or device reboot.
+
+## GitHub Actions Tasks
+
+1. Add an ESP32 firmware build workflow for `WAVESHARE_AMOLED_175`.
+2. Build on PRs to catch compile regressions.
+3. Build on version tags and upload `.bin` release assets.
+4. Generate SHA-256 metadata.
+5. Sign the manifest.
+6. Publish/update GitHub Pages manifest.
+7. Keep release artifacts target-specific and avoid ambiguous asset names.
+
+## Validation Plan
+
+### Unit/Protocol Tests
+
+- iOS manifest parsing, version comparison, and signature verification.
+- iOS transfer URL construction and token headers.
+- ESP32 path parsing, token validation, and size/hash validation.
+- Firmware target mismatch rejection.
+
+### Integration Tests
+
+- Existing map transfer still works after the shared transfer refactor.
+- Firmware update succeeds from iPhone over ESP32 SoftAP.
+- Interrupted upload leaves the device on the old firmware.
+- Hash mismatch is rejected and old firmware remains active.
+- Wrong target image is rejected.
+- App reconnects after reboot and reports updated version.
+- New firmware marks itself valid only after health checks.
+
+### Hardware Tests
+
+- Waveshare ESP32-S3 AMOLED 1.75 with SD card inserted.
+- Waveshare ESP32-S3 AMOLED 1.75 without SD card inserted.
+- iPhone foreground update.
+- iPhone lock/foreground interruption during upload.
+- Poor signal or forced Wi-Fi disconnect during upload.
+- USB recovery after intentionally bad test image.
+
+## Rollout Sequence
+
+1. Land shared transfer refactor with no firmware OTA behavior change.
+2. Land firmware metadata and status reporting.
+3. Land firmware HTTP endpoints behind a developer-only UI flag.
+4. Add GitHub Actions release artifact generation.
+5. Add iOS update check/download/verify path.
+6. Enable firmware upload/finalize for developer builds.
+7. Field test rollback and interruption behavior.
+8. Promote to normal Settings UI after repeated successful hardware updates.
+
+## Open Decisions
+
+- Exact release versioning scheme: semantic version only, build number only, or
+  both.
+- Whether firmware downgrade should be allowed behind a developer toggle.
+- Whether v1 needs resumable chunk uploads or full-image retry is sufficient.
+- Whether the firmware SoftAP should use an app-provided temporary WPA2
+  password instead of an open network.
+- Whether map transfer and firmware update should share the same HTTP port or
+  use feature-specific ports under the shared lifecycle.

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -182,11 +182,14 @@ Body:
 
 ```json
 {
+  "schemaVersion": 1,
   "version": "0.4.0",
   "build": 43,
   "target": "WAVESHARE_AMOLED_175",
+  "gitSha": "abc123",
   "size": 2178944,
   "sha256": "hex",
+  "minUpdaterProtocol": 1,
   "manifestSignature": "base64",
   "releaseUrl": "https://github.com/...",
   "allowDowngrade": false

--- a/docs/firmware-ota-transfer-implementation-plan.md
+++ b/docs/firmware-ota-transfer-implementation-plan.md
@@ -18,6 +18,9 @@ separate protocols on top of that layer.
 - Use BLE only for authenticated control/status. Use Wi-Fi/HTTP for bulk data.
 - Reuse the existing ESP32 SoftAP/iOS join flow, but do not reuse the map
   upload endpoint for firmware writes.
+- Build and publish target-specific firmware images for each supported board
+  target. The 1.75 and 2.06 Waveshare devices should not share one OTA binary
+  unless the firmware is later refactored for safe runtime board detection.
 - Treat firmware as security-sensitive: verify integrity before upload and
   before boot, and prefer signed release metadata over unsigned hashes.
 - Preserve USB flashing as the recovery path for bootloader, partition-table,
@@ -70,6 +73,9 @@ Add `esp32/lib/device_transfer/`:
 
 - Owns Wi-Fi mode transitions, temporary SoftAP lifecycle, HTTP server lifecycle,
   shared status, and last-error reporting.
+- Uses one shared local HTTP server and port for all transfer features. Feature
+  handlers are selected by path, for example `/map-transfer/...` and
+  `/firmware-update/...`.
 - Supports transfer modes:
   - `none`
   - `map`
@@ -90,7 +96,9 @@ Add `esp32/lib/device_transfer/`:
 
 Map transfer can continue to serve `/map-transfer/...`; firmware OTA gets its
 own `/firmware-update/...` endpoints. The shared layer routes requests by path
-to the active feature handler.
+to the active feature handler on the same HTTP server and port. This keeps the
+iOS network join/reachability flow stable while allowing feature-specific
+protocols and state machines.
 
 ### iOS
 
@@ -180,13 +188,17 @@ Body:
   "size": 2178944,
   "sha256": "hex",
   "manifestSignature": "base64",
-  "releaseUrl": "https://github.com/..."
+  "releaseUrl": "https://github.com/...",
+  "allowDowngrade": false
 }
 ```
 
 Behavior:
 
 - Validate target, version/build policy, size, and signature.
+- Reject downgrades by default. Allow them only when the iOS app sends
+  `allowDowngrade: true` from a developer-only flow and the image is otherwise
+  signed, target-matched, and valid.
 - Ensure image fits the inactive OTA partition.
 - Initialize OTA writer with `esp_ota_begin`.
 - Move status to `receiving`.
@@ -204,8 +216,8 @@ Recommended v1 behavior:
 - Move status to `received` when complete.
 
 Full retry is acceptable for v1 because the firmware image should be small
-enough to transfer quickly over local Wi-Fi. Add chunk offset resume later only
-if field testing shows it is needed.
+enough to transfer quickly over local Wi-Fi. Do not implement resumable chunk
+uploads in v1; restart the full image upload after interruption.
 
 ### `POST /firmware-update/finalize`
 
@@ -226,22 +238,34 @@ Abort an in-progress upload, call OTA cleanup, and return status to `idle`.
 Embed firmware identity in the app image:
 
 - target/environment, for example `WAVESHARE_AMOLED_175`
-- semantic version
-- monotonically increasing build number
+- semantic version for user-facing release identity
+- monotonically increasing build number for update ordering
 - git SHA
 - build timestamp
 - protocol version
 
-Expose this over BLE status so iOS can decide whether an update applies.
+Use both semantic version and build number. The semantic version is what users
+see. The build number is the authoritative ordering key for normal update
+checks, with explicit developer-downgrade support as described above.
+
+Expose this metadata over BLE status so iOS can decide whether an update
+applies.
 
 ## Release Hosting
 
 Use GitHub-native release hosting:
 
 - GitHub Actions builds firmware on tags and pull requests.
-- Tagged builds attach `WAVESHARE_AMOLED_175.bin` to GitHub Releases.
-- The workflow computes SHA-256 and signs the manifest.
-- GitHub Pages hosts the latest manifest at a stable HTTPS URL.
+- PR builds compile both target environments to catch regressions:
+  - `WAVESHARE_AMOLED_175`
+  - `WAVESHARE_AMOLED_206`
+- Tagged builds attach target-specific firmware assets to GitHub Releases:
+  - `WAVESHARE_AMOLED_175.bin`
+  - `WAVESHARE_AMOLED_206.bin`
+- The workflow computes SHA-256 and signs one manifest per target.
+- GitHub Pages hosts each latest manifest at a stable target-specific HTTPS URL:
+  - `/firmware/WAVESHARE_AMOLED_175/manifest.json`
+  - `/firmware/WAVESHARE_AMOLED_206/manifest.json`
 
 Example manifest:
 
@@ -263,11 +287,19 @@ Example manifest:
 iOS should verify the signature before offering the update. ESP32 should verify
 the same manifest fields and image hash before finalizing the OTA write.
 
+The iOS app must choose the manifest from the connected device's reported
+`target`. The ESP32 must reject any manifest or image whose target does not
+match its compiled firmware target.
+
 ## Security Model
 
 Minimum acceptable security:
 
 - BLE transfer commands require the existing authenticated session.
+- The v1 SoftAP can remain open. This is acceptable because transfer mode is
+  short-lived, entered only through authenticated BLE control, and firmware trust
+  comes from target-matched signed manifests plus image hash verification rather
+  than Wi-Fi secrecy.
 - Firmware transfer mode returns a short-lived session token.
 - Every firmware HTTP request includes `X-BikeComputer-Transfer-Token`.
 - iOS verifies the signed manifest before upload.
@@ -294,7 +326,8 @@ long-term trust boundary.
 5. Add `firmware_update` OTA state machine using ESP-IDF OTA APIs.
 6. Add `/firmware-update/status`, `/begin`, `/image`, `/finalize`, and
    `/cancel` endpoints.
-7. Add SHA-256 streaming verification and target/build checks.
+7. Add SHA-256 streaming verification, target/build checks, and
+   developer-controlled downgrade allowance.
 8. Enable boot validation and rollback handling:
    - mark the new app valid only after core boot checks pass.
    - report pending/rollback state over BLE.
@@ -318,17 +351,21 @@ long-term trust boundary.
    - available update.
    - update progress.
    - post-reboot success/failure.
-6. Persist update state so the app can resume status checks after foregrounding
+6. Add a developer-only downgrade toggle or action. Downgrade must still require
+   a signed, target-matched release image.
+7. Persist update state so the app can resume status checks after foregrounding
    or device reboot.
 
 ## GitHub Actions Tasks
 
-1. Add an ESP32 firmware build workflow for `WAVESHARE_AMOLED_175`.
+1. Add an ESP32 firmware build workflow for:
+   - `WAVESHARE_AMOLED_175`
+   - `WAVESHARE_AMOLED_206`
 2. Build on PRs to catch compile regressions.
-3. Build on version tags and upload `.bin` release assets.
+3. Build on version tags and upload target-specific `.bin` release assets.
 4. Generate SHA-256 metadata.
-5. Sign the manifest.
-6. Publish/update GitHub Pages manifest.
+5. Sign target-specific manifests.
+6. Publish/update target-specific GitHub Pages manifests.
 7. Keep release artifacts target-specific and avoid ambiguous asset names.
 
 ## Validation Plan
@@ -339,6 +376,7 @@ long-term trust boundary.
 - iOS transfer URL construction and token headers.
 - ESP32 path parsing, token validation, and size/hash validation.
 - Firmware target mismatch rejection.
+- Normal version/build update ordering and developer downgrade allowance.
 
 ### Integration Tests
 
@@ -347,6 +385,8 @@ long-term trust boundary.
 - Interrupted upload leaves the device on the old firmware.
 - Hash mismatch is rejected and old firmware remains active.
 - Wrong target image is rejected.
+- Developer downgrade to an older signed build succeeds only through the
+  developer flow.
 - App reconnects after reboot and reports updated version.
 - New firmware marks itself valid only after health checks.
 
@@ -354,6 +394,9 @@ long-term trust boundary.
 
 - Waveshare ESP32-S3 AMOLED 1.75 with SD card inserted.
 - Waveshare ESP32-S3 AMOLED 1.75 without SD card inserted.
+- Waveshare ESP32-S3 AMOLED 2.06 with target-matched firmware.
+- Cross-target update attempt from 1.75 to 2.06 firmware and 2.06 to 1.75
+  firmware.
 - iPhone foreground update.
 - iPhone lock/foreground interruption during upload.
 - Poor signal or forced Wi-Fi disconnect during upload.
@@ -369,14 +412,3 @@ long-term trust boundary.
 6. Enable firmware upload/finalize for developer builds.
 7. Field test rollback and interruption behavior.
 8. Promote to normal Settings UI after repeated successful hardware updates.
-
-## Open Decisions
-
-- Exact release versioning scheme: semantic version only, build number only, or
-  both.
-- Whether firmware downgrade should be allowed behind a developer toggle.
-- Whether v1 needs resumable chunk uploads or full-image retry is sufficient.
-- Whether the firmware SoftAP should use an app-provided temporary WPA2
-  password instead of an open network.
-- Whether map transfer and firmware update should share the same HTTP port or
-  use feature-specific ports under the shared lifecycle.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -554,6 +554,7 @@ static std::string genericTransferStatusJson() {
           jsonEscape(firmwareStatus.target) + "\",\"version\":\"" +
           jsonEscape(firmwareStatus.runningVersion) + "\",\"build\":" +
           std::to_string(firmwareStatus.runningBuild) +
+          ",\"gitSha\":\"" + jsonEscape(firmwareStatus.runningGitSha) + "\"" +
           ",\"updaterProtocol\":" +
           std::to_string(firmware_metadata::kUpdaterProtocolVersion) +
           ",\"receivedBytes\":" +

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -10,6 +10,9 @@
 #include "../gui/src/waitingScr.hpp"
 #include "../gui/src/globalGuiDef.h"
 #include "../maps/src/maps.hpp"
+#include "../device_transfer/device_transfer_http.hpp"
+#include "../firmware_metadata/firmware_metadata.hpp"
+#include "../firmware_update/firmware_update_http.hpp"
 #include "../map_transfer_http/map_transfer_http.hpp"
 #include "../route_overlay/route_overlay.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
@@ -27,7 +30,9 @@
 #include <WiFi.h>
 
 extern Gps gps;
+extern device_transfer::HttpTransferServer deviceTransferHttp;
 extern map_transfer::MapTransferHttpServer mapTransferHttp;
+extern firmware_update::FirmwareUpdateHttpServer firmwareUpdateHttp;
 extern Maps mapView;
 extern Storage storage;
 
@@ -495,6 +500,10 @@ static std::string mapTransferStatusJson() {
   if (!transferStatus.apSsid.empty()) {
     body += ",\"apSsid\":\"" + jsonEscape(transferStatus.apSsid) + "\"";
   }
+  if (!transferStatus.sessionToken.empty()) {
+    body += ",\"sessionToken\":\"" + jsonEscape(transferStatus.sessionToken) +
+            "\"";
+  }
 
   if (activeStatus.ok) {
     body += ",\"activeMapId\":\"" + jsonEscape(activeMapId) + "\"";
@@ -513,6 +522,52 @@ static std::string mapTransferStatusJson() {
   return body;
 }
 
+static std::string genericTransferStatusJson() {
+  device_transfer::HttpTransferStatus transferStatus =
+      deviceTransferHttp.status();
+  std::string body = std::string("{\"configured\":") +
+                     (transferStatus.configured ? "true" : "false") +
+                     ",\"enabled\":" +
+                     (transferStatus.enabled ? "true" : "false") +
+                     ",\"port\":" + std::to_string(transferStatus.port) +
+                     ",\"mode\":\"" + jsonEscape(transferStatus.mode) + "\"";
+
+  if (!transferStatus.baseUrl.empty()) {
+    body += ",\"baseUrl\":\"" + jsonEscape(transferStatus.baseUrl) + "\"";
+  }
+  if (!transferStatus.apSsid.empty()) {
+    body += ",\"apSsid\":\"" + jsonEscape(transferStatus.apSsid) + "\"";
+  }
+  if (!transferStatus.sessionToken.empty()) {
+    body += ",\"sessionToken\":\"" + jsonEscape(transferStatus.sessionToken) +
+            "\"";
+  }
+  if (!transferStatus.lastErrorCode.empty()) {
+    body += ",\"lastError\":{\"code\":\"" +
+            jsonEscape(transferStatus.lastErrorCode) + "\",\"message\":\"" +
+            jsonEscape(transferStatus.lastErrorMessage) + "\"}";
+  }
+  firmware_update::FirmwareUpdateStatus firmwareStatus =
+      firmwareUpdateHttp.status();
+  body += ",\"firmware\":{\"status\":\"" +
+          jsonEscape(firmwareStatus.status) + "\",\"target\":\"" +
+          jsonEscape(firmwareStatus.target) + "\",\"version\":\"" +
+          jsonEscape(firmwareStatus.runningVersion) + "\",\"build\":" +
+          std::to_string(firmwareStatus.runningBuild) +
+          ",\"updaterProtocol\":" +
+          std::to_string(firmware_metadata::kUpdaterProtocolVersion) +
+          ",\"receivedBytes\":" +
+          std::to_string(firmwareStatus.receivedBytes) +
+          ",\"totalBytes\":" + std::to_string(firmwareStatus.totalBytes);
+  if (!firmwareStatus.errorCode.empty()) {
+    body += ",\"lastError\":{\"code\":\"" +
+            jsonEscape(firmwareStatus.errorCode) + "\",\"message\":\"" +
+            jsonEscape(firmwareStatus.errorMessage) + "\"}";
+  }
+  body += "}}";
+  return body;
+}
+
 static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
   if (pChar == nullptr) {
     pChar = mapTransferStatusCharacteristic;
@@ -528,6 +583,21 @@ static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
                 (unsigned)response.size());
 }
 
+static void notifyGenericTransferStatus(NimBLECharacteristic *pChar) {
+  if (pChar == nullptr) {
+    pChar = mapTransferStatusCharacteristic;
+  }
+  if (pChar == nullptr) {
+    return;
+  }
+
+  std::string response = "DSTS" + genericTransferStatusJson();
+  pChar->setValue((uint8_t *)response.data(), response.size());
+  pChar->notify();
+  Serial.printf("BLE Device Transfer: status notified (%u bytes)\n",
+                (unsigned)response.size());
+}
+
 static void handleMapTransferControlPayload(const uint8_t *data, size_t len,
                                             NimBLECharacteristic *pChar) {
   std::string command;
@@ -537,6 +607,16 @@ static void handleMapTransferControlPayload(const uint8_t *data, size_t len,
   }
 
   if (command == "enter") {
+    device_transfer::HttpTransferStatus transferStatus =
+        deviceTransferHttp.status();
+    if (transferStatus.enabled && !transferStatus.mode.empty() &&
+        transferStatus.mode != "map") {
+      mapTransferHttp.setLastError("transfer_busy",
+                                   "another transfer mode is active");
+      Serial.println("BLE Map Transfer: enter rejected, transfer is busy");
+      notifyMapTransferStatus(pChar);
+      return;
+    }
     if (!storage.getSdLoaded()) {
       mapTransferHttp.setLastError("sd_unavailable",
                                    "SD card is not mounted");
@@ -551,8 +631,12 @@ static void handleMapTransferControlPayload(const uint8_t *data, size_t len,
   }
 
   if (command == "exit") {
-    bool disabled = mapTransferHttp.setEnabled(false);
-    Serial.printf("BLE Map Transfer: exit requested, disabled=%d\n", disabled);
+    bool disabled = true;
+    if (deviceTransferHttp.status().mode == "map") {
+      disabled = mapTransferHttp.setEnabled(false);
+    }
+    Serial.printf("BLE Map Transfer: exit requested, disabled=%d\n",
+                  disabled);
     notifyMapTransferStatus(pChar);
     return;
   }
@@ -560,6 +644,53 @@ static void handleMapTransferControlPayload(const uint8_t *data, size_t len,
   Serial.printf("BLE Map Transfer: rejected unknown command '%s'\n",
                 command.c_str());
   notifyMapTransferStatus(pChar);
+}
+
+static void handleGenericTransferControlPayload(const uint8_t *data, size_t len,
+                                                NimBLECharacteristic *pChar) {
+  std::string command;
+  if (data != nullptr && len > 0) {
+    command.assign(reinterpret_cast<const char *>(data), len);
+    command = trimAscii(command);
+  }
+
+  if (command == "enter|map") {
+    handleMapTransferControlPayload(reinterpret_cast<const uint8_t *>("enter"),
+                                    strlen("enter"), pChar);
+    notifyGenericTransferStatus(pChar);
+    return;
+  }
+
+  if (command == "enter|firmware") {
+    device_transfer::HttpTransferStatus transferStatus =
+        deviceTransferHttp.status();
+    if (transferStatus.enabled && !transferStatus.mode.empty() &&
+        transferStatus.mode != "firmware") {
+      firmwareUpdateHttp.setLastError("transfer_busy",
+                                      "another transfer mode is active");
+      Serial.println(
+          "BLE Device Transfer: firmware enter rejected, transfer is busy");
+      notifyGenericTransferStatus(pChar);
+      return;
+    }
+    bool enabled = firmwareUpdateHttp.setEnabled(true);
+    Serial.printf("BLE Device Transfer: firmware enter requested, enabled=%d\n",
+                  enabled);
+    notifyGenericTransferStatus(pChar);
+    return;
+  }
+
+  if (command == "exit") {
+    mapTransferHttp.setEnabled(false);
+    firmwareUpdateHttp.setEnabled(false);
+    Serial.println("BLE Device Transfer: exit requested");
+    notifyGenericTransferStatus(pChar);
+    return;
+  }
+
+  Serial.printf("BLE Device Transfer: rejected unknown command '%s'\n",
+                command.c_str());
+  notifyGenericTransferStatus(pChar);
 }
 
 static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
@@ -911,7 +1042,9 @@ public:
   }
 
   void onDisconnect(NimBLEServer *pServer) override {
-    mapTransferHttp.setEnabled(false);
+    if (deviceTransferHttp.status().mode == "map") {
+      mapTransferHttp.setEnabled(false);
+    }
     server->connected = false;
     bleSessionAuthenticated = false;
     unauthTimeoutDisconnectRequested = false;
@@ -980,6 +1113,23 @@ public:
       return;
     }
 
+    if (hasPrefix(value, "DTRN")) {
+      if (!requireAuthenticated("device transfer control")) {
+        return;
+      }
+      handleGenericTransferControlPayload((const uint8_t *)value.data() + 4,
+                                          value.length() - 4, pChar);
+      return;
+    }
+
+    if (hasPrefix(value, "DSTS")) {
+      if (!requireAuthenticated("device transfer status")) {
+        return;
+      }
+      notifyGenericTransferStatus(pChar);
+      return;
+    }
+
     if (!requireAuthenticated("navigation instruction")) {
       return;
     }
@@ -1042,6 +1192,24 @@ public:
         return;
       }
       notifyMapTransferStatus(mapTransferStatusCharacteristic);
+      return;
+    }
+
+    if (hasPrefix(value, "DTRN")) {
+      if (!requireAuthenticated("native device transfer control")) {
+        return;
+      }
+      handleGenericTransferControlPayload((const uint8_t *)value.data() + 4,
+                                          value.length() - 4,
+                                          mapTransferStatusCharacteristic);
+      return;
+    }
+
+    if (hasPrefix(value, "DSTS")) {
+      if (!requireAuthenticated("native device transfer status")) {
+        return;
+      }
+      notifyGenericTransferStatus(mapTransferStatusCharacteristic);
       return;
     }
 

--- a/esp32/lib/device_transfer/device_transfer_http.cpp
+++ b/esp32/lib/device_transfer/device_transfer_http.cpp
@@ -110,6 +110,8 @@ bool HttpTransferServer::setEnabled(bool enabled, std::string mode) {
   const bool configured = configured_;
   const bool wasEnabled = enabled_;
   const bool wasStartedAp = startedAp_;
+  const std::string previousMode = mode_;
+  const std::string previousSessionToken = sessionToken_;
   const std::string apSsid = apSsid_;
   unlockState();
 
@@ -152,7 +154,9 @@ bool HttpTransferServer::setEnabled(bool enabled, std::string mode) {
   enabled_ = enabled;
   mode_ = enabled ? std::move(mode) : "";
   if (enabled) {
-    sessionToken_ = generateSessionToken();
+    if (!wasEnabled || previousMode != mode_ || previousSessionToken.empty()) {
+      sessionToken_ = generateSessionToken();
+    }
   } else {
     sessionToken_.clear();
   }

--- a/esp32/lib/device_transfer/device_transfer_http.cpp
+++ b/esp32/lib/device_transfer/device_transfer_http.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
+#include <esp_system.h>
 #include <sstream>
 
 namespace device_transfer {
@@ -70,7 +71,11 @@ static std::string jsonEscape(const std::string &value) {
 
 void HttpTransferServer::configure(HttpRequestHandler *handler, uint16_t port,
                                    std::string apSsid) {
-  handler_ = handler;
+  configure(port, std::move(apSsid));
+  registerHandler("/", handler);
+}
+
+void HttpTransferServer::configure(uint16_t port, std::string apSsid) {
   port_ = port;
   if (!apSsid.empty())
     apSsid_ = std::move(apSsid);
@@ -80,7 +85,27 @@ void HttpTransferServer::configure(HttpRequestHandler *handler, uint16_t port,
   configured_ = true;
 }
 
+bool HttpTransferServer::registerHandler(std::string pathPrefix,
+                                         HttpRequestHandler *handler) {
+  if (handler == nullptr || pathPrefix.empty())
+    return false;
+  for (size_t i = 0; i < handlerCount_; ++i) {
+    if (handlers_[i].pathPrefix == pathPrefix) {
+      handlers_[i].handler = handler;
+      return true;
+    }
+  }
+  if (handlerCount_ >= handlers_.size())
+    return false;
+  handlers_[handlerCount_++] = {std::move(pathPrefix), handler};
+  return true;
+}
+
 bool HttpTransferServer::setEnabled(bool enabled) {
+  return setEnabled(enabled, enabled ? mode_ : "");
+}
+
+bool HttpTransferServer::setEnabled(bool enabled, std::string mode) {
   lockState();
   const bool configured = configured_;
   const bool wasEnabled = enabled_;
@@ -88,7 +113,7 @@ bool HttpTransferServer::setEnabled(bool enabled) {
   const std::string apSsid = apSsid_;
   unlockState();
 
-  if (!configured || handler_ == nullptr) {
+  if (!configured || handlerCount_ == 0) {
     lockState();
     rememberError("not_configured", "device transfer server is not configured");
     unlockState();
@@ -125,6 +150,12 @@ bool HttpTransferServer::setEnabled(bool enabled) {
   }
   lockState();
   enabled_ = enabled;
+  mode_ = enabled ? std::move(mode) : "";
+  if (enabled) {
+    sessionToken_ = generateSessionToken();
+  } else {
+    sessionToken_.clear();
+  }
   unlockState();
   return true;
 }
@@ -152,7 +183,9 @@ HttpTransferStatus HttpTransferServer::status() const {
   const bool enabled = enabled_;
   const bool startedAp = startedAp_;
   const uint16_t port = port_;
+  const std::string mode = mode_;
   const std::string apSsid = apSsid_;
+  const std::string sessionToken = sessionToken_;
   const std::string lastErrorCode = lastErrorCode_;
   const std::string lastErrorMessage = lastErrorMessage_;
   unlockState();
@@ -168,8 +201,18 @@ HttpTransferStatus HttpTransferServer::status() const {
                 std::to_string(port);
     }
   }
-  return {configured, enabled, port, baseUrl, startedAp ? apSsid : "",
-          lastErrorCode, lastErrorMessage};
+  return {configured,       enabled, port,     mode,
+          baseUrl,          startedAp ? apSsid : "",
+          sessionToken,     lastErrorCode,
+          lastErrorMessage};
+}
+
+bool HttpTransferServer::isRequestAuthorized(
+    const HttpRequest &request) const {
+  lockState();
+  const std::string sessionToken = sessionToken_;
+  unlockState();
+  return !sessionToken.empty() && request.transferToken == sessionToken;
 }
 
 void HttpTransferServer::handleClient(WiFiClient &client) {
@@ -199,12 +242,46 @@ void HttpTransferServer::handleClient(WiFiClient &client) {
     std::string value = trim(line.substr(colon + 1));
     if (name == "content-length")
       request.contentLength = strtoull(value.c_str(), nullptr, 10);
+    if (name == "x-bikecomputer-transfer-token")
+      request.transferToken = value;
   }
 
-  if (handler_ != nullptr && handler_->handleRequest(request, client))
+  HttpRequestHandler *handler = handlerForPath(request.path);
+  if (handler != nullptr && handler->handleRequest(request, client))
     return;
 
   sendError(client, 404, "not_found", "device transfer endpoint not found");
+}
+
+HttpRequestHandler *
+HttpTransferServer::handlerForPath(const std::string &path) const {
+  HttpRequestHandler *best = nullptr;
+  size_t bestLength = 0;
+  for (size_t i = 0; i < handlerCount_; ++i) {
+    const HandlerRegistration &registration = handlers_[i];
+    if (registration.handler == nullptr)
+      continue;
+    const std::string &prefix = registration.pathPrefix;
+    if (path.compare(0, prefix.size(), prefix) == 0 &&
+        prefix.size() >= bestLength) {
+      best = registration.handler;
+      bestLength = prefix.size();
+    }
+  }
+  return best;
+}
+
+std::string HttpTransferServer::generateSessionToken() const {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string token;
+  token.reserve(32);
+  for (int i = 0; i < 4; ++i) {
+    uint32_t value = esp_random();
+    for (int shift = 28; shift >= 0; shift -= 4) {
+      token.push_back(kHex[(value >> shift) & 0x0F]);
+    }
+  }
+  return token;
 }
 
 void HttpTransferServer::sendError(WiFiClient &client, int status,
@@ -246,6 +323,7 @@ void sendHttpJson(WiFiClient &client, int status, const std::string &body) {
   const char *reason = status == 200   ? "OK"
                        : status == 202 ? "Accepted"
                        : status == 400 ? "Bad Request"
+                       : status == 401 ? "Unauthorized"
                        : status == 403 ? "Forbidden"
                        : status == 404 ? "Not Found"
                        : status == 409 ? "Conflict"
@@ -266,6 +344,37 @@ void sendHttpError(WiFiClient &client, int status, const std::string &code,
                std::string("{\"ok\":false,\"error\":{\"code\":\"") +
                    jsonEscape(code) + "\",\"message\":\"" +
                    jsonEscape(message) + "\"}}");
+}
+
+bool readHttpBody(WiFiClient &client, uint64_t contentLength,
+                  uint64_t maxLength, std::string &body,
+                  uint32_t timeoutMs) {
+  body.clear();
+  if (contentLength > maxLength)
+    return false;
+  body.reserve(static_cast<size_t>(contentLength));
+  uint8_t buffer[256];
+  uint64_t remaining = contentLength;
+  uint32_t lastReadMs = millis();
+  while (remaining > 0 && millis() - lastReadMs < timeoutMs) {
+    int available = client.available();
+    if (available <= 0) {
+      delay(1);
+      continue;
+    }
+    size_t toRead = std::min<uint64_t>(sizeof(buffer), remaining);
+    toRead = std::min<size_t>(toRead, static_cast<size_t>(available));
+    int read = client.read(buffer, toRead);
+    if (read <= 0) {
+      delay(1);
+      continue;
+    }
+    body.append(reinterpret_cast<const char *>(buffer),
+                static_cast<size_t>(read));
+    remaining -= static_cast<uint64_t>(read);
+    lastReadMs = millis();
+  }
+  return remaining == 0;
 }
 
 } // namespace device_transfer

--- a/esp32/lib/device_transfer/device_transfer_http.cpp
+++ b/esp32/lib/device_transfer/device_transfer_http.cpp
@@ -1,0 +1,271 @@
+#include "device_transfer_http.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+
+namespace device_transfer {
+namespace {
+
+static std::string trim(const std::string &value) {
+  size_t begin = 0;
+  while (begin < value.size() &&
+         std::isspace(static_cast<unsigned char>(value[begin]))) {
+    begin++;
+  }
+  size_t end = value.size();
+  while (end > begin &&
+         std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+    end--;
+  }
+  return value.substr(begin, end - begin);
+}
+
+static std::string lower(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return value;
+}
+
+static bool readLine(WiFiClient &client, std::string &line,
+                     uint32_t timeoutMs = 2000) {
+  line.clear();
+  uint32_t started = millis();
+  while (millis() - started < timeoutMs) {
+    while (client.available()) {
+      char c = static_cast<char>(client.read());
+      if (c == '\r')
+        continue;
+      if (c == '\n')
+        return true;
+      if (line.size() < 512)
+        line.push_back(c);
+    }
+    delay(1);
+  }
+  return false;
+}
+
+static std::string jsonEscape(const std::string &value) {
+  std::string out;
+  out.reserve(value.size() + 8);
+  for (char c : value) {
+    if (c == '"' || c == '\\') {
+      out.push_back('\\');
+      out.push_back(c);
+    } else if (c == '\n') {
+      out += "\\n";
+    } else if (c == '\r') {
+      out += "\\r";
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+} // namespace
+
+void HttpTransferServer::configure(HttpRequestHandler *handler, uint16_t port,
+                                   std::string apSsid) {
+  handler_ = handler;
+  port_ = port;
+  if (!apSsid.empty())
+    apSsid_ = std::move(apSsid);
+  server_ = WiFiServer(port_);
+  if (stateMutex_ == nullptr)
+    stateMutex_ = xSemaphoreCreateMutex();
+  configured_ = true;
+}
+
+bool HttpTransferServer::setEnabled(bool enabled) {
+  lockState();
+  const bool configured = configured_;
+  const bool wasEnabled = enabled_;
+  const bool wasStartedAp = startedAp_;
+  const std::string apSsid = apSsid_;
+  unlockState();
+
+  if (!configured || handler_ == nullptr) {
+    lockState();
+    rememberError("not_configured", "device transfer server is not configured");
+    unlockState();
+    return false;
+  }
+
+  if (enabled && !wasEnabled) {
+    if (WiFi.status() != WL_CONNECTED) {
+      WiFi.mode(WIFI_AP);
+      if (!WiFi.softAP(apSsid.c_str())) {
+        lockState();
+        rememberError("wifi_ap", "could not start transfer Wi-Fi");
+        unlockState();
+        return false;
+      }
+      lockState();
+      startedAp_ = true;
+      unlockState();
+      Serial.printf("DEVICE_TRANSFER_HTTP: started AP ssid=%s ip=%s\n",
+                    apSsid.c_str(), WiFi.softAPIP().toString().c_str());
+    }
+    server_.begin();
+    server_.setNoDelay(true);
+  }
+  if (!enabled && wasEnabled) {
+    server_.stop();
+    if (wasStartedAp) {
+      WiFi.softAPdisconnect(true);
+      WiFi.mode(WIFI_OFF);
+      lockState();
+      startedAp_ = false;
+      unlockState();
+    }
+  }
+  lockState();
+  enabled_ = enabled;
+  unlockState();
+  return true;
+}
+
+void HttpTransferServer::setLastError(const std::string &code,
+                                      const std::string &message) {
+  lockState();
+  rememberError(code, message);
+  unlockState();
+}
+
+void HttpTransferServer::process() {
+  if (!enabled_)
+    return;
+  WiFiClient client = server_.accept();
+  if (!client)
+    return;
+  handleClient(client);
+  client.stop();
+}
+
+HttpTransferStatus HttpTransferServer::status() const {
+  lockState();
+  const bool configured = configured_;
+  const bool enabled = enabled_;
+  const bool startedAp = startedAp_;
+  const uint16_t port = port_;
+  const std::string apSsid = apSsid_;
+  const std::string lastErrorCode = lastErrorCode_;
+  const std::string lastErrorMessage = lastErrorMessage_;
+  unlockState();
+
+  std::string baseUrl;
+  if (enabled) {
+    IPAddress ip =
+        startedAp ? WiFi.softAPIP() : (WiFi.status() == WL_CONNECTED
+                                           ? WiFi.localIP()
+                                           : IPAddress());
+    if (ip != IPAddress()) {
+      baseUrl = std::string("http://") + ip.toString().c_str() + ":" +
+                std::to_string(port);
+    }
+  }
+  return {configured, enabled, port, baseUrl, startedAp ? apSsid : "",
+          lastErrorCode, lastErrorMessage};
+}
+
+void HttpTransferServer::handleClient(WiFiClient &client) {
+  std::string requestLine;
+  if (!readLine(client, requestLine)) {
+    sendError(client, 408, "timeout", "request timed out");
+    return;
+  }
+
+  HttpRequest request;
+  std::stringstream requestStream(requestLine);
+  std::string version;
+  requestStream >> request.method >> request.path >> version;
+  if (request.method.empty() || request.path.empty()) {
+    sendError(client, 400, "bad_request", "invalid request line");
+    return;
+  }
+
+  std::string line;
+  while (readLine(client, line)) {
+    if (line.empty())
+      break;
+    size_t colon = line.find(':');
+    if (colon == std::string::npos)
+      continue;
+    std::string name = lower(trim(line.substr(0, colon)));
+    std::string value = trim(line.substr(colon + 1));
+    if (name == "content-length")
+      request.contentLength = strtoull(value.c_str(), nullptr, 10);
+  }
+
+  if (handler_ != nullptr && handler_->handleRequest(request, client))
+    return;
+
+  sendError(client, 404, "not_found", "device transfer endpoint not found");
+}
+
+void HttpTransferServer::sendError(WiFiClient &client, int status,
+                                   const std::string &code,
+                                   const std::string &message) {
+  setLastError(code, message);
+  sendHttpError(client, status, code, message);
+}
+
+void HttpTransferServer::rememberError(const std::string &code,
+                                       const std::string &message) {
+  lastErrorCode_ = code;
+  lastErrorMessage_ = message;
+}
+
+void HttpTransferServer::lockState() const {
+  if (stateMutex_ != nullptr)
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
+}
+
+void HttpTransferServer::unlockState() const {
+  if (stateMutex_ != nullptr)
+    xSemaphoreGive(stateMutex_);
+}
+
+void sendHttpHead(WiFiClient &client, int status, uint64_t contentLength) {
+  const char *reason = status == 200   ? "OK"
+                       : status == 400 ? "Bad Request"
+                       : status == 403 ? "Forbidden"
+                       : status == 404 ? "Not Found"
+                                       : "Internal Server Error";
+  client.printf("HTTP/1.1 %d %s\r\n", status, reason);
+  client.print("Connection: close\r\n");
+  client.printf("Content-Length: %llu\r\n\r\n",
+                static_cast<unsigned long long>(contentLength));
+}
+
+void sendHttpJson(WiFiClient &client, int status, const std::string &body) {
+  const char *reason = status == 200   ? "OK"
+                       : status == 202 ? "Accepted"
+                       : status == 400 ? "Bad Request"
+                       : status == 403 ? "Forbidden"
+                       : status == 404 ? "Not Found"
+                       : status == 409 ? "Conflict"
+                       : status == 408 ? "Request Timeout"
+                       : status == 413 ? "Payload Too Large"
+                                       : "Internal Server Error";
+  client.printf("HTTP/1.1 %d %s\r\n", status, reason);
+  client.print("Content-Type: application/json\r\n");
+  client.print("Connection: close\r\n");
+  client.printf("Content-Length: %u\r\n\r\n",
+                static_cast<unsigned>(body.size()));
+  client.print(body.c_str());
+}
+
+void sendHttpError(WiFiClient &client, int status, const std::string &code,
+                   const std::string &message) {
+  sendHttpJson(client, status,
+               std::string("{\"ok\":false,\"error\":{\"code\":\"") +
+                   jsonEscape(code) + "\",\"message\":\"" +
+                   jsonEscape(message) + "\"}}");
+}
+
+} // namespace device_transfer

--- a/esp32/lib/device_transfer/device_transfer_http.hpp
+++ b/esp32/lib/device_transfer/device_transfer_http.hpp
@@ -5,6 +5,7 @@
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+#include <array>
 #include <string>
 
 namespace device_transfer {
@@ -13,8 +14,10 @@ struct HttpTransferStatus {
   bool configured = false;
   bool enabled = false;
   uint16_t port = 8080;
+  std::string mode;
   std::string baseUrl;
   std::string apSsid;
+  std::string sessionToken;
   std::string lastErrorCode;
   std::string lastErrorMessage;
 };
@@ -22,6 +25,7 @@ struct HttpTransferStatus {
 struct HttpRequest {
   std::string method;
   std::string path;
+  std::string transferToken;
   uint64_t contentLength = 0;
 };
 
@@ -34,26 +38,40 @@ public:
 
 class HttpTransferServer {
 public:
+  void configure(uint16_t port = 8080,
+                 std::string apSsid = "BikeComputer-Transfer");
   void configure(HttpRequestHandler *handler, uint16_t port = 8080,
                  std::string apSsid = "BikeComputer-Transfer");
+  bool registerHandler(std::string pathPrefix, HttpRequestHandler *handler);
   bool setEnabled(bool enabled);
+  bool setEnabled(bool enabled, std::string mode);
   void setLastError(const std::string &code, const std::string &message);
   void process();
   HttpTransferStatus status() const;
+  bool isRequestAuthorized(const HttpRequest &request) const;
 
 private:
-  HttpRequestHandler *handler_ = nullptr;
   uint16_t port_ = 8080;
   bool configured_ = false;
   bool enabled_ = false;
   bool startedAp_ = false;
+  std::string mode_;
   std::string apSsid_ = "BikeComputer-Transfer";
+  std::string sessionToken_;
   WiFiServer server_{8080};
   mutable SemaphoreHandle_t stateMutex_ = nullptr;
   std::string lastErrorCode_;
   std::string lastErrorMessage_;
+  struct HandlerRegistration {
+    std::string pathPrefix;
+    HttpRequestHandler *handler = nullptr;
+  };
+  std::array<HandlerRegistration, 4> handlers_{};
+  size_t handlerCount_ = 0;
 
   void handleClient(WiFiClient &client);
+  HttpRequestHandler *handlerForPath(const std::string &path) const;
+  std::string generateSessionToken() const;
   void sendError(WiFiClient &client, int status, const std::string &code,
                  const std::string &message);
   void rememberError(const std::string &code, const std::string &message);
@@ -66,5 +84,8 @@ void sendHttpHead(WiFiClient &client, int status,
 void sendHttpJson(WiFiClient &client, int status, const std::string &body);
 void sendHttpError(WiFiClient &client, int status, const std::string &code,
                    const std::string &message);
+bool readHttpBody(WiFiClient &client, uint64_t contentLength,
+                  uint64_t maxLength, std::string &body,
+                  uint32_t timeoutMs = 5000);
 
 } // namespace device_transfer

--- a/esp32/lib/device_transfer/device_transfer_http.hpp
+++ b/esp32/lib/device_transfer/device_transfer_http.hpp
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include <string>
+
+namespace device_transfer {
+
+struct HttpTransferStatus {
+  bool configured = false;
+  bool enabled = false;
+  uint16_t port = 8080;
+  std::string baseUrl;
+  std::string apSsid;
+  std::string lastErrorCode;
+  std::string lastErrorMessage;
+};
+
+struct HttpRequest {
+  std::string method;
+  std::string path;
+  uint64_t contentLength = 0;
+};
+
+class HttpRequestHandler {
+public:
+  virtual ~HttpRequestHandler() = default;
+  virtual bool handleRequest(const HttpRequest &request,
+                             WiFiClient &client) = 0;
+};
+
+class HttpTransferServer {
+public:
+  void configure(HttpRequestHandler *handler, uint16_t port = 8080,
+                 std::string apSsid = "BikeComputer-Transfer");
+  bool setEnabled(bool enabled);
+  void setLastError(const std::string &code, const std::string &message);
+  void process();
+  HttpTransferStatus status() const;
+
+private:
+  HttpRequestHandler *handler_ = nullptr;
+  uint16_t port_ = 8080;
+  bool configured_ = false;
+  bool enabled_ = false;
+  bool startedAp_ = false;
+  std::string apSsid_ = "BikeComputer-Transfer";
+  WiFiServer server_{8080};
+  mutable SemaphoreHandle_t stateMutex_ = nullptr;
+  std::string lastErrorCode_;
+  std::string lastErrorMessage_;
+
+  void handleClient(WiFiClient &client);
+  void sendError(WiFiClient &client, int status, const std::string &code,
+                 const std::string &message);
+  void rememberError(const std::string &code, const std::string &message);
+  void lockState() const;
+  void unlockState() const;
+};
+
+void sendHttpHead(WiFiClient &client, int status,
+                  uint64_t contentLength = 0);
+void sendHttpJson(WiFiClient &client, int status, const std::string &body);
+void sendHttpError(WiFiClient &client, int status, const std::string &code,
+                   const std::string &message);
+
+} // namespace device_transfer

--- a/esp32/lib/firmware_metadata/firmware_metadata.cpp
+++ b/esp32/lib/firmware_metadata/firmware_metadata.cpp
@@ -1,0 +1,65 @@
+#include "firmware_metadata.hpp"
+
+#ifndef VERSION
+#define VERSION "0.0.0"
+#endif
+
+#ifndef REVISION
+#define REVISION 0
+#endif
+
+#ifndef FLAVOR
+#define FLAVOR "unknown"
+#endif
+
+#ifndef GIT_SHA
+#define GIT_SHA "unknown"
+#endif
+
+#ifndef BUILD_TIMESTAMP
+#define BUILD_TIMESTAMP "unknown"
+#endif
+
+namespace firmware_metadata {
+namespace {
+
+static std::string jsonEscape(const std::string &value) {
+  std::string out;
+  out.reserve(value.size() + 8);
+  for (char c : value) {
+    if (c == '"' || c == '\\') {
+      out.push_back('\\');
+      out.push_back(c);
+    } else if (c == '\n') {
+      out += "\\n";
+    } else if (c == '\r') {
+      out += "\\r";
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+} // namespace
+
+const char *target() { return FLAVOR; }
+
+const char *version() { return VERSION; }
+
+uint32_t build() { return static_cast<uint32_t>(REVISION); }
+
+const char *gitSha() { return GIT_SHA; }
+
+const char *buildTimestamp() { return BUILD_TIMESTAMP; }
+
+std::string json() {
+  return std::string("{\"target\":\"") + jsonEscape(target()) +
+         "\",\"version\":\"" + jsonEscape(version()) + "\",\"build\":" +
+         std::to_string(build()) + ",\"gitSha\":\"" + jsonEscape(gitSha()) +
+         "\",\"buildTimestamp\":\"" + jsonEscape(buildTimestamp()) +
+         "\",\"updaterProtocol\":" +
+         std::to_string(kUpdaterProtocolVersion) + "}";
+}
+
+} // namespace firmware_metadata

--- a/esp32/lib/firmware_metadata/firmware_metadata.hpp
+++ b/esp32/lib/firmware_metadata/firmware_metadata.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace firmware_metadata {
+
+static constexpr uint32_t kUpdaterProtocolVersion = 1;
+
+const char *target();
+const char *version();
+uint32_t build();
+const char *gitSha();
+const char *buildTimestamp();
+std::string json();
+
+} // namespace firmware_metadata

--- a/esp32/lib/firmware_update/firmware_update_http.cpp
+++ b/esp32/lib/firmware_update/firmware_update_http.cpp
@@ -4,10 +4,15 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cstring>
 #include <esp_app_format.h>
 #include <esp_ota_ops.h>
+#include <mbedtls/base64.h>
+#include <mbedtls/md.h>
+#include <mbedtls/pk.h>
 #include <mbedtls/sha256.h>
 #include <sstream>
+#include <vector>
 
 namespace firmware_update {
 namespace {
@@ -18,6 +23,11 @@ static constexpr const char *kImagePath = "/firmware-update/image";
 static constexpr const char *kFinalizePath = "/firmware-update/finalize";
 static constexpr const char *kCancelPath = "/firmware-update/cancel";
 static constexpr uint64_t kMaxBeginBodyBytes = 2048;
+static constexpr const char *kManifestSigningPublicKeyPem =
+    "-----BEGIN PUBLIC KEY-----\n"
+    "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtohCWc591a7u6+lRHZX82FuT3ab3\n"
+    "kEv4w/ai84IAaR/g3R4OEw0fhxOIPyDqqbQiACLb/F7Sw04y8IwZjA+UKw==\n"
+    "-----END PUBLIC KEY-----\n";
 
 static std::string jsonEscape(const std::string &value) {
   std::string out;
@@ -176,6 +186,74 @@ static std::string sha256Hex(const uint8_t digest[32]) {
   return out;
 }
 
+static bool base64Decode(const std::string &value, std::vector<uint8_t> &out) {
+  size_t decodedLength = 0;
+  int result = mbedtls_base64_decode(
+      nullptr, 0, &decodedLength,
+      reinterpret_cast<const unsigned char *>(value.data()), value.size());
+  if (result != MBEDTLS_ERR_BASE64_BUFFER_TOO_SMALL || decodedLength == 0)
+    return false;
+  out.resize(decodedLength);
+  result = mbedtls_base64_decode(
+      out.data(), out.size(), &decodedLength,
+      reinterpret_cast<const unsigned char *>(value.data()), value.size());
+  if (result != 0)
+    return false;
+  out.resize(decodedLength);
+  return true;
+}
+
+static std::string manifestPayload(uint32_t schemaVersion,
+                                   const std::string &target,
+                                   const std::string &version, uint32_t build,
+                                   const std::string &gitSha, uint32_t size,
+                                   const std::string &sha256,
+                                   const std::string &releaseUrl,
+                                   uint32_t minUpdaterProtocol) {
+  std::ostringstream payload;
+  payload << "schemaVersion=" << schemaVersion << "\n"
+          << "target=" << target << "\n"
+          << "version=" << version << "\n"
+          << "build=" << build << "\n"
+          << "gitSha=" << gitSha << "\n"
+          << "size=" << size << "\n"
+          << "sha256=" << sha256 << "\n"
+          << "url=" << releaseUrl << "\n"
+          << "minUpdaterProtocol=" << minUpdaterProtocol << "\n";
+  return payload.str();
+}
+
+static bool verifyManifestSignature(const std::string &payload,
+                                    const std::string &signatureBase64) {
+  std::vector<uint8_t> signature;
+  if (!base64Decode(signatureBase64, signature))
+    return false;
+
+  uint8_t digest[32];
+  mbedtls_sha256_context sha;
+  mbedtls_sha256_init(&sha);
+  mbedtls_sha256_starts(&sha, 0);
+  mbedtls_sha256_update(
+      &sha, reinterpret_cast<const unsigned char *>(payload.data()),
+      payload.size());
+  mbedtls_sha256_finish(&sha, digest);
+  mbedtls_sha256_free(&sha);
+
+  mbedtls_pk_context publicKey;
+  mbedtls_pk_init(&publicKey);
+  int result = mbedtls_pk_parse_public_key(
+      &publicKey,
+      reinterpret_cast<const unsigned char *>(kManifestSigningPublicKeyPem),
+      strlen(kManifestSigningPublicKeyPem) + 1);
+  if (result == 0) {
+    result = mbedtls_pk_verify(&publicKey, MBEDTLS_MD_SHA256, digest,
+                               sizeof(digest), signature.data(),
+                               signature.size());
+  }
+  mbedtls_pk_free(&publicKey);
+  return result == 0;
+}
+
 } // namespace
 
 void FirmwareUpdateHttpServer::configure(
@@ -330,25 +408,50 @@ void FirmwareUpdateHttpServer::handleBegin(
   std::string version;
   std::string target;
   std::string sha256;
+  std::string gitSha;
+  std::string releaseUrl;
+  std::string manifestSignature;
+  uint32_t schemaVersion = 0;
   uint32_t build = 0;
   uint32_t size = 0;
+  uint32_t minUpdaterProtocol = 0;
   bool allowDowngrade = false;
-  if (!findJsonString(body, "version", version) ||
+  if (!findJsonUint(body, "schemaVersion", schemaVersion) ||
+      !findJsonString(body, "version", version) ||
       !findJsonString(body, "target", target) ||
+      !findJsonString(body, "gitSha", gitSha) ||
       !findJsonString(body, "sha256", sha256) ||
+      !findJsonString(body, "releaseUrl", releaseUrl) ||
+      !findJsonString(body, "manifestSignature", manifestSignature) ||
       !findJsonUint(body, "build", build) ||
-      !findJsonUint(body, "size", size)) {
+      !findJsonUint(body, "size", size) ||
+      !findJsonUint(body, "minUpdaterProtocol", minUpdaterProtocol)) {
     fail(client, 400, "begin_body_invalid", "missing firmware metadata");
     return;
   }
   findJsonBool(body, "allowDowngrade", allowDowngrade);
 
+  if (schemaVersion != 1 ||
+      minUpdaterProtocol > firmware_metadata::kUpdaterProtocolVersion) {
+    fail(client, 400, "manifest_unsupported",
+         "firmware manifest is not supported");
+    return;
+  }
   if (target != firmware_metadata::target()) {
     fail(client, 400, "target_mismatch", "firmware target does not match");
     return;
   }
-  if (version.empty() || !isHexSha256(sha256)) {
+  if (version.empty() || gitSha.empty() || releaseUrl.empty() ||
+      !isHexSha256(sha256)) {
     fail(client, 400, "metadata_invalid", "firmware metadata is invalid");
+    return;
+  }
+  const std::string signedPayload =
+      manifestPayload(schemaVersion, target, version, build, gitSha, size,
+                      sha256, releaseUrl, minUpdaterProtocol);
+  if (!verifyManifestSignature(signedPayload, manifestSignature)) {
+    fail(client, 400, "manifest_signature_invalid",
+         "firmware manifest signature is invalid");
     return;
   }
   if (build <= firmware_metadata::build() && !allowDowngrade) {

--- a/esp32/lib/firmware_update/firmware_update_http.cpp
+++ b/esp32/lib/firmware_update/firmware_update_http.cpp
@@ -292,6 +292,7 @@ FirmwareUpdateStatus FirmwareUpdateHttpServer::status() const {
   snapshot.target = firmware_metadata::target();
   snapshot.runningVersion = firmware_metadata::version();
   snapshot.runningBuild = firmware_metadata::build();
+  snapshot.runningGitSha = firmware_metadata::gitSha();
   snapshot.runningPartition = partitionLabel(running);
   snapshot.inactivePartition = partitionLabel(inactive);
   snapshot.maxImageBytes = inactive == nullptr ? 0 : inactive->size;
@@ -313,6 +314,9 @@ std::string FirmwareUpdateHttpServer::statusJson() const {
                      jsonEscape(snapshot.runningVersion) +
                      "\",\"runningBuild\":" +
                      std::to_string(snapshot.runningBuild) +
+                     ",\"runningGitSha\":\"" +
+                     jsonEscape(snapshot.runningGitSha) +
+                     "\"" +
                      ",\"runningPartition\":\"" +
                      jsonEscape(snapshot.runningPartition) +
                      "\",\"inactivePartition\":\"" +

--- a/esp32/lib/firmware_update/firmware_update_http.cpp
+++ b/esp32/lib/firmware_update/firmware_update_http.cpp
@@ -1,0 +1,575 @@
+#include "firmware_update_http.hpp"
+
+#include "../firmware_metadata/firmware_metadata.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <esp_app_format.h>
+#include <esp_ota_ops.h>
+#include <mbedtls/sha256.h>
+#include <sstream>
+
+namespace firmware_update {
+namespace {
+
+static constexpr const char *kStatusPath = "/firmware-update/status";
+static constexpr const char *kBeginPath = "/firmware-update/begin";
+static constexpr const char *kImagePath = "/firmware-update/image";
+static constexpr const char *kFinalizePath = "/firmware-update/finalize";
+static constexpr const char *kCancelPath = "/firmware-update/cancel";
+static constexpr uint64_t kMaxBeginBodyBytes = 2048;
+
+static std::string jsonEscape(const std::string &value) {
+  std::string out;
+  out.reserve(value.size() + 8);
+  for (char c : value) {
+    if (c == '"' || c == '\\') {
+      out.push_back('\\');
+      out.push_back(c);
+    } else if (c == '\n') {
+      out += "\\n";
+    } else if (c == '\r') {
+      out += "\\r";
+    } else {
+      out.push_back(c);
+    }
+  }
+  return out;
+}
+
+static bool startsWith(const std::string &value, const std::string &prefix) {
+  return value.size() >= prefix.size() &&
+         value.compare(0, prefix.size(), prefix) == 0;
+}
+
+static bool isHexSha256(const std::string &value) {
+  if (value.size() != 64)
+    return false;
+  for (char c : value) {
+    if (!std::isxdigit(static_cast<unsigned char>(c)))
+      return false;
+  }
+  return true;
+}
+
+static void skipSpaces(const std::string &body, size_t &index) {
+  while (index < body.size() &&
+         std::isspace(static_cast<unsigned char>(body[index]))) {
+    index++;
+  }
+}
+
+static bool findJsonValueStart(const std::string &body, const char *field,
+                               size_t &index) {
+  const std::string key = std::string("\"") + field + "\"";
+  size_t found = body.find(key);
+  if (found == std::string::npos)
+    return false;
+  found = body.find(':', found + key.size());
+  if (found == std::string::npos)
+    return false;
+  index = found + 1;
+  skipSpaces(body, index);
+  return index < body.size();
+}
+
+static bool findJsonString(const std::string &body, const char *field,
+                           std::string &value) {
+  size_t index = 0;
+  if (!findJsonValueStart(body, field, index) || body[index] != '"')
+    return false;
+  index++;
+  value.clear();
+  while (index < body.size()) {
+    char c = body[index++];
+    if (c == '"')
+      return true;
+    if (c == '\\' && index < body.size()) {
+      char escaped = body[index++];
+      if (escaped == 'n') {
+        value.push_back('\n');
+      } else if (escaped == 'r') {
+        value.push_back('\r');
+      } else {
+        value.push_back(escaped);
+      }
+    } else {
+      value.push_back(c);
+    }
+  }
+  return false;
+}
+
+static bool findJsonUint(const std::string &body, const char *field,
+                         uint32_t &value) {
+  size_t index = 0;
+  if (!findJsonValueStart(body, field, index))
+    return false;
+  uint64_t parsed = 0;
+  bool foundDigit = false;
+  while (index < body.size() &&
+         std::isdigit(static_cast<unsigned char>(body[index]))) {
+    foundDigit = true;
+    parsed = parsed * 10 + static_cast<uint64_t>(body[index] - '0');
+    if (parsed > UINT32_MAX)
+      return false;
+    index++;
+  }
+  if (!foundDigit)
+    return false;
+  value = static_cast<uint32_t>(parsed);
+  return true;
+}
+
+static bool findJsonBool(const std::string &body, const char *field,
+                         bool &value) {
+  size_t index = 0;
+  if (!findJsonValueStart(body, field, index))
+    return false;
+  if (body.compare(index, 4, "true") == 0) {
+    value = true;
+    return true;
+  }
+  if (body.compare(index, 5, "false") == 0) {
+    value = false;
+    return true;
+  }
+  return false;
+}
+
+static std::string partitionLabel(const esp_partition_t *partition) {
+  return partition == nullptr ? "" : std::string(partition->label);
+}
+
+static std::string otaStateName(const esp_partition_t *partition) {
+  if (partition == nullptr)
+    return "unknown";
+  esp_ota_img_states_t state;
+  esp_err_t result = esp_ota_get_state_partition(partition, &state);
+  if (result != ESP_OK)
+    return "unknown";
+  switch (state) {
+  case ESP_OTA_IMG_NEW:
+    return "new";
+  case ESP_OTA_IMG_PENDING_VERIFY:
+    return "pending_verify";
+  case ESP_OTA_IMG_VALID:
+    return "valid";
+  case ESP_OTA_IMG_INVALID:
+    return "invalid";
+  case ESP_OTA_IMG_ABORTED:
+    return "aborted";
+  case ESP_OTA_IMG_UNDEFINED:
+  default:
+    return "undefined";
+  }
+}
+
+static std::string sha256Hex(const uint8_t digest[32]) {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string out;
+  out.reserve(64);
+  for (size_t i = 0; i < 32; ++i) {
+    out.push_back(kHex[(digest[i] >> 4) & 0x0F]);
+    out.push_back(kHex[digest[i] & 0x0F]);
+  }
+  return out;
+}
+
+} // namespace
+
+void FirmwareUpdateHttpServer::configure(
+    device_transfer::HttpTransferServer *sharedServer, uint16_t port) {
+  if (stateMutex_ == nullptr)
+    stateMutex_ = xSemaphoreCreateMutex();
+  transferServer_ = sharedServer == nullptr ? &ownedTransferServer_ : sharedServer;
+  if (sharedServer == nullptr)
+    transferServer_->configure(port, "BikeComputer-Transfer");
+  transferServer_->registerHandler("/firmware-update", this);
+}
+
+bool FirmwareUpdateHttpServer::setEnabled(bool enabled) {
+  if (!enabled)
+    resetUploadState();
+  return transferServer_->setEnabled(enabled, enabled ? "firmware" : "");
+}
+
+void FirmwareUpdateHttpServer::setLastError(const std::string &code,
+                                            const std::string &message) {
+  lockState();
+  rememberError(code, message);
+  unlockState();
+  transferServer_->setLastError(code, message);
+}
+
+void FirmwareUpdateHttpServer::process() { transferServer_->process(); }
+
+FirmwareUpdateStatus FirmwareUpdateHttpServer::status() const {
+  const esp_partition_t *running = esp_ota_get_running_partition();
+  const esp_partition_t *inactive = esp_ota_get_next_update_partition(nullptr);
+
+  lockState();
+  FirmwareUpdateStatus snapshot;
+  snapshot.status = status_;
+  snapshot.target = firmware_metadata::target();
+  snapshot.runningVersion = firmware_metadata::version();
+  snapshot.runningBuild = firmware_metadata::build();
+  snapshot.runningPartition = partitionLabel(running);
+  snapshot.inactivePartition = partitionLabel(inactive);
+  snapshot.maxImageBytes = inactive == nullptr ? 0 : inactive->size;
+  snapshot.receivedBytes = receivedBytes_;
+  snapshot.totalBytes = totalBytes_;
+  snapshot.sha256 = actualSha256_.empty() ? expectedSha256_ : actualSha256_;
+  snapshot.errorCode = errorCode_;
+  snapshot.errorMessage = errorMessage_;
+  unlockState();
+  return snapshot;
+}
+
+std::string FirmwareUpdateHttpServer::statusJson() const {
+  FirmwareUpdateStatus snapshot = status();
+  const esp_partition_t *running = esp_ota_get_running_partition();
+  std::string body = std::string("{\"status\":\"") +
+                     jsonEscape(snapshot.status) + "\",\"target\":\"" +
+                     jsonEscape(snapshot.target) + "\",\"runningVersion\":\"" +
+                     jsonEscape(snapshot.runningVersion) +
+                     "\",\"runningBuild\":" +
+                     std::to_string(snapshot.runningBuild) +
+                     ",\"runningPartition\":\"" +
+                     jsonEscape(snapshot.runningPartition) +
+                     "\",\"inactivePartition\":\"" +
+                     jsonEscape(snapshot.inactivePartition) +
+                     "\",\"otaState\":\"" + jsonEscape(otaStateName(running)) +
+                     "\",\"maxImageBytes\":" +
+                     std::to_string(snapshot.maxImageBytes) +
+                     ",\"receivedBytes\":" +
+                     std::to_string(snapshot.receivedBytes) +
+                     ",\"totalBytes\":" +
+                     std::to_string(snapshot.totalBytes);
+  if (!snapshot.sha256.empty()) {
+    body += ",\"sha256\":\"" + jsonEscape(snapshot.sha256) + "\"";
+  } else {
+    body += ",\"sha256\":null";
+  }
+  if (!snapshot.errorCode.empty()) {
+    body += ",\"lastError\":{\"code\":\"" + jsonEscape(snapshot.errorCode) +
+            "\",\"message\":\"" + jsonEscape(snapshot.errorMessage) + "\"}";
+  } else {
+    body += ",\"lastError\":null";
+  }
+  body += ",\"device\":" + firmware_metadata::json() + "}";
+  return body;
+}
+
+void FirmwareUpdateHttpServer::markRunningAppValid() {
+  const esp_partition_t *running = esp_ota_get_running_partition();
+  esp_ota_img_states_t state;
+  if (running != nullptr &&
+      esp_ota_get_state_partition(running, &state) == ESP_OK &&
+      state == ESP_OTA_IMG_PENDING_VERIFY) {
+    esp_err_t result = esp_ota_mark_app_valid_cancel_rollback();
+    Serial.printf("FIRMWARE_UPDATE: mark running app valid result=%s\n",
+                  esp_err_to_name(result));
+  }
+}
+
+bool FirmwareUpdateHttpServer::handleRequest(
+    const device_transfer::HttpRequest &request, WiFiClient &client) {
+  if (!startsWith(request.path, "/firmware-update"))
+    return false;
+  Serial.printf("FIRMWARE_UPDATE_HTTP: %s %s length=%llu\n",
+                request.method.c_str(), request.path.c_str(),
+                static_cast<unsigned long long>(request.contentLength));
+  if (request.method == "GET" && request.path == kStatusPath) {
+    handleStatus(client);
+    return true;
+  }
+  if (transferServer_->status().mode != "firmware") {
+    fail(client, 403, "transfer_mode_mismatch",
+         "firmware transfer mode is not active");
+    return true;
+  }
+  if (!transferServer_->isRequestAuthorized(request)) {
+    fail(client, 401, "transfer_token_invalid",
+         "firmware transfer token is missing or invalid");
+    return true;
+  }
+  if (request.method == "POST" && request.path == kBeginPath) {
+    handleBegin(request, client);
+    return true;
+  }
+  if (request.method == "PUT" && request.path == kImagePath) {
+    handleImage(request, client);
+    return true;
+  }
+  if (request.method == "POST" && request.path == kFinalizePath) {
+    handleFinalize(client);
+    return true;
+  }
+  if (request.method == "POST" && request.path == kCancelPath) {
+    handleCancel(client);
+    return true;
+  }
+  fail(client, 404, "not_found", "firmware update endpoint not found");
+  return true;
+}
+
+void FirmwareUpdateHttpServer::handleStatus(WiFiClient &client) {
+  device_transfer::sendHttpJson(client, 200, statusJson());
+}
+
+void FirmwareUpdateHttpServer::handleBegin(
+    const device_transfer::HttpRequest &request, WiFiClient &client) {
+  std::string body;
+  if (!device_transfer::readHttpBody(client, request.contentLength,
+                                     kMaxBeginBodyBytes, body)) {
+    fail(client, 413, "begin_body_invalid", "invalid begin request body");
+    return;
+  }
+
+  std::string version;
+  std::string target;
+  std::string sha256;
+  uint32_t build = 0;
+  uint32_t size = 0;
+  bool allowDowngrade = false;
+  if (!findJsonString(body, "version", version) ||
+      !findJsonString(body, "target", target) ||
+      !findJsonString(body, "sha256", sha256) ||
+      !findJsonUint(body, "build", build) ||
+      !findJsonUint(body, "size", size)) {
+    fail(client, 400, "begin_body_invalid", "missing firmware metadata");
+    return;
+  }
+  findJsonBool(body, "allowDowngrade", allowDowngrade);
+
+  if (target != firmware_metadata::target()) {
+    fail(client, 400, "target_mismatch", "firmware target does not match");
+    return;
+  }
+  if (version.empty() || !isHexSha256(sha256)) {
+    fail(client, 400, "metadata_invalid", "firmware metadata is invalid");
+    return;
+  }
+  if (build <= firmware_metadata::build() && !allowDowngrade) {
+    fail(client, 409, "not_newer", "firmware build is not newer");
+    return;
+  }
+
+  const esp_partition_t *updatePartition =
+      esp_ota_get_next_update_partition(nullptr);
+  if (updatePartition == nullptr) {
+    fail(client, 500, "ota_partition_missing", "inactive OTA partition missing");
+    return;
+  }
+  if (size == 0 || size > updatePartition->size) {
+    fail(client, 413, "image_too_large", "firmware image does not fit");
+    return;
+  }
+
+  resetUploadState();
+  esp_ota_handle_t handle = 0;
+  esp_err_t result = esp_ota_begin(updatePartition, size, &handle);
+  if (result != ESP_OK) {
+    fail(client, 500, "ota_begin_failed", esp_err_to_name(result));
+    return;
+  }
+
+  lockState();
+  status_ = "receiving";
+  totalBytes_ = size;
+  expectedSha256_ = sha256;
+  pendingVersion_ = version;
+  pendingBuild_ = build;
+  allowDowngrade_ = allowDowngrade;
+  updatePartition_ = updatePartition;
+  otaHandle_ = handle;
+  otaOpen_ = true;
+  errorCode_.clear();
+  errorMessage_.clear();
+  unlockState();
+
+  device_transfer::sendHttpJson(client, 200, statusJson());
+}
+
+void FirmwareUpdateHttpServer::handleImage(
+    const device_transfer::HttpRequest &request, WiFiClient &client) {
+  lockState();
+  const bool ready = status_ == "receiving" && otaOpen_;
+  const uint32_t expectedSize = totalBytes_;
+  esp_ota_handle_t handle = otaHandle_;
+  unlockState();
+  if (!ready) {
+    fail(client, 409, "upload_not_started", "firmware upload was not started");
+    return;
+  }
+  if (request.contentLength != expectedSize) {
+    resetUploadState();
+    fail(client, 400, "size_mismatch", "firmware upload size mismatch");
+    return;
+  }
+
+  mbedtls_sha256_context sha;
+  mbedtls_sha256_init(&sha);
+  mbedtls_sha256_starts(&sha, 0);
+
+  uint8_t buffer[2048];
+  uint64_t remaining = request.contentLength;
+  uint32_t lastReadMs = millis();
+  while (remaining > 0 && millis() - lastReadMs < 10000) {
+    int available = client.available();
+    if (available <= 0) {
+      delay(1);
+      continue;
+    }
+    size_t toRead = std::min<uint64_t>(sizeof(buffer), remaining);
+    toRead = std::min<size_t>(toRead, static_cast<size_t>(available));
+    int bytesRead = client.read(buffer, toRead);
+    if (bytesRead <= 0) {
+      delay(1);
+      continue;
+    }
+    esp_err_t result = esp_ota_write(handle, buffer, bytesRead);
+    if (result != ESP_OK) {
+      mbedtls_sha256_free(&sha);
+      resetUploadState();
+      fail(client, 500, "ota_write_failed", esp_err_to_name(result));
+      return;
+    }
+    mbedtls_sha256_update(&sha, buffer, bytesRead);
+    remaining -= static_cast<uint64_t>(bytesRead);
+    lastReadMs = millis();
+
+    lockState();
+    receivedBytes_ += static_cast<uint32_t>(bytesRead);
+    unlockState();
+  }
+
+  if (remaining != 0) {
+    mbedtls_sha256_free(&sha);
+    resetUploadState();
+    fail(client, 408, "upload_timeout", "firmware upload timed out");
+    return;
+  }
+
+  uint8_t digest[32];
+  mbedtls_sha256_finish(&sha, digest);
+  mbedtls_sha256_free(&sha);
+  const std::string actualSha256 = sha256Hex(digest);
+
+  lockState();
+  const std::string expectedSha256 = expectedSha256_;
+  unlockState();
+  if (actualSha256 != expectedSha256) {
+    resetUploadState();
+    fail(client, 400, "sha256_mismatch", "firmware image hash mismatch");
+    return;
+  }
+
+  lockState();
+  actualSha256_ = actualSha256;
+  status_ = "received";
+  unlockState();
+  device_transfer::sendHttpJson(client, 200, statusJson());
+}
+
+void FirmwareUpdateHttpServer::handleFinalize(WiFiClient &client) {
+  lockState();
+  const bool ready = status_ == "received" && otaOpen_;
+  const esp_ota_handle_t handle = otaHandle_;
+  const esp_partition_t *updatePartition = updatePartition_;
+  unlockState();
+  if (!ready || updatePartition == nullptr) {
+    fail(client, 409, "finalize_not_ready", "firmware image is not ready");
+    return;
+  }
+
+  esp_err_t result = esp_ota_end(handle);
+  lockState();
+  otaOpen_ = false;
+  otaHandle_ = 0;
+  unlockState();
+  if (result != ESP_OK) {
+    resetUploadState();
+    fail(client, 400, "ota_end_failed", esp_err_to_name(result));
+    return;
+  }
+
+  esp_app_desc_t appDescription;
+  result = esp_ota_get_partition_description(updatePartition, &appDescription);
+  if (result != ESP_OK) {
+    resetUploadState();
+    fail(client, 400, "image_description_failed", esp_err_to_name(result));
+    return;
+  }
+
+  result = esp_ota_set_boot_partition(updatePartition);
+  if (result != ESP_OK) {
+    resetUploadState();
+    fail(client, 500, "set_boot_partition_failed", esp_err_to_name(result));
+    return;
+  }
+
+  lockState();
+  status_ = "finalizing";
+  unlockState();
+  device_transfer::sendHttpJson(client, 202, statusJson());
+  Serial.printf("FIRMWARE_UPDATE: boot partition set to %s version=%s; rebooting\n",
+                updatePartition->label, appDescription.version);
+  delay(750);
+  ESP.restart();
+}
+
+void FirmwareUpdateHttpServer::handleCancel(WiFiClient &client) {
+  resetUploadState();
+  device_transfer::sendHttpJson(client, 200, statusJson());
+}
+
+void FirmwareUpdateHttpServer::resetUploadState() {
+  lockState();
+  const bool otaOpen = otaOpen_;
+  const esp_ota_handle_t handle = otaHandle_;
+  otaOpen_ = false;
+  otaHandle_ = 0;
+  status_ = "idle";
+  receivedBytes_ = 0;
+  totalBytes_ = 0;
+  expectedSha256_.clear();
+  actualSha256_.clear();
+  pendingVersion_.clear();
+  pendingBuild_ = 0;
+  allowDowngrade_ = false;
+  updatePartition_ = nullptr;
+  unlockState();
+  if (otaOpen) {
+    esp_ota_abort(handle);
+  }
+}
+
+void FirmwareUpdateHttpServer::fail(WiFiClient &client, int httpStatus,
+                                    const std::string &code,
+                                    const std::string &message) {
+  setLastError(code, message);
+  lockState();
+  status_ = "failed";
+  unlockState();
+  device_transfer::sendHttpError(client, httpStatus, code, message);
+}
+
+void FirmwareUpdateHttpServer::rememberError(const std::string &code,
+                                             const std::string &message) {
+  errorCode_ = code;
+  errorMessage_ = message;
+}
+
+void FirmwareUpdateHttpServer::lockState() const {
+  if (stateMutex_ != nullptr)
+    xSemaphoreTake(stateMutex_, portMAX_DELAY);
+}
+
+void FirmwareUpdateHttpServer::unlockState() const {
+  if (stateMutex_ != nullptr)
+    xSemaphoreGive(stateMutex_);
+}
+
+} // namespace firmware_update

--- a/esp32/lib/firmware_update/firmware_update_http.cpp
+++ b/esp32/lib/firmware_update/firmware_update_http.cpp
@@ -581,9 +581,20 @@ void FirmwareUpdateHttpServer::handleFinalize(WiFiClient &client) {
   const bool ready = status_ == "received" && otaOpen_;
   const esp_ota_handle_t handle = otaHandle_;
   const esp_partition_t *updatePartition = updatePartition_;
+  const std::string expectedSha256 = expectedSha256_;
+  const std::string actualSha256 = actualSha256_;
+  const std::string pendingVersion = pendingVersion_;
+  const uint32_t pendingBuild = pendingBuild_;
   unlockState();
   if (!ready || updatePartition == nullptr) {
     fail(client, 409, "finalize_not_ready", "firmware image is not ready");
+    return;
+  }
+  if (expectedSha256.empty() || actualSha256 != expectedSha256 ||
+      pendingVersion.empty() || pendingBuild == 0) {
+    resetUploadState();
+    fail(client, 409, "finalize_metadata_invalid",
+         "verified firmware metadata is missing or inconsistent");
     return;
   }
 
@@ -617,8 +628,11 @@ void FirmwareUpdateHttpServer::handleFinalize(WiFiClient &client) {
   status_ = "finalizing";
   unlockState();
   device_transfer::sendHttpJson(client, 202, statusJson());
-  Serial.printf("FIRMWARE_UPDATE: boot partition set to %s version=%s; rebooting\n",
-                updatePartition->label, appDescription.version);
+  Serial.printf("FIRMWARE_UPDATE: boot partition set to %s manifest=%s(%u) "
+                "app=%s project=%s; rebooting\n",
+                updatePartition->label, pendingVersion.c_str(),
+                static_cast<unsigned>(pendingBuild), appDescription.version,
+                appDescription.project_name);
   delay(750);
   ESP.restart();
 }

--- a/esp32/lib/firmware_update/firmware_update_http.cpp
+++ b/esp32/lib/firmware_update/firmware_update_http.cpp
@@ -358,18 +358,18 @@ bool FirmwareUpdateHttpServer::handleRequest(
   Serial.printf("FIRMWARE_UPDATE_HTTP: %s %s length=%llu\n",
                 request.method.c_str(), request.path.c_str(),
                 static_cast<unsigned long long>(request.contentLength));
-  if (request.method == "GET" && request.path == kStatusPath) {
-    handleStatus(client);
-    return true;
-  }
   if (transferServer_->status().mode != "firmware") {
-    fail(client, 403, "transfer_mode_mismatch",
-         "firmware transfer mode is not active");
+    reject(client, 403, "transfer_mode_mismatch",
+           "firmware transfer mode is not active");
     return true;
   }
   if (!transferServer_->isRequestAuthorized(request)) {
-    fail(client, 401, "transfer_token_invalid",
-         "firmware transfer token is missing or invalid");
+    reject(client, 401, "transfer_token_invalid",
+           "firmware transfer token is missing or invalid");
+    return true;
+  }
+  if (request.method == "GET" && request.path == kStatusPath) {
+    handleStatus(client);
     return true;
   }
   if (request.method == "POST" && request.path == kBeginPath) {
@@ -388,7 +388,7 @@ bool FirmwareUpdateHttpServer::handleRequest(
     handleCancel(client);
     return true;
   }
-  fail(client, 404, "not_found", "firmware update endpoint not found");
+  reject(client, 404, "not_found", "firmware update endpoint not found");
   return true;
 }
 
@@ -661,6 +661,13 @@ void FirmwareUpdateHttpServer::resetUploadState() {
   if (otaOpen) {
     esp_ota_abort(handle);
   }
+}
+
+void FirmwareUpdateHttpServer::reject(WiFiClient &client, int httpStatus,
+                                      const std::string &code,
+                                      const std::string &message) {
+  transferServer_->setLastError(code, message);
+  device_transfer::sendHttpError(client, httpStatus, code, message);
 }
 
 void FirmwareUpdateHttpServer::fail(WiFiClient &client, int httpStatus,

--- a/esp32/lib/firmware_update/firmware_update_http.hpp
+++ b/esp32/lib/firmware_update/firmware_update_http.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <Arduino.h>
+#include <WiFi.h>
+#include <esp_ota_ops.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+#include "../device_transfer/device_transfer_http.hpp"
+
+#include <string>
+
+namespace firmware_update {
+
+struct FirmwareUpdateStatus {
+  std::string status = "idle";
+  std::string target;
+  std::string runningVersion;
+  uint32_t runningBuild = 0;
+  std::string runningPartition;
+  std::string inactivePartition;
+  uint32_t maxImageBytes = 0;
+  uint32_t receivedBytes = 0;
+  uint32_t totalBytes = 0;
+  std::string sha256;
+  std::string errorCode;
+  std::string errorMessage;
+};
+
+class FirmwareUpdateHttpServer : private device_transfer::HttpRequestHandler {
+public:
+  void configure(device_transfer::HttpTransferServer *sharedServer = nullptr,
+                 uint16_t port = 8080);
+  bool setEnabled(bool enabled);
+  void setLastError(const std::string &code, const std::string &message);
+  void process();
+  FirmwareUpdateStatus status() const;
+  std::string statusJson() const;
+  void markRunningAppValid();
+
+private:
+  device_transfer::HttpTransferServer ownedTransferServer_;
+  device_transfer::HttpTransferServer *transferServer_ =
+      &ownedTransferServer_;
+  mutable SemaphoreHandle_t stateMutex_ = nullptr;
+  std::string status_ = "idle";
+  uint32_t receivedBytes_ = 0;
+  uint32_t totalBytes_ = 0;
+  std::string expectedSha256_;
+  std::string actualSha256_;
+  std::string pendingVersion_;
+  uint32_t pendingBuild_ = 0;
+  bool allowDowngrade_ = false;
+  std::string errorCode_;
+  std::string errorMessage_;
+  const esp_partition_t *updatePartition_ = nullptr;
+  esp_ota_handle_t otaHandle_ = 0;
+  bool otaOpen_ = false;
+
+  bool handleRequest(const device_transfer::HttpRequest &request,
+                     WiFiClient &client) override;
+  void handleStatus(WiFiClient &client);
+  void handleBegin(const device_transfer::HttpRequest &request,
+                   WiFiClient &client);
+  void handleImage(const device_transfer::HttpRequest &request,
+                   WiFiClient &client);
+  void handleFinalize(WiFiClient &client);
+  void handleCancel(WiFiClient &client);
+  void resetUploadState();
+  void fail(WiFiClient &client, int httpStatus, const std::string &code,
+            const std::string &message);
+  void rememberError(const std::string &code, const std::string &message);
+  void lockState() const;
+  void unlockState() const;
+};
+
+} // namespace firmware_update

--- a/esp32/lib/firmware_update/firmware_update_http.hpp
+++ b/esp32/lib/firmware_update/firmware_update_http.hpp
@@ -17,6 +17,7 @@ struct FirmwareUpdateStatus {
   std::string target;
   std::string runningVersion;
   uint32_t runningBuild = 0;
+  std::string runningGitSha;
   std::string runningPartition;
   std::string inactivePartition;
   uint32_t maxImageBytes = 0;

--- a/esp32/lib/firmware_update/firmware_update_http.hpp
+++ b/esp32/lib/firmware_update/firmware_update_http.hpp
@@ -67,6 +67,8 @@ private:
   void handleFinalize(WiFiClient &client);
   void handleCancel(WiFiClient &client);
   void resetUploadState();
+  void reject(WiFiClient &client, int httpStatus, const std::string &code,
+              const std::string &message);
   void fail(WiFiClient &client, int httpStatus, const std::string &code,
             const std::string &message);
   void rememberError(const std::string &code, const std::string &message);

--- a/esp32/lib/map_transfer_http/map_transfer_http.cpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.cpp
@@ -1,10 +1,10 @@
 #include "map_transfer_http.hpp"
 
 #include <algorithm>
-#include <cctype>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <sys/stat.h>
@@ -44,27 +44,6 @@ static std::string dirnameOf(const std::string &path) {
 static bool startsWith(const std::string &value, const std::string &prefix) {
   return value.size() >= prefix.size() &&
          value.compare(0, prefix.size(), prefix) == 0;
-}
-
-static std::string trim(const std::string &value) {
-  size_t begin = 0;
-  while (begin < value.size() &&
-         std::isspace(static_cast<unsigned char>(value[begin]))) {
-    begin++;
-  }
-  size_t end = value.size();
-  while (end > begin &&
-         std::isspace(static_cast<unsigned char>(value[end - 1]))) {
-    end--;
-  }
-  return value.substr(begin, end - begin);
-}
-
-static std::string lower(std::string value) {
-  std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c) {
-    return static_cast<char>(std::tolower(c));
-  });
-  return value;
 }
 
 static bool safeId(const std::string &value) {
@@ -156,25 +135,6 @@ static std::string urlDecode(const std::string &value) {
   return out;
 }
 
-static bool readLine(WiFiClient &client, std::string &line,
-                     uint32_t timeoutMs = 2000) {
-  line.clear();
-  uint32_t started = millis();
-  while (millis() - started < timeoutMs) {
-    while (client.available()) {
-      char c = static_cast<char>(client.read());
-      if (c == '\r')
-        continue;
-      if (c == '\n')
-        return true;
-      if (line.size() < 512)
-        line.push_back(c);
-    }
-    delay(1);
-  }
-  return false;
-}
-
 static bool parseSessionPath(const std::string &path, std::string &sessionId,
                              std::string &relativePath) {
   if (!startsWith(path, kSessionPrefix))
@@ -212,149 +172,44 @@ void MapTransferHttpServer::configure(std::string storageRoot, uint16_t port) {
   storageRoot_ = std::move(storageRoot);
   if (!storageRoot_.empty() && storageRoot_.back() == '/')
     storageRoot_.pop_back();
-  port_ = port;
-  server_ = WiFiServer(port_);
   installer_ = MapTransferInstaller(storageRoot_);
   if (stateMutex_ == nullptr)
     stateMutex_ = xSemaphoreCreateMutex();
-  configured_ = true;
+  transferServer_.configure(this, port, "BikeComputer-Map");
 }
 
 bool MapTransferHttpServer::setEnabled(bool enabled) {
-  if (!configured_)
-    configure(storageRoot_, port_);
-  lockState();
-  const bool wasEnabled = enabled_;
-  const bool wasStartedAp = startedAp_;
-  unlockState();
-
-  if (enabled && !wasEnabled) {
-    if (WiFi.status() != WL_CONNECTED) {
-      const std::string apSsid = "BikeComputer-Map";
-      WiFi.mode(WIFI_AP);
-      if (!WiFi.softAP(apSsid.c_str())) {
-        lockState();
-        rememberError("wifi_ap", "could not start transfer Wi-Fi");
-        unlockState();
-        return false;
-      }
-      lockState();
-      startedAp_ = true;
-      apSsid_ = apSsid;
-      unlockState();
-      Serial.printf("MAP_TRANSFER_HTTP: started AP ssid=%s ip=%s\n",
-                    apSsid.c_str(), WiFi.softAPIP().toString().c_str());
-    }
-    server_.begin();
-    server_.setNoDelay(true);
-  }
-  if (!enabled && wasEnabled) {
-    server_.stop();
-    if (wasStartedAp) {
-      WiFi.softAPdisconnect(true);
-      WiFi.mode(WIFI_OFF);
-      lockState();
-      startedAp_ = false;
-      apSsid_.clear();
-      unlockState();
-    }
-  }
-  lockState();
-  enabled_ = enabled;
-  unlockState();
-  return true;
+  return transferServer_.setEnabled(enabled);
 }
 
 void MapTransferHttpServer::setLastError(const std::string &code,
                                          const std::string &message) {
-  lockState();
-  rememberError(code, message);
-  unlockState();
+  transferServer_.setLastError(code, message);
 }
 
-void MapTransferHttpServer::process() {
-  if (!enabled_)
-    return;
-  WiFiClient client = server_.accept();
-  if (!client)
-    return;
-  handleClient(client);
-  client.stop();
-}
+void MapTransferHttpServer::process() { transferServer_.process(); }
 
 HttpTransferStatus MapTransferHttpServer::status() const {
-  lockState();
-  const bool configured = configured_;
-  const bool enabled = enabled_;
-  const bool startedAp = startedAp_;
-  const uint16_t port = port_;
-  const std::string apSsid = apSsid_;
-  const std::string lastErrorCode = lastErrorCode_;
-  const std::string lastErrorMessage = lastErrorMessage_;
-  unlockState();
-
-  std::string baseUrl;
-  if (enabled) {
-    IPAddress ip =
-        startedAp ? WiFi.softAPIP() : (WiFi.status() == WL_CONNECTED
-                                           ? WiFi.localIP()
-                                           : IPAddress());
-    if (ip != IPAddress()) {
-      baseUrl = std::string("http://") + ip.toString().c_str() + ":" +
-                std::to_string(port);
-    }
-  }
-  return {configured, enabled, port, baseUrl, apSsid, lastErrorCode,
-          lastErrorMessage};
+  return transferServer_.status();
 }
 
-void MapTransferHttpServer::handleClient(WiFiClient &client) {
-  std::string requestLine;
-  if (!readLine(client, requestLine)) {
-    sendError(client, 408, "timeout", "request timed out");
-    return;
-  }
-  std::stringstream requestStream(requestLine);
-  std::string method;
-  std::string path;
-  std::string version;
-  requestStream >> method >> path >> version;
-  if (method.empty() || path.empty()) {
-    sendError(client, 400, "bad_request", "invalid request line");
-    return;
-  }
-
-  uint64_t contentLength = 0;
-  std::string line;
-  while (readLine(client, line)) {
-    if (line.empty())
-      break;
-    size_t colon = line.find(':');
-    if (colon == std::string::npos)
-      continue;
-    std::string name = lower(trim(line.substr(0, colon)));
-    std::string value = trim(line.substr(colon + 1));
-    if (name == "content-length")
-      contentLength = strtoull(value.c_str(), nullptr, 10);
-  }
-
-  if (method == "GET" && path == kStatusPath) {
+bool MapTransferHttpServer::handleRequest(
+    const device_transfer::HttpRequest &request, WiFiClient &client) {
+  if (request.method == "GET" && request.path == kStatusPath) {
     handleStatus(client);
-    return;
+    return true;
   }
-  if (!enabled_) {
-    sendError(client, 403, "transfer_disabled", "map transfer mode is disabled");
-    return;
-  }
-  Serial.printf("MAP_TRANSFER_HTTP: %s %s length=%llu\n", method.c_str(),
-                path.c_str(), static_cast<unsigned long long>(contentLength));
-  if (method == "HEAD" && handleHead(path, client))
-    return;
-  if (method == "PUT" && handlePut(path, contentLength, client))
-    return;
-  if (method == "POST" && handleActivate(path, client))
-    return;
-  sendError(client, 404, "not_found", "map transfer endpoint not found");
+  Serial.printf("MAP_TRANSFER_HTTP: %s %s length=%llu\n",
+                request.method.c_str(), request.path.c_str(),
+                static_cast<unsigned long long>(request.contentLength));
+  if (request.method == "HEAD" && handleHead(request.path, client))
+    return true;
+  if (request.method == "PUT" &&
+      handlePut(request.path, request.contentLength, client))
+    return true;
+  if (request.method == "POST" && handleActivate(request.path, client))
+    return true;
+  return false;
 }
 
 bool MapTransferHttpServer::handleHead(const std::string &path,
@@ -505,18 +360,19 @@ bool MapTransferHttpServer::handleActivate(const std::string &path,
 void MapTransferHttpServer::handleStatus(WiFiClient &client) {
   std::string activeMapId;
   InstallStatus active = installer_.readActiveMapId(activeMapId);
-  lockState();
-  const bool configured = configured_;
-  const bool enabled = enabled_;
-  const uint16_t port = port_;
-  const std::string lastErrorCode = lastErrorCode_;
-  const std::string lastErrorMessage = lastErrorMessage_;
-  unlockState();
+  HttpTransferStatus transferStatus = status();
 
   std::string body = std::string("{\"configured\":") +
-                     (configured ? "true" : "false") + ",\"enabled\":" +
-                     (enabled ? "true" : "false") + ",\"port\":" +
-                     std::to_string(port);
+                     (transferStatus.configured ? "true" : "false") +
+                     ",\"enabled\":" +
+                     (transferStatus.enabled ? "true" : "false") +
+                     ",\"port\":" + std::to_string(transferStatus.port);
+  if (!transferStatus.baseUrl.empty()) {
+    body += ",\"baseUrl\":\"" + jsonEscape(transferStatus.baseUrl) + "\"";
+  }
+  if (!transferStatus.apSsid.empty()) {
+    body += ",\"apSsid\":\"" + jsonEscape(transferStatus.apSsid) + "\"";
+  }
   if (active.ok) {
     body += ",\"activeMapId\":\"" + jsonEscape(activeMapId) + "\"";
   } else {
@@ -524,9 +380,10 @@ void MapTransferHttpServer::handleStatus(WiFiClient &client) {
             "\",\"message\":\"" + jsonEscape(active.message) + "\"}";
   }
   body += ",\"activation\":" + activationStatusJson();
-  if (!lastErrorCode.empty()) {
-    body += ",\"lastError\":{\"code\":\"" + jsonEscape(lastErrorCode) +
-            "\",\"message\":\"" + jsonEscape(lastErrorMessage) + "\"}";
+  if (!transferStatus.lastErrorCode.empty()) {
+    body += ",\"lastError\":{\"code\":\"" +
+            jsonEscape(transferStatus.lastErrorCode) + "\",\"message\":\"" +
+            jsonEscape(transferStatus.lastErrorMessage) + "\"}";
   }
   body += "}";
   sendJson(client, 200, body);
@@ -534,52 +391,19 @@ void MapTransferHttpServer::handleStatus(WiFiClient &client) {
 
 void MapTransferHttpServer::sendHead(WiFiClient &client, int status,
                                      uint64_t contentLength) {
-  const char *reason = status == 200   ? "OK"
-                       : status == 400 ? "Bad Request"
-                       : status == 403 ? "Forbidden"
-                       : status == 404 ? "Not Found"
-                                       : "Internal Server Error";
-  client.printf("HTTP/1.1 %d %s\r\n", status, reason);
-  client.print("Connection: close\r\n");
-  client.printf("Content-Length: %llu\r\n\r\n",
-                static_cast<unsigned long long>(contentLength));
+  device_transfer::sendHttpHead(client, status, contentLength);
 }
 
 void MapTransferHttpServer::sendJson(WiFiClient &client, int status,
                                      const std::string &body) {
-  const char *reason = status == 200   ? "OK"
-                       : status == 202 ? "Accepted"
-                       : status == 400 ? "Bad Request"
-                       : status == 403 ? "Forbidden"
-                       : status == 404 ? "Not Found"
-                       : status == 409 ? "Conflict"
-                       : status == 408 ? "Request Timeout"
-                       : status == 413 ? "Payload Too Large"
-                                       : "Internal Server Error";
-  client.printf("HTTP/1.1 %d %s\r\n", status, reason);
-  client.print("Content-Type: application/json\r\n");
-  client.print("Connection: close\r\n");
-  client.printf("Content-Length: %u\r\n\r\n",
-                static_cast<unsigned>(body.size()));
-  client.print(body.c_str());
+  device_transfer::sendHttpJson(client, status, body);
 }
 
 void MapTransferHttpServer::sendError(WiFiClient &client, int status,
                                       const std::string &code,
                                       const std::string &message) {
-  lockState();
-  rememberError(code, message);
-  unlockState();
-  sendJson(client, status,
-           std::string("{\"ok\":false,\"error\":{\"code\":\"") +
-               jsonEscape(code) + "\",\"message\":\"" + jsonEscape(message) +
-               "\"}}");
-}
-
-void MapTransferHttpServer::rememberError(const std::string &code,
-                                          const std::string &message) {
-  lastErrorCode_ = code;
-  lastErrorMessage_ = message;
+  transferServer_.setLastError(code, message);
+  device_transfer::sendHttpError(client, status, code, message);
 }
 
 void MapTransferHttpServer::lockState() const {
@@ -619,11 +443,10 @@ void MapTransferHttpServer::finishActivation(const std::string &status,
   activationMapId_ = mapId;
   activationErrorCode_ = errorCode;
   activationErrorMessage_ = errorMessage;
-  if (!errorCode.empty()) {
-    lastErrorCode_ = errorCode;
-    lastErrorMessage_ = errorMessage;
-  }
   unlockState();
+  if (!errorCode.empty()) {
+    transferServer_.setLastError(errorCode, errorMessage);
+  }
 }
 
 void MapTransferHttpServer::runActivationTask(const std::string &sessionId) {

--- a/esp32/lib/map_transfer_http/map_transfer_http.cpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.cpp
@@ -168,35 +168,45 @@ static std::string jsonEscape(const std::string &value) {
 
 } // namespace
 
-void MapTransferHttpServer::configure(std::string storageRoot, uint16_t port) {
+void MapTransferHttpServer::configure(
+    std::string storageRoot, uint16_t port,
+    device_transfer::HttpTransferServer *sharedServer) {
   storageRoot_ = std::move(storageRoot);
   if (!storageRoot_.empty() && storageRoot_.back() == '/')
     storageRoot_.pop_back();
   installer_ = MapTransferInstaller(storageRoot_);
   if (stateMutex_ == nullptr)
     stateMutex_ = xSemaphoreCreateMutex();
-  transferServer_.configure(this, port, "BikeComputer-Map");
+  transferServer_ = sharedServer == nullptr ? &ownedTransferServer_ : sharedServer;
+  if (sharedServer == nullptr)
+    transferServer_->configure(port, "BikeComputer-Transfer");
+  transferServer_->registerHandler("/map-transfer", this);
 }
 
 bool MapTransferHttpServer::setEnabled(bool enabled) {
-  return transferServer_.setEnabled(enabled);
+  return transferServer_->setEnabled(enabled, enabled ? "map" : "");
 }
 
 void MapTransferHttpServer::setLastError(const std::string &code,
                                          const std::string &message) {
-  transferServer_.setLastError(code, message);
+  transferServer_->setLastError(code, message);
 }
 
-void MapTransferHttpServer::process() { transferServer_.process(); }
+void MapTransferHttpServer::process() { transferServer_->process(); }
 
 HttpTransferStatus MapTransferHttpServer::status() const {
-  return transferServer_.status();
+  return transferServer_->status();
 }
 
 bool MapTransferHttpServer::handleRequest(
     const device_transfer::HttpRequest &request, WiFiClient &client) {
   if (request.method == "GET" && request.path == kStatusPath) {
     handleStatus(client);
+    return true;
+  }
+  if (status().mode != "map") {
+    sendError(client, 403, "transfer_mode_mismatch",
+              "map transfer mode is not active");
     return true;
   }
   Serial.printf("MAP_TRANSFER_HTTP: %s %s length=%llu\n",
@@ -402,7 +412,7 @@ void MapTransferHttpServer::sendJson(WiFiClient &client, int status,
 void MapTransferHttpServer::sendError(WiFiClient &client, int status,
                                       const std::string &code,
                                       const std::string &message) {
-  transferServer_.setLastError(code, message);
+  transferServer_->setLastError(code, message);
   device_transfer::sendHttpError(client, status, code, message);
 }
 
@@ -445,7 +455,7 @@ void MapTransferHttpServer::finishActivation(const std::string &status,
   activationErrorMessage_ = errorMessage;
   unlockState();
   if (!errorCode.empty()) {
-    transferServer_.setLastError(errorCode, errorMessage);
+    transferServer_->setLastError(errorCode, errorMessage);
   }
 }
 

--- a/esp32/lib/map_transfer_http/map_transfer_http.hpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.hpp
@@ -13,7 +13,8 @@ using HttpTransferStatus = device_transfer::HttpTransferStatus;
 
 class MapTransferHttpServer : private device_transfer::HttpRequestHandler {
 public:
-  void configure(std::string storageRoot = "/sdcard", uint16_t port = 8080);
+  void configure(std::string storageRoot = "/sdcard", uint16_t port = 8080,
+                 device_transfer::HttpTransferServer *sharedServer = nullptr);
   bool setEnabled(bool enabled);
   void setLastError(const std::string &code, const std::string &message);
   void process();
@@ -21,7 +22,9 @@ public:
 
 private:
   std::string storageRoot_ = "/sdcard";
-  device_transfer::HttpTransferServer transferServer_;
+  device_transfer::HttpTransferServer ownedTransferServer_;
+  device_transfer::HttpTransferServer *transferServer_ =
+      &ownedTransferServer_;
   MapTransferInstaller installer_{"/sdcard"};
   mutable SemaphoreHandle_t stateMutex_ = nullptr;
   bool activationRunning_ = false;

--- a/esp32/lib/map_transfer_http/map_transfer_http.hpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.hpp
@@ -1,25 +1,17 @@
 #pragma once
 
 #include <Arduino.h>
-#include <WiFi.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/semphr.h>
 
+#include "../device_transfer/device_transfer_http.hpp"
 #include "map_transfer.hpp"
 
 namespace map_transfer {
 
-struct HttpTransferStatus {
-  bool configured = false;
-  bool enabled = false;
-  uint16_t port = 8080;
-  std::string baseUrl;
-  std::string apSsid;
-  std::string lastErrorCode;
-  std::string lastErrorMessage;
-};
+using HttpTransferStatus = device_transfer::HttpTransferStatus;
 
-class MapTransferHttpServer {
+class MapTransferHttpServer : private device_transfer::HttpRequestHandler {
 public:
   void configure(std::string storageRoot = "/sdcard", uint16_t port = 8080);
   bool setEnabled(bool enabled);
@@ -29,16 +21,9 @@ public:
 
 private:
   std::string storageRoot_ = "/sdcard";
-  uint16_t port_ = 8080;
-  bool configured_ = false;
-  bool enabled_ = false;
-  bool startedAp_ = false;
-  std::string apSsid_;
-  WiFiServer server_{8080};
+  device_transfer::HttpTransferServer transferServer_;
   MapTransferInstaller installer_{"/sdcard"};
   mutable SemaphoreHandle_t stateMutex_ = nullptr;
-  std::string lastErrorCode_;
-  std::string lastErrorMessage_;
   bool activationRunning_ = false;
   std::string activationSessionId_;
   std::string activationStatus_ = "idle";
@@ -46,7 +31,8 @@ private:
   std::string activationErrorCode_;
   std::string activationErrorMessage_;
 
-  void handleClient(WiFiClient &client);
+  bool handleRequest(const device_transfer::HttpRequest &request,
+                     WiFiClient &client) override;
   bool handlePut(const std::string &path, uint64_t contentLength,
                  WiFiClient &client);
   bool handleHead(const std::string &path, WiFiClient &client);
@@ -56,7 +42,6 @@ private:
   void sendJson(WiFiClient &client, int status, const std::string &body);
   void sendError(WiFiClient &client, int status, const std::string &code,
                  const std::string &message);
-  void rememberError(const std::string &code, const std::string &message);
   void lockState() const;
   void unlockState() const;
   std::string activationStatusJson() const;

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.2.3
-revision = 87
+version = 0.2.4
+revision = 88
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0
@@ -177,8 +177,9 @@ monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 extra_scripts = pre:prebuild.py
 
-; Use pioarduino platform for Arduino Core 3.x (required for Arduino_GFX 1.4.7+)
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+; Use pioarduino platform for Arduino Core 3.x (required for Arduino_GFX 1.4.7+).
+; Pin the release archive so GitHub release firmware matches locally tested builds.
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
 framework = arduino
 
 ; Use Arduino_GFX-compatible libraries
@@ -295,7 +296,7 @@ board_build.arduino.memory_type = qio_opi
 board_build.partitions = default_16MB.csv
 board_upload.flash_size = 16MB
 
-platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip
+platform = https://github.com/pioarduino/platform-espressif32/releases/download/55.03.34/platform-espressif32.zip
 framework = arduino
 
 lib_deps =

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.2.2
-revision = 86
+version = 0.2.3
+revision = 87
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0
@@ -260,6 +260,7 @@ extends = waveshare_amoled_common
 build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_206
+  -DWAVESHARE_206_FORCE_AXP_DISPLAY=1
 
 [env:WAVESHARE_AMOLED_206_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_206

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -175,6 +175,7 @@ board_upload.flash_size = 16MB
 board_build.filesystem = fatfs
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
+extra_scripts = pre:prebuild.py
 
 ; Use pioarduino platform for Arduino Core 3.x (required for Arduino_GFX 1.4.7+)
 platform = https://github.com/pioarduino/platform-espressif32/releases/download/stable/platform-espressif32.zip

--- a/esp32/prebuild.py
+++ b/esp32/prebuild.py
@@ -5,6 +5,8 @@
 import os.path
 from platformio import util
 import shutil
+import subprocess
+from datetime import datetime, timezone
 from SCons.Script import DefaultEnvironment
 
 try:
@@ -22,6 +24,16 @@ srcdir = env.get("PROJECTSRC_DIR")
 flavor = env.get("PIOENV")
 revision = config.get("common","revision")
 version = config.get("common", "version")
+build_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+try:
+    git_sha = subprocess.check_output(
+        ["git", "rev-parse", "--short=12", "HEAD"],
+        cwd=env.get("PROJECT_DIR"),
+        stderr=subprocess.DEVNULL,
+        text=True,
+    ).strip()
+except Exception:
+    git_sha = "unknown"
 
 dfl_lat = os.environ.get('ICENAV3_LAT')
 dfl_lon = os.environ.get('ICENAV3_LON')
@@ -34,6 +46,8 @@ env.Append(BUILD_FLAGS=[
     u'-DREVISION=' + revision + '',
     u'-DVERSION=\\"' + version + '\\"',
     u'-DFLAVOR=\\"' + flavor + '\\"',
+    u'-DGIT_SHA=\\"' + git_sha + '\\"',
+    u'-DBUILD_TIMESTAMP=\\"' + build_timestamp + '\\"',
     u'-D'+ flavor + '=1'
     ])
 

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -350,9 +350,11 @@ void setup() {
 #endif
 
 #ifdef WAVESHARE_AMOLED_206
-  // The 2.06 vendor demos bring the CO5300 up before touching the PMU/I2C
-  // stack. Keep that order so display recovery stays close to the proven
-  // HelloWorld baseline.
+  // OTA rollback/recovery can leave the PMU display rail off. Bring the rail
+  // up before CO5300 init so the panel does not stay black after a bad image.
+  waveshare_board::recoverI2CBus();
+  waveshare_board::i2c::configureBus();
+  waveshare_board::enablePowerRails();
   initTFT();
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare 2.06 display probe complete; holding before I2C/PMU/SD/LVGL/BLE/touch init");
@@ -360,18 +362,20 @@ void setup() {
     delay(1000);
   }
 #endif
-  waveshare_board::recoverI2CBus();
 #endif
 
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#if defined(WAVESHARE_AMOLED_175)
   waveshare_board::i2c::configureBus();
-#else
+#elif !defined(WAVESHARE_AMOLED_206)
   Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
   Wire.begin();
 #endif
 
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#if defined(WAVESHARE_AMOLED_175)
   waveshare_board::enablePowerRails();
+#endif
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare display probe: skipping RTC and IMU init");
 #else

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -59,6 +59,8 @@ extern xSemaphoreHandle gpsMutex;
 #include "power.hpp"
 
 #include "maps.hpp"
+#include "device_transfer_http.hpp"
+#include "firmware_update_http.hpp"
 #include "map_transfer.hpp"
 #include "map_transfer_http.hpp"
 
@@ -80,7 +82,9 @@ extern Storage storage;
 extern Battery battery;
 extern Power power;
 extern Maps mapView;
+device_transfer::HttpTransferServer deviceTransferHttp;
 map_transfer::MapTransferHttpServer mapTransferHttp;
+firmware_update::FirmwareUpdateHttpServer firmwareUpdateHttp;
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 static void processWaveshareBootButton() {
@@ -425,7 +429,9 @@ void setup() {
                     activeStatus.code.c_str(), activeStatus.message.c_str());
     }
   }
-  mapTransferHttp.configure("/sdcard");
+  deviceTransferHttp.configure(8080, "BikeComputer-Transfer");
+  mapTransferHttp.configure("/sdcard", 8080, &deviceTransferHttp);
+  firmwareUpdateHttp.configure(&deviceTransferHttp);
 
   createGpxFolders();
 
@@ -492,6 +498,7 @@ void setup() {
   lv_screen_load(waitingScreen);
 
   log_i("Setup Complete");
+  firmwareUpdateHttp.markRunningAppValid();
 }
 
 /**
@@ -547,5 +554,5 @@ void loop() {
   }
 #endif
 
-  mapTransferHttp.process();
+  deviceTransferHttp.process();
 }

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -77,7 +77,8 @@ struct ContentView: View {
             .sheet(isPresented: $showingSettings) {
                 SettingsView(
                     locationAuthorized: coordinator.isLocationAuthorized,
-                    offlineMapManager: offlineMapManager
+                    offlineMapManager: offlineMapManager,
+                    firmwareUpdateManager: coordinator.firmwareUpdateManager
                 )
                     .environmentObject(coordinator.bleManager)
             }

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -164,7 +164,7 @@ struct ContentView: View {
                 .padding(.horizontal, 12)
             }
         }
-        .padding(.bottom, 12)
+        .padding(.bottom, 24)
         .animation(.spring(response: 0.34, dampingFraction: 0.88), value: isSearchPanelExpanded)
         .animation(.easeInOut(duration: 0.2), value: coordinator.routeCalculation.isCalculating)
         .animation(.easeInOut(duration: 0.2), value: coordinator.isNavigating)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -36,6 +36,8 @@ enum DeviceBLEProtocol {
     static let settingsFallbackPrefix = "MSET"
     static let mapTransferControlPrefix = "MTRN"
     static let mapTransferStatusPrefix = "MSTS"
+    static let deviceTransferControlPrefix = "DTRN"
+    static let deviceTransferStatusPrefix = "DSTS"
 
     static let brightnessSettingID: UInt8 = 12
     static let enabledScreensSettingID: UInt8 = 13

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -221,6 +221,17 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapTransferActiveMapId: String = ""
     @Published var mapTransferLastError: String?
     @Published var mapTransferStatusDescription: String = "unknown"
+    @Published var deviceTransferMode: String = ""
+    @Published var deviceTransferBaseURL: URL?
+    @Published var deviceTransferAccessPointSSID: String?
+    @Published var deviceTransferSessionToken: String?
+    @Published var firmwareTarget: String = ""
+    @Published var firmwareVersion: String = ""
+    @Published var firmwareBuild: Int = 0
+    @Published var firmwareUpdateStatus: String = "unknown"
+    @Published var firmwareUpdateReceivedBytes: Int = 0
+    @Published var firmwareUpdateTotalBytes: Int = 0
+    @Published var firmwareUpdateLastError: String?
     @Published var deviceHasSDCard: Bool?
     @Published var deviceMapFoundForCurrentLocation: Bool?
     @Published var deviceMapBlockCount: Int = 0
@@ -719,6 +730,32 @@ class BLEManager: NSObject, ObservableObject {
         return sentNative || sentFallback
     }
 
+    @discardableResult
+    func requestDeviceTransferMode(_ mode: DeviceTransferSession.Mode) -> Bool {
+        var packet = Data(DeviceBLEProtocol.deviceTransferControlPrefix.utf8)
+        packet.append(Data("enter|\(mode.rawValue)".utf8))
+        let sentNative = sendNativeMapTransferPacket(packet, label: "\(mode.rawValue) transfer enter")
+        let sentFallback = sendFallbackMapPacket(packet, label: "\(mode.rawValue) transfer enter")
+        return sentNative || sentFallback
+    }
+
+    @discardableResult
+    func requestDeviceTransferExit() -> Bool {
+        var packet = Data(DeviceBLEProtocol.deviceTransferControlPrefix.utf8)
+        packet.append(Data("exit".utf8))
+        let sentNative = sendNativeMapTransferPacket(packet, label: "device transfer exit")
+        let sentFallback = sendFallbackMapPacket(packet, label: "device transfer exit")
+        return sentNative || sentFallback
+    }
+
+    @discardableResult
+    func requestDeviceTransferStatus() -> Bool {
+        let packet = Data(DeviceBLEProtocol.deviceTransferStatusPrefix.utf8)
+        let sentNative = sendNativeMapTransferPacket(packet, label: "device transfer status")
+        let sentFallback = sendFallbackMapPacket(packet, label: "device transfer status")
+        return sentNative || sentFallback
+    }
+
     func sendDebugNavigationPacket() {
         let packet = "\(NavigationIconID.left)|123|Debug turn left"
         guard sendNavigationData(packet) else {
@@ -791,11 +828,7 @@ class BLEManager: NSObject, ObservableObject {
         settingsCharacteristic = nil
         navigationWriteEndpoint = nil
         isNavigationReady = false
-        mapTransferModeEnabled = false
-        mapTransferBaseURL = nil
-        mapTransferAccessPointSSID = nil
-        mapTransferLastError = nil
-        mapTransferStatusDescription = "unknown"
+        clearTransferState()
         deviceHasSDCard = nil
         deviceMapFoundForCurrentLocation = nil
         deviceMapBlockCount = 0
@@ -875,7 +908,24 @@ class BLEManager: NSObject, ObservableObject {
         authRetryTimer = nil
         authTimeoutTimer?.invalidate()
         authTimeoutTimer = nil
+        clearTransferState()
         stopMonitoringRSSI()
+    }
+
+    private func clearTransferState() {
+        mapTransferModeEnabled = false
+        mapTransferBaseURL = nil
+        mapTransferAccessPointSSID = nil
+        mapTransferLastError = nil
+        mapTransferStatusDescription = "unknown"
+        deviceTransferMode = ""
+        deviceTransferBaseURL = nil
+        deviceTransferAccessPointSSID = nil
+        deviceTransferSessionToken = nil
+        firmwareUpdateStatus = "unknown"
+        firmwareUpdateReceivedBytes = 0
+        firmwareUpdateTotalBytes = 0
+        firmwareUpdateLastError = nil
     }
 
     private func updateTrustedPeripheralDescription() {
@@ -1321,11 +1371,7 @@ extension BLEManager: CBCentralManagerDelegate {
         settingsCharacteristic = nil
         navigationWriteEndpoint = nil
         isNavigationReady = false
-        mapTransferModeEnabled = false
-        mapTransferBaseURL = nil
-        mapTransferAccessPointSSID = nil
-        mapTransferLastError = nil
-        mapTransferStatusDescription = "unknown"
+        clearTransferState()
         deviceHasSDCard = nil
         deviceMapFoundForCurrentLocation = nil
         deviceMapBlockCount = 0
@@ -1560,6 +1606,11 @@ extension BLEManager: CBPeripheralDelegate {
         }
 
         if characteristic.uuid == characteristicUUID,
+           handleDeviceTransferStatusNotification(data) {
+            return
+        }
+
+        if characteristic.uuid == characteristicUUID,
            handleMapTransferStatusNotification(data) {
             return
         }
@@ -1586,6 +1637,50 @@ extension BLEManager: CBPeripheralDelegate {
             model: deviceInformation[modelNumberCharacteristicUUID],
             hardware: deviceInformation[hardwareRevisionCharacteristicUUID]
         )
+    }
+
+    @discardableResult
+    func handleDeviceTransferStatusNotification(_ data: Data) -> Bool {
+        guard data.count >= 4,
+              String(data: data.prefix(4), encoding: .utf8) == DeviceBLEProtocol.deviceTransferStatusPrefix else {
+            return false
+        }
+
+        let body = data.dropFirst(4)
+        guard let object = try? JSONSerialization.jsonObject(with: Data(body)) as? [String: Any] else {
+            firmwareUpdateStatus = "invalid status"
+            log("Received invalid device transfer status payload")
+            return true
+        }
+
+        let enabled = object["enabled"] as? Bool ?? false
+        deviceTransferMode = object["mode"] as? String ?? ""
+        if let baseURLString = object["baseUrl"] as? String {
+            deviceTransferBaseURL = URL(string: baseURLString)
+        } else {
+            deviceTransferBaseURL = nil
+        }
+        deviceTransferAccessPointSSID = object["apSsid"] as? String
+        deviceTransferSessionToken = object["sessionToken"] as? String
+
+        if let firmware = object["firmware"] as? [String: Any] {
+            firmwareUpdateStatus = firmware["status"] as? String ?? (enabled ? "unknown" : "idle")
+            firmwareTarget = firmware["target"] as? String ?? firmwareTarget
+            firmwareVersion = firmware["version"] as? String ?? firmwareVersion
+            firmwareBuild = firmware["build"] as? Int ?? firmwareBuild
+            firmwareUpdateReceivedBytes = firmware["receivedBytes"] as? Int ?? 0
+            firmwareUpdateTotalBytes = firmware["totalBytes"] as? Int ?? 0
+            if let lastError = firmware["lastError"] as? [String: Any] {
+                let code = lastError["code"] as? String ?? "error"
+                let message = lastError["message"] as? String ?? ""
+                firmwareUpdateLastError = message.isEmpty ? code : "\(code): \(message)"
+            } else {
+                firmwareUpdateLastError = nil
+            }
+        }
+
+        log("Device transfer status: \(deviceTransferMode.isEmpty ? "none" : deviceTransferMode)")
+        return true
     }
 
     @discardableResult

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -228,6 +228,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var firmwareTarget: String = ""
     @Published var firmwareVersion: String = ""
     @Published var firmwareBuild: Int = 0
+    @Published var firmwareGitSha: String = ""
     @Published var firmwareUpdateStatus: String = "unknown"
     @Published var firmwareUpdateReceivedBytes: Int = 0
     @Published var firmwareUpdateTotalBytes: Int = 0
@@ -1668,6 +1669,7 @@ extension BLEManager: CBPeripheralDelegate {
             firmwareTarget = firmware["target"] as? String ?? firmwareTarget
             firmwareVersion = firmware["version"] as? String ?? firmwareVersion
             firmwareBuild = firmware["build"] as? Int ?? firmwareBuild
+            firmwareGitSha = firmware["gitSha"] as? String ?? firmwareGitSha
             firmwareUpdateReceivedBytes = firmware["receivedBytes"] as? Int ?? 0
             firmwareUpdateTotalBytes = firmware["totalBytes"] as? Int ?? 0
             if let lastError = firmware["lastError"] as? [String: Any] {

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -179,9 +179,12 @@ class BikeComputerCoordinator: ObservableObject {
             .removeDuplicates()
             .filter { $0 }
             .sink { [weak self] _ in
-                guard let self, let location = self.locationManager.currentLocation else { return }
-                self.navEngine.processExternalLocation(location)
+                guard let self else { return }
+                if let location = self.locationManager.currentLocation {
+                    self.navEngine.processExternalLocation(location)
+                }
                 self.requestMapTransferStatusAfterDeviceRefresh()
+                self.bleManager.requestDeviceTransferStatus()
             }
             .store(in: &cancellables)
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -19,6 +19,7 @@ class BikeComputerCoordinator: ObservableObject {
     // MARK: - Private Managers (Implementation Details)
 
     let bleManager = BLEManager()  // Accessible for settings view
+    let firmwareUpdateManager = FirmwareUpdateManager()
     private let navEngine = NavigationEngine()
     private let locationManager = CurrentLocationManager()
     private let healthKitManager = HealthKitManager()
@@ -185,6 +186,7 @@ class BikeComputerCoordinator: ObservableObject {
                 }
                 self.requestMapTransferStatusAfterDeviceRefresh()
                 self.bleManager.requestDeviceTransferStatus()
+                self.scheduleFirmwareUpdateCheckAfterDeviceRefresh()
             }
             .store(in: &cancellables)
 
@@ -296,6 +298,33 @@ class BikeComputerCoordinator: ObservableObject {
             guard let self, self.bleManager.isNavigationReady else { return }
             self.bleManager.requestMapTransferStatus()
         }
+    }
+
+    private func scheduleFirmwareUpdateCheckAfterDeviceRefresh() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            self?.runAutomaticFirmwareUpdateCheck(attempt: 0)
+        }
+    }
+
+    private func runAutomaticFirmwareUpdateCheck(attempt: Int) {
+        guard bleManager.isNavigationReady else { return }
+        guard isFirmwareMetadataReadyForUpdateCheck else {
+            if attempt < 5 {
+                bleManager.requestDeviceTransferStatus()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
+                    self?.runAutomaticFirmwareUpdateCheck(attempt: attempt + 1)
+                }
+            }
+            return
+        }
+        firmwareUpdateManager.checkForUpdateAutomatically(bleManager: bleManager)
+    }
+
+    private var isFirmwareMetadataReadyForUpdateCheck: Bool {
+        !bleManager.firmwareTarget.isEmpty &&
+        !bleManager.firmwareVersion.isEmpty &&
+        bleManager.firmwareBuild > 0 &&
+        !bleManager.firmwareGitSha.isEmpty
     }
 
     // MARK: - Public API: UI State

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
@@ -1,0 +1,134 @@
+//
+//  DeviceTransferManager.swift
+//  BikeComputer
+//
+//  Shared setup for BLE-controlled local Wi-Fi transfers.
+//
+
+import Foundation
+#if os(iOS)
+import NetworkExtension
+#endif
+
+struct DeviceTransferSession: Equatable {
+    enum Mode: String, Equatable {
+        case map
+        case firmware
+    }
+
+    let mode: Mode
+    let baseURL: URL
+    let accessPointSSID: String?
+}
+
+@MainActor
+final class DeviceTransferManager {
+    func enterMapTransfer(
+        bleManager: BLEManager,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> DeviceTransferSession {
+        status("requesting device transfer mode")
+        guard bleManager.isNavigationReady else {
+            throw OfflineMapPlatformError.missingTransferBaseURL
+        }
+
+        guard bleManager.requestMapTransferMode(enabled: true) else {
+            throw OfflineMapPlatformError.missingTransferBaseURL
+        }
+        guard bleManager.requestMapTransferStatus() else {
+            throw OfflineMapPlatformError.missingTransferBaseURL
+        }
+        guard await bleManager.waitForNavigationWritesToDrain(timeoutSeconds: 2) else {
+            throw OfflineMapPlatformError.transferCommandNotSent
+        }
+
+        for attempt in 0..<32 {
+            if bleManager.deviceHasSDCard == false {
+                throw OfflineMapPlatformError.deviceSDCardUnavailable
+            }
+            if bleManager.mapTransferModeEnabled, let baseURL = bleManager.mapTransferBaseURL {
+                let session = DeviceTransferSession(
+                    mode: .map,
+                    baseURL: baseURL,
+                    accessPointSSID: bleManager.mapTransferAccessPointSSID
+                )
+                await joinDeviceNetworkIfNeeded(session: session,
+                                                statusPath: "map-transfer/status",
+                                                status: status)
+                return session
+            }
+            if attempt % 4 == 3 {
+                bleManager.requestMapTransferStatus()
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        throw OfflineMapPlatformError.missingTransferBaseURL
+    }
+
+    func exitMapTransfer(bleManager: BLEManager) {
+        bleManager.requestMapTransferMode(enabled: false)
+    }
+
+    private func joinDeviceNetworkIfNeeded(
+        session: DeviceTransferSession,
+        statusPath: String,
+        status: @escaping @MainActor (String) -> Void
+    ) async {
+        guard session.baseURL.host == "192.168.4.1",
+              let ssid = session.accessPointSSID,
+              !ssid.isEmpty else {
+            return
+        }
+
+#if os(iOS)
+        status("joining device Wi-Fi")
+        let configuration = NEHotspotConfiguration(ssid: ssid)
+        configuration.joinOnce = true
+
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                NEHotspotConfigurationManager.shared.apply(configuration) { error in
+                    if let error = error as NSError? {
+                        let message = error.localizedDescription
+                        if message.localizedCaseInsensitiveContains("already") {
+                            continuation.resume()
+                        } else {
+                            continuation.resume(throwing: error)
+                        }
+                        return
+                    }
+                    continuation.resume()
+                }
+            }
+        } catch {
+            if await isTransferServerReachable(baseURL: session.baseURL,
+                                               statusPath: statusPath) {
+                return
+            }
+            status("using device Wi-Fi")
+            return
+        }
+
+        try? await Task.sleep(nanoseconds: 2_000_000_000)
+        if await isTransferServerReachable(baseURL: session.baseURL,
+                                           statusPath: statusPath) {
+            return
+        }
+        status("using device Wi-Fi")
+#endif
+    }
+
+    private func isTransferServerReachable(baseURL: URL, statusPath: String) async -> Bool {
+        let url = baseURL.appendingPathComponent(statusPath)
+        var request = URLRequest(url: url)
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 3
+
+        do {
+            let (_, response) = try await URLSession.shared.data(for: request)
+            return (response as? HTTPURLResponse)?.statusCode == 200
+        } catch {
+            return false
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
@@ -19,6 +19,7 @@ struct DeviceTransferSession: Equatable {
     let mode: Mode
     let baseURL: URL
     let accessPointSSID: String?
+    let sessionToken: String?
 }
 
 @MainActor
@@ -50,7 +51,8 @@ final class DeviceTransferManager {
                 let session = DeviceTransferSession(
                     mode: .map,
                     baseURL: baseURL,
-                    accessPointSSID: bleManager.mapTransferAccessPointSSID
+                    accessPointSSID: bleManager.mapTransferAccessPointSSID,
+                    sessionToken: bleManager.deviceTransferSessionToken
                 )
                 await joinDeviceNetworkIfNeeded(session: session,
                                                 statusPath: "map-transfer/status",
@@ -67,6 +69,53 @@ final class DeviceTransferManager {
 
     func exitMapTransfer(bleManager: BLEManager) {
         bleManager.requestMapTransferMode(enabled: false)
+    }
+
+    func enterFirmwareTransfer(
+        bleManager: BLEManager,
+        status: @escaping @MainActor (String) -> Void
+    ) async throws -> DeviceTransferSession {
+        status("requesting firmware transfer mode")
+        guard bleManager.isNavigationReady else {
+            throw FirmwareUpdateError.deviceNotReady
+        }
+
+        guard bleManager.requestDeviceTransferMode(.firmware) else {
+            throw FirmwareUpdateError.transferCommandNotSent
+        }
+        guard bleManager.requestDeviceTransferStatus() else {
+            throw FirmwareUpdateError.transferCommandNotSent
+        }
+        guard await bleManager.waitForNavigationWritesToDrain(timeoutSeconds: 2) else {
+            throw FirmwareUpdateError.transferCommandNotSent
+        }
+
+        for attempt in 0..<32 {
+            if bleManager.deviceTransferMode == DeviceTransferSession.Mode.firmware.rawValue,
+               let baseURL = bleManager.deviceTransferBaseURL,
+               let token = bleManager.deviceTransferSessionToken,
+               !token.isEmpty {
+                let session = DeviceTransferSession(
+                    mode: .firmware,
+                    baseURL: baseURL,
+                    accessPointSSID: bleManager.deviceTransferAccessPointSSID,
+                    sessionToken: token
+                )
+                await joinDeviceNetworkIfNeeded(session: session,
+                                                statusPath: "firmware-update/status",
+                                                status: status)
+                return session
+            }
+            if attempt % 4 == 3 {
+                bleManager.requestDeviceTransferStatus()
+            }
+            try await Task.sleep(nanoseconds: 250_000_000)
+        }
+        throw FirmwareUpdateError.missingTransferSession
+    }
+
+    func exitFirmwareTransfer(bleManager: BLEManager) {
+        bleManager.requestDeviceTransferExit()
     }
 
     private func joinDeviceNetworkIfNeeded(

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
@@ -56,6 +56,7 @@ final class DeviceTransferManager {
                 )
                 await joinDeviceNetworkIfNeeded(session: session,
                                                 statusPath: "map-transfer/status",
+                                                sessionToken: session.sessionToken,
                                                 status: status)
                 return session
             }
@@ -103,6 +104,7 @@ final class DeviceTransferManager {
                 )
                 await joinDeviceNetworkIfNeeded(session: session,
                                                 statusPath: "firmware-update/status",
+                                                sessionToken: session.sessionToken,
                                                 status: status)
                 return session
             }
@@ -121,6 +123,7 @@ final class DeviceTransferManager {
     private func joinDeviceNetworkIfNeeded(
         session: DeviceTransferSession,
         statusPath: String,
+        sessionToken: String?,
         status: @escaping @MainActor (String) -> Void
     ) async {
         guard session.baseURL.host == "192.168.4.1",
@@ -151,7 +154,8 @@ final class DeviceTransferManager {
             }
         } catch {
             if await isTransferServerReachable(baseURL: session.baseURL,
-                                               statusPath: statusPath) {
+                                               statusPath: statusPath,
+                                               sessionToken: sessionToken) {
                 return
             }
             status("using device Wi-Fi")
@@ -160,18 +164,24 @@ final class DeviceTransferManager {
 
         try? await Task.sleep(nanoseconds: 2_000_000_000)
         if await isTransferServerReachable(baseURL: session.baseURL,
-                                           statusPath: statusPath) {
+                                           statusPath: statusPath,
+                                           sessionToken: sessionToken) {
             return
         }
         status("using device Wi-Fi")
 #endif
     }
 
-    private func isTransferServerReachable(baseURL: URL, statusPath: String) async -> Bool {
+    private func isTransferServerReachable(baseURL: URL,
+                                           statusPath: String,
+                                           sessionToken: String?) async -> Bool {
         let url = baseURL.appendingPathComponent(statusPath)
         var request = URLRequest(url: url)
         request.cachePolicy = .reloadIgnoringLocalCacheData
         request.timeoutInterval = 3
+        if let sessionToken, !sessionToken.isEmpty {
+            request.setValue(sessionToken, forHTTPHeaderField: "X-BikeComputer-Transfer-Token")
+        }
 
         do {
             let (_, response) = try await URLSession.shared.data(for: request)

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -1,0 +1,346 @@
+//
+//  FirmwareUpdateManager.swift
+//  BikeComputer
+//
+//  iPhone-driven firmware OTA over the shared device transfer channel.
+//
+
+import Combine
+import CryptoKit
+import Foundation
+
+enum FirmwareUpdateError: LocalizedError, Equatable {
+    case deviceNotReady
+    case transferCommandNotSent
+    case missingTransferSession
+    case missingFirmwareTarget
+    case invalidManifest
+    case updateNotAvailable
+    case unsupportedUpdaterProtocol
+    case targetMismatch
+    case downgradeNotAllowed
+    case downloadSizeMismatch
+    case downloadHashMismatch
+    case serverError(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .deviceNotReady:
+            return "Device is not ready"
+        case .transferCommandNotSent:
+            return "Could not send transfer command"
+        case .missingTransferSession:
+            return "Device did not report a firmware transfer session"
+        case .missingFirmwareTarget:
+            return "Device firmware target is unknown"
+        case .invalidManifest:
+            return "Firmware manifest is invalid"
+        case .updateNotAvailable:
+            return "No newer firmware is available"
+        case .unsupportedUpdaterProtocol:
+            return "Firmware update requires a newer app"
+        case .targetMismatch:
+            return "Firmware target does not match this device"
+        case .downgradeNotAllowed:
+            return "Firmware downgrade is disabled"
+        case .downloadSizeMismatch:
+            return "Downloaded firmware size does not match the manifest"
+        case .downloadHashMismatch:
+            return "Downloaded firmware hash does not match the manifest"
+        case .serverError(let message):
+            return message
+        }
+    }
+}
+
+struct FirmwareReleaseManifest: Codable, Equatable {
+    let schemaVersion: Int
+    let target: String
+    let version: String
+    let build: Int
+    let gitSha: String?
+    let size: Int
+    let sha256: String
+    let url: URL
+    let minUpdaterProtocol: Int
+    let signature: String?
+
+    var isSupportedByApp: Bool {
+        schemaVersion == 1 && minUpdaterProtocol <= 1
+    }
+}
+
+struct FirmwareDeviceStatus: Decodable, Equatable {
+    let status: String
+    let target: String
+    let runningVersion: String
+    let runningBuild: Int
+    let runningPartition: String
+    let inactivePartition: String
+    let otaState: String
+    let maxImageBytes: Int
+    let receivedBytes: Int
+    let totalBytes: Int
+    let sha256: String?
+    let lastError: FirmwareStatusError?
+}
+
+struct FirmwareStatusError: Codable, Equatable {
+    let code: String
+    let message: String
+}
+
+@MainActor
+final class FirmwareUpdateManager: ObservableObject {
+    @Published var manifestBaseURLString: String {
+        didSet { defaults.set(manifestBaseURLString, forKey: Defaults.manifestBaseURLKey) }
+    }
+    @Published var allowDeveloperDowngrade: Bool {
+        didSet { defaults.set(allowDeveloperDowngrade, forKey: Defaults.allowDowngradeKey) }
+    }
+    @Published private(set) var latestManifest: FirmwareReleaseManifest?
+    @Published private(set) var deviceStatus: FirmwareDeviceStatus?
+    @Published private(set) var downloadProgress: Double = 0
+    @Published private(set) var uploadProgress: Double = 0
+    @Published private(set) var statusMessage: String = ""
+    @Published private(set) var errorMessage: String?
+    @Published private(set) var isBusy = false
+
+    private enum Defaults {
+        static let manifestBaseURLKey = "firmware.manifestBaseURL"
+        static let allowDowngradeKey = "firmware.allowDeveloperDowngrade"
+        static let defaultManifestBaseURL = "https://seichris.github.io/open-bike-computer/firmware"
+    }
+
+    private let defaults: UserDefaults
+    private let session: URLSession
+    private let deviceTransferManager = DeviceTransferManager()
+
+    init(defaults: UserDefaults = .standard, session: URLSession = .shared) {
+        self.defaults = defaults
+        self.session = session
+        self.manifestBaseURLString = defaults.string(forKey: Defaults.manifestBaseURLKey) ?? Defaults.defaultManifestBaseURL
+        self.allowDeveloperDowngrade = defaults.bool(forKey: Defaults.allowDowngradeKey)
+    }
+
+    func checkForUpdate(bleManager: BLEManager) {
+        Task {
+            await runBusy {
+                let manifest = try await self.fetchLatestManifest(bleManager: bleManager)
+                self.latestManifest = manifest
+                self.statusMessage = self.isUpdateAllowed(manifest, bleManager: bleManager) ? "firmware update available" : "firmware is current"
+            }
+        }
+    }
+
+    func installLatest(bleManager: BLEManager) {
+        Task {
+            await runBusy {
+                let manifest: FirmwareReleaseManifest
+                if let latestManifest = self.latestManifest {
+                    manifest = latestManifest
+                } else {
+                    manifest = try await self.fetchLatestManifest(bleManager: bleManager)
+                }
+                try self.validateInstall(manifest, bleManager: bleManager)
+                self.latestManifest = manifest
+                self.statusMessage = "downloading firmware"
+                self.downloadProgress = 0
+                self.uploadProgress = 0
+                let image = try await self.downloadFirmware(manifest: manifest)
+                self.downloadProgress = 1
+                try self.verify(image: image, manifest: manifest)
+
+                var finalized = false
+                let transferSession = try await self.deviceTransferManager.enterFirmwareTransfer(
+                    bleManager: bleManager
+                ) { message in
+                    self.statusMessage = message
+                }
+                defer {
+                    if !finalized {
+                        self.deviceTransferManager.exitFirmwareTransfer(bleManager: bleManager)
+                    }
+                }
+
+                let client = FirmwareUpdateDeviceClient(
+                    baseURL: transferSession.baseURL,
+                    sessionToken: transferSession.sessionToken ?? "",
+                    session: self.session
+                )
+                self.statusMessage = "preparing device update"
+                self.deviceStatus = try await client.begin(manifest: manifest,
+                                                           allowDowngrade: self.allowDeveloperDowngrade)
+                self.statusMessage = "uploading firmware"
+                self.uploadProgress = 0
+                self.deviceStatus = try await client.upload(image: image) { progress in
+                    self.uploadProgress = progress
+                }
+                self.statusMessage = "finalizing firmware"
+                self.deviceStatus = try await client.finalize()
+                finalized = true
+                self.statusMessage = "device rebooting"
+            }
+        }
+    }
+
+    func refreshDeviceFirmwareStatus(bleManager: BLEManager) {
+        bleManager.requestDeviceTransferStatus()
+    }
+
+    private func fetchLatestManifest(bleManager: BLEManager) async throws -> FirmwareReleaseManifest {
+        if bleManager.firmwareTarget.isEmpty {
+            bleManager.requestDeviceTransferStatus()
+            try await Task.sleep(nanoseconds: 500_000_000)
+        }
+        guard !bleManager.firmwareTarget.isEmpty else {
+            throw FirmwareUpdateError.missingFirmwareTarget
+        }
+        guard let baseURL = URL(string: manifestBaseURLString) else {
+            throw FirmwareUpdateError.invalidManifest
+        }
+        let manifestURL = baseURL
+            .appendingPathComponent(bleManager.firmwareTarget)
+            .appendingPathComponent("manifest.json")
+        let (data, response) = try await session.data(from: manifestURL)
+        try Self.validateHTTP(response)
+        let manifest = try JSONDecoder().decode(FirmwareReleaseManifest.self, from: data)
+        guard manifest.isSupportedByApp else {
+            throw FirmwareUpdateError.unsupportedUpdaterProtocol
+        }
+        guard manifest.target == bleManager.firmwareTarget else {
+            throw FirmwareUpdateError.targetMismatch
+        }
+        return manifest
+    }
+
+    private func validateInstall(_ manifest: FirmwareReleaseManifest, bleManager: BLEManager) throws {
+        guard manifest.target == bleManager.firmwareTarget else {
+            throw FirmwareUpdateError.targetMismatch
+        }
+        if manifest.build <= bleManager.firmwareBuild && !allowDeveloperDowngrade {
+            throw FirmwareUpdateError.updateNotAvailable
+        }
+    }
+
+    func isUpdateAllowed(_ manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> Bool {
+        manifest.target == bleManager.firmwareTarget &&
+        (manifest.build > bleManager.firmwareBuild || allowDeveloperDowngrade)
+    }
+
+    private func downloadFirmware(manifest: FirmwareReleaseManifest) async throws -> Data {
+        let (data, response) = try await session.data(from: manifest.url)
+        try Self.validateHTTP(response)
+        return data
+    }
+
+    private func verify(image: Data, manifest: FirmwareReleaseManifest) throws {
+        guard image.count == manifest.size else {
+            throw FirmwareUpdateError.downloadSizeMismatch
+        }
+        guard Self.sha256Hex(image) == manifest.sha256.lowercased() else {
+            throw FirmwareUpdateError.downloadHashMismatch
+        }
+    }
+
+    private func runBusy(_ operation: @MainActor @escaping () async throws -> Void) async {
+        isBusy = true
+        errorMessage = nil
+        do {
+            try await operation()
+        } catch {
+            errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        }
+        isBusy = false
+    }
+
+    private static func validateHTTP(_ response: URLResponse) throws {
+        guard let http = response as? HTTPURLResponse,
+              (200..<300).contains(http.statusCode) else {
+            throw FirmwareUpdateError.serverError("Firmware server request failed")
+        }
+    }
+
+    nonisolated static func sha256Hex(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+struct FirmwareUpdateDeviceClient {
+    let baseURL: URL
+    let sessionToken: String
+    var session: URLSession = .shared
+
+    func begin(manifest: FirmwareReleaseManifest,
+               allowDowngrade: Bool) async throws -> FirmwareDeviceStatus {
+        let body: [String: Any] = [
+            "version": manifest.version,
+            "build": manifest.build,
+            "target": manifest.target,
+            "size": manifest.size,
+            "sha256": manifest.sha256,
+            "manifestSignature": manifest.signature ?? "",
+            "releaseUrl": manifest.url.absoluteString,
+            "allowDowngrade": allowDowngrade
+        ]
+        let data = try JSONSerialization.data(withJSONObject: body)
+        return try await request(path: "firmware-update/begin",
+                                 method: "POST",
+                                 body: data,
+                                 contentType: "application/json")
+    }
+
+    @MainActor
+    func upload(image: Data,
+                progress: @escaping @MainActor (Double) -> Void) async throws -> FirmwareDeviceStatus {
+        progress(0)
+        let status: FirmwareDeviceStatus = try await request(path: "firmware-update/image",
+                                                             method: "PUT",
+                                                             body: image,
+                                                             contentType: "application/octet-stream")
+        progress(1)
+        return status
+    }
+
+    func finalize() async throws -> FirmwareDeviceStatus {
+        try await request(path: "firmware-update/finalize",
+                          method: "POST",
+                          body: Data(),
+                          contentType: "application/json")
+    }
+
+    private func request<T: Decodable>(path: String,
+                                       method: String,
+                                       body: Data?,
+                                       contentType: String? = nil) async throws -> T {
+        var request = URLRequest(url: baseURL.appendingPathComponent(path))
+        request.httpMethod = method
+        request.cachePolicy = .reloadIgnoringLocalCacheData
+        request.timeoutInterval = 60
+        request.setValue(sessionToken, forHTTPHeaderField: "X-BikeComputer-Transfer-Token")
+        if let contentType {
+            request.setValue(contentType, forHTTPHeaderField: "Content-Type")
+        }
+        let (data, response) = try await session.upload(for: request, from: body ?? Data())
+        guard let http = response as? HTTPURLResponse else {
+            throw FirmwareUpdateError.serverError("Device did not return HTTP")
+        }
+        guard (200..<300).contains(http.statusCode) else {
+            if let message = Self.errorMessage(from: data) {
+                throw FirmwareUpdateError.serverError(message)
+            }
+            throw FirmwareUpdateError.serverError("Device firmware request failed")
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    private static func errorMessage(from data: Data) -> String? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let error = object["error"] as? [String: Any] else {
+            return nil
+        }
+        let code = error["code"] as? String ?? "error"
+        let message = error["message"] as? String ?? ""
+        return message.isEmpty ? code : "\(code): \(message)"
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -20,6 +20,7 @@ enum FirmwareUpdateError: LocalizedError, Equatable {
     case targetMismatch
     case downgradeNotAllowed
     case invalidManifestSignature
+    case postRebootVerificationFailed
     case downloadSizeMismatch
     case downloadHashMismatch
     case serverError(String)
@@ -46,6 +47,8 @@ enum FirmwareUpdateError: LocalizedError, Equatable {
             return "Firmware downgrade is disabled"
         case .invalidManifestSignature:
             return "Firmware manifest signature is invalid"
+        case .postRebootVerificationFailed:
+            return "Device did not report the updated firmware after reboot"
         case .downloadSizeMismatch:
             return "Downloaded firmware size does not match the manifest"
         case .downloadHashMismatch:
@@ -91,6 +94,14 @@ struct FirmwareDeviceStatus: Decodable, Equatable {
 struct FirmwareStatusError: Codable, Equatable {
     let code: String
     let message: String
+}
+
+struct PendingFirmwareUpdate: Codable, Equatable {
+    let target: String
+    let version: String
+    let build: Int
+    let startedAt: Date
+    var status: String
 }
 
 enum FirmwareManifestSignatureVerifier {
@@ -143,6 +154,7 @@ final class FirmwareUpdateManager: ObservableObject {
     private enum Defaults {
         static let manifestBaseURLKey = "firmware.manifestBaseURL"
         static let allowDowngradeKey = "firmware.allowDeveloperDowngrade"
+        static let pendingUpdateKey = "firmware.pendingUpdate"
         static let defaultManifestBaseURL = "https://seichris.github.io/open-bike-computer/firmware"
     }
 
@@ -155,6 +167,9 @@ final class FirmwareUpdateManager: ObservableObject {
         self.session = session
         self.manifestBaseURLString = defaults.string(forKey: Defaults.manifestBaseURLKey) ?? Defaults.defaultManifestBaseURL
         self.allowDeveloperDowngrade = defaults.bool(forKey: Defaults.allowDowngradeKey)
+        if let pending = loadPendingUpdate() {
+            self.statusMessage = pending.status
+        }
     }
 
     func checkForUpdate(bleManager: BLEManager) {
@@ -179,6 +194,7 @@ final class FirmwareUpdateManager: ObservableObject {
                 try self.validateInstall(manifest, bleManager: bleManager)
                 self.latestManifest = manifest
                 self.statusMessage = "downloading firmware"
+                self.persistPendingUpdate(manifest: manifest, status: self.statusMessage)
                 self.downloadProgress = 0
                 self.uploadProgress = 0
                 let image = try await self.downloadFirmware(manifest: manifest)
@@ -203,23 +219,35 @@ final class FirmwareUpdateManager: ObservableObject {
                     session: self.session
                 )
                 self.statusMessage = "preparing device update"
+                self.updatePendingStatus(self.statusMessage)
                 self.deviceStatus = try await client.begin(manifest: manifest,
                                                            allowDowngrade: self.allowDeveloperDowngrade)
                 self.statusMessage = "uploading firmware"
+                self.updatePendingStatus(self.statusMessage)
                 self.uploadProgress = 0
                 self.deviceStatus = try await client.upload(image: image) { progress in
                     self.uploadProgress = progress
                 }
                 self.statusMessage = "finalizing firmware"
+                self.updatePendingStatus(self.statusMessage)
                 self.deviceStatus = try await client.finalize()
                 finalized = true
                 self.statusMessage = "device rebooting"
+                self.updatePendingStatus(self.statusMessage)
+                try await self.waitForPostRebootVerification(bleManager: bleManager,
+                                                             manifest: manifest)
+                self.statusMessage = "firmware update installed"
+                self.clearPendingUpdate()
             }
         }
     }
 
     func refreshDeviceFirmwareStatus(bleManager: BLEManager) {
         bleManager.requestDeviceTransferStatus()
+        Task {
+            try? await Task.sleep(nanoseconds: 600_000_000)
+            self.reconcilePendingUpdate(bleManager: bleManager)
+        }
     }
 
     private func fetchLatestManifest(bleManager: BLEManager) async throws -> FirmwareReleaseManifest {
@@ -280,6 +308,82 @@ final class FirmwareUpdateManager: ObservableObject {
         }
     }
 
+    private func waitForPostRebootVerification(bleManager: BLEManager,
+                                               manifest: FirmwareReleaseManifest) async throws {
+        var sawDeviceUnavailable = !bleManager.isNavigationReady
+        for attempt in 0..<90 {
+            if bleManager.isNavigationReady {
+                bleManager.requestDeviceTransferStatus()
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                if sawDeviceUnavailable && isDeviceRunning(manifest, bleManager: bleManager) {
+                    return
+                }
+            } else {
+                sawDeviceUnavailable = true
+                if attempt % 4 == 0 {
+                    bleManager.reconnectToLastDevice()
+                }
+            }
+            try await Task.sleep(nanoseconds: 1_000_000_000)
+        }
+        updatePendingStatus("firmware update status unknown")
+        throw FirmwareUpdateError.postRebootVerificationFailed
+    }
+
+    private func reconcilePendingUpdate(bleManager: BLEManager) {
+        guard let pending = loadPendingUpdate() else { return }
+        if bleManager.firmwareTarget == pending.target &&
+            bleManager.firmwareVersion == pending.version &&
+            bleManager.firmwareBuild == pending.build {
+            statusMessage = "firmware update installed"
+            clearPendingUpdate()
+        } else if let error = bleManager.firmwareUpdateLastError {
+            statusMessage = "firmware update failed: \(error)"
+            updatePendingStatus(statusMessage)
+        } else {
+            statusMessage = pending.status
+        }
+    }
+
+    private func isDeviceRunning(_ manifest: FirmwareReleaseManifest,
+                                 bleManager: BLEManager) -> Bool {
+        bleManager.firmwareTarget == manifest.target &&
+        bleManager.firmwareVersion == manifest.version &&
+        bleManager.firmwareBuild == manifest.build
+    }
+
+    private func persistPendingUpdate(manifest: FirmwareReleaseManifest, status: String) {
+        let pending = PendingFirmwareUpdate(target: manifest.target,
+                                            version: manifest.version,
+                                            build: manifest.build,
+                                            startedAt: Date(),
+                                            status: status)
+        savePendingUpdate(pending)
+    }
+
+    private func updatePendingStatus(_ status: String) {
+        guard var pending = loadPendingUpdate() else { return }
+        pending.status = status
+        savePendingUpdate(pending)
+    }
+
+    private func loadPendingUpdate() -> PendingFirmwareUpdate? {
+        guard let data = defaults.data(forKey: Defaults.pendingUpdateKey) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(PendingFirmwareUpdate.self, from: data)
+    }
+
+    private func savePendingUpdate(_ pending: PendingFirmwareUpdate) {
+        if let data = try? JSONEncoder().encode(pending) {
+            defaults.set(data, forKey: Defaults.pendingUpdateKey)
+        }
+    }
+
+    private func clearPendingUpdate() {
+        defaults.removeObject(forKey: Defaults.pendingUpdateKey)
+    }
+
     private func runBusy(_ operation: @MainActor @escaping () async throws -> Void) async {
         isBusy = true
         errorMessage = nil
@@ -287,6 +391,7 @@ final class FirmwareUpdateManager: ObservableObject {
             try await operation()
         } catch {
             errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            updatePendingStatus(errorMessage ?? "firmware update failed")
         }
         isBusy = false
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -19,6 +19,7 @@ enum FirmwareUpdateError: LocalizedError, Equatable {
     case unsupportedUpdaterProtocol
     case targetMismatch
     case downgradeNotAllowed
+    case invalidManifestSignature
     case downloadSizeMismatch
     case downloadHashMismatch
     case serverError(String)
@@ -43,6 +44,8 @@ enum FirmwareUpdateError: LocalizedError, Equatable {
             return "Firmware target does not match this device"
         case .downgradeNotAllowed:
             return "Firmware downgrade is disabled"
+        case .invalidManifestSignature:
+            return "Firmware manifest signature is invalid"
         case .downloadSizeMismatch:
             return "Downloaded firmware size does not match the manifest"
         case .downloadHashMismatch:
@@ -88,6 +91,37 @@ struct FirmwareDeviceStatus: Decodable, Equatable {
 struct FirmwareStatusError: Codable, Equatable {
     let code: String
     let message: String
+}
+
+enum FirmwareManifestSignatureVerifier {
+    static let publicKeyBase64 = "BLaIQlnOfdWu7uvpUR2V/Nhbk92m95BL+MP2ovOCAGkf4N0eDhMNH4cTiD8g6qm0IgAi2/xe0sNOMvCMGYwPlCs="
+
+    static func verify(_ manifest: FirmwareReleaseManifest,
+                       publicKeyBase64: String = publicKeyBase64) -> Bool {
+        guard let signature = manifest.signature,
+              let publicKeyData = Data(base64Encoded: publicKeyBase64),
+              let signatureData = Data(base64Encoded: signature),
+              let publicKey = try? P256.Signing.PublicKey(x963Representation: publicKeyData),
+              let signature = try? P256.Signing.ECDSASignature(derRepresentation: signatureData) else {
+            return false
+        }
+        let payload = canonicalPayload(for: manifest)
+        return publicKey.isValidSignature(signature, for: Data(payload.utf8))
+    }
+
+    static func canonicalPayload(for manifest: FirmwareReleaseManifest) -> String {
+        [
+            "schemaVersion=\(manifest.schemaVersion)",
+            "target=\(manifest.target)",
+            "version=\(manifest.version)",
+            "build=\(manifest.build)",
+            "gitSha=\(manifest.gitSha ?? "")",
+            "size=\(manifest.size)",
+            "sha256=\(manifest.sha256)",
+            "url=\(manifest.url.absoluteString)",
+            "minUpdaterProtocol=\(manifest.minUpdaterProtocol)"
+        ].joined(separator: "\n") + "\n"
+    }
 }
 
 @MainActor
@@ -211,6 +245,9 @@ final class FirmwareUpdateManager: ObservableObject {
         guard manifest.target == bleManager.firmwareTarget else {
             throw FirmwareUpdateError.targetMismatch
         }
+        guard FirmwareManifestSignatureVerifier.verify(manifest) else {
+            throw FirmwareUpdateError.invalidManifestSignature
+        }
         return manifest
     }
 
@@ -274,11 +311,14 @@ struct FirmwareUpdateDeviceClient {
     func begin(manifest: FirmwareReleaseManifest,
                allowDowngrade: Bool) async throws -> FirmwareDeviceStatus {
         let body: [String: Any] = [
+            "schemaVersion": manifest.schemaVersion,
             "version": manifest.version,
             "build": manifest.build,
             "target": manifest.target,
+            "gitSha": manifest.gitSha ?? "",
             "size": manifest.size,
             "sha256": manifest.sha256,
+            "minUpdaterProtocol": manifest.minUpdaterProtocol,
             "manifestSignature": manifest.signature ?? "",
             "releaseUrl": manifest.url.absoluteString,
             "allowDowngrade": allowDowngrade

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -164,7 +164,7 @@ final class FirmwareUpdateManager: ObservableObject {
     private let defaults: UserDefaults
     private let session: URLSession
     private let deviceTransferManager = DeviceTransferManager()
-    private var lastAutomaticCheckDeviceKey: String?
+    private var lastSuccessfulAutomaticCheckDeviceKey: String?
 
     init(defaults: UserDefaults = .standard, session: URLSession = .shared) {
         self.defaults = defaults
@@ -190,8 +190,8 @@ final class FirmwareUpdateManager: ObservableObject {
     func checkForUpdateAutomatically(bleManager: BLEManager) {
         guard !isBusy, bleManager.isNavigationReady else { return }
         let deviceKey = automaticCheckDeviceKey(bleManager: bleManager)
-        guard !deviceKey.isEmpty, deviceKey != lastAutomaticCheckDeviceKey else { return }
-        lastAutomaticCheckDeviceKey = deviceKey
+        guard !deviceKey.isEmpty,
+              deviceKey != lastSuccessfulAutomaticCheckDeviceKey else { return }
 
         Task {
             await runQuietly {
@@ -199,6 +199,7 @@ final class FirmwareUpdateManager: ObservableObject {
                 self.latestManifest = manifest
                 self.statusMessage = self.availabilityMessage(for: manifest, bleManager: bleManager)
                 self.errorMessage = nil
+                self.lastSuccessfulAutomaticCheckDeviceKey = deviceKey
             }
         }
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -81,6 +81,7 @@ struct FirmwareDeviceStatus: Decodable, Equatable {
     let target: String
     let runningVersion: String
     let runningBuild: Int
+    let runningGitSha: String?
     let runningPartition: String
     let inactivePartition: String
     let otaState: String
@@ -100,6 +101,7 @@ struct PendingFirmwareUpdate: Codable, Equatable {
     let target: String
     let version: String
     let build: Int
+    let gitSha: String
     let startedAt: Date
     var status: String
 }
@@ -149,6 +151,7 @@ final class FirmwareUpdateManager: ObservableObject {
     @Published private(set) var uploadProgress: Double = 0
     @Published private(set) var statusMessage: String = ""
     @Published private(set) var errorMessage: String?
+    @Published private(set) var lastManifestURLString: String = ""
     @Published private(set) var isBusy = false
 
     private enum Defaults {
@@ -175,6 +178,7 @@ final class FirmwareUpdateManager: ObservableObject {
     func checkForUpdate(bleManager: BLEManager) {
         Task {
             await runBusy {
+                self.statusMessage = "checking firmware manifest"
                 let manifest = try await self.fetchLatestManifest(bleManager: bleManager)
                 self.latestManifest = manifest
                 self.statusMessage = self.isUpdateAllowed(manifest, bleManager: bleManager) ? "firmware update available" : "firmware is current"
@@ -264,6 +268,7 @@ final class FirmwareUpdateManager: ObservableObject {
         let manifestURL = baseURL
             .appendingPathComponent(bleManager.firmwareTarget)
             .appendingPathComponent("manifest.json")
+        lastManifestURLString = manifestURL.absoluteString
         let (data, response) = try await session.data(from: manifestURL)
         try Self.validateHTTP(response)
         let manifest = try JSONDecoder().decode(FirmwareReleaseManifest.self, from: data)
@@ -341,7 +346,8 @@ final class FirmwareUpdateManager: ObservableObject {
         guard let pending = loadPendingUpdate() else { return }
         if bleManager.firmwareTarget == pending.target &&
             bleManager.firmwareVersion == pending.version &&
-            bleManager.firmwareBuild == pending.build {
+            bleManager.firmwareBuild == pending.build &&
+            bleManager.firmwareGitSha == pending.gitSha {
             statusMessage = "firmware update installed"
             clearPendingUpdate()
         } else if let error = bleManager.firmwareUpdateLastError {
@@ -356,13 +362,15 @@ final class FirmwareUpdateManager: ObservableObject {
                                  bleManager: BLEManager) -> Bool {
         bleManager.firmwareTarget == manifest.target &&
         bleManager.firmwareVersion == manifest.version &&
-        bleManager.firmwareBuild == manifest.build
+        bleManager.firmwareBuild == manifest.build &&
+        bleManager.firmwareGitSha == manifest.gitSha
     }
 
     private func persistPendingUpdate(manifest: FirmwareReleaseManifest, status: String) {
         let pending = PendingFirmwareUpdate(target: manifest.target,
                                             version: manifest.version,
                                             build: manifest.build,
+                                            gitSha: manifest.gitSha,
                                             startedAt: Date(),
                                             status: status)
         savePendingUpdate(pending)
@@ -398,6 +406,7 @@ final class FirmwareUpdateManager: ObservableObject {
             try await operation()
         } catch {
             errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            statusMessage = errorMessage ?? "firmware update failed"
             updatePendingStatus(errorMessage ?? "firmware update failed")
         }
         isBusy = false

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -164,6 +164,7 @@ final class FirmwareUpdateManager: ObservableObject {
     private let defaults: UserDefaults
     private let session: URLSession
     private let deviceTransferManager = DeviceTransferManager()
+    private var lastAutomaticCheckDeviceKey: String?
 
     init(defaults: UserDefaults = .standard, session: URLSession = .shared) {
         self.defaults = defaults
@@ -182,6 +183,22 @@ final class FirmwareUpdateManager: ObservableObject {
                 let manifest = try await self.fetchLatestManifest(bleManager: bleManager)
                 self.latestManifest = manifest
                 self.statusMessage = self.availabilityMessage(for: manifest, bleManager: bleManager)
+            }
+        }
+    }
+
+    func checkForUpdateAutomatically(bleManager: BLEManager) {
+        guard !isBusy, bleManager.isNavigationReady else { return }
+        let deviceKey = automaticCheckDeviceKey(bleManager: bleManager)
+        guard !deviceKey.isEmpty, deviceKey != lastAutomaticCheckDeviceKey else { return }
+        lastAutomaticCheckDeviceKey = deviceKey
+
+        Task {
+            await runQuietly {
+                let manifest = try await self.fetchLatestManifest(bleManager: bleManager)
+                self.latestManifest = manifest
+                self.statusMessage = self.availabilityMessage(for: manifest, bleManager: bleManager)
+                self.errorMessage = nil
             }
         }
     }
@@ -311,6 +328,11 @@ final class FirmwareUpdateManager: ObservableObject {
         return manifest.build > bleManager.firmwareBuild || allowDeveloperDowngrade
     }
 
+    func isNewerUpdateAvailable(_ manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> Bool {
+        manifest.target == bleManager.firmwareTarget &&
+        manifest.build > bleManager.firmwareBuild
+    }
+
     func availabilityMessage(for manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> String {
         guard manifest.target == bleManager.firmwareTarget else {
             return "firmware target mismatch"
@@ -332,6 +354,21 @@ final class FirmwareUpdateManager: ObservableObject {
         manifest.version == bleManager.firmwareVersion &&
         manifest.build == bleManager.firmwareBuild &&
         manifest.gitSha == bleManager.firmwareGitSha
+    }
+
+    private func automaticCheckDeviceKey(bleManager: BLEManager) -> String {
+        guard !bleManager.firmwareTarget.isEmpty,
+              !bleManager.firmwareVersion.isEmpty,
+              bleManager.firmwareBuild > 0,
+              !bleManager.firmwareGitSha.isEmpty else {
+            return ""
+        }
+        return [
+            bleManager.firmwareTarget,
+            bleManager.firmwareVersion,
+            String(bleManager.firmwareBuild),
+            bleManager.firmwareGitSha
+        ].joined(separator: "|")
     }
 
     private func downloadFirmware(manifest: FirmwareReleaseManifest) async throws -> Data {
@@ -439,6 +476,14 @@ final class FirmwareUpdateManager: ObservableObject {
             updatePendingStatus(errorMessage ?? "firmware update failed")
         }
         isBusy = false
+    }
+
+    private func runQuietly(_ operation: @MainActor @escaping () async throws -> Void) async {
+        do {
+            try await operation()
+        } catch {
+            print("Firmware auto-check failed: \((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)")
+        }
     }
 
     private static func validateHTTP(_ response: URLResponse) throws {

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -64,7 +64,7 @@ struct FirmwareReleaseManifest: Codable, Equatable {
     let target: String
     let version: String
     let build: Int
-    let gitSha: String?
+    let gitSha: String
     let size: Int
     let sha256: String
     let url: URL
@@ -126,7 +126,7 @@ enum FirmwareManifestSignatureVerifier {
             "target=\(manifest.target)",
             "version=\(manifest.version)",
             "build=\(manifest.build)",
-            "gitSha=\(manifest.gitSha ?? "")",
+            "gitSha=\(manifest.gitSha)",
             "size=\(manifest.size)",
             "sha256=\(manifest.sha256)",
             "url=\(manifest.url.absoluteString)",
@@ -272,6 +272,13 @@ final class FirmwareUpdateManager: ObservableObject {
         }
         guard manifest.target == bleManager.firmwareTarget else {
             throw FirmwareUpdateError.targetMismatch
+        }
+        guard !manifest.version.isEmpty,
+              !manifest.gitSha.isEmpty,
+              manifest.size > 0,
+              !manifest.sha256.isEmpty,
+              manifest.signature?.isEmpty == false else {
+            throw FirmwareUpdateError.invalidManifest
         }
         guard FirmwareManifestSignatureVerifier.verify(manifest) else {
             throw FirmwareUpdateError.invalidManifestSignature
@@ -420,7 +427,7 @@ struct FirmwareUpdateDeviceClient {
             "version": manifest.version,
             "build": manifest.build,
             "target": manifest.target,
-            "gitSha": manifest.gitSha ?? "",
+            "gitSha": manifest.gitSha,
             "size": manifest.size,
             "sha256": manifest.sha256,
             "minUpdaterProtocol": manifest.minUpdaterProtocol,

--- a/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift
@@ -181,7 +181,7 @@ final class FirmwareUpdateManager: ObservableObject {
                 self.statusMessage = "checking firmware manifest"
                 let manifest = try await self.fetchLatestManifest(bleManager: bleManager)
                 self.latestManifest = manifest
-                self.statusMessage = self.isUpdateAllowed(manifest, bleManager: bleManager) ? "firmware update available" : "firmware is current"
+                self.statusMessage = self.availabilityMessage(for: manifest, bleManager: bleManager)
             }
         }
     }
@@ -295,14 +295,43 @@ final class FirmwareUpdateManager: ObservableObject {
         guard manifest.target == bleManager.firmwareTarget else {
             throw FirmwareUpdateError.targetMismatch
         }
+        if isCurrentFirmware(manifest, bleManager: bleManager) {
+            throw FirmwareUpdateError.updateNotAvailable
+        }
         if manifest.build <= bleManager.firmwareBuild && !allowDeveloperDowngrade {
             throw FirmwareUpdateError.updateNotAvailable
         }
     }
 
     func isUpdateAllowed(_ manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> Bool {
+        guard manifest.target == bleManager.firmwareTarget,
+              !isCurrentFirmware(manifest, bleManager: bleManager) else {
+            return false
+        }
+        return manifest.build > bleManager.firmwareBuild || allowDeveloperDowngrade
+    }
+
+    func availabilityMessage(for manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> String {
+        guard manifest.target == bleManager.firmwareTarget else {
+            return "firmware target mismatch"
+        }
+        if isCurrentFirmware(manifest, bleManager: bleManager) {
+            return "firmware is current"
+        }
+        if manifest.build > bleManager.firmwareBuild {
+            return "firmware update available"
+        }
+        if allowDeveloperDowngrade {
+            return "developer firmware install available"
+        }
+        return "firmware is current"
+    }
+
+    private func isCurrentFirmware(_ manifest: FirmwareReleaseManifest, bleManager: BLEManager) -> Bool {
         manifest.target == bleManager.firmwareTarget &&
-        (manifest.build > bleManager.firmwareBuild || allowDeveloperDowngrade)
+        manifest.version == bleManager.firmwareVersion &&
+        manifest.build == bleManager.firmwareBuild &&
+        manifest.gitSha == bleManager.firmwareGitSha
     }
 
     private func downloadFirmware(manifest: FirmwareReleaseManifest) async throws -> Data {

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -8,9 +8,6 @@
 import CoreLocation
 import Combine
 import Foundation
-#if os(iOS)
-import NetworkExtension
-#endif
 
 private enum OfflineMapDefaults {
     nonisolated static let serverURLKey = "offlineMap.serverURL"
@@ -56,6 +53,7 @@ final class OfflineMapManager: ObservableObject {
     @Published private(set) var errorMessage: String?
 
     private let defaults: UserDefaults
+    private let deviceTransferManager = DeviceTransferManager()
     private var packDisplayNames: [String: String]
 
     init(defaults: UserDefaults = .standard) {
@@ -352,16 +350,17 @@ final class OfflineMapManager: ObservableObject {
             try OfflineMapPackArchive(url: packURL)
         }.value
         let expectedMapId = try? archive.manifest().mapId
-        statusMessage = "requesting device transfer mode"
-        let baseURL = try await enableDeviceTransferMode(bleManager: bleManager)
-        await joinDeviceTransferNetworkIfNeeded(bleManager: bleManager,
-                                                baseURL: baseURL)
+        let transferSession = try await deviceTransferManager.enterMapTransfer(
+            bleManager: bleManager
+        ) { message in
+            self.statusMessage = message
+        }
         defer {
-            bleManager.requestMapTransferMode(enabled: false)
+            deviceTransferManager.exitMapTransfer(bleManager: bleManager)
         }
         downloadedPackURL = packURL
         let sessionId = transferSessionId(for: expectedMapId)
-        let client = MapTransferDeviceClient(baseURL: baseURL)
+        let client = MapTransferDeviceClient(baseURL: transferSession.baseURL)
         transferProgress = 0
         statusMessage = "uploading to device"
         try await client.upload(archive: archive, sessionId: sessionId) { completed, total, path, didUpload in
@@ -538,93 +537,6 @@ final class OfflineMapManager: ObservableObject {
             return Self.cleanDisplayName(value)
         }
         return nil
-    }
-
-    private func enableDeviceTransferMode(bleManager: BLEManager) async throws -> URL {
-        guard bleManager.isNavigationReady else {
-            throw OfflineMapPlatformError.missingTransferBaseURL
-        }
-
-        guard bleManager.requestMapTransferMode(enabled: true) else {
-            throw OfflineMapPlatformError.missingTransferBaseURL
-        }
-        guard bleManager.requestMapTransferStatus() else {
-            throw OfflineMapPlatformError.missingTransferBaseURL
-        }
-        guard await bleManager.waitForNavigationWritesToDrain(timeoutSeconds: 2) else {
-            throw OfflineMapPlatformError.transferCommandNotSent
-        }
-        for attempt in 0..<32 {
-            if bleManager.deviceHasSDCard == false {
-                throw OfflineMapPlatformError.deviceSDCardUnavailable
-            }
-            if bleManager.mapTransferModeEnabled, let baseURL = bleManager.mapTransferBaseURL {
-                return baseURL
-            }
-            if attempt % 4 == 3 {
-                bleManager.requestMapTransferStatus()
-            }
-            try await Task.sleep(nanoseconds: 250_000_000)
-        }
-        throw OfflineMapPlatformError.missingTransferBaseURL
-    }
-
-    private func joinDeviceTransferNetworkIfNeeded(bleManager: BLEManager,
-                                                   baseURL: URL) async {
-        guard baseURL.host == "192.168.4.1",
-              let ssid = bleManager.mapTransferAccessPointSSID,
-              !ssid.isEmpty else {
-            return
-        }
-
-#if os(iOS)
-        statusMessage = "joining device Wi-Fi"
-        let configuration = NEHotspotConfiguration(ssid: ssid)
-        configuration.joinOnce = true
-
-        do {
-            try await withCheckedThrowingContinuation { continuation in
-                NEHotspotConfigurationManager.shared.apply(configuration) { error in
-                    if let error = error as NSError? {
-                        let message = error.localizedDescription
-                        if message.localizedCaseInsensitiveContains("already") {
-                            continuation.resume()
-                        } else {
-                            continuation.resume(throwing: error)
-                        }
-                        return
-                    }
-                    continuation.resume()
-                }
-            }
-        } catch {
-            if await isDeviceTransferServerReachable(baseURL: baseURL) {
-                return
-            }
-            statusMessage = "using device Wi-Fi"
-            return
-        }
-
-        try? await Task.sleep(nanoseconds: 2_000_000_000)
-        if await isDeviceTransferServerReachable(baseURL: baseURL) {
-            return
-        }
-        statusMessage = "using device Wi-Fi"
-#endif
-    }
-
-    private func isDeviceTransferServerReachable(baseURL: URL) async -> Bool {
-        let url = baseURL.appendingPathComponent("map-transfer/status")
-        var request = URLRequest(url: url)
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        request.timeoutInterval = 3
-
-        do {
-            let (_, response) = try await URLSession.shared.data(for: request)
-            return (response as? HTTPURLResponse)?.statusCode == 200
-        } catch {
-            return false
-        }
     }
 
     private func runBusy(_ operation: @MainActor @escaping () async throws -> Void) async {

--- a/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
@@ -76,12 +76,6 @@ struct RouteSearchPanel: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Capsule()
-                .fill(Color.secondary.opacity(0.35))
-                .frame(width: 38, height: 5)
-                .padding(.top, 8)
-                .padding(.bottom, 10)
-
             if isExpanded {
                 expandedContent
             } else {
@@ -146,7 +140,7 @@ struct RouteSearchPanel: View {
             }
         }
         .padding(.horizontal, 14)
-        .padding(.bottom, 14)
+        .padding(.vertical, 14)
     }
 
     private var destinationSearchField: some View {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -12,6 +12,7 @@ struct SettingsView: View {
     @EnvironmentObject var bleManager: BLEManager
     @Environment(\.openURL) private var openURL
     @ObservedObject private var offlineMapManager: OfflineMapManager
+    @StateObject private var firmwareUpdateManager = FirmwareUpdateManager()
     let locationAuthorized: Bool
 
     init(
@@ -59,7 +60,10 @@ struct SettingsView: View {
                     }
 
                     NavigationLink {
-                        DeveloperSettingsView(offlineMapManager: offlineMapManager)
+                        DeveloperSettingsView(
+                            offlineMapManager: offlineMapManager,
+                            firmwareUpdateManager: firmwareUpdateManager
+                        )
                     } label: {
                         Label("Developer Settings", systemImage: "wrench.and.screwdriver")
                     }
@@ -197,6 +201,91 @@ private struct OfflineMapDeviceTransferSettingsSection: View {
                 ProgressView(value: manager.transferProgress)
             }
         }
+    }
+}
+
+private struct FirmwareUpdateSettingsSection: View {
+    @EnvironmentObject private var bleManager: BLEManager
+    @ObservedObject var manager: FirmwareUpdateManager
+
+    var body: some View {
+        Section(header: Text("Firmware Update")) {
+            SettingsValueRow(
+                title: "Current",
+                value: currentFirmwareSummary
+            )
+            SettingsValueRow(
+                title: "Target",
+                value: bleManager.firmwareTarget.isEmpty ? "unknown" : bleManager.firmwareTarget
+            )
+            SettingsValueRow(
+                title: "Status",
+                value: manager.statusMessage.isEmpty ? bleManager.firmwareUpdateStatus : manager.statusMessage
+            )
+
+            TextField("Manifest Base URL", text: $manager.manifestBaseURLString)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .keyboardType(.URL)
+
+            Toggle("Allow Developer Downgrade", isOn: $manager.allowDeveloperDowngrade)
+
+            if let manifest = manager.latestManifest {
+                SettingsValueRow(
+                    title: "Available",
+                    value: "\(manifest.version) (\(manifest.build))"
+                )
+            }
+
+            if manager.downloadProgress > 0 && manager.downloadProgress < 1 {
+                ProgressView(value: manager.downloadProgress)
+            }
+            if manager.uploadProgress > 0 && manager.uploadProgress < 1 {
+                ProgressView(value: manager.uploadProgress)
+            }
+            if let error = manager.errorMessage ?? bleManager.firmwareUpdateLastError {
+                Text(error)
+                    .font(.caption)
+                    .foregroundColor(.red)
+            }
+
+            Button {
+                manager.refreshDeviceFirmwareStatus(bleManager: bleManager)
+            } label: {
+                Label("Refresh Firmware Status", systemImage: "arrow.clockwise")
+            }
+            .disabled(!bleManager.isNavigationReady)
+
+            Button {
+                manager.checkForUpdate(bleManager: bleManager)
+            } label: {
+                Label("Check for Firmware Update", systemImage: "square.and.arrow.down")
+            }
+            .disabled(manager.isBusy || !bleManager.isNavigationReady)
+
+            Button {
+                manager.installLatest(bleManager: bleManager)
+            } label: {
+                Label("Install Firmware Update", systemImage: "arrow.up.forward.app")
+            }
+            .disabled(!canInstall)
+        }
+    }
+
+    private var canInstall: Bool {
+        guard !manager.isBusy,
+              bleManager.isNavigationReady,
+              let manifest = manager.latestManifest else {
+            return false
+        }
+        return manager.isUpdateAllowed(manifest, bleManager: bleManager)
+    }
+
+    private var currentFirmwareSummary: String {
+        if bleManager.firmwareVersion.isEmpty && bleManager.firmwareBuild == 0 {
+            return "unknown"
+        }
+        return "\(bleManager.firmwareVersion) (\(bleManager.firmwareBuild))"
     }
 }
 
@@ -415,6 +504,7 @@ private struct HardwareCustomizationSettingsView: View {
 private struct DeveloperSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
     @ObservedObject var offlineMapManager: OfflineMapManager
+    @ObservedObject var firmwareUpdateManager: FirmwareUpdateManager
 
     var body: some View {
         Form {
@@ -433,6 +523,7 @@ private struct DeveloperSettingsView: View {
             }
 
             OfflineMapDeviceTransferSettingsSection(manager: offlineMapManager)
+            FirmwareUpdateSettingsSection(manager: firmwareUpdateManager)
 
             Section {
                 HStack {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -12,15 +12,17 @@ struct SettingsView: View {
     @EnvironmentObject var bleManager: BLEManager
     @Environment(\.openURL) private var openURL
     @ObservedObject private var offlineMapManager: OfflineMapManager
-    @StateObject private var firmwareUpdateManager = FirmwareUpdateManager()
+    @ObservedObject private var firmwareUpdateManager: FirmwareUpdateManager
     let locationAuthorized: Bool
 
     init(
         locationAuthorized: Bool = true,
-        offlineMapManager: OfflineMapManager
+        offlineMapManager: OfflineMapManager,
+        firmwareUpdateManager: FirmwareUpdateManager
     ) {
         self.locationAuthorized = locationAuthorized
         self.offlineMapManager = offlineMapManager
+        self.firmwareUpdateManager = firmwareUpdateManager
     }
     
     var body: some View {
@@ -40,6 +42,7 @@ struct SettingsView: View {
                     }
                 }
 
+                MainFirmwareUpdateSection(manager: firmwareUpdateManager)
                 DeviceScreensSettingsSection()
                 SavedMapsSettingsSection(manager: offlineMapManager)
                 if offlineMapManager.isBusy || offlineMapManager.errorMessage != nil {
@@ -71,6 +74,45 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private struct MainFirmwareUpdateSection: View {
+    @EnvironmentObject private var bleManager: BLEManager
+    @ObservedObject var manager: FirmwareUpdateManager
+
+    var body: some View {
+        if let manifest = manager.latestManifest,
+           manager.isNewerUpdateAvailable(manifest, bleManager: bleManager) {
+            Section(header: Text("Firmware Update")) {
+                SettingsValueRow(
+                    title: "Available",
+                    value: "\(manifest.version) (\(manifest.build))"
+                )
+
+                if manager.isBusy, !manager.statusMessage.isEmpty {
+                    StatusValueRow(status: manager.statusMessage, isBusy: true)
+                }
+                if manager.downloadProgress > 0 && manager.downloadProgress < 1 {
+                    ProgressView(value: manager.downloadProgress)
+                }
+                if manager.uploadProgress > 0 && manager.uploadProgress < 1 {
+                    ProgressView(value: manager.uploadProgress)
+                }
+                if let error = manager.errorMessage {
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+
+                Button {
+                    manager.installLatest(bleManager: bleManager)
+                } label: {
+                    Label("Install Update", systemImage: "arrow.up.forward.app")
+                }
+                .disabled(manager.isBusy || !bleManager.isNavigationReady)
+            }
         }
     }
 }
@@ -668,6 +710,9 @@ private struct StatusValueRow: View {
 }
 
 #Preview {
-    SettingsView(offlineMapManager: OfflineMapManager())
+    SettingsView(
+        offlineMapManager: OfflineMapManager(),
+        firmwareUpdateManager: FirmwareUpdateManager()
+    )
         .environmentObject(BLEManager())
 }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -214,6 +214,12 @@ private struct FirmwareUpdateSettingsSection: View {
                 title: "Current",
                 value: currentFirmwareSummary
             )
+            if !bleManager.firmwareGitSha.isEmpty {
+                SettingsValueRow(
+                    title: "Current SHA",
+                    value: String(bleManager.firmwareGitSha.prefix(12))
+                )
+            }
             SettingsValueRow(
                 title: "Target",
                 value: bleManager.firmwareTarget.isEmpty ? "unknown" : bleManager.firmwareTarget
@@ -229,6 +235,13 @@ private struct FirmwareUpdateSettingsSection: View {
                 .keyboardType(.URL)
 
             Toggle("Allow Developer Downgrade", isOn: $manager.allowDeveloperDowngrade)
+
+            if !manager.lastManifestURLString.isEmpty {
+                SettingsValueRow(
+                    title: "Manifest",
+                    value: manager.lastManifestURLString
+                )
+            }
 
             if let manifest = manager.latestManifest {
                 SettingsValueRow(

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -658,6 +658,8 @@ struct NavigationProtocolTests {
         manager.allowDeveloperDowngrade = true
         assert(!manager.isUpdateAllowed(current, bleManager: bleManager),
                "exactly installed firmware should not be installable as an update even with developer downgrade enabled")
+        assert(!manager.isNewerUpdateAvailable(current, bleManager: bleManager),
+               "exactly installed firmware should not show in the main update prompt")
         assertEqual(manager.availabilityMessage(for: current, bleManager: bleManager),
                     "firmware is current",
                     "exactly installed firmware reports current")
@@ -676,6 +678,8 @@ struct NavigationProtocolTests {
         )
         assert(manager.isUpdateAllowed(newer, bleManager: bleManager),
                "newer build should be installable")
+        assert(manager.isNewerUpdateAvailable(newer, bleManager: bleManager),
+               "newer build should show in the main update prompt")
         assertEqual(manager.availabilityMessage(for: newer, bleManager: bleManager),
                     "firmware update available",
                     "newer build reports update available")
@@ -694,6 +698,8 @@ struct NavigationProtocolTests {
         )
         assert(manager.isUpdateAllowed(older, bleManager: bleManager),
                "older build remains installable behind developer downgrade")
+        assert(!manager.isNewerUpdateAvailable(older, bleManager: bleManager),
+               "developer downgrade should not show in the main update prompt")
         assertEqual(manager.availabilityMessage(for: older, bleManager: bleManager),
                     "developer firmware install available",
                     "developer downgrade is not labeled as a normal update")

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -505,7 +505,7 @@ struct NavigationProtocolTests {
           "sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
           "url": "https://github.com/seichris/open-bike-computer/releases/download/v0.4.0/WAVESHARE_AMOLED_175.bin",
           "minUpdaterProtocol": 1,
-          "signature": "base64-signature"
+          "signature": "MEUCIQCoFhwd6SnmvltHkUu5jfNQce/pPk87c84AcHt2u9DmDQIgfwklONo1MEyfgfX0VhlTDyi/B+dGZdsvckb/rFEGOM8="
         }
         """.utf8)
 
@@ -518,6 +518,33 @@ struct NavigationProtocolTests {
         assertEqual(manifest.build, 87, "manifest exposes build")
         assert(manifest.isSupportedByApp, "manifest updater protocol is supported")
         assertEqual(FirmwareUpdateManager.sha256Hex(Data("abc".utf8)), manifest.sha256, "firmware hash verification uses SHA-256 hex")
+        assert(
+            FirmwareManifestSignatureVerifier.verify(
+                manifest,
+                publicKeyBase64: "BGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPShOUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfU="
+            ),
+            "firmware manifest signature verifies over canonical release metadata"
+        )
+
+        let tampered = FirmwareReleaseManifest(
+            schemaVersion: manifest.schemaVersion,
+            target: manifest.target,
+            version: manifest.version,
+            build: manifest.build + 1,
+            gitSha: manifest.gitSha,
+            size: manifest.size,
+            sha256: manifest.sha256,
+            url: manifest.url,
+            minUpdaterProtocol: manifest.minUpdaterProtocol,
+            signature: manifest.signature
+        )
+        assert(
+            !FirmwareManifestSignatureVerifier.verify(
+                tampered,
+                publicKeyBase64: "BGsX0fLhLEJH+Lzm5WOkQPJ3A32BLeszoPShOUXYmMKWT+NC4v4af5uO5+tKfA+eFivOM1drMV7Oy7ZAaDe/UfU="
+            ),
+            "firmware manifest signature rejects tampered metadata"
+        )
     }
 
     static func testNavigationPacketBuilder() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -613,6 +613,7 @@ struct NavigationProtocolTests {
             target: "WAVESHARE_AMOLED_175",
             version: "0.4.0",
             build: 87,
+            gitSha: "abcdef123456",
             startedAt: Date(timeIntervalSince1970: 10),
             status: "device rebooting"
         )

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -560,6 +560,8 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.settingsFallbackPrefix, "MSET", "settings fallback remains framed over navigation writes")
         assertEqual(DeviceBLEProtocol.mapTransferControlPrefix, "MTRN", "map transfer control remains framed over navigation writes")
         assertEqual(DeviceBLEProtocol.mapTransferStatusPrefix, "MSTS", "map transfer status remains framed over navigation notifications")
+        assertEqual(DeviceBLEProtocol.deviceTransferControlPrefix, "DTRN", "generic transfer control remains firmware-compatible")
+        assertEqual(DeviceBLEProtocol.deviceTransferStatusPrefix, "DSTS", "generic transfer status remains firmware-compatible")
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -170,7 +170,9 @@ struct NavigationProtocolTests {
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
         testBLEManagerSendsMapTransferControlFrames()
+        testBLEManagerSendsDeviceTransferControlFrames()
         testBLEManagerParsesMapTransferStatus()
+        testBLEManagerParsesDeviceTransferStatus()
         testBLEManagerSendsBrightnessFallbackSetting()
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
@@ -188,6 +190,7 @@ struct NavigationProtocolTests {
         testOfflineMapManifestDecoding()
         testMapTransferUploadURLEncodesPlusPathComponents()
         testMapTransferDeviceStatusDecodesActivationFailure()
+        testFirmwareManifestDecodingAndHash()
         print("NavigationProtocolTests passed")
     }
 
@@ -490,6 +493,33 @@ struct NavigationProtocolTests {
         assertEqual(status.activation?.error?.message, "sha mismatch for VECTMAP/new-map/1.fmb", "status exposes activation error message")
     }
 
+    static func testFirmwareManifestDecodingAndHash() {
+        let body = Data("""
+        {
+          "schemaVersion": 1,
+          "target": "WAVESHARE_AMOLED_175",
+          "version": "0.4.0",
+          "build": 87,
+          "gitSha": "abcdef123456",
+          "size": 3,
+          "sha256": "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+          "url": "https://github.com/seichris/open-bike-computer/releases/download/v0.4.0/WAVESHARE_AMOLED_175.bin",
+          "minUpdaterProtocol": 1,
+          "signature": "base64-signature"
+        }
+        """.utf8)
+
+        guard let manifest = try? JSONDecoder().decode(FirmwareReleaseManifest.self, from: body) else {
+            assert(false, "firmware manifest should decode")
+            return
+        }
+
+        assertEqual(manifest.target, "WAVESHARE_AMOLED_175", "manifest exposes target")
+        assertEqual(manifest.build, 87, "manifest exposes build")
+        assert(manifest.isSupportedByApp, "manifest updater protocol is supported")
+        assertEqual(FirmwareUpdateManager.sha256Hex(Data("abc".utf8)), manifest.sha256, "firmware hash verification uses SHA-256 hex")
+    }
+
     static func testNavigationPacketBuilder() {
         let shortPacket = "2|150|Turn left"
         guard let shortData = NavigationPacketBuilder.data(from: shortPacket, maxLength: NavigationPacketBuilder.protocolMaxBytes) else {
@@ -694,6 +724,28 @@ struct NavigationProtocolTests {
         assertEqual(String(data: sentPackets[2], encoding: .utf8), "MTRNexit", "exit command uses MTRN frame")
     }
 
+    static func testBLEManagerSendsDeviceTransferControlFrames() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 64,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        assert(manager.requestDeviceTransferMode(.firmware), "firmware transfer enter should queue when BLE is ready")
+        assert(manager.requestDeviceTransferStatus(), "device transfer status should queue when BLE is ready")
+        assert(manager.requestDeviceTransferExit(), "device transfer exit should queue when BLE is ready")
+
+        assertEqual(sentPackets.count, 3, "device transfer control should write three packets")
+        assertEqual(String(data: sentPackets[0], encoding: .utf8), "DTRNenter|firmware", "firmware enter command uses DTRN frame")
+        assertEqual(String(data: sentPackets[1], encoding: .utf8), "DSTS", "status command uses DSTS frame")
+        assertEqual(String(data: sentPackets[2], encoding: .utf8), "DTRNexit", "exit command uses DTRN frame")
+    }
+
     static func testBLEManagerParsesMapTransferStatus() {
         let manager = BLEManager()
         let json = """
@@ -709,6 +761,27 @@ struct NavigationProtocolTests {
         assertEqual(manager.deviceMapFoundForCurrentLocation, false, "status parser exposes current map coverage")
         assertEqual(manager.deviceMapBlockCount, 0, "status parser exposes current map block count")
         assertEqual(manager.mapTransferLastError, "previous: previous upload failed", "status parser exposes last transfer error")
+    }
+
+    static func testBLEManagerParsesDeviceTransferStatus() {
+        let manager = BLEManager()
+        let json = """
+        {"configured":true,"enabled":true,"port":8080,"mode":"firmware","baseUrl":"http://192.168.4.1:8080","apSsid":"BikeComputer-Transfer","sessionToken":"abc123","firmware":{"status":"receiving","target":"WAVESHARE_AMOLED_175","version":"0.2.2","build":86,"updaterProtocol":1,"receivedBytes":1024,"totalBytes":2048,"lastError":{"code":"previous","message":"previous update failed"}}}
+        """
+        let packet = Data(DeviceBLEProtocol.deviceTransferStatusPrefix.utf8) + Data(json.utf8)
+
+        assert(manager.handleDeviceTransferStatusNotification(packet), "DSTS notification should be consumed")
+        assertEqual(manager.deviceTransferMode, "firmware", "status parser exposes transfer mode")
+        assertEqual(manager.deviceTransferBaseURL?.absoluteString, "http://192.168.4.1:8080", "status parser exposes base URL")
+        assertEqual(manager.deviceTransferAccessPointSSID, "BikeComputer-Transfer", "status parser exposes SSID")
+        assertEqual(manager.deviceTransferSessionToken, "abc123", "status parser exposes session token")
+        assertEqual(manager.firmwareTarget, "WAVESHARE_AMOLED_175", "status parser exposes firmware target")
+        assertEqual(manager.firmwareVersion, "0.2.2", "status parser exposes firmware version")
+        assertEqual(manager.firmwareBuild, 86, "status parser exposes firmware build")
+        assertEqual(manager.firmwareUpdateStatus, "receiving", "status parser exposes firmware update status")
+        assertEqual(manager.firmwareUpdateReceivedBytes, 1024, "status parser exposes received bytes")
+        assertEqual(manager.firmwareUpdateTotalBytes, 2048, "status parser exposes total bytes")
+        assertEqual(manager.firmwareUpdateLastError, "previous: previous update failed", "status parser exposes firmware error")
     }
 
     static func testBLEManagerSendsBrightnessFallbackSetting() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -191,6 +191,7 @@ struct NavigationProtocolTests {
         testMapTransferUploadURLEncodesPlusPathComponents()
         testMapTransferDeviceStatusDecodesActivationFailure()
         testFirmwareManifestDecodingAndHash()
+        testFirmwareUpdateManagerRestoresPendingStatus()
         print("NavigationProtocolTests passed")
     }
 
@@ -545,6 +546,31 @@ struct NavigationProtocolTests {
             ),
             "firmware manifest signature rejects tampered metadata"
         )
+    }
+
+    @MainActor
+    static func testFirmwareUpdateManagerRestoresPendingStatus() {
+        let suiteName = "FirmwareUpdateManagerTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            assert(false, "test defaults should be available")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let pending = PendingFirmwareUpdate(
+            target: "WAVESHARE_AMOLED_175",
+            version: "0.4.0",
+            build: 87,
+            startedAt: Date(timeIntervalSince1970: 10),
+            status: "device rebooting"
+        )
+        let data = try? JSONEncoder().encode(pending)
+        defaults.set(data, forKey: "firmware.pendingUpdate")
+
+        let manager = FirmwareUpdateManager(defaults: defaults)
+        assertEqual(manager.statusMessage,
+                    "device rebooting",
+                    "firmware manager restores pending reboot status after app relaunch")
     }
 
     static func testNavigationPacketBuilder() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -243,6 +243,7 @@ struct NavigationProtocolTests {
         testMapTransferDeviceStatusDecodesActivationFailure()
         testFirmwareManifestDecodingAndHash()
         testFirmwareUpdateManagerRestoresPendingStatus()
+        testFirmwareUpdateAvailabilitySemantics()
         testFirmwareDeviceClientSendsSignedBeginRequest()
         print("NavigationProtocolTests passed")
     }
@@ -624,6 +625,78 @@ struct NavigationProtocolTests {
         assertEqual(manager.statusMessage,
                     "device rebooting",
                     "firmware manager restores pending reboot status after app relaunch")
+    }
+
+    @MainActor
+    static func testFirmwareUpdateAvailabilitySemantics() {
+        let suiteName = "FirmwareUpdateAvailabilityTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            assert(false, "test defaults should be available")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let manager = FirmwareUpdateManager(defaults: defaults)
+        let bleManager = BLEManager()
+        bleManager.firmwareTarget = "WAVESHARE_AMOLED_206"
+        bleManager.firmwareVersion = "0.2.4"
+        bleManager.firmwareBuild = 88
+        bleManager.firmwareGitSha = "abcdef123456"
+
+        let current = FirmwareReleaseManifest(
+            schemaVersion: 1,
+            target: "WAVESHARE_AMOLED_206",
+            version: "0.2.4",
+            build: 88,
+            gitSha: "abcdef123456",
+            size: 3,
+            sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            url: URL(string: "https://github.com/seichris/open-bike-computer/releases/download/v0.2.4/WAVESHARE_AMOLED_206.bin")!,
+            minUpdaterProtocol: 1,
+            signature: "signature"
+        )
+        manager.allowDeveloperDowngrade = true
+        assert(!manager.isUpdateAllowed(current, bleManager: bleManager),
+               "exactly installed firmware should not be installable as an update even with developer downgrade enabled")
+        assertEqual(manager.availabilityMessage(for: current, bleManager: bleManager),
+                    "firmware is current",
+                    "exactly installed firmware reports current")
+
+        let newer = FirmwareReleaseManifest(
+            schemaVersion: current.schemaVersion,
+            target: current.target,
+            version: "0.2.5",
+            build: 89,
+            gitSha: "bbbbbb123456",
+            size: current.size,
+            sha256: current.sha256,
+            url: current.url,
+            minUpdaterProtocol: current.minUpdaterProtocol,
+            signature: current.signature
+        )
+        assert(manager.isUpdateAllowed(newer, bleManager: bleManager),
+               "newer build should be installable")
+        assertEqual(manager.availabilityMessage(for: newer, bleManager: bleManager),
+                    "firmware update available",
+                    "newer build reports update available")
+
+        let older = FirmwareReleaseManifest(
+            schemaVersion: current.schemaVersion,
+            target: current.target,
+            version: "0.2.3",
+            build: 87,
+            gitSha: "aaaaaa123456",
+            size: current.size,
+            sha256: current.sha256,
+            url: current.url,
+            minUpdaterProtocol: current.minUpdaterProtocol,
+            signature: current.signature
+        )
+        assert(manager.isUpdateAllowed(older, bleManager: bleManager),
+               "older build remains installable behind developer downgrade")
+        assertEqual(manager.availabilityMessage(for: older, bleManager: bleManager),
+                    "developer firmware install available",
+                    "developer downgrade is not labeled as a normal update")
     }
 
     static func testFirmwareDeviceClientSendsSignedBeginRequest() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -102,6 +102,57 @@ final class TestBLEManager: BLEManager {
     }
 }
 
+final class FirmwareRequestCaptureProtocol: URLProtocol {
+    static var handler: ((URLRequest, Data) throws -> (HTTPURLResponse, Data))?
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        do {
+            guard let handler = Self.handler else {
+                throw FirmwareUpdateError.serverError("missing test handler")
+            }
+            let (response, data) = try handler(request, Self.bodyData(from: request))
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        } catch {
+            client?.urlProtocol(self, didFailWithError: error)
+        }
+    }
+
+    override func stopLoading() {}
+
+    private static func bodyData(from request: URLRequest) -> Data {
+        if let body = request.httpBody {
+            return body
+        }
+        guard let stream = request.httpBodyStream else {
+            return Data()
+        }
+        stream.open()
+        defer { stream.close() }
+        var data = Data()
+        let bufferSize = 4096
+        let buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { buffer.deallocate() }
+        while stream.hasBytesAvailable {
+            let count = stream.read(buffer, maxLength: bufferSize)
+            if count <= 0 {
+                break
+            }
+            data.append(buffer, count: count)
+        }
+        return data
+    }
+}
+
 final class TestRouteStep: MKRoute.Step {
     private let storedInstructions: String
     private let storedPolyline: MKPolyline
@@ -192,6 +243,7 @@ struct NavigationProtocolTests {
         testMapTransferDeviceStatusDecodesActivationFailure()
         testFirmwareManifestDecodingAndHash()
         testFirmwareUpdateManagerRestoresPendingStatus()
+        testFirmwareDeviceClientSendsSignedBeginRequest()
         print("NavigationProtocolTests passed")
     }
 
@@ -571,6 +623,94 @@ struct NavigationProtocolTests {
         assertEqual(manager.statusMessage,
                     "device rebooting",
                     "firmware manager restores pending reboot status after app relaunch")
+    }
+
+    static func testFirmwareDeviceClientSendsSignedBeginRequest() {
+        let manifest = FirmwareReleaseManifest(
+            schemaVersion: 1,
+            target: "WAVESHARE_AMOLED_175",
+            version: "0.4.0",
+            build: 87,
+            gitSha: "abcdef123456",
+            size: 3,
+            sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+            url: URL(string: "https://github.com/seichris/open-bike-computer/releases/download/v0.4.0/WAVESHARE_AMOLED_175.bin")!,
+            minUpdaterProtocol: 1,
+            signature: "MEUCIQCoFhwd6SnmvltHkUu5jfNQce/pPk87c84AcHt2u9DmDQIgfwklONo1MEyfgfX0VhlTDyi/B+dGZdsvckb/rFEGOM8="
+        )
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [FirmwareRequestCaptureProtocol.self]
+        let session = URLSession(configuration: configuration)
+        defer {
+            session.invalidateAndCancel()
+            FirmwareRequestCaptureProtocol.handler = nil
+        }
+
+        FirmwareRequestCaptureProtocol.handler = { request, body in
+            assertEqual(request.httpMethod, "POST", "begin request uses POST")
+            assertEqual(request.url?.path, "/firmware-update/begin", "begin request uses firmware path")
+            assertEqual(request.value(forHTTPHeaderField: "X-BikeComputer-Transfer-Token"), "token-123", "begin request includes transfer token")
+            assertEqual(request.value(forHTTPHeaderField: "Content-Type"), "application/json", "begin request declares JSON")
+            guard let object = try JSONSerialization.jsonObject(with: body) as? [String: Any] else {
+                assert(false, "begin request body should be JSON")
+                throw FirmwareUpdateError.invalidManifest
+            }
+            assertEqual(object["target"] as? String, manifest.target, "begin request sends target")
+            assertEqual(object["gitSha"] as? String, manifest.gitSha, "begin request sends git SHA")
+            assertEqual(object["manifestSignature"] as? String, manifest.signature, "begin request sends manifest signature")
+            assertEqual(object["releaseUrl"] as? String, manifest.url.absoluteString, "begin request sends release URL")
+            assertEqual(object["allowDowngrade"] as? Bool, true, "begin request sends developer downgrade flag")
+
+            let data = Data("""
+            {
+              "status": "receiving",
+              "target": "WAVESHARE_AMOLED_175",
+              "runningVersion": "0.2.2",
+              "runningBuild": 86,
+              "runningPartition": "ota_0",
+              "inactivePartition": "ota_1",
+              "otaState": "valid",
+              "maxImageBytes": 3145728,
+              "receivedBytes": 0,
+              "totalBytes": 3,
+              "sha256": null,
+              "lastError": null
+            }
+            """.utf8)
+            let response = HTTPURLResponse(url: request.url!,
+                                           statusCode: 200,
+                                           httpVersion: nil,
+                                           headerFields: nil)!
+            return (response, data)
+        }
+
+        runAsyncTest {
+            let client = FirmwareUpdateDeviceClient(
+                baseURL: URL(string: "http://192.168.4.1:8080")!,
+                sessionToken: "token-123",
+                session: session
+            )
+            let status = try await client.begin(manifest: manifest, allowDowngrade: true)
+            assertEqual(status.status, "receiving", "begin response decodes firmware status")
+            assertEqual(status.totalBytes, 3, "begin response decodes expected byte count")
+        }
+    }
+
+    static func runAsyncTest(_ operation: @escaping () async throws -> Void) {
+        let semaphore = DispatchSemaphore(value: 0)
+        var failure: Error?
+        Task {
+            do {
+                try await operation()
+            } catch {
+                failure = error
+            }
+            semaphore.signal()
+        }
+        semaphore.wait()
+        if let failure {
+            assert(false, "async test failed: \(failure)")
+        }
     }
 
     static func testNavigationPacketBuilder() {

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -11,6 +11,7 @@ cd "${REPO_DIR}"
 xcrun swiftc \
   -o "${OUT}" \
   ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
   ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift \
   ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -12,6 +12,7 @@ xcrun swiftc \
   -o "${OUT}" \
   ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
   ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift \
   ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \

--- a/tools/firmware_manifest.py
+++ b/tools/firmware_manifest.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Generate and sign firmware release manifests."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import configparser
+import hashlib
+import json
+import pathlib
+import sys
+from dataclasses import dataclass
+
+try:
+    from cryptography.hazmat.primitives import hashes
+    from cryptography.hazmat.primitives.asymmetric import ec
+except ImportError as exc:  # pragma: no cover - exercised in CI by dependency install
+    raise SystemExit(
+        "cryptography is required: python -m pip install cryptography"
+    ) from exc
+
+
+SIGNATURE_FIELDS = (
+    "schemaVersion",
+    "target",
+    "version",
+    "build",
+    "gitSha",
+    "size",
+    "sha256",
+    "url",
+    "minUpdaterProtocol",
+)
+
+
+@dataclass(frozen=True)
+class FirmwareMetadata:
+    version: str
+    build: int
+
+
+def read_firmware_metadata(platformio_ini: pathlib.Path) -> FirmwareMetadata:
+    config = configparser.ConfigParser()
+    with platformio_ini.open("r", encoding="utf-8") as handle:
+        config.read_file(handle)
+    return FirmwareMetadata(
+        version=config.get("common", "version"),
+        build=config.getint("common", "revision"),
+    )
+
+
+def sha256_hex(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def canonical_payload(manifest: dict[str, object]) -> bytes:
+    lines = []
+    for field in SIGNATURE_FIELDS:
+        if field not in manifest:
+            raise ValueError(f"manifest is missing {field}")
+        lines.append(f"{field}={manifest[field]}")
+    return ("\n".join(lines) + "\n").encode("utf-8")
+
+
+def sign_manifest(manifest: dict[str, object], private_key_base64: str) -> str:
+    key_bytes = base64.b64decode(private_key_base64, validate=True)
+    if len(key_bytes) != 32:
+        raise ValueError("P-256 private scalar must be 32 raw bytes encoded as base64")
+    private_value = int.from_bytes(key_bytes, byteorder="big")
+    if private_value <= 0:
+        raise ValueError("P-256 private scalar must be greater than zero")
+    private_key = ec.derive_private_key(private_value, ec.SECP256R1())
+    signature = private_key.sign(
+        canonical_payload(manifest), ec.ECDSA(hashes.SHA256())
+    )
+    return base64.b64encode(signature).decode("ascii")
+
+
+def write_manifest(args: argparse.Namespace) -> None:
+    firmware = args.firmware.resolve()
+    if not firmware.is_file():
+        raise SystemExit(f"firmware image not found: {firmware}")
+
+    metadata = read_firmware_metadata(args.platformio_ini)
+    version = args.version or metadata.version
+    build = args.build if args.build is not None else metadata.build
+    tag = args.tag or f"v{version}"
+    asset_name = args.asset_name or f"{args.target}.bin"
+    release_url = (
+        f"https://github.com/{args.repository}/releases/download/{tag}/{asset_name}"
+    )
+
+    manifest: dict[str, object] = {
+        "schemaVersion": 1,
+        "target": args.target,
+        "version": version,
+        "build": build,
+        "gitSha": args.git_sha,
+        "size": firmware.stat().st_size,
+        "sha256": sha256_hex(firmware),
+        "url": release_url,
+        "minUpdaterProtocol": args.min_updater_protocol,
+    }
+    manifest["signature"] = sign_manifest(manifest, args.private_key_base64)
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as handle:
+        json.dump(manifest, handle, indent=2)
+        handle.write("\n")
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--firmware", type=pathlib.Path, required=True)
+    parser.add_argument("--target", required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--git-sha", required=True)
+    parser.add_argument("--private-key-base64", required=True)
+    parser.add_argument("--output", type=pathlib.Path, required=True)
+    parser.add_argument(
+        "--platformio-ini",
+        type=pathlib.Path,
+        default=pathlib.Path("esp32/platformio.ini"),
+    )
+    parser.add_argument("--version")
+    parser.add_argument("--build", type=int)
+    parser.add_argument("--tag")
+    parser.add_argument("--asset-name")
+    parser.add_argument("--min-updater-protocol", type=int, default=1)
+    args = parser.parse_args(argv)
+    write_manifest(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary
- Add the reusable BLE-controlled local Wi-Fi device transfer layer used by both map uploads and firmware OTA.
- Add iPhone-driven firmware OTA for Waveshare AMOLED 1.75 and 2.06 targets, including signed manifests, transfer tokens, SHA-256 image verification, rollback validation, and post-reboot app verification.
- Add GitHub-native firmware release hosting with signed per-target manifests published through GitHub Pages and binaries attached to versioned releases.
- Keep the implementation plan and validation notes updated with completed work and remaining follow-up items.

## Validation
- `./scripts/run-navigation-tests.sh` from `ios-app`
- `pio run -e WAVESHARE_AMOLED_206` from `esp32`
- `pio run -e WAVESHARE_AMOLED_175` from `esp32`
- GitHub PR checks are passing, including iOS, ESP32 host tests, both ESP32 firmware targets, map backend, OSM pipeline, and firmware release publishing.

## Hardware Validation
- OTA from the iPhone app to a Waveshare AMOLED 2.06 device was tested successfully: the app uploaded firmware, the device rebooted, reconnected over BLE, reported firmware `0.2.4 (88)`, and returned to the map UI.
