### PR TITLE
Gate ride telemetry while idle

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -87,8 +87,8 @@ class NavigationEngine: NSObject, ObservableObject {
         } else {
             acceptedRouteLocation = nil
         }
-        updateRideTelemetry(gpsLocation: location, routeLocation: acceptedRouteLocation)
         if isNavigating {
+            updateRideTelemetry(gpsLocation: location, routeLocation: acceptedRouteLocation)
             sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
         } else {
             lastDeviceGpsLocation = (location, false)
@@ -390,7 +390,8 @@ class NavigationEngine: NSObject, ObservableObject {
         guard let lastDeviceGpsLocation else { return }
 
         sendDeviceGpsPosition(lastDeviceGpsLocation.location,
-                              convertFromMapKitRoute: lastDeviceGpsLocation.convertFromMapKitRoute)
+                              convertFromMapKitRoute: lastDeviceGpsLocation.convertFromMapKitRoute,
+                              includeRideTelemetry: isNavigating)
     }
 
     private func sendIdleDeviceTimeSyncIfNeeded(_ location: CLLocation) {
@@ -398,7 +399,7 @@ class NavigationEngine: NSObject, ObservableObject {
         guard now.timeIntervalSince(lastIdleGpsSyncTime) >= idleGpsSyncInterval else { return }
         guard let bleManager, bleManager.isConnected, bleManager.isNavigationReady else { return }
 
-        sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
+        sendDeviceGpsPosition(location, convertFromMapKitRoute: false, includeRideTelemetry: false)
         lastIdleGpsSyncTime = now
     }
 
@@ -494,7 +495,7 @@ class NavigationEngine: NSObject, ObservableObject {
         print("Sent to ESP32: \(snapshot.packet)")
     }
 
-    private func sendDeviceGpsPosition(_ location: CLLocation, convertFromMapKitRoute: Bool) {
+    private func sendDeviceGpsPosition(_ location: CLLocation, convertFromMapKitRoute: Bool, includeRideTelemetry: Bool = true) {
         lastDeviceGpsLocation = (location, convertFromMapKitRoute)
         let wgsCoordinate = convertFromMapKitRoute
             ? CoordinateConverter.gcj02ToWGS84(coordinate: location.coordinate)
@@ -503,11 +504,11 @@ class NavigationEngine: NSObject, ObservableObject {
         bleManager?.sendGPSPosition(lat: wgsCoordinate.latitude,
                                     lon: wgsCoordinate.longitude,
                                     heading: heading,
-                                    speedMetersPerSecond: location.speed,
-                                    altitudeMeters: location.altitude,
-                                    distanceTraveledMeters: rideDistanceMeters,
-                                    elapsedSeconds: rideStartDate.map { Date().timeIntervalSince($0) },
-                                    routeRemainingMeters: lastRouteRemainingMeters)
+                                    speedMetersPerSecond: includeRideTelemetry ? location.speed : nil,
+                                    altitudeMeters: includeRideTelemetry ? location.altitude : nil,
+                                    distanceTraveledMeters: includeRideTelemetry ? rideDistanceMeters : nil,
+                                    elapsedSeconds: includeRideTelemetry ? rideStartDate.map { Date().timeIntervalSince($0) } : nil,
+                                    routeRemainingMeters: includeRideTelemetry ? lastRouteRemainingMeters : nil)
     }
 
     private func sendInitialDeviceGpsPosition(_ location: CLLocation, convertFromMapKitRoute: Bool) {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -79,6 +79,7 @@ func assertCoordinate(
 final class TestBLEManager: BLEManager {
     var sentPackets: [String] = []
     var sentRouteGeometry: [Data] = []
+    var sentGPSPositions: [Data] = []
 
     override func centralManagerDidUpdateState(_ central: CBCentralManager) {
         // Keep CoreBluetooth startup callbacks from changing test-controlled state.
@@ -99,6 +100,32 @@ final class TestBLEManager: BLEManager {
         }
 
         sentRouteGeometry.append(data)
+    }
+
+    override func sendGPSPosition(
+        lat: Double,
+        lon: Double,
+        heading: Double = 0,
+        speedMetersPerSecond: Double? = nil,
+        altitudeMeters: Double? = nil,
+        distanceTraveledMeters: Double? = nil,
+        elapsedSeconds: TimeInterval? = nil,
+        routeRemainingMeters: Double? = nil
+    ) {
+        guard isConnected, isNavigationReady else {
+            return
+        }
+
+        sentGPSPositions.append(DeviceGPSPacketBuilder.data(
+            lat: lat,
+            lon: lon,
+            heading: heading,
+            speedMetersPerSecond: speedMetersPerSecond,
+            altitudeMeters: altitudeMeters,
+            distanceTraveledMeters: distanceTraveledMeters,
+            elapsedSeconds: elapsedSeconds,
+            routeRemainingMeters: routeRemainingMeters
+        ))
     }
 }
 
@@ -179,6 +206,7 @@ struct NavigationProtocolTests {
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
+        testNavigationEngineOmitsRideTelemetryWhenIdle()
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testOfflineMapCustomBBoxRequest()
         testOfflineMapCreateJobURLRequest()
@@ -921,6 +949,38 @@ struct NavigationProtocolTests {
         RunLoop.main.run(until: Date().addingTimeInterval(0.1))
 
         assertEqual(manager.sentRouteGeometry, [Data()], "idle readiness should clear route geometry")
+    }
+
+    static func testNavigationEngineOmitsRideTelemetryWhenIdle() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        let idleLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            altitude: 42,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 90,
+            speed: 5,
+            timestamp: Date()
+        )
+        engine.processExternalLocation(idleLocation)
+
+        assertEqual(manager.sentGPSPositions.count, 1, "idle GPS sync should still send position/time")
+        let packet = manager.sentGPSPositions[0]
+        assertEqual(readUInt16LE(packet, offset: 14),
+                    DeviceGPSPacketBuilder.invalidSpeedCmps,
+                    "idle GPS sync should omit speed telemetry")
+        assertEqual(readInt16LE(packet, offset: 16), 0, "idle GPS sync should omit altitude telemetry")
+        assertEqual(readUInt32LE(packet, offset: 18), 0, "idle GPS sync should omit distance telemetry")
+        assertEqual(readUInt32LE(packet, offset: 22), 0, "idle GPS sync should omit elapsed telemetry")
+        assertEqual(readUInt32LE(packet, offset: 26),
+                    DeviceGPSPacketBuilder.invalidRouteRemainingMeters,
+                    "idle GPS sync should omit route remaining telemetry")
     }
 
     static func testNavigationEngineIgnoresLiveLocationFarFromRouteStart() {


### PR DESCRIPTION
## Summary

Gates ride telemetry updates behind active navigation so the Stats screen no longer accumulates speed, altitude, distance, elapsed time, or route-left values while the app is idle.

Idle GPS/time sync still sends position/time to the device, but now omits ride telemetry fields from those packets.

## Root Cause

`processExternalLocation` updated ride telemetry on every location update before checking `isNavigating`. The idle GPS sync path also reused the full GPS packet sender, which populated ride fields from the latest CoreLocation sample.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- XcodeBuildMCP simulator build for `BikeComputer` on iPhone 17: passed
