### PR TITLE
Add disconnected power timeout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,11 @@ empty monitor.
 
 #### ESP32 on Chris's Mac over USB-C
 
+Before the first device action in a thread (build/upload/serial capture/device
+debugging), ask which physical device is currently connected. Do not assume
+`WAVESHARE_AMOLED_175` vs `WAVESHARE_AMOLED_206`; flashing the wrong
+environment can leave the screen black even when upload succeeds.
+
 Observed working device/port:
 - ESP32-S3 USB CDC/JTAG enumerated as `/dev/cu.usbmodem2101`.
 - `pio device list` described it as `USB JTAG/serial debug unit` with VID:PID `303A:1001`.

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -105,6 +105,7 @@ Current setting IDs:
 | `12` | Device brightness | `5...100` percent on supported hardware |
 | `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation. Invalid or empty masks fall back to all supported screens. |
 | `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation. Invalid or disabled defaults fall back to Map if enabled, otherwise the first enabled screen. |
+| `15` | Disconnected sleep timeout | seconds before deep sleep while not connected to the app: `60`, `120`, `300`, `600`; `0` disables automatic disconnected sleep. |
 
 Feature visibility toggles are authoritative for their classes. Detail level
 controls small-area density without overriding the visibility mask: high uses

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -102,6 +102,13 @@ static uint8_t normalizedDefaultScreen(int32_t rawDefault,
   return DEVICE_SCREEN_MAP_PLUS_NAVIGATION;
 }
 
+static uint32_t normalizedDisconnectedSleepTimeoutSeconds(int64_t rawSeconds) {
+  if (rawSeconds <= 0) {
+    return 0;
+  }
+  return (uint32_t)std::min(std::max(rawSeconds, (int64_t)60), (int64_t)600);
+}
+
 static void clearCurrentNavigationData() {
   currentNavData = {0, 0, ""};
   navDataUpdated = true;
@@ -943,13 +950,8 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                   mapRenderSettings.defaultScreen);
     break;
   case 15: {
-    if (settingValue <= 0) {
-      mapRenderSettings.disconnectedSleepTimeoutSeconds = 0;
-    } else {
-      mapRenderSettings.disconnectedSleepTimeoutSeconds =
-          (uint32_t)std::min(std::max(settingValue, (int32_t)60),
-                             (int32_t)600);
-    }
+    mapRenderSettings.disconnectedSleepTimeoutSeconds =
+        normalizedDisconnectedSleepTimeoutSeconds(settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUInt("discSleepSec",
                           mapRenderSettings.disconnectedSleepTimeoutSeconds);
@@ -1279,7 +1281,8 @@ static void loadSettingsFromNVS() {
       prefs.getUChar("defaultScreen", DEVICE_SCREEN_MAP_PLUS_NAVIGATION),
       mapRenderSettings.enabledScreensMask);
   mapRenderSettings.disconnectedSleepTimeoutSeconds =
-      prefs.getUInt("discSleepSec", 120);
+      normalizedDisconnectedSleepTimeoutSeconds(
+          prefs.getUInt("discSleepSec", 120));
   mapRenderSettings.visibilityMask = prefs.getUInt("visMask", 0xFFFFFFFF);
 
   prefs.end();

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -942,6 +942,24 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     Serial.printf("BLE Settings: defaultScreen = %d (saved)\n",
                   mapRenderSettings.defaultScreen);
     break;
+  case 15: {
+    if (settingValue <= 0) {
+      mapRenderSettings.disconnectedSleepTimeoutSeconds = 0;
+    } else {
+      mapRenderSettings.disconnectedSleepTimeoutSeconds =
+          (uint32_t)std::min(std::max(settingValue, (int32_t)60),
+                             (int32_t)600);
+    }
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUInt("discSleepSec",
+                          mapRenderSettings.disconnectedSleepTimeoutSeconds);
+    settingsPrefs.end();
+    Serial.printf("BLE Settings: disconnectedSleepTimeoutSeconds = %lu "
+                  "(saved, 0=never)\n",
+                  (unsigned long)
+                      mapRenderSettings.disconnectedSleepTimeoutSeconds);
+    break;
+  }
   case 4:
     mapRenderSettings.displayRotation =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)3);
@@ -1260,6 +1278,8 @@ static void loadSettingsFromNVS() {
   mapRenderSettings.defaultScreen = normalizedDefaultScreen(
       prefs.getUChar("defaultScreen", DEVICE_SCREEN_MAP_PLUS_NAVIGATION),
       mapRenderSettings.enabledScreensMask);
+  mapRenderSettings.disconnectedSleepTimeoutSeconds =
+      prefs.getUInt("discSleepSec", 120);
   mapRenderSettings.visibilityMask = prefs.getUInt("visMask", 0xFFFFFFFF);
 
   prefs.end();
@@ -1267,7 +1287,7 @@ static void loadSettingsFromNVS() {
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
                 "detailLevel=%d, routeWidth=%d, streetBoost=%d, "
                 "markerScale=%d, rotation=%d, tapSwitch=%d, "
-                "screenMask=0x%02X, defaultScreen=%d\n",
+                "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
                 mapRenderSettings.minPolygonSize, mapRenderSettings.detailLevel,
                 mapRenderSettings.routeLineWidth,
                 mapRenderSettings.streetLineWidthBoost,
@@ -1275,7 +1295,9 @@ static void loadSettingsFromNVS() {
                 mapRenderSettings.displayRotation,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,
-                mapRenderSettings.defaultScreen);
+                mapRenderSettings.defaultScreen,
+                (unsigned long)
+                    mapRenderSettings.disconnectedSleepTimeoutSeconds);
 }
 
 void BLENavigationServer::init(const char *deviceName) {

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -33,7 +33,7 @@ struct NavigationData {
  * Settings IDs: 1=minPolygonSize, 2=detailLevel, 3=routeLineWidth,
  * 4=displayRotation, 6=mapRotationMode, 7=zoomLevel, 8=visibilityMask,
  * 9=streetLineWidthBoost, 10=positionMarkerScale, 11=tapToSwitchScreens,
- * 13=enabledScreensMask, 14=defaultScreen
+ * 13=enabledScreensMask, 14=defaultScreen, 15=disconnectedSleepTimeoutSeconds
  */
 enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
@@ -61,6 +61,8 @@ struct MapRenderSettings {
       DEVICE_SCREEN_SUPPORTED_MASK; // Bits follow DeviceScreenSetting
   uint8_t defaultScreen =
       DEVICE_SCREEN_MAP_PLUS_NAVIGATION; // DeviceScreenSetting value
+  uint32_t disconnectedSleepTimeoutSeconds =
+      120; // 0=never auto-sleep while disconnected
   uint32_t visibilityMask =
       0xFFFFFFFF; // Bits: 0 buildings, 1 green, 2 paths, 3 major roads,
                   // 4 local streets, 5 water, 6 rail, 7 other areas,

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -10,9 +10,10 @@
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "axp2101.hpp"
-#endif
-
+#include "hal.hpp"
+#else
 extern const uint8_t BOARD_BOOT_PIN;
+#endif
 
 /**
  * @brief Power Class constructor

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -139,6 +139,8 @@ static uint32_t lvglHandlerCount = 0;
 static uint32_t lastLvglHandlerMs = 0;
 static uint32_t lastLvglHandlerDurationUs = 0;
 static uint32_t maxLvglHandlerDurationUs = 0;
+static constexpr uint32_t APP_CONNECTION_SHUTDOWN_TIMEOUT_MS =
+    2UL * 60UL * 1000UL;
 
 #include "lvglSetup.hpp"
 #include "settings.hpp"
@@ -296,6 +298,38 @@ static void logSystemDebugHeartbeat() {
                 (unsigned long)bleStats.gpsPacketCount,
                 (unsigned long)bleStats.settingsPacketCount);
 #endif
+}
+
+static void processDisconnectedShutdown() {
+  static uint32_t disconnectedSinceMs = 0;
+  static bool shutdownAnnounced = false;
+
+  if (bleNavServer.isConnected()) {
+    disconnectedSinceMs = 0;
+    shutdownAnnounced = false;
+    return;
+  }
+
+  const uint32_t now = millis();
+  if (disconnectedSinceMs == 0) {
+    disconnectedSinceMs = now;
+    Serial.printf("Power: app not connected; shutdown in %lu seconds if still disconnected\n",
+                  APP_CONNECTION_SHUTDOWN_TIMEOUT_MS / 1000UL);
+    return;
+  }
+
+  if (now - disconnectedSinceMs < APP_CONNECTION_SHUTDOWN_TIMEOUT_MS) {
+    return;
+  }
+
+  if (!shutdownAnnounced) {
+    shutdownAnnounced = true;
+    Serial.println("Power: app was disconnected for 2 minutes; entering deep sleep");
+    Serial.println("Power: press BOOT to wake the device");
+    Serial.flush();
+  }
+
+  power.deviceShutdown();
 }
 
 /**
@@ -538,6 +572,7 @@ void loop() {
 
   // Process BLE events
   bleNavServer.process();
+  processDisconnectedShutdown();
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::imu::process();

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -139,9 +139,6 @@ static uint32_t lvglHandlerCount = 0;
 static uint32_t lastLvglHandlerMs = 0;
 static uint32_t lastLvglHandlerDurationUs = 0;
 static uint32_t maxLvglHandlerDurationUs = 0;
-static constexpr uint32_t APP_CONNECTION_SHUTDOWN_TIMEOUT_MS =
-    2UL * 60UL * 1000UL;
-
 #include "lvglSetup.hpp"
 #include "settings.hpp"
 #include "tasks.hpp"
@@ -302,29 +299,49 @@ static void logSystemDebugHeartbeat() {
 
 static void processDisconnectedShutdown() {
   static uint32_t disconnectedSinceMs = 0;
+  static uint32_t lastTimeoutSeconds = 120;
   static bool shutdownAnnounced = false;
 
   if (bleNavServer.isConnected()) {
     disconnectedSinceMs = 0;
+    lastTimeoutSeconds = mapRenderSettings.disconnectedSleepTimeoutSeconds;
     shutdownAnnounced = false;
     return;
+  }
+
+  const uint32_t timeoutSeconds =
+      mapRenderSettings.disconnectedSleepTimeoutSeconds;
+  if (timeoutSeconds == 0) {
+    disconnectedSinceMs = 0;
+    lastTimeoutSeconds = 0;
+    shutdownAnnounced = false;
+    return;
+  }
+
+  if (timeoutSeconds != lastTimeoutSeconds) {
+    disconnectedSinceMs = 0;
+    lastTimeoutSeconds = timeoutSeconds;
+    shutdownAnnounced = false;
   }
 
   const uint32_t now = millis();
   if (disconnectedSinceMs == 0) {
     disconnectedSinceMs = now;
-    Serial.printf("Power: app not connected; shutdown in %lu seconds if still disconnected\n",
-                  APP_CONNECTION_SHUTDOWN_TIMEOUT_MS / 1000UL);
+    Serial.printf("Power: app not connected; shutdown in %lu seconds if still "
+                  "disconnected\n",
+                  (unsigned long)timeoutSeconds);
     return;
   }
 
-  if (now - disconnectedSinceMs < APP_CONNECTION_SHUTDOWN_TIMEOUT_MS) {
+  if (now - disconnectedSinceMs < timeoutSeconds * 1000UL) {
     return;
   }
 
   if (!shutdownAnnounced) {
     shutdownAnnounced = true;
-    Serial.println("Power: app was disconnected for 2 minutes; entering deep sleep");
+    Serial.printf("Power: app was disconnected for %lu seconds; entering deep "
+                  "sleep\n",
+                  (unsigned long)timeoutSeconds);
     Serial.println("Power: press BOOT to wake the device");
     Serial.flush();
   }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -42,6 +42,7 @@ enum DeviceBLEProtocol {
     static let brightnessSettingID: UInt8 = 12
     static let enabledScreensSettingID: UInt8 = 13
     static let defaultScreenSettingID: UInt8 = 14
+    static let disconnectedSleepTimeoutSettingID: UInt8 = 15
 
     static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
     static var navigationCharacteristicUUID: CBUUID { CBUUID(string: navigationCharacteristicUUIDString) }
@@ -108,6 +109,39 @@ enum DeviceScreen: Int, CaseIterable, Identifiable {
             return candidate
         }
         return displayOrder.first { mask & $0.bit != 0 } ?? .mapPlusNavigation
+    }
+}
+
+enum DisconnectedSleepTimeout: Int, CaseIterable, Identifiable {
+    case oneMinute = 60
+    case twoMinutes = 120
+    case fiveMinutes = 300
+    case tenMinutes = 600
+    case never = 0
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .oneMinute:
+            return "1 min"
+        case .twoMinutes:
+            return "2 min"
+        case .fiveMinutes:
+            return "5 min"
+        case .tenMinutes:
+            return "10 min"
+        case .never:
+            return "Never"
+        }
+    }
+
+    var settingValue: Int32 {
+        Int32(rawValue)
+    }
+
+    static func normalized(rawValue: Int) -> DisconnectedSleepTimeout {
+        DisconnectedSleepTimeout(rawValue: rawValue) ?? .twoMinutes
     }
 }
 
@@ -250,6 +284,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
     @Published var defaultDeviceScreen: DeviceScreen = .mapPlusNavigation
     @Published var deviceBrightnessPercent: Double = 100
+    @Published var disconnectedSleepTimeout: DisconnectedSleepTimeout = .twoMinutes
     
     // Feature Visibility
     @Published var showBuildings: Bool = true
@@ -336,6 +371,7 @@ class BLEManager: NSObject, ObservableObject {
         static let defaultDeviceScreen = "deviceSettings.defaultScreen"
         static let defaultDeviceScreenMigrated = "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1"
         static let deviceBrightnessPercent = "deviceSettings.brightnessPercent"
+        static let disconnectedSleepTimeoutSeconds = "deviceSettings.disconnectedSleepTimeoutSeconds"
         static let showBuildings = "mapSettings.showBuildings"
         static let showGreenSpace = "mapSettings.showGreenSpace"
         static let showPaths = "mapSettings.showPaths"
@@ -395,6 +431,9 @@ class BLEManager: NSObject, ObservableObject {
             defaults.set(true, forKey: SettingsKeys.defaultDeviceScreenMigrated)
         }
         deviceBrightnessPercent = defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
+        disconnectedSleepTimeout = DisconnectedSleepTimeout.normalized(
+            rawValue: defaults.object(forKey: SettingsKeys.disconnectedSleepTimeoutSeconds) as? Int ?? DisconnectedSleepTimeout.twoMinutes.rawValue
+        )
         showBuildings = defaults.object(forKey: SettingsKeys.showBuildings) as? Bool ?? true
         let legacyNature = defaults.object(forKey: SettingsKeys.legacyShowNature) as? Bool ?? true
         let legacyMinorRoads = defaults.object(forKey: SettingsKeys.legacyShowMinorRoads) as? Bool ?? true
@@ -434,6 +473,7 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(enabledDeviceScreensMask, forKey: SettingsKeys.enabledDeviceScreensMask)
         defaults.set(defaultDeviceScreen.rawValue, forKey: SettingsKeys.defaultDeviceScreen)
         defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
+        defaults.set(disconnectedSleepTimeout.rawValue, forKey: SettingsKeys.disconnectedSleepTimeoutSeconds)
         defaults.set(showBuildings, forKey: SettingsKeys.showBuildings)
         defaults.set(showGreenSpace, forKey: SettingsKeys.showGreenSpace)
         defaults.set(showPaths, forKey: SettingsKeys.showPaths)
@@ -1124,6 +1164,8 @@ class BLEManager: NSObject, ObservableObject {
         sendEnabledDeviceScreensMask()
         sendDefaultDeviceScreen()
         sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(deviceBrightnessPercent))
+        sendSetting(id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
+                    value: disconnectedSleepTimeout.settingValue)
     }
 
     private func sendOrQueueClientProof(_ proofData: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic) {

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -14,6 +14,7 @@ import CoreLocation
 
 /// Main coordinator for the Bike Computer app
 /// Manages BLE, Navigation, Location, and HealthKit subsystems
+@MainActor
 class BikeComputerCoordinator: ObservableObject {
 
     // MARK: - Private Managers (Implementation Details)

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -552,7 +552,7 @@ private struct HardwareCustomizationSettingsView: View {
             .disabled(!bleManager.supportsDeviceSettings)
 
             Section(header: Text("Power")) {
-                Picker("Disconnected Sleep", selection: $bleManager.disconnectedSleepTimeout) {
+                Picker("Disconnected Sleep After", selection: $bleManager.disconnectedSleepTimeout) {
                     ForEach(DisconnectedSleepTimeout.allCases) { timeout in
                         Text(timeout.title).tag(timeout)
                     }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -550,6 +550,21 @@ private struct HardwareCustomizationSettingsView: View {
                 }
             }
             .disabled(!bleManager.supportsDeviceSettings)
+
+            Section(header: Text("Power")) {
+                Picker("Disconnected Sleep", selection: $bleManager.disconnectedSleepTimeout) {
+                    ForEach(DisconnectedSleepTimeout.allCases) { timeout in
+                        Text(timeout.title).tag(timeout)
+                    }
+                }
+                .onChange(of: bleManager.disconnectedSleepTimeout) { newValue in
+                    bleManager.sendSetting(
+                        id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
+                        value: newValue.settingValue
+                    )
+                }
+            }
+            .disabled(!bleManager.supportsDeviceSettings)
         }
         .navigationTitle("Hardware Customization")
         .navigationBarTitleDisplayMode(.inline)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -252,6 +252,7 @@ struct NavigationProtocolTests {
         testBLEManagerParsesMapTransferStatus()
         testBLEManagerParsesDeviceTransferStatus()
         testBLEManagerSendsBrightnessFallbackSetting()
+        testBLEManagerSendsDisconnectedSleepTimeoutSetting()
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
         testNavigationSendTrackerReadinessRetry()
@@ -896,6 +897,7 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
+        assertEqual(DeviceBLEProtocol.disconnectedSleepTimeoutSettingID, 15, "disconnected sleep timeout uses firmware setting ID 15")
         assertEqual(DeviceScreen.map.rawValue, 0, "Map screen protocol value stays stable")
         assertEqual(DeviceScreen.navigation.rawValue, 1, "Navigation screen protocol value stays stable")
         assertEqual(DeviceScreen.rideStats.rawValue, 2, "Ride Stats screen protocol value stays stable")
@@ -904,6 +906,12 @@ struct NavigationProtocolTests {
         assertEqual(DeviceScreen.displayOrder[0], .mapPlusNavigation, "Map + Navigation is the first device screen in settings")
         assertEqual(DeviceScreen.displayOrder[1], .rideStats, "Ride Stats is the second device screen in settings")
         assertEqual(DeviceScreen.allScreensMask, 0x0F, "all supported device screens use the low four mask bits")
+        assertEqual(DisconnectedSleepTimeout.oneMinute.settingValue, 60, "one-minute sleep timeout sends seconds")
+        assertEqual(DisconnectedSleepTimeout.twoMinutes.settingValue, 120, "two-minute sleep timeout sends seconds")
+        assertEqual(DisconnectedSleepTimeout.fiveMinutes.settingValue, 300, "five-minute sleep timeout sends seconds")
+        assertEqual(DisconnectedSleepTimeout.tenMinutes.settingValue, 600, "ten-minute sleep timeout sends seconds")
+        assertEqual(DisconnectedSleepTimeout.never.settingValue, 0, "never sleep sends zero seconds")
+        assertEqual(DisconnectedSleepTimeout.normalized(rawValue: 999), .twoMinutes, "unknown sleep timeout falls back to two minutes")
     }
 
     static func testDeviceScreenValidation() {
@@ -1047,6 +1055,34 @@ struct NavigationProtocolTests {
         assertEqual(String(data: sentPackets[2], encoding: .utf8), "DTRNexit", "exit command uses DTRN frame")
     }
 
+    static func testBLEManagerSendsDisconnectedSleepTimeoutSetting() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.disconnectedSleepTimeout = .fiveMinutes
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendSetting(id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
+                            value: manager.disconnectedSleepTimeout.settingValue)
+
+        assertEqual(sentPackets.count, 1, "sleep timeout setting should send one fallback packet")
+        assertEqual(String(data: sentPackets[0].prefix(4), encoding: .utf8),
+                    DeviceBLEProtocol.settingsFallbackPrefix,
+                    "sleep timeout fallback uses MSET prefix")
+        assertEqual(sentPackets[0][4],
+                    DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
+                    "sleep timeout uses setting ID 15")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5),
+                    DisconnectedSleepTimeout.fiveMinutes.settingValue,
+                    "sleep timeout fallback includes little-endian seconds")
+    }
+
     static func testBLEManagerParsesMapTransferStatus() {
         let manager = BLEManager()
         let json = """
@@ -1155,7 +1191,8 @@ struct NavigationProtocolTests {
             "mapSettings.zoomLevel",
             "deviceSettings.enabledScreensMask",
             "deviceSettings.defaultScreen",
-            "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1"
+            "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1",
+            "deviceSettings.disconnectedSleepTimeoutSeconds"
         ]
         keys.forEach { defaults.removeObject(forKey: $0) }
 
@@ -1172,6 +1209,7 @@ struct NavigationProtocolTests {
         manager.zoomLevel = 5
         manager.enabledDeviceScreensMask = DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit
         manager.defaultDeviceScreen = .mapPlusNavigation
+        manager.disconnectedSleepTimeout = .tenMinutes
         manager.saveSettings()
 
         let reloaded = BLEManager()
@@ -1181,6 +1219,7 @@ struct NavigationProtocolTests {
                     DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit,
                     "enabled device screens should persist across BLEManager reloads")
         assertEqual(reloaded.defaultDeviceScreen, .mapPlusNavigation, "default device screen should persist across BLEManager reloads")
+        assertEqual(reloaded.disconnectedSleepTimeout, .tenMinutes, "disconnected sleep timeout should persist across BLEManager reloads")
 
         keys.forEach { defaults.removeObject(forKey: $0) }
     }


### PR DESCRIPTION
## Summary

- Shut down the ESP32 after the configured disconnected sleep timeout when there is no app BLE connection.
- Add an iOS Hardware Customization setting for disconnected sleep: 1 min, 2 min, 5 min, 10 min, or Never.
- Persist and sync the timeout through BLE setting ID 15; 0 disables automatic disconnected sleep.
- Reset the shutdown timer while BLE is connected and restart it after disconnect.
- Fix the Waveshare power helper to use the header-defined BOOT pin for Waveshare builds.
- Document that agents should confirm the connected physical device before first device actions in a thread.

## Why

Battery-powered devices were staying on indefinitely when not connected to the iOS app. The shutdown path already supports deep sleep with BOOT/GPIO0 wake, so this wires that policy into the main loop and lets the app choose the timeout.

## Validation

- `git diff --check`
- `cd ios-app && swiftc BikeComputer/BikeComputer/Models/AppModels.swift BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift BikeComputer/BikeComputer/Managers/BLEManager.swift BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift BikeComputer/BikeComputer/Managers/NavigationEngine.swift BikeComputer/BikeComputer/Managers/OfflineMapManager.swift BikeComputer/BikeComputer/Models/OfflineMapServiceConfig.swift BikeComputerTests/NavigationProtocolTests.swift -o /tmp/NavigationProtocolTests && /tmp/NavigationProtocolTests`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_175`
- `cd esp32 && pio run -e WAVESHARE_AMOLED_206`
- `cd ios-app && xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`