### PR TITLE
Move test navigation to developer settings

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -86,8 +86,17 @@ struct ContentView: View {
             .sheet(isPresented: $showingSettings) {
                 SettingsView(
                     locationAuthorized: coordinator.isLocationAuthorized,
+                    currentLocation: coordinator.currentLocation,
                     offlineMapManager: offlineMapManager,
-                    firmwareUpdateManager: coordinator.firmwareUpdateManager
+                    firmwareUpdateManager: coordinator.firmwareUpdateManager,
+                    onStartTestNavigation: { destination in
+                        coordinator.startNavigation(
+                            from: .currentLocation,
+                            to: .query(destination),
+                            transportType: RouteTransportTypes.cycling,
+                            isTestMode: true
+                        )
+                    }
                 )
                     .environmentObject(coordinator.bleManager)
             }
@@ -165,9 +174,9 @@ struct ContentView: View {
                     currentAddress: coordinator.currentAddress,
                     currentLocation: coordinator.currentLocation,
                     maxExpandedHeight: maxHeight,
-                    onStartNavigation: { source, destination, transport, isTestMode in
+                    onStartNavigation: { source, destination, transport in
                         isSearchPanelExpanded = false
-                        coordinator.startNavigation(from: source, to: destination, transportType: transport, isTestMode: isTestMode)
+                        coordinator.startNavigation(from: source, to: destination, transportType: transport)
                     }
                 )
                 .padding(.horizontal, 12)

--- a/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
@@ -57,7 +57,7 @@ struct RouteSearchPanel: View {
     let currentAddress: String
     let currentLocation: CLLocation?
     let maxExpandedHeight: CGFloat
-    var onStartNavigation: (RouteEndpoint, RouteEndpoint, MKDirectionsTransportType, Bool) -> Void
+    var onStartNavigation: (RouteEndpoint, RouteEndpoint, MKDirectionsTransportType) -> Void
 
     @StateObject private var destinationCompleter = AddressSearchCompleter()
     @StateObject private var sourceCompleter = AddressSearchCompleter()
@@ -68,7 +68,6 @@ struct RouteSearchPanel: View {
     @State private var isSelectingFromSuggestion = false
     @State private var isEditingSource = false
     @State private var hasSelectedSource = false
-    @State private var isTestMode = false
     @State private var selectedTransportType: MKDirectionsTransportType = RouteTransportTypes.cycling
     @State private var recentDestinationSearches: [String] = []
 
@@ -130,7 +129,6 @@ struct RouteSearchPanel: View {
             if hasSelectedDestination {
                 sourcePicker
                 transportControls
-                testModeToggle
             }
 
             searchResults
@@ -272,14 +270,6 @@ struct RouteSearchPanel: View {
         }
     }
 
-    private var testModeToggle: some View {
-        Toggle(isOn: $isTestMode) {
-            Label("Test Mode", systemImage: "testtube.2")
-                .foregroundColor(.primary)
-        }
-        .tint(.orange)
-    }
-
     @ViewBuilder
     private var searchResults: some View {
         if isEditingSource {
@@ -359,14 +349,14 @@ struct RouteSearchPanel: View {
                 sourceAddress: sourceAddress
             )
             saveRecentDestinationSearch(destinationAddress)
-            onStartNavigation(sourceEndpoint, .query(destinationAddress), selectedTransportType, isTestMode)
+            onStartNavigation(sourceEndpoint, .query(destinationAddress), selectedTransportType)
         }) {
-            Text(isTestMode ? "Go (Test)" : "Go")
+            Text("Go")
                 .font(.headline)
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
                 .padding()
-                .background(isTestMode ? Color.orange : Color.blue, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .background(Color.blue, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
         }
         .buttonStyle(.plain)
     }
@@ -481,7 +471,7 @@ struct RouteInputView: View {
     let currentAddress: String
     let currentLocation: CLLocation?  // User's exact GPS location for region-biased search
     
-    var onStartNavigation: (RouteEndpoint, RouteEndpoint, MKDirectionsTransportType, Bool) -> Void
+    var onStartNavigation: (RouteEndpoint, RouteEndpoint, MKDirectionsTransportType) -> Void
     
     @StateObject private var destinationCompleter = AddressSearchCompleter()
     @StateObject private var sourceCompleter = AddressSearchCompleter()
@@ -494,7 +484,6 @@ struct RouteInputView: View {
     @State private var isEditingSource = false
     @State private var hasSelectedSource = false
     
-    @State private var isTestMode = false
     @State private var selectedTransportType: MKDirectionsTransportType = RouteTransportTypes.cycling
     @State private var recentDestinationSearches: [String] = []
 
@@ -631,18 +620,6 @@ struct RouteInputView: View {
                     .padding(.horizontal)
                     .transition(.move(edge: .top).combined(with: .opacity))
                     
-                    // Test Mode Toggle
-                    Toggle(isOn: $isTestMode) {
-                        HStack {
-                            Image(systemName: "testtube.2")
-                            .foregroundColor(.orange)
-                            Text("Test Mode")
-                            .foregroundColor(.primary)
-                        }
-                    }
-                    .padding(.horizontal)
-                    .padding(.top, 8)
-                    .tint(.orange)
                 }
                 
                 // Suggestions List
@@ -687,15 +664,15 @@ struct RouteInputView: View {
                             sourceAddress: sourceAddress
                         )
                         saveRecentDestinationSearch(destinationAddress)
-                        onStartNavigation(sourceEndpoint, .query(destinationAddress), selectedTransportType, isTestMode)
+                        onStartNavigation(sourceEndpoint, .query(destinationAddress), selectedTransportType)
                         dismiss()
                     }) {
-                        Text(isTestMode ? "Go (Test)" : "Go")
+                        Text("Go")
                             .font(.headline)
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .padding()
-                            .background(isTestMode ? Color.orange : Color.blue)
+                            .background(Color.blue)
                             .cornerRadius(12)
                     }
                     .padding()

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -7,22 +7,31 @@
 
 import SwiftUI
 import UIKit
+import CoreLocation
+import MapKit
 
 struct SettingsView: View {
     @EnvironmentObject var bleManager: BLEManager
+    @Environment(\.dismiss) private var dismiss
     @Environment(\.openURL) private var openURL
     @ObservedObject private var offlineMapManager: OfflineMapManager
     @ObservedObject private var firmwareUpdateManager: FirmwareUpdateManager
     let locationAuthorized: Bool
+    let currentLocation: CLLocation?
+    let onStartTestNavigation: (String) -> Void
 
     init(
         locationAuthorized: Bool = true,
+        currentLocation: CLLocation?,
         offlineMapManager: OfflineMapManager,
-        firmwareUpdateManager: FirmwareUpdateManager
+        firmwareUpdateManager: FirmwareUpdateManager,
+        onStartTestNavigation: @escaping (String) -> Void
     ) {
         self.locationAuthorized = locationAuthorized
+        self.currentLocation = currentLocation
         self.offlineMapManager = offlineMapManager
         self.firmwareUpdateManager = firmwareUpdateManager
+        self.onStartTestNavigation = onStartTestNavigation
     }
     
     var body: some View {
@@ -65,7 +74,12 @@ struct SettingsView: View {
                     NavigationLink {
                         DeveloperSettingsView(
                             offlineMapManager: offlineMapManager,
-                            firmwareUpdateManager: firmwareUpdateManager
+                            firmwareUpdateManager: firmwareUpdateManager,
+                            currentLocation: currentLocation,
+                            onStartTestNavigation: { destination in
+                                onStartTestNavigation(destination)
+                                dismiss()
+                            }
                         )
                     } label: {
                         Label("Developer Settings", systemImage: "wrench.and.screwdriver")
@@ -650,10 +664,109 @@ private struct HardwareCustomizationSettingsView: View {
     }
 }
 
+private struct TestNavigationSettingsSection: View {
+    let currentLocation: CLLocation?
+    let onStartNavigation: (String) -> Void
+
+    @StateObject private var destinationCompleter = AddressSearchCompleter()
+    @State private var destination = ""
+    @State private var isApplyingSuggestion = false
+    @FocusState private var isDestinationFocused: Bool
+
+    var body: some View {
+        Section {
+            TextField("Destination", text: $destination)
+                .textContentType(.fullStreetAddress)
+                .submitLabel(.go)
+                .focused($isDestinationFocused)
+                .onChange(of: destination) { newValue in
+                    if isApplyingSuggestion {
+                        isApplyingSuggestion = false
+                        return
+                    }
+                    destinationCompleter.search(query: newValue)
+                }
+                .onSubmit(startNavigation)
+
+            if isDestinationFocused && !normalizedDestination.isEmpty {
+                ForEach(Array(destinationCompleter.suggestions.prefix(5)), id: \.self) { suggestion in
+                    Button {
+                        isApplyingSuggestion = true
+                        destination = formattedAddress(for: suggestion)
+                        isDestinationFocused = false
+                    } label: {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(suggestion.title)
+                                .foregroundColor(.primary)
+                            if !suggestion.subtitle.isEmpty {
+                                Text(suggestion.subtitle)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+
+            Button(action: startNavigation) {
+                Label("Start Test Navigation", systemImage: "testtube.2")
+            }
+            .disabled(!canStartNavigation)
+        } header: {
+            Text("Test Navigation")
+        } footer: {
+            Text(footerText)
+        }
+        .onAppear(perform: updateSearchRegion)
+        .onChange(of: currentLocation) { _ in
+            updateSearchRegion()
+        }
+    }
+
+    private var normalizedDestination: String {
+        destination.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private var canStartNavigation: Bool {
+        currentLocation != nil && !normalizedDestination.isEmpty
+    }
+
+    private var footerText: String {
+        if currentLocation == nil {
+            return "Waiting for your current location. Test navigation starts from your live position."
+        }
+        return "Starts a simulated Bike route from your current location to this destination."
+    }
+
+    private func startNavigation() {
+        guard canStartNavigation else { return }
+        isDestinationFocused = false
+        onStartNavigation(normalizedDestination)
+    }
+
+    private func formattedAddress(for suggestion: MKLocalSearchCompletion) -> String {
+        suggestion.subtitle.isEmpty ? suggestion.title : "\(suggestion.title), \(suggestion.subtitle)"
+    }
+
+    private func updateSearchRegion() {
+        guard let currentLocation else { return }
+        destinationCompleter.updateRegion(
+            MKCoordinateRegion(
+                center: currentLocation.coordinate,
+                latitudinalMeters: 50000,
+                longitudinalMeters: 50000
+            )
+        )
+    }
+}
+
 private struct DeveloperSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
     @ObservedObject var offlineMapManager: OfflineMapManager
     @ObservedObject var firmwareUpdateManager: FirmwareUpdateManager
+    let currentLocation: CLLocation?
+    let onStartTestNavigation: (String) -> Void
 
     var body: some View {
         Form {
@@ -673,6 +786,10 @@ private struct DeveloperSettingsView: View {
 
             OfflineMapDeviceTransferSettingsSection(manager: offlineMapManager)
             FirmwareUpdateSettingsSection(manager: firmwareUpdateManager)
+            TestNavigationSettingsSection(
+                currentLocation: currentLocation,
+                onStartNavigation: onStartTestNavigation
+            )
 
             Section {
                 HStack {
@@ -700,13 +817,6 @@ private struct DeveloperSettingsView: View {
                 }) {
                     Label("Reconnect", systemImage: "antenna.radiowaves.left.and.right")
                 }
-
-                Button(action: {
-                    bleManager.sendDebugNavigationPacket()
-                }) {
-                    Label("Send Test Navigation", systemImage: "arrow.turn.up.left")
-                }
-                .disabled(!bleManager.isNavigationReady)
 
                 Button(role: .destructive, action: {
                     bleManager.forgetTrustedPeripheral()
@@ -805,8 +915,10 @@ private struct StatusValueRow: View {
 
 #Preview {
     SettingsView(
+        currentLocation: nil,
         offlineMapManager: OfflineMapManager(),
-        firmwareUpdateManager: FirmwareUpdateManager()
+        firmwareUpdateManager: FirmwareUpdateManager(),
+        onStartTestNavigation: { _ in }
     )
         .environmentObject(BLEManager())
 }


### PR DESCRIPTION
## Summary

- remove Test Mode from the Bike, Drive, and Walk route chooser
- add a destination field with nearby-biased place suggestions below Firmware Update in Developer Settings
- start simulated Bike navigation from the phone's live current location to the chosen destination
- replace the older static test-navigation packet action

## Why

This keeps the normal route flow focused on real navigation modes while making simulated navigation an explicit developer tool with a meaningful route and destination.

## User impact

Regular destination entry now presents only Bike, Drive, and Walk. Test navigation is available in Developer Settings and dismisses Settings when started so the navigation screen is immediately visible.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' -derivedDataPath /tmp/open-bike-test-navigation-derived CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
