### PR TITLE
Separate map profiles and road visibility controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,23 @@ jobs:
         working-directory: esp32
     steps:
       - uses: actions/checkout@v4
+      - name: GUI layout host tests
+        run: |
+          g++ -std=c++17 \
+            tools/tests/test_gui_layout.cpp \
+            -o /tmp/test_gui_layout_175
+          /tmp/test_gui_layout_175
+          g++ -std=c++17 \
+            -DWAVESHARE_AMOLED_206 \
+            tools/tests/test_gui_layout.cpp \
+            -o /tmp/test_gui_layout_206
+          /tmp/test_gui_layout_206
+      - name: Map profile protocol host tests
+        run: |
+          g++ -std=c++17 \
+            tools/tests/test_map_profile_protocol.cpp \
+            -o /tmp/test_map_profile_protocol
+          /tmp/test_map_profile_protocol
       - name: Map transfer host tests
         run: |
           g++ -std=c++17 \

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -92,26 +92,38 @@ Current setting IDs:
 
 | ID | Meaning | Range |
 | --- | --- | --- |
-| `1` | Minimum polygon size | `0...50` |
-| `2` | Detail level | `0` low, `1` medium, `2` high |
-| `3` | Route line width | `2...48` |
+| `1` | Map minimum polygon size | `0...50` |
+| `2` | Map detail level | `0` low, `1` medium, `2` high |
+| `3` | Map route line width | `2...48` |
 | `4` | Display rotation | `0...3` |
 | `6` | Map rotation mode | `0` north-up, `1` course-up |
-| `7` | Zoom level | `0...5` |
-| `8` | Visibility mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/tracks, bit 3 major roads, bit 4 local streets, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker |
-| `9` | Street line width boost | `0...24` px added to known road/path line style widths; legacy unknown lines are boosted when their stored style width is at least 3px; final rendered width is capped at 24px |
-| `10` | Current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a white dot when no route is loaded and a white arrow while navigating. |
+| `7` | Map zoom level | `0...5` |
+| `8` | Map visibility and global navigation-overlay mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/tracks, bit 3 major roads, bit 4 local streets, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker |
+| `9` | Map street line width boost | `0...24` px added to known road/path line style widths; legacy unknown lines are boosted when their stored style width is at least 3px; final rendered width is capped at 24px |
+| `10` | Map current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a white dot when no route is loaded and a white arrow while navigating. |
 | `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device through the enabled main screens. Map drags and long presses are ignored by this shortcut. |
 | `12` | Device brightness | `5...100` percent on supported hardware |
 | `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation. Invalid or empty masks fall back to all supported screens. |
 | `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation. Invalid or disabled defaults fall back to Map if enabled, otherwise the first enabled screen. |
 | `15` | Disconnected sleep timeout | seconds before deep sleep while not connected to the app: `60`, `120`, `300`, `600`; `0` disables automatic disconnected sleep. |
+| `16` | Map + Navigation minimum polygon size | `0...50` |
+| `17` | Map + Navigation detail level | `0` low, `1` medium, `2` high |
+| `18` | Map + Navigation route line width | `2...48` |
+| `19` | Map + Navigation zoom level | `0...5` |
+| `20` | Map + Navigation feature visibility mask | bits `0...7` use the same feature classes as ID `8`; navigation overlay bits remain global via ID `8` |
+| `21` | Map + Navigation street line width boost | `0...24` px |
+| `22` | Map + Navigation current-position marker scale | `1...5` |
 
 Feature visibility toggles are authoritative for their classes. Detail level
 controls small-area density without overriding the visibility mask: high uses
 the explicit Min Polygon Size, medium applies at least a 12px floor, and low
 applies at least a 24px floor. For example, the Buildings toggle can show or
-hide buildings at any detail level.
+hide buildings at any detail level. IDs `1`, `2`, `3`, `7`, `8`, `9`, and `10`
+form the Map screen profile. IDs `16...22` form the independent Map +
+Navigation profile. On firmware upgrade, missing Map + Navigation values inherit
+the persisted Map values. Map rotation mode remains Map-only; Map + Navigation
+automatically uses course-up while navigating. Route and current-position
+overlay visibility remains shared by both profiles.
 
 ## Device Sound Playback
 

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -98,7 +98,7 @@ Current setting IDs:
 | `4` | Display rotation | `0...3` |
 | `6` | Map rotation mode | `0` north-up, `1` course-up |
 | `7` | Map zoom level | `0...5` |
-| `8` | Map visibility and global navigation-overlay mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/tracks, bit 3 major roads, bit 4 local streets, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker |
+| `8` | Map visibility and global navigation-overlay mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/footways, bit 3 major roads, bit 4 residential/other local roads, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker, bit 10 service roads, bit 11 tracks, bit 12 extended-mask marker |
 | `9` | Map street line width boost | `0...24` px added to known road/path line style widths; legacy unknown lines are boosted when their stored style width is at least 3px; final rendered width is capped at 24px |
 | `10` | Map current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a white dot when no route is loaded and a white arrow while navigating. |
 | `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device through the enabled main screens. Map drags and long presses are ignored by this shortcut. |
@@ -110,7 +110,7 @@ Current setting IDs:
 | `17` | Map + Navigation detail level | `0` low, `1` medium, `2` high |
 | `18` | Map + Navigation route line width | `2...48` |
 | `19` | Map + Navigation zoom level | `0...5` |
-| `20` | Map + Navigation feature visibility mask | bits `0...7` use the same feature classes as ID `8`; navigation overlay bits remain global via ID `8` |
+| `20` | Map + Navigation feature visibility mask | feature bits and the extended-mask marker use the same meanings as ID `8`; navigation overlay bits remain global via ID `8` |
 | `21` | Map + Navigation street line width boost | `0...24` px |
 | `22` | Map + Navigation current-position marker scale | `1...5` |
 
@@ -124,6 +124,10 @@ Navigation profile. On firmware upgrade, missing Map + Navigation values inherit
 the persisted Map values. Map rotation mode remains Map-only; Map + Navigation
 automatically uses course-up while navigating. Route and current-position
 overlay visibility remains shared by both profiles.
+
+Apps that support the extended visibility classes set marker bit `12`. Without
+that marker, firmware preserves the legacy behavior by applying bit `4` to both
+local and service roads and bit `2` to both paths and tracks.
 
 ## Device Sound Playback
 
@@ -198,6 +202,9 @@ configuration:
 "CAPS" | Flags: UInt8 | Enabled: UInt8 | SoundID: UInt8 | VolumePercent: UInt8
 ```
 
+Version `2` enables independent Map and Map + Navigation profiles. Version `3`
+requests the extended map visibility classes.
+
 Legacy four-byte requests and five-byte responses remain supported. This lets
 new apps treat the device as the source of truth after reconnecting, while new
 apps still interoperate with older firmware and older apps still receive the
@@ -208,10 +215,12 @@ Flag bit `0` reports runtime device-sound availability after the speaker queue
 and task start successfully. Flag bit `1` reports PWR-button honk support. Flag
 bit `2` reports `SNHA` acknowledgement support; iOS only retries PWR
 configuration when this bit is set, preserving one-shot writes for older
-firmware. The app retries discovery after each connection, enables controls
-only when their bits are set, and restores the device-persisted PWR
-configuration from versioned responses. With legacy responses, it synchronizes
-the app-persisted configuration after discovery.
+firmware. Flag bit `3` reports independent map profiles for older app builds;
+current app builds always send separate Map and Map + Navigation profiles. Flag
+bit `4` reports separate service-road and track visibility. The app retries
+discovery after each connection, uses the sound-related bits to enable sound
+controls, and restores the device-persisted PWR configuration from versioned
+responses.
 
 ## OSM Map Blocks
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -43,6 +43,8 @@ BLENavigationServer bleNavServer;
 // Forward declaration of map redraw trigger
 extern void triggerMapRedraw();
 extern void applyDeviceScreenSettings();
+extern bool isMapScreenActive();
+extern bool isMapGuidanceScreenActive();
 
 // NavigationData struct is now in ble_navigation.hpp
 
@@ -1037,51 +1039,54 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
 
   switch (settingId) {
   case 1:
-    mapRenderSettings.minPolygonSize =
+    mapRenderSettings.mapStyle.minPolygonSize =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)50);
     settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("minPolySize", mapRenderSettings.minPolygonSize);
+    settingsPrefs.putUChar("minPolySize",
+                           mapRenderSettings.mapStyle.minPolygonSize);
     settingsPrefs.end();
     Serial.printf("BLE Settings: minPolygonSize = %d (saved)\n",
-                  mapRenderSettings.minPolygonSize);
+                  mapRenderSettings.mapStyle.minPolygonSize);
     break;
   case 2:
-    mapRenderSettings.detailLevel =
+    mapRenderSettings.mapStyle.detailLevel =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)2);
     settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("detailLevel", mapRenderSettings.detailLevel);
+    settingsPrefs.putUChar("detailLevel",
+                           mapRenderSettings.mapStyle.detailLevel);
     settingsPrefs.end();
     Serial.printf("BLE Settings: detailLevel = %d (saved)\n",
-                  mapRenderSettings.detailLevel);
+                  mapRenderSettings.mapStyle.detailLevel);
     break;
   case 3:
-    mapRenderSettings.routeLineWidth =
+    mapRenderSettings.mapStyle.routeLineWidth =
         (uint8_t)std::min(std::max(settingValue, (int32_t)2), (int32_t)48);
     settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("routeWidth", mapRenderSettings.routeLineWidth);
+    settingsPrefs.putUChar("routeWidth",
+                           mapRenderSettings.mapStyle.routeLineWidth);
     settingsPrefs.end();
     Serial.printf("BLE Settings: routeLineWidth = %d (saved)\n",
-                  mapRenderSettings.routeLineWidth);
+                  mapRenderSettings.mapStyle.routeLineWidth);
     break;
   case 9:
-    mapRenderSettings.streetLineWidthBoost =
+    mapRenderSettings.mapStyle.streetLineWidthBoost =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)24);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("streetBoost",
-                           mapRenderSettings.streetLineWidthBoost);
+                           mapRenderSettings.mapStyle.streetLineWidthBoost);
     settingsPrefs.end();
     Serial.printf("BLE Settings: streetLineWidthBoost = %d (saved)\n",
-                  mapRenderSettings.streetLineWidthBoost);
+                  mapRenderSettings.mapStyle.streetLineWidthBoost);
     break;
   case 10:
-    mapRenderSettings.positionMarkerScale =
+    mapRenderSettings.mapStyle.positionMarkerScale =
         (uint8_t)std::min(std::max(settingValue, (int32_t)1), (int32_t)5);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("markerScale",
-                           mapRenderSettings.positionMarkerScale);
+                           mapRenderSettings.mapStyle.positionMarkerScale);
     settingsPrefs.end();
     Serial.printf("BLE Settings: positionMarkerScale = %d (saved)\n",
-                  mapRenderSettings.positionMarkerScale);
+                  mapRenderSettings.mapStyle.positionMarkerScale);
     break;
   case 11:
     mapRenderSettings.tapToSwitchScreens = settingValue != 0 ? 1 : 0;
@@ -1153,23 +1158,92 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     break;
   case 7: {
     extern uint8_t zoom;
-    mapRenderSettings.zoomLevel =
+    mapRenderSettings.mapStyle.zoomLevel =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)5);
-    zoom = mapRenderSettings.zoomLevel;
+    if (isMapScreenActive()) {
+      zoom = mapRenderSettings.mapStyle.zoomLevel;
+    }
     settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("zoomLevel", mapRenderSettings.zoomLevel);
+    settingsPrefs.putUChar("zoomLevel", mapRenderSettings.mapStyle.zoomLevel);
     settingsPrefs.end();
     Serial.printf("BLE Settings: zoomLevel = %d (saved)\n",
-                  mapRenderSettings.zoomLevel);
+                  mapRenderSettings.mapStyle.zoomLevel);
     break;
   }
-  case 8:
-    mapRenderSettings.visibilityMask = (uint32_t)settingValue;
+  case 8: {
+    const uint32_t mask = (uint32_t)settingValue;
+    mapRenderSettings.mapStyle.visibilityMask = mask & 0xFF;
+    mapRenderSettings.navigationOverlayVisibilityMask = mask & 0x300;
     settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUInt("visMask", mapRenderSettings.visibilityMask);
+    settingsPrefs.putUInt(
+        "visMask", mapRenderSettings.mapStyle.visibilityMask |
+                       mapRenderSettings.navigationOverlayVisibilityMask);
     settingsPrefs.end();
     Serial.printf("BLE Settings: visibilityMask = 0x%08X (saved)\n",
-                  mapRenderSettings.visibilityMask);
+                  mask);
+    break;
+  }
+  case 16:
+    mapRenderSettings.mapNavigationStyle.minPolygonSize =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)50);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar(
+        "navMinPoly", mapRenderSettings.mapNavigationStyle.minPolygonSize);
+    settingsPrefs.end();
+    break;
+  case 17:
+    mapRenderSettings.mapNavigationStyle.detailLevel =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)2);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar("navDetail",
+                           mapRenderSettings.mapNavigationStyle.detailLevel);
+    settingsPrefs.end();
+    break;
+  case 18:
+    mapRenderSettings.mapNavigationStyle.routeLineWidth =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)2), (int32_t)48);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar(
+        "navRouteW", mapRenderSettings.mapNavigationStyle.routeLineWidth);
+    settingsPrefs.end();
+    break;
+  case 19:
+    mapRenderSettings.mapNavigationStyle.zoomLevel =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)5);
+    if (isMapGuidanceScreenActive()) {
+      extern uint8_t zoom;
+      zoom = mapRenderSettings.mapNavigationStyle.zoomLevel;
+    }
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar("navZoom",
+                           mapRenderSettings.mapNavigationStyle.zoomLevel);
+    settingsPrefs.end();
+    break;
+  case 20:
+    mapRenderSettings.mapNavigationStyle.visibilityMask =
+        (uint32_t)settingValue & 0xFF;
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUInt(
+        "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask);
+    settingsPrefs.end();
+    break;
+  case 21:
+    mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)24);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar(
+        "navStreetB",
+        mapRenderSettings.mapNavigationStyle.streetLineWidthBoost);
+    settingsPrefs.end();
+    break;
+  case 22:
+    mapRenderSettings.mapNavigationStyle.positionMarkerScale =
+        (uint8_t)std::min(std::max(settingValue, (int32_t)1), (int32_t)5);
+    settingsPrefs.begin("mapSettings", false);
+    settingsPrefs.putUChar(
+        "navMarkerS",
+        mapRenderSettings.mapNavigationStyle.positionMarkerScale);
+    settingsPrefs.end();
     break;
   default:
     Serial.printf("BLE Settings: Unknown setting ID %d from %s\n", settingId,
@@ -1458,15 +1532,30 @@ static void loadSettingsFromNVS() {
   Preferences prefs;
   prefs.begin("mapSettings", true); // read-only
 
-  mapRenderSettings.minPolygonSize = prefs.getUChar("minPolySize", 0);
-  mapRenderSettings.detailLevel = prefs.getUChar("detailLevel", 2);
-  mapRenderSettings.routeLineWidth = prefs.getUChar("routeWidth", 4);
-  mapRenderSettings.streetLineWidthBoost = prefs.getUChar("streetBoost", 0);
-  mapRenderSettings.positionMarkerScale = prefs.getUChar("markerScale", 2);
+  mapRenderSettings.mapStyle.minPolygonSize = prefs.getUChar("minPolySize", 0);
+  mapRenderSettings.mapStyle.detailLevel = prefs.getUChar("detailLevel", 2);
+  mapRenderSettings.mapStyle.routeLineWidth = prefs.getUChar("routeWidth", 4);
+  mapRenderSettings.mapStyle.streetLineWidthBoost =
+      prefs.getUChar("streetBoost", 0);
+  mapRenderSettings.mapStyle.positionMarkerScale =
+      prefs.getUChar("markerScale", 2);
+  mapRenderSettings.mapStyle.zoomLevel = prefs.getUChar("zoomLevel", 4);
+
+  mapRenderSettings.mapNavigationStyle.minPolygonSize = prefs.getUChar(
+      "navMinPoly", mapRenderSettings.mapStyle.minPolygonSize);
+  mapRenderSettings.mapNavigationStyle.detailLevel =
+      prefs.getUChar("navDetail", mapRenderSettings.mapStyle.detailLevel);
+  mapRenderSettings.mapNavigationStyle.routeLineWidth =
+      prefs.getUChar("navRouteW", mapRenderSettings.mapStyle.routeLineWidth);
+  mapRenderSettings.mapNavigationStyle.streetLineWidthBoost = prefs.getUChar(
+      "navStreetB", mapRenderSettings.mapStyle.streetLineWidthBoost);
+  mapRenderSettings.mapNavigationStyle.positionMarkerScale = prefs.getUChar(
+      "navMarkerS", mapRenderSettings.mapStyle.positionMarkerScale);
+  mapRenderSettings.mapNavigationStyle.zoomLevel =
+      prefs.getUChar("navZoom", mapRenderSettings.mapStyle.zoomLevel);
   mapRenderSettings.displayRotation =
       sanitizeMapDisplayRotation(prefs.getUChar("rotation", 0), "NVS");
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
-  mapRenderSettings.zoomLevel = prefs.getUChar("zoomLevel", 4);
   mapRenderSettings.tapToSwitchScreens = prefs.getUChar("tapSwitch", 0);
   mapRenderSettings.enabledScreensMask =
       normalizedEnabledScreensMask(prefs.getUChar("screenMask",
@@ -1477,7 +1566,13 @@ static void loadSettingsFromNVS() {
   mapRenderSettings.disconnectedSleepTimeoutSeconds =
       normalizedDisconnectedSleepTimeoutSeconds(
           prefs.getUInt("discSleepSec", 120));
-  mapRenderSettings.visibilityMask = prefs.getUInt("visMask", 0xFFFFFFFF);
+  const uint32_t legacyVisibilityMask = prefs.getUInt("visMask", 0x3FF);
+  mapRenderSettings.mapStyle.visibilityMask = legacyVisibilityMask & 0xFF;
+  mapRenderSettings.navigationOverlayVisibilityMask =
+      legacyVisibilityMask & 0x300;
+  mapRenderSettings.mapNavigationStyle.visibilityMask =
+      prefs.getUInt("navVis", mapRenderSettings.mapStyle.visibilityMask) &
+      0xFF;
 
   prefs.end();
 
@@ -1485,10 +1580,11 @@ static void loadSettingsFromNVS() {
                 "detailLevel=%d, routeWidth=%d, streetBoost=%d, "
                 "markerScale=%d, rotation=%d, tapSwitch=%d, "
                 "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
-                mapRenderSettings.minPolygonSize, mapRenderSettings.detailLevel,
-                mapRenderSettings.routeLineWidth,
-                mapRenderSettings.streetLineWidthBoost,
-                mapRenderSettings.positionMarkerScale,
+                mapRenderSettings.mapStyle.minPolygonSize,
+                mapRenderSettings.mapStyle.detailLevel,
+                mapRenderSettings.mapStyle.routeLineWidth,
+                mapRenderSettings.mapStyle.streetLineWidthBoost,
+                mapRenderSettings.mapStyle.positionMarkerScale,
                 mapRenderSettings.displayRotation,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -59,6 +59,9 @@ static Preferences settingsPrefs;
 static NavigationData currentNavData = {0, 0, ""};
 static volatile bool navDataUpdated = false;
 static bool bleSessionAuthenticated = false;
+static bool bleSessionUsesIndependentMapProfiles = false;
+static constexpr uint8_t CAPABILITY_EXTENDED_MAP_VISIBILITY =
+    map_profile_protocol::EXTENDED_VISIBILITY_CAPABILITY_MASK;
 static char pendingAuthNonce[33] = "";
 static NimBLECharacteristic *authCharacteristic = nullptr;
 static NimBLECharacteristic *mapTransferStatusCharacteristic = nullptr;
@@ -397,6 +400,7 @@ static void handleAuthPayload(const std::string &value) {
     char mac[65];
     char response[112];
     bleSessionAuthenticated = false;
+    bleSessionUsesIndependentMapProfiles = false;
     snprintf(message, sizeof(message), "server|%s", nonce);
     if (!hmacSha256Hex(message, mac, sizeof(mac))) {
       Serial.println("BLE: Failed to compute auth response");
@@ -712,9 +716,12 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
       waveshare_board::speaker::isPowerButtonHonkAvailable();
   uint8_t response[8] = {
       'C', 'A', 'P', 'S',
-      waveshare_board::speaker::capabilityFlags(
-          speakerAvailable, powerButtonHonkAvailable,
-          powerButtonHonkAvailable),
+      static_cast<uint8_t>(
+          waveshare_board::speaker::capabilityFlags(
+              speakerAvailable, powerButtonHonkAvailable,
+              powerButtonHonkAvailable) |
+          map_profile_protocol::CAPABILITY_MASK |
+          CAPABILITY_EXTENDED_MAP_VISIBILITY),
   };
   size_t responseSize = 5;
   waveshare_board::speaker::PowerButtonHonkConfig config{};
@@ -765,8 +772,12 @@ static bool handleDeviceCapabilitiesCommand(const std::string &value,
     return false;
   }
   if (requireAuthenticated(authLabel)) {
+    const uint8_t clientVersion =
+        value.length() == 5 ? static_cast<uint8_t>(value[4]) : 0;
+    bleSessionUsesIndependentMapProfiles =
+        map_profile_protocol::clientSupportsIndependentProfiles(clientVersion);
     const bool includePowerButtonConfig =
-        value.length() == 5 && static_cast<uint8_t>(value[4]) >= 1;
+        clientVersion >= 1;
     notifyDeviceCapabilities(pChar, includePowerButtonConfig);
   }
   return true;
@@ -1036,54 +1047,99 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                              const char *source) {
   bleDebugStats.settingsPacketCount++;
   bleDebugStats.lastSettingsPacketMs = millis();
+  const bool mirrorLegacyMapProfile =
+      map_profile_protocol::shouldMirrorLegacySetting(
+          settingId, bleSessionUsesIndependentMapProfiles);
 
   switch (settingId) {
   case 1:
     mapRenderSettings.mapStyle.minPolygonSize =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)50);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.minPolygonSize =
+          mapRenderSettings.mapStyle.minPolygonSize;
+    }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("minPolySize",
                            mapRenderSettings.mapStyle.minPolygonSize);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar(
+          "navMinPoly", mapRenderSettings.mapNavigationStyle.minPolygonSize);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: minPolygonSize = %d (saved)\n",
                   mapRenderSettings.mapStyle.minPolygonSize);
     break;
   case 2:
     mapRenderSettings.mapStyle.detailLevel =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)2);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.detailLevel =
+          mapRenderSettings.mapStyle.detailLevel;
+    }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("detailLevel",
                            mapRenderSettings.mapStyle.detailLevel);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar("navDetail",
+                             mapRenderSettings.mapNavigationStyle.detailLevel);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: detailLevel = %d (saved)\n",
                   mapRenderSettings.mapStyle.detailLevel);
     break;
   case 3:
     mapRenderSettings.mapStyle.routeLineWidth =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)2), (int32_t)48);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.routeLineWidth =
+          mapRenderSettings.mapStyle.routeLineWidth;
+    }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("routeWidth",
                            mapRenderSettings.mapStyle.routeLineWidth);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar(
+          "navRouteW", mapRenderSettings.mapNavigationStyle.routeLineWidth);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: routeLineWidth = %d (saved)\n",
                   mapRenderSettings.mapStyle.routeLineWidth);
     break;
   case 9:
     mapRenderSettings.mapStyle.streetLineWidthBoost =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)24);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
+          mapRenderSettings.mapStyle.streetLineWidthBoost;
+    }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("streetBoost",
                            mapRenderSettings.mapStyle.streetLineWidthBoost);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar(
+          "navStreetB",
+          mapRenderSettings.mapNavigationStyle.streetLineWidthBoost);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: streetLineWidthBoost = %d (saved)\n",
                   mapRenderSettings.mapStyle.streetLineWidthBoost);
     break;
   case 10:
     mapRenderSettings.mapStyle.positionMarkerScale =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)1), (int32_t)5);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.positionMarkerScale =
+          mapRenderSettings.mapStyle.positionMarkerScale;
+    }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("markerScale",
                            mapRenderSettings.mapStyle.positionMarkerScale);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar(
+          "navMarkerS",
+          mapRenderSettings.mapNavigationStyle.positionMarkerScale);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: positionMarkerScale = %d (saved)\n",
                   mapRenderSettings.mapStyle.positionMarkerScale);
@@ -1159,12 +1215,20 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
   case 7: {
     extern uint8_t zoom;
     mapRenderSettings.mapStyle.zoomLevel =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)5);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.zoomLevel =
+          mapRenderSettings.mapStyle.zoomLevel;
+    }
     if (isMapScreenActive()) {
       zoom = mapRenderSettings.mapStyle.zoomLevel;
     }
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("zoomLevel", mapRenderSettings.mapStyle.zoomLevel);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUChar("navZoom",
+                             mapRenderSettings.mapNavigationStyle.zoomLevel);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: zoomLevel = %d (saved)\n",
                   mapRenderSettings.mapStyle.zoomLevel);
@@ -1172,44 +1236,60 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
   }
   case 8: {
     const uint32_t mask = (uint32_t)settingValue;
-    mapRenderSettings.mapStyle.visibilityMask = mask & 0xFF;
-    mapRenderSettings.navigationOverlayVisibilityMask = mask & 0x300;
+    mapRenderSettings.mapStyle.visibilityMask =
+        normalizedMapFeatureVisibilityMask(mask);
+    if (mirrorLegacyMapProfile) {
+      mapRenderSettings.mapNavigationStyle.visibilityMask =
+          mapRenderSettings.mapStyle.visibilityMask;
+    }
+    mapRenderSettings.navigationOverlayVisibilityMask =
+        mask & MAP_VISIBILITY_OVERLAY_MASK;
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUInt(
         "visMask", mapRenderSettings.mapStyle.visibilityMask |
-                       mapRenderSettings.navigationOverlayVisibilityMask);
+                       mapRenderSettings.navigationOverlayVisibilityMask |
+                       MAP_VISIBILITY_EXTENDED_MARKER);
+    if (mirrorLegacyMapProfile) {
+      settingsPrefs.putUInt(
+          "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask |
+                        MAP_VISIBILITY_EXTENDED_MARKER);
+    }
     settingsPrefs.end();
     Serial.printf("BLE Settings: visibilityMask = 0x%08X (saved)\n",
                   mask);
     break;
   }
   case 16:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.minPolygonSize =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)50);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar(
         "navMinPoly", mapRenderSettings.mapNavigationStyle.minPolygonSize);
     settingsPrefs.end();
     break;
   case 17:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.detailLevel =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)2);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar("navDetail",
                            mapRenderSettings.mapNavigationStyle.detailLevel);
     settingsPrefs.end();
     break;
   case 18:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.routeLineWidth =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)2), (int32_t)48);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar(
         "navRouteW", mapRenderSettings.mapNavigationStyle.routeLineWidth);
     settingsPrefs.end();
     break;
   case 19:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.zoomLevel =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)5);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     if (isMapGuidanceScreenActive()) {
       extern uint8_t zoom;
       zoom = mapRenderSettings.mapNavigationStyle.zoomLevel;
@@ -1220,16 +1300,19 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     settingsPrefs.end();
     break;
   case 20:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.visibilityMask =
-        (uint32_t)settingValue & 0xFF;
+        normalizedMapFeatureVisibilityMask((uint32_t)settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUInt(
-        "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask);
+        "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask |
+                      MAP_VISIBILITY_EXTENDED_MARKER);
     settingsPrefs.end();
     break;
   case 21:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)24);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar(
         "navStreetB",
@@ -1237,8 +1320,9 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     settingsPrefs.end();
     break;
   case 22:
+    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.positionMarkerScale =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)1), (int32_t)5);
+        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     settingsPrefs.begin("mapSettings", false);
     settingsPrefs.putUChar(
         "navMarkerS",
@@ -1282,6 +1366,7 @@ public:
     activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
     server->connected = true;
     bleSessionAuthenticated = false;
+    bleSessionUsesIndependentMapProfiles = false;
     unauthTimeoutDisconnectRequested = false;
     bleDebugStats.connected = true;
     bleDebugStats.authenticated = false;
@@ -1306,6 +1391,7 @@ public:
     }
     server->connected = false;
     bleSessionAuthenticated = false;
+    bleSessionUsesIndependentMapProfiles = false;
     unauthTimeoutDisconnectRequested = false;
     activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
     bleDebugStats.connected = false;
@@ -1566,13 +1652,15 @@ static void loadSettingsFromNVS() {
   mapRenderSettings.disconnectedSleepTimeoutSeconds =
       normalizedDisconnectedSleepTimeoutSeconds(
           prefs.getUInt("discSleepSec", 120));
-  const uint32_t legacyVisibilityMask = prefs.getUInt("visMask", 0x3FF);
-  mapRenderSettings.mapStyle.visibilityMask = legacyVisibilityMask & 0xFF;
+  const uint32_t storedVisibilityMask = prefs.getUInt("visMask", 0x3FF);
+  mapRenderSettings.mapStyle.visibilityMask =
+      normalizedMapFeatureVisibilityMask(storedVisibilityMask);
   mapRenderSettings.navigationOverlayVisibilityMask =
-      legacyVisibilityMask & 0x300;
+      storedVisibilityMask & MAP_VISIBILITY_OVERLAY_MASK;
   mapRenderSettings.mapNavigationStyle.visibilityMask =
-      prefs.getUInt("navVis", mapRenderSettings.mapStyle.visibilityMask) &
-      0xFF;
+      normalizedMapFeatureVisibilityMask(prefs.getUInt(
+          "navVis", mapRenderSettings.mapStyle.visibilityMask |
+                        MAP_VISIBILITY_EXTENDED_MARKER));
 
   prefs.end();
 

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -30,10 +30,8 @@ struct NavigationData {
 
 /**
  * @brief Map rendering settings (configurable via BLE from iOS app)
- * Settings IDs: 1=minPolygonSize, 2=detailLevel, 3=routeLineWidth,
- * 4=displayRotation, 6=mapRotationMode, 7=zoomLevel, 8=visibilityMask,
- * 9=streetLineWidthBoost, 10=positionMarkerScale, 11=tapToSwitchScreens,
- * 13=enabledScreensMask, 14=defaultScreen, 15=disconnectedSleepTimeoutSeconds
+ * IDs 1,2,3,7,8,9,10 configure the Map screen. IDs 16-22 configure
+ * Map + Navigation. IDs 4,6,11-15 configure shared/device behavior.
  */
 enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
@@ -46,16 +44,24 @@ static constexpr uint8_t DEVICE_SCREEN_SUPPORTED_MASK =
     (1 << DEVICE_SCREEN_MAP) | (1 << DEVICE_SCREEN_NAVIGATION) |
     (1 << DEVICE_SCREEN_RIDE_STATS) | (1 << DEVICE_SCREEN_MAP_PLUS_NAVIGATION);
 
-struct MapRenderSettings {
+struct ScreenMapRenderSettings {
   uint8_t minPolygonSize = 0; // 0-50: Skip polygons smaller than N pixels²
   uint8_t detailLevel = 2;    // 0=Low, 1=Med, 2=High
   uint8_t routeLineWidth = 4; // 2-48: Route overlay line width in pixels
   uint8_t streetLineWidthBoost = 0; // 0-24: Extra map street width in pixels
   uint8_t positionMarkerScale = 2;  // 1-5: Current-position marker scale
+  uint8_t zoomLevel = 2;             // 0-5: Zoom level (0=super, 2=default)
+  uint32_t visibilityMask =
+      0xFF; // Bits 0-7: buildings, green, paths, major/local roads, water,
+            // rail, other areas
+};
+
+struct MapRenderSettings {
+  ScreenMapRenderSettings mapStyle;
+  ScreenMapRenderSettings mapNavigationStyle;
   uint8_t displayRotation =
       0; // 0-3: Display rotation (0=0°, 1=90°, 2=180°, 3=270°)
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
-  uint8_t zoomLevel = 2;       // 0-5: Zoom level (0=super, 2=default)
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
   uint8_t enabledScreensMask =
       DEVICE_SCREEN_SUPPORTED_MASK; // Bits follow DeviceScreenSetting
@@ -63,13 +69,12 @@ struct MapRenderSettings {
       DEVICE_SCREEN_MAP_PLUS_NAVIGATION; // DeviceScreenSetting value
   uint32_t disconnectedSleepTimeoutSeconds =
       120; // 0=never auto-sleep while disconnected
-  uint32_t visibilityMask =
-      0xFFFFFFFF; // Bits: 0 buildings, 1 green, 2 paths, 3 major roads,
-                  // 4 local streets, 5 water, 6 rail, 7 other areas,
-                  // 8 route overlay, 9 current position
+  uint32_t navigationOverlayVisibilityMask =
+      (1 << 8) | (1 << 9); // Bit 8 route, bit 9 current position
 };
 
 extern MapRenderSettings mapRenderSettings;
+const ScreenMapRenderSettings &currentMapStyleSettings();
 
 NavigationData getCurrentNavigationData();
 bool hasCurrentNavigationData();

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -13,6 +13,7 @@
  */
 
 #include <Arduino.h>
+#include "map_profile_protocol.hpp"
 
 // Forward declarations - actual NimBLE includes only in .cpp
 class NimBLEServer;
@@ -44,6 +45,41 @@ static constexpr uint8_t DEVICE_SCREEN_SUPPORTED_MASK =
     (1 << DEVICE_SCREEN_MAP) | (1 << DEVICE_SCREEN_NAVIGATION) |
     (1 << DEVICE_SCREEN_RIDE_STATS) | (1 << DEVICE_SCREEN_MAP_PLUS_NAVIGATION);
 
+static constexpr uint32_t MAP_VISIBILITY_BUILDINGS =
+    map_profile_protocol::VISIBILITY_BUILDINGS;
+static constexpr uint32_t MAP_VISIBILITY_GREEN_SPACE =
+    map_profile_protocol::VISIBILITY_GREEN_SPACE;
+static constexpr uint32_t MAP_VISIBILITY_PATHS =
+    map_profile_protocol::VISIBILITY_PATHS;
+static constexpr uint32_t MAP_VISIBILITY_MAJOR_ROADS =
+    map_profile_protocol::VISIBILITY_MAJOR_ROADS;
+static constexpr uint32_t MAP_VISIBILITY_LOCAL_STREETS =
+    map_profile_protocol::VISIBILITY_LOCAL_STREETS;
+static constexpr uint32_t MAP_VISIBILITY_WATER =
+    map_profile_protocol::VISIBILITY_WATER;
+static constexpr uint32_t MAP_VISIBILITY_RAILWAYS =
+    map_profile_protocol::VISIBILITY_RAILWAYS;
+static constexpr uint32_t MAP_VISIBILITY_OTHER_AREAS =
+    map_profile_protocol::VISIBILITY_OTHER_AREAS;
+static constexpr uint32_t MAP_VISIBILITY_ROUTE_OVERLAY =
+    map_profile_protocol::VISIBILITY_ROUTE_OVERLAY;
+static constexpr uint32_t MAP_VISIBILITY_POSITION_MARKER =
+    map_profile_protocol::VISIBILITY_POSITION_MARKER;
+static constexpr uint32_t MAP_VISIBILITY_SERVICE_ROADS =
+    map_profile_protocol::VISIBILITY_SERVICE_ROADS;
+static constexpr uint32_t MAP_VISIBILITY_TRACKS =
+    map_profile_protocol::VISIBILITY_TRACKS;
+static constexpr uint32_t MAP_VISIBILITY_EXTENDED_MARKER =
+    map_profile_protocol::VISIBILITY_EXTENDED_MARKER;
+static constexpr uint32_t MAP_VISIBILITY_EXTENDED_FEATURE_MASK =
+    map_profile_protocol::VISIBILITY_EXTENDED_FEATURE_MASK;
+static constexpr uint32_t MAP_VISIBILITY_OVERLAY_MASK =
+    map_profile_protocol::VISIBILITY_OVERLAY_MASK;
+
+static inline uint32_t normalizedMapFeatureVisibilityMask(uint32_t mask) {
+  return map_profile_protocol::normalizedFeatureVisibilityMask(mask);
+}
+
 struct ScreenMapRenderSettings {
   uint8_t minPolygonSize = 0; // 0-50: Skip polygons smaller than N pixels²
   uint8_t detailLevel = 2;    // 0=Low, 1=Med, 2=High
@@ -51,9 +87,7 @@ struct ScreenMapRenderSettings {
   uint8_t streetLineWidthBoost = 0; // 0-24: Extra map street width in pixels
   uint8_t positionMarkerScale = 2;  // 1-5: Current-position marker scale
   uint8_t zoomLevel = 2;             // 0-5: Zoom level (0=super, 2=default)
-  uint32_t visibilityMask =
-      0xFF; // Bits 0-7: buildings, green, paths, major/local roads, water,
-            // rail, other areas
+  uint32_t visibilityMask = MAP_VISIBILITY_EXTENDED_FEATURE_MASK;
 };
 
 struct MapRenderSettings {
@@ -70,7 +104,7 @@ struct MapRenderSettings {
   uint32_t disconnectedSleepTimeoutSeconds =
       120; // 0=never auto-sleep while disconnected
   uint32_t navigationOverlayVisibilityMask =
-      (1 << 8) | (1 << 9); // Bit 8 route, bit 9 current position
+      MAP_VISIBILITY_OVERLAY_MASK;
 };
 
 extern MapRenderSettings mapRenderSettings;

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace map_profile_protocol {
+
+constexpr uint8_t CAPABILITY_MASK = 1 << 3;
+constexpr uint8_t CLIENT_VERSION = 2;
+constexpr uint8_t EXTENDED_VISIBILITY_CAPABILITY_MASK = 1 << 4;
+constexpr uint8_t EXTENDED_VISIBILITY_CLIENT_VERSION = 3;
+
+constexpr uint32_t VISIBILITY_BUILDINGS = 1u << 0;
+constexpr uint32_t VISIBILITY_GREEN_SPACE = 1u << 1;
+constexpr uint32_t VISIBILITY_PATHS = 1u << 2;
+constexpr uint32_t VISIBILITY_MAJOR_ROADS = 1u << 3;
+constexpr uint32_t VISIBILITY_LOCAL_STREETS = 1u << 4;
+constexpr uint32_t VISIBILITY_WATER = 1u << 5;
+constexpr uint32_t VISIBILITY_RAILWAYS = 1u << 6;
+constexpr uint32_t VISIBILITY_OTHER_AREAS = 1u << 7;
+constexpr uint32_t VISIBILITY_ROUTE_OVERLAY = 1u << 8;
+constexpr uint32_t VISIBILITY_POSITION_MARKER = 1u << 9;
+constexpr uint32_t VISIBILITY_SERVICE_ROADS = 1u << 10;
+constexpr uint32_t VISIBILITY_TRACKS = 1u << 11;
+constexpr uint32_t VISIBILITY_EXTENDED_MARKER = 1u << 12;
+constexpr uint32_t VISIBILITY_LEGACY_FEATURE_MASK = 0xFF;
+constexpr uint32_t VISIBILITY_EXTENDED_FEATURE_MASK =
+    VISIBILITY_LEGACY_FEATURE_MASK | VISIBILITY_SERVICE_ROADS |
+    VISIBILITY_TRACKS;
+constexpr uint32_t VISIBILITY_OVERLAY_MASK =
+    VISIBILITY_ROUTE_OVERLAY | VISIBILITY_POSITION_MARKER;
+
+inline bool clientSupportsIndependentProfiles(uint8_t clientVersion) {
+  return clientVersion >= CLIENT_VERSION;
+}
+
+inline bool clientSupportsExtendedVisibility(uint8_t clientVersion) {
+  return clientVersion >= EXTENDED_VISIBILITY_CLIENT_VERSION;
+}
+
+inline uint32_t normalizedFeatureVisibilityMask(uint32_t mask) {
+  uint32_t normalized = mask & VISIBILITY_LEGACY_FEATURE_MASK;
+  if ((mask & VISIBILITY_EXTENDED_MARKER) != 0) {
+    normalized |= mask & (VISIBILITY_SERVICE_ROADS | VISIBILITY_TRACKS);
+  } else {
+    if ((normalized & VISIBILITY_LOCAL_STREETS) != 0)
+      normalized |= VISIBILITY_SERVICE_ROADS;
+    if ((normalized & VISIBILITY_PATHS) != 0)
+      normalized |= VISIBILITY_TRACKS;
+  }
+  return normalized;
+}
+
+inline bool isServiceRoadTypeId(uint8_t typeId) { return typeId == 10; }
+
+inline bool isTrackTypeId(uint8_t typeId) { return typeId == 50; }
+
+inline bool isPathTypeId(uint8_t typeId) {
+  return typeId > 50 && typeId < 100;
+}
+
+inline bool isLocalStreetTypeId(uint8_t typeId) {
+  return typeId >= 6 && typeId < 50 && !isServiceRoadTypeId(typeId);
+}
+
+inline bool isIndependentSetting(uint8_t settingId) {
+  return settingId >= 16 && settingId <= 22;
+}
+
+inline bool isLegacySetting(uint8_t settingId) {
+  return settingId == 1 || settingId == 2 || settingId == 3 ||
+         settingId == 7 || settingId == 8 || settingId == 9 ||
+         settingId == 10;
+}
+
+inline bool shouldMirrorLegacySetting(uint8_t settingId,
+                                      bool independentProfilesEnabled) {
+  return isLegacySetting(settingId) && !independentProfilesEnabled;
+}
+
+inline int32_t clampValue(uint8_t settingId, int32_t value) {
+  int32_t minimum = 0;
+  int32_t maximum = 0;
+  switch (settingId) {
+  case 1:
+  case 16:
+    maximum = 50;
+    break;
+  case 2:
+  case 17:
+    maximum = 2;
+    break;
+  case 3:
+  case 18:
+    minimum = 2;
+    maximum = 48;
+    break;
+  case 7:
+  case 19:
+    maximum = 5;
+    break;
+  case 9:
+  case 21:
+    maximum = 24;
+    break;
+  case 10:
+  case 22:
+    minimum = 1;
+    maximum = 5;
+    break;
+  default:
+    return value;
+  }
+  return value < minimum ? minimum : (value > maximum ? maximum : value);
+}
+
+template <typename Profile>
+inline const Profile &select(const Profile &mapStyle,
+                             const Profile &mapNavigationStyle,
+                             bool mapNavigationActive) {
+  return mapNavigationActive ? mapNavigationStyle : mapStyle;
+}
+
+} // namespace map_profile_protocol

--- a/esp32/lib/gui/src/guiLayout.hpp
+++ b/esp32/lib/gui/src/guiLayout.hpp
@@ -12,7 +12,7 @@ namespace gui_layout {
 #if defined(WAVESHARE_AMOLED_206)
 constexpr uint16_t MAP_NONFULLSCREEN_RESERVED_HEIGHT = 72;
 constexpr uint8_t MAP_ANCHOR_X_PERCENT = 50;
-constexpr uint8_t MAP_ANCHOR_Y_PERCENT = 58;
+constexpr uint8_t MAP_ANCHOR_Y_PERCENT = 50;
 constexpr uint8_t MAP_TOOLBAR_OFFSET = 92;
 constexpr uint8_t MAP_TOOLBAR_SPACE = 54;
 constexpr uint8_t MAP_TOOLBAR_INSET = 12;
@@ -51,6 +51,23 @@ inline int16_t mapAnchorX(uint16_t width) {
 
 inline int16_t mapAnchorY(uint16_t height) {
   return (height * MAP_ANCHOR_Y_PERCENT) / 100;
+}
+
+inline int16_t centeredViewportOrigin(uint16_t containerExtent,
+                                      uint16_t viewportExtent) {
+  return (static_cast<int32_t>(containerExtent) - viewportExtent) / 2;
+}
+
+inline int16_t mapScreenAnchorX(uint16_t containerWidth,
+                                uint16_t mapWidth) {
+  return centeredViewportOrigin(containerWidth, mapWidth) +
+         mapAnchorX(mapWidth);
+}
+
+inline int16_t mapScreenAnchorY(uint16_t containerHeight,
+                                uint16_t mapHeight) {
+  return centeredViewportOrigin(containerHeight, mapHeight) +
+         mapAnchorY(mapHeight);
 }
 
 inline int16_t mapDragDelta(int16_t delta) {

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -56,20 +56,28 @@ lv_obj_t *btnZoomOut;
 static lv_obj_t *mapGuidanceOverlay;
 static lv_obj_t *mapGuidanceArrow;
 static lv_obj_t *mapGuidanceDistance;
-static lv_obj_t *mapGuidanceUnit;
 
 Maps mapView;
+
+bool isMapScreenActive() { return activeTile == MAP; }
+
+bool isMapGuidanceScreenActive() { return activeTile == MAP_GUIDANCE; }
+
+const ScreenMapRenderSettings &currentMapStyleSettings() {
+  return isMapGuidanceScreenActive() ? mapRenderSettings.mapNavigationStyle
+                                     : mapRenderSettings.mapStyle;
+}
 
 static void tapCycleScreenEvent(lv_event_t *event);
 
 static int16_t mapInteractionAnchorX() {
-  return gui_layout::mapAnchorX(mapView.mapScrWidth);
+  return gui_layout::mapScreenAnchorX(TFT_WIDTH, mapView.mapScrWidth);
 }
 
 static int16_t mapInteractionAnchorY() {
   const uint16_t mapHeight =
       mapSet.mapFullScreen ? mapView.mapScrFull : mapView.mapScrHeight;
-  return gui_layout::mapAnchorY(mapHeight);
+  return gui_layout::mapScreenAnchorY(TFT_HEIGHT, mapHeight);
 }
 
 static uint16_t currentCourseUpHeading() {
@@ -222,7 +230,7 @@ static void applyMapRotationForActiveTile() {
 }
 
 static void updateMapGuidanceOverlay() {
-  if (!mapGuidanceArrow || !mapGuidanceDistance || !mapGuidanceUnit) {
+  if (!mapGuidanceArrow || !mapGuidanceDistance) {
     return;
   }
 
@@ -232,19 +240,16 @@ static void updateMapGuidanceOverlay() {
   if (!hasCurrentNavigationData()) {
     lv_img_set_angle(mapGuidanceArrow, 0);
     lv_label_set_text_static(mapGuidanceDistance, "--");
-    lv_label_set_text_static(mapGuidanceUnit, "");
     return;
   }
 
   NavigationData navData = getCurrentNavigationData();
   lv_img_set_angle(mapGuidanceArrow, navigationArrowAngle(navData.iconID));
   if (navData.distance >= 1000) {
-    lv_label_set_text_fmt(mapGuidanceDistance, "%.1f",
+    lv_label_set_text_fmt(mapGuidanceDistance, "%.1f km",
                           navData.distance / 1000.0f);
-    lv_label_set_text_static(mapGuidanceUnit, "km");
   } else {
-    lv_label_set_text_fmt(mapGuidanceDistance, "%u", navData.distance);
-    lv_label_set_text_static(mapGuidanceUnit, "m");
+    lv_label_set_text_fmt(mapGuidanceDistance, "%u m", navData.distance);
   }
 }
 
@@ -763,9 +768,9 @@ void scrollMapEvent(lv_event_t *event) {
             log_i("MAP SHORT TAP: cycling main screen");
             showNextMainScreen();
           } else {
-            // GPS indicator is at the board-specific map anchor when followGps
-            // is true. When followGps is false, use the center area since users
-            // expect to tap the center indicator.
+            // GPS indicator is centered in the rendered map viewport when
+            // followGps is true. When followGps is false, use that center area
+            // since users expect to tap the center indicator.
             int centerX = mapInteractionAnchorX();
             int centerY = mapInteractionAnchorY();
             int distX = abs(p.x - centerX);
@@ -937,18 +942,11 @@ static void createMapGuidanceOverlay() {
   lv_obj_align(mapGuidanceArrow, LV_ALIGN_LEFT_MID, 20, 0);
 
   mapGuidanceDistance = lv_label_create(mapGuidanceOverlay);
-  lv_obj_set_style_text_font(mapGuidanceDistance, fontVeryLarge, 0);
+  lv_obj_set_style_text_font(mapGuidanceDistance, &lv_font_montserrat_48, 0);
   lv_obj_set_style_text_color(mapGuidanceDistance, lv_color_white(), 0);
   lv_obj_set_style_text_align(mapGuidanceDistance, LV_TEXT_ALIGN_LEFT, 0);
   lv_label_set_text_static(mapGuidanceDistance, "--");
-  lv_obj_align(mapGuidanceDistance, LV_ALIGN_CENTER, 46, -10);
-
-  mapGuidanceUnit = lv_label_create(mapGuidanceOverlay);
-  lv_obj_set_style_text_font(mapGuidanceUnit, fontOptions, 0);
-  lv_obj_set_style_text_color(mapGuidanceUnit, lv_color_white(), 0);
-  lv_label_set_text_static(mapGuidanceUnit, "");
-  lv_obj_align_to(mapGuidanceUnit, mapGuidanceDistance, LV_ALIGN_OUT_BOTTOM_LEFT,
-                  4, -8);
+  lv_obj_align(mapGuidanceDistance, LV_ALIGN_CENTER, 46, 0);
 
   lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
 }
@@ -965,6 +963,10 @@ static void showMainTile(tileName tile) {
 
   activeTile = tile;
   canScrollMap = tile == MAP;
+  if (isMapBackedTile(activeTile)) {
+    zoom = currentMapStyleSettings().zoomLevel;
+    mapView.isPosMoved = true;
+  }
 
   switch (tile) {
   case MAP_GUIDANCE:
@@ -1099,7 +1101,7 @@ void createMainScr() {
 
   // Sync zoom level from settings
   extern uint8_t zoom;
-  if (mapRenderSettings.zoomLevel >= 0 && mapRenderSettings.zoomLevel <= 5) {
-    zoom = mapRenderSettings.zoomLevel;
+  if (mapRenderSettings.mapStyle.zoomLevel <= 5) {
+    zoom = mapRenderSettings.mapStyle.zoomLevel;
   }
 }

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -64,8 +64,9 @@ bool isMapScreenActive() { return activeTile == MAP; }
 bool isMapGuidanceScreenActive() { return activeTile == MAP_GUIDANCE; }
 
 const ScreenMapRenderSettings &currentMapStyleSettings() {
-  return isMapGuidanceScreenActive() ? mapRenderSettings.mapNavigationStyle
-                                     : mapRenderSettings.mapStyle;
+  return map_profile_protocol::select(mapRenderSettings.mapStyle,
+                                      mapRenderSettings.mapNavigationStyle,
+                                      isMapGuidanceScreenActive());
 }
 
 static void tapCycleScreenEvent(lv_event_t *event);

--- a/esp32/lib/gui/src/mainScr.hpp
+++ b/esp32/lib/gui/src/mainScr.hpp
@@ -80,6 +80,8 @@ void zoomOutEvent(lv_event_t *event);
 void zoomInEvent(lv_event_t *event);
 void updateNavEvent(lv_event_t *event);
 void showNextMainScreen();
+bool isMapScreenActive();
+bool isMapGuidanceScreenActive();
 
 void createMainScr();
 void toggleNavigationScreen();

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -43,7 +43,7 @@ enum class VisibilityClass : uint8_t {
 };
 
 static inline bool isClassVisible(VisibilityClass visibilityClass,
-                                  const MapRenderSettings &settings) {
+                                  const ScreenMapRenderSettings &settings) {
   if (visibilityClass == VisibilityClass::Always)
     return true;
 
@@ -140,7 +140,7 @@ static inline VisibilityClass legacyLineVisibilityClass(uint16_t color,
 // Bits: 0 buildings, 1 green space, 2 paths, 3 major roads, 4 local streets,
 // 5 water, 6 rail, 7 other areas.
 static inline bool isTypeVisible(uint8_t typeId,
-                                 const MapRenderSettings &settings) {
+                                 const ScreenMapRenderSettings &settings) {
   if (typeId == 0)
     return true; // Unknown types always visible
   return isClassVisible(visibilityClassForTypeId(typeId), settings);
@@ -158,31 +158,31 @@ static inline uint8_t detailPolygonSizeFloor(uint8_t detailLevel) {
 }
 
 static inline uint8_t effectiveMinPolygonSize(
-    const MapRenderSettings &settings) {
+    const ScreenMapRenderSettings &settings) {
   return std::max(settings.minPolygonSize,
                   detailPolygonSizeFloor(settings.detailLevel));
 }
 
 static inline bool isPolygonVisible(uint8_t typeId, uint16_t color,
-                                    const MapRenderSettings &settings) {
+                                    const ScreenMapRenderSettings &settings) {
   if (typeId != 0)
     return isTypeVisible(typeId, settings);
   return isClassVisible(legacyPolygonVisibilityClass(color), settings);
 }
 
 static inline bool isLineVisible(uint8_t typeId, uint16_t color, uint8_t width,
-                                 const MapRenderSettings &settings) {
+                                 const ScreenMapRenderSettings &settings) {
   if (typeId != 0)
     return isTypeVisible(typeId, settings);
   return isClassVisible(legacyLineVisibilityClass(color, width), settings);
 }
 
 static inline bool isRouteOverlayVisible(const MapRenderSettings &settings) {
-  return (settings.visibilityMask & (1 << 8)) != 0;
+  return (settings.navigationOverlayVisibilityMask & (1 << 8)) != 0;
 }
 
 static inline bool isCurrentPositionVisible(const MapRenderSettings &settings) {
-  return (settings.visibilityMask & (1 << 9)) != 0;
+  return (settings.navigationOverlayVisibilityMask & (1 << 9)) != 0;
 }
 
 static inline bool shouldBoostLineWidth(uint8_t typeId, uint8_t styleWidth) {
@@ -398,9 +398,8 @@ static void drawPositionDotMarker(lv_obj_t *canvas) {
 }
 
 static uint8_t currentMarkerScale() {
-  return (uint8_t)std::min(std::max((int)mapRenderSettings.positionMarkerScale,
-                                    1),
-                           5);
+  return (uint8_t)std::min(
+      std::max((int)currentMapStyleSettings().positionMarkerScale, 1), 5);
 }
 
 static void applyNavigationMarkerScale(lv_obj_t *canvas) {
@@ -1485,6 +1484,7 @@ void Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
 void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
                          lv_obj_t *canvas, uint8_t zoom, double rotation) {
   Polygon newPolygon;
+  const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const uint32_t drawStartMs = MAPIO_TIME_MS();
   const uint32_t fillStartMs = MAPIO_TIME_MS();
   lv_canvas_fill_bg(canvas, lv_color_hex(BACKGROUND_COLOR), LV_OPA_COVER);
@@ -1495,8 +1495,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   double sinA = sin(rotation);
 
   // Use the actual canvas dimensions, not mapScrHeight which may differ from
-  // canvas height in fullscreen mode. The anchor may be board-specific: 1.75
-  // stays centered; 2.06 shifts down to show more route ahead on the tall panel.
+  // canvas height in fullscreen mode.
   lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
   int16_t screenAnchorX =
       mapAnchorXForWidth(draw_buf ? draw_buf->header.w : Maps::mapScrWidth);
@@ -1609,8 +1608,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             }
 
             // Skip if type is hidden by visibility mask
-            if (!isPolygonVisible(polygon.typeId, polygon.color,
-                                  mapRenderSettings)) {
+            if (!isPolygonVisible(polygon.typeId, polygon.color, style)) {
               continue;
             }
 
@@ -1641,7 +1639,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
 
             // Skip tiny polygons based on explicit min size plus detail density.
             const uint8_t minPolygonSize =
-                effectiveMinPolygonSize(mapRenderSettings);
+                effectiveMinPolygonSize(style);
             int16_t polyWidth = maxX - minX;
             int16_t polyHeight = maxY - minY;
             if (minPolygonSize > 0 &&
@@ -1672,8 +1670,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           continue;
 
         // Skip if type is hidden by visibility mask
-        if (!isLineVisible(line.typeId, line.color, line.width,
-                           mapRenderSettings))
+        if (!isLineVisible(line.typeId, line.color, line.width, style))
           continue;
 
         uint16_t color_swapped = line.color; // Use color directly (RGB565)
@@ -1703,7 +1700,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
 
         Point16 p1 = transformPoint(line.points[0]);
         int32_t streetBoost = shouldBoostLineWidth(line.typeId, line.width)
-                                  ? mapRenderSettings.streetLineWidthBoost
+                                  ? style.streetLineWidthBoost
                                   : 0;
         uint8_t lineWidth = (uint8_t)std::min<int32_t>(
             std::max<int32_t>(line.width, 1) + streetBoost, 24);
@@ -2356,6 +2353,12 @@ void Maps::displayMap() {
     }
 
     uint16_t h = mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
+    const uint16_t containerWidth = lv_obj_get_width(mapTile);
+    const uint16_t containerHeight = lv_obj_get_height(mapTile);
+    const int16_t mapOriginX =
+        gui_layout::centeredViewportOrigin(containerWidth, Maps::mapScrWidth);
+    const int16_t mapOriginY =
+        gui_layout::centeredViewportOrigin(containerHeight, h);
     const int16_t anchorX = mapAnchorXForWidth(Maps::mapScrWidth);
     const int16_t anchorY = mapAnchorYForHeight(h);
     updateCurrentPositionMarker(Maps::canvasArrow);
@@ -2363,10 +2366,11 @@ void Maps::displayMap() {
     int16_t x, y;
 
     if (Maps::followGps) {
-      // Board-specific map anchor when following GPS (48x48 icon, so offset
-      // by -24). The 1.75 stays centered; the 2.06 anchor is lower.
-      x = anchorX - 24;
-      y = anchorY - 24;
+      // The marker is a sibling of the centered map canvas, so translate the
+      // canvas-local anchor into map-tile coordinates before applying the
+      // 48x48 icon's center offset.
+      x = mapOriginX + anchorX - 24;
+      y = mapOriginY + anchorY - 24;
       lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       lv_obj_set_pos(Maps::canvasArrow, x, y);
       ESP_LOGI(TAG, "GPS indicator: followGps mode, anchor screen pos(%d,%d)",
@@ -2402,8 +2406,8 @@ void Maps::displayMap() {
 
       // 3. Translate to screen center (centered on arrow)
       // 48x48 icon, so offset by -24
-      x = (round(rx) + anchorX) - 24;
-      y = (round(ry) + anchorY) - 24;
+      x = mapOriginX + round(rx) + anchorX - 24;
+      y = mapOriginY + round(ry) + anchorY - 24;
 
       ESP_LOGI(TAG,
                "GPS indicator: gps(%.6f,%.6f) -> mercator(%d,%d) -> "
@@ -2417,10 +2421,11 @@ void Maps::displayMap() {
       // Simple bounds check to hide if too far off screen
       const int16_t centerX = x + 24;
       const int16_t centerY = y + 24;
-      if (centerX < -markerVisualHalf ||
-          centerX > (int16_t)Maps::mapScrWidth + markerVisualHalf ||
-          centerY < -markerVisualHalf ||
-          centerY > (int16_t)h + markerVisualHalf) {
+      if (centerX < mapOriginX - markerVisualHalf ||
+          centerX > mapOriginX + (int16_t)Maps::mapScrWidth +
+                        markerVisualHalf ||
+          centerY < mapOriginY - markerVisualHalf ||
+          centerY > mapOriginY + (int16_t)h + markerVisualHalf) {
         lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
         ESP_LOGI(TAG, "GPS indicator hidden: off-screen at (%d,%d)", x, y);
       } else {

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -34,10 +34,12 @@ enum class VisibilityClass : uint8_t {
   Always,
   MajorRoad,
   LocalStreet,
+  ServiceRoad,
   Building,
   GreenSpace,
   Water,
   Path,
+  Track,
   Rail,
   OtherArea,
 };
@@ -50,21 +52,25 @@ static inline bool isClassVisible(VisibilityClass visibilityClass,
   uint32_t visMask = settings.visibilityMask;
   switch (visibilityClass) {
   case VisibilityClass::MajorRoad:
-    return (visMask & (1 << 3)) != 0;
+    return (visMask & MAP_VISIBILITY_MAJOR_ROADS) != 0;
   case VisibilityClass::LocalStreet:
-    return (visMask & (1 << 4)) != 0;
+    return (visMask & MAP_VISIBILITY_LOCAL_STREETS) != 0;
+  case VisibilityClass::ServiceRoad:
+    return (visMask & MAP_VISIBILITY_SERVICE_ROADS) != 0;
   case VisibilityClass::Building:
-    return (visMask & (1 << 0)) != 0;
+    return (visMask & MAP_VISIBILITY_BUILDINGS) != 0;
   case VisibilityClass::GreenSpace:
-    return (visMask & (1 << 1)) != 0;
+    return (visMask & MAP_VISIBILITY_GREEN_SPACE) != 0;
   case VisibilityClass::Water:
-    return (visMask & (1 << 5)) != 0;
+    return (visMask & MAP_VISIBILITY_WATER) != 0;
   case VisibilityClass::Path:
-    return (visMask & (1 << 2)) != 0;
+    return (visMask & MAP_VISIBILITY_PATHS) != 0;
+  case VisibilityClass::Track:
+    return (visMask & MAP_VISIBILITY_TRACKS) != 0;
   case VisibilityClass::Rail:
-    return (visMask & (1 << 6)) != 0;
+    return (visMask & MAP_VISIBILITY_RAILWAYS) != 0;
   case VisibilityClass::OtherArea:
-    return (visMask & (1 << 7)) != 0;
+    return (visMask & MAP_VISIBILITY_OTHER_AREAS) != 0;
   case VisibilityClass::Always:
   default:
     return true;
@@ -74,9 +80,13 @@ static inline bool isClassVisible(VisibilityClass visibilityClass,
 static inline VisibilityClass visibilityClassForTypeId(uint8_t typeId) {
   if (typeId >= 1 && typeId <= 5)
     return VisibilityClass::MajorRoad;
-  if (typeId >= 6 && typeId < 50)
+  if (map_profile_protocol::isServiceRoadTypeId(typeId))
+    return VisibilityClass::ServiceRoad;
+  if (map_profile_protocol::isLocalStreetTypeId(typeId))
     return VisibilityClass::LocalStreet;
-  if (typeId >= 50 && typeId < 100)
+  if (map_profile_protocol::isTrackTypeId(typeId))
+    return VisibilityClass::Track;
+  if (map_profile_protocol::isPathTypeId(typeId))
     return VisibilityClass::Path;
   if (typeId >= 100 && typeId < 150)
     return VisibilityClass::Building;
@@ -138,7 +148,7 @@ static inline VisibilityClass legacyLineVisibilityClass(uint16_t color,
 
 // Helper: Check if a typeId is visible based on detail level and visibilityMask.
 // Bits: 0 buildings, 1 green space, 2 paths, 3 major roads, 4 local streets,
-// 5 water, 6 rail, 7 other areas.
+// 5 water, 6 rail, 7 other areas, 10 service roads, 11 tracks.
 static inline bool isTypeVisible(uint8_t typeId,
                                  const ScreenMapRenderSettings &settings) {
   if (typeId == 0)

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -363,10 +363,10 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,
     }
 
     // Draw thick line segment
-    int16_t routeLineWidth =
-        std::min<int16_t>(std::max<int16_t>(
-                              1, (int16_t)mapRenderSettings.routeLineWidth),
-                          48);
+    int16_t routeLineWidth = std::min<int16_t>(
+        std::max<int16_t>(
+            1, (int16_t)currentMapStyleSettings().routeLineWidth),
+        48);
     drawThickLine(buf, bufW, bufH, stride, x1, y1, x2, y2, ROUTE_COLOR,
                   routeLineWidth);
     drawnCount++;

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -1,0 +1,18 @@
+#include "../../lib/gui/src/guiLayout.hpp"
+
+#include <cassert>
+
+int main() {
+  // 1.75-inch viewport: 466px screen with 100px reserved UI space.
+  assert(gui_layout::mapScreenAnchorX(466, 466) == 233);
+  assert(gui_layout::mapScreenAnchorY(466, 366) == 233);
+
+  // 2.06-inch viewport: 502px screen with 72px reserved UI space.
+  assert(gui_layout::mapScreenAnchorX(410, 410) == 205);
+  assert(gui_layout::mapScreenAnchorY(502, 430) == 251);
+
+  // Fullscreen maps use the same physical screen center.
+  assert(gui_layout::mapScreenAnchorY(466, 466) == 233);
+  assert(gui_layout::mapScreenAnchorY(502, 502) == 251);
+  return 0;
+}

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -3,16 +3,18 @@
 #include <cassert>
 
 int main() {
-  // 1.75-inch viewport: 466px screen with 100px reserved UI space.
-  assert(gui_layout::mapScreenAnchorX(466, 466) == 233);
-  assert(gui_layout::mapScreenAnchorY(466, 366) == 233);
-
+#if defined(WAVESHARE_AMOLED_206)
   // 2.06-inch viewport: 502px screen with 72px reserved UI space.
+  assert(gui_layout::mapViewportHeight(502) == 430);
   assert(gui_layout::mapScreenAnchorX(410, 410) == 205);
   assert(gui_layout::mapScreenAnchorY(502, 430) == 251);
-
-  // Fullscreen maps use the same physical screen center.
-  assert(gui_layout::mapScreenAnchorY(466, 466) == 233);
   assert(gui_layout::mapScreenAnchorY(502, 502) == 251);
+#else
+  // 1.75-inch viewport: 466px screen with 100px reserved UI space.
+  assert(gui_layout::mapViewportHeight(466) == 366);
+  assert(gui_layout::mapScreenAnchorX(466, 466) == 233);
+  assert(gui_layout::mapScreenAnchorY(466, 366) == 233);
+  assert(gui_layout::mapScreenAnchorY(466, 466) == 233);
+#endif
   return 0;
 }

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -1,0 +1,72 @@
+#include "../../lib/ble_navigation/map_profile_protocol.hpp"
+
+#include <cassert>
+
+struct TestProfile {
+  int sentinel;
+};
+
+int main() {
+  using namespace map_profile_protocol;
+
+  assert(CAPABILITY_MASK == (1 << 3));
+  assert(EXTENDED_VISIBILITY_CAPABILITY_MASK == (1 << 4));
+  assert(!clientSupportsIndependentProfiles(0));
+  assert(!clientSupportsIndependentProfiles(1));
+  assert(clientSupportsIndependentProfiles(2));
+  assert(clientSupportsIndependentProfiles(3));
+  assert(!clientSupportsExtendedVisibility(2));
+  assert(clientSupportsExtendedVisibility(3));
+
+  const uint32_t allLegacyFeatures = VISIBILITY_LEGACY_FEATURE_MASK;
+  assert(normalizedFeatureVisibilityMask(allLegacyFeatures) ==
+         VISIBILITY_EXTENDED_FEATURE_MASK);
+  assert(normalizedFeatureVisibilityMask(VISIBILITY_LOCAL_STREETS) ==
+         (VISIBILITY_LOCAL_STREETS | VISIBILITY_SERVICE_ROADS));
+  assert(normalizedFeatureVisibilityMask(VISIBILITY_PATHS) ==
+         (VISIBILITY_PATHS | VISIBILITY_TRACKS));
+  const uint32_t extendedServiceOnly =
+      VISIBILITY_EXTENDED_MARKER | VISIBILITY_SERVICE_ROADS;
+  assert(normalizedFeatureVisibilityMask(extendedServiceOnly) ==
+         VISIBILITY_SERVICE_ROADS);
+  const uint32_t extendedTrackOnly =
+      VISIBILITY_EXTENDED_MARKER | VISIBILITY_TRACKS;
+  assert(normalizedFeatureVisibilityMask(extendedTrackOnly) ==
+         VISIBILITY_TRACKS);
+  assert(isLocalStreetTypeId(6));
+  assert(isLocalStreetTypeId(7));
+  assert(!isLocalStreetTypeId(10));
+  assert(isServiceRoadTypeId(10));
+  assert(!isServiceRoadTypeId(7));
+  assert(isTrackTypeId(50));
+  assert(!isPathTypeId(50));
+  assert(isPathTypeId(51));
+  assert(isPathTypeId(54));
+
+  assert(shouldMirrorLegacySetting(1, false));
+  assert(shouldMirrorLegacySetting(10, false));
+  assert(!shouldMirrorLegacySetting(1, true));
+  assert(!shouldMirrorLegacySetting(16, false));
+  assert(isIndependentSetting(16));
+  assert(isIndependentSetting(22));
+  assert(!isIndependentSetting(15));
+
+  assert(clampValue(1, -1) == 0);
+  assert(clampValue(16, 51) == 50);
+  assert(clampValue(2, 3) == 2);
+  assert(clampValue(17, -1) == 0);
+  assert(clampValue(3, 1) == 2);
+  assert(clampValue(18, 49) == 48);
+  assert(clampValue(7, 6) == 5);
+  assert(clampValue(19, -1) == 0);
+  assert(clampValue(9, 25) == 24);
+  assert(clampValue(21, -1) == 0);
+  assert(clampValue(10, 0) == 1);
+  assert(clampValue(22, 6) == 5);
+
+  const TestProfile map{1};
+  const TestProfile mapNavigation{2};
+  assert(&select(map, mapNavigation, false) == &map);
+  assert(&select(map, mapNavigation, true) == &mapNavigation);
+  return 0;
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -52,6 +52,13 @@ enum DeviceBLEProtocol {
     static let enabledScreensSettingID: UInt8 = 13
     static let defaultScreenSettingID: UInt8 = 14
     static let disconnectedSleepTimeoutSettingID: UInt8 = 15
+    static let mapPlusNavigationMinPolygonSizeSettingID: UInt8 = 16
+    static let mapPlusNavigationDetailLevelSettingID: UInt8 = 17
+    static let mapPlusNavigationRouteLineWidthSettingID: UInt8 = 18
+    static let mapPlusNavigationZoomLevelSettingID: UInt8 = 19
+    static let mapPlusNavigationVisibilityMaskSettingID: UInt8 = 20
+    static let mapPlusNavigationStreetLineWidthBoostSettingID: UInt8 = 21
+    static let mapPlusNavigationPositionMarkerScaleSettingID: UInt8 = 22
 
     static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
     static var navigationCharacteristicUUID: CBUUID { CBUUID(string: navigationCharacteristicUUIDString) }
@@ -376,6 +383,12 @@ class BLEManager: NSObject, ObservableObject {
     @Published var displayRotation: Int = 0 
     @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up  // 0-3: 0°, 90°, 180°, 270°
     @Published var zoomLevel: Int = 2 // 0-4: 0=super-zoom, 1=closest, 4=farthest
+    @Published var mapPlusNavigationMinPolygonSize: Double = 0
+    @Published var mapPlusNavigationDetailLevel: Int = 2
+    @Published var mapPlusNavigationRouteLineWidth: Double = 4
+    @Published var mapPlusNavigationStreetLineWidthBoost: Double = 0
+    @Published var mapPlusNavigationPositionMarkerScale: Double = 2
+    @Published var mapPlusNavigationZoomLevel: Int = 2
     @Published var tapToSwitchScreens: Bool = false
     @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
     @Published var defaultDeviceScreen: DeviceScreen = .mapPlusNavigation
@@ -394,6 +407,14 @@ class BLEManager: NSObject, ObservableObject {
     @Published var showWater: Bool = true
     @Published var showRailways: Bool = true
     @Published var showOtherAreas: Bool = true
+    @Published var mapPlusNavigationShowBuildings: Bool = true
+    @Published var mapPlusNavigationShowGreenSpace: Bool = true
+    @Published var mapPlusNavigationShowPaths: Bool = true
+    @Published var mapPlusNavigationShowMajorRoads: Bool = true
+    @Published var mapPlusNavigationShowLocalStreets: Bool = true
+    @Published var mapPlusNavigationShowWater: Bool = true
+    @Published var mapPlusNavigationShowRailways: Bool = true
+    @Published var mapPlusNavigationShowOtherAreas: Bool = true
     @Published var showRouteOverlay: Bool = true
     @Published var showCurrentPosition: Bool = true
     
@@ -475,6 +496,21 @@ class BLEManager: NSObject, ObservableObject {
         static let mapRotationMode = "mapSettings.mapRotationMode"
         static let resetMapRotationModeToNorthUp = "mapSettings.resetMapRotationModeToNorthUp.v1"
         static let zoomLevel = "mapSettings.zoomLevel"
+        static let mapPlusNavigationMinPolygonSize = "mapPlusNavigationSettings.minPolygonSize"
+        static let mapPlusNavigationDetailLevel = "mapPlusNavigationSettings.detailLevel"
+        static let mapPlusNavigationRouteLineWidth = "mapPlusNavigationSettings.routeLineWidth"
+        static let mapPlusNavigationStreetLineWidthBoost = "mapPlusNavigationSettings.streetLineWidthBoost"
+        static let mapPlusNavigationPositionMarkerScale = "mapPlusNavigationSettings.positionMarkerScale"
+        static let mapPlusNavigationZoomLevel = "mapPlusNavigationSettings.zoomLevel"
+        static let mapPlusNavigationShowBuildings = "mapPlusNavigationSettings.showBuildings"
+        static let mapPlusNavigationShowGreenSpace = "mapPlusNavigationSettings.showGreenSpace"
+        static let mapPlusNavigationShowPaths = "mapPlusNavigationSettings.showPaths"
+        static let mapPlusNavigationShowMajorRoads = "mapPlusNavigationSettings.showMajorRoads"
+        static let mapPlusNavigationShowLocalStreets = "mapPlusNavigationSettings.showLocalStreets"
+        static let mapPlusNavigationShowWater = "mapPlusNavigationSettings.showWater"
+        static let mapPlusNavigationShowRailways = "mapPlusNavigationSettings.showRailways"
+        static let mapPlusNavigationShowOtherAreas = "mapPlusNavigationSettings.showOtherAreas"
+        static let mapPlusNavigationProfileMigrated = "mapPlusNavigationSettings.migrated.v1"
         static let tapToSwitchScreens = "deviceSettings.tapToSwitchScreens"
         static let enabledDeviceScreensMask = "deviceSettings.enabledScreensMask"
         static let defaultDeviceScreen = "deviceSettings.defaultScreen"
@@ -569,8 +605,74 @@ class BLEManager: NSObject, ObservableObject {
         showWater = defaults.object(forKey: SettingsKeys.showWater) as? Bool ?? legacyNature
         showRailways = defaults.object(forKey: SettingsKeys.showRailways) as? Bool ?? true
         showOtherAreas = defaults.object(forKey: SettingsKeys.showOtherAreas) as? Bool ?? true
+        let shouldMigrateMapPlusNavigationProfile = !defaults.bool(
+            forKey: SettingsKeys.mapPlusNavigationProfileMigrated
+        )
+        if shouldMigrateMapPlusNavigationProfile {
+            mapPlusNavigationMinPolygonSize = minPolygonSize
+            mapPlusNavigationDetailLevel = detailLevel
+            mapPlusNavigationRouteLineWidth = routeLineWidth
+            mapPlusNavigationStreetLineWidthBoost = streetLineWidthBoost
+            mapPlusNavigationPositionMarkerScale = positionMarkerScale
+            mapPlusNavigationZoomLevel = zoomLevel
+            mapPlusNavigationShowBuildings = showBuildings
+            mapPlusNavigationShowGreenSpace = showGreenSpace
+            mapPlusNavigationShowPaths = showPaths
+            mapPlusNavigationShowMajorRoads = showMajorRoads
+            mapPlusNavigationShowLocalStreets = showLocalStreets
+            mapPlusNavigationShowWater = showWater
+            mapPlusNavigationShowRailways = showRailways
+            mapPlusNavigationShowOtherAreas = showOtherAreas
+        } else {
+            mapPlusNavigationMinPolygonSize = defaults.double(
+                forKey: SettingsKeys.mapPlusNavigationMinPolygonSize
+            )
+            mapPlusNavigationDetailLevel = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationDetailLevel
+            ) as? Int ?? 2
+            mapPlusNavigationRouteLineWidth = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationRouteLineWidth
+            ) as? Double ?? 4
+            mapPlusNavigationStreetLineWidthBoost = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationStreetLineWidthBoost
+            ) as? Double ?? 0
+            mapPlusNavigationPositionMarkerScale = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale
+            ) as? Double ?? 2
+            mapPlusNavigationZoomLevel = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationZoomLevel
+            ) as? Int ?? 2
+            mapPlusNavigationShowBuildings = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowBuildings
+            ) as? Bool ?? true
+            mapPlusNavigationShowGreenSpace = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowGreenSpace
+            ) as? Bool ?? true
+            mapPlusNavigationShowPaths = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowPaths
+            ) as? Bool ?? true
+            mapPlusNavigationShowMajorRoads = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowMajorRoads
+            ) as? Bool ?? true
+            mapPlusNavigationShowLocalStreets = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowLocalStreets
+            ) as? Bool ?? true
+            mapPlusNavigationShowWater = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowWater
+            ) as? Bool ?? true
+            mapPlusNavigationShowRailways = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowRailways
+            ) as? Bool ?? true
+            mapPlusNavigationShowOtherAreas = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowOtherAreas
+            ) as? Bool ?? true
+        }
         showRouteOverlay = defaults.object(forKey: SettingsKeys.showRouteOverlay) as? Bool ?? true
         showCurrentPosition = defaults.object(forKey: SettingsKeys.showCurrentPosition) as? Bool ?? true
+        if shouldMigrateMapPlusNavigationProfile {
+            defaults.set(true, forKey: SettingsKeys.mapPlusNavigationProfileMigrated)
+            saveSettings()
+        }
     }
 
     private func loadLastPeripheralIdentifier() {
@@ -589,6 +691,12 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(displayRotation, forKey: SettingsKeys.displayRotation)
         defaults.set(mapRotationMode, forKey: SettingsKeys.mapRotationMode)
         defaults.set(zoomLevel, forKey: SettingsKeys.zoomLevel)
+        defaults.set(mapPlusNavigationMinPolygonSize, forKey: SettingsKeys.mapPlusNavigationMinPolygonSize)
+        defaults.set(mapPlusNavigationDetailLevel, forKey: SettingsKeys.mapPlusNavigationDetailLevel)
+        defaults.set(mapPlusNavigationRouteLineWidth, forKey: SettingsKeys.mapPlusNavigationRouteLineWidth)
+        defaults.set(mapPlusNavigationStreetLineWidthBoost, forKey: SettingsKeys.mapPlusNavigationStreetLineWidthBoost)
+        defaults.set(mapPlusNavigationPositionMarkerScale, forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale)
+        defaults.set(mapPlusNavigationZoomLevel, forKey: SettingsKeys.mapPlusNavigationZoomLevel)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
         enabledDeviceScreensMask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
         defaultDeviceScreen = DeviceScreen.fallbackDefault(
@@ -611,6 +719,15 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(showWater, forKey: SettingsKeys.showWater)
         defaults.set(showRailways, forKey: SettingsKeys.showRailways)
         defaults.set(showOtherAreas, forKey: SettingsKeys.showOtherAreas)
+        defaults.set(mapPlusNavigationShowBuildings, forKey: SettingsKeys.mapPlusNavigationShowBuildings)
+        defaults.set(mapPlusNavigationShowGreenSpace, forKey: SettingsKeys.mapPlusNavigationShowGreenSpace)
+        defaults.set(mapPlusNavigationShowPaths, forKey: SettingsKeys.mapPlusNavigationShowPaths)
+        defaults.set(mapPlusNavigationShowMajorRoads, forKey: SettingsKeys.mapPlusNavigationShowMajorRoads)
+        defaults.set(mapPlusNavigationShowLocalStreets, forKey: SettingsKeys.mapPlusNavigationShowLocalStreets)
+        defaults.set(mapPlusNavigationShowWater, forKey: SettingsKeys.mapPlusNavigationShowWater)
+        defaults.set(mapPlusNavigationShowRailways, forKey: SettingsKeys.mapPlusNavigationShowRailways)
+        defaults.set(mapPlusNavigationShowOtherAreas, forKey: SettingsKeys.mapPlusNavigationShowOtherAreas)
+        defaults.set(true, forKey: SettingsKeys.mapPlusNavigationProfileMigrated)
         defaults.set(showRouteOverlay, forKey: SettingsKeys.showRouteOverlay)
         defaults.set(showCurrentPosition, forKey: SettingsKeys.showCurrentPosition)
     }
@@ -841,19 +958,41 @@ class BLEManager: NSObject, ObservableObject {
     
     /// Send feature visibility bitmask
     func sendVisibilityMask() {
+        sendVisibilityMask(for: .map)
+    }
+
+    func sendVisibilityMask(for screen: DeviceScreen) {
         var mask: Int32 = 0
-        if showBuildings { mask |= (1 << 0) }
-        if showGreenSpace { mask |= (1 << 1) }
-        if showPaths { mask |= (1 << 2) }
-        if showMajorRoads { mask |= (1 << 3) }
-        if showLocalStreets { mask |= (1 << 4) }
-        if showWater { mask |= (1 << 5) }
-        if showRailways { mask |= (1 << 6) }
-        if showOtherAreas { mask |= (1 << 7) }
-        if showRouteOverlay { mask |= (1 << 8) }
-        if showCurrentPosition { mask |= (1 << 9) }
-        
-        sendSetting(id: 8, value: mask)
+        let settingID: UInt8
+
+        switch screen {
+        case .map:
+            if showBuildings { mask |= (1 << 0) }
+            if showGreenSpace { mask |= (1 << 1) }
+            if showPaths { mask |= (1 << 2) }
+            if showMajorRoads { mask |= (1 << 3) }
+            if showLocalStreets { mask |= (1 << 4) }
+            if showWater { mask |= (1 << 5) }
+            if showRailways { mask |= (1 << 6) }
+            if showOtherAreas { mask |= (1 << 7) }
+            if showRouteOverlay { mask |= (1 << 8) }
+            if showCurrentPosition { mask |= (1 << 9) }
+            settingID = 8
+        case .mapPlusNavigation:
+            if mapPlusNavigationShowBuildings { mask |= (1 << 0) }
+            if mapPlusNavigationShowGreenSpace { mask |= (1 << 1) }
+            if mapPlusNavigationShowPaths { mask |= (1 << 2) }
+            if mapPlusNavigationShowMajorRoads { mask |= (1 << 3) }
+            if mapPlusNavigationShowLocalStreets { mask |= (1 << 4) }
+            if mapPlusNavigationShowWater { mask |= (1 << 5) }
+            if mapPlusNavigationShowRailways { mask |= (1 << 6) }
+            if mapPlusNavigationShowOtherAreas { mask |= (1 << 7) }
+            settingID = DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID
+        case .navigation, .rideStats:
+            return
+        }
+
+        sendSetting(id: settingID, value: mask)
     }
 
     func isDeviceScreenEnabled(_ screen: DeviceScreen) -> Bool {
@@ -1523,6 +1662,19 @@ class BLEManager: NSObject, ObservableObject {
         sendSetting(id: 4, value: Int32(displayRotation))
         sendSetting(id: 6, value: Int32(mapRotationMode))
         sendSetting(id: 7, value: Int32(zoomLevel))
+        sendVisibilityMask(for: .mapPlusNavigation)
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID,
+                    value: Int32(mapPlusNavigationMinPolygonSize))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
+                    value: Int32(mapPlusNavigationDetailLevel))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
+                    value: Int32(mapPlusNavigationRouteLineWidth))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
+                    value: Int32(mapPlusNavigationStreetLineWidthBoost))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
+                    value: Int32(mapPlusNavigationPositionMarkerScale))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
+                    value: Int32(mapPlusNavigationZoomLevel))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
         sendEnabledDeviceScreensMask()
         sendDefaultDeviceScreen()

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -45,8 +45,13 @@ enum DeviceBLEProtocol {
     static let deviceSoundsCapabilityMask: UInt8 = 1 << 0
     static let powerButtonHonkCapabilityMask: UInt8 = 1 << 1
     static let powerButtonHonkAcknowledgementCapabilityMask: UInt8 = 1 << 2
-    static let deviceCapabilitiesVersion: UInt8 = 1
+    static let extendedMapVisibilityCapabilityMask: UInt8 = 1 << 4
+    static let deviceCapabilitiesVersion: UInt8 = 3
     static let fallbackWriteQueueCapacity = 32
+
+    static let serviceRoadsVisibilityMask: Int32 = 1 << 10
+    static let tracksVisibilityMask: Int32 = 1 << 11
+    static let extendedVisibilityMarker: Int32 = 1 << 12
 
     static let brightnessSettingID: UInt8 = 12
     static let enabledScreensSettingID: UInt8 = 13
@@ -344,6 +349,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var supportsDeviceSounds: Bool = false
     @Published var supportsPowerButtonHonk: Bool = false
     @Published var supportsPowerButtonHonkAcknowledgement: Bool = false
+    @Published private(set) var supportsExtendedMapVisibility: Bool = false
     @Published private(set) var powerButtonHonkConfigurationError: String?
     @Published private(set) var hasReceivedDeviceCapabilities: Bool = false
     @Published var peripheralName: String = ""
@@ -402,16 +408,20 @@ class BLEManager: NSObject, ObservableObject {
     @Published var showBuildings: Bool = true
     @Published var showGreenSpace: Bool = true
     @Published var showPaths: Bool = true
+    @Published var showTracks: Bool = true
     @Published var showMajorRoads: Bool = true
     @Published var showLocalStreets: Bool = true
+    @Published var showServiceRoads: Bool = true
     @Published var showWater: Bool = true
     @Published var showRailways: Bool = true
     @Published var showOtherAreas: Bool = true
     @Published var mapPlusNavigationShowBuildings: Bool = true
     @Published var mapPlusNavigationShowGreenSpace: Bool = true
     @Published var mapPlusNavigationShowPaths: Bool = true
+    @Published var mapPlusNavigationShowTracks: Bool = true
     @Published var mapPlusNavigationShowMajorRoads: Bool = true
     @Published var mapPlusNavigationShowLocalStreets: Bool = true
+    @Published var mapPlusNavigationShowServiceRoads: Bool = true
     @Published var mapPlusNavigationShowWater: Bool = true
     @Published var mapPlusNavigationShowRailways: Bool = true
     @Published var mapPlusNavigationShowOtherAreas: Bool = true
@@ -479,6 +489,7 @@ class BLEManager: NSObject, ObservableObject {
     private var powerButtonHonkRetryWorkItem: DispatchWorkItem?
     private var powerButtonHonkAckTimeout: TimeInterval = 1.0
     private var powerButtonHonkFailureRetryDelay: TimeInterval = 0.1
+    private var hasSentMapProfilesForConnection = false
     private var shouldPairAfterDisconnect: Bool = false
     private var suppressNextReconnect: Bool = false
     private var hasActiveBLESession: Bool {
@@ -505,8 +516,10 @@ class BLEManager: NSObject, ObservableObject {
         static let mapPlusNavigationShowBuildings = "mapPlusNavigationSettings.showBuildings"
         static let mapPlusNavigationShowGreenSpace = "mapPlusNavigationSettings.showGreenSpace"
         static let mapPlusNavigationShowPaths = "mapPlusNavigationSettings.showPaths"
+        static let mapPlusNavigationShowTracks = "mapPlusNavigationSettings.showTracks"
         static let mapPlusNavigationShowMajorRoads = "mapPlusNavigationSettings.showMajorRoads"
         static let mapPlusNavigationShowLocalStreets = "mapPlusNavigationSettings.showLocalStreets"
+        static let mapPlusNavigationShowServiceRoads = "mapPlusNavigationSettings.showServiceRoads"
         static let mapPlusNavigationShowWater = "mapPlusNavigationSettings.showWater"
         static let mapPlusNavigationShowRailways = "mapPlusNavigationSettings.showRailways"
         static let mapPlusNavigationShowOtherAreas = "mapPlusNavigationSettings.showOtherAreas"
@@ -523,8 +536,10 @@ class BLEManager: NSObject, ObservableObject {
         static let showBuildings = "mapSettings.showBuildings"
         static let showGreenSpace = "mapSettings.showGreenSpace"
         static let showPaths = "mapSettings.showPaths"
+        static let showTracks = "mapSettings.showTracks"
         static let showMajorRoads = "mapSettings.showMajorRoads"
         static let showLocalStreets = "mapSettings.showLocalStreets"
+        static let showServiceRoads = "mapSettings.showServiceRoads"
         static let showWater = "mapSettings.showWater"
         static let showRailways = "mapSettings.showRailways"
         static let showOtherAreas = "mapSettings.showOtherAreas"
@@ -600,8 +615,10 @@ class BLEManager: NSObject, ObservableObject {
         let legacyMinorRoads = defaults.object(forKey: SettingsKeys.legacyShowMinorRoads) as? Bool ?? true
         showGreenSpace = defaults.object(forKey: SettingsKeys.showGreenSpace) as? Bool ?? legacyNature
         showPaths = defaults.object(forKey: SettingsKeys.showPaths) as? Bool ?? legacyMinorRoads
+        showTracks = defaults.object(forKey: SettingsKeys.showTracks) as? Bool ?? showPaths
         showMajorRoads = defaults.object(forKey: SettingsKeys.showMajorRoads) as? Bool ?? true
         showLocalStreets = defaults.object(forKey: SettingsKeys.showLocalStreets) as? Bool ?? true
+        showServiceRoads = defaults.object(forKey: SettingsKeys.showServiceRoads) as? Bool ?? showLocalStreets
         showWater = defaults.object(forKey: SettingsKeys.showWater) as? Bool ?? legacyNature
         showRailways = defaults.object(forKey: SettingsKeys.showRailways) as? Bool ?? true
         showOtherAreas = defaults.object(forKey: SettingsKeys.showOtherAreas) as? Bool ?? true
@@ -618,8 +635,10 @@ class BLEManager: NSObject, ObservableObject {
             mapPlusNavigationShowBuildings = showBuildings
             mapPlusNavigationShowGreenSpace = showGreenSpace
             mapPlusNavigationShowPaths = showPaths
+            mapPlusNavigationShowTracks = showTracks
             mapPlusNavigationShowMajorRoads = showMajorRoads
             mapPlusNavigationShowLocalStreets = showLocalStreets
+            mapPlusNavigationShowServiceRoads = showServiceRoads
             mapPlusNavigationShowWater = showWater
             mapPlusNavigationShowRailways = showRailways
             mapPlusNavigationShowOtherAreas = showOtherAreas
@@ -651,12 +670,18 @@ class BLEManager: NSObject, ObservableObject {
             mapPlusNavigationShowPaths = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationShowPaths
             ) as? Bool ?? true
+            mapPlusNavigationShowTracks = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowTracks
+            ) as? Bool ?? mapPlusNavigationShowPaths
             mapPlusNavigationShowMajorRoads = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationShowMajorRoads
             ) as? Bool ?? true
             mapPlusNavigationShowLocalStreets = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationShowLocalStreets
             ) as? Bool ?? true
+            mapPlusNavigationShowServiceRoads = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationShowServiceRoads
+            ) as? Bool ?? mapPlusNavigationShowLocalStreets
             mapPlusNavigationShowWater = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationShowWater
             ) as? Bool ?? true
@@ -714,16 +739,20 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(showBuildings, forKey: SettingsKeys.showBuildings)
         defaults.set(showGreenSpace, forKey: SettingsKeys.showGreenSpace)
         defaults.set(showPaths, forKey: SettingsKeys.showPaths)
+        defaults.set(showTracks, forKey: SettingsKeys.showTracks)
         defaults.set(showMajorRoads, forKey: SettingsKeys.showMajorRoads)
         defaults.set(showLocalStreets, forKey: SettingsKeys.showLocalStreets)
+        defaults.set(showServiceRoads, forKey: SettingsKeys.showServiceRoads)
         defaults.set(showWater, forKey: SettingsKeys.showWater)
         defaults.set(showRailways, forKey: SettingsKeys.showRailways)
         defaults.set(showOtherAreas, forKey: SettingsKeys.showOtherAreas)
         defaults.set(mapPlusNavigationShowBuildings, forKey: SettingsKeys.mapPlusNavigationShowBuildings)
         defaults.set(mapPlusNavigationShowGreenSpace, forKey: SettingsKeys.mapPlusNavigationShowGreenSpace)
         defaults.set(mapPlusNavigationShowPaths, forKey: SettingsKeys.mapPlusNavigationShowPaths)
+        defaults.set(mapPlusNavigationShowTracks, forKey: SettingsKeys.mapPlusNavigationShowTracks)
         defaults.set(mapPlusNavigationShowMajorRoads, forKey: SettingsKeys.mapPlusNavigationShowMajorRoads)
         defaults.set(mapPlusNavigationShowLocalStreets, forKey: SettingsKeys.mapPlusNavigationShowLocalStreets)
+        defaults.set(mapPlusNavigationShowServiceRoads, forKey: SettingsKeys.mapPlusNavigationShowServiceRoads)
         defaults.set(mapPlusNavigationShowWater, forKey: SettingsKeys.mapPlusNavigationShowWater)
         defaults.set(mapPlusNavigationShowRailways, forKey: SettingsKeys.mapPlusNavigationShowRailways)
         defaults.set(mapPlusNavigationShowOtherAreas, forKey: SettingsKeys.mapPlusNavigationShowOtherAreas)
@@ -955,6 +984,44 @@ class BLEManager: NSObject, ObservableObject {
         }
         sendFallbackMapPacket(fallback, label: "setting id=\(id)")
     }
+
+    private func sendMapProfilesAfterCapabilityNegotiation() {
+        guard isConnected,
+              isNavigationReady,
+              hasReceivedDeviceCapabilities,
+              !hasSentMapProfilesForConnection else { return }
+
+        hasSentMapProfilesForConnection = true
+        sendVisibilityMask(for: .map)
+        sendSetting(id: 1, value: Int32(minPolygonSize))
+        sendSetting(id: 2, value: Int32(detailLevel))
+        sendSetting(id: 3, value: Int32(routeLineWidth))
+        sendSetting(id: 9, value: Int32(streetLineWidthBoost))
+        sendSetting(id: 10, value: Int32(positionMarkerScale))
+        sendSetting(id: 7, value: Int32(zoomLevel))
+
+        sendVisibilityMask(for: .mapPlusNavigation)
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID,
+                    value: Int32(mapPlusNavigationMinPolygonSize))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
+                    value: Int32(mapPlusNavigationDetailLevel))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
+                    value: Int32(mapPlusNavigationRouteLineWidth))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
+                    value: Int32(mapPlusNavigationStreetLineWidthBoost))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
+                    value: Int32(mapPlusNavigationPositionMarkerScale))
+        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
+                    value: Int32(mapPlusNavigationZoomLevel))
+    }
+
+    func useDeviceCapabilitiesFallback() {
+        guard isConnected, isNavigationReady, !hasReceivedDeviceCapabilities else { return }
+        supportsExtendedMapVisibility = false
+        hasReceivedDeviceCapabilities = true
+        log("Device capabilities unavailable; using baseline feature visibility")
+        sendMapProfilesAfterCapabilityNegotiation()
+    }
     
     /// Send feature visibility bitmask
     func sendVisibilityMask() {
@@ -969,24 +1036,34 @@ class BLEManager: NSObject, ObservableObject {
         case .map:
             if showBuildings { mask |= (1 << 0) }
             if showGreenSpace { mask |= (1 << 1) }
-            if showPaths { mask |= (1 << 2) }
+            if showPaths || (!supportsExtendedMapVisibility && showTracks) { mask |= (1 << 2) }
             if showMajorRoads { mask |= (1 << 3) }
-            if showLocalStreets { mask |= (1 << 4) }
+            if showLocalStreets || (!supportsExtendedMapVisibility && showServiceRoads) { mask |= (1 << 4) }
             if showWater { mask |= (1 << 5) }
             if showRailways { mask |= (1 << 6) }
             if showOtherAreas { mask |= (1 << 7) }
             if showRouteOverlay { mask |= (1 << 8) }
             if showCurrentPosition { mask |= (1 << 9) }
+            if supportsExtendedMapVisibility {
+                if showServiceRoads { mask |= DeviceBLEProtocol.serviceRoadsVisibilityMask }
+                if showTracks { mask |= DeviceBLEProtocol.tracksVisibilityMask }
+                mask |= DeviceBLEProtocol.extendedVisibilityMarker
+            }
             settingID = 8
         case .mapPlusNavigation:
             if mapPlusNavigationShowBuildings { mask |= (1 << 0) }
             if mapPlusNavigationShowGreenSpace { mask |= (1 << 1) }
-            if mapPlusNavigationShowPaths { mask |= (1 << 2) }
+            if mapPlusNavigationShowPaths || (!supportsExtendedMapVisibility && mapPlusNavigationShowTracks) { mask |= (1 << 2) }
             if mapPlusNavigationShowMajorRoads { mask |= (1 << 3) }
-            if mapPlusNavigationShowLocalStreets { mask |= (1 << 4) }
+            if mapPlusNavigationShowLocalStreets || (!supportsExtendedMapVisibility && mapPlusNavigationShowServiceRoads) { mask |= (1 << 4) }
             if mapPlusNavigationShowWater { mask |= (1 << 5) }
             if mapPlusNavigationShowRailways { mask |= (1 << 6) }
             if mapPlusNavigationShowOtherAreas { mask |= (1 << 7) }
+            if supportsExtendedMapVisibility {
+                if mapPlusNavigationShowServiceRoads { mask |= DeviceBLEProtocol.serviceRoadsVisibilityMask }
+                if mapPlusNavigationShowTracks { mask |= DeviceBLEProtocol.tracksVisibilityMask }
+                mask |= DeviceBLEProtocol.extendedVisibilityMarker
+            }
             settingID = DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID
         case .navigation, .rideStats:
             return
@@ -1442,8 +1519,10 @@ class BLEManager: NSObject, ObservableObject {
         supportsDeviceSounds = false
         supportsPowerButtonHonk = false
         supportsPowerButtonHonkAcknowledgement = false
+        supportsExtendedMapVisibility = false
         powerButtonHonkConfigurationError = nil
         hasReceivedDeviceCapabilities = false
+        hasSentMapProfilesForConnection = false
         clearPendingPowerButtonHonkConfiguration()
     }
 
@@ -1653,28 +1732,8 @@ class BLEManager: NSObject, ObservableObject {
         updateTrustedPeripheralDescription()
         log("BLE peripheral authenticated")
         requestDeviceCapabilities()
-        sendVisibilityMask()
-        sendSetting(id: 1, value: Int32(minPolygonSize))
-        sendSetting(id: 2, value: Int32(detailLevel))
-        sendSetting(id: 3, value: Int32(routeLineWidth))
-        sendSetting(id: 9, value: Int32(streetLineWidthBoost))
-        sendSetting(id: 10, value: Int32(positionMarkerScale))
         sendSetting(id: 4, value: Int32(displayRotation))
         sendSetting(id: 6, value: Int32(mapRotationMode))
-        sendSetting(id: 7, value: Int32(zoomLevel))
-        sendVisibilityMask(for: .mapPlusNavigation)
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID,
-                    value: Int32(mapPlusNavigationMinPolygonSize))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
-                    value: Int32(mapPlusNavigationDetailLevel))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
-                    value: Int32(mapPlusNavigationRouteLineWidth))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
-                    value: Int32(mapPlusNavigationStreetLineWidthBoost))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
-                    value: Int32(mapPlusNavigationPositionMarkerScale))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
-                    value: Int32(mapPlusNavigationZoomLevel))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
         sendEnabledDeviceScreensMask()
         sendDefaultDeviceScreen()
@@ -2268,6 +2327,7 @@ extension BLEManager: CBPeripheralDelegate {
             supportsDeviceSounds = false
             supportsPowerButtonHonk = false
             supportsPowerButtonHonkAcknowledgement = false
+            supportsExtendedMapVisibility = false
             hasReceivedDeviceCapabilities = false
             clearPendingPowerButtonHonkConfiguration()
             log("Received invalid device capabilities payload")
@@ -2280,6 +2340,8 @@ extension BLEManager: CBPeripheralDelegate {
             flags & DeviceBLEProtocol.powerButtonHonkCapabilityMask != 0
         let hasPowerButtonHonkAcknowledgement = hasPowerButtonHonk &&
             flags & DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask != 0
+        let hasExtendedMapVisibility =
+            flags & DeviceBLEProtocol.extendedMapVisibilityCapabilityMask != 0
         let hasDevicePowerButtonConfig = data.count == 8
         if hasDevicePowerButtonConfig {
             guard hasPowerButtonHonk,
@@ -2289,6 +2351,7 @@ extension BLEManager: CBPeripheralDelegate {
                 supportsDeviceSounds = false
                 supportsPowerButtonHonk = false
                 supportsPowerButtonHonkAcknowledgement = false
+                supportsExtendedMapVisibility = false
                 hasReceivedDeviceCapabilities = false
                 clearPendingPowerButtonHonkConfiguration()
                 log("Received invalid device capabilities configuration")
@@ -2312,11 +2375,13 @@ extension BLEManager: CBPeripheralDelegate {
         supportsDeviceSounds = hasDeviceSounds
         supportsPowerButtonHonk = hasPowerButtonHonk
         supportsPowerButtonHonkAcknowledgement = hasPowerButtonHonkAcknowledgement
+        supportsExtendedMapVisibility = hasExtendedMapVisibility
         if !hasPowerButtonHonkAcknowledgement {
             clearPendingPowerButtonHonkConfiguration()
         }
         hasReceivedDeviceCapabilities = true
         log("Device capabilities: flags=0x\(String(format: "%02X", flags))")
+        sendMapProfilesAfterCapabilityNegotiation()
         if shouldSynchronizePowerButtonHonk {
             // @Published updates in willSet. Defer until the support flag is
             // observable so the guarded send uses the negotiated capability.

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -311,11 +311,19 @@ class BikeComputerCoordinator: ObservableObject {
     }
 
     private func refreshDeviceCapabilities(attempt: Int) {
-        guard DeviceCapabilityRetry.shouldRequest(
+        let shouldRequest = DeviceCapabilityRetry.shouldRequest(
             isNavigationReady: bleManager.isNavigationReady,
             hasReceivedCapabilities: bleManager.hasReceivedDeviceCapabilities,
             attempt: attempt
-        ) else { return }
+        )
+        guard shouldRequest else {
+            if bleManager.isNavigationReady,
+               !bleManager.hasReceivedDeviceCapabilities,
+               attempt >= DeviceCapabilityRetry.maxAttempts {
+                bleManager.useDeviceCapabilitiesFallback()
+            }
+            return
+        }
 
         bleManager.requestDeviceCapabilities()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -465,105 +465,17 @@ private struct UICustomizationSettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Navigation Overlays"), footer: Text("Show or hide live navigation layers drawn above the map.")) {
-                Toggle("Route Line", isOn: $bleManager.showRouteOverlay)
-                    .onChange(of: bleManager.showRouteOverlay) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Current Position", isOn: $bleManager.showCurrentPosition)
-                    .onChange(of: bleManager.showCurrentPosition) { _ in bleManager.sendVisibilityMask() }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
-            Section(header: Text("Roads & Paths"), footer: Text("Control which street and trail classes appear on the device map.")) {
-                Toggle("Major Roads", isOn: $bleManager.showMajorRoads)
-                    .onChange(of: bleManager.showMajorRoads) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Local Streets", isOn: $bleManager.showLocalStreets)
-                    .onChange(of: bleManager.showLocalStreets) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Paths & Tracks", isOn: $bleManager.showPaths)
-                    .onChange(of: bleManager.showPaths) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Railways", isOn: $bleManager.showRailways)
-                    .onChange(of: bleManager.showRailways) { _ in bleManager.sendVisibilityMask() }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
-            Section(header: Text("Places & Terrain"), footer: Text("Control background map areas and lower-priority context.")) {
-                Toggle("Buildings", isOn: $bleManager.showBuildings)
-                    .onChange(of: bleManager.showBuildings) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Parks & Nature", isOn: $bleManager.showGreenSpace)
-                    .onChange(of: bleManager.showGreenSpace) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Water", isOn: $bleManager.showWater)
-                    .onChange(of: bleManager.showWater) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Other Areas", isOn: $bleManager.showOtherAreas)
-                    .onChange(of: bleManager.showOtherAreas) { _ in bleManager.sendVisibilityMask() }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
-            Section(header: Text("Map Rendering"), footer: Text("Feature toggles control map categories; polygon size filters tiny filled areas.")) {
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text("Min Polygon Size")
-                        Spacer()
-                        Text("\(Int(bleManager.minPolygonSize)) px²")
-                            .foregroundColor(.secondary)
-                    }
-                    Slider(value: $bleManager.minPolygonSize, in: 0...50, step: 5)
-                        .onChange(of: bleManager.minPolygonSize) { newValue in
-                            bleManager.sendSetting(id: 1, value: Int32(newValue))
-                        }
-                }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
-            Section(header: Text("Detail Level"), footer: Text("Controls small-area density without overriding feature visibility.")) {
-                Picker("Detail", selection: $bleManager.detailLevel) {
-                    Text("Low").tag(0)
-                    Text("Medium").tag(1)
-                    Text("High").tag(2)
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: bleManager.detailLevel) { newValue in
-                    bleManager.sendSetting(id: 2, value: Int32(newValue))
-                }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
-            Section(header: Text("Line Thickness")) {
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text("Route Line Width")
-                        Spacer()
-                        Text("\(Int(bleManager.routeLineWidth)) px")
-                            .foregroundColor(.secondary)
-                    }
-                    Slider(value: $bleManager.routeLineWidth, in: 2...48, step: 1)
-                        .onChange(of: bleManager.routeLineWidth) { newValue in
-                            bleManager.sendSetting(id: 3, value: Int32(newValue))
-                        }
+            Section(header: Text("Screen Styles"), footer: Text("Configure map appearance independently for each device screen.")) {
+                NavigationLink {
+                    MapStyleSettingsView(screen: .map)
+                } label: {
+                    Label("Map", systemImage: "map")
                 }
 
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text("Street Width Boost")
-                        Spacer()
-                        Text("+\(Int(bleManager.streetLineWidthBoost)) px")
-                            .foregroundColor(.secondary)
-                    }
-                    Slider(value: $bleManager.streetLineWidthBoost, in: 0...24, step: 1)
-                        .onChange(of: bleManager.streetLineWidthBoost) { newValue in
-                            bleManager.sendSetting(id: 9, value: Int32(newValue))
-                        }
-                }
-
-                VStack(alignment: .leading) {
-                    HStack {
-                        Text("Position Marker Size")
-                        Spacer()
-                        Text("\(Int(bleManager.positionMarkerScale))x")
-                            .foregroundColor(.secondary)
-                    }
-                    Slider(value: $bleManager.positionMarkerScale, in: 1...5, step: 1)
-                        .onChange(of: bleManager.positionMarkerScale) { newValue in
-                            bleManager.sendSetting(id: 10, value: Int32(newValue))
-                        }
+                NavigationLink {
+                    MapStyleSettingsView(screen: .mapPlusNavigation)
+                } label: {
+                    Label("Map + Navigation", systemImage: "location.north.line")
                 }
             }
             .disabled(!bleManager.supportsDeviceSettings)
@@ -579,7 +491,7 @@ private struct UICustomizationSettingsView: View {
             }
             .disabled(!bleManager.supportsDeviceSettings)
 
-            Section(header: Text("Map Mode")) {
+            Section(header: Text("Map Mode"), footer: Text("Applies only to the Map screen. Map + Navigation automatically uses course-up while navigating.")) {
                 Picker("Rotation", selection: $bleManager.mapRotationMode) {
                     Text("North Up").tag(0)
                     Text("Course Up").tag(1)
@@ -591,24 +503,222 @@ private struct UICustomizationSettingsView: View {
             }
             .disabled(!bleManager.supportsDeviceSettings)
 
-            Section(header: Text("Zoom Level"), footer: Text("0 = Super Zoom, 5 = Farthest")) {
-                Picker("Zoom", selection: $bleManager.zoomLevel) {
-                    Text("0").tag(0)
-                    Text("1").tag(1)
-                    Text("2").tag(2)
-                    Text("3").tag(3)
-                    Text("4").tag(4)
-                    Text("5").tag(5)
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: bleManager.zoomLevel) { newValue in
-                    bleManager.sendSetting(id: 7, value: Int32(newValue))
-                }
+            Section(header: Text("Navigation Overlays"), footer: Text("Show or hide live navigation layers drawn above both map screens.")) {
+                Toggle("Route Line", isOn: $bleManager.showRouteOverlay)
+                    .onChange(of: bleManager.showRouteOverlay) { _ in bleManager.sendVisibilityMask() }
+                Toggle("Current Position", isOn: $bleManager.showCurrentPosition)
+                    .onChange(of: bleManager.showCurrentPosition) { _ in bleManager.sendVisibilityMask() }
             }
             .disabled(!bleManager.supportsDeviceSettings)
         }
         .navigationTitle("UI Customization")
         .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private enum MapStyleScreen {
+    case map
+    case mapPlusNavigation
+
+    var title: String {
+        switch self {
+        case .map: return "Map"
+        case .mapPlusNavigation: return "Map + Navigation"
+        }
+    }
+
+    var deviceScreen: DeviceScreen {
+        switch self {
+        case .map: return .map
+        case .mapPlusNavigation: return .mapPlusNavigation
+        }
+    }
+
+    func settingID(map: UInt8, mapPlusNavigation: UInt8) -> UInt8 {
+        self == .map ? map : mapPlusNavigation
+    }
+}
+
+private struct MapStyleSettingsView: View {
+    @EnvironmentObject private var bleManager: BLEManager
+    let screen: MapStyleScreen
+
+    private func binding<Value>(
+        map: ReferenceWritableKeyPath<BLEManager, Value>,
+        mapPlusNavigation: ReferenceWritableKeyPath<BLEManager, Value>
+    ) -> Binding<Value> {
+        let keyPath = screen == .map ? map : mapPlusNavigation
+        return Binding(
+            get: { bleManager[keyPath: keyPath] },
+            set: { bleManager[keyPath: keyPath] = $0 }
+        )
+    }
+
+    private var minPolygonSize: Binding<Double> {
+        binding(map: \.minPolygonSize, mapPlusNavigation: \.mapPlusNavigationMinPolygonSize)
+    }
+
+    private var detailLevel: Binding<Int> {
+        binding(map: \.detailLevel, mapPlusNavigation: \.mapPlusNavigationDetailLevel)
+    }
+
+    private var routeLineWidth: Binding<Double> {
+        binding(map: \.routeLineWidth, mapPlusNavigation: \.mapPlusNavigationRouteLineWidth)
+    }
+
+    private var streetLineWidthBoost: Binding<Double> {
+        binding(map: \.streetLineWidthBoost, mapPlusNavigation: \.mapPlusNavigationStreetLineWidthBoost)
+    }
+
+    private var positionMarkerScale: Binding<Double> {
+        binding(map: \.positionMarkerScale, mapPlusNavigation: \.mapPlusNavigationPositionMarkerScale)
+    }
+
+    private var zoomLevel: Binding<Int> {
+        binding(map: \.zoomLevel, mapPlusNavigation: \.mapPlusNavigationZoomLevel)
+    }
+
+    private var showMajorRoads: Binding<Bool> {
+        binding(map: \.showMajorRoads, mapPlusNavigation: \.mapPlusNavigationShowMajorRoads)
+    }
+
+    private var showLocalStreets: Binding<Bool> {
+        binding(map: \.showLocalStreets, mapPlusNavigation: \.mapPlusNavigationShowLocalStreets)
+    }
+
+    private var showPaths: Binding<Bool> {
+        binding(map: \.showPaths, mapPlusNavigation: \.mapPlusNavigationShowPaths)
+    }
+
+    private var showRailways: Binding<Bool> {
+        binding(map: \.showRailways, mapPlusNavigation: \.mapPlusNavigationShowRailways)
+    }
+
+    private var showBuildings: Binding<Bool> {
+        binding(map: \.showBuildings, mapPlusNavigation: \.mapPlusNavigationShowBuildings)
+    }
+
+    private var showGreenSpace: Binding<Bool> {
+        binding(map: \.showGreenSpace, mapPlusNavigation: \.mapPlusNavigationShowGreenSpace)
+    }
+
+    private var showWater: Binding<Bool> {
+        binding(map: \.showWater, mapPlusNavigation: \.mapPlusNavigationShowWater)
+    }
+
+    private var showOtherAreas: Binding<Bool> {
+        binding(map: \.showOtherAreas, mapPlusNavigation: \.mapPlusNavigationShowOtherAreas)
+    }
+
+    var body: some View {
+        Form {
+            Section(header: Text("Roads & Paths"), footer: Text("Control which street and trail classes appear on this screen.")) {
+                Toggle("Major Roads", isOn: showMajorRoads)
+                    .onChange(of: showMajorRoads.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Local Streets", isOn: showLocalStreets)
+                    .onChange(of: showLocalStreets.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Paths & Tracks", isOn: showPaths)
+                    .onChange(of: showPaths.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Railways", isOn: showRailways)
+                    .onChange(of: showRailways.wrappedValue) { _ in sendVisibilityMask() }
+            }
+
+            Section(header: Text("Places & Terrain"), footer: Text("Control background map areas and lower-priority context on this screen.")) {
+                Toggle("Buildings", isOn: showBuildings)
+                    .onChange(of: showBuildings.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Parks & Nature", isOn: showGreenSpace)
+                    .onChange(of: showGreenSpace.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Water", isOn: showWater)
+                    .onChange(of: showWater.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Other Areas", isOn: showOtherAreas)
+                    .onChange(of: showOtherAreas.wrappedValue) { _ in sendVisibilityMask() }
+            }
+
+            Section(header: Text("Map Rendering"), footer: Text("Feature toggles control map categories; polygon size filters tiny filled areas.")) {
+                VStack(alignment: .leading) {
+                    HStack {
+                        Text("Min Polygon Size")
+                        Spacer()
+                        Text("\(Int(minPolygonSize.wrappedValue)) px²")
+                            .foregroundColor(.secondary)
+                    }
+                    Slider(value: minPolygonSize, in: 0...50, step: 5)
+                        .onChange(of: minPolygonSize.wrappedValue) { newValue in
+                            sendSetting(mapID: 1, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID, value: Int32(newValue))
+                        }
+                }
+            }
+
+            Section(header: Text("Detail Level"), footer: Text("Controls small-area density without overriding feature visibility.")) {
+                Picker("Detail", selection: detailLevel) {
+                    Text("Low").tag(0)
+                    Text("Medium").tag(1)
+                    Text("High").tag(2)
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: detailLevel.wrappedValue) { newValue in
+                    sendSetting(mapID: 2, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID, value: Int32(newValue))
+                }
+            }
+
+            Section(header: Text("Line Thickness")) {
+                settingSlider(title: "Route Line Width", value: routeLineWidth, range: 2...48, prefix: "", suffix: " px") { newValue in
+                    sendSetting(mapID: 3, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID, value: Int32(newValue))
+                }
+                settingSlider(title: "Street Width Boost", value: streetLineWidthBoost, range: 0...24, prefix: "+", suffix: " px") { newValue in
+                    sendSetting(mapID: 9, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID, value: Int32(newValue))
+                }
+                settingSlider(title: "Position Marker Size", value: positionMarkerScale, range: 1...5, prefix: "", suffix: "x") { newValue in
+                    sendSetting(mapID: 10, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID, value: Int32(newValue))
+                }
+            }
+
+            Section(header: Text("Zoom Level"), footer: Text("0 = Super Zoom, 5 = Farthest")) {
+                Picker("Zoom", selection: zoomLevel) {
+                    ForEach(0...5, id: \.self) { level in
+                        Text("\(level)").tag(level)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .onChange(of: zoomLevel.wrappedValue) { newValue in
+                    sendSetting(mapID: 7, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID, value: Int32(newValue))
+                }
+            }
+        }
+        .disabled(!bleManager.supportsDeviceSettings)
+        .navigationTitle(screen.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private func sendVisibilityMask() {
+        bleManager.sendVisibilityMask(for: screen.deviceScreen)
+    }
+
+    private func sendSetting(mapID: UInt8, mapPlusNavigationID: UInt8, value: Int32) {
+        bleManager.sendSetting(
+            id: screen.settingID(map: mapID, mapPlusNavigation: mapPlusNavigationID),
+            value: value
+        )
+    }
+
+    private func settingSlider(
+        title: String,
+        value: Binding<Double>,
+        range: ClosedRange<Double>,
+        prefix: String,
+        suffix: String,
+        onChange: @escaping (Double) -> Void
+    ) -> some View {
+        VStack(alignment: .leading) {
+            HStack {
+                Text(title)
+                Spacer()
+                Text("\(prefix)\(Int(value.wrappedValue))\(suffix)")
+                    .foregroundColor(.secondary)
+            }
+            Slider(value: value, in: range, step: 1)
+                .onChange(of: value.wrappedValue, perform: onChange)
+        }
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -590,6 +590,14 @@ private struct MapStyleSettingsView: View {
         binding(map: \.showPaths, mapPlusNavigation: \.mapPlusNavigationShowPaths)
     }
 
+    private var showTracks: Binding<Bool> {
+        binding(map: \.showTracks, mapPlusNavigation: \.mapPlusNavigationShowTracks)
+    }
+
+    private var showServiceRoads: Binding<Bool> {
+        binding(map: \.showServiceRoads, mapPlusNavigation: \.mapPlusNavigationShowServiceRoads)
+    }
+
     private var showRailways: Binding<Bool> {
         binding(map: \.showRailways, mapPlusNavigation: \.mapPlusNavigationShowRailways)
     }
@@ -612,13 +620,17 @@ private struct MapStyleSettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Roads & Paths"), footer: Text("Control which street and trail classes appear on this screen.")) {
+            Section(header: Text("Roads & Paths"), footer: Text("Service roads commonly include driveways and internal compound roads; exact results depend on the OpenStreetMap tags in the downloaded map.")) {
                 Toggle("Major Roads", isOn: showMajorRoads)
                     .onChange(of: showMajorRoads.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Local Streets", isOn: showLocalStreets)
+                Toggle("Residential & Local Roads", isOn: showLocalStreets)
                     .onChange(of: showLocalStreets.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Paths & Tracks", isOn: showPaths)
+                Toggle("Service Roads", isOn: showServiceRoads)
+                    .onChange(of: showServiceRoads.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Paths & Footways", isOn: showPaths)
                     .onChange(of: showPaths.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle("Tracks", isOn: showTracks)
+                    .onChange(of: showTracks.wrappedValue) { _ in sendVisibilityMask() }
                 Toggle("Railways", isOn: showRailways)
                     .onChange(of: showRailways.wrappedValue) { _ in sendVisibilityMask() }
             }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -269,6 +269,7 @@ struct NavigationProtocolTests {
         testBLEPairingAuthenticator()
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
+        testBLEManagerSendsSeparateMapProfileSettings()
         testBLEManagerSendsDeviceSoundFallback()
         testBLEManagerSendsPowerButtonHonkFallback()
         testPowerButtonHonkTimeoutAndTransportFailures()
@@ -981,6 +982,13 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
         assertEqual(DeviceBLEProtocol.disconnectedSleepTimeoutSettingID, 15, "disconnected sleep timeout uses firmware setting ID 15")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID, 16, "Map + Navigation polygon size uses setting ID 16")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID, 17, "Map + Navigation detail uses setting ID 17")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID, 18, "Map + Navigation route width uses setting ID 18")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID, 19, "Map + Navigation zoom uses setting ID 19")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID, 20, "Map + Navigation visibility uses setting ID 20")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID, 21, "Map + Navigation street width uses setting ID 21")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID, 22, "Map + Navigation marker scale uses setting ID 22")
         assertEqual(DeviceScreen.map.rawValue, 0, "Map screen protocol value stays stable")
         assertEqual(DeviceScreen.navigation.rawValue, 1, "Navigation screen protocol value stays stable")
         assertEqual(DeviceScreen.rideStats.rawValue, 2, "Ride Stats screen protocol value stays stable")
@@ -1352,6 +1360,49 @@ struct NavigationProtocolTests {
             | (Int32(valueBytes[2]) << 16)
             | (Int32(valueBytes[3]) << 24)
         assertEqual(value, 7, "fallback settings packet includes little-endian value")
+    }
+
+    static func testBLEManagerSendsSeparateMapProfileSettings() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.showBuildings = true
+        manager.showGreenSpace = false
+        manager.showPaths = false
+        manager.showMajorRoads = false
+        manager.showLocalStreets = false
+        manager.showWater = false
+        manager.showRailways = false
+        manager.showOtherAreas = false
+        manager.showRouteOverlay = true
+        manager.showCurrentPosition = false
+        manager.mapPlusNavigationShowBuildings = false
+        manager.mapPlusNavigationShowGreenSpace = false
+        manager.mapPlusNavigationShowPaths = false
+        manager.mapPlusNavigationShowMajorRoads = true
+        manager.mapPlusNavigationShowLocalStreets = false
+        manager.mapPlusNavigationShowWater = false
+        manager.mapPlusNavigationShowRailways = false
+        manager.mapPlusNavigationShowOtherAreas = false
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendVisibilityMask(for: .map)
+        manager.sendVisibilityMask(for: .mapPlusNavigation)
+
+        assertEqual(sentPackets.count, 2, "each map screen sends its own visibility profile")
+        assertEqual(sentPackets[0][4], 8, "Map visibility keeps legacy setting ID 8")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5), 0x101,
+                    "Map visibility includes its feature bits and global overlays")
+        assertEqual(sentPackets[1][4], DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID,
+                    "Map + Navigation visibility uses its profile setting ID")
+        assertEqual(readInt32LE(sentPackets[1], offset: 5), 0x08,
+                    "Map + Navigation visibility contains only its feature bits")
     }
 
     static func testBLEManagerSendsDeviceSoundFallback() {
@@ -1788,8 +1839,25 @@ struct NavigationProtocolTests {
     static func testBLEManagerPersistsNewMapSettings() {
         let defaults = UserDefaults.standard
         let keys = [
+            "mapSettings.detailLevel",
             "mapSettings.mapRotationMode",
             "mapSettings.zoomLevel",
+            "mapSettings.showBuildings",
+            "mapPlusNavigationSettings.minPolygonSize",
+            "mapPlusNavigationSettings.detailLevel",
+            "mapPlusNavigationSettings.routeLineWidth",
+            "mapPlusNavigationSettings.streetLineWidthBoost",
+            "mapPlusNavigationSettings.positionMarkerScale",
+            "mapPlusNavigationSettings.zoomLevel",
+            "mapPlusNavigationSettings.showBuildings",
+            "mapPlusNavigationSettings.showGreenSpace",
+            "mapPlusNavigationSettings.showPaths",
+            "mapPlusNavigationSettings.showMajorRoads",
+            "mapPlusNavigationSettings.showLocalStreets",
+            "mapPlusNavigationSettings.showWater",
+            "mapPlusNavigationSettings.showRailways",
+            "mapPlusNavigationSettings.showOtherAreas",
+            "mapPlusNavigationSettings.migrated.v1",
             "deviceSettings.enabledScreensMask",
             "deviceSettings.defaultScreen",
             "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1",
@@ -1805,9 +1873,24 @@ struct NavigationProtocolTests {
         let migratedManager = BLEManager()
         assertEqual(migratedManager.defaultDeviceScreen, .mapPlusNavigation, "old Map defaults migrate to Map + Navigation")
 
+        defaults.set(1, forKey: "mapSettings.detailLevel")
+        defaults.set(4, forKey: "mapSettings.zoomLevel")
+        defaults.set(false, forKey: "mapSettings.showBuildings")
+        defaults.removeObject(forKey: "mapPlusNavigationSettings.migrated.v1")
+        let migratedProfileManager = BLEManager()
+        assertEqual(migratedProfileManager.mapPlusNavigationDetailLevel, 1,
+                    "existing shared detail migrates into Map + Navigation")
+        assertEqual(migratedProfileManager.mapPlusNavigationZoomLevel, 4,
+                    "existing shared zoom migrates into Map + Navigation")
+        assert(!migratedProfileManager.mapPlusNavigationShowBuildings,
+               "existing shared visibility migrates into Map + Navigation")
+
         let manager = BLEManager()
         manager.mapRotationMode = 1
         manager.zoomLevel = 5
+        manager.mapPlusNavigationDetailLevel = 0
+        manager.mapPlusNavigationZoomLevel = 3
+        manager.mapPlusNavigationShowBuildings = true
         manager.enabledDeviceScreensMask = DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit
         manager.defaultDeviceScreen = .mapPlusNavigation
         manager.disconnectedSleepTimeout = .tenMinutes
@@ -1816,6 +1899,12 @@ struct NavigationProtocolTests {
         let reloaded = BLEManager()
         assertEqual(reloaded.mapRotationMode, 1, "map rotation mode should persist across BLEManager reloads")
         assertEqual(reloaded.zoomLevel, 5, "zoom level should persist across BLEManager reloads")
+        assertEqual(reloaded.mapPlusNavigationDetailLevel, 0,
+                    "Map + Navigation detail should persist independently")
+        assertEqual(reloaded.mapPlusNavigationZoomLevel, 3,
+                    "Map + Navigation zoom should persist independently")
+        assert(reloaded.mapPlusNavigationShowBuildings,
+               "Map + Navigation visibility should persist independently")
         assertEqual(reloaded.enabledDeviceScreensMask,
                     DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit,
                     "enabled device screens should persist across BLEManager reloads")

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -262,6 +262,7 @@ struct NavigationProtocolTests {
         testDevicePacketRouting()
         testDeviceSoundProtocol()
         testDeviceCapabilitiesProtocol()
+        testMapProfilesRemainIndependentWithoutCapabilityBit()
         testDeviceCapabilitySynchronizesPowerButtonHonkOnce()
         testDeviceCapabilityRetryPolicy()
         testDeviceScreenValidation()
@@ -270,6 +271,7 @@ struct NavigationProtocolTests {
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
         testBLEManagerSendsSeparateMapProfileSettings()
+        testBLEManagerFoldsExtendedVisibilityForLegacyFirmware()
         testBLEManagerSendsDeviceSoundFallback()
         testBLEManagerSendsPowerButtonHonkFallback()
         testPowerButtonHonkTimeoutAndTransportFailures()
@@ -978,6 +980,11 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.powerButtonHonkPrefix, "SNDH", "PWR honk configuration remains firmware-compatible")
         assertEqual(DeviceBLEProtocol.powerButtonHonkStatusPrefix, "SNHA", "PWR honk acknowledgement remains firmware-compatible")
         assertEqual(DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask, 4, "PWR honk acknowledgement uses capability bit 2")
+        assertEqual(DeviceBLEProtocol.extendedMapVisibilityCapabilityMask, 16, "extended map visibility uses capability bit 4")
+        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 3, "capability version requests extended map visibility")
+        assertEqual(DeviceBLEProtocol.serviceRoadsVisibilityMask, 0x400, "service roads use visibility bit 10")
+        assertEqual(DeviceBLEProtocol.tracksVisibilityMask, 0x800, "tracks use visibility bit 11")
+        assertEqual(DeviceBLEProtocol.extendedVisibilityMarker, 0x1000, "extended visibility uses marker bit 12")
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
@@ -1117,6 +1124,13 @@ struct NavigationProtocolTests {
                "older PWR-capable firmware remains a one-shot configuration target")
         assert(manager.hasReceivedDeviceCapabilities, "valid CAPS completes capability negotiation")
 
+        let extended = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.extendedMapVisibilityCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(extended),
+               "extended map visibility CAPS should be consumed")
+        assert(manager.supportsExtendedMapVisibility,
+               "CAPS bit enables independent service-road and track visibility")
+
         let acknowledgedFlags = supportedFlags |
             DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask
         let acknowledged = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
@@ -1158,11 +1172,43 @@ struct NavigationProtocolTests {
         assert(!manager.supportsPowerButtonHonk, "malformed CAPS clears PWR honk support")
         assert(!manager.supportsPowerButtonHonkAcknowledgement,
                "malformed CAPS clears PWR honk acknowledgement support")
+        assert(!manager.supportsExtendedMapVisibility,
+               "malformed CAPS clears extended map visibility support")
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
         UserDefaults.standard.removeObject(forKey: "deviceSettings.soundVolumePercent")
         UserDefaults.standard.removeObject(forKey: "deviceSettings.powerButtonHonkEnabled")
+    }
+
+    static func testMapProfilesRemainIndependentWithoutCapabilityBit() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.detailLevel = 2
+        manager.zoomLevel = 5
+        manager.showBuildings = true
+        manager.mapPlusNavigationDetailLevel = 0
+        manager.mapPlusNavigationZoomLevel = 1
+        manager.mapPlusNavigationShowBuildings = false
+        var packets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { packets.append($0) }
+        ))
+
+        let baselineCapabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])
+        assert(manager.handleDeviceCapabilitiesNotification(baselineCapabilities),
+               "baseline capability response should be consumed")
+        assertEqual(packets.map { $0[4] },
+                    [8, 1, 2, 3, 9, 10, 7, 20, 16, 17, 18, 21, 22, 19],
+                    "every firmware receives both complete map profiles")
+        let mapNavigationDetailPacket = packets.first { $0[4] == 17 }
+        assertEqual(readInt32LE(mapNavigationDetailPacket!, offset: 5), 0,
+                    "Map + Navigation keeps its independent detail value")
+        assertEqual(manager.mapPlusNavigationZoomLevel, 1,
+                    "capability negotiation does not overwrite Map + Navigation settings")
     }
 
     static func testDeviceCapabilitySynchronizesPowerButtonHonkOnce() {
@@ -1189,9 +1235,12 @@ struct NavigationProtocolTests {
         assert(manager.handleDeviceCapabilitiesNotification(capabilities),
                "first CAPS notification should be consumed")
         RunLoop.main.run(until: Date().addingTimeInterval(0.01))
-        assertEqual(sentPackets.count, 1,
+        let honkPackets = sentPackets.filter {
+            String(data: $0.prefix(4), encoding: .utf8) == DeviceBLEProtocol.powerButtonHonkPrefix
+        }
+        assertEqual(honkPackets.count, 1,
                     "first PWR capability notification synchronizes configuration")
-        assertEqual(String(data: sentPackets[0].prefix(4), encoding: .utf8), "SNDH",
+        assertEqual(String(data: honkPackets[0].prefix(4), encoding: .utf8), "SNDH",
                     "capability synchronization sends a PWR honk frame")
 
         let staleDeviceConfig = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
@@ -1205,14 +1254,16 @@ struct NavigationProtocolTests {
         assertEqual(manager.deviceSoundVolumePercent, 55,
                     "an older device snapshot does not replace the pending volume")
 
-        let successStatus = powerButtonHonkStatus(for: sentPackets[0], applied: 1)
+        let successStatus = powerButtonHonkStatus(for: honkPackets[0], applied: 1)
         assert(manager.handleNavigationCharacteristicNotification(successStatus),
                "capability synchronization acknowledgement should be consumed")
 
         assert(manager.handleDeviceCapabilitiesNotification(capabilities),
                "duplicate CAPS notification should be consumed")
         RunLoop.main.run(until: Date().addingTimeInterval(0.01))
-        assertEqual(sentPackets.count, 1,
+        assertEqual(sentPackets.filter {
+            String(data: $0.prefix(4), encoding: .utf8) == DeviceBLEProtocol.powerButtonHonkPrefix
+        }.count, 1,
                     "duplicate PWR capability notification does not resend configuration")
 
         let deviceConfig = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
@@ -1220,7 +1271,9 @@ struct NavigationProtocolTests {
         assert(manager.handleDeviceCapabilitiesNotification(deviceConfig),
                "versioned capability response should restore device state")
         RunLoop.main.run(until: Date().addingTimeInterval(0.01))
-        assertEqual(sentPackets.count, 1,
+        assertEqual(sentPackets.filter {
+            String(data: $0.prefix(4), encoding: .utf8) == DeviceBLEProtocol.powerButtonHonkPrefix
+        }.count, 1,
                     "device-authoritative capability state is not written back")
         assert(manager.isPowerButtonHonkEnabled,
                "device-authoritative capability state remains enabled")
@@ -1364,13 +1417,19 @@ struct NavigationProtocolTests {
 
     static func testBLEManagerSendsSeparateMapProfileSettings() {
         let manager = BLEManager()
+        let capabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.extendedMapVisibilityCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(capabilities),
+               "extended visibility capability should be accepted")
         manager.isConnected = true
         manager.isNavigationReady = true
         manager.showBuildings = true
         manager.showGreenSpace = false
         manager.showPaths = false
+        manager.showTracks = true
         manager.showMajorRoads = false
         manager.showLocalStreets = false
+        manager.showServiceRoads = true
         manager.showWater = false
         manager.showRailways = false
         manager.showOtherAreas = false
@@ -1379,8 +1438,10 @@ struct NavigationProtocolTests {
         manager.mapPlusNavigationShowBuildings = false
         manager.mapPlusNavigationShowGreenSpace = false
         manager.mapPlusNavigationShowPaths = false
+        manager.mapPlusNavigationShowTracks = true
         manager.mapPlusNavigationShowMajorRoads = true
         manager.mapPlusNavigationShowLocalStreets = false
+        manager.mapPlusNavigationShowServiceRoads = false
         manager.mapPlusNavigationShowWater = false
         manager.mapPlusNavigationShowRailways = false
         manager.mapPlusNavigationShowOtherAreas = false
@@ -1397,12 +1458,43 @@ struct NavigationProtocolTests {
 
         assertEqual(sentPackets.count, 2, "each map screen sends its own visibility profile")
         assertEqual(sentPackets[0][4], 8, "Map visibility keeps legacy setting ID 8")
-        assertEqual(readInt32LE(sentPackets[0], offset: 5), 0x101,
-                    "Map visibility includes its feature bits and global overlays")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5), 0x1D01,
+                    "Map visibility separates service roads and tracks while retaining overlays")
         assertEqual(sentPackets[1][4], DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID,
                     "Map + Navigation visibility uses its profile setting ID")
-        assertEqual(readInt32LE(sentPackets[1], offset: 5), 0x08,
-                    "Map + Navigation visibility contains only its feature bits")
+        assertEqual(readInt32LE(sentPackets[1], offset: 5), 0x1808,
+                    "Map + Navigation visibility sends its independent track bit")
+    }
+
+    static func testBLEManagerFoldsExtendedVisibilityForLegacyFirmware() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.showBuildings = false
+        manager.showGreenSpace = false
+        manager.showPaths = false
+        manager.showTracks = true
+        manager.showMajorRoads = false
+        manager.showLocalStreets = false
+        manager.showServiceRoads = true
+        manager.showWater = false
+        manager.showRailways = false
+        manager.showOtherAreas = false
+        manager.showRouteOverlay = false
+        manager.showCurrentPosition = false
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendVisibilityMask(for: .map)
+
+        assertEqual(sentPackets.count, 1, "legacy firmware receives one visibility packet")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5), 0x14,
+                    "legacy firmware folds tracks into paths and service roads into local streets")
     }
 
     static func testBLEManagerSendsDeviceSoundFallback() {
@@ -1843,6 +1935,10 @@ struct NavigationProtocolTests {
             "mapSettings.mapRotationMode",
             "mapSettings.zoomLevel",
             "mapSettings.showBuildings",
+            "mapSettings.showPaths",
+            "mapSettings.showTracks",
+            "mapSettings.showLocalStreets",
+            "mapSettings.showServiceRoads",
             "mapPlusNavigationSettings.minPolygonSize",
             "mapPlusNavigationSettings.detailLevel",
             "mapPlusNavigationSettings.routeLineWidth",
@@ -1852,8 +1948,10 @@ struct NavigationProtocolTests {
             "mapPlusNavigationSettings.showBuildings",
             "mapPlusNavigationSettings.showGreenSpace",
             "mapPlusNavigationSettings.showPaths",
+            "mapPlusNavigationSettings.showTracks",
             "mapPlusNavigationSettings.showMajorRoads",
             "mapPlusNavigationSettings.showLocalStreets",
+            "mapPlusNavigationSettings.showServiceRoads",
             "mapPlusNavigationSettings.showWater",
             "mapPlusNavigationSettings.showRailways",
             "mapPlusNavigationSettings.showOtherAreas",
@@ -1876,6 +1974,12 @@ struct NavigationProtocolTests {
         defaults.set(1, forKey: "mapSettings.detailLevel")
         defaults.set(4, forKey: "mapSettings.zoomLevel")
         defaults.set(false, forKey: "mapSettings.showBuildings")
+        defaults.set(false, forKey: "mapSettings.showPaths")
+        defaults.set(false, forKey: "mapSettings.showLocalStreets")
+        defaults.removeObject(forKey: "mapSettings.showTracks")
+        defaults.removeObject(forKey: "mapSettings.showServiceRoads")
+        defaults.removeObject(forKey: "mapPlusNavigationSettings.showTracks")
+        defaults.removeObject(forKey: "mapPlusNavigationSettings.showServiceRoads")
         defaults.removeObject(forKey: "mapPlusNavigationSettings.migrated.v1")
         let migratedProfileManager = BLEManager()
         assertEqual(migratedProfileManager.mapPlusNavigationDetailLevel, 1,
@@ -1884,6 +1988,10 @@ struct NavigationProtocolTests {
                     "existing shared zoom migrates into Map + Navigation")
         assert(!migratedProfileManager.mapPlusNavigationShowBuildings,
                "existing shared visibility migrates into Map + Navigation")
+        assert(!migratedProfileManager.showTracks && !migratedProfileManager.mapPlusNavigationShowTracks,
+               "track visibility inherits the previous paths setting")
+        assert(!migratedProfileManager.showServiceRoads && !migratedProfileManager.mapPlusNavigationShowServiceRoads,
+               "service-road visibility inherits the previous local-streets setting")
 
         let manager = BLEManager()
         manager.mapRotationMode = 1
@@ -1891,6 +1999,10 @@ struct NavigationProtocolTests {
         manager.mapPlusNavigationDetailLevel = 0
         manager.mapPlusNavigationZoomLevel = 3
         manager.mapPlusNavigationShowBuildings = true
+        manager.showTracks = false
+        manager.showServiceRoads = false
+        manager.mapPlusNavigationShowTracks = false
+        manager.mapPlusNavigationShowServiceRoads = false
         manager.enabledDeviceScreensMask = DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit
         manager.defaultDeviceScreen = .mapPlusNavigation
         manager.disconnectedSleepTimeout = .tenMinutes
@@ -1905,6 +2017,12 @@ struct NavigationProtocolTests {
                     "Map + Navigation zoom should persist independently")
         assert(reloaded.mapPlusNavigationShowBuildings,
                "Map + Navigation visibility should persist independently")
+        assert(!reloaded.showTracks, "Map track visibility should persist")
+        assert(!reloaded.showServiceRoads, "Map service-road visibility should persist")
+        assert(!reloaded.mapPlusNavigationShowTracks,
+               "Map + Navigation track visibility should persist independently")
+        assert(!reloaded.mapPlusNavigationShowServiceRoads,
+               "Map + Navigation service-road visibility should persist independently")
         assertEqual(reloaded.enabledDeviceScreensMask,
                     DeviceScreen.navigation.bit | DeviceScreen.mapPlusNavigation.bit,
                     "enabled device screens should persist across BLEManager reloads")


### PR DESCRIPTION
## What changed

- keep Map and Map + Navigation as independent style profiles in the app and firmware
- enlarge the Map + Navigation distance text to match Ride Stats
- center the position dot and navigation arrow on both 1.75 and 2.06 layouts
- separate per-screen Roads & Paths, Places & Terrain, Map Rendering, Detail Level, Line Thickness, and Zoom Level controls
- keep Map Mode Map-only and move Navigation Overlays to the bottom of UI Customization
- split road visibility into Major Roads, Residential & Local Roads, Service Roads, Paths & Footways, and Tracks
- select and persist the correct profile independently in firmware

## Compatibility

- negotiate independent profiles before sending IDs 16...22, while preserving legacy shared-profile behavior with older firmware/apps
- recover safely from dropped, delayed, and reconnect-crossing capability responses
- preserve hidden independent settings while connected to legacy firmware
- combine controls when firmware lacks extended road visibility
- keep service/local roads and paths/tracks combined for legacy v1 map blocks; current v2 maps support independent classes

## Validation

- five-pass adversarial review loop: no remaining P0/P1/P2 findings
- `./ios-app/scripts/run-navigation-tests.sh`
- iOS Simulator `xcodebuild` with code signing disabled
- ESP32 host tests for both board layouts, profile protocol, persistence/migration, map transfer, sound, and codec recovery
- PlatformIO builds: `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206`
- signed iPhone device build, install, and launch
- `git diff --check`
