### PR TITLE
Harden map profile compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,12 @@ jobs:
             tools/tests/test_map_profile_protocol.cpp \
             -o /tmp/test_map_profile_protocol
           /tmp/test_map_profile_protocol
+      - name: Map profile persistence host tests
+        run: |
+          g++ -std=c++17 \
+            tools/tests/test_map_profile_persistence.cpp \
+            -o /tmp/test_map_profile_persistence
+          /tmp/test_map_profile_persistence
       - name: Map transfer host tests
         run: |
           g++ -std=c++17 \

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -128,6 +128,9 @@ overlay visibility remains shared by both profiles.
 Apps that support the extended visibility classes set marker bit `12`. Without
 that marker, firmware preserves the legacy behavior by applying bit `4` to both
 local and service roads and bit `2` to both paths and tracks.
+Legacy v1 map blocks do not contain feature type IDs, so the renderer also
+combines Local with Service and Paths with Tracks for those blocks. Downloading
+a current v2 map is required for independent road-class visibility.
 
 ## Device Sound Playback
 
@@ -202,8 +205,12 @@ configuration:
 "CAPS" | Flags: UInt8 | Enabled: UInt8 | SoundID: UInt8 | VolumePercent: UInt8
 ```
 
-Version `2` enables independent Map and Map + Navigation profiles. Version `3`
-requests the extended map visibility classes.
+Version `2` advertises that the client understands independent Map and Map +
+Navigation profiles. Version `3` also requests the extended map visibility
+classes. Receiving a `CAPS` request alone does not switch the firmware's
+setting semantics: a session switches to independent profiles only after the
+first setting ID in `16...22` is received. This keeps legacy IDs shared when a
+capability response is dropped.
 
 Legacy four-byte requests and five-byte responses remain supported. This lets
 new apps treat the device as the source of truth after reconnecting, while new
@@ -215,12 +222,13 @@ Flag bit `0` reports runtime device-sound availability after the speaker queue
 and task start successfully. Flag bit `1` reports PWR-button honk support. Flag
 bit `2` reports `SNHA` acknowledgement support; iOS only retries PWR
 configuration when this bit is set, preserving one-shot writes for older
-firmware. Flag bit `3` reports independent map profiles for older app builds;
-current app builds always send separate Map and Map + Navigation profiles. Flag
-bit `4` reports separate service-road and track visibility. The app retries
-discovery after each connection, uses the sound-related bits to enable sound
-controls, and restores the device-persisted PWR configuration from versioned
-responses.
+firmware. Flag bit `3` reports independent map profiles. Apps send IDs `16...22`
+only after this bit is received; otherwise they send the legacy Map profile and
+the firmware mirrors it to Map + Navigation. Flag bit `4` reports separate
+service-road and track visibility. The app retries discovery after each
+connection, ignores retry timers from older BLE sessions, uses the sound-related
+bits to enable sound controls, and restores the device-persisted PWR
+configuration from versioned responses.
 
 ## OSM Map Blocks
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ble_navigation.hpp"
+#include "map_profile_persistence.hpp"
 #include "../gps/gps.hpp"
 #include "../gui/src/waitingScr.hpp"
 #include "../gui/src/globalGuiDef.h"
@@ -774,8 +775,6 @@ static bool handleDeviceCapabilitiesCommand(const std::string &value,
   if (requireAuthenticated(authLabel)) {
     const uint8_t clientVersion =
         value.length() == 5 ? static_cast<uint8_t>(value[4]) : 0;
-    bleSessionUsesIndependentMapProfiles =
-        map_profile_protocol::clientSupportsIndependentProfiles(clientVersion);
     const bool includePowerButtonConfig =
         clientVersion >= 1;
     notifyDeviceCapabilities(pChar, includePowerButtonConfig);
@@ -1047,9 +1046,21 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                              const char *source) {
   bleDebugStats.settingsPacketCount++;
   bleDebugStats.lastSettingsPacketMs = millis();
+  if (map_profile_protocol::isIndependentSetting(settingId)) {
+    bleSessionUsesIndependentMapProfiles = true;
+  }
   const bool mirrorLegacyMapProfile =
       map_profile_protocol::shouldMirrorLegacySetting(
           settingId, bleSessionUsesIndependentMapProfiles);
+  const auto persistMapProfileSetting = [&]() {
+    settingsPrefs.begin("mapSettings", false);
+    map_profile_persistence::persistSetting(
+        settingsPrefs, mapRenderSettings.mapStyle,
+        mapRenderSettings.mapNavigationStyle,
+        mapRenderSettings.navigationOverlayVisibilityMask, settingId,
+        mirrorLegacyMapProfile);
+    settingsPrefs.end();
+  };
 
   switch (settingId) {
   case 1:
@@ -1059,14 +1070,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       mapRenderSettings.mapNavigationStyle.minPolygonSize =
           mapRenderSettings.mapStyle.minPolygonSize;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("minPolySize",
-                           mapRenderSettings.mapStyle.minPolygonSize);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar(
-          "navMinPoly", mapRenderSettings.mapNavigationStyle.minPolygonSize);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: minPolygonSize = %d (saved)\n",
                   mapRenderSettings.mapStyle.minPolygonSize);
     break;
@@ -1077,14 +1081,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       mapRenderSettings.mapNavigationStyle.detailLevel =
           mapRenderSettings.mapStyle.detailLevel;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("detailLevel",
-                           mapRenderSettings.mapStyle.detailLevel);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar("navDetail",
-                             mapRenderSettings.mapNavigationStyle.detailLevel);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: detailLevel = %d (saved)\n",
                   mapRenderSettings.mapStyle.detailLevel);
     break;
@@ -1095,14 +1092,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       mapRenderSettings.mapNavigationStyle.routeLineWidth =
           mapRenderSettings.mapStyle.routeLineWidth;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("routeWidth",
-                           mapRenderSettings.mapStyle.routeLineWidth);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar(
-          "navRouteW", mapRenderSettings.mapNavigationStyle.routeLineWidth);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: routeLineWidth = %d (saved)\n",
                   mapRenderSettings.mapStyle.routeLineWidth);
     break;
@@ -1113,15 +1103,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
           mapRenderSettings.mapStyle.streetLineWidthBoost;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("streetBoost",
-                           mapRenderSettings.mapStyle.streetLineWidthBoost);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar(
-          "navStreetB",
-          mapRenderSettings.mapNavigationStyle.streetLineWidthBoost);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: streetLineWidthBoost = %d (saved)\n",
                   mapRenderSettings.mapStyle.streetLineWidthBoost);
     break;
@@ -1132,15 +1114,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       mapRenderSettings.mapNavigationStyle.positionMarkerScale =
           mapRenderSettings.mapStyle.positionMarkerScale;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("markerScale",
-                           mapRenderSettings.mapStyle.positionMarkerScale);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar(
-          "navMarkerS",
-          mapRenderSettings.mapNavigationStyle.positionMarkerScale);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: positionMarkerScale = %d (saved)\n",
                   mapRenderSettings.mapStyle.positionMarkerScale);
     break;
@@ -1222,14 +1196,11 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     }
     if (isMapScreenActive()) {
       zoom = mapRenderSettings.mapStyle.zoomLevel;
+    } else if (map_profile_protocol::shouldApplyMirroredZoomToMapNavigation(
+                   mirrorLegacyMapProfile, isMapGuidanceScreenActive())) {
+      zoom = mapRenderSettings.mapNavigationStyle.zoomLevel;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("zoomLevel", mapRenderSettings.mapStyle.zoomLevel);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUChar("navZoom",
-                             mapRenderSettings.mapNavigationStyle.zoomLevel);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: zoomLevel = %d (saved)\n",
                   mapRenderSettings.mapStyle.zoomLevel);
     break;
@@ -1244,90 +1215,49 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     }
     mapRenderSettings.navigationOverlayVisibilityMask =
         mask & MAP_VISIBILITY_OVERLAY_MASK;
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUInt(
-        "visMask", mapRenderSettings.mapStyle.visibilityMask |
-                       mapRenderSettings.navigationOverlayVisibilityMask |
-                       MAP_VISIBILITY_EXTENDED_MARKER);
-    if (mirrorLegacyMapProfile) {
-      settingsPrefs.putUInt(
-          "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask |
-                        MAP_VISIBILITY_EXTENDED_MARKER);
-    }
-    settingsPrefs.end();
+    persistMapProfileSetting();
     Serial.printf("BLE Settings: visibilityMask = 0x%08X (saved)\n",
                   mask);
     break;
   }
   case 16:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.minPolygonSize =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar(
-        "navMinPoly", mapRenderSettings.mapNavigationStyle.minPolygonSize);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 17:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.detailLevel =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("navDetail",
-                           mapRenderSettings.mapNavigationStyle.detailLevel);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 18:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.routeLineWidth =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar(
-        "navRouteW", mapRenderSettings.mapNavigationStyle.routeLineWidth);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 19:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.zoomLevel =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
     if (isMapGuidanceScreenActive()) {
       extern uint8_t zoom;
       zoom = mapRenderSettings.mapNavigationStyle.zoomLevel;
     }
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("navZoom",
-                           mapRenderSettings.mapNavigationStyle.zoomLevel);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 20:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.visibilityMask =
         normalizedMapFeatureVisibilityMask((uint32_t)settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUInt(
-        "navVis", mapRenderSettings.mapNavigationStyle.visibilityMask |
-                      MAP_VISIBILITY_EXTENDED_MARKER);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 21:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar(
-        "navStreetB",
-        mapRenderSettings.mapNavigationStyle.streetLineWidthBoost);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   case 22:
-    bleSessionUsesIndependentMapProfiles = true;
     mapRenderSettings.mapNavigationStyle.positionMarkerScale =
         (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar(
-        "navMarkerS",
-        mapRenderSettings.mapNavigationStyle.positionMarkerScale);
-    settingsPrefs.end();
+    persistMapProfileSetting();
     break;
   default:
     Serial.printf("BLE Settings: Unknown setting ID %d from %s\n", settingId,
@@ -1618,27 +1548,8 @@ static void loadSettingsFromNVS() {
   Preferences prefs;
   prefs.begin("mapSettings", true); // read-only
 
-  mapRenderSettings.mapStyle.minPolygonSize = prefs.getUChar("minPolySize", 0);
-  mapRenderSettings.mapStyle.detailLevel = prefs.getUChar("detailLevel", 2);
-  mapRenderSettings.mapStyle.routeLineWidth = prefs.getUChar("routeWidth", 4);
-  mapRenderSettings.mapStyle.streetLineWidthBoost =
-      prefs.getUChar("streetBoost", 0);
-  mapRenderSettings.mapStyle.positionMarkerScale =
-      prefs.getUChar("markerScale", 2);
-  mapRenderSettings.mapStyle.zoomLevel = prefs.getUChar("zoomLevel", 4);
-
-  mapRenderSettings.mapNavigationStyle.minPolygonSize = prefs.getUChar(
-      "navMinPoly", mapRenderSettings.mapStyle.minPolygonSize);
-  mapRenderSettings.mapNavigationStyle.detailLevel =
-      prefs.getUChar("navDetail", mapRenderSettings.mapStyle.detailLevel);
-  mapRenderSettings.mapNavigationStyle.routeLineWidth =
-      prefs.getUChar("navRouteW", mapRenderSettings.mapStyle.routeLineWidth);
-  mapRenderSettings.mapNavigationStyle.streetLineWidthBoost = prefs.getUChar(
-      "navStreetB", mapRenderSettings.mapStyle.streetLineWidthBoost);
-  mapRenderSettings.mapNavigationStyle.positionMarkerScale = prefs.getUChar(
-      "navMarkerS", mapRenderSettings.mapStyle.positionMarkerScale);
-  mapRenderSettings.mapNavigationStyle.zoomLevel =
-      prefs.getUChar("navZoom", mapRenderSettings.mapStyle.zoomLevel);
+  map_profile_persistence::load(prefs, mapRenderSettings.mapStyle,
+                                mapRenderSettings.mapNavigationStyle);
   mapRenderSettings.displayRotation =
       sanitizeMapDisplayRotation(prefs.getUChar("rotation", 0), "NVS");
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
@@ -1653,14 +1564,8 @@ static void loadSettingsFromNVS() {
       normalizedDisconnectedSleepTimeoutSeconds(
           prefs.getUInt("discSleepSec", 120));
   const uint32_t storedVisibilityMask = prefs.getUInt("visMask", 0x3FF);
-  mapRenderSettings.mapStyle.visibilityMask =
-      normalizedMapFeatureVisibilityMask(storedVisibilityMask);
   mapRenderSettings.navigationOverlayVisibilityMask =
       storedVisibilityMask & MAP_VISIBILITY_OVERLAY_MASK;
-  mapRenderSettings.mapNavigationStyle.visibilityMask =
-      normalizedMapFeatureVisibilityMask(prefs.getUInt(
-          "navVis", mapRenderSettings.mapStyle.visibilityMask |
-                        MAP_VISIBILITY_EXTENDED_MARKER));
 
   prefs.end();
 

--- a/esp32/lib/ble_navigation/map_profile_persistence.hpp
+++ b/esp32/lib/ble_navigation/map_profile_persistence.hpp
@@ -1,0 +1,111 @@
+#pragma once
+
+#include "map_profile_protocol.hpp"
+
+#include <stdint.h>
+
+namespace map_profile_persistence {
+
+template <typename Store, typename Profile>
+inline void load(Store &store, Profile &mapStyle,
+                 Profile &mapNavigationStyle) {
+  mapStyle.minPolygonSize = store.getUChar("minPolySize", 0);
+  mapStyle.detailLevel = store.getUChar("detailLevel", 2);
+  mapStyle.routeLineWidth = store.getUChar("routeWidth", 4);
+  mapStyle.streetLineWidthBoost = store.getUChar("streetBoost", 0);
+  mapStyle.positionMarkerScale = store.getUChar("markerScale", 2);
+  mapStyle.zoomLevel = store.getUChar("zoomLevel", 4);
+  const uint32_t storedMapVisibility = store.getUInt("visMask", 0x3FF);
+  mapStyle.visibilityMask =
+      map_profile_protocol::normalizedFeatureVisibilityMask(storedMapVisibility);
+
+  mapNavigationStyle.minPolygonSize =
+      store.getUChar("navMinPoly", mapStyle.minPolygonSize);
+  mapNavigationStyle.detailLevel =
+      store.getUChar("navDetail", mapStyle.detailLevel);
+  mapNavigationStyle.routeLineWidth =
+      store.getUChar("navRouteW", mapStyle.routeLineWidth);
+  mapNavigationStyle.streetLineWidthBoost =
+      store.getUChar("navStreetB", mapStyle.streetLineWidthBoost);
+  mapNavigationStyle.positionMarkerScale =
+      store.getUChar("navMarkerS", mapStyle.positionMarkerScale);
+  mapNavigationStyle.zoomLevel = store.getUChar("navZoom", mapStyle.zoomLevel);
+  mapNavigationStyle.visibilityMask =
+      map_profile_protocol::normalizedFeatureVisibilityMask(store.getUInt(
+          "navVis", mapStyle.visibilityMask |
+                        map_profile_protocol::VISIBILITY_EXTENDED_MARKER));
+}
+
+template <typename Store, typename Profile>
+inline bool persistSetting(Store &store, const Profile &mapStyle,
+                           const Profile &mapNavigationStyle,
+                           uint32_t navigationOverlayVisibilityMask,
+                           uint8_t settingId, bool mirrorLegacySetting) {
+  switch (settingId) {
+  case 1:
+    store.putUChar("minPolySize", mapStyle.minPolygonSize);
+    if (mirrorLegacySetting)
+      store.putUChar("navMinPoly", mapNavigationStyle.minPolygonSize);
+    return true;
+  case 2:
+    store.putUChar("detailLevel", mapStyle.detailLevel);
+    if (mirrorLegacySetting)
+      store.putUChar("navDetail", mapNavigationStyle.detailLevel);
+    return true;
+  case 3:
+    store.putUChar("routeWidth", mapStyle.routeLineWidth);
+    if (mirrorLegacySetting)
+      store.putUChar("navRouteW", mapNavigationStyle.routeLineWidth);
+    return true;
+  case 7:
+    store.putUChar("zoomLevel", mapStyle.zoomLevel);
+    if (mirrorLegacySetting)
+      store.putUChar("navZoom", mapNavigationStyle.zoomLevel);
+    return true;
+  case 8:
+    store.putUInt("visMask",
+                  mapStyle.visibilityMask | navigationOverlayVisibilityMask |
+                      map_profile_protocol::VISIBILITY_EXTENDED_MARKER);
+    if (mirrorLegacySetting) {
+      store.putUInt("navVis", mapNavigationStyle.visibilityMask |
+                                    map_profile_protocol::VISIBILITY_EXTENDED_MARKER);
+    }
+    return true;
+  case 9:
+    store.putUChar("streetBoost", mapStyle.streetLineWidthBoost);
+    if (mirrorLegacySetting)
+      store.putUChar("navStreetB", mapNavigationStyle.streetLineWidthBoost);
+    return true;
+  case 10:
+    store.putUChar("markerScale", mapStyle.positionMarkerScale);
+    if (mirrorLegacySetting)
+      store.putUChar("navMarkerS", mapNavigationStyle.positionMarkerScale);
+    return true;
+  case 16:
+    store.putUChar("navMinPoly", mapNavigationStyle.minPolygonSize);
+    return true;
+  case 17:
+    store.putUChar("navDetail", mapNavigationStyle.detailLevel);
+    return true;
+  case 18:
+    store.putUChar("navRouteW", mapNavigationStyle.routeLineWidth);
+    return true;
+  case 19:
+    store.putUChar("navZoom", mapNavigationStyle.zoomLevel);
+    return true;
+  case 20:
+    store.putUInt("navVis", mapNavigationStyle.visibilityMask |
+                                map_profile_protocol::VISIBILITY_EXTENDED_MARKER);
+    return true;
+  case 21:
+    store.putUChar("navStreetB", mapNavigationStyle.streetLineWidthBoost);
+    return true;
+  case 22:
+    store.putUChar("navMarkerS", mapNavigationStyle.positionMarkerScale);
+    return true;
+  default:
+    return false;
+  }
+}
+
+} // namespace map_profile_persistence

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -50,6 +50,25 @@ inline uint32_t normalizedFeatureVisibilityMask(uint32_t mask) {
   return normalized;
 }
 
+inline uint32_t visibilityMaskForMapVersion(uint32_t mask,
+                                            uint8_t mapVersion) {
+  if (mapVersion >= 2)
+    return mask;
+
+  const uint32_t localAndService =
+      VISIBILITY_LOCAL_STREETS | VISIBILITY_SERVICE_ROADS;
+  const uint32_t pathsAndTracks = VISIBILITY_PATHS | VISIBILITY_TRACKS;
+  if ((mask & localAndService) != 0)
+    mask |= localAndService;
+  else
+    mask &= ~localAndService;
+  if ((mask & pathsAndTracks) != 0)
+    mask |= pathsAndTracks;
+  else
+    mask &= ~pathsAndTracks;
+  return mask;
+}
+
 inline bool isServiceRoadTypeId(uint8_t typeId) { return typeId == 10; }
 
 inline bool isTrackTypeId(uint8_t typeId) { return typeId == 50; }
@@ -75,6 +94,11 @@ inline bool isLegacySetting(uint8_t settingId) {
 inline bool shouldMirrorLegacySetting(uint8_t settingId,
                                       bool independentProfilesEnabled) {
   return isLegacySetting(settingId) && !independentProfilesEnabled;
+}
+
+inline bool shouldApplyMirroredZoomToMapNavigation(
+    bool mirrorLegacySetting, bool mapNavigationActive) {
+  return mirrorLegacySetting && mapNavigationActive;
 }
 
 inline int32_t clampValue(uint8_t settingId, int32_t value) {

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -1029,6 +1029,7 @@ Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
   // Get version from 4th byte
   uint8_t version = (uint8_t)file[3];
   bool hasTypeId = (version >= 2);
+  mblock->formatVersion = version;
   ESP_LOGI(TAG, "Map file version: %d (typeId: %s)", version,
            hasTypeId ? "yes" : "no");
   offset += 4;
@@ -1534,6 +1535,11 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       if (!mblock->inView)
         continue;
 
+      ScreenMapRenderSettings blockStyle = style;
+      blockStyle.visibilityMask =
+          map_profile_protocol::visibilityMaskForMapVersion(
+              style.visibilityMask, mblock->formatVersion);
+
       // block to draw
       Point16 screen_center_mc =
           viewPort.center.toPoint16() -
@@ -1618,7 +1624,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             }
 
             // Skip if type is hidden by visibility mask
-            if (!isPolygonVisible(polygon.typeId, polygon.color, style)) {
+            if (!isPolygonVisible(polygon.typeId, polygon.color, blockStyle)) {
               continue;
             }
 
@@ -1649,7 +1655,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
 
             // Skip tiny polygons based on explicit min size plus detail density.
             const uint8_t minPolygonSize =
-                effectiveMinPolygonSize(style);
+                effectiveMinPolygonSize(blockStyle);
             int16_t polyWidth = maxX - minX;
             int16_t polyHeight = maxY - minY;
             if (minPolygonSize > 0 &&
@@ -1680,7 +1686,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           continue;
 
         // Skip if type is hidden by visibility mask
-        if (!isLineVisible(line.typeId, line.color, line.width, style))
+        if (!isLineVisible(line.typeId, line.color, line.width, blockStyle))
           continue;
 
         uint16_t color_swapped = line.color; // Use color directly (RGB565)
@@ -1710,7 +1716,7 @@ void Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
 
         Point16 p1 = transformPoint(line.points[0]);
         int32_t streetBoost = shouldBoostLineWidth(line.typeId, line.width)
-                                  ? style.streetLineWidthBoost
+                                  ? blockStyle.streetLineWidthBoost
                                   : 0;
         uint8_t lineWidth = (uint8_t)std::min<int32_t>(
             std::max<int32_t>(line.width, 1) + streetBoost, 24);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -79,6 +79,7 @@ private:
   {
     Point32 offset;
     bool inView = false;
+    uint8_t formatVersion = 1;
     std::vector<Polyline, PsramAllocator<Polyline>> polylines;
     std::vector<Polygon, PsramAllocator<Polygon>> polygons;
 

--- a/esp32/tools/tests/test_map_profile_persistence.cpp
+++ b/esp32/tools/tests/test_map_profile_persistence.cpp
@@ -1,0 +1,107 @@
+#include "../../lib/ble_navigation/map_profile_persistence.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <iostream>
+#include <string>
+#include <unordered_map>
+
+struct TestProfile {
+  uint8_t minPolygonSize = 0;
+  uint8_t detailLevel = 0;
+  uint8_t routeLineWidth = 0;
+  uint8_t streetLineWidthBoost = 0;
+  uint8_t positionMarkerScale = 0;
+  uint8_t zoomLevel = 0;
+  uint32_t visibilityMask = 0;
+};
+
+class FakeStore {
+public:
+  uint8_t getUChar(const char *key, uint8_t fallback) const {
+    const auto value = values.find(key);
+    return value == values.end() ? fallback
+                                 : static_cast<uint8_t>(value->second);
+  }
+  uint32_t getUInt(const char *key, uint32_t fallback) const {
+    const auto value = values.find(key);
+    return value == values.end() ? fallback : value->second;
+  }
+  void putUChar(const char *key, uint8_t value) { values[key] = value; }
+  void putUInt(const char *key, uint32_t value) { values[key] = value; }
+
+private:
+  std::unordered_map<std::string, uint32_t> values;
+};
+
+static TestProfile profile(uint8_t base, uint32_t visibilityMask) {
+  return TestProfile{base, static_cast<uint8_t>(base + 1),
+                     static_cast<uint8_t>(base + 2),
+                     static_cast<uint8_t>(base + 3),
+                     static_cast<uint8_t>(base + 4),
+                     static_cast<uint8_t>(base + 5), visibilityMask};
+}
+
+static void persistProfile(FakeStore &store, const TestProfile &map,
+                           const TestProfile &navigation, bool mirror) {
+  for (uint8_t settingId : {1, 2, 3, 7, 8, 9, 10}) {
+    assert(map_profile_persistence::persistSetting(
+        store, map, navigation,
+        map_profile_protocol::VISIBILITY_OVERLAY_MASK, settingId, mirror));
+  }
+}
+
+int main() {
+  using namespace map_profile_protocol;
+
+  FakeStore legacyStore;
+  const TestProfile legacyMap = profile(1, VISIBILITY_LEGACY_FEATURE_MASK);
+  legacyStore.putUChar("minPolySize", legacyMap.minPolygonSize);
+  legacyStore.putUChar("detailLevel", legacyMap.detailLevel);
+  legacyStore.putUChar("routeWidth", legacyMap.routeLineWidth);
+  legacyStore.putUChar("streetBoost", legacyMap.streetLineWidthBoost);
+  legacyStore.putUChar("markerScale", legacyMap.positionMarkerScale);
+  legacyStore.putUChar("zoomLevel", legacyMap.zoomLevel);
+  legacyStore.putUInt("visMask", legacyMap.visibilityMask);
+  TestProfile loadedMap;
+  TestProfile loadedNavigation;
+  map_profile_persistence::load(legacyStore, loadedMap, loadedNavigation);
+  assert(loadedMap.visibilityMask == VISIBILITY_EXTENDED_FEATURE_MASK);
+  assert(loadedNavigation.visibilityMask == VISIBILITY_EXTENDED_FEATURE_MASK);
+  assert(loadedNavigation.zoomLevel == legacyMap.zoomLevel);
+
+  FakeStore mirroredStore;
+  const TestProfile mirrored = profile(2, VISIBILITY_EXTENDED_FEATURE_MASK);
+  persistProfile(mirroredStore, mirrored, mirrored, true);
+  map_profile_persistence::load(mirroredStore, loadedMap, loadedNavigation);
+  assert(loadedMap.minPolygonSize == mirrored.minPolygonSize);
+  assert(loadedNavigation.minPolygonSize == mirrored.minPolygonSize);
+  assert(loadedNavigation.positionMarkerScale == mirrored.positionMarkerScale);
+  assert(mirroredStore.getUInt("visMask", 0) ==
+         (mirrored.visibilityMask | VISIBILITY_OVERLAY_MASK |
+          VISIBILITY_EXTENDED_MARKER));
+
+  FakeStore independentStore;
+  const TestProfile map = profile(1, VISIBILITY_LOCAL_STREETS);
+  const TestProfile originalNavigation = map;
+  persistProfile(independentStore, map, originalNavigation, false);
+  const TestProfile navigation =
+      profile(7, VISIBILITY_SERVICE_ROADS | VISIBILITY_TRACKS);
+  for (uint8_t settingId : {16, 17, 18, 19, 20, 21, 22}) {
+    assert(map_profile_persistence::persistSetting(
+        independentStore, map, navigation, VISIBILITY_POSITION_MARKER,
+        settingId, false));
+  }
+  map_profile_persistence::load(independentStore, loadedMap,
+                                loadedNavigation);
+  assert(loadedMap.minPolygonSize == map.minPolygonSize);
+  assert(loadedMap.visibilityMask == map.visibilityMask);
+  assert(loadedNavigation.minPolygonSize == navigation.minPolygonSize);
+  assert(loadedNavigation.visibilityMask == navigation.visibilityMask);
+  assert(independentStore.getUInt("visMask", 0) ==
+         (map.visibilityMask | VISIBILITY_OVERLAY_MASK |
+          VISIBILITY_EXTENDED_MARKER));
+
+  std::cout << "Map profile persistence tests passed\n";
+  return 0;
+}

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -33,6 +33,12 @@ int main() {
       VISIBILITY_EXTENDED_MARKER | VISIBILITY_TRACKS;
   assert(normalizedFeatureVisibilityMask(extendedTrackOnly) ==
          VISIBILITY_TRACKS);
+  assert(visibilityMaskForMapVersion(VISIBILITY_SERVICE_ROADS, 1) ==
+         (VISIBILITY_LOCAL_STREETS | VISIBILITY_SERVICE_ROADS));
+  assert(visibilityMaskForMapVersion(VISIBILITY_TRACKS, 1) ==
+         (VISIBILITY_PATHS | VISIBILITY_TRACKS));
+  assert(visibilityMaskForMapVersion(VISIBILITY_SERVICE_ROADS, 2) ==
+         VISIBILITY_SERVICE_ROADS);
   assert(isLocalStreetTypeId(6));
   assert(isLocalStreetTypeId(7));
   assert(!isLocalStreetTypeId(10));
@@ -50,6 +56,9 @@ int main() {
   assert(isIndependentSetting(16));
   assert(isIndependentSetting(22));
   assert(!isIndependentSetting(15));
+  assert(!shouldApplyMirroredZoomToMapNavigation(false, true));
+  assert(!shouldApplyMirroredZoomToMapNavigation(true, false));
+  assert(shouldApplyMirroredZoomToMapNavigation(true, true));
 
   assert(clampValue(1, -1) == 0);
   assert(clampValue(16, 51) == 50);

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -45,6 +45,7 @@ enum DeviceBLEProtocol {
     static let deviceSoundsCapabilityMask: UInt8 = 1 << 0
     static let powerButtonHonkCapabilityMask: UInt8 = 1 << 1
     static let powerButtonHonkAcknowledgementCapabilityMask: UInt8 = 1 << 2
+    static let independentMapProfilesCapabilityMask: UInt8 = 1 << 3
     static let extendedMapVisibilityCapabilityMask: UInt8 = 1 << 4
     static let deviceCapabilitiesVersion: UInt8 = 3
     static let fallbackWriteQueueCapacity = 32
@@ -349,6 +350,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var supportsDeviceSounds: Bool = false
     @Published var supportsPowerButtonHonk: Bool = false
     @Published var supportsPowerButtonHonkAcknowledgement: Bool = false
+    @Published private(set) var supportsIndependentMapProfiles: Bool = false
     @Published private(set) var supportsExtendedMapVisibility: Bool = false
     @Published private(set) var powerButtonHonkConfigurationError: String?
     @Published private(set) var hasReceivedDeviceCapabilities: Bool = false
@@ -489,7 +491,9 @@ class BLEManager: NSObject, ObservableObject {
     private var powerButtonHonkRetryWorkItem: DispatchWorkItem?
     private var powerButtonHonkAckTimeout: TimeInterval = 1.0
     private var powerButtonHonkFailureRetryDelay: TimeInterval = 0.1
-    private var hasSentMapProfilesForConnection = false
+    private var hasSentMapProfileForConnection = false
+    private var hasSentMapNavigationProfileForConnection = false
+    private var isSendingNegotiatedMapProfiles = false
     private var shouldPairAfterDisconnect: Bool = false
     private var suppressNextReconnect: Bool = false
     private var hasActiveBLESession: Bool {
@@ -949,8 +953,21 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     /// Persist and send a runtime map setting to ESP32 when supported.
-    func sendSetting(id: UInt8, value: Int32) {
+    func sendSetting(id: UInt8, value: Int32,
+                     synchronizeLegacyProfile: Bool = true) {
+        if hasReceivedDeviceCapabilities,
+           !supportsIndependentMapProfiles,
+           !isSendingNegotiatedMapProfiles,
+           synchronizeLegacyProfile,
+           Self.isLegacyMapProfileSetting(id) {
+            synchronizeMapPlusNavigationProfileWithMap(for: id)
+        }
         saveSettings()
+        if Self.isIndependentMapProfileSetting(id),
+           (!hasReceivedDeviceCapabilities || !supportsIndependentMapProfiles) {
+            log("Independent map setting id=\(id) not sent: connected firmware does not advertise support")
+            return
+        }
         guard isConnected, isNavigationReady else {
             log("Settings characteristic unsupported; saved local setting id=\(id), value=\(value)")
             return
@@ -985,38 +1002,92 @@ class BLEManager: NSObject, ObservableObject {
         sendFallbackMapPacket(fallback, label: "setting id=\(id)")
     }
 
+    private static func isLegacyMapProfileSetting(_ id: UInt8) -> Bool {
+        id == 1 || id == 2 || id == 3 || id == 7 || id == 8 || id == 9 || id == 10
+    }
+
+    private static func isIndependentMapProfileSetting(_ id: UInt8) -> Bool {
+        id >= DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID &&
+            id <= DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID
+    }
+
+    private func synchronizeMapPlusNavigationProfileWithMap(for settingID: UInt8) {
+        switch settingID {
+        case 1:
+            mapPlusNavigationMinPolygonSize = minPolygonSize
+        case 2:
+            mapPlusNavigationDetailLevel = detailLevel
+        case 3:
+            mapPlusNavigationRouteLineWidth = routeLineWidth
+        case 7:
+            mapPlusNavigationZoomLevel = zoomLevel
+        case 8:
+            mapPlusNavigationShowBuildings = showBuildings
+            mapPlusNavigationShowGreenSpace = showGreenSpace
+            mapPlusNavigationShowPaths = showPaths
+            mapPlusNavigationShowTracks = showTracks
+            mapPlusNavigationShowMajorRoads = showMajorRoads
+            mapPlusNavigationShowLocalStreets = showLocalStreets
+            mapPlusNavigationShowServiceRoads = showServiceRoads
+            mapPlusNavigationShowWater = showWater
+            mapPlusNavigationShowRailways = showRailways
+            mapPlusNavigationShowOtherAreas = showOtherAreas
+        case 9:
+            mapPlusNavigationStreetLineWidthBoost = streetLineWidthBoost
+        case 10:
+            mapPlusNavigationPositionMarkerScale = positionMarkerScale
+        default:
+            break
+        }
+    }
+
     private func sendMapProfilesAfterCapabilityNegotiation() {
         guard isConnected,
               isNavigationReady,
-              hasReceivedDeviceCapabilities,
-              !hasSentMapProfilesForConnection else { return }
+              hasReceivedDeviceCapabilities else { return }
 
-        hasSentMapProfilesForConnection = true
-        sendVisibilityMask(for: .map)
-        sendSetting(id: 1, value: Int32(minPolygonSize))
-        sendSetting(id: 2, value: Int32(detailLevel))
-        sendSetting(id: 3, value: Int32(routeLineWidth))
-        sendSetting(id: 9, value: Int32(streetLineWidthBoost))
-        sendSetting(id: 10, value: Int32(positionMarkerScale))
-        sendSetting(id: 7, value: Int32(zoomLevel))
+        let shouldSendMap = !hasSentMapProfileForConnection
+        let shouldSendMapNavigation = supportsIndependentMapProfiles &&
+            !hasSentMapNavigationProfileForConnection
+        guard shouldSendMap || shouldSendMapNavigation else { return }
 
-        sendVisibilityMask(for: .mapPlusNavigation)
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID,
-                    value: Int32(mapPlusNavigationMinPolygonSize))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
-                    value: Int32(mapPlusNavigationDetailLevel))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
-                    value: Int32(mapPlusNavigationRouteLineWidth))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
-                    value: Int32(mapPlusNavigationStreetLineWidthBoost))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
-                    value: Int32(mapPlusNavigationPositionMarkerScale))
-        sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
-                    value: Int32(mapPlusNavigationZoomLevel))
+        isSendingNegotiatedMapProfiles = true
+        defer { isSendingNegotiatedMapProfiles = false }
+
+        // The first independent packet switches new firmware out of legacy
+        // mirroring mode before the Map profile's legacy IDs arrive.
+        if shouldSendMapNavigation {
+            hasSentMapNavigationProfileForConnection = true
+            sendVisibilityMask(for: .mapPlusNavigation)
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationMinPolygonSizeSettingID,
+                        value: Int32(mapPlusNavigationMinPolygonSize))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
+                        value: Int32(mapPlusNavigationDetailLevel))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
+                        value: Int32(mapPlusNavigationRouteLineWidth))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
+                        value: Int32(mapPlusNavigationStreetLineWidthBoost))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
+                        value: Int32(mapPlusNavigationPositionMarkerScale))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
+                        value: Int32(mapPlusNavigationZoomLevel))
+        }
+
+        if shouldSendMap {
+            hasSentMapProfileForConnection = true
+            sendVisibilityMask(for: .map)
+            sendSetting(id: 1, value: Int32(minPolygonSize))
+            sendSetting(id: 2, value: Int32(detailLevel))
+            sendSetting(id: 3, value: Int32(routeLineWidth))
+            sendSetting(id: 9, value: Int32(streetLineWidthBoost))
+            sendSetting(id: 10, value: Int32(positionMarkerScale))
+            sendSetting(id: 7, value: Int32(zoomLevel))
+        }
     }
 
     func useDeviceCapabilitiesFallback() {
         guard isConnected, isNavigationReady, !hasReceivedDeviceCapabilities else { return }
+        supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
         hasReceivedDeviceCapabilities = true
         log("Device capabilities unavailable; using baseline feature visibility")
@@ -1025,10 +1096,11 @@ class BLEManager: NSObject, ObservableObject {
     
     /// Send feature visibility bitmask
     func sendVisibilityMask() {
-        sendVisibilityMask(for: .map)
+        sendVisibilityMask(for: .map, synchronizeLegacyProfile: false)
     }
 
-    func sendVisibilityMask(for screen: DeviceScreen) {
+    func sendVisibilityMask(for screen: DeviceScreen,
+                            synchronizeLegacyProfile: Bool = true) {
         var mask: Int32 = 0
         let settingID: UInt8
 
@@ -1069,7 +1141,8 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        sendSetting(id: settingID, value: mask)
+        sendSetting(id: settingID, value: mask,
+                    synchronizeLegacyProfile: synchronizeLegacyProfile)
     }
 
     func isDeviceScreenEnabled(_ screen: DeviceScreen) -> Bool {
@@ -1519,10 +1592,13 @@ class BLEManager: NSObject, ObservableObject {
         supportsDeviceSounds = false
         supportsPowerButtonHonk = false
         supportsPowerButtonHonkAcknowledgement = false
+        supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
         powerButtonHonkConfigurationError = nil
         hasReceivedDeviceCapabilities = false
-        hasSentMapProfilesForConnection = false
+        hasSentMapProfileForConnection = false
+        hasSentMapNavigationProfileForConnection = false
+        isSendingNegotiatedMapProfiles = false
         clearPendingPowerButtonHonkConfiguration()
     }
 
@@ -2327,6 +2403,7 @@ extension BLEManager: CBPeripheralDelegate {
             supportsDeviceSounds = false
             supportsPowerButtonHonk = false
             supportsPowerButtonHonkAcknowledgement = false
+            supportsIndependentMapProfiles = false
             supportsExtendedMapVisibility = false
             hasReceivedDeviceCapabilities = false
             clearPendingPowerButtonHonkConfiguration()
@@ -2340,6 +2417,8 @@ extension BLEManager: CBPeripheralDelegate {
             flags & DeviceBLEProtocol.powerButtonHonkCapabilityMask != 0
         let hasPowerButtonHonkAcknowledgement = hasPowerButtonHonk &&
             flags & DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask != 0
+        let hasIndependentMapProfiles =
+            flags & DeviceBLEProtocol.independentMapProfilesCapabilityMask != 0
         let hasExtendedMapVisibility =
             flags & DeviceBLEProtocol.extendedMapVisibilityCapabilityMask != 0
         let hasDevicePowerButtonConfig = data.count == 8
@@ -2351,6 +2430,7 @@ extension BLEManager: CBPeripheralDelegate {
                 supportsDeviceSounds = false
                 supportsPowerButtonHonk = false
                 supportsPowerButtonHonkAcknowledgement = false
+                supportsIndependentMapProfiles = false
                 supportsExtendedMapVisibility = false
                 hasReceivedDeviceCapabilities = false
                 clearPendingPowerButtonHonkConfiguration()
@@ -2372,9 +2452,18 @@ extension BLEManager: CBPeripheralDelegate {
         let shouldSynchronizePowerButtonHonk = hasPowerButtonHonk &&
             !hasDevicePowerButtonConfig &&
             (!hasReceivedDeviceCapabilities || !supportsPowerButtonHonk)
+        let shouldResendMapProfilesForExtendedVisibility =
+            hasReceivedDeviceCapabilities &&
+            !supportsExtendedMapVisibility &&
+            hasExtendedMapVisibility
+        if shouldResendMapProfilesForExtendedVisibility {
+            hasSentMapProfileForConnection = false
+            hasSentMapNavigationProfileForConnection = false
+        }
         supportsDeviceSounds = hasDeviceSounds
         supportsPowerButtonHonk = hasPowerButtonHonk
         supportsPowerButtonHonkAcknowledgement = hasPowerButtonHonkAcknowledgement
+        supportsIndependentMapProfiles = hasIndependentMapProfiles
         supportsExtendedMapVisibility = hasExtendedMapVisibility
         if !hasPowerButtonHonkAcknowledgement {
             clearPendingPowerButtonHonkConfiguration()

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -76,6 +76,7 @@ class BikeComputerCoordinator: ObservableObject {
     private var ongoingDestinationSearch: MKLocalSearch?
     private var ongoingDirections: MKDirections?
     private var transportType: MKDirectionsTransportType = RouteTransportTypes.cycling
+    private var deviceCapabilityRefreshGeneration: UInt = 0
 
     // MARK: - Initialization
 
@@ -179,15 +180,18 @@ class BikeComputerCoordinator: ObservableObject {
 
         bleManager.$isNavigationReady
             .removeDuplicates()
-            .filter { $0 }
-            .sink { [weak self] _ in
+            .sink { [weak self] isReady in
                 guard let self else { return }
+                self.deviceCapabilityRefreshGeneration &+= 1
+                guard isReady else { return }
+                let generation = self.deviceCapabilityRefreshGeneration
                 if let location = self.locationManager.currentLocation {
                     self.navEngine.processExternalLocation(location)
                 }
                 self.requestMapTransferStatusAfterDeviceRefresh()
                 DeviceCapabilityRetry.scheduleInitial { [weak self] in
-                    self?.refreshDeviceCapabilities(attempt: 0)
+                    self?.refreshDeviceCapabilities(attempt: 0,
+                                                    generation: generation)
                 }
                 self.bleManager.requestDeviceTransferStatus()
                 self.scheduleFirmwareUpdateCheckAfterDeviceRefresh()
@@ -310,7 +314,11 @@ class BikeComputerCoordinator: ObservableObject {
         }
     }
 
-    private func refreshDeviceCapabilities(attempt: Int) {
+    private func refreshDeviceCapabilities(attempt: Int, generation: UInt) {
+        guard DeviceCapabilityRetry.isCurrentSession(
+            generation,
+            currentGeneration: deviceCapabilityRefreshGeneration
+        ) else { return }
         let shouldRequest = DeviceCapabilityRetry.shouldRequest(
             isNavigationReady: bleManager.isNavigationReady,
             hasReceivedCapabilities: bleManager.hasReceivedDeviceCapabilities,
@@ -327,7 +335,8 @@ class BikeComputerCoordinator: ObservableObject {
 
         bleManager.requestDeviceCapabilities()
         DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-            self?.refreshDeviceCapabilities(attempt: attempt + 1)
+            self?.refreshDeviceCapabilities(attempt: attempt + 1,
+                                            generation: generation)
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Utilities/DeviceCapabilityRetry.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/DeviceCapabilityRetry.swift
@@ -9,6 +9,11 @@ enum DeviceCapabilityRetry {
         isNavigationReady && !hasReceivedCapabilities && attempt < maxAttempts
     }
 
+    static func isCurrentSession(_ generation: UInt,
+                                 currentGeneration: UInt) -> Bool {
+        generation == currentGeneration
+    }
+
     static func scheduleInitial(on queue: DispatchQueue = .main,
                                 _ action: @escaping () -> Void) {
         queue.async {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -463,22 +463,36 @@ private struct DeviceScreensSettingsSection: View {
 private struct UICustomizationSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
 
+    private var screenStylesFooter: String {
+        if !bleManager.hasReceivedDeviceCapabilities {
+            return "Checking whether the connected firmware supports independent map styles."
+        }
+        if bleManager.supportsIndependentMapProfiles {
+            return "Configure map appearance independently for each device screen."
+        }
+        return "This firmware uses one shared style for both map screens. Update the firmware to configure them independently."
+    }
+
     var body: some View {
         Form {
-            Section(header: Text("Screen Styles"), footer: Text("Configure map appearance independently for each device screen.")) {
+            Section(header: Text("Screen Styles"), footer: Text(screenStylesFooter)) {
                 NavigationLink {
                     MapStyleSettingsView(screen: .map)
                 } label: {
-                    Label("Map", systemImage: "map")
+                    Label(bleManager.supportsIndependentMapProfiles ? "Map" : "Map Screens",
+                          systemImage: "map")
                 }
 
-                NavigationLink {
-                    MapStyleSettingsView(screen: .mapPlusNavigation)
-                } label: {
-                    Label("Map + Navigation", systemImage: "location.north.line")
+                if bleManager.supportsIndependentMapProfiles {
+                    NavigationLink {
+                        MapStyleSettingsView(screen: .mapPlusNavigation)
+                    } label: {
+                        Label("Map + Navigation", systemImage: "location.north.line")
+                    }
                 }
             }
-            .disabled(!bleManager.supportsDeviceSettings)
+            .disabled(!bleManager.supportsDeviceSettings ||
+                      !bleManager.hasReceivedDeviceCapabilities)
 
             Section(header: Text("Display Rotation"), footer: Text("Rotate display 90° CCW. Requires reboot.")) {
                 Toggle("Rotate 90°", isOn: Binding(
@@ -543,6 +557,12 @@ private struct MapStyleSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
     let screen: MapStyleScreen
 
+    private var navigationTitle: String {
+        screen == .map && !bleManager.supportsIndependentMapProfiles
+            ? "Map Screens"
+            : screen.title
+    }
+
     private func binding<Value>(
         map: ReferenceWritableKeyPath<BLEManager, Value>,
         mapPlusNavigation: ReferenceWritableKeyPath<BLEManager, Value>
@@ -586,8 +606,34 @@ private struct MapStyleSettingsView: View {
         binding(map: \.showLocalStreets, mapPlusNavigation: \.mapPlusNavigationShowLocalStreets)
     }
 
+    private var localRoadsControl: Binding<Bool> {
+        guard !bleManager.supportsExtendedMapVisibility else {
+            return showLocalStreets
+        }
+        return Binding(
+            get: { showLocalStreets.wrappedValue || showServiceRoads.wrappedValue },
+            set: {
+                showLocalStreets.wrappedValue = $0
+                showServiceRoads.wrappedValue = $0
+            }
+        )
+    }
+
     private var showPaths: Binding<Bool> {
         binding(map: \.showPaths, mapPlusNavigation: \.mapPlusNavigationShowPaths)
+    }
+
+    private var pathsControl: Binding<Bool> {
+        guard !bleManager.supportsExtendedMapVisibility else {
+            return showPaths
+        }
+        return Binding(
+            get: { showPaths.wrappedValue || showTracks.wrappedValue },
+            set: {
+                showPaths.wrappedValue = $0
+                showTracks.wrappedValue = $0
+            }
+        )
     }
 
     private var showTracks: Binding<Bool> {
@@ -620,17 +666,27 @@ private struct MapStyleSettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Roads & Paths"), footer: Text("Service roads commonly include driveways and internal compound roads; exact results depend on the OpenStreetMap tags in the downloaded map.")) {
+            Section(header: Text("Roads & Paths"), footer: Text("Service roads commonly include driveways and internal compound roads. Separate Service Roads and Tracks require current v2 map downloads; legacy maps keep each pair combined.")) {
                 Toggle("Major Roads", isOn: showMajorRoads)
                     .onChange(of: showMajorRoads.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Residential & Local Roads", isOn: showLocalStreets)
-                    .onChange(of: showLocalStreets.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Service Roads", isOn: showServiceRoads)
-                    .onChange(of: showServiceRoads.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Paths & Footways", isOn: showPaths)
-                    .onChange(of: showPaths.wrappedValue) { _ in sendVisibilityMask() }
-                Toggle("Tracks", isOn: showTracks)
-                    .onChange(of: showTracks.wrappedValue) { _ in sendVisibilityMask() }
+                Toggle(bleManager.supportsExtendedMapVisibility
+                       ? "Residential & Local Roads"
+                       : "Residential, Local & Service Roads",
+                       isOn: localRoadsControl)
+                    .onChange(of: localRoadsControl.wrappedValue) { _ in sendVisibilityMask() }
+                if bleManager.supportsExtendedMapVisibility {
+                    Toggle("Service Roads", isOn: showServiceRoads)
+                        .onChange(of: showServiceRoads.wrappedValue) { _ in sendVisibilityMask() }
+                }
+                Toggle(bleManager.supportsExtendedMapVisibility
+                       ? "Paths & Footways"
+                       : "Paths, Footways & Tracks",
+                       isOn: pathsControl)
+                    .onChange(of: pathsControl.wrappedValue) { _ in sendVisibilityMask() }
+                if bleManager.supportsExtendedMapVisibility {
+                    Toggle("Tracks", isOn: showTracks)
+                        .onChange(of: showTracks.wrappedValue) { _ in sendVisibilityMask() }
+                }
                 Toggle("Railways", isOn: showRailways)
                     .onChange(of: showRailways.wrappedValue) { _ in sendVisibilityMask() }
             }
@@ -697,8 +753,11 @@ private struct MapStyleSettingsView: View {
                 }
             }
         }
-        .disabled(!bleManager.supportsDeviceSettings)
-        .navigationTitle(screen.title)
+        .disabled(!bleManager.supportsDeviceSettings ||
+                  !bleManager.hasReceivedDeviceCapabilities ||
+                  (screen == .mapPlusNavigation &&
+                   !bleManager.supportsIndependentMapProfiles))
+        .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -262,7 +262,7 @@ struct NavigationProtocolTests {
         testDevicePacketRouting()
         testDeviceSoundProtocol()
         testDeviceCapabilitiesProtocol()
-        testMapProfilesRemainIndependentWithoutCapabilityBit()
+        testMapProfileCapabilityNegotiation()
         testDeviceCapabilitySynchronizesPowerButtonHonkOnce()
         testDeviceCapabilityRetryPolicy()
         testDeviceScreenValidation()
@@ -980,6 +980,7 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.powerButtonHonkPrefix, "SNDH", "PWR honk configuration remains firmware-compatible")
         assertEqual(DeviceBLEProtocol.powerButtonHonkStatusPrefix, "SNHA", "PWR honk acknowledgement remains firmware-compatible")
         assertEqual(DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask, 4, "PWR honk acknowledgement uses capability bit 2")
+        assertEqual(DeviceBLEProtocol.independentMapProfilesCapabilityMask, 8, "independent map profiles use capability bit 3")
         assertEqual(DeviceBLEProtocol.extendedMapVisibilityCapabilityMask, 16, "extended map visibility uses capability bit 4")
         assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 3, "capability version requests extended map visibility")
         assertEqual(DeviceBLEProtocol.serviceRoadsVisibilityMask, 0x400, "service roads use visibility bit 10")
@@ -1131,6 +1132,13 @@ struct NavigationProtocolTests {
         assert(manager.supportsExtendedMapVisibility,
                "CAPS bit enables independent service-road and track visibility")
 
+        let independent = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(independent),
+               "independent map profile CAPS should be consumed")
+        assert(manager.supportsIndependentMapProfiles,
+               "CAPS bit enables independent map profile controls")
+
         let acknowledgedFlags = supportedFlags |
             DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask
         let acknowledged = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
@@ -1174,6 +1182,8 @@ struct NavigationProtocolTests {
                "malformed CAPS clears PWR honk acknowledgement support")
         assert(!manager.supportsExtendedMapVisibility,
                "malformed CAPS clears extended map visibility support")
+        assert(!manager.supportsIndependentMapProfiles,
+               "malformed CAPS clears independent map profile support")
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
@@ -1181,34 +1191,77 @@ struct NavigationProtocolTests {
         UserDefaults.standard.removeObject(forKey: "deviceSettings.powerButtonHonkEnabled")
     }
 
-    static func testMapProfilesRemainIndependentWithoutCapabilityBit() {
-        let manager = BLEManager()
-        manager.isConnected = true
-        manager.isNavigationReady = true
-        manager.detailLevel = 2
-        manager.zoomLevel = 5
-        manager.showBuildings = true
-        manager.mapPlusNavigationDetailLevel = 0
-        manager.mapPlusNavigationZoomLevel = 1
-        manager.mapPlusNavigationShowBuildings = false
-        var packets: [Data] = []
-        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
-            maximumWriteLength: 20,
-            canSend: { true },
-            write: { packets.append($0) }
-        ))
+    static func testMapProfileCapabilityNegotiation() {
+        func configuredManager() -> (BLEManager, () -> [Data]) {
+            let manager = BLEManager()
+            manager.isConnected = true
+            manager.isNavigationReady = true
+            manager.detailLevel = 2
+            manager.zoomLevel = 5
+            manager.showBuildings = true
+            manager.mapPlusNavigationDetailLevel = 0
+            manager.mapPlusNavigationZoomLevel = 1
+            manager.mapPlusNavigationShowBuildings = false
+            var packets: [Data] = []
+            manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+                maximumWriteLength: 20,
+                canSend: { true },
+                write: { packets.append($0) }
+            ))
+            return (manager, { packets })
+        }
 
+        let independentFlags = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask])
+        let (independentManager, independentPackets) = configuredManager()
+        assert(independentManager.handleDeviceCapabilitiesNotification(independentFlags),
+               "independent profile capability response should be consumed")
+        assertEqual(independentPackets().map { $0[4] },
+                    [20, 16, 17, 18, 21, 22, 19, 8, 1, 2, 3, 9, 10, 7],
+                    "new firmware receives the independent profile before legacy Map IDs")
+        let independentDetail = independentPackets().first { $0[4] == 17 }
+        assertEqual(readInt32LE(independentDetail!, offset: 5), 0,
+                    "independent Map + Navigation detail remains distinct")
+
+        let (legacyManager, legacyPackets) = configuredManager()
         let baselineCapabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])
-        assert(manager.handleDeviceCapabilitiesNotification(baselineCapabilities),
+        assert(legacyManager.handleDeviceCapabilitiesNotification(baselineCapabilities),
                "baseline capability response should be consumed")
-        assertEqual(packets.map { $0[4] },
-                    [8, 1, 2, 3, 9, 10, 7, 20, 16, 17, 18, 21, 22, 19],
-                    "every firmware receives both complete map profiles")
-        let mapNavigationDetailPacket = packets.first { $0[4] == 17 }
-        assertEqual(readInt32LE(mapNavigationDetailPacket!, offset: 5), 0,
-                    "Map + Navigation keeps its independent detail value")
-        assertEqual(manager.mapPlusNavigationZoomLevel, 1,
-                    "capability negotiation does not overwrite Map + Navigation settings")
+        assertEqual(legacyPackets().map { $0[4] }, [8, 1, 2, 3, 9, 10, 7],
+                    "legacy firmware receives only its shared Map profile IDs")
+        assertEqual(legacyManager.mapPlusNavigationZoomLevel, 1,
+                    "negotiation preserves the hidden independent local profile")
+        legacyManager.detailLevel = 1
+        legacyManager.sendSetting(id: 2, value: 1)
+        assertEqual(legacyManager.mapPlusNavigationDetailLevel, 1,
+                    "live legacy edits synchronize the local shared profile")
+        legacyManager.mapPlusNavigationZoomLevel = 1
+        legacyManager.showRouteOverlay = false
+        legacyManager.sendVisibilityMask()
+        assertEqual(legacyManager.mapPlusNavigationZoomLevel, 1,
+                    "global overlay edits preserve the hidden independent profile")
+        let packetCountBeforeUnsupportedWrite = legacyPackets().count
+        legacyManager.sendSetting(id: DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID,
+                                  value: 0)
+        assertEqual(legacyPackets().count, packetCountBeforeUnsupportedWrite,
+                    "unsupported independent setting IDs are not sent")
+
+        let (lateManager, latePackets) = configuredManager()
+        lateManager.useDeviceCapabilitiesFallback()
+        assertEqual(latePackets().map { $0[4] }, [8, 1, 2, 3, 9, 10, 7],
+                    "timeout fallback sends only the legacy shared profile")
+        let lateExtendedFlags = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask |
+                  DeviceBLEProtocol.extendedMapVisibilityCapabilityMask])
+        assert(lateManager.handleDeviceCapabilitiesNotification(lateExtendedFlags),
+               "late independent profile response should still be consumed")
+        assertEqual(Array(latePackets().map { $0[4] }.suffix(14)),
+                    [20, 16, 17, 18, 21, 22, 19, 8, 1, 2, 3, 9, 10, 7],
+                    "late extended response resends both profiles with new semantics")
+        let resentMapVisibility = latePackets().last { $0[4] == 8 }
+        assert(readInt32LE(resentMapVisibility!, offset: 5) &
+               DeviceBLEProtocol.extendedVisibilityMarker != 0,
+               "late extended response repairs the folded Map visibility mask")
     }
 
     static func testDeviceCapabilitySynchronizesPowerButtonHonkOnce() {
@@ -1309,6 +1362,10 @@ struct NavigationProtocolTests {
                                                     hasReceivedCapabilities: false,
                                                     attempt: DeviceCapabilityRetry.maxAttempts),
                "capability retries stop at the attempt limit")
+        assert(DeviceCapabilityRetry.isCurrentSession(4, currentGeneration: 4),
+               "retry tokens remain valid within one BLE session")
+        assert(!DeviceCapabilityRetry.isCurrentSession(4, currentGeneration: 5),
+               "retry tokens from a previous BLE session are rejected")
         assert(PowerButtonHonkRetry.shouldRetry(isNavigationReady: true, attempt: 0),
                "PWR honk acknowledgement retries after the first attempt")
         assert(PowerButtonHonkRetry.shouldRetry(isNavigationReady: true, attempt: 1),
@@ -1418,7 +1475,8 @@ struct NavigationProtocolTests {
     static func testBLEManagerSendsSeparateMapProfileSettings() {
         let manager = BLEManager()
         let capabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
-            Data([DeviceBLEProtocol.extendedMapVisibilityCapabilityMask])
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask |
+                  DeviceBLEProtocol.extendedMapVisibilityCapabilityMask])
         assert(manager.handleDeviceCapabilitiesNotification(capabilities),
                "extended visibility capability should be accepted")
         manager.isConnected = true


### PR DESCRIPTION
## Summary

Follow-up to #50 after a five-pass deep review loop.

- negotiate independent map profiles safely across old/new app and firmware combinations
- handle dropped, late, and reconnect-crossing capability responses
- preserve hidden independent settings while connected to legacy firmware
- keep global navigation-overlay edits from overwriting either style profile
- present combined road/path controls when firmware cannot apply them independently
- explicitly combine indistinguishable road/path classes for legacy v1 map blocks
- centralize and test firmware profile persistence and migration
- keep both 1.75 and 2.06 layout checks in CI

## Review result

No remaining P0/P1/P2 findings after pass 5.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- iOS Simulator `xcodebuild` with code signing disabled
- PlatformIO builds for `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206`
- ESP32 host layout, map-profile protocol, persistence, map-transfer, sound, and codec tests
- `git diff --check`
