### PR TITLE
Show offline map generation timing and progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,6 +96,8 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - name: Install backend test dependencies
+        run: python -m pip install -e '.[test]'
       - name: Python syntax
         run: python -m py_compile map_platform/*.py tests/*.py
       - name: Unit tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
         run: |
           python -m py_compile \
             scripts/extract_features.py \
+            scripts/block_progress.py \
             scripts/feature_types.py \
             scripts/funcs.py \
             scripts/map_format.py \

--- a/OSM_Extract/scripts/block_progress.py
+++ b/OSM_Extract/scripts/block_progress.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 import sys
-from typing import TextIO
+from collections.abc import Iterable, Iterator
+from typing import TextIO, TypeVar
+
+
+T = TypeVar("T")
 
 
 class BlockProgressReporter:
@@ -27,3 +31,8 @@ class BlockProgressReporter:
             file=self.stream,
             flush=True,
         )
+
+    def track(self, items: Iterable[T]) -> Iterator[T]:
+        for item in items:
+            yield item
+            self.advance()

--- a/OSM_Extract/scripts/block_progress.py
+++ b/OSM_Extract/scripts/block_progress.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import sys
+from typing import TextIO
+
+
+class BlockProgressReporter:
+    def __init__(self, total: int, *, stream: TextIO | None = None):
+        if total <= 0:
+            raise ValueError("progress total must be positive")
+        self.total = total
+        self.completed = 0
+        self.stream = stream or sys.stdout
+
+    def advance(self) -> None:
+        if self.completed >= self.total:
+            raise ValueError("progress cannot exceed total")
+        self.completed += 1
+        print(
+            "  Step 5/5 Building map. {:.0%}  ".format(self.completed / self.total),
+            end="\r",
+            file=self.stream,
+            flush=True,
+        )
+        print(
+            f"\nMAP_PROGRESS:{self.completed}:{self.total}",
+            file=self.stream,
+            flush=True,
+        )

--- a/OSM_Extract/scripts/extract_features.py
+++ b/OSM_Extract/scripts/extract_features.py
@@ -2,6 +2,7 @@
 from funcs import process_features, clip_lines, clip_polygons, style_features, render_map, lat2y, lon2x
 from feature_types import get_type_id
 from map_format import write_fmb
+from block_progress import BlockProgressReporter
 from shapely import box
 import json, yaml
 import os, sys
@@ -49,11 +50,7 @@ polygons = style_features( polygons, styles) # styled_polygons
 x_positions = range(area_min_x, area_max_x, 4096)
 y_positions = range(area_min_y, area_max_y, 4096)
 total = len(x_positions) * len(y_positions)
-done = 0
-
-def report_progress():
-    print("  Step 5/5 Building map. {:.0%}  ".format(done/total), end='\r', flush=True)
-    print(f"\nMAP_PROGRESS:{done}:{total}", flush=True)
+progress = BlockProgressReporter(total)
 
 for init_x in x_positions:
     for init_y in y_positions:
@@ -67,8 +64,7 @@ for init_x in x_positions:
         clipped_lines = clip_lines( lines, mapblock_bbox)
         clipped_polygons = clip_polygons( polygons, mapblock_bbox)
         if len(clipped_lines) == 0 and len( clipped_polygons) == 0:
-            done += 1
-            report_progress()
+            progress.advance()
             continue
 
         # export map files
@@ -84,9 +80,8 @@ for init_x in x_positions:
         
         # SKIP if file already exists (RESUME feature)
         if os.path.exists(f"{file_name}.fmb"):
-            done += 1
             print(f"  Step 5/5 Skipping existing block {block_x}_{block_y}      ", end='\r')
-            report_progress()
+            progress.advance()
             continue
 
         os.makedirs( folder_name, exist_ok=True)
@@ -136,5 +131,4 @@ for init_x in x_positions:
             min_y,
         )
 
-        done += 1
-        report_progress()
+        progress.advance()

--- a/OSM_Extract/scripts/extract_features.py
+++ b/OSM_Extract/scripts/extract_features.py
@@ -46,10 +46,17 @@ lines = style_features( lines, styles) # styled_lines
 polygons = style_features( polygons, styles) # styled_polygons
 # polygons = make_all_convex( polygons)
 
-total = ((area_max_x - area_min_x)/4096) * ((area_max_y - area_min_y)/4096)
+x_positions = range(area_min_x, area_max_x, 4096)
+y_positions = range(area_min_y, area_max_y, 4096)
+total = len(x_positions) * len(y_positions)
 done = 0
-for init_x in range(area_min_x, area_max_x, 4096):
-    for init_y in range(area_min_y, area_max_y, 4096):
+
+def report_progress():
+    print("  Step 5/5 Building map. {:.0%}  ".format(done/total), end='\r', flush=True)
+    print(f"\nMAP_PROGRESS:{done}:{total}", flush=True)
+
+for init_x in x_positions:
+    for init_y in y_positions:
         # print("--------------------")
         # print("init_x, init_y", init_x, init_y)
         min_x = init_x & (~mapblock_mask)
@@ -61,6 +68,7 @@ for init_x in range(area_min_x, area_max_x, 4096):
         clipped_polygons = clip_polygons( polygons, mapblock_bbox)
         if len(clipped_lines) == 0 and len( clipped_polygons) == 0:
             done += 1
+            report_progress()
             continue
 
         # export map files
@@ -78,6 +86,7 @@ for init_x in range(area_min_x, area_max_x, 4096):
         if os.path.exists(f"{file_name}.fmb"):
             done += 1
             print(f"  Step 5/5 Skipping existing block {block_x}_{block_y}      ", end='\r')
+            report_progress()
             continue
 
         os.makedirs( folder_name, exist_ok=True)
@@ -128,5 +137,4 @@ for init_x in range(area_min_x, area_max_x, 4096):
         )
 
         done += 1
-        print("  Step 5/5 Building map. {:.0%}  ".format(done/total), end='\r')
-
+        report_progress()

--- a/OSM_Extract/scripts/extract_features.py
+++ b/OSM_Extract/scripts/extract_features.py
@@ -3,6 +3,7 @@ from funcs import process_features, clip_lines, clip_polygons, style_features, r
 from feature_types import get_type_id
 from map_format import write_fmb
 from block_progress import BlockProgressReporter
+from itertools import product
 from shapely import box
 import json, yaml
 import os, sys
@@ -52,8 +53,7 @@ y_positions = range(area_min_y, area_max_y, 4096)
 total = len(x_positions) * len(y_positions)
 progress = BlockProgressReporter(total)
 
-for init_x in x_positions:
-    for init_y in y_positions:
+for init_x, init_y in progress.track(product(x_positions, y_positions)):
         # print("--------------------")
         # print("init_x, init_y", init_x, init_y)
         min_x = init_x & (~mapblock_mask)
@@ -64,7 +64,6 @@ for init_x in x_positions:
         clipped_lines = clip_lines( lines, mapblock_bbox)
         clipped_polygons = clip_polygons( polygons, mapblock_bbox)
         if len(clipped_lines) == 0 and len( clipped_polygons) == 0:
-            progress.advance()
             continue
 
         # export map files
@@ -81,7 +80,6 @@ for init_x in x_positions:
         # SKIP if file already exists (RESUME feature)
         if os.path.exists(f"{file_name}.fmb"):
             print(f"  Step 5/5 Skipping existing block {block_x}_{block_y}      ", end='\r')
-            progress.advance()
             continue
 
         os.makedirs( folder_name, exist_ok=True)
@@ -130,5 +128,3 @@ for init_x in x_positions:
             min_x,
             min_y,
         )
-
-        progress.advance()

--- a/OSM_Extract/tests/test_block_progress.py
+++ b/OSM_Extract/tests/test_block_progress.py
@@ -1,0 +1,39 @@
+import io
+import pathlib
+import sys
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "scripts"))
+
+from block_progress import BlockProgressReporter
+
+
+class BlockProgressReporterTests(unittest.TestCase):
+    def test_reports_exact_progress_for_each_processed_block(self):
+        output = io.StringIO()
+        progress = BlockProgressReporter(3, stream=output)
+
+        progress.advance()  # empty block path
+        progress.advance()  # resumed/skipped block path
+        progress.advance()  # rendered block path
+
+        self.assertEqual(progress.completed, 3)
+        self.assertEqual(
+            [line for line in output.getvalue().splitlines() if line.startswith("MAP_PROGRESS:")],
+            ["MAP_PROGRESS:1:3", "MAP_PROGRESS:2:3", "MAP_PROGRESS:3:3"],
+        )
+
+    def test_rejects_invalid_totals_and_overflow(self):
+        with self.assertRaises(ValueError):
+            BlockProgressReporter(0)
+
+        progress = BlockProgressReporter(1, stream=io.StringIO())
+        progress.advance()
+        with self.assertRaises(ValueError):
+            progress.advance()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/OSM_Extract/tests/test_block_progress.py
+++ b/OSM_Extract/tests/test_block_progress.py
@@ -15,10 +15,13 @@ class BlockProgressReporterTests(unittest.TestCase):
         output = io.StringIO()
         progress = BlockProgressReporter(3, stream=output)
 
-        progress.advance()  # empty block path
-        progress.advance()  # resumed/skipped block path
-        progress.advance()  # rendered block path
+        visited = []
+        for branch in progress.track(["empty", "skipped", "rendered"]):
+            visited.append(branch)
+            if branch in {"empty", "skipped"}:
+                continue
 
+        self.assertEqual(visited, ["empty", "skipped", "rendered"])
         self.assertEqual(progress.completed, 3)
         self.assertEqual(
             [line for line in output.getvalue().splitlines() if line.startswith("MAP_PROGRESS:")],

--- a/backend/map_platform/api.py
+++ b/backend/map_platform/api.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from .downloads import DownloadSigner, DownloadTokenError
 from .geofabrik_sources import GeofabrikSourceProvider
-from .jobs import JobStore, MapJobService
+from .jobs import JobClaimError, JobStore, MapJobService
 from .limits import JobLimits
 from .pipeline import MapBuildPipeline, PipelinePaths, run_job
 from .source_cache import SourceCache, SourceCacheError
@@ -86,7 +86,10 @@ def create_app():
             service.get_job(job_id)
         except KeyError as exc:
             raise HTTPException(status_code=404, detail="job not found") from exc
-        return run_job(service.store, pipeline, job_id).to_dict()
+        try:
+            return run_job(service.store, pipeline, job_id).to_dict()
+        except JobClaimError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     @app.post("/v1/map-jobs/{job_id}/cancel", dependencies=[Depends(require_api_token)])
     def cancel_map_job(job_id: str) -> dict[str, Any]:

--- a/backend/map_platform/jobs.py
+++ b/backend/map_platform/jobs.py
@@ -166,6 +166,53 @@ class JobStore:
             self.save(job)
             return job
 
+    def complete_job(
+        self,
+        job_id: str,
+        *,
+        worker_id: str,
+        map_id: str,
+        built_archive: Path,
+        published_archive: Path,
+    ) -> MapJob:
+        with self._queue_lock():
+            job = self.get(job_id)
+            if job.status == JobStatus.CANCELLED:
+                raise RuntimeError("job was cancelled")
+            if job.worker_id != worker_id:
+                raise RuntimeError("job is owned by another worker")
+            published_archive.parent.mkdir(parents=True, exist_ok=True)
+            if built_archive != published_archive:
+                built_archive.replace(published_archive)
+            return self._update_status_unlocked(
+                job_id,
+                JobStatus.READY,
+                map_id=map_id,
+                pack_path=str(published_archive),
+                pack_bytes=published_archive.stat().st_size,
+                worker_id=worker_id,
+                event="map pack ready",
+                finished=True,
+            )
+
+    def cancel_if_active(self, job_id: str) -> MapJob:
+        terminal_statuses = {
+            JobStatus.READY,
+            JobStatus.FAILED,
+            JobStatus.EXPIRED,
+            JobStatus.CANCELLED,
+        }
+        with self._queue_lock():
+            job = self.get(job_id)
+            if job.status in terminal_statuses:
+                return job
+            return self._update_status_unlocked(
+                job_id,
+                JobStatus.CANCELLED,
+                event="cancelled by request",
+                finished=True,
+            )
+
     def heartbeat_unless_cancelled(self, job_id: str, *, worker_id: str) -> MapJob:
         with self._queue_lock():
             job = self.get(job_id)
@@ -362,10 +409,7 @@ class MapJobService:
         return None
 
     def cancel_job(self, job_id: str) -> MapJob:
-        job = self.store.get(job_id)
-        if job.status in {JobStatus.READY, JobStatus.FAILED, JobStatus.EXPIRED, JobStatus.CANCELLED}:
-            return job
-        return self.store.update_status(job_id, JobStatus.CANCELLED, event="cancelled by request", finished=True)
+        return self.store.cancel_if_active(job_id)
 
     def _new_job_id(self) -> str:
         return uuid.uuid4().hex[:20]

--- a/backend/map_platform/jobs.py
+++ b/backend/map_platform/jobs.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import threading
 import time
 import uuid
 from contextlib import contextmanager
@@ -165,37 +166,100 @@ class JobStore:
             self.save(job)
             return job
 
-    def claim_next(self, worker_id: str) -> MapJob | None:
+    def heartbeat_unless_cancelled(self, job_id: str, *, worker_id: str) -> MapJob:
+        with self._queue_lock():
+            job = self.get(job_id)
+            if job.status == JobStatus.CANCELLED:
+                raise RuntimeError("job was cancelled")
+            if job.worker_id != worker_id:
+                raise RuntimeError("job is owned by another worker")
+            job.updated_at = utc_now_iso()
+            self.save(job)
+            return job
+
+    @contextmanager
+    def keep_worker_lease_alive(self, job_id: str, *, worker_id: str, interval_seconds: float = 30.0):
+        if interval_seconds <= 0:
+            raise ValueError("heartbeat interval must be positive")
+        stop = threading.Event()
+
+        def heartbeat_loop() -> None:
+            while not stop.wait(interval_seconds):
+                try:
+                    self.heartbeat_unless_cancelled(job_id, worker_id=worker_id)
+                except (KeyError, RuntimeError):
+                    return
+
+        thread = threading.Thread(target=heartbeat_loop, name=f"map-job-heartbeat-{job_id}", daemon=True)
+        thread.start()
+        try:
+            yield
+        finally:
+            stop.set()
+            thread.join(timeout=max(interval_seconds, 1.0))
+
+    def claim(self, job_id: str, worker_id: str) -> MapJob:
+        with self._queue_lock():
+            job = self.get(job_id)
+            if job.status != JobStatus.QUEUED:
+                raise JobClaimError(f"job is {job.status.value}, not queued")
+            return self._claim_unlocked(job, worker_id)
+
+    def claim_next(self, worker_id: str, *, interrupted_job_stale_seconds: float | None = None) -> MapJob | None:
         with self._queue_lock():
             for job in self.list():
                 if job.status != JobStatus.QUEUED:
                     continue
-                if job.attempts >= job.max_attempts:
-                    self._update_status_unlocked(
-                        job.job_id,
-                        JobStatus.FAILED,
-                        error="maximum retry attempts exceeded",
-                        finished=True,
-                    )
+                claimed = self._claim_unlocked(job, worker_id)
+                if claimed.status == JobStatus.VALIDATING:
+                    return claimed
+            if interrupted_job_stale_seconds is None:
+                return None
+            for job in self.list():
+                if not self._is_interrupted(job, worker_id, interrupted_job_stale_seconds):
                     continue
-                job.status = JobStatus.VALIDATING
+                job.status = JobStatus.QUEUED
                 job.updated_at = utc_now_iso()
-                job.started_at = job.started_at or job.updated_at
-                job.worker_id = worker_id
-                job.attempts += 1
-                job.error = None
+                job.finished_at = None
                 job.progress_completed = None
                 job.progress_total = None
                 job.events.append(
                     {
                         "at": job.updated_at,
-                        "status": job.status.value,
-                        "message": f"claimed by worker {worker_id}",
+                        "status": JobStatus.QUEUED.value,
+                        "message": "requeued after worker restart",
                     }
                 )
-                self.save(job)
-                return job
+                claimed = self._claim_unlocked(job, worker_id)
+                if claimed.status == JobStatus.VALIDATING:
+                    return claimed
             return None
+
+    def _claim_unlocked(self, job: MapJob, worker_id: str) -> MapJob:
+        if job.attempts >= job.max_attempts:
+            return self._update_status_unlocked(
+                job.job_id,
+                JobStatus.FAILED,
+                error="maximum retry attempts exceeded",
+                finished=True,
+            )
+        job.status = JobStatus.VALIDATING
+        job.updated_at = utc_now_iso()
+        job.started_at = job.started_at or job.updated_at
+        job.worker_id = worker_id
+        job.attempts += 1
+        job.error = None
+        job.progress_completed = None
+        job.progress_total = None
+        job.events.append(
+            {
+                "at": job.updated_at,
+                "status": job.status.value,
+                "message": f"claimed by worker {worker_id}",
+            }
+        )
+        self.save(job)
+        return job
 
     def requeue_retryable_failures(self) -> int:
         count = 0
@@ -212,7 +276,7 @@ class JobStore:
                     count += 1
         return count
 
-    def requeue_interrupted_jobs(self, worker_id: str, *, stale_after_seconds: float) -> int:
+    def _is_interrupted(self, job: MapJob, worker_id: str, stale_after_seconds: float) -> bool:
         active_statuses = {
             JobStatus.VALIDATING,
             JobStatus.RESOLVING_SOURCE,
@@ -220,31 +284,12 @@ class JobStore:
             JobStatus.CONVERTING_FEATURES,
             JobStatus.PACKAGING,
         }
-        count = 0
-        with self._queue_lock():
-            for job in self.list():
-                if job.status not in active_statuses:
-                    continue
-                if not job.worker_id or job.worker_id == worker_id:
-                    continue
-                if _age_seconds(job.updated_at) < stale_after_seconds:
-                    continue
-                job.status = JobStatus.QUEUED
-                job.updated_at = utc_now_iso()
-                job.finished_at = None
-                job.worker_id = None
-                job.progress_completed = None
-                job.progress_total = None
-                job.events.append(
-                    {
-                        "at": job.updated_at,
-                        "status": JobStatus.QUEUED.value,
-                        "message": "requeued after worker restart",
-                    }
-                )
-                self.save(job)
-                count += 1
-        return count
+        return (
+            job.status in active_statuses
+            and bool(job.worker_id)
+            and job.worker_id != worker_id
+            and _age_seconds(job.updated_at) >= stale_after_seconds
+        )
 
     def _path(self, job_id: str) -> Path:
         if not re.match(r"^[a-zA-Z0-9_-]+$", job_id):
@@ -324,6 +369,10 @@ class MapJobService:
 
     def _new_job_id(self) -> str:
         return uuid.uuid4().hex[:20]
+
+
+class JobClaimError(RuntimeError):
+    pass
 
 
 def _age_seconds(value: str) -> float:

--- a/backend/map_platform/jobs.py
+++ b/backend/map_platform/jobs.py
@@ -135,6 +135,28 @@ class JobStore:
         self.save(job)
         return job
 
+    def update_progress_unless_cancelled(
+        self,
+        job_id: str,
+        completed: int,
+        total: int,
+        *,
+        worker_id: str | None = None,
+    ) -> MapJob:
+        if total <= 0:
+            raise ValueError("progress total must be positive")
+        with self._queue_lock():
+            job = self.get(job_id)
+            if job.status == JobStatus.CANCELLED:
+                raise RuntimeError("job was cancelled")
+            job.progress_completed = max(0, min(int(completed), int(total)))
+            job.progress_total = int(total)
+            job.updated_at = utc_now_iso()
+            if worker_id is not None:
+                job.worker_id = worker_id
+            self.save(job)
+            return job
+
     def claim_next(self, worker_id: str) -> MapJob | None:
         with self._queue_lock():
             for job in self.list():
@@ -154,6 +176,8 @@ class JobStore:
                 job.worker_id = worker_id
                 job.attempts += 1
                 job.error = None
+                job.progress_completed = None
+                job.progress_total = None
                 job.events.append(
                     {
                         "at": job.updated_at,
@@ -173,6 +197,8 @@ class JobStore:
                     job.status = JobStatus.QUEUED
                     job.updated_at = utc_now_iso()
                     job.finished_at = None
+                    job.progress_completed = None
+                    job.progress_total = None
                     job.events.append({"at": job.updated_at, "status": job.status.value, "message": "requeued for retry"})
                     self.save(job)
                     count += 1

--- a/backend/map_platform/jobs.py
+++ b/backend/map_platform/jobs.py
@@ -6,6 +6,7 @@ import re
 import time
 import uuid
 from contextlib import contextmanager
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -80,6 +81,8 @@ class JobStore:
             current = self.get(job_id)
             if current.status == JobStatus.CANCELLED:
                 raise RuntimeError("job was cancelled")
+            if worker_id is not None and current.worker_id not in {None, worker_id}:
+                raise RuntimeError("job is owned by another worker")
             return self._update_status_unlocked(
                 job_id,
                 status,
@@ -110,6 +113,9 @@ class JobStore:
         job.status = status
         job.updated_at = utc_now_iso()
         job.error = error
+        if previous_status != status and status in {JobStatus.QUEUED, JobStatus.VALIDATING}:
+            job.progress_completed = None
+            job.progress_total = None
         if status in {JobStatus.VALIDATING, JobStatus.RESOLVING_SOURCE, JobStatus.EXTRACTING_PBF} and job.started_at is None:
             job.started_at = job.updated_at
         if finished or status in {JobStatus.READY, JobStatus.FAILED, JobStatus.EXPIRED, JobStatus.CANCELLED}:
@@ -149,6 +155,8 @@ class JobStore:
             job = self.get(job_id)
             if job.status == JobStatus.CANCELLED:
                 raise RuntimeError("job was cancelled")
+            if worker_id is not None and job.worker_id not in {None, worker_id}:
+                raise RuntimeError("job is owned by another worker")
             job.progress_completed = max(0, min(int(completed), int(total)))
             job.progress_total = int(total)
             job.updated_at = utc_now_iso()
@@ -202,6 +210,40 @@ class JobStore:
                     job.events.append({"at": job.updated_at, "status": job.status.value, "message": "requeued for retry"})
                     self.save(job)
                     count += 1
+        return count
+
+    def requeue_interrupted_jobs(self, worker_id: str, *, stale_after_seconds: float) -> int:
+        active_statuses = {
+            JobStatus.VALIDATING,
+            JobStatus.RESOLVING_SOURCE,
+            JobStatus.EXTRACTING_PBF,
+            JobStatus.CONVERTING_FEATURES,
+            JobStatus.PACKAGING,
+        }
+        count = 0
+        with self._queue_lock():
+            for job in self.list():
+                if job.status not in active_statuses:
+                    continue
+                if not job.worker_id or job.worker_id == worker_id:
+                    continue
+                if _age_seconds(job.updated_at) < stale_after_seconds:
+                    continue
+                job.status = JobStatus.QUEUED
+                job.updated_at = utc_now_iso()
+                job.finished_at = None
+                job.worker_id = None
+                job.progress_completed = None
+                job.progress_total = None
+                job.events.append(
+                    {
+                        "at": job.updated_at,
+                        "status": JobStatus.QUEUED.value,
+                        "message": "requeued after worker restart",
+                    }
+                )
+                self.save(job)
+                count += 1
         return count
 
     def _path(self, job_id: str) -> Path:
@@ -282,3 +324,13 @@ class MapJobService:
 
     def _new_job_id(self) -> str:
         return uuid.uuid4().hex[:20]
+
+
+def _age_seconds(value: str) -> float:
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        return float("inf")
+    return max((datetime.now(timezone.utc) - parsed).total_seconds(), 0)

--- a/backend/map_platform/models.py
+++ b/backend/map_platform/models.py
@@ -27,7 +27,7 @@ class JobStatus(str, Enum):
 
 
 def utc_now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return datetime.now(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
 
 
 @dataclass(frozen=True)

--- a/backend/map_platform/models.py
+++ b/backend/map_platform/models.py
@@ -130,6 +130,8 @@ class MapJob:
     worker_id: str | None = None
     started_at: str | None = None
     finished_at: str | None = None
+    progress_completed: int | None = None
+    progress_total: int | None = None
     events: list[dict[str, Any]] = field(default_factory=list)
 
     def to_dict(self) -> dict[str, Any]:
@@ -150,6 +152,7 @@ class MapJob:
             "workerId": self.worker_id,
             "startedAt": self.started_at,
             "finishedAt": self.finished_at,
+            "progress": self.progress(),
             "events": self.events,
             "phaseTimings": self.phase_timings(),
         }
@@ -183,8 +186,20 @@ class MapJob:
             worker_id=data.get("workerId"),
             started_at=data.get("startedAt"),
             finished_at=data.get("finishedAt"),
+            progress_completed=_progress_value(data.get("progress"), "completedBlocks"),
+            progress_total=_progress_value(data.get("progress"), "totalBlocks"),
             events=list(data.get("events", [])),
         )
+
+    def progress(self) -> dict[str, Any] | None:
+        if self.progress_completed is None or self.progress_total is None or self.progress_total <= 0:
+            return None
+        completed = max(0, min(self.progress_completed, self.progress_total))
+        return {
+            "completedBlocks": completed,
+            "totalBlocks": self.progress_total,
+            "fraction": completed / self.progress_total,
+        }
 
     def phase_timings(self) -> list[dict[str, Any]]:
         transitions: list[tuple[str, str]] = []
@@ -219,6 +234,15 @@ def _parse_utc(value: str) -> datetime | None:
             value = value[:-1] + "+00:00"
         return datetime.fromisoformat(value)
     except ValueError:
+        return None
+
+
+def _progress_value(progress: Any, key: str) -> int | None:
+    if not isinstance(progress, dict) or progress.get(key) is None:
+        return None
+    try:
+        return int(progress[key])
+    except (TypeError, ValueError):
         return None
 
 

--- a/backend/map_platform/pipeline.py
+++ b/backend/map_platform/pipeline.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 import json
+import math
 import re
 import shutil
 import subprocess
+import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -73,6 +76,30 @@ def parse_map_progress(line: str) -> tuple[int, int] | None:
     if total <= 0 or completed < 0 or completed > total:
         return None
     return completed, total
+
+
+class ProgressCoalescer:
+    def __init__(self, *, min_interval_seconds: float = 2.0, min_fraction_delta: float = 0.01, clock=None):
+        self.min_interval_seconds = min_interval_seconds
+        self.min_fraction_delta = min_fraction_delta
+        self.clock = clock or time.monotonic
+        self.last_completed: int | None = None
+        self.last_emitted_at: float | None = None
+
+    def should_emit(self, completed: int, total: int) -> bool:
+        now = self.clock()
+        block_delta = max(1, math.ceil(total * self.min_fraction_delta))
+        should_emit = (
+            self.last_completed is None
+            or completed >= total
+            or completed - self.last_completed >= block_delta
+            or self.last_emitted_at is None
+            or now - self.last_emitted_at >= self.min_interval_seconds
+        )
+        if should_emit:
+            self.last_completed = completed
+            self.last_emitted_at = now
+        return should_emit
 
 
 class MapBuildPipeline:
@@ -177,10 +204,11 @@ class MapBuildPipeline:
             str(geojson_prefix),
             str(raw_output_dir),
         ]
+        progress_coalescer = ProgressCoalescer()
 
         def handle_output(line: str) -> None:
             progress = parse_map_progress(line)
-            if progress is not None and on_progress:
+            if progress is not None and on_progress and progress_coalescer.should_emit(*progress):
                 on_progress(*progress)
 
         if on_progress and hasattr(self.runner, "run_streaming"):
@@ -217,23 +245,33 @@ class MapBuildPipeline:
 
 
 def run_job(store, pipeline: MapBuildPipeline, job_id: str) -> MapJob:
-    job = store.update_status(job_id, JobStatus.VALIDATING)
+    worker_id = f"api-{uuid.uuid4().hex[:8]}"
+    job = store.update_status(job_id, JobStatus.VALIDATING, worker_id=worker_id)
 
     def update(status: JobStatus) -> None:
-        store.update_status(job_id, status)
+        store.update_status_unless_cancelled(job_id, status, worker_id=worker_id)
 
     def update_progress(completed: int, total: int) -> None:
-        store.update_progress_unless_cancelled(job_id, completed, total)
+        store.update_progress_unless_cancelled(job_id, completed, total, worker_id=worker_id)
 
     try:
         map_id, archive_path = pipeline.build(job, on_status=update, on_progress=update_progress)
-        return store.update_status(
+        return store.update_status_unless_cancelled(
             job_id,
             JobStatus.READY,
             map_id=map_id,
             pack_path=str(archive_path),
             pack_bytes=archive_path.stat().st_size if archive_path.exists() else None,
+            worker_id=worker_id,
             finished=True,
         )
     except Exception as exc:
-        return store.update_status(job_id, JobStatus.FAILED, error=str(exc))
+        current = store.get(job_id)
+        if current.status == JobStatus.CANCELLED or current.worker_id != worker_id:
+            return current
+        return store.update_status_unless_cancelled(
+            job_id,
+            JobStatus.FAILED,
+            error=str(exc),
+            worker_id=worker_id,
+        )

--- a/backend/map_platform/pipeline.py
+++ b/backend/map_platform/pipeline.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -27,6 +28,52 @@ class CommandRunner:
         result = subprocess.run(args, cwd=cwd, check=True, text=True, capture_output=True)
         return (result.stdout or result.stderr).strip()
 
+    def run_streaming(self, args: list[str], *, cwd: Path | None = None, on_output=None) -> str:
+        process = subprocess.Popen(
+            args,
+            cwd=cwd,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            bufsize=1,
+        )
+        output: list[str] = []
+        try:
+            assert process.stdout is not None
+            for line in process.stdout:
+                output.append(line)
+                if on_output:
+                    on_output(line)
+            return_code = process.wait()
+        except BaseException:
+            process.terminate()
+            try:
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            raise
+        finally:
+            if process.stdout is not None:
+                process.stdout.close()
+        combined_output = "".join(output)
+        if return_code != 0:
+            raise subprocess.CalledProcessError(return_code, args, output=combined_output)
+        return combined_output.strip()
+
+
+_MAP_PROGRESS_PATTERN = re.compile(r"MAP_PROGRESS:(\d+):(\d+)")
+
+
+def parse_map_progress(line: str) -> tuple[int, int] | None:
+    match = _MAP_PROGRESS_PATTERN.search(line)
+    if match is None:
+        return None
+    completed, total = int(match.group(1)), int(match.group(2))
+    if total <= 0 or completed < 0 or completed > total:
+        return None
+    return completed, total
+
 
 class MapBuildPipeline:
     def __init__(self, paths: PipelinePaths, runner: CommandRunner | None = None, source_cache: SourceCache | None = None):
@@ -34,7 +81,7 @@ class MapBuildPipeline:
         self.runner = runner or CommandRunner()
         self.source_cache = source_cache or SourceCache(paths.repo_root)
 
-    def build(self, job: MapJob, on_status=None) -> tuple[str, Path]:
+    def build(self, job: MapJob, on_status=None, on_progress=None) -> tuple[str, Path]:
         map_id = stable_map_id(job)
         job.map_id = map_id
         job_dir = self.paths.work_root / job.job_id
@@ -59,7 +106,7 @@ class MapBuildPipeline:
         if on_status:
             on_status(JobStatus.CONVERTING_FEATURES)
         self._convert_to_geojson(job, clipped_pbf, geojson_prefix)
-        self._extract_features(job, geojson_prefix, raw_output_dir)
+        self._extract_features(job, geojson_prefix, raw_output_dir, on_progress=on_progress)
         if on_status:
             on_status(JobStatus.PACKAGING)
         self._stage_vectmap(raw_output_dir, vectmap_output)
@@ -117,22 +164,37 @@ class MapBuildPipeline:
             cwd=self.paths.osm_extract_root / "scripts",
         )
 
-    def _extract_features(self, job: MapJob, geojson_prefix: Path, raw_output_dir: Path) -> None:
+    def _extract_features(self, job: MapJob, geojson_prefix: Path, raw_output_dir: Path, on_progress=None) -> None:
         bounds = job.geometry.bounds
         script = self.paths.osm_extract_root / "scripts" / "extract_features.py"
-        self.runner.run(
-            [
-                "python",
-                str(script),
-                str(bounds.min_lon),
-                str(bounds.min_lat),
-                str(bounds.max_lon),
-                str(bounds.max_lat),
-                str(geojson_prefix),
-                str(raw_output_dir),
-            ],
-            cwd=self.paths.osm_extract_root / "scripts",
-        )
+        args = [
+            "python",
+            str(script),
+            str(bounds.min_lon),
+            str(bounds.min_lat),
+            str(bounds.max_lon),
+            str(bounds.max_lat),
+            str(geojson_prefix),
+            str(raw_output_dir),
+        ]
+
+        def handle_output(line: str) -> None:
+            progress = parse_map_progress(line)
+            if progress is not None and on_progress:
+                on_progress(*progress)
+
+        if on_progress and hasattr(self.runner, "run_streaming"):
+            self.runner.run_streaming(
+                args,
+                cwd=self.paths.osm_extract_root / "scripts",
+                on_output=handle_output,
+            )
+            return
+
+        output = self.runner.run(args, cwd=self.paths.osm_extract_root / "scripts")
+        if on_progress:
+            for line in output.splitlines():
+                handle_output(line)
 
     def _stage_vectmap(self, raw_output_dir: Path, vectmap_output: Path) -> None:
         if not raw_output_dir.exists():
@@ -160,8 +222,11 @@ def run_job(store, pipeline: MapBuildPipeline, job_id: str) -> MapJob:
     def update(status: JobStatus) -> None:
         store.update_status(job_id, status)
 
+    def update_progress(completed: int, total: int) -> None:
+        store.update_progress_unless_cancelled(job_id, completed, total)
+
     try:
-        map_id, archive_path = pipeline.build(job, on_status=update)
+        map_id, archive_path = pipeline.build(job, on_status=update, on_progress=update_progress)
         return store.update_status(
             job_id,
             JobStatus.READY,

--- a/backend/map_platform/pipeline.py
+++ b/backend/map_platform/pipeline.py
@@ -111,18 +111,18 @@ class MapBuildPipeline:
     def build(self, job: MapJob, on_status=None, on_progress=None) -> tuple[str, Path]:
         map_id = stable_map_id(job)
         job.map_id = map_id
-        job_dir = self.paths.work_root / job.job_id
+        attempt_id = re.sub(r"[^a-zA-Z0-9_-]", "-", job.worker_id or f"attempt-{job.attempts}")
+        job_dir = self.paths.work_root / job.job_id / attempt_id
         clipped_pbf = job_dir / "clipped.osm.pbf"
         geojson_prefix = job_dir / "features"
         raw_output_dir = job_dir / "raw-map"
         pack_root = job_dir / "pack"
         vectmap_output = pack_root / "VECTMAP" / map_id
-        archive_path = self.paths.pack_root / f"{map_id}.zip"
+        archive_path = job_dir / f"{map_id}.zip"
 
         if job_dir.exists():
             shutil.rmtree(job_dir)
         job_dir.mkdir(parents=True)
-        self.paths.pack_root.mkdir(parents=True, exist_ok=True)
 
         if on_status:
             on_status(JobStatus.RESOLVING_SOURCE)
@@ -141,6 +141,9 @@ class MapBuildPipeline:
         manifest = build_manifest(job, pack_root, self._pipeline_metadata())
         write_pack_archive(pack_root, manifest, archive_path)
         return map_id, archive_path
+
+    def published_archive_path(self, map_id: str) -> Path:
+        return self.paths.pack_root / f"{map_id}.zip"
 
     def _source_pbf_path(self, job: MapJob) -> Path:
         return self.source_cache.ensure(job.source_region).path
@@ -261,14 +264,17 @@ def run_job(store, pipeline: MapBuildPipeline, job_id: str, *, heartbeat_interva
             interval_seconds=heartbeat_interval_seconds,
         ):
             map_id, archive_path = pipeline.build(job, on_status=update, on_progress=update_progress)
-        return store.update_status_unless_cancelled(
+        published_archive = (
+            pipeline.published_archive_path(map_id)
+            if hasattr(pipeline, "published_archive_path")
+            else archive_path
+        )
+        return store.complete_job(
             job_id,
-            JobStatus.READY,
-            map_id=map_id,
-            pack_path=str(archive_path),
-            pack_bytes=archive_path.stat().st_size if archive_path.exists() else None,
             worker_id=worker_id,
-            finished=True,
+            map_id=map_id,
+            built_archive=archive_path,
+            published_archive=published_archive,
         )
     except Exception as exc:
         current = store.get(job_id)

--- a/backend/map_platform/pipeline.py
+++ b/backend/map_platform/pipeline.py
@@ -244,9 +244,9 @@ class MapBuildPipeline:
         return PipelineMetadata(osmium_version=osmium_version)
 
 
-def run_job(store, pipeline: MapBuildPipeline, job_id: str) -> MapJob:
+def run_job(store, pipeline: MapBuildPipeline, job_id: str, *, heartbeat_interval_seconds: float = 30.0) -> MapJob:
     worker_id = f"api-{uuid.uuid4().hex[:8]}"
-    job = store.update_status(job_id, JobStatus.VALIDATING, worker_id=worker_id)
+    job = store.claim(job_id, worker_id)
 
     def update(status: JobStatus) -> None:
         store.update_status_unless_cancelled(job_id, status, worker_id=worker_id)
@@ -255,7 +255,12 @@ def run_job(store, pipeline: MapBuildPipeline, job_id: str) -> MapJob:
         store.update_progress_unless_cancelled(job_id, completed, total, worker_id=worker_id)
 
     try:
-        map_id, archive_path = pipeline.build(job, on_status=update, on_progress=update_progress)
+        with store.keep_worker_lease_alive(
+            job_id,
+            worker_id=worker_id,
+            interval_seconds=heartbeat_interval_seconds,
+        ):
+            map_id, archive_path = pipeline.build(job, on_status=update, on_progress=update_progress)
         return store.update_status_unless_cancelled(
             job_id,
             JobStatus.READY,

--- a/backend/map_platform/worker.py
+++ b/backend/map_platform/worker.py
@@ -26,21 +26,20 @@ class MapWorker:
         *,
         worker_id: str | None = None,
         interrupted_job_stale_seconds: float = 15 * 60,
+        heartbeat_interval_seconds: float = 30.0,
     ):
         self.store = store
         self.pipeline = pipeline
         self.worker_id = worker_id or f"worker-{uuid.uuid4().hex[:8]}"
         self.interrupted_job_stale_seconds = interrupted_job_stale_seconds
+        self.heartbeat_interval_seconds = heartbeat_interval_seconds
 
     def run_next(self) -> WorkerResult:
-        # Production runs a single worker. A stale job owned by a different
-        # process was interrupted and must be claimed again from scratch.
-        self.store.requeue_interrupted_jobs(
-            self.worker_id,
-            stale_after_seconds=self.interrupted_job_stale_seconds,
-        )
         self.store.requeue_retryable_failures()
-        job = self.store.claim_next(self.worker_id)
+        job = self.store.claim_next(
+            self.worker_id,
+            interrupted_job_stale_seconds=self.interrupted_job_stale_seconds,
+        )
         if job is None:
             return WorkerResult(worker_id=self.worker_id, job=None, processed=False)
 
@@ -56,11 +55,16 @@ class MapWorker:
             )
 
         try:
-            map_id, archive_path = self.pipeline.build(
-                job,
-                on_status=update,
-                on_progress=update_progress,
-            )
+            with self.store.keep_worker_lease_alive(
+                job.job_id,
+                worker_id=self.worker_id,
+                interval_seconds=self.heartbeat_interval_seconds,
+            ):
+                map_id, archive_path = self.pipeline.build(
+                    job,
+                    on_status=update,
+                    on_progress=update_progress,
+                )
             finished = self.store.update_status_unless_cancelled(
                 job.job_id,
                 JobStatus.READY,

--- a/backend/map_platform/worker.py
+++ b/backend/map_platform/worker.py
@@ -33,8 +33,20 @@ class MapWorker:
         def update(status: JobStatus) -> None:
             self.store.update_status_unless_cancelled(job.job_id, status, worker_id=self.worker_id)
 
+        def update_progress(completed: int, total: int) -> None:
+            self.store.update_progress_unless_cancelled(
+                job.job_id,
+                completed,
+                total,
+                worker_id=self.worker_id,
+            )
+
         try:
-            map_id, archive_path = self.pipeline.build(job, on_status=update)
+            map_id, archive_path = self.pipeline.build(
+                job,
+                on_status=update,
+                on_progress=update_progress,
+            )
             finished = self.store.update_status_unless_cancelled(
                 job.job_id,
                 JobStatus.READY,

--- a/backend/map_platform/worker.py
+++ b/backend/map_platform/worker.py
@@ -65,15 +65,17 @@ class MapWorker:
                     on_status=update,
                     on_progress=update_progress,
                 )
-            finished = self.store.update_status_unless_cancelled(
+            published_archive = (
+                self.pipeline.published_archive_path(map_id)
+                if hasattr(self.pipeline, "published_archive_path")
+                else archive_path
+            )
+            finished = self.store.complete_job(
                 job.job_id,
-                JobStatus.READY,
-                map_id=map_id,
-                pack_path=str(archive_path),
-                pack_bytes=archive_path.stat().st_size if archive_path.exists() else None,
                 worker_id=self.worker_id,
-                event="map pack ready",
-                finished=True,
+                map_id=map_id,
+                built_archive=archive_path,
+                published_archive=published_archive,
             )
             return WorkerResult(worker_id=self.worker_id, job=finished, processed=True)
         except Exception as exc:

--- a/backend/map_platform/worker.py
+++ b/backend/map_platform/worker.py
@@ -19,12 +19,26 @@ class WorkerResult:
 
 
 class MapWorker:
-    def __init__(self, store: JobStore, pipeline: MapBuildPipeline, *, worker_id: str | None = None):
+    def __init__(
+        self,
+        store: JobStore,
+        pipeline: MapBuildPipeline,
+        *,
+        worker_id: str | None = None,
+        interrupted_job_stale_seconds: float = 15 * 60,
+    ):
         self.store = store
         self.pipeline = pipeline
         self.worker_id = worker_id or f"worker-{uuid.uuid4().hex[:8]}"
+        self.interrupted_job_stale_seconds = interrupted_job_stale_seconds
 
     def run_next(self) -> WorkerResult:
+        # Production runs a single worker. A stale job owned by a different
+        # process was interrupted and must be claimed again from scratch.
+        self.store.requeue_interrupted_jobs(
+            self.worker_id,
+            stale_after_seconds=self.interrupted_job_stale_seconds,
+        )
         self.store.requeue_retryable_failures()
         job = self.store.claim_next(self.worker_id)
         if job is None:
@@ -60,9 +74,9 @@ class MapWorker:
             return WorkerResult(worker_id=self.worker_id, job=finished, processed=True)
         except Exception as exc:
             current = self.store.get(job.job_id)
-            if current.status == JobStatus.CANCELLED:
+            if current.status == JobStatus.CANCELLED or current.worker_id != self.worker_id:
                 return WorkerResult(worker_id=self.worker_id, job=current, processed=True)
-            failed = self.store.update_status(
+            failed = self.store.update_status_unless_cancelled(
                 job.job_id,
                 JobStatus.FAILED,
                 error=str(exc),
@@ -71,7 +85,7 @@ class MapWorker:
                 finished=True,
             )
             if failed.attempts < failed.max_attempts:
-                failed = self.store.update_status(
+                failed = self.store.update_status_unless_cancelled(
                     job.job_id,
                     JobStatus.QUEUED,
                     error=str(exc),

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -14,7 +14,10 @@ api = [
   "fastapi>=0.115,<1",
   "uvicorn[standard]>=0.30,<1"
 ]
-test = []
+test = [
+  "fastapi>=0.115,<1",
+  "httpx>=0.27,<1"
+]
 
 [project.scripts]
 map-platform = "map_platform.cli:main"

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,84 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from fastapi.testclient import TestClient
+
+from map_platform.api import create_app
+
+
+class MapJobRunAPITests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.repo_root = Path(__file__).resolve().parents[2]
+        self.environment = patch.dict(
+            os.environ,
+            {
+                "MAP_PLATFORM_REPO_ROOT": str(self.repo_root),
+                "MAP_PLATFORM_DATA_ROOT": self.tmp.name,
+                "MAP_PLATFORM_SOURCE_INDEX": str(self.repo_root / "backend" / "config" / "source-regions.json"),
+                "MAP_PLATFORM_API_TOKEN": "",
+                "MAP_PLATFORM_DOWNLOAD_SECRET": "test-secret",
+            },
+            clear=False,
+        )
+        self.environment.start()
+        self.client = TestClient(create_app())
+
+    def tearDown(self):
+        self.client.close()
+        self.environment.stop()
+        self.tmp.cleanup()
+
+    def create_job(self) -> str:
+        response = self.client.post(
+            "/v1/map-jobs",
+            json={"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]},
+        )
+        self.assertEqual(response.status_code, 200)
+        return response.json()["jobId"]
+
+    def test_run_route_returns_queued_job_result(self):
+        job_id = self.create_job()
+        result = Mock()
+        result.to_dict.return_value = {"jobId": job_id, "status": "ready"}
+
+        with patch("map_platform.api.run_job", return_value=result):
+            response = self.client.post(f"/v1/map-jobs/{job_id}/run")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()["status"], "ready")
+
+    def test_run_route_rejects_active_job(self):
+        job_id = self.create_job()
+        job_path = Path(self.tmp.name) / "jobs" / f"{job_id}.json"
+        job = json.loads(job_path.read_text())
+        job["status"] = "validating"
+        job["workerId"] = "worker-active"
+        job_path.write_text(json.dumps(job))
+
+        response = self.client.post(f"/v1/map-jobs/{job_id}/run")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("not queued", response.json()["detail"])
+
+    def test_run_route_rejects_cancelled_job(self):
+        job_id = self.create_job()
+        self.assertEqual(self.client.post(f"/v1/map-jobs/{job_id}/cancel").status_code, 200)
+
+        response = self.client.post(f"/v1/map-jobs/{job_id}/run")
+
+        self.assertEqual(response.status_code, 409)
+        self.assertIn("cancelled", response.json()["detail"])
+
+    def test_run_route_returns_not_found_for_missing_job(self):
+        response = self.client.post("/v1/map-jobs/missing-job/run")
+
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_pipeline_progress.py
+++ b/backend/tests/test_pipeline_progress.py
@@ -1,7 +1,7 @@
 import sys
 import unittest
 
-from map_platform.pipeline import CommandRunner, parse_map_progress
+from map_platform.pipeline import CommandRunner, ProgressCoalescer, parse_map_progress
 
 
 class PipelineProgressTests(unittest.TestCase):
@@ -23,6 +23,17 @@ class PipelineProgressTests(unittest.TestCase):
             [(1, 2), (2, 2)],
         )
         self.assertIn("MAP_PROGRESS:2:2", output)
+
+    def test_progress_coalescer_throttles_fast_updates_and_forces_final(self):
+        now = [0.0]
+        coalescer = ProgressCoalescer(clock=lambda: now[0])
+
+        self.assertTrue(coalescer.should_emit(1, 1_000))
+        self.assertFalse(coalescer.should_emit(2, 1_000))
+        self.assertTrue(coalescer.should_emit(11, 1_000))
+        now[0] = 2.0
+        self.assertTrue(coalescer.should_emit(12, 1_000))
+        self.assertTrue(coalescer.should_emit(1_000, 1_000))
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_pipeline_progress.py
+++ b/backend/tests/test_pipeline_progress.py
@@ -1,0 +1,29 @@
+import sys
+import unittest
+
+from map_platform.pipeline import CommandRunner, parse_map_progress
+
+
+class PipelineProgressTests(unittest.TestCase):
+    def test_parse_map_progress(self):
+        self.assertEqual(parse_map_progress("MAP_PROGRESS:24:100\n"), (24, 100))
+        self.assertEqual(parse_map_progress("building\rMAP_PROGRESS:100:100\n"), (100, 100))
+        self.assertIsNone(parse_map_progress("MAP_PROGRESS:101:100\n"))
+        self.assertIsNone(parse_map_progress("unrelated output\n"))
+
+    def test_streaming_runner_reports_output_before_completion(self):
+        lines = []
+        output = CommandRunner().run_streaming(
+            [sys.executable, "-c", "print('MAP_PROGRESS:1:2', flush=True); print('MAP_PROGRESS:2:2', flush=True)"],
+            on_output=lines.append,
+        )
+
+        self.assertEqual(
+            [parse_map_progress(line) for line in lines],
+            [(1, 2), (2, 2)],
+        )
+        self.assertIn("MAP_PROGRESS:2:2", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/backend/tests/test_pipeline_progress.py
+++ b/backend/tests/test_pipeline_progress.py
@@ -1,7 +1,19 @@
 import sys
+import tempfile
 import unittest
+from pathlib import Path
 
-from map_platform.pipeline import CommandRunner, ProgressCoalescer, parse_map_progress
+from map_platform.jobs import JobStore, MapJobService
+from map_platform.models import Bounds, SourceRegion
+from map_platform.pipeline import CommandRunner, MapBuildPipeline, PipelinePaths, ProgressCoalescer, parse_map_progress
+from map_platform.sources import SourceIndex
+
+
+class FakeStreamingRunner:
+    def run_streaming(self, args, *, cwd=None, on_output=None):
+        for line in ["MAP_PROGRESS:1:100\n", "noise\n", "MAP_PROGRESS:100:100\n"]:
+            on_output(line)
+        return "complete"
 
 
 class PipelineProgressTests(unittest.TestCase):
@@ -34,6 +46,41 @@ class PipelineProgressTests(unittest.TestCase):
         now[0] = 2.0
         self.assertTrue(coalescer.should_emit(12, 1_000))
         self.assertTrue(coalescer.should_emit(1_000, 1_000))
+
+    def test_streamed_extractor_progress_reaches_job_store(self):
+        source = SourceRegion(
+            id="sg",
+            provider="test",
+            name="Singapore",
+            url="https://example.invalid/sg.osm.pbf",
+            bounds=Bounds(103.0, 1.0, 104.5, 1.8),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = JobStore(root / "jobs")
+            service = MapJobService(SourceIndex([source]), store)
+            created = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            job = store.claim(created.job_id, "worker-test")
+            pipeline = MapBuildPipeline(
+                PipelinePaths(repo_root=root, work_root=root / "work", pack_root=root / "packs"),
+                runner=FakeStreamingRunner(),
+            )
+
+            pipeline._extract_features(
+                job,
+                root / "features",
+                root / "raw-map",
+                on_progress=lambda completed, total: store.update_progress_unless_cancelled(
+                    job.job_id,
+                    completed,
+                    total,
+                    worker_id="worker-test",
+                ),
+            )
+
+            persisted = store.get(job.job_id)
+            self.assertEqual(persisted.progress_completed, 100)
+            self.assertEqual(persisted.progress_total, 100)
 
 
 if __name__ == "__main__":

--- a/backend/tests/test_sources_jobs.py
+++ b/backend/tests/test_sources_jobs.py
@@ -120,6 +120,26 @@ class SourceAndJobTests(unittest.TestCase):
             self.assertEqual(loaded.status.value, "queued")
             self.assertEqual(loaded.source_region.id, "sg")
             self.assertEqual(loaded.request["displayName"], "Singapore central")
+            self.assertIsNone(loaded.to_dict()["progress"])
+
+    def test_job_store_persists_generation_progress(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp))
+            service = MapJobService(SourceIndex([self.singapore]), store)
+            job = service.create_job(
+                {
+                    "mode": "custom_bbox",
+                    "bbox": [103.75, 1.24, 103.93, 1.37],
+                }
+            )
+
+            updated = store.update_progress_unless_cancelled(job.job_id, 7, 10, worker_id="worker-test")
+            response = service.get_job(job.job_id).to_dict()
+
+            self.assertEqual(updated.worker_id, "worker-test")
+            self.assertEqual(response["progress"]["completedBlocks"], 7)
+            self.assertEqual(response["progress"]["totalBlocks"], 10)
+            self.assertEqual(response["progress"]["fraction"], 0.7)
 
     def test_create_job_enforces_active_job_limit(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_sources_jobs.py
+++ b/backend/tests/test_sources_jobs.py
@@ -2,6 +2,7 @@ import json
 import tempfile
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from map_platform.jobs import JobStore, MapJobService
 from map_platform.limits import JobLimits
@@ -133,10 +134,12 @@ class SourceAndJobTests(unittest.TestCase):
                 }
             )
 
-            updated = store.update_progress_unless_cancelled(job.job_id, 7, 10, worker_id="worker-test")
+            with patch("map_platform.jobs.utc_now_iso", return_value="2026-07-12T00:00:00.000001Z"):
+                updated = store.update_progress_unless_cancelled(job.job_id, 7, 10, worker_id="worker-test")
             response = service.get_job(job.job_id).to_dict()
 
             self.assertEqual(updated.worker_id, "worker-test")
+            self.assertEqual(response["updatedAt"], "2026-07-12T00:00:00.000001Z")
             self.assertEqual(response["progress"]["completedBlocks"], 7)
             self.assertEqual(response["progress"]["totalBlocks"], 10)
             self.assertEqual(response["progress"]["fraction"], 0.7)

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -3,7 +3,8 @@ import unittest
 from pathlib import Path
 
 from map_platform.jobs import JobStore, MapJobService
-from map_platform.models import Bounds, SourceRegion
+from map_platform.models import Bounds, JobStatus, SourceRegion
+from map_platform.pipeline import run_job
 from map_platform.sources import SourceIndex
 from map_platform.worker import MapWorker, cleanup_work_dirs, expire_ready_jobs
 
@@ -15,10 +16,10 @@ class FakePipeline:
 
     def build(self, job, on_status=None, on_progress=None):
         self.calls += 1
-        if self.calls <= self.failures:
-            raise RuntimeError("temporary worker failure")
         if on_progress:
             on_progress(8, 10)
+        if self.calls <= self.failures:
+            raise RuntimeError("temporary worker failure")
         pack_path = Path(tempfile.gettempdir()) / f"map-123-{job.job_id}.zip"
         pack_path.write_bytes(b"zip-data")
         return "map-123", pack_path
@@ -30,6 +31,8 @@ class CancellingPipeline:
 
     def build(self, job, on_status=None, on_progress=None):
         self.service.cancel_job(job.job_id)
+        if on_progress:
+            on_progress(1, 10)
         return "map-123", Path("/tmp/map-123.zip")
 
 
@@ -98,6 +101,7 @@ class WorkerTests(unittest.TestCase):
             self.assertIsNotNone(loaded.finished_at)
             first_queued_event = next(event for event in first.job.events if event["status"] == "queued")
             self.assertIsNone(first.job.finished_at)
+            self.assertIsNone(first.job.to_dict()["progress"])
             self.assertEqual(first_queued_event["message"], "queued for retry")
 
     def test_worker_ignores_cancelled_job(self):
@@ -124,6 +128,71 @@ class WorkerTests(unittest.TestCase):
             self.assertTrue(result.processed)
             self.assertEqual(loaded.status.value, "cancelled")
             self.assertIsNone(loaded.map_id)
+
+    def test_new_worker_requeues_job_interrupted_by_previous_worker(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            self.assertIsNotNone(store.claim_next("worker-old"))
+            store.update_status(job.job_id, JobStatus.CONVERTING_FEATURES, worker_id="worker-old")
+            store.update_progress_unless_cancelled(job.job_id, 6, 10, worker_id="worker-old")
+
+            result = MapWorker(
+                store,
+                FakePipeline(),
+                worker_id="worker-new",
+                interrupted_job_stale_seconds=0,
+            ).run_next()
+            loaded = store.get(job.job_id)
+
+            self.assertTrue(result.processed)
+            self.assertEqual(loaded.status, JobStatus.READY)
+            self.assertEqual(loaded.attempts, 2)
+            self.assertTrue(any(event["message"] == "requeued after worker restart" for event in loaded.events))
+
+    def test_new_worker_leaves_fresh_foreign_job_running(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            self.assertIsNotNone(store.claim_next("worker-old"))
+            store.update_status(job.job_id, JobStatus.CONVERTING_FEATURES, worker_id="worker-old")
+
+            requeued = store.requeue_interrupted_jobs("worker-new", stale_after_seconds=60)
+            loaded = store.get(job.job_id)
+
+            self.assertEqual(requeued, 0)
+            self.assertEqual(loaded.status, JobStatus.CONVERTING_FEATURES)
+            self.assertEqual(loaded.worker_id, "worker-old")
+
+    def test_previous_worker_cannot_write_after_job_is_reclaimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            self.assertIsNotNone(store.claim_next("worker-old"))
+            store.update_status(job.job_id, JobStatus.CONVERTING_FEATURES, worker_id="worker-old")
+            self.assertEqual(store.requeue_interrupted_jobs("worker-new", stale_after_seconds=0), 1)
+            self.assertIsNotNone(store.claim_next("worker-new"))
+
+            with self.assertRaisesRegex(RuntimeError, "owned by another worker"):
+                store.update_progress_unless_cancelled(job.job_id, 7, 10, worker_id="worker-old")
+
+            loaded = store.get(job.job_id)
+            self.assertEqual(loaded.worker_id, "worker-new")
+            self.assertIsNone(loaded.progress_completed)
+
+    def test_synchronous_run_preserves_cancellation_from_progress_callback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+
+            result = run_job(store, CancellingPipeline(service), job.job_id)
+
+            self.assertEqual(result.status, JobStatus.CANCELLED)
+            self.assertEqual(store.get(job.job_id).status, JobStatus.CANCELLED)
 
     def test_expire_ready_jobs_and_cleanup_work_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -1,8 +1,10 @@
 import tempfile
+import threading
+import time
 import unittest
 from pathlib import Path
 
-from map_platform.jobs import JobStore, MapJobService
+from map_platform.jobs import JobClaimError, JobStore, MapJobService
 from map_platform.models import Bounds, JobStatus, SourceRegion
 from map_platform.pipeline import run_job
 from map_platform.sources import SourceIndex
@@ -34,6 +36,22 @@ class CancellingPipeline:
         if on_progress:
             on_progress(1, 10)
         return "map-123", Path("/tmp/map-123.zip")
+
+
+class BlockingPipeline:
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def build(self, job, on_status=None, on_progress=None):
+        if on_status:
+            on_status(JobStatus.EXTRACTING_PBF)
+        self.started.set()
+        if not self.release.wait(timeout=2):
+            raise TimeoutError("test pipeline was not released")
+        pack_path = Path(tempfile.gettempdir()) / f"map-blocking-{job.job_id}.zip"
+        pack_path.write_bytes(b"zip-data")
+        return "map-blocking", pack_path
 
 
 class WorkerTests(unittest.TestCase):
@@ -159,10 +177,10 @@ class WorkerTests(unittest.TestCase):
             self.assertIsNotNone(store.claim_next("worker-old"))
             store.update_status(job.job_id, JobStatus.CONVERTING_FEATURES, worker_id="worker-old")
 
-            requeued = store.requeue_interrupted_jobs("worker-new", stale_after_seconds=60)
+            claimed = store.claim_next("worker-new", interrupted_job_stale_seconds=60)
             loaded = store.get(job.job_id)
 
-            self.assertEqual(requeued, 0)
+            self.assertIsNone(claimed)
             self.assertEqual(loaded.status, JobStatus.CONVERTING_FEATURES)
             self.assertEqual(loaded.worker_id, "worker-old")
 
@@ -173,8 +191,8 @@ class WorkerTests(unittest.TestCase):
             job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
             self.assertIsNotNone(store.claim_next("worker-old"))
             store.update_status(job.job_id, JobStatus.CONVERTING_FEATURES, worker_id="worker-old")
-            self.assertEqual(store.requeue_interrupted_jobs("worker-new", stale_after_seconds=0), 1)
-            self.assertIsNotNone(store.claim_next("worker-new"))
+            reclaimed = store.claim_next("worker-new", interrupted_job_stale_seconds=0)
+            self.assertIsNotNone(reclaimed)
 
             with self.assertRaisesRegex(RuntimeError, "owned by another worker"):
                 store.update_progress_unless_cancelled(job.job_id, 7, 10, worker_id="worker-old")
@@ -182,6 +200,40 @@ class WorkerTests(unittest.TestCase):
             loaded = store.get(job.job_id)
             self.assertEqual(loaded.worker_id, "worker-new")
             self.assertIsNone(loaded.progress_completed)
+
+    def test_live_worker_heartbeat_prevents_reclaim_during_long_phase(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            pipeline = BlockingPipeline()
+            first_worker = MapWorker(
+                store,
+                pipeline,
+                worker_id="worker-live",
+                interrupted_job_stale_seconds=0.03,
+                heartbeat_interval_seconds=0.005,
+            )
+            results = []
+            thread = threading.Thread(target=lambda: results.append(first_worker.run_next()))
+            thread.start()
+            self.assertTrue(pipeline.started.wait(timeout=1))
+            time.sleep(0.06)
+
+            second = MapWorker(
+                store,
+                FakePipeline(),
+                worker_id="worker-second",
+                interrupted_job_stale_seconds=0.03,
+                heartbeat_interval_seconds=0.005,
+            ).run_next()
+            pipeline.release.set()
+            thread.join(timeout=2)
+
+            self.assertFalse(second.processed)
+            self.assertEqual(len(results), 1)
+            self.assertEqual(store.get(job.job_id).status, JobStatus.READY)
+            self.assertEqual(store.get(job.job_id).worker_id, "worker-live")
 
     def test_synchronous_run_preserves_cancellation_from_progress_callback(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -193,6 +245,23 @@ class WorkerTests(unittest.TestCase):
 
             self.assertEqual(result.status, JobStatus.CANCELLED)
             self.assertEqual(store.get(job.job_id).status, JobStatus.CANCELLED)
+
+    def test_synchronous_run_rejects_cancelled_or_owned_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            cancelled = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            service.cancel_job(cancelled.job_id)
+
+            with self.assertRaisesRegex(JobClaimError, "cancelled, not queued"):
+                run_job(store, FakePipeline(), cancelled.job_id)
+            self.assertEqual(store.get(cancelled.job_id).status, JobStatus.CANCELLED)
+
+            active = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            self.assertIsNotNone(store.claim_next("worker-active"))
+            with self.assertRaisesRegex(JobClaimError, "validating, not queued"):
+                run_job(store, FakePipeline(), active.job_id)
+            self.assertEqual(store.get(active.job_id).worker_id, "worker-active")
 
     def test_expire_ready_jobs_and_cleanup_work_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -201,6 +201,42 @@ class WorkerTests(unittest.TestCase):
             self.assertEqual(loaded.worker_id, "worker-new")
             self.assertIsNone(loaded.progress_completed)
 
+    def test_previous_worker_cannot_publish_after_job_is_reclaimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            store = JobStore(root / "jobs")
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            self.assertIsNotNone(store.claim_next("worker-old"))
+            store.update_status(job.job_id, JobStatus.PACKAGING, worker_id="worker-old")
+            old_archive = root / "old-attempt.zip"
+            old_archive.write_bytes(b"old")
+
+            reclaimed = store.claim_next("worker-new", interrupted_job_stale_seconds=0)
+            self.assertIsNotNone(reclaimed)
+            new_archive = root / "new-attempt.zip"
+            new_archive.write_bytes(b"new")
+            published = root / "packs" / "map.zip"
+            store.complete_job(
+                job.job_id,
+                worker_id="worker-new",
+                map_id="map-new",
+                built_archive=new_archive,
+                published_archive=published,
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "owned by another worker"):
+                store.complete_job(
+                    job.job_id,
+                    worker_id="worker-old",
+                    map_id="map-old",
+                    built_archive=old_archive,
+                    published_archive=published,
+                )
+
+            self.assertEqual(published.read_bytes(), b"new")
+            self.assertEqual(store.get(job.job_id).map_id, "map-new")
+
     def test_live_worker_heartbeat_prevents_reclaim_during_long_phase(self):
         with tempfile.TemporaryDirectory() as tmp:
             store = JobStore(tmp)
@@ -262,6 +298,19 @@ class WorkerTests(unittest.TestCase):
             with self.assertRaisesRegex(JobClaimError, "validating, not queued"):
                 run_job(store, FakePipeline(), active.job_id)
             self.assertEqual(store.get(active.job_id).worker_id, "worker-active")
+
+    def test_cancel_does_not_overwrite_completed_job(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job({"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]})
+            ready = MapWorker(store, FakePipeline(), worker_id="worker-test").run_next().job
+
+            cancelled = service.cancel_job(job.job_id)
+
+            self.assertEqual(ready.status, JobStatus.READY)
+            self.assertEqual(cancelled.status, JobStatus.READY)
+            self.assertEqual(cancelled.map_id, "map-123")
 
     def test_expire_ready_jobs_and_cleanup_work_dirs(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/backend/tests/test_worker.py
+++ b/backend/tests/test_worker.py
@@ -13,10 +13,12 @@ class FakePipeline:
         self.failures = failures
         self.calls = 0
 
-    def build(self, job, on_status=None):
+    def build(self, job, on_status=None, on_progress=None):
         self.calls += 1
         if self.calls <= self.failures:
             raise RuntimeError("temporary worker failure")
+        if on_progress:
+            on_progress(8, 10)
         pack_path = Path(tempfile.gettempdir()) / f"map-123-{job.job_id}.zip"
         pack_path.write_bytes(b"zip-data")
         return "map-123", pack_path
@@ -26,7 +28,7 @@ class CancellingPipeline:
     def __init__(self, service):
         self.service = service
 
-    def build(self, job, on_status=None):
+    def build(self, job, on_status=None, on_progress=None):
         self.service.cancel_job(job.job_id)
         return "map-123", Path("/tmp/map-123.zip")
 
@@ -58,6 +60,9 @@ class WorkerTests(unittest.TestCase):
             self.assertEqual(loaded.pack_bytes, 8)
             response = loaded.to_dict()
             self.assertEqual(response["packBytes"], 8)
+            self.assertEqual(response["progress"]["completedBlocks"], 8)
+            self.assertEqual(response["progress"]["totalBlocks"], 10)
+            self.assertEqual(response["progress"]["fraction"], 0.8)
             timings = response["phaseTimings"]
             self.assertTrue(any(timing["status"] == "ready" for timing in timings))
             self.assertTrue(all("durationSeconds" in timing for timing in timings))

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -211,6 +211,7 @@ struct ContentView: View {
 
     private var shouldShowOfflineMapStatusChip: Bool {
         offlineMapManager.isBusy ||
+            offlineMapManager.hasPendingMapJob ||
             offlineMapManager.currentJob != nil ||
             offlineMapManager.downloadedPackURL != nil ||
             offlineMapManager.errorMessage != nil

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -104,6 +104,9 @@ struct ContentView: View {
         .onChange(of: coordinator.selectedView) { newValue in
             coordinator.updateSelectedView(newValue)
         }
+        .onAppear {
+            offlineMapManager.resumePendingMapJobIfNeeded()
+        }
         .onChange(of: offlineMapManager.isMapAreaSelectionActive) { isActive in
             if isActive {
                 showingSettings = false

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -105,7 +105,7 @@ struct ContentView: View {
             coordinator.updateSelectedView(newValue)
         }
         .onAppear {
-            offlineMapManager.resumePendingMapJobIfNeeded()
+            offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: offlineMapManager.isMapAreaSelectionActive) { isActive in
             if isActive {
@@ -222,10 +222,7 @@ struct ContentView: View {
         } label: {
             HStack(spacing: 10) {
                 if offlineMapManager.isBusy {
-                    ProgressView(
-                        value: offlineMapManager.mapPreparationProgress ??
-                            (offlineMapManager.downloadProgress > 0 ? offlineMapManager.downloadProgress : nil)
-                    )
+                    ProgressView(value: offlineMapManager.activityProgress)
                         .frame(width: 22, height: 22)
                 } else {
                     Image(systemName: offlineMapManager.downloadedPackURL == nil ? "map" : "checkmark.circle.fill")

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -219,7 +219,10 @@ struct ContentView: View {
         } label: {
             HStack(spacing: 10) {
                 if offlineMapManager.isBusy {
-                    ProgressView(value: offlineMapManager.downloadProgress > 0 ? offlineMapManager.downloadProgress : nil)
+                    ProgressView(
+                        value: offlineMapManager.mapPreparationProgress ??
+                            (offlineMapManager.downloadProgress > 0 ? offlineMapManager.downloadProgress : nil)
+                    )
                         .frame(width: 22, height: 22)
                 } else {
                     Image(systemName: offlineMapManager.downloadedPackURL == nil ? "map" : "checkmark.circle.fill")

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -123,6 +123,7 @@ struct ContentView: View {
         guard !dismissedOfflineMapOnboarding else { return false }
         guard !offlineMapManager.isMapAreaSelectionActive else { return false }
         guard !offlineMapManager.isBusy,
+              !offlineMapManager.hasPendingMapJob,
               offlineMapManager.currentJob == nil,
               offlineMapManager.downloadedPackURL == nil,
               offlineMapManager.errorMessage == nil else { return false }

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -240,6 +240,7 @@ enum OfflineMapJobPoller {
 
 nonisolated enum OfflineMapJobPersistence {
     private static let activeJobIdKey = "offlineMap.activeJobId"
+    private static let installOnDeviceKey = "offlineMap.activeJobInstallOnDevice"
 
     static func activeJobId(defaults: UserDefaults) -> String? {
         guard let value = defaults.string(forKey: activeJobIdKey), !value.isEmpty else {
@@ -248,12 +249,18 @@ nonisolated enum OfflineMapJobPersistence {
         return value
     }
 
-    static func save(jobId: String, defaults: UserDefaults) {
+    static func shouldInstallOnDevice(defaults: UserDefaults) -> Bool {
+        defaults.bool(forKey: installOnDeviceKey)
+    }
+
+    static func save(jobId: String, installOnDevice: Bool = false, defaults: UserDefaults) {
         defaults.set(jobId, forKey: activeJobIdKey)
+        defaults.set(installOnDevice, forKey: installOnDeviceKey)
     }
 
     static func clear(defaults: UserDefaults) {
         defaults.removeObject(forKey: activeJobIdKey)
+        defaults.removeObject(forKey: installOnDeviceKey)
     }
 }
 
@@ -289,9 +296,15 @@ final class OfflineMapManager: ObservableObject {
     @Published private(set) var lastTransferMapId: String
     @Published private(set) var lastTransferOutcome: String
 
-    var mapPreparationProgress: Double? {
-        guard currentJob?.status == "converting_features" else { return nil }
-        return currentJob?.progress?.fraction
+    var activityProgress: Double? {
+        OfflineMapProgressPresentation.value(
+            job: currentJob,
+            downloadProgress: downloadProgress
+        )
+    }
+
+    var hasPendingMapJob: Bool {
+        OfflineMapJobPersistence.activeJobId(defaults: defaults) != nil
     }
 
     private let defaults: UserDefaults
@@ -364,7 +377,7 @@ final class OfflineMapManager: ObservableObject {
                 sideLengthKm: Double(manager.sideLengthKm) ?? 25
             ))
             manager.currentJob = try await client.createJob(request)
-            manager.persistCurrentJob()
+            manager.persistCurrentJob(installOnDevice: true)
             manager.downloadURL = nil
             manager.downloadedPackURL = nil
             manager.downloadProgress = 0
@@ -375,26 +388,31 @@ final class OfflineMapManager: ObservableObject {
             try await manager.waitForReadyMap(client: client)
             try await manager.downloadReadyPack(client: client)
             try await manager.transferReadyPack(bleManager: bleManager)
+            manager.clearPersistedJob()
         }
     }
 
-    func resumePendingMapJobIfNeeded() {
+    func resumePendingMapJobIfNeeded(bleManager: BLEManager? = nil) {
         guard mapJobTask == nil,
               !isBusy,
               let jobId = OfflineMapJobPersistence.activeJobId(defaults: defaults) else {
             return
         }
+        let shouldInstallOnDevice = OfflineMapJobPersistence.shouldInstallOnDevice(defaults: defaults)
 
         startMapJobTask { manager in
             do {
                 let client = try manager.makeClient()
-                let job = try await client.job(id: jobId)
-                manager.currentJob = job
-                manager.statusMessage = job.status
-                if job.status != "ready" || job.mapId == nil {
-                    try await manager.waitForReadyMap(client: client)
-                }
+                try await manager.waitForReadyMap(client: client, jobId: jobId)
                 try await manager.downloadReadyPack(client: client)
+                if shouldInstallOnDevice {
+                    guard let bleManager else {
+                        manager.statusMessage = "map downloaded; reconnect device to install"
+                        return
+                    }
+                    try await manager.transferReadyPack(bleManager: bleManager)
+                }
+                manager.clearPersistedJob()
             } catch {
                 if manager.shouldForgetPersistedJob(after: error) {
                     manager.clearPersistedJob()
@@ -402,6 +420,12 @@ final class OfflineMapManager: ObservableObject {
                 throw error
             }
         }
+    }
+
+    func pausePendingMapJob() {
+        guard mapJobTask != nil else { return }
+        mapJobTask?.cancel()
+        statusMessage = "map preparation paused"
     }
 
     func refreshJob() {
@@ -605,10 +629,11 @@ final class OfflineMapManager: ObservableObject {
             manager.statusMessage = "creating map job"
 
             manager.currentJob = try await client.createJob(request)
-            manager.persistCurrentJob()
+            manager.persistCurrentJob(installOnDevice: false)
             manager.statusMessage = manager.currentJob?.status ?? ""
             try await manager.waitForReadyMap(client: client)
             try await manager.downloadReadyPack(client: client)
+            manager.clearPersistedJob()
         }
     }
 
@@ -656,8 +681,11 @@ final class OfflineMapManager: ObservableObject {
         return mapId
     }
 
-    private func waitForReadyMap(client: OfflineMapPlatformClient) async throws {
-        guard let jobId = currentJob?.jobId else {
+    private func waitForReadyMap(
+        client: OfflineMapPlatformClient,
+        jobId explicitJobId: String? = nil
+    ) async throws {
+        guard let jobId = explicitJobId ?? currentJob?.jobId else {
             throw OfflineMapPlatformError.invalidResponse
         }
 
@@ -716,12 +744,15 @@ final class OfflineMapManager: ObservableObject {
         downloadByteProgress = nil
         transferProgress = 0
         statusMessage = "pack downloaded"
-        clearPersistedJob()
     }
 
-    private func persistCurrentJob() {
+    private func persistCurrentJob(installOnDevice: Bool) {
         guard let jobId = currentJob?.jobId else { return }
-        OfflineMapJobPersistence.save(jobId: jobId, defaults: defaults)
+        OfflineMapJobPersistence.save(
+            jobId: jobId,
+            installOnDevice: installOnDevice,
+            defaults: defaults
+        )
     }
 
     private func clearPersistedJob() {

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -165,6 +165,98 @@ nonisolated enum MapTransferSessionIdentity {
     }
 }
 
+nonisolated enum OfflineMapPollingRetryPolicy {
+    static func shouldRetry(_ error: Error) -> Bool {
+        if error is CancellationError {
+            return false
+        }
+        if let platformError = error as? OfflineMapPlatformError,
+           case .serverStatus(let status, _) = platformError {
+            return status == 408 || status == 425 || status == 429 || (500...599).contains(status)
+        }
+        guard let urlError = error as? URLError else { return false }
+        return [
+            .timedOut,
+            .cannotFindHost,
+            .cannotConnectToHost,
+            .networkConnectionLost,
+            .dnsLookupFailed,
+            .notConnectedToInternet,
+            .resourceUnavailable,
+            .dataNotAllowed,
+        ].contains(urlError.code)
+    }
+
+    static func delayNanoseconds(failureCount: Int) -> UInt64 {
+        let exponent = min(max(failureCount - 1, 0), 4)
+        let seconds = min(2 * (1 << exponent), 30)
+        return UInt64(seconds) * 1_000_000_000
+    }
+}
+
+@MainActor
+enum OfflineMapJobPoller {
+    static func waitForReady(
+        jobId: String,
+        pollIntervalNanoseconds: UInt64,
+        fetch: @escaping (String) async throws -> OfflineMapJob,
+        sleep: @escaping (UInt64) async throws -> Void,
+        onUpdate: @escaping (OfflineMapJob) -> Void,
+        onRetry: @escaping () -> Void
+    ) async throws -> OfflineMapJob {
+        var consecutiveFailures = 0
+        while !Task.isCancelled {
+            let job: OfflineMapJob
+            do {
+                job = try await fetch(jobId)
+                consecutiveFailures = 0
+            } catch {
+                guard OfflineMapPollingRetryPolicy.shouldRetry(error) else { throw error }
+                consecutiveFailures += 1
+                onRetry()
+                try await sleep(
+                    OfflineMapPollingRetryPolicy.delayNanoseconds(
+                        failureCount: consecutiveFailures
+                    )
+                )
+                continue
+            }
+
+            onUpdate(job)
+            if job.status == "ready", job.mapId != nil {
+                return job
+            }
+            if job.isTerminal {
+                throw OfflineMapPlatformError.serverStatus(
+                    409,
+                    job.error ?? "Map job ended with status \(job.status)"
+                )
+            }
+            try await sleep(pollIntervalNanoseconds)
+        }
+        throw CancellationError()
+    }
+}
+
+nonisolated enum OfflineMapJobPersistence {
+    private static let activeJobIdKey = "offlineMap.activeJobId"
+
+    static func activeJobId(defaults: UserDefaults) -> String? {
+        guard let value = defaults.string(forKey: activeJobIdKey), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    static func save(jobId: String, defaults: UserDefaults) {
+        defaults.set(jobId, forKey: activeJobIdKey)
+    }
+
+    static func clear(defaults: UserDefaults) {
+        defaults.removeObject(forKey: activeJobIdKey)
+    }
+}
+
 @MainActor
 final class OfflineMapManager: ObservableObject {
     @Published var serverURLString: String {
@@ -205,6 +297,7 @@ final class OfflineMapManager: ObservableObject {
     private let defaults: UserDefaults
     private let deviceTransferManager = DeviceTransferManager()
     private var packDisplayNames: [String: String]
+    private var mapJobTask: Task<Void, Never>?
 
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
@@ -264,24 +357,49 @@ final class OfflineMapManager: ObservableObject {
         centerLatitude = String(format: "%.6f", location.coordinate.latitude)
         centerLongitude = String(format: "%.6f", location.coordinate.longitude)
 
-        Task {
-            await runBusy {
-                let client = try self.makeClient()
-                let request = OfflineMapJobRequest.customBBox(OfflineMapBounds(
-                    center: location.coordinate,
-                    sideLengthKm: Double(self.sideLengthKm) ?? 25
-                ))
-                self.currentJob = try await client.createJob(request)
-                self.downloadURL = nil
-                self.downloadedPackURL = nil
-                self.downloadProgress = 0
-                self.downloadByteProgress = nil
-                self.transferProgress = 0
-                self.statusMessage = "creating map"
+        startMapJobTask { manager in
+            let client = try manager.makeClient()
+            let request = OfflineMapJobRequest.customBBox(OfflineMapBounds(
+                center: location.coordinate,
+                sideLengthKm: Double(manager.sideLengthKm) ?? 25
+            ))
+            manager.currentJob = try await client.createJob(request)
+            manager.persistCurrentJob()
+            manager.downloadURL = nil
+            manager.downloadedPackURL = nil
+            manager.downloadProgress = 0
+            manager.downloadByteProgress = nil
+            manager.transferProgress = 0
+            manager.statusMessage = "creating map"
 
-                try await self.waitForReadyMap(client: client)
-                try await self.downloadReadyPack(client: client)
-                try await self.transferReadyPack(bleManager: bleManager)
+            try await manager.waitForReadyMap(client: client)
+            try await manager.downloadReadyPack(client: client)
+            try await manager.transferReadyPack(bleManager: bleManager)
+        }
+    }
+
+    func resumePendingMapJobIfNeeded() {
+        guard mapJobTask == nil,
+              !isBusy,
+              let jobId = OfflineMapJobPersistence.activeJobId(defaults: defaults) else {
+            return
+        }
+
+        startMapJobTask { manager in
+            do {
+                let client = try manager.makeClient()
+                let job = try await client.job(id: jobId)
+                manager.currentJob = job
+                manager.statusMessage = job.status
+                if job.status != "ready" || job.mapId == nil {
+                    try await manager.waitForReadyMap(client: client)
+                }
+                try await manager.downloadReadyPack(client: client)
+            } catch {
+                if manager.shouldForgetPersistedJob(after: error) {
+                    manager.clearPersistedJob()
+                }
+                throw error
             }
         }
     }
@@ -476,22 +594,34 @@ final class OfflineMapManager: ObservableObject {
     }
 
     private func createJobAndDownload(request: OfflineMapJobRequest) {
-        Task {
-            await runBusy {
-                let client = try self.makeClient()
-                self.currentJob = nil
-                self.downloadURL = nil
-                self.downloadedPackURL = nil
-                self.downloadProgress = 0
-                self.downloadByteProgress = nil
-                self.transferProgress = 0
-                self.statusMessage = "creating map job"
+        startMapJobTask { manager in
+            let client = try manager.makeClient()
+            manager.currentJob = nil
+            manager.downloadURL = nil
+            manager.downloadedPackURL = nil
+            manager.downloadProgress = 0
+            manager.downloadByteProgress = nil
+            manager.transferProgress = 0
+            manager.statusMessage = "creating map job"
 
-                self.currentJob = try await client.createJob(request)
-                self.statusMessage = self.currentJob?.status ?? ""
-                try await self.waitForReadyMap(client: client)
-                try await self.downloadReadyPack(client: client)
+            manager.currentJob = try await client.createJob(request)
+            manager.persistCurrentJob()
+            manager.statusMessage = manager.currentJob?.status ?? ""
+            try await manager.waitForReadyMap(client: client)
+            try await manager.downloadReadyPack(client: client)
+        }
+    }
+
+    private func startMapJobTask(
+        _ operation: @MainActor @escaping (OfflineMapManager) async throws -> Void
+    ) {
+        guard mapJobTask == nil else { return }
+        mapJobTask = Task { [weak self] in
+            guard let self else { return }
+            await runBusy {
+                try await operation(self)
             }
+            mapJobTask = nil
         }
     }
 
@@ -531,20 +661,26 @@ final class OfflineMapManager: ObservableObject {
             throw OfflineMapPlatformError.invalidResponse
         }
 
-        while !Task.isCancelled {
-            let job = try await client.job(id: jobId)
-            currentJob = job
-            statusMessage = job.status
-            if job.status == "ready", job.mapId != nil {
-                return
+        do {
+            currentJob = try await OfflineMapJobPoller.waitForReady(
+                jobId: jobId,
+                pollIntervalNanoseconds: OfflineMapDefaults.mapJobPollIntervalNanoseconds,
+                fetch: { id in try await client.job(id: id) },
+                sleep: { nanoseconds in try await Task.sleep(nanoseconds: nanoseconds) },
+                onUpdate: { [weak self] job in
+                    self?.currentJob = job
+                    self?.statusMessage = job.status
+                },
+                onRetry: { [weak self] in
+                    self?.statusMessage = "reconnecting to map server"
+                }
+            )
+        } catch {
+            if currentJob?.isTerminal == true || shouldForgetPersistedJob(after: error) {
+                clearPersistedJob()
             }
-            if job.isTerminal {
-                throw OfflineMapPlatformError.serverStatus(409, job.error ?? "Map job ended with status \(job.status)")
-            }
-            try await Task.sleep(nanoseconds: OfflineMapDefaults.mapJobPollIntervalNanoseconds)
+            throw error
         }
-
-        throw CancellationError()
     }
 
     private func downloadReadyPack(client: OfflineMapPlatformClient) async throws {
@@ -580,6 +716,24 @@ final class OfflineMapManager: ObservableObject {
         downloadByteProgress = nil
         transferProgress = 0
         statusMessage = "pack downloaded"
+        clearPersistedJob()
+    }
+
+    private func persistCurrentJob() {
+        guard let jobId = currentJob?.jobId else { return }
+        OfflineMapJobPersistence.save(jobId: jobId, defaults: defaults)
+    }
+
+    private func clearPersistedJob() {
+        OfflineMapJobPersistence.clear(defaults: defaults)
+    }
+
+    private func shouldForgetPersistedJob(after error: Error) -> Bool {
+        guard let platformError = error as? OfflineMapPlatformError,
+              case .serverStatus(let status, _) = platformError else {
+            return false
+        }
+        return status == 404 || status == 409
     }
 
     private func transferReadyPack(bleManager: BLEManager) async throws {
@@ -919,6 +1073,8 @@ final class OfflineMapManager: ObservableObject {
         defer { isBusy = false }
         do {
             try await operation()
+        } catch is CancellationError {
+            return
         } catch {
             errorMessage = diagnosticMessage(for: error)
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -23,7 +23,7 @@ private enum OfflineMapDefaults {
     nonisolated static let lastTransferPreviousSequenceKey = "offlineMap.lastTransfer.previousSequence"
     nonisolated static let lastTransferAcceptedSequenceKey = "offlineMap.lastTransfer.acceptedSequence"
     nonisolated static let lastTransferOutcomeKey = "offlineMap.lastTransfer.outcome"
-    nonisolated static let mapJobPollAttempts = 1800
+    nonisolated static let mapJobPollIntervalNanoseconds: UInt64 = 2_000_000_000
     nonisolated static let activationConfirmationTimeout: TimeInterval = 10 * 60
     nonisolated static let activationPollIntervalNanoseconds: UInt64 = 2_000_000_000
     nonisolated static let legacyServerURLs = [
@@ -196,6 +196,11 @@ final class OfflineMapManager: ObservableObject {
     @Published private(set) var errorMessage: String?
     @Published private(set) var lastTransferMapId: String
     @Published private(set) var lastTransferOutcome: String
+
+    var mapPreparationProgress: Double? {
+        guard currentJob?.status == "converting_features" else { return nil }
+        return currentJob?.progress?.fraction
+    }
 
     private let defaults: UserDefaults
     private let deviceTransferManager = DeviceTransferManager()
@@ -526,7 +531,7 @@ final class OfflineMapManager: ObservableObject {
             throw OfflineMapPlatformError.invalidResponse
         }
 
-        for _ in 0..<OfflineMapDefaults.mapJobPollAttempts {
+        while !Task.isCancelled {
             let job = try await client.job(id: jobId)
             currentJob = job
             statusMessage = job.status
@@ -536,13 +541,10 @@ final class OfflineMapManager: ObservableObject {
             if job.isTerminal {
                 throw OfflineMapPlatformError.serverStatus(409, job.error ?? "Map job ended with status \(job.status)")
             }
-            try await Task.sleep(nanoseconds: 2_000_000_000)
+            try await Task.sleep(nanoseconds: OfflineMapDefaults.mapJobPollIntervalNanoseconds)
         }
 
-        throw OfflineMapPlatformError.serverStatus(
-            408,
-            "Map job is still running. Larger areas can take a long time to prepare."
-        )
+        throw CancellationError()
     }
 
     private func downloadReadyPack(client: OfflineMapPlatformClient) async throws {

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -344,6 +344,7 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func beginMapAreaSelection() {
+        guard canStartNewMapJob() else { return }
         errorMessage = nil
         selectedMapBounds = nil
         isMapAreaSelectionActive = true
@@ -358,6 +359,7 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func createJobFromSelectedMapArea() {
+        guard canStartNewMapJob() else { return }
         guard let selectedMapBounds else {
             errorMessage = OfflineMapPlatformError.invalidResponse.localizedDescription
             return
@@ -367,6 +369,7 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func installCurrentLocationMap(location: CLLocation, bleManager: BLEManager) {
+        guard canStartNewMapJob() else { return }
         centerLatitude = String(format: "%.6f", location.coordinate.latitude)
         centerLongitude = String(format: "%.6f", location.coordinate.longitude)
 
@@ -618,6 +621,7 @@ final class OfflineMapManager: ObservableObject {
     }
 
     private func createJobAndDownload(request: OfflineMapJobRequest) {
+        guard canStartNewMapJob() else { return }
         startMapJobTask { manager in
             let client = try manager.makeClient()
             manager.currentJob = nil
@@ -757,6 +761,14 @@ final class OfflineMapManager: ObservableObject {
 
     private func clearPersistedJob() {
         OfflineMapJobPersistence.clear(defaults: defaults)
+    }
+
+    private func canStartNewMapJob() -> Bool {
+        guard !hasPendingMapJob else {
+            errorMessage = "Resume the pending map before starting another download."
+            return false
+        }
+        return true
     }
 
     private func shouldForgetPersistedJob(after error: Error) -> Bool {

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -190,7 +190,7 @@ struct OfflineMapDownloadURL: Decodable, Equatable {
     let expiresInSeconds: Int
 }
 
-enum OfflineMapPlatformError: LocalizedError {
+nonisolated enum OfflineMapPlatformError: LocalizedError {
     case invalidBaseURL
     case missingMapId
     case missingDownloadURL

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -154,6 +154,15 @@ struct OfflineMapJobProgress: Decodable, Equatable {
     }
 }
 
+enum OfflineMapProgressPresentation {
+    static func value(job: OfflineMapJob?, downloadProgress: Double) -> Double? {
+        if job?.status == "converting_features", let progress = job?.progress {
+            return progress.fraction
+        }
+        return downloadProgress > 0 ? downloadProgress : nil
+    }
+}
+
 struct OfflineMapJobGeometry: Decodable, Equatable {
     let mode: String
     let bounds: [Double]

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -133,9 +133,24 @@ struct OfflineMapJob: Decodable, Equatable {
     let packPath: String?
     let geometry: OfflineMapJobGeometry?
     let sourceRegion: OfflineMapSourceRegion?
+    let progress: OfflineMapJobProgress?
 
     var isTerminal: Bool {
         ["ready", "failed", "expired", "cancelled"].contains(status)
+    }
+}
+
+struct OfflineMapJobProgress: Decodable, Equatable {
+    let completedBlocks: Int
+    let totalBlocks: Int
+
+    var fraction: Double {
+        guard totalBlocks > 0 else { return 0 }
+        return min(max(Double(completedBlocks) / Double(totalBlocks), 0), 1)
+    }
+
+    var percentage: Int {
+        Int((fraction * 100).rounded())
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -163,6 +163,12 @@ enum OfflineMapProgressPresentation {
     }
 }
 
+enum OfflineMapDownloadingSectionPresentation {
+    static func isVisible(isBusy: Bool, hasPendingJob: Bool, errorMessage: String?) -> Bool {
+        isBusy || hasPendingJob || errorMessage != nil
+    }
+}
+
 struct OfflineMapJobGeometry: Decodable, Equatable {
     let mode: String
     let bounds: [Double]

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -147,6 +147,21 @@ struct OfflineMapJobGeometry: Decodable, Equatable {
     let routePointCount: Int
 }
 
+enum OfflineMapPreparationTimeEstimate {
+    static func description(for areaKm2: Double) -> String {
+        switch max(areaKm2, 0) {
+        case ..<10:
+            return "Usually under a minute"
+        case ..<1_000:
+            return "Usually a few minutes"
+        case ..<15_000:
+            return "May take 15–90 minutes"
+        default:
+            return "May take several hours"
+        }
+    }
+}
+
 struct OfflineMapSourceRegion: Decodable, Equatable {
     let id: String
     let name: String

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
@@ -29,7 +29,7 @@ struct OfflineMapsView: View {
                 Button(action: manager.beginMapAreaSelection) {
                     Label("Choose Area", systemImage: "rectangle.dashed")
                 }
-                .disabled(manager.isBusy)
+                .disabled(manager.isBusy || manager.hasPendingMapJob)
 
                 if let bounds = manager.selectedMapBounds {
                     OfflineMapValueRow(

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -208,6 +208,7 @@ private struct MainFirmwareUpdateSection: View {
 }
 
 private struct DownloadingMapsSettingsSection: View {
+    @EnvironmentObject private var bleManager: BLEManager
     @ObservedObject var manager: OfflineMapManager
 
     var body: some View {
@@ -259,6 +260,20 @@ private struct DownloadingMapsSettingsSection: View {
                 Text(error)
                     .font(.caption)
                     .foregroundColor(.red)
+            }
+
+            if manager.isBusy, manager.hasPendingMapJob {
+                Button(role: .destructive) {
+                    manager.pausePendingMapJob()
+                } label: {
+                    Label("Pause Map Preparation", systemImage: "pause.circle")
+                }
+            } else if manager.hasPendingMapJob {
+                Button {
+                    manager.resumePendingMapJobIfNeeded(bleManager: bleManager)
+                } label: {
+                    Label("Resume Map Preparation", systemImage: "play.circle")
+                }
             }
         }
     }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -54,7 +54,11 @@ struct SettingsView: View {
                 MainFirmwareUpdateSection(manager: firmwareUpdateManager)
                 DeviceScreensSettingsSection()
                 SavedMapsSettingsSection(manager: offlineMapManager)
-                if offlineMapManager.isBusy || offlineMapManager.errorMessage != nil {
+                if OfflineMapDownloadingSectionPresentation.isVisible(
+                    isBusy: offlineMapManager.isBusy,
+                    hasPendingJob: offlineMapManager.hasPendingMapJob,
+                    errorMessage: offlineMapManager.errorMessage
+                ) {
                     DownloadingMapsSettingsSection(manager: offlineMapManager)
                 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -229,6 +229,21 @@ private struct DownloadingMapsSettingsSection: View {
                 StatusValueRow(status: manager.statusMessage, isBusy: manager.isBusy)
             }
 
+            if let generationProgress {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Generation Progress")
+                        Spacer()
+                        Text("\(generationProgress.percentage)%")
+                            .foregroundColor(.secondary)
+                    }
+                    ProgressView(value: generationProgress.fraction)
+                    Text("\(generationProgress.completedBlocks) of \(generationProgress.totalBlocks) map blocks")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+
             if let sourceSummary {
                 SettingsValueRow(title: "Source", value: sourceSummary)
             }
@@ -263,6 +278,11 @@ private struct DownloadingMapsSettingsSection: View {
             return nil
         }
         return OfflineMapPreparationTimeEstimate.description(for: areaKm2)
+    }
+
+    private var generationProgress: OfflineMapJobProgress? {
+        guard manager.currentJob?.status == "converting_features" else { return nil }
+        return manager.currentJob?.progress
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -233,6 +233,13 @@ private struct DownloadingMapsSettingsSection: View {
                 SettingsValueRow(title: "Source", value: sourceSummary)
             }
 
+            if let preparationTimeEstimate {
+                SettingsValueRow(title: "Estimated Preparation", value: preparationTimeEstimate)
+                Text("Feature density and water coverage can affect preparation time.")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
             if let error = manager.errorMessage {
                 Text(error)
                     .font(.caption)
@@ -247,6 +254,15 @@ private struct DownloadingMapsSettingsSection: View {
             return "\(regionName) \(Int(area.rounded())) km²"
         }
         return regionName
+    }
+
+    private var preparationTimeEstimate: String? {
+        guard let job = manager.currentJob,
+              !job.isTerminal,
+              let areaKm2 = job.geometry?.areaKm2 else {
+            return nil
+        }
+        return OfflineMapPreparationTimeEstimate.description(for: areaKm2)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -334,7 +334,7 @@ private struct SavedMapsSettingsSection: View {
             Button(action: manager.beginMapAreaSelection) {
                 Label("Download a new Map", systemImage: "rectangle.dashed")
             }
-            .disabled(manager.isBusy)
+            .disabled(manager.isBusy || manager.hasPendingMapJob)
         }
         .onAppear {
             manager.reconcileLastTransfer(bleManager: bleManager)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -298,6 +298,7 @@ struct NavigationProtocolTests {
         testOfflineMapPreparationTimeEstimate()
         testOfflineMapJobProgressDecoding()
         testOfflineMapJobProgressAbsentFallback()
+        testOfflineMapProgressPresentation()
         testOfflineMapJobPersistence()
         await testOfflineMapPollerOutlivesLegacyAttemptLimit()
         await testOfflineMapPollerRetriesTransientFailure()
@@ -532,17 +533,55 @@ struct NavigationProtocolTests {
         }
         defer { defaults.removePersistentDomain(forName: suite) }
 
-        OfflineMapJobPersistence.save(jobId: "job-resume", defaults: defaults)
+        OfflineMapJobPersistence.save(
+            jobId: "job-resume",
+            installOnDevice: true,
+            defaults: defaults
+        )
         assertEqual(
             OfflineMapJobPersistence.activeJobId(defaults: defaults),
             "job-resume",
             "active map job survives app relaunch"
+        )
+        assert(
+            OfflineMapJobPersistence.shouldInstallOnDevice(defaults: defaults),
+            "onboarding map job preserves install intent"
         )
         OfflineMapJobPersistence.clear(defaults: defaults)
         assertEqual(
             OfflineMapJobPersistence.activeJobId(defaults: defaults),
             nil,
             "completed map job clears persisted recovery state"
+        )
+        assert(
+            !OfflineMapJobPersistence.shouldInstallOnDevice(defaults: defaults),
+            "completed map job clears install intent"
+        )
+    }
+
+    static func testOfflineMapProgressPresentation() {
+        let legacy = offlineMapJob(status: "converting_features")
+        let progressPayload = Data(
+            """
+            {"jobId":"progress-job","status":"converting_features","progress":{"completedBlocks":4,"totalBlocks":10}}
+            """.utf8
+        )
+        let progressJob = try? JSONDecoder().decode(OfflineMapJob.self, from: progressPayload)
+
+        assertEqual(
+            OfflineMapProgressPresentation.value(job: legacy, downloadProgress: 0),
+            nil,
+            "older servers keep the indeterminate progress view"
+        )
+        assertEqual(
+            OfflineMapProgressPresentation.value(job: progressJob, downloadProgress: 0),
+            0.4,
+            "generation block progress drives the determinate progress view"
+        )
+        assertEqual(
+            OfflineMapProgressPresentation.value(job: progressJob, downloadProgress: 0.75),
+            0.4,
+            "generation progress takes precedence while conversion is active"
         )
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -296,6 +296,7 @@ struct NavigationProtocolTests {
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testOfflineMapCustomBBoxRequest()
         testOfflineMapPreparationTimeEstimate()
+        testOfflineMapJobProgressDecoding()
         testOfflineMapCreateJobURLRequest()
         testOfflineMapManagerMigratesProductionConfig()
         testOfflineMapManagerRestoresLastTransferIdentity()
@@ -481,6 +482,32 @@ struct NavigationProtocolTests {
             "May take several hours",
             "very large map preparation estimate"
         )
+    }
+
+    static func testOfflineMapJobProgressDecoding() {
+        let payload = Data(
+            """
+            {
+              "jobId": "job-progress",
+              "status": "converting_features",
+              "progress": {
+                "completedBlocks": 79,
+                "totalBlocks": 100,
+                "fraction": 0.79
+              }
+            }
+            """.utf8
+        )
+        guard let job = try? JSONDecoder().decode(OfflineMapJob.self, from: payload),
+              let progress = job.progress else {
+            assert(false, "map job progress should decode")
+            return
+        }
+
+        assertEqual(progress.completedBlocks, 79, "map progress decodes completed blocks")
+        assertEqual(progress.totalBlocks, 100, "map progress decodes total blocks")
+        assertEqual(progress.percentage, 79, "map progress calculates percentage")
+        assert(abs(progress.fraction - 0.79) < 0.000001, "map progress calculates fraction")
     }
 
     static func testOfflineMapCreateJobURLRequest() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -247,7 +247,7 @@ final class TestRoute: MKRoute {
 @main
 struct NavigationProtocolTests {
     @MainActor
-    static func main() {
+    static func main() async {
         testIconMapping()
         testRouteEndpointExtraction()
         testRouteRemainingDistance()
@@ -297,6 +297,11 @@ struct NavigationProtocolTests {
         testOfflineMapCustomBBoxRequest()
         testOfflineMapPreparationTimeEstimate()
         testOfflineMapJobProgressDecoding()
+        testOfflineMapJobProgressAbsentFallback()
+        testOfflineMapJobPersistence()
+        await testOfflineMapPollerOutlivesLegacyAttemptLimit()
+        await testOfflineMapPollerRetriesTransientFailure()
+        await testOfflineMapPollerStopsOnTerminalAndCancellation()
         testOfflineMapCreateJobURLRequest()
         testOfflineMapManagerMigratesProductionConfig()
         testOfflineMapManagerRestoresLastTransferIdentity()
@@ -508,6 +513,147 @@ struct NavigationProtocolTests {
         assertEqual(progress.totalBlocks, 100, "map progress decodes total blocks")
         assertEqual(progress.percentage, 79, "map progress calculates percentage")
         assert(abs(progress.fraction - 0.79) < 0.000001, "map progress calculates fraction")
+    }
+
+    static func testOfflineMapJobProgressAbsentFallback() {
+        let payload = Data("{\"jobId\":\"legacy-job\",\"status\":\"converting_features\"}".utf8)
+        guard let job = try? JSONDecoder().decode(OfflineMapJob.self, from: payload) else {
+            assert(false, "legacy map job should decode without progress")
+            return
+        }
+        assertEqual(job.progress, nil, "legacy server response keeps indeterminate progress fallback")
+    }
+
+    static func testOfflineMapJobPersistence() {
+        let suite = "offline-map-job-persistence-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            assert(false, "job persistence test defaults should create")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        OfflineMapJobPersistence.save(jobId: "job-resume", defaults: defaults)
+        assertEqual(
+            OfflineMapJobPersistence.activeJobId(defaults: defaults),
+            "job-resume",
+            "active map job survives app relaunch"
+        )
+        OfflineMapJobPersistence.clear(defaults: defaults)
+        assertEqual(
+            OfflineMapJobPersistence.activeJobId(defaults: defaults),
+            nil,
+            "completed map job clears persisted recovery state"
+        )
+    }
+
+    @MainActor
+    static func testOfflineMapPollerOutlivesLegacyAttemptLimit() async {
+        guard let running = offlineMapJob(status: "converting_features"),
+              let ready = offlineMapJob(status: "ready", mapId: "map-ready") else {
+            assert(false, "poller test jobs should decode")
+            return
+        }
+        var fetchCount = 0
+        let result = try? await OfflineMapJobPoller.waitForReady(
+            jobId: "long-job",
+            pollIntervalNanoseconds: 0,
+            fetch: { _ in
+                fetchCount += 1
+                return fetchCount <= 1_801 ? running : ready
+            },
+            sleep: { _ in },
+            onUpdate: { _ in },
+            onRetry: {}
+        )
+
+        assertEqual(fetchCount, 1_802, "poller continues beyond the former 1,800-attempt limit")
+        assertEqual(result?.mapId, "map-ready", "poller returns the eventual ready map")
+    }
+
+    @MainActor
+    static func testOfflineMapPollerRetriesTransientFailure() async {
+        guard let ready = offlineMapJob(status: "ready", mapId: "map-ready") else {
+            assert(false, "retry test job should decode")
+            return
+        }
+        var fetchCount = 0
+        var retryCount = 0
+        var delays: [UInt64] = []
+        let result = try? await OfflineMapJobPoller.waitForReady(
+            jobId: "retry-job",
+            pollIntervalNanoseconds: 0,
+            fetch: { _ in
+                fetchCount += 1
+                if fetchCount == 1 {
+                    throw URLError(.timedOut)
+                }
+                return ready
+            },
+            sleep: { delays.append($0) },
+            onUpdate: { _ in },
+            onRetry: { retryCount += 1 }
+        )
+
+        assertEqual(result?.mapId, "map-ready", "transient polling failure recovers")
+        assertEqual(retryCount, 1, "transient polling failure reports reconnecting state")
+        assertEqual(delays, [2_000_000_000], "first retry uses bounded backoff")
+        assert(!OfflineMapPollingRetryPolicy.shouldRetry(
+            OfflineMapPlatformError.serverStatus(401, "unauthorized")
+        ), "authentication failures remain terminal")
+    }
+
+    @MainActor
+    static func testOfflineMapPollerStopsOnTerminalAndCancellation() async {
+        guard let failed = offlineMapJob(status: "failed", error: "conversion failed"),
+              let running = offlineMapJob(status: "converting_features") else {
+            assert(false, "terminal poller test jobs should decode")
+            return
+        }
+
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "failed-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in failed },
+                sleep: { _ in },
+                onUpdate: { _ in },
+                onRetry: {}
+            )
+            assert(false, "terminal map job should throw")
+        } catch OfflineMapPlatformError.serverStatus(let status, let body) {
+            assertEqual(status, 409, "terminal map job uses conflict status")
+            assert(body.contains("conversion failed"), "terminal map job preserves server error")
+        } catch {
+            assert(false, "terminal map job should use platform error")
+        }
+
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "cancel-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in running },
+                sleep: { _ in throw CancellationError() },
+                onUpdate: { _ in },
+                onRetry: {}
+            )
+            assert(false, "cancelled polling should throw")
+        } catch is CancellationError {
+            // Expected.
+        } catch {
+            assert(false, "cancelled polling should preserve CancellationError")
+        }
+    }
+
+    static func offlineMapJob(
+        status: String,
+        mapId: String? = nil,
+        error: String? = nil
+    ) -> OfflineMapJob? {
+        var payload: [String: Any] = ["jobId": "job-\(status)", "status": status]
+        if let mapId { payload["mapId"] = mapId }
+        if let error { payload["error"] = error }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return nil }
+        return try? JSONDecoder().decode(OfflineMapJob.self, from: data)
     }
 
     static func testOfflineMapCreateJobURLRequest() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -299,6 +299,7 @@ struct NavigationProtocolTests {
         testOfflineMapJobProgressDecoding()
         testOfflineMapJobProgressAbsentFallback()
         testOfflineMapProgressPresentation()
+        testOfflineMapDownloadingSectionPresentation()
         testOfflineMapJobPersistence()
         await testOfflineMapPollerOutlivesLegacyAttemptLimit()
         await testOfflineMapPollerRetriesTransientFailure()
@@ -582,6 +583,25 @@ struct NavigationProtocolTests {
             OfflineMapProgressPresentation.value(job: progressJob, downloadProgress: 0.75),
             0.4,
             "generation progress takes precedence while conversion is active"
+        )
+    }
+
+    static func testOfflineMapDownloadingSectionPresentation() {
+        assert(
+            OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: false,
+                hasPendingJob: true,
+                errorMessage: nil
+            ),
+            "paused persisted jobs keep the resume section reachable"
+        )
+        assert(
+            !OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: false,
+                hasPendingJob: false,
+                errorMessage: nil
+            ),
+            "idle map settings omit an empty downloading section"
         )
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -301,6 +301,7 @@ struct NavigationProtocolTests {
         testOfflineMapProgressPresentation()
         testOfflineMapDownloadingSectionPresentation()
         testOfflineMapJobPersistence()
+        testPendingOfflineMapJobBlocksEveryCreationIngress()
         await testOfflineMapPollerOutlivesLegacyAttemptLimit()
         await testOfflineMapPollerRetriesTransientFailure()
         await testOfflineMapPollerStopsOnTerminalAndCancellation()
@@ -602,6 +603,40 @@ struct NavigationProtocolTests {
                 errorMessage: nil
             ),
             "idle map settings omit an empty downloading section"
+        )
+    }
+
+    @MainActor
+    static func testPendingOfflineMapJobBlocksEveryCreationIngress() {
+        let suite = "offline-map-pending-ingress-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            assert(false, "pending job ingress test defaults should create")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+        OfflineMapJobPersistence.save(jobId: "job-existing", defaults: defaults)
+        let manager = OfflineMapManager(defaults: defaults)
+
+        manager.beginMapAreaSelection()
+        manager.createCustomCutoutJob()
+        manager.createJobFromSelectedMapArea()
+        manager.installCurrentLocationMap(
+            location: CLLocation(latitude: 31.2304, longitude: 121.4737),
+            bleManager: BLEManager()
+        )
+
+        assert(
+            !manager.isMapAreaSelectionActive,
+            "pending job blocks the area-selection creation ingress"
+        )
+        assert(
+            !manager.isBusy,
+            "pending job blocks all creation tasks before network work starts"
+        )
+        assertEqual(
+            OfflineMapJobPersistence.activeJobId(defaults: defaults),
+            "job-existing",
+            "all creation ingresses preserve the paused job recovery ID"
         )
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -295,6 +295,7 @@ struct NavigationProtocolTests {
         testNavigationEngineOmitsRideTelemetryWhenIdle()
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testOfflineMapCustomBBoxRequest()
+        testOfflineMapPreparationTimeEstimate()
         testOfflineMapCreateJobURLRequest()
         testOfflineMapManagerMigratesProductionConfig()
         testOfflineMapManagerRestoresLastTransferIdentity()
@@ -457,6 +458,29 @@ struct NavigationProtocolTests {
         assert(request.bbox != nil, "custom cut-out includes bbox")
         assert(abs((request.bbox?[1] ?? 0) - 34.9) < 0.001, "bbox min latitude uses requested size")
         assert(abs((request.bbox?[3] ?? 0) - 35.1) < 0.001, "bbox max latitude uses requested size")
+    }
+
+    static func testOfflineMapPreparationTimeEstimate() {
+        assertEqual(
+            OfflineMapPreparationTimeEstimate.description(for: 1),
+            "Usually under a minute",
+            "small map preparation estimate"
+        )
+        assertEqual(
+            OfflineMapPreparationTimeEstimate.description(for: 785),
+            "Usually a few minutes",
+            "city map preparation estimate"
+        )
+        assertEqual(
+            OfflineMapPreparationTimeEstimate.description(for: 14_252),
+            "May take 15–90 minutes",
+            "large map preparation estimate"
+        )
+        assertEqual(
+            OfflineMapPreparationTimeEstimate.description(for: 37_019),
+            "May take several hours",
+            "very large map preparation estimate"
+        )
     }
 
     static func testOfflineMapCreateJobURLRequest() {


### PR DESCRIPTION
## What changed

- show area-based preparation-time estimates while an offline map job is active
- emit exact completed-block progress from all map extraction paths
- persist coalesced live progress and a fresh `updatedAt` heartbeat in each job response
- keep iOS polling until the job reaches a terminal state instead of stopping after one hour
- retry transient polling failures with bounded backoff and resume an active generation after app relaunch
- preserve create-download-install intent across relaunch, with visible pause and resume controls
- prevent a paused job from being orphaned by starting another map
- recover interrupted workers using heartbeated leases, atomic ownership handoff, attempt-isolated work paths, and owner-checked archive publication
- reject `/run` attempts against active, cancelled, or otherwise non-queued jobs
- show a determinate generation progress bar in Settings and in the map status chip
- remain compatible with older servers by falling back to the existing indeterminate spinner

## Why

Large offline-map selections can remain in `converting_features` for many hours. The app previously stopped polling after 1,800 two-second attempts, so its activity indicator disappeared after exactly one hour even while the server continued working. The API also exposed only coarse phase names, preventing the app from showing real progress.

## Validation

- `PYTHONPATH=backend python3 -W error::ResourceWarning -m unittest discover -s backend/tests` (42 tests)
- `python3 -m unittest discover -s OSM_Extract/tests` (10 tests)
- `ios-app/scripts/run-navigation-tests.sh`
- `python3 -m compileall -q backend/map_platform OSM_Extract/scripts`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

## Operational note

The current production Shanghai job should be allowed to finish before this PR is merged/deployed, because replacing the worker container would interrupt that in-flight conversion.