### PR TITLE
Prepare firmware v0.3.0

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.2.4
-revision = 88
+version = 0.3.0
+revision = 89
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
## Summary

- bump the firmware version from 0.2.4 to 0.3.0
- increment the firmware build from 88 to 89
- align release metadata for the streamed map-install firmware now on main

## Validation

- `pio run -e WAVESHARE_AMOLED_175`
- `pio run -e WAVESHARE_AMOLED_206`
- `PYTHONPATH=tools python3 -m unittest tools.tests.test_firmware_build_identity`