### PR TITLE
Fix ride stats distance formatting

### DIFF
--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -55,7 +55,13 @@ static void setDistanceLabel(lv_obj_t *label, uint32_t meters) {
   if (meters >= 10000) {
     lv_label_set_text_fmt(label, "%lu km", (unsigned long)(meters / 1000));
   } else if (meters >= 1000) {
-    lv_label_set_text_fmt(label, "%.1f km", meters / 1000.0f);
+    // LVGL's built-in formatter has float support disabled in lv_conf.h.
+    // Format tenths using integers so 1-9.9 km does not render as a literal
+    // "f" from the unsupported %.1f conversion.
+    const uint32_t roundedDeciKilometers = (meters + 50U) / 100U;
+    lv_label_set_text_fmt(label, "%lu.%lu km",
+                          (unsigned long)(roundedDeciKilometers / 10U),
+                          (unsigned long)(roundedDeciKilometers % 10U));
   } else {
     lv_label_set_text_fmt(label, "%lu m", (unsigned long)meters);
   }


### PR DESCRIPTION
## Summary

- replace the ride-stats distance labels' unsupported floating-point formatting with integer tenths
- preserve one-decimal rounding between 1 km and 10 km
- fix both the Distance and Route left values

## Root cause

The firmware configures LVGL's built-in formatter with `LV_USE_FLOAT=0`. The ride-stats screen nevertheless used `%.1f km`, so LVGL treated the unsupported conversion as a literal and rendered `f` for values between 1,000 and 9,999 meters.

## Validation

- `git diff --check`
- boundary formatting checks at 999 m, 1,000 m, 1,050 m, 9,949 m, 9,950 m, 9,999 m, and 10,000 m
- PR CI will compile the firmware for the 1.75-inch and 2.06-inch targets
