### PR TITLE
Fix saved map names and missing thumbnails

### DIFF
--- a/backend/map_platform/manifest.py
+++ b/backend/map_platform/manifest.py
@@ -33,8 +33,12 @@ class PipelineMetadata:
 
 
 def stable_map_id(job: MapJob) -> str:
-    display_name = str(job.request.get("displayName", "custom-map"))
-    slug = re.sub(r"[^a-zA-Z0-9]+", "-", display_name).strip("-").lower() or "custom-map"
+    slug = (
+        re.sub(r"[^a-zA-Z0-9]+", "-", job.artifact_display_name)
+        .strip("-")
+        .lower()
+        or "offline-map"
+    )
     source = json.dumps(
         {
             "mode": job.geometry.mode.value,
@@ -49,7 +53,7 @@ def stable_map_id(job: MapJob) -> str:
     )
     digest = hashlib.sha256(source.encode("utf-8")).hexdigest()[:10]
     maximum_slug_bytes = MAX_PACK_MAP_ID_BYTES - len(digest) - 1
-    slug = slug[:maximum_slug_bytes].rstrip("-") or "custom-map"
+    slug = slug[:maximum_slug_bytes].rstrip("-") or "offline-map"
     return f"{slug}-{digest}"
 
 
@@ -110,7 +114,7 @@ def build_manifest(job: MapJob, map_root: Path, pipeline: PipelineMetadata) -> d
     return {
         "schemaVersion": 1,
         "mapId": map_id,
-        "displayName": str(job.request.get("displayName", map_id)),
+        "displayName": job.artifact_display_name,
         "geometryType": job.geometry.mode.value,
         "bounds": job.geometry.bounds.to_list(),
         "createdAt": job.created_at,
@@ -122,6 +126,7 @@ def build_manifest(job: MapJob, map_root: Path, pipeline: PipelineMetadata) -> d
         "source": {
             "provider": job.source_region.provider,
             "region": job.source_region.id,
+            "name": job.source_region.name,
             "publishedAt": job.source_region.published_at,
             "license": job.source_region.license,
             "url": job.source_region.url,

--- a/backend/map_platform/models.py
+++ b/backend/map_platform/models.py
@@ -183,6 +183,16 @@ class MapJob:
     progress_total: int | None = None
     events: list[dict[str, Any]] = field(default_factory=list)
 
+    @property
+    def artifact_display_name(self) -> str:
+        """Return the immutable pack name available when the job is created."""
+        requested = self.request.get("displayName")
+        if isinstance(requested, str) and (trimmed := requested.strip()):
+            return trimmed
+        if trimmed_source := self.source_region.name.strip():
+            return trimmed_source
+        return "Offline map"
+
     def to_dict(self, *, include_internal: bool = False) -> dict[str, Any]:
         result = {
             "jobId": self.job_id,

--- a/backend/map_platform/reuse.py
+++ b/backend/map_platform/reuse.py
@@ -111,7 +111,7 @@ def reuse_keys(
     compatibility = _document_sha256(compatibility_document)
     exact_document = {
         "compatibilityKey": compatibility,
-        "packDisplayName": job.request.get("displayName"),
+        "packDisplayName": job.artifact_display_name,
         "geometry": {
             "mode": job.geometry.mode.value,
             "bounds": job.geometry.bounds.to_list(),

--- a/backend/tests/test_manifest.py
+++ b/backend/tests/test_manifest.py
@@ -87,6 +87,31 @@ class ManifestTests(unittest.TestCase):
                 zipfile.ZIP_STORED,
             )
 
+    def test_source_name_is_the_default_pack_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            job = fake_job()
+            job.request.pop("displayName")
+            map_id = stable_map_id(job)
+            job.map_id = map_id
+            folder = root / "VECTMAP" / map_id / "+0032+0008"
+            folder.mkdir(parents=True)
+            (folder / "123_456.fmb").write_bytes(b"map-block")
+
+            manifest = build_manifest(job, root, PipelineMetadata())
+
+            self.assertTrue(map_id.startswith("singapore-"))
+            self.assertNotIn("custom-map", map_id)
+            self.assertEqual(manifest["displayName"], "Singapore")
+            self.assertEqual(manifest["source"]["name"], "Singapore")
+
+    def test_explicit_pack_name_overrides_source_name(self):
+        job = fake_job()
+        job.request["displayName"] = "  Marina Bay rides  "
+
+        self.assertEqual(job.artifact_display_name, "Marina Bay rides")
+        self.assertTrue(stable_map_id(job).startswith("marina-bay-rides-"))
+
     def test_archive_remains_compatible_without_optional_preview(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)

--- a/backend/tests/test_reuse.py
+++ b/backend/tests/test_reuse.py
@@ -167,6 +167,33 @@ class MapReuseTests(unittest.TestCase):
             self.assertIsNotNone(changed_source_snapshot)
             self.assertNotEqual(first_source_snapshot, changed_source_snapshot)
 
+    def test_exact_key_uses_source_name_when_request_has_no_pack_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            service = MapJobService(SourceIndex([self.source]), JobStore(tmp))
+            unnamed = service.create_job(
+                {"mode": "custom_bbox", "bbox": [103.70, 1.20, 104.00, 1.50]}
+            )
+            explicitly_named = service.create_job(
+                {
+                    "mode": "custom_bbox",
+                    "bbox": [103.70, 1.20, 104.00, 1.50],
+                    "displayName": "Singapore",
+                }
+            )
+
+            self.assertEqual(
+                reuse_keys(
+                    unnamed,
+                    producer_build_sha256=PRODUCER_BUILD,
+                    producer_image_digest=PRODUCER_IMAGE,
+                ),
+                reuse_keys(
+                    explicitly_named,
+                    producer_build_sha256=PRODUCER_BUILD,
+                    producer_image_digest=PRODUCER_IMAGE,
+                ),
+            )
+
     def test_bbox_processing_bounds_are_complete_blocks(self):
         with tempfile.TemporaryDirectory() as tmp:
             service = MapJobService(SourceIndex([self.source]), JobStore(tmp))

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -2082,7 +2082,7 @@ final class OfflineMapManager: ObservableObject {
         downloadProgress = 0
         downloadByteProgress = nil
         var temporaryURL: URL?
-        var verifiedStream: VerifiedBikeMapArtifact?
+        var artifactDisplayName: String?
         let trustStore = mapStreamTrustStore
         do {
             let constraints = try OfflineMapDownloadConstraints.mapArtifact(primaryArtifact)
@@ -2093,7 +2093,7 @@ final class OfflineMapManager: ObservableObject {
             })
             temporaryURL = downloadedURL
             let validationTask = Task.detached(priority: .userInitiated) {
-                () throws -> VerifiedBikeMapArtifact? in
+                () throws -> String? in
                 switch choice {
                 case .bikeMapStream(let artifact, _):
                     return try BikeMapStreamArtifactValidator.validate(
@@ -2101,7 +2101,7 @@ final class OfflineMapManager: ObservableObject {
                         artifact: artifact,
                         expectedMapID: mapId,
                         trustStore: trustStore
-                    )
+                    ).displayName
                 case .legacyZip(let artifact):
                     if let artifact {
                         try OfflineMapArtifactFileValidator.validate(
@@ -2111,10 +2111,10 @@ final class OfflineMapManager: ObservableObject {
                     }
                     let archive = try OfflineMapPackArchive(url: downloadedURL)
                     try archive.validate(expectedMapId: mapId)
-                    return nil
+                    return try archive.manifest().displayName
                 }
             }
-            verifiedStream = try await withTaskCancellationHandler {
+            artifactDisplayName = try await withTaskCancellationHandler {
                 try await validationTask.value
             } onCancel: {
                 validationTask.cancel()
@@ -2144,7 +2144,7 @@ final class OfflineMapManager: ObservableObject {
                         !SavedMapDisplayNamePolicy.isGeneratedGenericName($0))
             }
         let defaultDisplayName = SavedMapDisplayNamePolicy.resolve(
-            artifactDisplayName: verifiedStream?.displayName,
+            artifactDisplayName: artifactDisplayName,
             sourceRegionName: job.sourceRegion?.name,
             mapID: mapId
         )
@@ -3763,15 +3763,19 @@ final class OfflineMapManager: ObservableObject {
         guard let manifest = OfflineMapPackPreviewReader.manifest(for: packURL) else {
             return nil
         }
-        let candidates = [
-            manifest.source?.name,
+        if let displayName = SavedMapDisplayNamePolicy.preferred(manifest.displayName) {
+            return displayName
+        }
+        if let sourceName = SavedMapDisplayNamePolicy.preferred(manifest.source?.name) {
+            return sourceName
+        }
+        let sourceCandidates = [
             manifest.source?.url.flatMap { URL(string: $0)?.lastPathComponent },
-            manifest.source?.region,
-            manifest.displayName
+            manifest.source?.region
         ]
-        for candidate in candidates {
-            if let displayName = SavedMapDisplayNamePolicy.preferred(candidate) {
-                return displayName
+        for candidate in sourceCandidates {
+            if let sourceName = SavedMapDisplayNamePolicy.preferredSourceName(candidate) {
+                return sourceName
             }
         }
         return nil

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -41,6 +41,54 @@ private enum OfflineMapDefaults {
     ]
 }
 
+#if canImport(UIKit)
+@MainActor
+private enum OfflineMapFallbackPreviewRenderer {
+    private static let size = CGSize(width: 160, height: 96)
+    private static let padding: CGFloat = 8
+
+    static func image(for bounds: OfflineMapPreviewBounds) -> UIImage {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = false
+        return UIGraphicsImageRenderer(size: size, format: format).image { _ in
+            let centerLatitude = (bounds.minLatitude + bounds.maxLatitude) / 2
+            let longitudeScale = max(0.1, cos(centerLatitude * .pi / 180))
+            let projectedWidth = (bounds.maxLongitude - bounds.minLongitude) * longitudeScale
+            let projectedHeight = bounds.maxLatitude - bounds.minLatitude
+            let scale = min(
+                (Double(size.width - padding * 2) / projectedWidth),
+                (Double(size.height - padding * 2) / projectedHeight)
+            )
+            let width = CGFloat(projectedWidth * scale)
+            let height = CGFloat(projectedHeight * scale)
+            let rect = CGRect(
+                x: (size.width - width) / 2,
+                y: (size.height - height) / 2,
+                width: width,
+                height: height
+            )
+            let path = UIBezierPath(roundedRect: rect, cornerRadius: 3)
+            UIColor(
+                red: 76 / 255,
+                green: 139 / 255,
+                blue: 168 / 255,
+                alpha: 0.82
+            ).setFill()
+            path.fill()
+            UIColor(
+                red: 40 / 255,
+                green: 96 / 255,
+                blue: 124 / 255,
+                alpha: 1
+            ).setStroke()
+            path.lineWidth = 2
+            path.stroke()
+        }
+    }
+}
+#endif
+
 nonisolated enum OfflineMapServerIdentity {
     private static let managedIdentity = "managed-production"
 
@@ -1323,18 +1371,32 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func displayName(forCachedPack packURL: URL) -> String {
-        if let displayName = packDisplayNames[packURL.lastPathComponent], !displayName.isEmpty {
+        let metadata = SavedMapArtifactMetadataStore.load(for: packURL)
+        if let displayName = packDisplayNames[packURL.lastPathComponent],
+           !displayName.isEmpty,
+           (metadata?.userDefinedDisplayName == true ||
+               !SavedMapDisplayNamePolicy.isGeneratedGenericName(displayName)) {
             return displayName
         }
-        if let displayName = SavedMapArtifactMetadataStore.load(for: packURL)?.displayName,
-           !displayName.isEmpty {
+        if metadata?.userDefinedDisplayName == true,
+           let displayName = metadata?.displayName,
+           !displayName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return displayName
         }
-        if currentJob?.mapId == packURL.deletingPathExtension().lastPathComponent,
-           let displayName = displayNameForCurrentJob() {
+        if let displayName = SavedMapDisplayNamePolicy.preferred(metadata?.displayName) {
             return displayName
         }
-        return packURL.deletingPathExtension().lastPathComponent
+        if let manifestName = manifestDisplayName(for: packURL) {
+            return manifestName
+        }
+        if currentJob?.mapId == packURL.deletingPathExtension().lastPathComponent {
+            return displayNameForCurrentJob()
+        }
+        return SavedMapDisplayNamePolicy.resolve(
+            artifactDisplayName: nil,
+            sourceRegionName: nil,
+            mapID: packURL.deletingPathExtension().lastPathComponent
+        )
     }
 
 #if canImport(UIKit)
@@ -1351,8 +1413,8 @@ final class OfflineMapManager: ObservableObject {
         }
         let token = previewLoadRegistry.begin(for: key)
         previewLoadTasks[key] = Task { [weak self] in
-            let data = await Task.detached(priority: .utility) {
-                OfflineMapPackPreviewReader.imageData(for: packURL)
+            let preview = await Task.detached(priority: .utility) {
+                OfflineMapPackPreviewReader.content(for: packURL)
             }.value
             guard let self else { return }
             guard self.previewLoadRegistry.finishIfCurrent(
@@ -1366,16 +1428,22 @@ final class OfflineMapManager: ObservableObject {
                   }) else {
                 return
             }
-            guard let data,
-                  let image = UIImage(data: data),
-                  image.size.width > 0,
-                  image.size.height > 0,
-                  image.size.width <= 512,
-                  image.size.height <= 512 else {
-                self.unavailablePackPreviews.insert(key)
+            if let data = preview?.imageData,
+               let image = UIImage(data: data),
+               image.size.width > 0,
+               image.size.height > 0,
+               image.size.width <= 512,
+               image.size.height <= 512 {
+                self.packPreviewImages[key] = image
                 return
             }
-            self.packPreviewImages[key] = image
+            if let bounds = preview?.bounds {
+                self.packPreviewImages[key] = OfflineMapFallbackPreviewRenderer.image(
+                    for: bounds
+                )
+                return
+            }
+            self.unavailablePackPreviews.insert(key)
         }
     }
 #endif
@@ -1775,8 +1843,12 @@ final class OfflineMapManager: ObservableObject {
                       let sourceName, !sourceName.isEmpty else {
                     return false
                 }
-                return Self.cleanDisplayName(localName).localizedCaseInsensitiveCompare(
-                    Self.cleanDisplayName(sourceName)
+                guard !SavedMapDisplayNamePolicy.isGeneratedGenericName(localName) else {
+                    return false
+                }
+                return SavedMapDisplayNamePolicy.clean(localName)
+                    .localizedCaseInsensitiveCompare(
+                        SavedMapDisplayNamePolicy.clean(sourceName)
                 ) != .orderedSame
             }()
         }
@@ -2066,13 +2138,22 @@ final class OfflineMapManager: ObservableObject {
             .first
         let existingDisplayName = ["\(mapId).bmap", "\(mapId).zip"]
             .compactMap { packDisplayNames[$0] }
-            .first { !$0.isEmpty }
-        let defaultDisplayName = verifiedStream?.displayName ?? displayNameForCurrentJob()
+            .first {
+                !$0.isEmpty &&
+                    (existingMetadata?.userDefinedDisplayName == true ||
+                        !SavedMapDisplayNamePolicy.isGeneratedGenericName($0))
+            }
+        let defaultDisplayName = SavedMapDisplayNamePolicy.resolve(
+            artifactDisplayName: verifiedStream?.displayName,
+            sourceRegionName: job.sourceRegion?.name,
+            mapID: mapId
+        )
         let displayName = existingDisplayName ?? defaultDisplayName
         let userDefinedDisplayName = existingMetadata?.userDefinedDisplayName ?? {
-            guard let existingDisplayName, let defaultDisplayName else { return false }
-            return Self.cleanDisplayName(existingDisplayName).localizedCaseInsensitiveCompare(
-                Self.cleanDisplayName(defaultDisplayName)
+            guard let existingDisplayName else { return false }
+            return SavedMapDisplayNamePolicy.clean(existingDisplayName)
+                .localizedCaseInsensitiveCompare(
+                    SavedMapDisplayNamePolicy.clean(defaultDisplayName)
             ) != .orderedSame
         }()
         let downloadReceiptID = UUID().uuidString.lowercased()
@@ -2150,8 +2231,7 @@ final class OfflineMapManager: ObservableObject {
             mapId: mapId,
             defaults: defaults
         )
-        if packDisplayNames[destination.lastPathComponent]?.isEmpty != false,
-           let displayName {
+        if packDisplayNames[destination.lastPathComponent]?.isEmpty != false {
             packDisplayNames[destination.lastPathComponent] = displayName
         }
         persistPackDisplayNames()
@@ -2169,7 +2249,7 @@ final class OfflineMapManager: ObservableObject {
                 )
             )
         }
-        if userDefinedDisplayName, let displayName, !displayName.isEmpty {
+        if userDefinedDisplayName, !displayName.isEmpty {
             try? await client.updateDisplayName(jobId: job.jobId, displayName: displayName)
         }
         refreshCachedPacks()
@@ -3528,23 +3608,12 @@ final class OfflineMapManager: ObservableObject {
         }
     }
 
-    private func displayNameForCurrentJob() -> String? {
-        if let regionName = currentJob?.sourceRegion?.name.trimmingCharacters(in: .whitespacesAndNewlines),
-           !regionName.isEmpty {
-            return Self.cleanDisplayName(regionName)
-        }
-        if let mapId = currentJob?.mapId, !mapId.isEmpty {
-            return mapId
-        }
-        return nil
-    }
-
-    private static func cleanDisplayName(_ value: String) -> String {
-        value
-            .replacingOccurrences(of: "-latest.osm.pbf", with: "")
-            .replacingOccurrences(of: ".osm.pbf", with: "")
-            .replacingOccurrences(of: ".zip", with: "")
-            .replacingOccurrences(of: "geofabrik-", with: "")
+    private func displayNameForCurrentJob() -> String {
+        SavedMapDisplayNamePolicy.resolve(
+            artifactDisplayName: nil,
+            sourceRegionName: currentJob?.sourceRegion?.name,
+            mapID: currentJob?.mapId
+        )
     }
 
     private func persistPackDisplayNames() {
@@ -3623,7 +3692,7 @@ final class OfflineMapManager: ObservableObject {
             }
             unavailablePackPreviews.formIntersection(activePreviewKeys)
 #endif
-            cacheMissingDisplayNames(for: packURLs)
+            cacheDefaultDisplayNames(for: packURLs)
             cachedPackURLs = packURLs
         } catch {
 #if canImport(UIKit)
@@ -3655,11 +3724,29 @@ final class OfflineMapManager: ObservableObject {
     private func invalidateCachedPreview(for packURL: URL) {}
 #endif
 
-    private func cacheMissingDisplayNames(for packURLs: [URL]) {
+    private func cacheDefaultDisplayNames(for packURLs: [URL]) {
         var didChange = false
-        for packURL in packURLs where packDisplayNames[packURL.lastPathComponent]?.isEmpty != false {
+        for packURL in packURLs {
+            let metadata = SavedMapArtifactMetadataStore.load(for: packURL)
+            let existing = packDisplayNames[packURL.lastPathComponent]
+            if existing?.isEmpty != false,
+               metadata?.userDefinedDisplayName == true,
+               let userName = metadata?.displayName,
+               !userName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                packDisplayNames[packURL.lastPathComponent] = userName
+                didChange = true
+                continue
+            }
+            let needsDefault = existing?.isEmpty != false ||
+                (metadata?.userDefinedDisplayName != true &&
+                    SavedMapDisplayNamePolicy.isGeneratedGenericName(existing))
+            guard needsDefault else { continue }
             guard let displayName = manifestDisplayName(for: packURL) else { continue }
             packDisplayNames[packURL.lastPathComponent] = displayName
+            if var metadata, metadata.userDefinedDisplayName != true {
+                metadata.displayName = displayName
+                try? SavedMapArtifactMetadataStore.save(metadata, for: packURL)
+            }
             didChange = true
         }
         if didChange {
@@ -3668,26 +3755,24 @@ final class OfflineMapManager: ObservableObject {
     }
 
     private func manifestDisplayName(for packURL: URL) -> String? {
-        if let displayName = SavedMapArtifactMetadataStore.load(for: packURL)?.displayName,
-           !displayName.isEmpty {
+        if let displayName = SavedMapDisplayNamePolicy.preferred(
+            SavedMapArtifactMetadataStore.load(for: packURL)?.displayName
+        ) {
             return displayName
         }
-        guard let archive = try? OfflineMapPackArchive(url: packURL),
-              let manifest = try? archive.manifest() else {
+        guard let manifest = OfflineMapPackPreviewReader.manifest(for: packURL) else {
             return nil
         }
         let candidates = [
+            manifest.source?.name,
             manifest.source?.url.flatMap { URL(string: $0)?.lastPathComponent },
             manifest.source?.region,
             manifest.displayName
         ]
         for candidate in candidates {
-            guard let value = candidate?.trimmingCharacters(in: .whitespacesAndNewlines),
-                  !value.isEmpty,
-                  !value.hasPrefix("custom-map-") else {
-                continue
+            if let displayName = SavedMapDisplayNamePolicy.preferred(candidate) {
+                return displayName
             }
-            return Self.cleanDisplayName(value)
         }
         return nil
     }

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -605,6 +605,97 @@ struct OfflineMapPackEntry: Equatable {
     let crc32: UInt32
 }
 
+nonisolated enum SavedMapDisplayNamePolicy {
+    static func resolve(
+        artifactDisplayName: String?,
+        sourceRegionName: String?,
+        mapID: String?
+    ) -> String {
+        if let artifactName = preferred(artifactDisplayName) {
+            return artifactName
+        }
+        if let sourceName = preferred(sourceRegionName) {
+            return sourceName
+        }
+        if let mapName = preferred(mapID) {
+            return mapName
+        }
+        return "Offline Map"
+    }
+
+    static func preferred(_ candidate: String?) -> String? {
+        guard let candidate else { return nil }
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !isGeneratedGenericName(trimmed) else { return nil }
+        let cleaned = clean(trimmed)
+        return cleaned.isEmpty ? nil : cleaned
+    }
+
+    static func isGeneratedGenericName(_ candidate: String?) -> Bool {
+        guard let candidate else { return false }
+        let normalized = candidate
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return normalized == "custom-map" || normalized.hasPrefix("custom-map-")
+    }
+
+    static func clean(_ candidate: String) -> String {
+        var value = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        for suffix in ["-latest.osm.pbf", ".osm.pbf", ".zip", ".bmap"]
+            where value.lowercased().hasSuffix(suffix) {
+            value.removeLast(suffix.count)
+            break
+        }
+        if value.lowercased().hasPrefix("geofabrik-") {
+            value.removeFirst("geofabrik-".count)
+        }
+        value = value
+            .replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+        if value == value.lowercased() {
+            return value.localizedCapitalized
+        }
+        return value
+    }
+}
+
+nonisolated struct OfflineMapPreviewBounds: Equatable, Sendable {
+    let minLongitude: Double
+    let minLatitude: Double
+    let maxLongitude: Double
+    let maxLatitude: Double
+
+    init?(coordinates: [Double]) {
+        guard coordinates.count == 4,
+              coordinates.allSatisfy(\.isFinite) else {
+            return nil
+        }
+        let minLongitude = coordinates[0]
+        let minLatitude = coordinates[1]
+        let maxLongitude = coordinates[2]
+        let maxLatitude = coordinates[3]
+        guard (-180...180).contains(minLongitude),
+              (-180...180).contains(maxLongitude),
+              (-90...90).contains(minLatitude),
+              (-90...90).contains(maxLatitude),
+              minLongitude < maxLongitude,
+              minLatitude < maxLatitude else {
+            return nil
+        }
+        self.minLongitude = minLongitude
+        self.minLatitude = minLatitude
+        self.maxLongitude = maxLongitude
+        self.maxLatitude = maxLatitude
+    }
+}
+
+nonisolated struct OfflineMapPackPreviewContent: Equatable, Sendable {
+    let imageData: Data?
+    let bounds: OfflineMapPreviewBounds?
+}
+
 nonisolated struct OfflineMapPackManifest: Decodable, Equatable {
     struct File: Decodable, Equatable {
         let path: String
@@ -614,6 +705,7 @@ nonisolated struct OfflineMapPackManifest: Decodable, Equatable {
 
     struct Source: Decodable, Equatable {
         let region: String?
+        let name: String?
         let url: String?
     }
 
@@ -631,6 +723,18 @@ nonisolated struct OfflineMapPackManifest: Decodable, Equatable {
     let source: Source?
     let preview: Preview?
     let files: [File]?
+    let bounds: [Double]?
+    let boundsE7: [Int]?
+
+    var previewBounds: OfflineMapPreviewBounds? {
+        if let bounds, let decoded = OfflineMapPreviewBounds(coordinates: bounds) {
+            return decoded
+        }
+        guard let boundsE7, boundsE7.count == 4 else { return nil }
+        return OfflineMapPreviewBounds(
+            coordinates: boundsE7.map { Double($0) / 10_000_000 }
+        )
+    }
 
     private enum CodingKeys: String, CodingKey {
         case mapId
@@ -638,6 +742,8 @@ nonisolated struct OfflineMapPackManifest: Decodable, Equatable {
         case source
         case preview
         case files
+        case bounds
+        case boundsE7
     }
 
     nonisolated init(from decoder: Decoder) throws {
@@ -647,6 +753,8 @@ nonisolated struct OfflineMapPackManifest: Decodable, Equatable {
         source = try container.decodeIfPresent(Source.self, forKey: .source)
         preview = try? container.decode(Preview.self, forKey: .preview)
         files = try container.decodeIfPresent([File].self, forKey: .files)
+        bounds = try? container.decode([Double].self, forKey: .bounds)
+        boundsE7 = try? container.decode([Int].self, forKey: .boundsE7)
     }
 }
 
@@ -1193,12 +1301,45 @@ nonisolated enum OfflineMapPackPreviewReader {
     private static let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
 
     static func imageData(for packURL: URL) -> Data? {
+        content(for: packURL)?.imageData
+    }
+
+    static func content(for packURL: URL) -> OfflineMapPackPreviewContent? {
         switch packURL.pathExtension.lowercased() {
         case "zip":
-            return try? OfflineMapPackArchive(url: packURL).previewImageData()
+            guard let archive = try? OfflineMapPackArchive(url: packURL),
+                  let manifest = try? archive.manifest() else {
+                return nil
+            }
+            return OfflineMapPackPreviewContent(
+                imageData: archive.previewImageData(),
+                bounds: manifest.previewBounds
+            )
         case "bmap":
-            guard let manifestData = streamManifestData(for: packURL) else { return nil }
-            return imageData(fromManifestData: manifestData)
+            guard let manifestData = streamManifestData(for: packURL),
+                  let manifest = try? JSONDecoder().decode(
+                    OfflineMapPackManifest.self,
+                    from: manifestData
+                  ) else {
+                return nil
+            }
+            return OfflineMapPackPreviewContent(
+                imageData: imageData(from: manifest),
+                bounds: manifest.previewBounds
+            )
+        default:
+            return nil
+        }
+    }
+
+    static func manifest(for packURL: URL) -> OfflineMapPackManifest? {
+        switch packURL.pathExtension.lowercased() {
+        case "zip":
+            guard let archive = try? OfflineMapPackArchive(url: packURL) else { return nil }
+            return try? archive.manifest()
+        case "bmap":
+            guard let data = streamManifestData(for: packURL) else { return nil }
+            return try? JSONDecoder().decode(OfflineMapPackManifest.self, from: data)
         default:
             return nil
         }
@@ -1206,10 +1347,14 @@ nonisolated enum OfflineMapPackPreviewReader {
 
     static func imageData(fromManifestData data: Data) -> Data? {
         guard data.count <= BikeMapStreamFormat.maximumManifestBytes,
-              let manifest = try? JSONDecoder().decode(OfflineMapPackManifest.self, from: data),
-              let preview = validPreview(manifest.preview) else {
+              let manifest = try? JSONDecoder().decode(OfflineMapPackManifest.self, from: data) else {
             return nil
         }
+        return imageData(from: manifest)
+    }
+
+    private static func imageData(from manifest: OfflineMapPackManifest) -> Data? {
+        guard let preview = validPreview(manifest.preview) else { return nil }
         return inlineImageData(preview)
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -617,7 +617,7 @@ nonisolated enum SavedMapDisplayNamePolicy {
         if let sourceName = preferred(sourceRegionName) {
             return sourceName
         }
-        if let mapName = preferred(mapID) {
+        if let mapName = preferredSourceName(mapID) {
             return mapName
         }
         return "Offline Map"
@@ -627,7 +627,12 @@ nonisolated enum SavedMapDisplayNamePolicy {
         guard let candidate else { return nil }
         let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty, !isGeneratedGenericName(trimmed) else { return nil }
-        let cleaned = clean(trimmed)
+        return trimmed
+    }
+
+    static func preferredSourceName(_ candidate: String?) -> String? {
+        guard let candidate = preferred(candidate) else { return nil }
+        let cleaned = clean(candidate)
         return cleaned.isEmpty ? nil : cleaned
     }
 
@@ -636,7 +641,10 @@ nonisolated enum SavedMapDisplayNamePolicy {
         let normalized = candidate
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
-        return normalized == "custom-map" || normalized.hasPrefix("custom-map-")
+        return normalized == "custom-map" || normalized.range(
+            of: "^custom-map-[0-9a-f]{10}$",
+            options: .regularExpression
+        ) != nil
     }
 
     static func clean(_ candidate: String) -> String {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -466,6 +466,8 @@ struct NavigationProtocolTests {
         testOfflineMapListJobsURLRequest()
         testOfflineMapInventoryMutationURLRequests()
         testOfflineMapManagerMigratesProductionConfig()
+        testSavedMapDefaultNamePolicy()
+        testOfflineMapManagerRepairsGeneratedPackDefaults()
         testOfflineMapManagerRenamesCachedPack()
         testSavedMapRenameViewWiring()
         testOfflineMapManagerRestoresLastTransferIdentity()
@@ -3999,6 +4001,101 @@ struct NavigationProtocolTests {
         )
     }
 
+    static func testSavedMapDefaultNamePolicy() {
+        assertEqual(
+            SavedMapDisplayNamePolicy.resolve(
+                artifactDisplayName: "custom-map-4dc48b9bcb",
+                sourceRegionName: "China",
+                mapID: "custom-map-4dc48b9bcb"
+            ),
+            "China",
+            "a generated artifact ID never outranks the Geofabrik area name"
+        )
+        assertEqual(
+            SavedMapDisplayNamePolicy.resolve(
+                artifactDisplayName: "Shanghai Suzhou",
+                sourceRegionName: "China",
+                mapID: "shanghai-suzhou"
+            ),
+            "Shanghai Suzhou",
+            "an explicit pack name still outranks the source area"
+        )
+        assertEqual(
+            SavedMapDisplayNamePolicy.preferred("china-latest.osm.pbf"),
+            "China",
+            "legacy Geofabrik filenames become readable area names"
+        )
+        assertEqual(
+            SavedMapDisplayNamePolicy.resolve(
+                artifactDisplayName: "custom-map-deadbeef00",
+                sourceRegionName: nil,
+                mapID: "custom-map-deadbeef00"
+            ),
+            "Offline Map",
+            "generic IDs are never shown even when legacy metadata has no source"
+        )
+    }
+
+    @MainActor
+    static func testOfflineMapManagerRepairsGeneratedPackDefaults() {
+        let suite = "offline-map-default-repair-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            assert(false, "default repair test defaults should create")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("offline-map-default-repair-\(UUID().uuidString)")
+        try! FileManager.default.createDirectory(
+            at: cacheDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+        let mapID = "custom-map-4dc48b9bcb"
+        let packURL = cacheDirectory.appendingPathComponent("\(mapID).zip")
+        let manifest = try! JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "mapId": mapID,
+            "displayName": mapID,
+            "bounds": [120.90, 30.70, 121.95, 31.55],
+            "source": [
+                "provider": "geofabrik",
+                "region": "geofabrik-asia-china",
+                "url": "https://download.geofabrik.de/asia/china-latest.osm.pbf",
+            ],
+        ])
+        try! makeStoredZip(entries: [
+            ("manifest.json", manifest),
+            ("VECTMAP/\(mapID)/+0000+0000/1.fmb", Data("map-block".utf8)),
+        ]).write(to: packURL)
+        defaults.set(
+            [packURL.lastPathComponent: mapID],
+            forKey: "offlineMap.packDisplayNames"
+        )
+
+        let manager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory
+        )
+
+        assertEqual(
+            manager.displayName(forCachedPack: packURL),
+            "China",
+            "restart repairs an old generated label from Geofabrik manifest metadata"
+        )
+        assertEqual(
+            OfflineMapPackPreviewReader.content(for: packURL)?.bounds,
+            OfflineMapPreviewBounds(coordinates: [120.90, 30.70, 121.95, 31.55]),
+            "a preview-less legacy artifact still exposes bounds for local rendering"
+        )
+        assertEqual(
+            OfflineMapPackPreviewReader.content(for: packURL)?.imageData,
+            nil,
+            "the bounds fallback does not pretend a legacy artifact embedded an image"
+        )
+    }
+
     @MainActor
     static func testOfflineMapManagerRenamesCachedPack() {
         let suite = "offline-map-rename-test-\(UUID().uuidString)"
@@ -4130,8 +4227,10 @@ struct NavigationProtocolTests {
         }
         assert(
             managerSource.contains("Task.detached(priority: .utility)") &&
+                managerSource.contains("OfflineMapPackPreviewReader.content(for: packURL)") &&
+                managerSource.contains("OfflineMapFallbackPreviewRenderer.image") &&
                 !managerSource.contains("packURLs.forEach(cachePreviewIfAvailable)"),
-            "saved-map previews load lazily without scanning cached archives on the main actor"
+            "saved-map previews load lazily and render bounds when an old pack has no image"
         )
         assert(
             managerSource.contains(
@@ -4329,6 +4428,7 @@ struct NavigationProtocolTests {
         let manifest = try! JSONSerialization.data(withJSONObject: [
             "schemaVersion": 1,
             "mapId": "map-1",
+            "boundsE7": [1_037_500_000, 12_400_000, 1_039_300_000, 13_700_000],
             "preview": previewMetadata,
         ])
         let url = FileManager.default.temporaryDirectory
@@ -4462,6 +4562,11 @@ struct NavigationProtocolTests {
             OfflineMapPackPreviewReader.imageData(for: streamURL),
             preview,
             "cached signed streams expose their inline boundary preview"
+        )
+        assertEqual(
+            OfflineMapPackPreviewReader.content(for: streamURL)?.bounds,
+            OfflineMapPreviewBounds(coordinates: [103.75, 1.24, 103.93, 1.37]),
+            "cached signed streams retain bounds for the local thumbnail fallback"
         )
 
         var corruptPreview = previewMetadata

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -112,6 +112,23 @@ func makeStoredZip(entries: [(String, Data)]) -> Data {
     return zip
 }
 
+func makePreviewReadableBikeMapStream(manifest: Data) -> Data {
+    var stream = Data("BIKEMAP1".utf8)
+    appendUInt16LE(1, to: &stream)
+    appendUInt16LE(0, to: &stream)
+    appendUInt32LE(UInt32(manifest.count), to: &stream)
+    appendUInt16LE(5, to: &stream)
+    appendUInt16LE(0, to: &stream)
+    appendUInt32LE(1, to: &stream)
+    for shift in stride(from: 0, through: 56, by: 8) {
+        stream.append(UInt8((UInt64(1) >> UInt64(shift)) & 0xff))
+    }
+    stream.append(manifest)
+    stream.append(Data(repeating: 0, count: 5))
+    stream.append(0)
+    return stream
+}
+
 actor AsyncTestGate {
     private var isOpen = false
     private var waiter: CheckedContinuation<Void, Never>?
@@ -3032,6 +3049,8 @@ struct NavigationProtocolTests {
             mapId: String,
             installationId: String? = nil,
             installOnDevice: Bool? = nil,
+            sourceRegionName: String? = nil,
+            artifacts: [OfflineMapArtifact]? = nil,
             createdAt: String = "2026-07-12T04:00:00Z"
         ) -> Data {
             var payload: [String: Any] = [
@@ -3042,6 +3061,18 @@ struct NavigationProtocolTests {
             ]
             if let installationId { payload["clientInstallationId"] = installationId }
             if let installOnDevice { payload["installOnDevice"] = installOnDevice }
+            if let sourceRegionName {
+                payload["sourceRegion"] = [
+                    "id": "geofabrik-asia-china",
+                    "name": sourceRegionName,
+                    "provider": "geofabrik",
+                ]
+            }
+            if let artifacts {
+                payload["artifacts"] = try! JSONSerialization.jsonObject(
+                    with: JSONEncoder().encode(artifacts)
+                )
+            }
             return try! JSONSerialization.data(withJSONObject: payload)
         }
 
@@ -3056,6 +3087,7 @@ struct NavigationProtocolTests {
 
         func packData(
             mapId: String,
+            displayName: String = "Recovery Test",
             storedMapData: Data = Data([0x01]),
             hashedMapData: Data? = nil
         ) -> Data {
@@ -3063,7 +3095,7 @@ struct NavigationProtocolTests {
             let declaredData = hashedMapData ?? storedMapData
             let manifest = try! JSONSerialization.data(withJSONObject: [
                 "mapId": mapId,
-                "displayName": "Recovery Test",
+                "displayName": displayName,
                 "files": [[
                     "path": mapPath,
                     "bytes": declaredData.count,
@@ -3123,7 +3155,14 @@ struct NavigationProtocolTests {
         var persistedDownloadCount = 0
         OfflineMapTestURLProtocol.configure { request in
             if request.url?.path == "/v1/map-jobs/job-persisted" {
-                return (200, jobData(jobId: "job-persisted", mapId: "map-persisted"))
+                return (
+                    200,
+                    jobData(
+                        jobId: "job-persisted",
+                        mapId: "map-persisted",
+                        sourceRegionName: "China"
+                    )
+                )
             }
             if request.url?.path == "/v1/map-packs/map-persisted/download-url" {
                 return (200, downloadURLData(mapId: "map-persisted"))
@@ -3140,7 +3179,10 @@ struct NavigationProtocolTests {
                 let url = FileManager.default.temporaryDirectory
                     .appendingPathComponent(UUID().uuidString)
                     .appendingPathExtension("zip")
-                try packData(mapId: "map-persisted").write(to: url)
+                try packData(
+                    mapId: "map-persisted",
+                    displayName: "COVID-19 Rides"
+                ).write(to: url)
                 return url
             }
         )
@@ -3153,6 +3195,15 @@ struct NavigationProtocolTests {
             persistedManager.hasDownloadedPendingDeviceInstall,
             "downloaded deferred install becomes eligible for BLE-ready auto-resume"
         )
+        if let downloadedURL = persistedManager.downloadedPackURL {
+            assertEqual(
+                persistedManager.displayName(forCachedPack: downloadedURL),
+                "COVID-19 Rides",
+                "legacy ZIP download preserves an explicit manifest name over its source"
+            )
+        } else {
+            assert(false, "persisted recovery should expose its downloaded ZIP")
+        }
         assertEqual(
             OfflineMapJobPersistence.downloadedJobId(defaults: persistedDefaults),
             "job-persisted",
@@ -3200,6 +3251,237 @@ struct NavigationProtocolTests {
             relaunchedPersistedManager.deleteCachedPack(at: url)
         }
         relaunchedPersistedManager.forgetPendingMapJob()
+
+        let signedFixtureURL = URL(
+            fileURLWithPath: "backend/tests/fixtures/map_stream_v1_golden.txt"
+        )
+        let signedFixtureText = try! String(contentsOf: signedFixtureURL, encoding: .utf8)
+        let signedFixture = Dictionary(
+            uniqueKeysWithValues: signedFixtureText.split(separator: "\n").map { line in
+                let parts = line.split(
+                    separator: "=",
+                    maxSplits: 1,
+                    omittingEmptySubsequences: false
+                )
+                return (String(parts[0]), String(parts[1]))
+            }
+        )
+        let signedStream = Data(hex: signedFixture["stream_hex"]!)!
+        let signedPublicKey = Data(hex: signedFixture["public_key_x963_hex"]!)!
+        let signedPublicKeyHash = FirmwareUpdateManager.sha256Hex(signedPublicKey)
+        let signedArtifact = OfflineMapArtifact(
+            format: OfflineMapArtifact.bikeMapStreamFormat,
+            mediaType: "application/vnd.openbikecomputer.map-stream",
+            filename: "golden-map.bmap",
+            objectKey: "maps/golden-map/bike-map-stream-v1/map-test-2026-01/" +
+                "\(signedPublicKeyHash)/\(String(repeating: "1", count: 64))/" +
+                "\(String(repeating: "2", count: 64))/" +
+                "\(signedFixture["signed_manifest_receipt"]!).bmap",
+            bytes: Int64(signedStream.count),
+            sha256: FirmwareUpdateManager.sha256Hex(signedStream),
+            manifestReceipt: signedFixture["manifest_receipt"],
+            signedManifestReceipt: signedFixture["signed_manifest_receipt"],
+            signatureKeyId: "map-test-2026-01",
+            signatureKeySha256: signedPublicKeyHash,
+            producerBuildSha256: String(repeating: "1", count: 64),
+            producerImageDigest: "sha256:" + String(repeating: "2", count: 64),
+            requiredIosBuild: "100",
+            requiredIosGitSha: String(repeating: "a", count: 40),
+            requiredIosBuildSha256: String(repeating: "b", count: 64),
+            requiredFirmwareVersion: nil,
+            requiredFirmwareBuild: nil,
+            requiredFirmwareGitSha: nil
+        )
+        let signedTrustStore = BikeMapStreamTrustStore(publicKeysByID: [
+            "map-test-2026-01": signedPublicKey,
+        ])
+
+        func runSignedRecovery(
+            jobID: String,
+            userDefinedName: String?
+        ) async {
+            let suite = "offline-map-signed-recovery-\(UUID().uuidString)"
+            let defaults = UserDefaults(suiteName: suite)!
+            defer { defaults.removePersistentDomain(forName: suite) }
+            let cache = FileManager.default.temporaryDirectory.appendingPathComponent(
+                "offline-map-signed-recovery-cache-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            defer { try? FileManager.default.removeItem(at: cache) }
+            try! FileManager.default.createDirectory(at: cache, withIntermediateDirectories: true)
+
+            let serverURL = "https://signed-recovery.example"
+            let credential = OfflineMapInstallationCredential(
+                clientInstallationId: "inst_v2_1234567890abcdef1234567890abcdef",
+                clientInstallationToken: "v1." + String(repeating: "A", count: 43)
+            )
+            try! OfflineMapInstallationCredentialStore(defaults: defaults).save(
+                credential,
+                serverURLString: serverURL
+            )
+            defaults.set(serverURL, forKey: "offlineMap.serverURL")
+            OfflineMapJobPersistence.save(
+                jobId: jobID,
+                serverURLString: serverURL,
+                defaults: defaults
+            )
+
+            let legacyURL = cache.appendingPathComponent("golden-map.zip")
+            if let userDefinedName {
+                try! packData(mapId: "golden-map", displayName: "Golden Map")
+                    .write(to: legacyURL)
+                defaults.set(
+                    [legacyURL.lastPathComponent: userDefinedName],
+                    forKey: "offlineMap.packDisplayNames"
+                )
+                try! SavedMapArtifactMetadataStore.save(
+                    SavedMapArtifactMetadata(
+                        schemaVersion: SavedMapArtifactMetadata.currentSchemaVersion,
+                        mapID: "golden-map",
+                        displayName: userDefinedName,
+                        localArtifactFilename: legacyURL.lastPathComponent,
+                        streamFormatVersion: nil,
+                        jobID: "older-job",
+                        serverURLString: serverURL,
+                        clientInstallationID: credential.clientInstallationId,
+                        primaryArtifact: nil,
+                        legacyArtifact: nil,
+                        lastTransferProtocol: nil,
+                        lastTransferStreamFormat: nil,
+                        lastTransferSessionID: nil,
+                        lastBackgroundTaskID: nil,
+                        lastDeviceSequence: nil,
+                        lastDeviceState: nil,
+                        lastDeviceStep: nil,
+                        lastDeviceStepCount: nil,
+                        lastDeviceProgress: nil,
+                        expectedActiveMapID: "golden-map",
+                        expectedActiveSessionID: nil,
+                        lastTransferOutcome: nil,
+                        userDefinedDisplayName: true
+                    ),
+                    for: legacyURL
+                )
+            }
+
+            OfflineMapTestURLProtocol.configure { request in
+                switch request.url?.path {
+                case "/v1/map-jobs/\(jobID)":
+                    return (
+                        200,
+                        jobData(
+                            jobId: jobID,
+                            mapId: "golden-map",
+                            sourceRegionName: "China",
+                            artifacts: [signedArtifact]
+                        )
+                    )
+                case "/v1/map-packs/golden-map/artifacts/bike-map-stream-v1/download-url":
+                    var response = try! JSONSerialization.jsonObject(
+                        with: JSONEncoder().encode(signedArtifact)
+                    ) as! [String: Any]
+                    response["url"] = "/immutable/golden-map.bmap"
+                    response["expiresAt"] = 2_000_000_000
+                    response["expiresInSeconds"] = 900
+                    return (200, try! JSONSerialization.data(withJSONObject: response))
+                case "/v1/map-jobs":
+                    return (200, try! JSONSerialization.data(withJSONObject: ["jobs": []]))
+                case "/v1/map-jobs/\(jobID)/downloads",
+                     "/v1/map-jobs/\(jobID)/display-name":
+                    return (
+                        200,
+                        try! JSONSerialization.data(withJSONObject: [
+                            "jobId": jobID,
+                            "downloadCount": 1,
+                        ])
+                    )
+                default:
+                    return (404, Data())
+                }
+            }
+            let manager = OfflineMapManager(
+                defaults: defaults,
+                mapPlatformSession: session,
+                cacheDirectory: cache,
+                mapStreamTrustStore: signedTrustStore,
+                packDownload: { _, _, onProgress, _ in
+                    onProgress(1)
+                    let url = FileManager.default.temporaryDirectory
+                        .appendingPathComponent(UUID().uuidString)
+                        .appendingPathExtension("bmap")
+                    try signedStream.write(to: url)
+                    return url
+                }
+            )
+            manager.resumePendingMapJobIfNeeded()
+            let signedRecoveryCompleted = await waitForMapTaskCompletion(manager)
+            assert(
+                signedRecoveryCompleted,
+                "signed BMAP recovery should complete"
+            )
+            guard let downloadedURL = manager.downloadedPackURL else {
+                assert(false, "signed BMAP recovery should publish its downloaded artifact")
+                return
+            }
+            assertEqual(
+                downloadedURL.pathExtension,
+                "bmap",
+                "signed recovery publishes the canonical BMAP extension"
+            )
+            let expectedName = userDefinedName ?? "Golden Map"
+            assertEqual(
+                manager.displayName(forCachedPack: downloadedURL),
+                expectedName,
+                userDefinedName == nil
+                    ? "signed manifest displayName outranks the source-region fallback"
+                    : "signed replacement preserves an explicit user name"
+            )
+            let downloadedMetadata = SavedMapArtifactMetadataStore.load(for: downloadedURL)
+            assertEqual(
+                downloadedMetadata?.displayName,
+                expectedName,
+                "signed recovery persists the resolved display name"
+            )
+            assertEqual(
+                downloadedMetadata?.userDefinedDisplayName,
+                userDefinedName != nil,
+                "signed replacement preserves display-name provenance"
+            )
+            assertEqual(
+                downloadedMetadata?.primaryArtifact,
+                signedArtifact,
+                "signed recovery persists the verified stream artifact"
+            )
+            assert(
+                OfflineMapTestURLProtocol.requests().contains {
+                    $0.url?.path ==
+                        "/v1/map-packs/golden-map/artifacts/bike-map-stream-v1/download-url"
+                },
+                "signed recovery exercises the immutable artifact URL path"
+            )
+            if userDefinedName != nil {
+                assert(
+                    !FileManager.default.fileExists(atPath: legacyURL.path),
+                    "signed replacement removes the obsolete ZIP"
+                )
+                assert(
+                    SavedMapArtifactMetadataStore.load(for: legacyURL) == nil,
+                    "signed replacement removes the obsolete ZIP metadata"
+                )
+                assert(
+                    defaults.dictionary(forKey: "offlineMap.packDisplayNames")?[
+                        legacyURL.lastPathComponent
+                    ] == nil,
+                    "signed replacement removes the obsolete ZIP display-name entry"
+                )
+            }
+        }
+
+        await runSignedRecovery(jobID: "job-signed-name", userDefinedName: nil)
+        await runSignedRecovery(
+            jobID: "job-signed-replacement",
+            userDefinedName: "Weekend Ride"
+        )
 
         let managedSuite = "offline-map-managed-token-route-\(UUID().uuidString)"
         let managedDefaults = UserDefaults(suiteName: managedSuite)!
@@ -3399,6 +3681,16 @@ struct NavigationProtocolTests {
         let downloadRetryPack = downloadRetryCache.appendingPathComponent("map-download-retry.zip")
         let originalDownloadRetryPackData = packData(mapId: "map-download-retry")
         try! originalDownloadRetryPackData.write(to: downloadRetryPack)
+        let originalDownloadRetryMetadata = try! JSONSerialization.data(withJSONObject: [
+            "schemaVersion": SavedMapArtifactMetadata.currentSchemaVersion,
+            "mapID": "map-download-retry",
+            "displayName": "Shanghai Riverside",
+            "localArtifactFilename": downloadRetryPack.lastPathComponent,
+            "userDefinedDisplayName": true,
+        ])
+        try! originalDownloadRetryMetadata.write(
+            to: SavedMapArtifactMetadataStore.metadataURL(for: downloadRetryPack)
+        )
         var downloadURLIssueCount = 0
         var packDownloadAttemptCount = 0
         var rejectedTemporaryURLs: [URL] = []
@@ -3498,6 +3790,16 @@ struct NavigationProtocolTests {
             downloadRetryManager.displayName(forCachedPack: downloadRetryPack),
             "Shanghai Riverside",
             "same-map replacement preserves the user rename"
+        )
+        assertEqual(
+            SavedMapArtifactMetadataStore.load(for: downloadRetryPack)?.displayName,
+            "Shanghai Riverside",
+            "same-map replacement persists the user rename in artifact metadata"
+        )
+        assertEqual(
+            SavedMapArtifactMetadataStore.load(for: downloadRetryPack)?.userDefinedDisplayName,
+            true,
+            "same-map replacement preserves explicit user-name provenance"
         )
         downloadRetryManager.deleteCachedPack(at: downloadRetryPack)
 
@@ -4021,9 +4323,31 @@ struct NavigationProtocolTests {
             "an explicit pack name still outranks the source area"
         )
         assertEqual(
-            SavedMapDisplayNamePolicy.preferred("china-latest.osm.pbf"),
+            SavedMapDisplayNamePolicy.resolve(
+                artifactDisplayName: "COVID-19 Rides",
+                sourceRegionName: "China",
+                mapID: "covid-19-rides"
+            ),
+            "COVID-19 Rides",
+            "explicit artifact punctuation and casing are preserved"
+        )
+        assertEqual(
+            SavedMapDisplayNamePolicy.resolve(
+                artifactDisplayName: "gravel loop",
+                sourceRegionName: "China",
+                mapID: "gravel-loop"
+            ),
+            "gravel loop",
+            "explicit lowercase artifact names are preserved"
+        )
+        assertEqual(
+            SavedMapDisplayNamePolicy.preferredSourceName("china-latest.osm.pbf"),
             "China",
             "legacy Geofabrik filenames become readable area names"
+        )
+        assert(
+            !SavedMapDisplayNamePolicy.isGeneratedGenericName("custom-map-weekend"),
+            "a user label sharing the old prefix is not mistaken for a generated ID"
         )
         assertEqual(
             SavedMapDisplayNamePolicy.resolve(
@@ -4054,6 +4378,7 @@ struct NavigationProtocolTests {
         defer { try? FileManager.default.removeItem(at: cacheDirectory) }
         let mapID = "custom-map-4dc48b9bcb"
         let packURL = cacheDirectory.appendingPathComponent("\(mapID).zip")
+        let sourceName = "Shanghai and Suzhou"
         let manifest = try! JSONSerialization.data(withJSONObject: [
             "schemaVersion": 1,
             "mapId": mapID,
@@ -4062,6 +4387,7 @@ struct NavigationProtocolTests {
             "source": [
                 "provider": "geofabrik",
                 "region": "geofabrik-asia-china",
+                "name": sourceName,
                 "url": "https://download.geofabrik.de/asia/china-latest.osm.pbf",
             ],
         ])
@@ -4069,8 +4395,56 @@ struct NavigationProtocolTests {
             ("manifest.json", manifest),
             ("VECTMAP/\(mapID)/+0000+0000/1.fmb", Data("map-block".utf8)),
         ]).write(to: packURL)
+
+        let explicitMapID = "marina-bay-rides-deadbeef00"
+        let explicitPackURL = cacheDirectory.appendingPathComponent("\(explicitMapID).zip")
+        let explicitManifest = try! JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "mapId": explicitMapID,
+            "displayName": "COVID-19 Rides",
+            "bounds": [103.80, 1.25, 103.90, 1.35],
+            "source": [
+                "provider": "geofabrik",
+                "region": "geofabrik-asia-malaysia-singapore-brunei",
+                "name": "Malaysia, Singapore, and Brunei",
+            ],
+        ])
+        try! makeStoredZip(entries: [
+            ("manifest.json", explicitManifest),
+            ("VECTMAP/\(explicitMapID)/+0000+0000/1.fmb", Data("map-block".utf8)),
+        ]).write(to: explicitPackURL)
+
+        let prefixedUserMapID = "custom-map-aabbccddee"
+        let prefixedUserPackURL = cacheDirectory
+            .appendingPathComponent("\(prefixedUserMapID).zip")
+        let prefixedUserManifest = try! JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "mapId": prefixedUserMapID,
+            "displayName": prefixedUserMapID,
+            "bounds": [120.90, 30.70, 121.95, 31.55],
+            "source": ["name": "China"],
+        ])
+        try! makeStoredZip(entries: [
+            ("manifest.json", prefixedUserManifest),
+            ("VECTMAP/\(prefixedUserMapID)/+0000+0000/1.fmb", Data("map-block".utf8)),
+        ]).write(to: prefixedUserPackURL)
+
+        let streamMapID = "custom-map-cafebabe00"
+        let streamPackURL = cacheDirectory.appendingPathComponent("\(streamMapID).bmap")
+        let streamManifest = try! JSONSerialization.data(withJSONObject: [
+            "schemaVersion": 1,
+            "mapId": streamMapID,
+            "displayName": streamMapID,
+            "boundsE7": [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000],
+            "source": ["name": "Yangtze Delta"],
+        ])
+        try! makePreviewReadableBikeMapStream(manifest: streamManifest)
+            .write(to: streamPackURL)
         defaults.set(
-            [packURL.lastPathComponent: mapID],
+            [
+                packURL.lastPathComponent: mapID,
+                prefixedUserPackURL.lastPathComponent: "custom-map-weekend",
+            ],
             forKey: "offlineMap.packDisplayNames"
         )
 
@@ -4081,8 +4455,30 @@ struct NavigationProtocolTests {
 
         assertEqual(
             manager.displayName(forCachedPack: packURL),
-            "China",
-            "restart repairs an old generated label from Geofabrik manifest metadata"
+            sourceName,
+            "restart repairs an old generated label from manifest source.name"
+        )
+        assertEqual(
+            manager.displayName(forCachedPack: explicitPackURL),
+            "COVID-19 Rides",
+            "an explicit ZIP manifest name outranks and preserves source metadata"
+        )
+        assertEqual(
+            manager.displayName(forCachedPack: prefixedUserPackURL),
+            "custom-map-weekend",
+            "a legacy user label sharing the generated prefix is preserved"
+        )
+        assertEqual(
+            defaults.dictionary(forKey: "offlineMap.packDisplayNames")?[
+                prefixedUserPackURL.lastPathComponent
+            ] as? String,
+            "custom-map-weekend",
+            "repair does not rewrite a legacy user label that only shares the prefix"
+        )
+        assertEqual(
+            manager.displayName(forCachedPack: streamPackURL),
+            "Yangtze Delta",
+            "a BMAP manifest source.name is used through the manager display path"
         )
         assertEqual(
             OfflineMapPackPreviewReader.content(for: packURL)?.bounds,
@@ -4529,31 +4925,7 @@ struct NavigationProtocolTests {
             preview,
             "stream manifests expose their inline signed boundary preview"
         )
-        var stream = Data("BIKEMAP1".utf8)
-        func appendUInt16LE(_ value: UInt16) {
-            stream.append(UInt8(value & 0xff))
-            stream.append(UInt8(value >> 8))
-        }
-        func appendUInt32LE(_ value: UInt32) {
-            for shift in stride(from: 0, through: 24, by: 8) {
-                stream.append(UInt8((value >> UInt32(shift)) & 0xff))
-            }
-        }
-        func appendUInt64LE(_ value: UInt64) {
-            for shift in stride(from: 0, through: 56, by: 8) {
-                stream.append(UInt8((value >> UInt64(shift)) & 0xff))
-            }
-        }
-        appendUInt16LE(1)
-        appendUInt16LE(0)
-        appendUInt32LE(UInt32(manifest.count))
-        appendUInt16LE(5)
-        appendUInt16LE(0)
-        appendUInt32LE(1)
-        appendUInt64LE(1)
-        stream.append(manifest)
-        stream.append(Data(repeating: 0, count: 5))
-        stream.append(0)
+        let stream = makePreviewReadableBikeMapStream(manifest: manifest)
         let streamURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("offline-map-preview-\(UUID().uuidString).bmap")
         try? stream.write(to: streamURL)

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import UIKit
+
+private func fail(_ message: String) -> Never {
+    fputs("FAIL: \(message)\n", stderr)
+    Foundation.exit(1)
+}
+
+private func appendUInt16LE(_ value: UInt16, to data: inout Data) {
+    data.append(UInt8(value & 0xff))
+    data.append(UInt8(value >> 8))
+}
+
+private func appendUInt32LE(_ value: UInt32, to data: inout Data) {
+    data.append(UInt8(value & 0xff))
+    data.append(UInt8((value >> 8) & 0xff))
+    data.append(UInt8((value >> 16) & 0xff))
+    data.append(UInt8((value >> 24) & 0xff))
+}
+
+private func crc32(_ data: Data) -> UInt32 {
+    var crc = UInt32.max
+    for byte in data {
+        var value = (crc ^ UInt32(byte)) & 0xff
+        for _ in 0..<8 {
+            value = value & 1 == 1
+                ? (value >> 1) ^ 0xedb8_8320
+                : value >> 1
+        }
+        crc = (crc >> 8) ^ value
+    }
+    return crc ^ UInt32.max
+}
+
+private func storedZip(entries: [(String, Data)]) -> Data {
+    var zip = Data()
+    for (path, body) in entries {
+        let name = Data(path.utf8)
+        appendUInt32LE(0x0403_4B50, to: &zip)
+        appendUInt16LE(20, to: &zip)
+        appendUInt16LE(0, to: &zip)
+        appendUInt16LE(0, to: &zip)
+        appendUInt16LE(0, to: &zip)
+        appendUInt16LE(0, to: &zip)
+        appendUInt32LE(crc32(body), to: &zip)
+        appendUInt32LE(UInt32(body.count), to: &zip)
+        appendUInt32LE(UInt32(body.count), to: &zip)
+        appendUInt16LE(UInt16(name.count), to: &zip)
+        appendUInt16LE(0, to: &zip)
+        zip.append(name)
+        zip.append(body)
+    }
+    return zip
+}
+
+private func hasVisiblePixel(_ image: UIImage) -> Bool {
+    guard let source = image.cgImage else { return false }
+    let width = source.width
+    let height = source.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    return pixels.withUnsafeMutableBytes { bytes in
+        guard let context = CGContext(
+            data: bytes.baseAddress,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return false
+        }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return stride(from: 3, to: bytes.count, by: 4).contains { bytes[$0] > 0 }
+    }
+}
+
+@main
+struct SavedMapPreviewCatalystTests {
+    @MainActor
+    static func main() async {
+        let suite = "saved-map-preview-catalyst-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suite) else {
+            fail("test defaults should create")
+        }
+        defer { defaults.removePersistentDomain(forName: suite) }
+
+        let cacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("saved-map-preview-catalyst-\(UUID().uuidString)")
+        do {
+            try FileManager.default.createDirectory(
+                at: cacheDirectory,
+                withIntermediateDirectories: true
+            )
+        } catch {
+            fail("test cache should create: \(error)")
+        }
+        defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+
+        let mapID = "custom-map-4dc48b9bcb"
+        let packURL = cacheDirectory.appendingPathComponent("\(mapID).zip")
+        let manifest: Data
+        do {
+            manifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": mapID,
+                "displayName": mapID,
+                "bounds": [120.90, 30.70, 121.95, 31.55],
+                "source": ["name": "Shanghai and Suzhou"],
+            ])
+            try storedZip(entries: [
+                ("manifest.json", manifest),
+                ("VECTMAP/\(mapID)/+0000+0000/1.fmb", Data("map-block".utf8)),
+            ]).write(to: packURL)
+        } catch {
+            fail("preview-less test pack should write: \(error)")
+        }
+        defaults.set(
+            [packURL.lastPathComponent: mapID],
+            forKey: "offlineMap.packDisplayNames"
+        )
+
+        let manager = OfflineMapManager(defaults: defaults, cacheDirectory: cacheDirectory)
+        guard manager.displayName(forCachedPack: packURL) == "Shanghai and Suzhou" else {
+            fail("source.name should repair the generated saved-map title")
+        }
+
+        manager.loadPreviewIfNeeded(forCachedPack: packURL)
+        let deadline = Date().addingTimeInterval(3)
+        while manager.previewImage(forCachedPack: packURL) == nil && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard let image = manager.previewImage(forCachedPack: packURL) else {
+            fail("bounds fallback should publish a preview through OfflineMapManager")
+        }
+        guard image.size == CGSize(width: 160, height: 96) else {
+            fail("bounds fallback should publish the expected 160x96 image")
+        }
+        guard hasVisiblePixel(image) else {
+            fail("bounds fallback should contain visible rendered pixels")
+        }
+
+        print("SavedMapPreviewCatalystTests passed")
+    }
+}

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -48,3 +48,32 @@ xcrun swiftc \
   ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
 
 "${CATALYST_OUT}"
+
+PREVIEW_CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-saved-map-preview-tests"
+
+xcrun swiftc \
+  -D HOST_TESTING \
+  -parse-as-library \
+  -target "$(uname -m)-apple-ios15.0-macabi" \
+  -sdk "${MACOS_SDK}" \
+  -F "${IOS_SUPPORT}/System/Library/Frameworks" \
+  -I "${IOS_SUPPORT}/usr/lib/swift" \
+  -L "${IOS_SUPPORT}/usr/lib/swift" \
+  -o "${PREVIEW_CATALYST_OUT}" \
+  ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift \
+  ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
+  ios-app/BikeComputer/BikeComputer/Models/BikeMapStreamFormat.swift \
+  ios-app/BikeComputer/BikeComputer/Models/BikeMapStreamProductionTrust.generated.swift \
+  ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift \
+  ios-app/BikeComputer/BikeComputer/Models/OfflineMapServiceConfig.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/DeviceCapabilityRetry.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
+  ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+
+"${PREVIEW_CATALYST_OUT}"


### PR DESCRIPTION
## Summary

- derive unnamed map-pack titles from the resolved Geofabrik/source area instead of generated `custom-map-*` identifiers
- repair generic labels for previously downloaded maps while preserving explicit user names
- render a local bounds-based thumbnail when an older ZIP/BMAP artifact has no embedded preview
- include the resolved source name in manifests and keep map reuse identifiers consistent

## Why

Newly downloaded map packs could arrive without an embedded preview image, so the iOS saved-maps list fell back to the generic map icon. The same flow also persisted the backend's generated artifact identifier as the visible map title when no explicit name was supplied.

## Impact

Fresh downloads now use the best source-area name available and show a thumbnail even when the artifact only contains geographic bounds. Existing user-defined names remain unchanged.

## Validation

- backend unit suite: 152 tests passed, 1 skipped
- Swift navigation/helper tests passed
- Catalyst layout tests passed
- generic unsigned iPhoneOS build succeeded
- signed build for the connected iPhone succeeded
