### PR TITLE
Prepare iOS build 3 for App Store

### DIFF
--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				Info.plist,
+				Info.plist.template,
 			);
 			target = 83E6EF962EED853C00AE5F9B /* BikeComputer */;
 		};
@@ -289,7 +290,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -332,7 +333,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
+				CURRENT_PROJECT_VERSION = 3;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;

--- a/ios-app/BikeComputer/BikeComputer/Info.plist
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist
@@ -2,6 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>
@@ -43,10 +46,6 @@
 		<key>Navigation</key>
 		<string>BikeComputer needs precise location for accurate turn-by-turn navigation.</string>
 	</dict>
-	
-	<!-- Required Background Fetch -->
-	<key>UIApplicationExitsOnSuspend</key>
-	<false/>
 	
 	<!-- Supported Interface Orientations -->
 	<key>UISupportedInterfaceOrientations</key>

--- a/ios-app/BikeComputer/BikeComputer/Info.plist.template
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist.template
@@ -2,6 +2,9 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
+
 	<!-- 
 	Info.plist Configuration Template for BikeComputer
 	
@@ -47,10 +50,6 @@
 		<key>Navigation</key>
 		<string>BikeComputer needs precise location for accurate turn-by-turn navigation.</string>
 	</dict>
-	
-	<!-- Required Background Fetch -->
-	<key>UIApplicationExitsOnSuspend</key>
-	<false/>
 	
 	<!-- Supported Interface Orientations -->
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
## What changed

- bump the iOS build number to 3
- declare non-exempt encryption as false in both plist sources
- remove the obsolete exits-on-suspend key
- exclude `Info.plist.template` from app resources

## Why

The App Store build needs a new build number and the same bundle-cleanliness fixes that made build 2 valid. Without the synchronized-group exception, the plist template can be copied into the app bundle; without the encryption declaration, App Store Connect requires manual export-compliance answers.

## Validation

- `plutil -lint` on both plist files
- `./ios-app/scripts/run-navigation-tests.sh`
- Release generic-device build with store validation (`** BUILD SUCCEEDED **`)
- verified version 1.0, build 3, `ITSAppUsesNonExemptEncryption=false`, and no bundled `Info.plist.template`
- physical iPhone install and launch confirmed through Xcode result logs
