### PR TITLE
Enable map reuse without signed streaming

### DIFF
--- a/backend/map_platform/cli.py
+++ b/backend/map_platform/cli.py
@@ -20,6 +20,28 @@ from .sources import SourceIndex
 from .worker import MapWorker, cleanup_work_dirs, expire_ready_jobs
 
 
+def _pipeline_producer_identity(
+    repo_root: Path,
+    worker_image_reference: str,
+    *,
+    required: bool,
+) -> tuple[str | None, str | None]:
+    """Load the fail-closed worker identity used by streams and pack reuse."""
+    try:
+        producer_image_digest = image_digest_from_reference(
+            worker_image_reference
+        )
+        build_identity = verify_map_stream_build_identity(
+            repo_root / "config" / "map-stream-build-identity.json",
+            repo_root,
+        )
+    except (OSError, ValueError):
+        if required:
+            raise
+        return None, None
+    return build_identity.producer_build_sha256, producer_image_digest
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Offline map platform operations")
     parser.add_argument("--repo-root", default=os.environ.get("MAP_PLATFORM_REPO_ROOT", Path(__file__).resolve().parents[2]))
@@ -104,18 +126,12 @@ def main() -> int:
             "MAP_PLATFORM_WORKER_IMAGE_REFERENCE",
             "",
         ).strip()
-        producer_image_digest = (
-            image_digest_from_reference(worker_image_reference)
-            if map_signer is not None
-            else None
-        )
-        build_identity = (
-            verify_map_stream_build_identity(
-                repo_root / "config" / "map-stream-build-identity.json",
+        producer_build_sha256, producer_image_digest = (
+            _pipeline_producer_identity(
                 repo_root,
+                worker_image_reference,
+                required=map_signer is not None,
             )
-            if map_signer is not None
-            else None
         )
         return MapBuildPipeline(
             PipelinePaths(
@@ -126,9 +142,7 @@ def main() -> int:
             source_cache=source_cache,
             artifact_store=create_artifact_store_from_environment(data_root),
             map_signer=map_signer,
-            producer_build_sha256=(
-                build_identity.producer_build_sha256 if build_identity else None
-            ),
+            producer_build_sha256=producer_build_sha256,
             producer_image_digest=producer_image_digest,
             source_preview_geometry_resolver=(
                 source_provider.preview_geometry_for_source

--- a/backend/tests/test_cli.py
+++ b/backend/tests/test_cli.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from map_platform.cli import _pipeline_producer_identity
+from map_platform.map_stream_build_identity import MapStreamBuildIdentity
+
+
+class PipelineProducerIdentityTests(unittest.TestCase):
+    @patch("map_platform.cli.verify_map_stream_build_identity")
+    @patch("map_platform.cli.image_digest_from_reference")
+    def test_loads_identity_when_map_stream_signing_is_disabled(
+        self,
+        image_digest_from_reference,
+        verify_map_stream_build_identity,
+    ):
+        image_digest_from_reference.return_value = "sha256:" + "2" * 64
+        verify_map_stream_build_identity.return_value = MapStreamBuildIdentity(
+            producer_build_sha256="1" * 64
+        )
+
+        result = _pipeline_producer_identity(
+            Path("/app"),
+            "registry.example/map@sha256:" + "2" * 64,
+            required=False,
+        )
+
+        self.assertEqual(result, ("1" * 64, "sha256:" + "2" * 64))
+        verify_map_stream_build_identity.assert_called_once_with(
+            Path("/app/config/map-stream-build-identity.json"),
+            Path("/app"),
+        )
+
+    @patch("map_platform.cli.image_digest_from_reference")
+    def test_optional_identity_fails_closed_without_blocking_builds(
+        self,
+        image_digest_from_reference,
+    ):
+        image_digest_from_reference.side_effect = ValueError("not pinned")
+
+        self.assertEqual(
+            _pipeline_producer_identity(
+                Path("/app"),
+                "open-bike-map-platform:local",
+                required=False,
+            ),
+            (None, None),
+        )
+
+    @patch("map_platform.cli.image_digest_from_reference")
+    def test_signed_streams_still_require_a_valid_identity(
+        self,
+        image_digest_from_reference,
+    ):
+        image_digest_from_reference.side_effect = ValueError("not pinned")
+
+        with self.assertRaisesRegex(ValueError, "not pinned"):
+            _pipeline_producer_identity(
+                Path("/app"),
+                "open-bike-map-platform:local",
+                required=True,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- load the immutable worker identity even when signed map-stream generation is disabled
- keep invalid optional identities fail-closed so normal local builds still work
- add regression tests for optional and required identity behavior

## Production evidence
A live exact and contained-subset acceptance run fell back to full builds because `create_pipeline()` only supplied reuse identity when a map signer was active. Production intentionally has signed stream generation disabled, so this patch removes that unrelated coupling.

## Verification
- `PYTHONPATH=backend /tmp/open-bike-mapfix-venv/bin/python -m unittest backend.tests.test_cli backend.tests.test_reuse` (9 tests)
- `PYTHONPATH=backend /tmp/open-bike-mapfix-venv/bin/python -m unittest discover -s backend/tests -p "test_*.py"` (152 tests)