### PR TITLE
Show saved map snapshots for selected areas

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -1055,6 +1055,11 @@ nonisolated enum SavedMapArtifactMetadataStore {
     }
 }
 
+typealias SavedMapArtifactMetadataSaveOperation = @MainActor (
+    SavedMapArtifactMetadata,
+    URL
+) throws -> Void
+
 nonisolated enum SavedMapStreamMigrationFallback {
     static func shouldUseLegacyArtifact(
         for metadata: SavedMapArtifactMetadata
@@ -1266,6 +1271,7 @@ final class OfflineMapManager: ObservableObject {
     private let packDownload: PackDownloadOperation
     private let previewLoad: OfflineMapPreviewLoadOperation
     private let mapSnapshot: OfflineMapSnapshotOperation
+    private let metadataSave: SavedMapArtifactMetadataSaveOperation
     private let cacheDirectoryOverride: URL?
     private let installationCredentialStore: OfflineMapInstallationCredentialStore
     private let mapStreamTrustStore: BikeMapStreamTrustStore
@@ -1315,6 +1321,9 @@ final class OfflineMapManager: ObservableObject {
         },
         mapSnapshot: @escaping OfflineMapSnapshotOperation = { bounds in
             try await OfflineMapSnapshotPreviewRenderer.pngData(for: bounds)
+        },
+        metadataSave: @escaping SavedMapArtifactMetadataSaveOperation = { metadata, url in
+            try SavedMapArtifactMetadataStore.save(metadata, for: url)
         }
     ) {
         OfflineMapPackCompatibilityArchive.removeOrphans()
@@ -1323,6 +1332,7 @@ final class OfflineMapManager: ObservableObject {
         self.packDownload = packDownload
         self.previewLoad = previewLoad
         self.mapSnapshot = mapSnapshot
+        self.metadataSave = metadataSave
         self.cacheDirectoryOverride = cacheDirectory
         self.installationCredentialStore = OfflineMapInstallationCredentialStore(defaults: defaults)
         self.mapStreamTrustStore = mapStreamTrustStore
@@ -2542,48 +2552,18 @@ final class OfflineMapManager: ObservableObject {
             userDefinedDisplayName: userDefinedDisplayName,
             downloadReceiptID: downloadReceiptID
         )
-        let backup = destination
-            .deletingLastPathComponent()
-            .appendingPathComponent(".\(destination.lastPathComponent).\(UUID().uuidString).backup")
-        let metadataURL = SavedMapArtifactMetadataStore.metadataURL(for: destination)
-        let metadataBackup = SavedMapArtifactMetadataStore.metadataURL(for: backup)
-        var backedUpArtifact = false
-        var backedUpMetadata = false
         do {
-            if FileManager.default.fileExists(atPath: destination.path) {
-                try FileManager.default.moveItem(at: destination, to: backup)
-                backedUpArtifact = true
-            }
-            if FileManager.default.fileExists(atPath: metadataURL.path) {
-                try FileManager.default.moveItem(at: metadataURL, to: metadataBackup)
-                backedUpMetadata = true
-            }
-            try FileManager.default.moveItem(at: temporaryURL, to: destination)
-            try SavedMapArtifactMetadataStore.save(metadata, for: destination)
-            let obsoleteExtension = fileExtension == "bmap" ? "zip" : "bmap"
-            let obsolete = try cachedPackURL(mapId: mapId, fileExtension: obsoleteExtension)
-            if FileManager.default.fileExists(atPath: obsolete.path) {
-                try? FileManager.default.removeItem(at: obsolete)
-                try? SavedMapArtifactMetadataStore.delete(for: obsolete)
-                packDisplayNames.removeValue(forKey: obsolete.lastPathComponent)
-                invalidateCachedPreview(for: obsolete)
-            }
-            if backedUpArtifact { try? FileManager.default.removeItem(at: backup) }
-            if backedUpMetadata { try? FileManager.default.removeItem(at: metadataBackup) }
+            try replaceDownloadedArtifact(
+                at: temporaryURL,
+                destination: destination,
+                metadata: metadata,
+                mapID: mapId,
+                fileExtension: fileExtension
+            )
         } catch {
-            try? FileManager.default.removeItem(at: temporaryURL)
-            try? FileManager.default.removeItem(at: destination)
-            try? SavedMapArtifactMetadataStore.delete(for: destination)
-            if backedUpArtifact {
-                try? FileManager.default.moveItem(at: backup, to: destination)
-            }
-            if backedUpMetadata {
-                try? FileManager.default.moveItem(at: metadataBackup, to: metadataURL)
-            }
             downloadURL = nil
             throw error
         }
-        invalidateCachedPreview(for: destination)
         downloadedPackURL = destination
         OfflineMapJobPersistence.markPackDownloaded(
             jobId: job.jobId,
@@ -2619,6 +2599,59 @@ final class OfflineMapManager: ObservableObject {
         downloadByteProgress = nil
         transferProgress = 0
         statusMessage = "map downloaded"
+    }
+
+    func replaceDownloadedArtifact(
+        at temporaryURL: URL,
+        destination: URL,
+        metadata: SavedMapArtifactMetadata,
+        mapID: String,
+        fileExtension: String
+    ) throws {
+        defer { invalidateCachedPreview(for: destination) }
+        let backup = destination
+            .deletingLastPathComponent()
+            .appendingPathComponent(".\(destination.lastPathComponent).\(UUID().uuidString).backup")
+        let metadataURL = SavedMapArtifactMetadataStore.metadataURL(for: destination)
+        let metadataBackup = SavedMapArtifactMetadataStore.metadataURL(for: backup)
+        var backedUpArtifact = false
+        var backedUpMetadata = false
+        do {
+            if FileManager.default.fileExists(atPath: destination.path) {
+                try FileManager.default.moveItem(at: destination, to: backup)
+                backedUpArtifact = true
+            }
+            if FileManager.default.fileExists(atPath: metadataURL.path) {
+                try FileManager.default.moveItem(at: metadataURL, to: metadataBackup)
+                backedUpMetadata = true
+            }
+            try FileManager.default.moveItem(at: temporaryURL, to: destination)
+            try metadataSave(metadata, destination)
+            let obsoleteExtension = fileExtension == "bmap" ? "zip" : "bmap"
+            let obsolete = try cachedPackURL(
+                mapId: mapID,
+                fileExtension: obsoleteExtension
+            )
+            if FileManager.default.fileExists(atPath: obsolete.path) {
+                try? FileManager.default.removeItem(at: obsolete)
+                try? SavedMapArtifactMetadataStore.delete(for: obsolete)
+                packDisplayNames.removeValue(forKey: obsolete.lastPathComponent)
+                invalidateCachedPreview(for: obsolete)
+            }
+            if backedUpArtifact { try? FileManager.default.removeItem(at: backup) }
+            if backedUpMetadata { try? FileManager.default.removeItem(at: metadataBackup) }
+        } catch {
+            try? FileManager.default.removeItem(at: temporaryURL)
+            try? FileManager.default.removeItem(at: destination)
+            try? SavedMapArtifactMetadataStore.delete(for: destination)
+            if backedUpArtifact {
+                try? FileManager.default.moveItem(at: backup, to: destination)
+            }
+            if backedUpMetadata {
+                try? FileManager.default.moveItem(at: metadataBackup, to: metadataURL)
+            }
+            throw error
+        }
     }
 
     private func finishRecoveredJob(

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -236,6 +236,15 @@ typealias OfflineMapSnapshotOperation = @MainActor (
     OfflineMapPreviewBounds
 ) async throws -> Data?
 
+nonisolated struct OfflineMapPreviewLoadResult: Sendable {
+    let snapshotData: Data?
+    let packContent: OfflineMapPackPreviewContent?
+}
+
+typealias OfflineMapPreviewLoadOperation = @MainActor (
+    URL
+) async -> OfflineMapPreviewLoadResult
+
 #if canImport(UIKit)
 nonisolated enum SavedMapSnapshotPreviewStore {
     static let maximumImageBytes = 1_048_576
@@ -1255,6 +1264,7 @@ final class OfflineMapManager: ObservableObject {
     private let defaults: UserDefaults
     private let mapPlatformSession: URLSession
     private let packDownload: PackDownloadOperation
+    private let previewLoad: OfflineMapPreviewLoadOperation
     private let mapSnapshot: OfflineMapSnapshotOperation
     private let cacheDirectoryOverride: URL?
     private let installationCredentialStore: OfflineMapInstallationCredentialStore
@@ -1290,6 +1300,19 @@ final class OfflineMapManager: ObservableObject {
                 onByteProgress: onByteProgress
             )
         },
+        previewLoad: @escaping OfflineMapPreviewLoadOperation = { packURL in
+            await Task.detached(priority: .utility) {
+#if canImport(UIKit)
+                let snapshotData = SavedMapSnapshotPreviewStore.imageData(for: packURL)
+#else
+                let snapshotData: Data? = nil
+#endif
+                return OfflineMapPreviewLoadResult(
+                    snapshotData: snapshotData,
+                    packContent: OfflineMapPackPreviewReader.content(for: packURL)
+                )
+            }.value
+        },
         mapSnapshot: @escaping OfflineMapSnapshotOperation = { bounds in
             try await OfflineMapSnapshotPreviewRenderer.pngData(for: bounds)
         }
@@ -1298,6 +1321,7 @@ final class OfflineMapManager: ObservableObject {
         self.defaults = defaults
         self.mapPlatformSession = mapPlatformSession
         self.packDownload = packDownload
+        self.previewLoad = previewLoad
         self.mapSnapshot = mapSnapshot
         self.cacheDirectoryOverride = cacheDirectory
         self.installationCredentialStore = OfflineMapInstallationCredentialStore(defaults: defaults)
@@ -1674,13 +1698,9 @@ final class OfflineMapManager: ObservableObject {
             return
         }
         let token = previewLoadRegistry.begin(for: key)
+        let previewLoad = self.previewLoad
         previewLoadTasks[key] = Task { [weak self] in
-            let loaded = await Task.detached(priority: .utility) {
-                (
-                    snapshotData: SavedMapSnapshotPreviewStore.imageData(for: packURL),
-                    packContent: OfflineMapPackPreviewReader.content(for: packURL)
-                )
-            }.value
+            let loaded = await previewLoad(packURL)
             guard let self else { return }
             if let image = self.usableSnapshotImage(from: loaded.snapshotData) {
                 guard self.previewLoadRegistry.finishIfCurrent(token, for: key) else {
@@ -1696,16 +1716,15 @@ final class OfflineMapManager: ObservableObject {
                 self.packPreviewImages[key] = image
                 return
             }
-            if loaded.snapshotData != nil {
-                try? SavedMapSnapshotPreviewStore.delete(for: packURL)
-            }
-
             guard self.previewLoadRegistry.isCurrent(token, for: key),
                   !Task.isCancelled,
                   self.cachedPackURLs.contains(where: {
                       self.previewCacheKey(for: $0) == key
                   }) else {
                 return
+            }
+            if loaded.snapshotData != nil {
+                try? SavedMapSnapshotPreviewStore.delete(for: packURL)
             }
             var publishedFallback = false
             if let image = self.usablePreviewImage(from: loaded.packContent?.imageData) {

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -46,8 +46,44 @@ private enum OfflineMapDefaults {
 
 @MainActor
 enum OfflineMapSnapshotPreviewRenderer {
+#if canImport(UIKit) && canImport(MapKit)
+    struct Request {
+        let options: MKMapSnapshotter.Options
+        let northWestCoordinate: CLLocationCoordinate2D
+        let southEastCoordinate: CLLocationCoordinate2D
+    }
+
+    struct SnapshotResult {
+        let image: UIImage
+        let pointForCoordinate: @MainActor (CLLocationCoordinate2D) -> CGPoint
+    }
+
+    typealias SnapshotOperation = @MainActor (
+        MKMapSnapshotter.Options
+    ) async throws -> SnapshotResult
+#endif
+
     static func pngData(for bounds: OfflineMapPreviewBounds) async throws -> Data? {
 #if canImport(UIKit) && canImport(MapKit)
+        try await pngData(for: bounds) { options in
+            let snapshotter = MKMapSnapshotter(options: options)
+            let snapshot = try await withTaskCancellationHandler {
+                try await snapshotter.start()
+            } onCancel: {
+                snapshotter.cancel()
+            }
+            return SnapshotResult(
+                image: snapshot.image,
+                pointForCoordinate: { snapshot.point(for: $0) }
+            )
+        }
+#else
+        nil
+#endif
+    }
+
+#if canImport(UIKit) && canImport(MapKit)
+    static func request(for bounds: OfflineMapPreviewBounds) -> Request {
         let options = MKMapSnapshotter.Options()
         let northWestCoordinate = CLLocationCoordinate2D(
             latitude: bounds.maxLatitude,
@@ -73,29 +109,79 @@ enum OfflineMapSnapshotPreviewRenderer {
         } else {
             options.mapType = .standard
         }
+        return Request(
+            options: options,
+            northWestCoordinate: northWestCoordinate,
+            southEastCoordinate: southEastCoordinate
+        )
+    }
 
-        let snapshotter = MKMapSnapshotter(options: options)
-        let snapshot = try await withTaskCancellationHandler {
-            try await snapshotter.start()
-        } onCancel: {
-            snapshotter.cancel()
-        }
+    static func pngData(
+        for bounds: OfflineMapPreviewBounds,
+        snapshot: SnapshotOperation
+    ) async throws -> Data? {
+        let request = request(for: bounds)
+        let result = try await snapshot(request.options)
         try Task.checkCancellation()
         guard let croppedImage = croppedImage(
-            from: snapshot.image,
-            northWestPoint: snapshot.point(for: northWestCoordinate),
-            southEastPoint: snapshot.point(for: southEastCoordinate)
-        ) else {
+            from: result.image,
+            request: request,
+            pointForCoordinate: result.pointForCoordinate
+        ), hasMeaningfulVisualVariation(croppedImage) else {
             return nil
         }
         return croppedImage.pngData()
-#else
-        return nil
-#endif
     }
 
-#if canImport(UIKit) && canImport(MapKit)
     static func croppedImage(
+        from image: UIImage,
+        request: Request,
+        pointForCoordinate: @MainActor (CLLocationCoordinate2D) -> CGPoint
+    ) -> UIImage? {
+        croppedImage(
+            from: image,
+            northWestPoint: pointForCoordinate(request.northWestCoordinate),
+            southEastPoint: pointForCoordinate(request.southEastCoordinate)
+        )
+    }
+
+    static func hasMeaningfulVisualVariation(_ image: UIImage) -> Bool {
+        guard let source = image.cgImage else { return false }
+        let width = source.width
+        let height = source.height
+        var pixels = [UInt8](repeating: 0, count: width * height * 4)
+        let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
+            guard let context = CGContext(
+                data: bytes.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: width * 4,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+            ) else {
+                return false
+            }
+            context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard rendered else { return false }
+
+        var minimum = [UInt8](repeating: .max, count: 3)
+        var maximum = [UInt8](repeating: .min, count: 3)
+        for offset in stride(from: 0, to: pixels.count, by: 4)
+            where pixels[offset + 3] >= 128 {
+            for channel in 0..<3 {
+                minimum[channel] = min(minimum[channel], pixels[offset + channel])
+                maximum[channel] = max(maximum[channel], pixels[offset + channel])
+            }
+        }
+        return zip(minimum, maximum).contains { minimum, maximum in
+            Int(maximum) - Int(minimum) >= 8
+        }
+    }
+
+    private static func croppedImage(
         from image: UIImage,
         northWestPoint: CGPoint,
         southEastPoint: CGPoint
@@ -1596,7 +1682,7 @@ final class OfflineMapManager: ObservableObject {
                 )
             }.value
             guard let self else { return }
-            if let image = self.usablePreviewImage(from: loaded.snapshotData) {
+            if let image = self.usableSnapshotImage(from: loaded.snapshotData) {
                 guard self.previewLoadRegistry.finishIfCurrent(token, for: key) else {
                     return
                 }
@@ -1666,7 +1752,7 @@ final class OfflineMapManager: ObservableObject {
                   }) else {
                 return
             }
-            if let image = self.usablePreviewImage(from: generatedSnapshotData),
+            if let image = self.usableSnapshotImage(from: generatedSnapshotData),
                let generatedSnapshotData {
                 try? SavedMapSnapshotPreviewStore.save(
                     generatedSnapshotData,
@@ -1688,6 +1774,14 @@ final class OfflineMapManager: ObservableObject {
               image.size.height > 0,
               image.size.width <= 512,
               image.size.height <= 512 else {
+            return nil
+        }
+        return image
+    }
+
+    private func usableSnapshotImage(from data: Data?) -> UIImage? {
+        guard let image = usablePreviewImage(from: data),
+              OfflineMapSnapshotPreviewRenderer.hasMeaningfulVisualVariation(image) else {
             return nil
         }
         return image

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -82,9 +82,9 @@ enum OfflineMapSnapshotPreviewRenderer {
         }
         try Task.checkCancellation()
         guard let croppedImage = croppedImage(
-            from: snapshot,
-            northWest: northWestCoordinate,
-            southEast: southEastCoordinate
+            from: snapshot.image,
+            northWestPoint: snapshot.point(for: northWestCoordinate),
+            southEastPoint: snapshot.point(for: southEastCoordinate)
         ) else {
             return nil
         }
@@ -95,15 +95,13 @@ enum OfflineMapSnapshotPreviewRenderer {
     }
 
 #if canImport(UIKit) && canImport(MapKit)
-    private static func croppedImage(
-        from snapshot: MKMapSnapshotter.Snapshot,
-        northWest: CLLocationCoordinate2D,
-        southEast: CLLocationCoordinate2D
+    static func croppedImage(
+        from image: UIImage,
+        northWestPoint: CGPoint,
+        southEastPoint: CGPoint
     ) -> UIImage? {
-        guard let source = snapshot.image.cgImage else { return nil }
-        let scale = snapshot.image.scale
-        let northWestPoint = snapshot.point(for: northWest)
-        let southEastPoint = snapshot.point(for: southEast)
+        guard let source = image.cgImage else { return nil }
+        let scale = image.scale
         let minimumX = max(
             0,
             ceil(min(northWestPoint.x, southEastPoint.x) * scale)
@@ -132,7 +130,7 @@ enum OfflineMapSnapshotPreviewRenderer {
         let croppedImage = UIImage(
             cgImage: cropped,
             scale: scale,
-            orientation: snapshot.image.imageOrientation
+            orientation: image.imageOrientation
         )
         let normalizedSize = CGSize(
             width: min(160, max(1, floor(croppedImage.size.width))),

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -11,6 +11,9 @@ import Foundation
 #if canImport(UIKit)
 import UIKit
 #endif
+#if canImport(UIKit) && canImport(MapKit)
+import MapKit
+#endif
 #if os(iOS)
 import Security
 #endif
@@ -41,7 +44,108 @@ private enum OfflineMapDefaults {
     ]
 }
 
+@MainActor
+private enum OfflineMapSnapshotPreviewRenderer {
+    static func pngData(for bounds: OfflineMapPreviewBounds) async throws -> Data? {
+#if canImport(UIKit) && canImport(MapKit)
+        let options = MKMapSnapshotter.Options()
+        let northWest = MKMapPoint(CLLocationCoordinate2D(
+            latitude: bounds.maxLatitude,
+            longitude: bounds.minLongitude
+        ))
+        let southEast = MKMapPoint(CLLocationCoordinate2D(
+            latitude: bounds.minLatitude,
+            longitude: bounds.maxLongitude
+        ))
+        options.mapRect = MKMapRect(
+            x: min(northWest.x, southEast.x),
+            y: min(northWest.y, southEast.y),
+            width: abs(southEast.x - northWest.x),
+            height: abs(southEast.y - northWest.y)
+        )
+        options.size = CGSize(width: 160, height: 96)
+        options.scale = 1
+        options.traitCollection = UITraitCollection(userInterfaceStyle: .light)
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
+            options.preferredConfiguration = MKStandardMapConfiguration(elevationStyle: .flat)
+        } else {
+            options.mapType = .standard
+        }
+
+        let snapshotter = MKMapSnapshotter(options: options)
+        let snapshot = try await withTaskCancellationHandler {
+            try await snapshotter.start()
+        } onCancel: {
+            snapshotter.cancel()
+        }
+        try Task.checkCancellation()
+        return snapshot.image.pngData()
+#else
+        return nil
+#endif
+    }
+}
+
+typealias OfflineMapSnapshotOperation = @MainActor (
+    OfflineMapPreviewBounds
+) async throws -> Data?
+
 #if canImport(UIKit)
+nonisolated enum SavedMapSnapshotPreviewStore {
+    static let maximumImageBytes = 1_048_576
+    private static let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+
+    static func imageURL(for artifactURL: URL) -> URL {
+        artifactURL.appendingPathExtension("thumbnail.png")
+    }
+
+    static func imageData(for artifactURL: URL) -> Data? {
+        let url = imageURL(for: artifactURL)
+        guard let values = try? url.resourceValues(forKeys: [.fileSizeKey, .isRegularFileKey]),
+              values.isRegularFile == true,
+              let fileSize = values.fileSize,
+              (33...maximumImageBytes).contains(fileSize),
+              let data = try? Data(contentsOf: url),
+              isValidPNG(data) else {
+            return nil
+        }
+        return data
+    }
+
+    static func save(_ data: Data, for artifactURL: URL) throws {
+        guard isValidPNG(data) else {
+            throw OfflineMapPlatformError.invalidPack("map snapshot preview is not a valid PNG")
+        }
+        try data.write(to: imageURL(for: artifactURL), options: .atomic)
+    }
+
+    static func delete(for artifactURL: URL) throws {
+        let url = imageURL(for: artifactURL)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    private static func isValidPNG(_ data: Data) -> Bool {
+        guard (33...maximumImageBytes).contains(data.count),
+              data.starts(with: pngSignature),
+              uint32BE(data, at: 8) == 13,
+              data.subdata(in: 12..<16) == Data("IHDR".utf8) else {
+            return false
+        }
+        let width = uint32BE(data, at: 16)
+        let height = uint32BE(data, at: 20)
+        return (1...1_024).contains(width) && (1...1_024).contains(height)
+    }
+
+    private static func uint32BE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset]) << 24 |
+            UInt32(data[offset + 1]) << 16 |
+            UInt32(data[offset + 2]) << 8 |
+            UInt32(data[offset + 3])
+    }
+}
+
 @MainActor
 private enum OfflineMapFallbackPreviewRenderer {
     private static let size = CGSize(width: 160, height: 96)
@@ -786,6 +890,9 @@ nonisolated enum SavedMapArtifactMetadataStore {
         if FileManager.default.fileExists(atPath: url.path) {
             try FileManager.default.removeItem(at: url)
         }
+#if canImport(UIKit)
+        try SavedMapSnapshotPreviewStore.delete(for: artifactURL)
+#endif
     }
 }
 
@@ -998,6 +1105,7 @@ final class OfflineMapManager: ObservableObject {
     private let defaults: UserDefaults
     private let mapPlatformSession: URLSession
     private let packDownload: PackDownloadOperation
+    private let mapSnapshot: OfflineMapSnapshotOperation
     private let cacheDirectoryOverride: URL?
     private let installationCredentialStore: OfflineMapInstallationCredentialStore
     private let mapStreamTrustStore: BikeMapStreamTrustStore
@@ -1031,12 +1139,16 @@ final class OfflineMapManager: ObservableObject {
                 onProgress: onProgress,
                 onByteProgress: onByteProgress
             )
+        },
+        mapSnapshot: @escaping OfflineMapSnapshotOperation = { bounds in
+            try await OfflineMapSnapshotPreviewRenderer.pngData(for: bounds)
         }
     ) {
         OfflineMapPackCompatibilityArchive.removeOrphans()
         self.defaults = defaults
         self.mapPlatformSession = mapPlatformSession
         self.packDownload = packDownload
+        self.mapSnapshot = mapSnapshot
         self.cacheDirectoryOverride = cacheDirectory
         self.installationCredentialStore = OfflineMapInstallationCredentialStore(defaults: defaults)
         self.mapStreamTrustStore = mapStreamTrustStore
@@ -1413,10 +1525,45 @@ final class OfflineMapManager: ObservableObject {
         }
         let token = previewLoadRegistry.begin(for: key)
         previewLoadTasks[key] = Task { [weak self] in
-            let preview = await Task.detached(priority: .utility) {
-                OfflineMapPackPreviewReader.content(for: packURL)
+            let loaded = await Task.detached(priority: .utility) {
+                (
+                    snapshotData: SavedMapSnapshotPreviewStore.imageData(for: packURL),
+                    packContent: OfflineMapPackPreviewReader.content(for: packURL)
+                )
             }.value
             guard let self else { return }
+            if let image = self.usablePreviewImage(from: loaded.snapshotData) {
+                guard self.previewLoadRegistry.finishIfCurrent(token, for: key) else {
+                    return
+                }
+                self.previewLoadTasks.removeValue(forKey: key)
+                guard !Task.isCancelled,
+                      self.cachedPackURLs.contains(where: {
+                          self.previewCacheKey(for: $0) == key
+                      }) else {
+                    return
+                }
+                self.packPreviewImages[key] = image
+                return
+            }
+            if loaded.snapshotData != nil {
+                try? SavedMapSnapshotPreviewStore.delete(for: packURL)
+            }
+
+            var generatedSnapshotData: Data?
+            if let bounds = loaded.packContent?.bounds {
+                do {
+                    generatedSnapshotData = try await self.mapSnapshot(bounds)
+                } catch is CancellationError {
+                    if self.previewLoadRegistry.finishIfCurrent(token, for: key) {
+                        self.previewLoadTasks.removeValue(forKey: key)
+                    }
+                    return
+                } catch {
+                    generatedSnapshotData = nil
+                }
+            }
+
             guard self.previewLoadRegistry.finishIfCurrent(
                 token,
                 for: key
@@ -1428,16 +1575,20 @@ final class OfflineMapManager: ObservableObject {
                   }) else {
                 return
             }
-            if let data = preview?.imageData,
-               let image = UIImage(data: data),
-               image.size.width > 0,
-               image.size.height > 0,
-               image.size.width <= 512,
-               image.size.height <= 512 {
+            if let image = self.usablePreviewImage(from: generatedSnapshotData),
+               let generatedSnapshotData {
+                try? SavedMapSnapshotPreviewStore.save(
+                    generatedSnapshotData,
+                    for: packURL
+                )
                 self.packPreviewImages[key] = image
                 return
             }
-            if let bounds = preview?.bounds {
+            if let image = self.usablePreviewImage(from: loaded.packContent?.imageData) {
+                self.packPreviewImages[key] = image
+                return
+            }
+            if let bounds = loaded.packContent?.bounds {
                 self.packPreviewImages[key] = OfflineMapFallbackPreviewRenderer.image(
                     for: bounds
                 )
@@ -1445,6 +1596,18 @@ final class OfflineMapManager: ObservableObject {
             }
             self.unavailablePackPreviews.insert(key)
         }
+    }
+
+    private func usablePreviewImage(from data: Data?) -> UIImage? {
+        guard let data,
+              let image = UIImage(data: data),
+              image.size.width > 0,
+              image.size.height > 0,
+              image.size.width <= 512,
+              image.size.height <= 512 else {
+            return nil
+        }
+        return image
     }
 #endif
 
@@ -3719,6 +3882,7 @@ final class OfflineMapManager: ObservableObject {
         previewLoadTasks.removeValue(forKey: key)?.cancel()
         packPreviewImages.removeValue(forKey: key)
         unavailablePackPreviews.remove(key)
+        try? SavedMapSnapshotPreviewStore.delete(for: packURL)
     }
 #else
     private func invalidateCachedPreview(for packURL: URL) {}

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -45,18 +45,20 @@ private enum OfflineMapDefaults {
 }
 
 @MainActor
-private enum OfflineMapSnapshotPreviewRenderer {
+enum OfflineMapSnapshotPreviewRenderer {
     static func pngData(for bounds: OfflineMapPreviewBounds) async throws -> Data? {
 #if canImport(UIKit) && canImport(MapKit)
         let options = MKMapSnapshotter.Options()
-        let northWest = MKMapPoint(CLLocationCoordinate2D(
+        let northWestCoordinate = CLLocationCoordinate2D(
             latitude: bounds.maxLatitude,
             longitude: bounds.minLongitude
-        ))
-        let southEast = MKMapPoint(CLLocationCoordinate2D(
+        )
+        let southEastCoordinate = CLLocationCoordinate2D(
             latitude: bounds.minLatitude,
             longitude: bounds.maxLongitude
-        ))
+        )
+        let northWest = MKMapPoint(northWestCoordinate)
+        let southEast = MKMapPoint(southEastCoordinate)
         options.mapRect = MKMapRect(
             x: min(northWest.x, southEast.x),
             y: min(northWest.y, southEast.y),
@@ -79,11 +81,71 @@ private enum OfflineMapSnapshotPreviewRenderer {
             snapshotter.cancel()
         }
         try Task.checkCancellation()
-        return snapshot.image.pngData()
+        guard let croppedImage = croppedImage(
+            from: snapshot,
+            northWest: northWestCoordinate,
+            southEast: southEastCoordinate
+        ) else {
+            return nil
+        }
+        return croppedImage.pngData()
 #else
         return nil
 #endif
     }
+
+#if canImport(UIKit) && canImport(MapKit)
+    private static func croppedImage(
+        from snapshot: MKMapSnapshotter.Snapshot,
+        northWest: CLLocationCoordinate2D,
+        southEast: CLLocationCoordinate2D
+    ) -> UIImage? {
+        guard let source = snapshot.image.cgImage else { return nil }
+        let scale = snapshot.image.scale
+        let northWestPoint = snapshot.point(for: northWest)
+        let southEastPoint = snapshot.point(for: southEast)
+        let minimumX = max(
+            0,
+            ceil(min(northWestPoint.x, southEastPoint.x) * scale)
+        )
+        let minimumY = max(
+            0,
+            ceil(min(northWestPoint.y, southEastPoint.y) * scale)
+        )
+        let maximumX = min(
+            CGFloat(source.width),
+            floor(max(northWestPoint.x, southEastPoint.x) * scale)
+        )
+        let maximumY = min(
+            CGFloat(source.height),
+            floor(max(northWestPoint.y, southEastPoint.y) * scale)
+        )
+        guard maximumX > minimumX, maximumY > minimumY,
+              let cropped = source.cropping(to: CGRect(
+                  x: minimumX,
+                  y: minimumY,
+                  width: maximumX - minimumX,
+                  height: maximumY - minimumY
+              )) else {
+            return nil
+        }
+        let croppedImage = UIImage(
+            cgImage: cropped,
+            scale: scale,
+            orientation: snapshot.image.imageOrientation
+        )
+        let normalizedSize = CGSize(
+            width: min(160, max(1, floor(croppedImage.size.width))),
+            height: min(96, max(1, floor(croppedImage.size.height)))
+        )
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        return UIGraphicsImageRenderer(size: normalizedSize, format: format).image { _ in
+            croppedImage.draw(in: CGRect(origin: .zero, size: normalizedSize))
+        }
+    }
+#endif
 }
 
 typealias OfflineMapSnapshotOperation = @MainActor (
@@ -417,6 +479,10 @@ final class OfflineMapPreviewLoadRegistry {
         guard tokens[key] == token else { return false }
         tokens.removeValue(forKey: key)
         return true
+    }
+
+    func isCurrent(_ token: UUID, for key: String) -> Bool {
+        tokens[key] == token
     }
 
     func invalidate(_ key: String) {
@@ -1550,18 +1616,45 @@ final class OfflineMapManager: ObservableObject {
                 try? SavedMapSnapshotPreviewStore.delete(for: packURL)
             }
 
-            var generatedSnapshotData: Data?
-            if let bounds = loaded.packContent?.bounds {
-                do {
-                    generatedSnapshotData = try await self.mapSnapshot(bounds)
-                } catch is CancellationError {
-                    if self.previewLoadRegistry.finishIfCurrent(token, for: key) {
-                        self.previewLoadTasks.removeValue(forKey: key)
-                    }
+            guard self.previewLoadRegistry.isCurrent(token, for: key),
+                  !Task.isCancelled,
+                  self.cachedPackURLs.contains(where: {
+                      self.previewCacheKey(for: $0) == key
+                  }) else {
+                return
+            }
+            var publishedFallback = false
+            if let image = self.usablePreviewImage(from: loaded.packContent?.imageData) {
+                self.packPreviewImages[key] = image
+                publishedFallback = true
+            } else if let bounds = loaded.packContent?.bounds {
+                self.packPreviewImages[key] = OfflineMapFallbackPreviewRenderer.image(
+                    for: bounds
+                )
+                publishedFallback = true
+            }
+
+            guard let bounds = loaded.packContent?.bounds else {
+                guard self.previewLoadRegistry.finishIfCurrent(token, for: key) else {
                     return
-                } catch {
-                    generatedSnapshotData = nil
                 }
+                self.previewLoadTasks.removeValue(forKey: key)
+                if !publishedFallback {
+                    self.unavailablePackPreviews.insert(key)
+                }
+                return
+            }
+
+            let generatedSnapshotData: Data?
+            do {
+                generatedSnapshotData = try await self.mapSnapshot(bounds)
+            } catch is CancellationError {
+                if self.previewLoadRegistry.finishIfCurrent(token, for: key) {
+                    self.previewLoadTasks.removeValue(forKey: key)
+                }
+                return
+            } catch {
+                generatedSnapshotData = nil
             }
 
             guard self.previewLoadRegistry.finishIfCurrent(
@@ -1584,17 +1677,9 @@ final class OfflineMapManager: ObservableObject {
                 self.packPreviewImages[key] = image
                 return
             }
-            if let image = self.usablePreviewImage(from: loaded.packContent?.imageData) {
-                self.packPreviewImages[key] = image
-                return
+            if !publishedFallback {
+                self.unavailablePackPreviews.insert(key)
             }
-            if let bounds = loaded.packContent?.bounds {
-                self.packPreviewImages[key] = OfflineMapFallbackPreviewRenderer.image(
-                    for: bounds
-                )
-                return
-            }
-            self.unavailablePackPreviews.insert(key)
         }
     }
 

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -146,6 +146,27 @@ private func cropFixtureImage() -> UIImage {
     }
 }
 
+private func variedSnapshotPNG() -> Data {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    format.opaque = true
+    let image = UIGraphicsImageRenderer(
+        size: CGSize(width: 160, height: 96),
+        format: format
+    ).image { context in
+        UIColor(red: 0.88, green: 0.86, blue: 0.75, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 0, y: 0, width: 160, height: 96))
+        UIColor(red: 0.28, green: 0.66, blue: 0.78, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 70, y: 0, width: 18, height: 96))
+        UIColor(red: 0.45, green: 0.43, blue: 0.40, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 0, y: 38, width: 160, height: 7))
+    }
+    guard let data = image.pngData() else {
+        fail("varied test snapshot should encode as PNG")
+    }
+    return data
+}
+
 private func pixel(
     in image: UIImage,
     x: Int,
@@ -166,38 +187,19 @@ private func pixel(
     )
 }
 
-private func hasMeaningfulVisualVariation(_ image: UIImage) -> Bool {
-    guard let source = image.cgImage,
-          let pixels = rgbaPixels(image) else {
-        return false
-    }
-    let pixelCount = source.width * source.height
-    let sampleStride = max(1, pixelCount / 4_096)
-    var quantizedColors = Set<UInt32>()
-    var minimum = [UInt8](repeating: .max, count: 3)
-    var maximum = [UInt8](repeating: .min, count: 3)
-    for index in stride(from: 0, to: pixelCount, by: sampleStride) {
-        let offset = index * 4
-        guard pixels[offset + 3] >= 128 else { continue }
-        let red = pixels[offset]
-        let green = pixels[offset + 1]
-        let blue = pixels[offset + 2]
-        minimum[0] = min(minimum[0], red)
-        minimum[1] = min(minimum[1], green)
-        minimum[2] = min(minimum[2], blue)
-        maximum[0] = max(maximum[0], red)
-        maximum[1] = max(maximum[1], green)
-        maximum[2] = max(maximum[2], blue)
-        quantizedColors.insert(
-            UInt32(red >> 4) << 8 |
-                UInt32(green >> 4) << 4 |
-                UInt32(blue >> 4)
-        )
-    }
-    let widestChannelRange = zip(minimum, maximum)
-        .map { Int($0.1) - Int($0.0) }
-        .max() ?? 0
-    return quantizedColors.count >= 3 && widestChannelRange >= 24
+private func coordinatesMatch(
+    _ lhs: CLLocationCoordinate2D,
+    _ rhs: CLLocationCoordinate2D
+) -> Bool {
+    abs(lhs.latitude - rhs.latitude) < 0.000_000_001 &&
+        abs(lhs.longitude - rhs.longitude) < 0.000_000_001
+}
+
+private func mapRectsMatch(_ lhs: MKMapRect, _ rhs: MKMapRect) -> Bool {
+    abs(lhs.origin.x - rhs.origin.x) < 0.001 &&
+        abs(lhs.origin.y - rhs.origin.y) < 0.001 &&
+        abs(lhs.size.width - rhs.size.width) < 0.001 &&
+        abs(lhs.size.height - rhs.size.height) < 0.001
 }
 
 @main
@@ -270,7 +272,7 @@ struct SavedMapPreviewCatalystTests {
         }
 
         let outlinePNG = solidPNG(color: .systemBlue)
-        let snapshotPNG = solidPNG(color: .systemOrange)
+        let snapshotPNG = variedSnapshotPNG()
         let snapshotMapID = "custom-map-snapshot"
         let snapshotPackURL = cacheDirectory
             .appendingPathComponent("\(snapshotMapID).zip")
@@ -321,6 +323,35 @@ struct SavedMapPreviewCatalystTests {
         }
         guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
             fail("an embedded boundary fallback should not be persisted as a map snapshot")
+        }
+
+        let uniformSnapshotPNG = solidPNG(color: .systemGray)
+        var uniformSnapshotReturned = false
+        let uniformSnapshotManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in
+                uniformSnapshotReturned = true
+                return uniformSnapshotPNG
+            }
+        )
+        uniformSnapshotManager.loadPreviewIfNeeded(forCachedPack: snapshotPackURL)
+        let uniformDeadline = Date().addingTimeInterval(3)
+        while !uniformSnapshotReturned && Date() < uniformDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard uniformSnapshotReturned else {
+            fail("uniform snapshot negative control should finish")
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        guard imageMatchesPNG(
+            uniformSnapshotManager.previewImage(forCachedPack: snapshotPackURL),
+            data: outlinePNG
+        ) else {
+            fail("a uniform snapshot should not replace the embedded boundary fallback")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
+            fail("a uniform snapshot should not be persisted")
         }
 
         var generatedBounds: OfflineMapPreviewBounds?
@@ -524,22 +555,75 @@ struct SavedMapPreviewCatalystTests {
             fail("a late snapshot must not persist after its map was deleted")
         }
 
-        let northWest = MKMapPoint(CLLocationCoordinate2D(
+        let northWestCoordinate = CLLocationCoordinate2D(
             latitude: expectedBounds.maxLatitude,
             longitude: expectedBounds.minLongitude
-        ))
-        let southEast = MKMapPoint(CLLocationCoordinate2D(
+        )
+        let southEastCoordinate = CLLocationCoordinate2D(
             latitude: expectedBounds.minLatitude,
             longitude: expectedBounds.maxLongitude
-        ))
+        )
+        let northWest = MKMapPoint(northWestCoordinate)
+        let southEast = MKMapPoint(southEastCoordinate)
+        let expectedMapRect = MKMapRect(
+            x: min(northWest.x, southEast.x),
+            y: min(northWest.y, southEast.y),
+            width: abs(southEast.x - northWest.x),
+            height: abs(southEast.y - northWest.y)
+        )
         let expectedAspectRatio = abs(southEast.x - northWest.x) /
             abs(southEast.y - northWest.y)
-        guard let croppedFixture = OfflineMapSnapshotPreviewRenderer.croppedImage(
-            from: cropFixtureImage(),
-            northWestPoint: CGPoint(x: 30, y: 0),
-            southEastPoint: CGPoint(x: 130, y: 96)
-        ) else {
-            fail("production crop helper should crop a deterministic snapshot fixture")
+        var capturedMapRect: MKMapRect?
+        var capturedSize: CGSize?
+        var capturedScale: CGFloat?
+        var mappedCoordinates: [CLLocationCoordinate2D] = []
+        let deterministicSnapshotData: Data
+        do {
+            guard let data = try await OfflineMapSnapshotPreviewRenderer.pngData(
+                for: expectedBounds,
+                snapshot: { options in
+                    capturedMapRect = options.mapRect
+                    capturedSize = options.size
+                    capturedScale = options.scale
+                    return OfflineMapSnapshotPreviewRenderer.SnapshotResult(
+                        image: cropFixtureImage(),
+                        pointForCoordinate: { coordinate in
+                            mappedCoordinates.append(coordinate)
+                            if coordinatesMatch(coordinate, northWestCoordinate) {
+                                return CGPoint(x: 30, y: 0)
+                            }
+                            if coordinatesMatch(coordinate, southEastCoordinate) {
+                                return CGPoint(x: 130, y: 96)
+                            }
+                            return .zero
+                        }
+                    )
+                }
+            ) else {
+                fail("production renderer should process a deterministic snapshot fixture")
+            }
+            deterministicSnapshotData = data
+        } catch {
+            fail("deterministic production renderer should complete: \(error)")
+        }
+        guard let capturedMapRect,
+              mapRectsMatch(capturedMapRect, expectedMapRect),
+              capturedSize == CGSize(width: 160, height: 96),
+              (capturedScale ?? 0) > 0 else {
+            fail(
+                "production renderer should request the exact projected map bounds " +
+                    "(rect: \(String(describing: capturedMapRect)), " +
+                    "size: \(String(describing: capturedSize)), " +
+                    "scale: \(String(describing: capturedScale)))"
+            )
+        }
+        guard mappedCoordinates.count == 2,
+              coordinatesMatch(mappedCoordinates[0], northWestCoordinate),
+              coordinatesMatch(mappedCoordinates[1], southEastCoordinate) else {
+            fail("production renderer should crop using the requested bounds coordinates")
+        }
+        guard let croppedFixture = UIImage(data: deterministicSnapshotData) else {
+            fail("deterministic production renderer output should decode")
         }
         guard croppedFixture.size == CGSize(width: 100, height: 96),
               let bluePixel = pixel(in: croppedFixture, x: 5, y: 20),
@@ -552,19 +636,73 @@ struct SavedMapPreviewCatalystTests {
               whitePixel.red > 220,
               whitePixel.green > 220,
               whitePixel.blue > 220 else {
-            fail("production crop helper should return only the selected fixture area")
+            fail("production renderer should return only the selected fixture area")
         }
-        guard OfflineMapSnapshotPreviewRenderer.croppedImage(
-            from: cropFixtureImage(),
-            northWestPoint: CGPoint(x: 40, y: 40),
-            southEastPoint: CGPoint(x: 40, y: 40)
-        ) == nil else {
-            fail("production crop helper should reject an empty selected area")
+        guard OfflineMapSnapshotPreviewRenderer.hasMeaningfulVisualVariation(croppedFixture) else {
+            fail("production renderer output should contain varied map content")
         }
-        guard hasMeaningfulVisualVariation(croppedFixture),
-              let blankImage = UIImage(data: solidPNG(color: .systemGray)),
-              !hasMeaningfulVisualVariation(blankImage) else {
-            fail("map content validation should reject uniform placeholder images")
+
+        do {
+            let emptyCropData = try await OfflineMapSnapshotPreviewRenderer.pngData(
+                for: expectedBounds,
+                snapshot: { _ in
+                    OfflineMapSnapshotPreviewRenderer.SnapshotResult(
+                        image: cropFixtureImage(),
+                        pointForCoordinate: { _ in CGPoint(x: 40, y: 40) }
+                    )
+                }
+            )
+            guard emptyCropData == nil else {
+                fail("production renderer should reject an empty selected area")
+            }
+            let blankImage = UIImage(data: uniformSnapshotPNG)!
+            let blankSnapshotData = try await OfflineMapSnapshotPreviewRenderer.pngData(
+                for: expectedBounds,
+                snapshot: { _ in
+                    OfflineMapSnapshotPreviewRenderer.SnapshotResult(
+                        image: blankImage,
+                        pointForCoordinate: { coordinate in
+                            coordinatesMatch(coordinate, northWestCoordinate)
+                                ? CGPoint(x: 30, y: 0)
+                                : CGPoint(x: 130, y: 96)
+                        }
+                    )
+                }
+            )
+            guard blankSnapshotData == nil else {
+                fail("production renderer should reject a uniform placeholder image")
+            }
+        } catch {
+            fail("production renderer negative controls should complete: \(error)")
+        }
+
+        let alternateBounds = OfflineMapPreviewBounds(
+            coordinates: [10.0, 20.0, 11.0, 21.0]
+        )!
+        var alternateMapRect: MKMapRect?
+        do {
+            guard try await OfflineMapSnapshotPreviewRenderer.pngData(
+                for: alternateBounds,
+                snapshot: { options in
+                    alternateMapRect = options.mapRect
+                    return OfflineMapSnapshotPreviewRenderer.SnapshotResult(
+                        image: cropFixtureImage(),
+                        pointForCoordinate: { coordinate in
+                            coordinate.latitude == alternateBounds.maxLatitude
+                                ? CGPoint(x: 30, y: 0)
+                                : CGPoint(x: 130, y: 96)
+                        }
+                    )
+                }
+            ) != nil else {
+                fail("alternate-bounds renderer fixture should produce output")
+            }
+        } catch {
+            fail("alternate-bounds renderer fixture should complete: \(error)")
+        }
+        guard let alternateMapRect,
+              !mapRectsMatch(alternateMapRect, expectedMapRect) else {
+            fail("production renderer request should change for a different geographic region")
         }
 
         if ProcessInfo.processInfo.environment["RUN_LIVE_MAPKIT_SNAPSHOT_TESTS"] == "1" {
@@ -595,7 +733,9 @@ struct SavedMapPreviewCatalystTests {
             }
             guard liveSnapshotImage.size.width <= 160,
                   liveSnapshotImage.size.height <= 96,
-                  hasMeaningfulVisualVariation(liveSnapshotImage) else {
+                  OfflineMapSnapshotPreviewRenderer.hasMeaningfulVisualVariation(
+                      liveSnapshotImage
+                  ) else {
                 fail(
                     "production MapKit renderer should return varied map content within " +
                         "thumbnail limits (size: \(liveSnapshotImage.size))"

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -7,6 +7,10 @@ private func fail(_ message: String) -> Never {
     Foundation.exit(1)
 }
 
+private enum ExpectedPreviewTestError: Error {
+    case metadataSave
+}
+
 private func appendUInt16LE(_ value: UInt16, to data: inout Data) {
     data.append(UInt8(value & 0xff))
     data.append(UInt8(value >> 8))
@@ -430,6 +434,147 @@ struct SavedMapPreviewCatalystTests {
         try? await Task.sleep(nanoseconds: 50_000_000)
         guard SavedMapSnapshotPreviewStore.imageData(for: stalePackURL) == snapshotPNG else {
             fail("a stale invalid-preview load must not delete a replacement snapshot")
+        }
+
+        let rollbackMapID = "custom-map-rollback-preview"
+        let rollbackPackURL = cacheDirectory.appendingPathComponent("\(rollbackMapID).zip")
+        let rollbackOldPackData: Data
+        let rollbackNewPackData: Data
+        let rollbackReplacementMetadata: SavedMapArtifactMetadata
+        do {
+            let oldManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": rollbackMapID,
+                "displayName": "Old Rollback Map",
+                "bounds": [120.90, 30.70, 121.95, 31.55],
+            ])
+            rollbackOldPackData = storedZip(entries: [
+                ("manifest.json", oldManifest),
+                (
+                    "VECTMAP/\(rollbackMapID)/+0000+0000/1.fmb",
+                    Data("old-map-block".utf8)
+                ),
+            ])
+            let newManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": rollbackMapID,
+                "displayName": "Replacement Rollback Map",
+                "bounds": [10.0, 20.0, 11.0, 21.0],
+            ])
+            rollbackNewPackData = storedZip(entries: [
+                ("manifest.json", newManifest),
+                (
+                    "VECTMAP/\(rollbackMapID)/+0000+0000/1.fmb",
+                    Data("new-map-block".utf8)
+                ),
+            ])
+            try rollbackOldPackData.write(to: rollbackPackURL)
+            let oldMetadataData = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": SavedMapArtifactMetadata.currentSchemaVersion,
+                "mapID": rollbackMapID,
+                "displayName": "Old Rollback Map",
+                "localArtifactFilename": rollbackPackURL.lastPathComponent,
+                "userDefinedDisplayName": true,
+            ])
+            let oldMetadata = try JSONDecoder().decode(
+                SavedMapArtifactMetadata.self,
+                from: oldMetadataData
+            )
+            try SavedMapArtifactMetadataStore.save(oldMetadata, for: rollbackPackURL)
+            let replacementMetadataData = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": SavedMapArtifactMetadata.currentSchemaVersion,
+                "mapID": rollbackMapID,
+                "displayName": "Replacement Rollback Map",
+                "localArtifactFilename": rollbackPackURL.lastPathComponent,
+                "userDefinedDisplayName": false,
+            ])
+            rollbackReplacementMetadata = try JSONDecoder().decode(
+                SavedMapArtifactMetadata.self,
+                from: replacementMetadataData
+            )
+        } catch {
+            fail("rollback preview race fixture should write: \(error)")
+        }
+        let rollbackReplacementContent = OfflineMapPreviewLoadResult(
+            snapshotData: nil,
+            packContent: OfflineMapPackPreviewContent(
+                imageData: nil,
+                bounds: OfflineMapPreviewBounds(
+                    coordinates: [10.0, 20.0, 11.0, 21.0]
+                )
+            )
+        )
+        var rollbackLoadStarted = false
+        var rollbackLoadReturned = false
+        var rollbackSnapshotGenerationCount = 0
+        var rollbackLoadContinuation: CheckedContinuation<
+            OfflineMapPreviewLoadResult,
+            Never
+        >?
+        let rollbackManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            previewLoad: { _ in
+                rollbackLoadStarted = true
+                let result = await withCheckedContinuation { continuation in
+                    rollbackLoadContinuation = continuation
+                }
+                rollbackLoadReturned = true
+                return result
+            },
+            mapSnapshot: { _ in
+                rollbackSnapshotGenerationCount += 1
+                return snapshotPNG
+            },
+            metadataSave: { _, _ in
+                throw ExpectedPreviewTestError.metadataSave
+            }
+        )
+        rollbackManager.loadPreviewIfNeeded(forCachedPack: rollbackPackURL)
+        let rollbackStartedDeadline = Date().addingTimeInterval(3)
+        while !rollbackLoadStarted && Date() < rollbackStartedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard rollbackLoadStarted, let rollbackContinuation = rollbackLoadContinuation else {
+            fail("rollback preview load should start")
+        }
+        let rollbackIncomingURL = cacheDirectory.appendingPathComponent(
+            ".rollback-incoming-\(UUID().uuidString).zip"
+        )
+        do {
+            try rollbackNewPackData.write(to: rollbackIncomingURL)
+            try rollbackManager.replaceDownloadedArtifact(
+                at: rollbackIncomingURL,
+                destination: rollbackPackURL,
+                metadata: rollbackReplacementMetadata,
+                mapID: rollbackMapID,
+                fileExtension: "zip"
+            )
+            fail("rollback replacement should fail at metadata persistence")
+        } catch ExpectedPreviewTestError.metadataSave {
+            // Expected failure after the replacement artifact has been moved into place.
+        } catch {
+            fail("rollback replacement should fail with the injected error: \(error)")
+        }
+        guard (try? Data(contentsOf: rollbackPackURL)) == rollbackOldPackData,
+              SavedMapArtifactMetadataStore.load(for: rollbackPackURL)?.displayName ==
+                  "Old Rollback Map" else {
+            fail("failed replacement should restore the previous artifact and metadata")
+        }
+        rollbackLoadContinuation = nil
+        rollbackContinuation.resume(returning: rollbackReplacementContent)
+        let rollbackReturnedDeadline = Date().addingTimeInterval(3)
+        while !rollbackLoadReturned && Date() < rollbackReturnedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard rollbackLoadReturned else {
+            fail("non-cooperative rollback preview load should return")
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        guard rollbackSnapshotGenerationCount == 0,
+              rollbackManager.previewImage(forCachedPack: rollbackPackURL) == nil,
+              SavedMapSnapshotPreviewStore.imageData(for: rollbackPackURL) == nil else {
+            fail("failed replacement should invalidate transient preview work")
         }
 
         var generatedBounds: OfflineMapPreviewBounds?

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -354,6 +354,84 @@ struct SavedMapPreviewCatalystTests {
             fail("a uniform snapshot should not be persisted")
         }
 
+        let staleMapID = "custom-map-stale-preview"
+        let stalePackURL = cacheDirectory.appendingPathComponent("\(staleMapID).zip")
+        do {
+            let staleManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": staleMapID,
+                "bounds": [120.90, 30.70, 121.95, 31.55],
+            ])
+            try storedZip(entries: [
+                ("manifest.json", staleManifest),
+                (
+                    "VECTMAP/\(staleMapID)/+0000+0000/1.fmb",
+                    Data("map-block".utf8)
+                ),
+            ]).write(to: stalePackURL)
+            try SavedMapSnapshotPreviewStore.save(
+                uniformSnapshotPNG,
+                for: stalePackURL
+            )
+        } catch {
+            fail("stale preview race fixture should write: \(error)")
+        }
+        guard let staleSnapshotData = SavedMapSnapshotPreviewStore.imageData(
+            for: stalePackURL
+        ) else {
+            fail("stale preview race should capture its invalid snapshot")
+        }
+        let staleLoadResult = OfflineMapPreviewLoadResult(
+            snapshotData: staleSnapshotData,
+            packContent: OfflineMapPackPreviewReader.content(for: stalePackURL)
+        )
+        var staleLoadStarted = false
+        var staleLoadReturned = false
+        var staleLoadContinuation: CheckedContinuation<
+            OfflineMapPreviewLoadResult,
+            Never
+        >?
+        let staleLoadManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            previewLoad: { _ in
+                staleLoadStarted = true
+                let result = await withCheckedContinuation { continuation in
+                    staleLoadContinuation = continuation
+                }
+                staleLoadReturned = true
+                return result
+            },
+            mapSnapshot: { _ in nil }
+        )
+        staleLoadManager.loadPreviewIfNeeded(forCachedPack: stalePackURL)
+        let staleStartedDeadline = Date().addingTimeInterval(3)
+        while !staleLoadStarted && Date() < staleStartedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard staleLoadStarted, let continuation = staleLoadContinuation else {
+            fail("stale preview load should start")
+        }
+        staleLoadManager.deleteCachedPack(at: stalePackURL)
+        do {
+            try SavedMapSnapshotPreviewStore.save(snapshotPNG, for: stalePackURL)
+        } catch {
+            fail("replacement snapshot should save during stale-load race: \(error)")
+        }
+        staleLoadContinuation = nil
+        continuation.resume(returning: staleLoadResult)
+        let staleReturnedDeadline = Date().addingTimeInterval(3)
+        while !staleLoadReturned && Date() < staleReturnedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard staleLoadReturned else {
+            fail("non-cooperative stale preview load should return")
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        guard SavedMapSnapshotPreviewStore.imageData(for: stalePackURL) == snapshotPNG else {
+            fail("a stale invalid-preview load must not delete a replacement snapshot")
+        }
+
         var generatedBounds: OfflineMapPreviewBounds?
         var snapshotContinuation: CheckedContinuation<Data?, Never>?
         var gatedSnapshotStarted = false

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -75,6 +75,23 @@ private func hasVisiblePixel(_ image: UIImage) -> Bool {
     }
 }
 
+private func solidPNG(color: UIColor) -> Data {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 1
+    format.opaque = true
+    let image = UIGraphicsImageRenderer(
+        size: CGSize(width: 160, height: 96),
+        format: format
+    ).image { context in
+        color.setFill()
+        context.cgContext.fill(CGRect(x: 0, y: 0, width: 160, height: 96))
+    }
+    guard let data = image.pngData() else {
+        fail("test snapshot should encode as PNG")
+    }
+    return data
+}
+
 @main
 struct SavedMapPreviewCatalystTests {
     @MainActor
@@ -120,7 +137,11 @@ struct SavedMapPreviewCatalystTests {
             forKey: "offlineMap.packDisplayNames"
         )
 
-        let manager = OfflineMapManager(defaults: defaults, cacheDirectory: cacheDirectory)
+        let manager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil }
+        )
         guard manager.displayName(forCachedPack: packURL) == "Shanghai and Suzhou" else {
             fail("source.name should repair the generated saved-map title")
         }
@@ -138,6 +159,163 @@ struct SavedMapPreviewCatalystTests {
         }
         guard hasVisiblePixel(image) else {
             fail("bounds fallback should contain visible rendered pixels")
+        }
+
+        let outlinePNG = solidPNG(color: .systemBlue)
+        let snapshotPNG = solidPNG(color: .systemOrange)
+        let snapshotMapID = "custom-map-snapshot"
+        let snapshotPackURL = cacheDirectory
+            .appendingPathComponent("\(snapshotMapID).zip")
+        let expectedBounds = OfflineMapPreviewBounds(
+            coordinates: [120.90, 30.70, 121.95, 31.55]
+        )!
+        do {
+            let snapshotManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": snapshotMapID,
+                "bounds": [120.90, 30.70, 121.95, 31.55],
+                "preview": [
+                    "type": "boundary-png",
+                    "path": "preview.png",
+                    "width": 160,
+                    "height": 96,
+                    "dataBase64": outlinePNG.base64EncodedString(),
+                ],
+            ])
+            try storedZip(entries: [
+                ("manifest.json", snapshotManifest),
+                ("preview.png", outlinePNG),
+                (
+                    "VECTMAP/\(snapshotMapID)/+0000+0000/1.fmb",
+                    Data("map-block".utf8)
+                ),
+            ]).write(to: snapshotPackURL)
+        } catch {
+            fail("snapshot test pack should write: \(error)")
+        }
+
+        let outlineFallbackManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil }
+        )
+        outlineFallbackManager.loadPreviewIfNeeded(forCachedPack: snapshotPackURL)
+        let outlineDeadline = Date().addingTimeInterval(3)
+        while outlineFallbackManager.previewImage(forCachedPack: snapshotPackURL) == nil &&
+            Date() < outlineDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard outlineFallbackManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+            fail("embedded boundary image should remain the MapKit failure fallback")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
+            fail("an embedded boundary fallback should not be persisted as a map snapshot")
+        }
+
+        var generatedBounds: OfflineMapPreviewBounds?
+        let snapshotManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { bounds in
+                generatedBounds = bounds
+                return snapshotPNG
+            }
+        )
+        snapshotManager.loadPreviewIfNeeded(forCachedPack: snapshotPackURL)
+        let snapshotDeadline = Date().addingTimeInterval(3)
+        while snapshotManager.previewImage(forCachedPack: snapshotPackURL) == nil &&
+            Date() < snapshotDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard generatedBounds == expectedBounds else {
+            fail("snapshot generation should use the downloaded map's exact bounds")
+        }
+        guard snapshotManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+            fail("generated map snapshot should replace the embedded boundary fallback")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == snapshotPNG else {
+            fail("generated map snapshot should persist beside the saved artifact")
+        }
+
+        var restoredGenerationCount = 0
+        let restoredManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in
+                restoredGenerationCount += 1
+                return nil
+            }
+        )
+        restoredManager.loadPreviewIfNeeded(forCachedPack: snapshotPackURL)
+        let restoredDeadline = Date().addingTimeInterval(3)
+        while restoredManager.previewImage(forCachedPack: snapshotPackURL) == nil &&
+            Date() < restoredDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard restoredManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+            fail("persisted map snapshot should load after relaunch")
+        }
+        guard restoredGenerationCount == 0 else {
+            fail("persisted map snapshot should avoid an unnecessary MapKit request")
+        }
+        restoredManager.deleteCachedPack(at: snapshotPackURL)
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
+            fail("deleting a saved map should delete its persisted snapshot")
+        }
+
+        let cancellationMapID = "custom-map-cancel"
+        let cancellationPackURL = cacheDirectory
+            .appendingPathComponent("\(cancellationMapID).zip")
+        do {
+            let cancellationManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": cancellationMapID,
+                "bounds": [120.91, 30.71, 121.94, 31.54],
+            ])
+            try storedZip(entries: [
+                ("manifest.json", cancellationManifest),
+                (
+                    "VECTMAP/\(cancellationMapID)/+0000+0000/1.fmb",
+                    Data("map-block".utf8)
+                ),
+            ]).write(to: cancellationPackURL)
+        } catch {
+            fail("cancellation test pack should write: \(error)")
+        }
+        var snapshotStarted = false
+        var snapshotCancelled = false
+        let cancellationManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in
+                snapshotStarted = true
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                    return snapshotPNG
+                } catch is CancellationError {
+                    snapshotCancelled = true
+                    throw CancellationError()
+                }
+            }
+        )
+        cancellationManager.loadPreviewIfNeeded(forCachedPack: cancellationPackURL)
+        let startedDeadline = Date().addingTimeInterval(3)
+        while !snapshotStarted && Date() < startedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard snapshotStarted else {
+            fail("snapshot generation should start for a previewable map")
+        }
+        cancellationManager.deleteCachedPack(at: cancellationPackURL)
+        let cancelledDeadline = Date().addingTimeInterval(3)
+        while !snapshotCancelled && Date() < cancelledDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard snapshotCancelled else {
+            fail("deleting a map should cancel its in-flight snapshot")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: cancellationPackURL) == nil else {
+            fail("a cancelled snapshot must not recreate a deleted map's thumbnail")
         }
 
         print("SavedMapPreviewCatalystTests passed")

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -127,6 +127,79 @@ private func solidPNG(color: UIColor) -> Data {
     return data
 }
 
+private func cropFixtureImage() -> UIImage {
+    let format = UIGraphicsImageRendererFormat()
+    format.scale = 2
+    format.opaque = true
+    return UIGraphicsImageRenderer(
+        size: CGSize(width: 160, height: 96),
+        format: format
+    ).image { context in
+        UIColor(red: 0.75, green: 0.05, blue: 0.05, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 0, y: 0, width: 160, height: 96))
+        UIColor(red: 0.05, green: 0.25, blue: 0.75, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 30, y: 0, width: 100, height: 96))
+        UIColor(red: 0.95, green: 0.75, blue: 0.05, alpha: 1).setFill()
+        context.cgContext.fill(CGRect(x: 75, y: 0, width: 10, height: 96))
+        UIColor.white.setFill()
+        context.cgContext.fill(CGRect(x: 30, y: 44, width: 100, height: 8))
+    }
+}
+
+private func pixel(
+    in image: UIImage,
+    x: Int,
+    y: Int
+) -> (red: UInt8, green: UInt8, blue: UInt8, alpha: UInt8)? {
+    guard let source = image.cgImage,
+          x >= 0, x < source.width,
+          y >= 0, y < source.height,
+          let pixels = rgbaPixels(image) else {
+        return nil
+    }
+    let offset = (y * source.width + x) * 4
+    return (
+        pixels[offset],
+        pixels[offset + 1],
+        pixels[offset + 2],
+        pixels[offset + 3]
+    )
+}
+
+private func hasMeaningfulVisualVariation(_ image: UIImage) -> Bool {
+    guard let source = image.cgImage,
+          let pixels = rgbaPixels(image) else {
+        return false
+    }
+    let pixelCount = source.width * source.height
+    let sampleStride = max(1, pixelCount / 4_096)
+    var quantizedColors = Set<UInt32>()
+    var minimum = [UInt8](repeating: .max, count: 3)
+    var maximum = [UInt8](repeating: .min, count: 3)
+    for index in stride(from: 0, to: pixelCount, by: sampleStride) {
+        let offset = index * 4
+        guard pixels[offset + 3] >= 128 else { continue }
+        let red = pixels[offset]
+        let green = pixels[offset + 1]
+        let blue = pixels[offset + 2]
+        minimum[0] = min(minimum[0], red)
+        minimum[1] = min(minimum[1], green)
+        minimum[2] = min(minimum[2], blue)
+        maximum[0] = max(maximum[0], red)
+        maximum[1] = max(maximum[1], green)
+        maximum[2] = max(maximum[2], blue)
+        quantizedColors.insert(
+            UInt32(red >> 4) << 8 |
+                UInt32(green >> 4) << 4 |
+                UInt32(blue >> 4)
+        )
+    }
+    let widestChannelRange = zip(minimum, maximum)
+        .map { Int($0.1) - Int($0.0) }
+        .max() ?? 0
+    return quantizedColors.count >= 3 && widestChannelRange >= 24
+}
+
 @main
 struct SavedMapPreviewCatalystTests {
     @MainActor
@@ -451,26 +524,6 @@ struct SavedMapPreviewCatalystTests {
             fail("a late snapshot must not persist after its map was deleted")
         }
 
-        let liveSnapshotTask = Task { @MainActor in
-            try await OfflineMapSnapshotPreviewRenderer.pngData(for: expectedBounds)
-        }
-        let liveSnapshotTimeout = Task {
-            try? await Task.sleep(nanoseconds: 15_000_000_000)
-            liveSnapshotTask.cancel()
-        }
-        let liveSnapshotData: Data
-        do {
-            guard let data = try await liveSnapshotTask.value else {
-                fail("production MapKit renderer should return a cropped PNG")
-            }
-            liveSnapshotData = data
-        } catch {
-            fail("production MapKit renderer should complete: \(error)")
-        }
-        liveSnapshotTimeout.cancel()
-        guard let liveSnapshotImage = UIImage(data: liveSnapshotData) else {
-            fail("production MapKit renderer output should decode")
-        }
         let northWest = MKMapPoint(CLLocationCoordinate2D(
             latitude: expectedBounds.maxLatitude,
             longitude: expectedBounds.minLongitude
@@ -481,18 +534,75 @@ struct SavedMapPreviewCatalystTests {
         ))
         let expectedAspectRatio = abs(southEast.x - northWest.x) /
             abs(southEast.y - northWest.y)
-        let actualAspectRatio = liveSnapshotImage.size.width / liveSnapshotImage.size.height
-        guard abs(actualAspectRatio - expectedAspectRatio) / expectedAspectRatio < 0.05 else {
-            fail("production MapKit renderer should crop to the selected bounds aspect ratio")
+        guard let croppedFixture = OfflineMapSnapshotPreviewRenderer.croppedImage(
+            from: cropFixtureImage(),
+            northWestPoint: CGPoint(x: 30, y: 0),
+            southEastPoint: CGPoint(x: 130, y: 96)
+        ) else {
+            fail("production crop helper should crop a deterministic snapshot fixture")
         }
-        guard liveSnapshotImage.size.width <= 160,
-              liveSnapshotImage.size.height <= 96,
-              !imageMatchesPNG(liveSnapshotImage, data: outlinePNG) else {
-            fail(
-                "production MapKit renderer should return map content within thumbnail limits " +
-                    "(size: \(liveSnapshotImage.size), outline: " +
-                    "\(imageMatchesPNG(liveSnapshotImage, data: outlinePNG)))"
-            )
+        guard croppedFixture.size == CGSize(width: 100, height: 96),
+              let bluePixel = pixel(in: croppedFixture, x: 5, y: 20),
+              Int(bluePixel.blue) > Int(bluePixel.red) + 80,
+              let yellowPixel = pixel(in: croppedFixture, x: 50, y: 20),
+              yellowPixel.red > 180,
+              yellowPixel.green > 140,
+              yellowPixel.blue < 100,
+              let whitePixel = pixel(in: croppedFixture, x: 5, y: 48),
+              whitePixel.red > 220,
+              whitePixel.green > 220,
+              whitePixel.blue > 220 else {
+            fail("production crop helper should return only the selected fixture area")
+        }
+        guard OfflineMapSnapshotPreviewRenderer.croppedImage(
+            from: cropFixtureImage(),
+            northWestPoint: CGPoint(x: 40, y: 40),
+            southEastPoint: CGPoint(x: 40, y: 40)
+        ) == nil else {
+            fail("production crop helper should reject an empty selected area")
+        }
+        guard hasMeaningfulVisualVariation(croppedFixture),
+              let blankImage = UIImage(data: solidPNG(color: .systemGray)),
+              !hasMeaningfulVisualVariation(blankImage) else {
+            fail("map content validation should reject uniform placeholder images")
+        }
+
+        if ProcessInfo.processInfo.environment["RUN_LIVE_MAPKIT_SNAPSHOT_TESTS"] == "1" {
+            let liveSnapshotTask = Task { @MainActor in
+                try await OfflineMapSnapshotPreviewRenderer.pngData(for: expectedBounds)
+            }
+            let liveSnapshotTimeout = Task {
+                try? await Task.sleep(nanoseconds: 15_000_000_000)
+                liveSnapshotTask.cancel()
+            }
+            let liveSnapshotData: Data
+            do {
+                guard let data = try await liveSnapshotTask.value else {
+                    fail("production MapKit renderer should return a cropped PNG")
+                }
+                liveSnapshotData = data
+            } catch {
+                fail("production MapKit renderer should complete: \(error)")
+            }
+            liveSnapshotTimeout.cancel()
+            guard let liveSnapshotImage = UIImage(data: liveSnapshotData) else {
+                fail("production MapKit renderer output should decode")
+            }
+            let actualAspectRatio = liveSnapshotImage.size.width /
+                liveSnapshotImage.size.height
+            guard abs(actualAspectRatio - expectedAspectRatio) / expectedAspectRatio < 0.05 else {
+                fail("production MapKit renderer should crop to the selected bounds aspect ratio")
+            }
+            guard liveSnapshotImage.size.width <= 160,
+                  liveSnapshotImage.size.height <= 96,
+                  hasMeaningfulVisualVariation(liveSnapshotImage) else {
+                fail(
+                    "production MapKit renderer should return varied map content within " +
+                        "thumbnail limits (size: \(liveSnapshotImage.size))"
+                )
+            }
+        } else {
+            print("Skipping opt-in live MapKit snapshot smoke test")
         }
 
         print("SavedMapPreviewCatalystTests passed")

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MapKit
 import UIKit
 
 private func fail(_ message: String) -> Never {
@@ -73,6 +74,40 @@ private func hasVisiblePixel(_ image: UIImage) -> Bool {
         context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
         return stride(from: 3, to: bytes.count, by: 4).contains { bytes[$0] > 0 }
     }
+}
+
+private func rgbaPixels(_ image: UIImage) -> [UInt8]? {
+    guard let source = image.cgImage else { return nil }
+    let width = source.width
+    let height = source.height
+    var pixels = [UInt8](repeating: 0, count: width * height * 4)
+    let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
+        guard let context = CGContext(
+            data: bytes.baseAddress,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return false
+        }
+        context.draw(source, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return true
+    }
+    return rendered ? pixels : nil
+}
+
+private func imageMatchesPNG(_ image: UIImage?, data: Data) -> Bool {
+    guard let image,
+          let expected = UIImage(data: data),
+          image.size == expected.size,
+          let actualPixels = rgbaPixels(image),
+          let expectedPixels = rgbaPixels(expected) else {
+        return false
+    }
+    return actualPixels == expectedPixels
 }
 
 private func solidPNG(color: UIColor) -> Data {
@@ -205,7 +240,10 @@ struct SavedMapPreviewCatalystTests {
             Date() < outlineDeadline {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        guard outlineFallbackManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+        guard imageMatchesPNG(
+            outlineFallbackManager.previewImage(forCachedPack: snapshotPackURL),
+            data: outlinePNG
+        ) else {
             fail("embedded boundary image should remain the MapKit failure fallback")
         }
         guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
@@ -213,24 +251,55 @@ struct SavedMapPreviewCatalystTests {
         }
 
         var generatedBounds: OfflineMapPreviewBounds?
+        var snapshotContinuation: CheckedContinuation<Data?, Never>?
+        var gatedSnapshotStarted = false
         let snapshotManager = OfflineMapManager(
             defaults: defaults,
             cacheDirectory: cacheDirectory,
             mapSnapshot: { bounds in
                 generatedBounds = bounds
-                return snapshotPNG
+                gatedSnapshotStarted = true
+                return await withCheckedContinuation { continuation in
+                    snapshotContinuation = continuation
+                }
             }
         )
         snapshotManager.loadPreviewIfNeeded(forCachedPack: snapshotPackURL)
+        let fallbackDeadline = Date().addingTimeInterval(3)
+        while (!gatedSnapshotStarted ||
+            snapshotManager.previewImage(forCachedPack: snapshotPackURL) == nil) &&
+            Date() < fallbackDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard gatedSnapshotStarted else {
+            fail("snapshot generation should start after publishing the offline fallback")
+        }
+        guard imageMatchesPNG(
+            snapshotManager.previewImage(forCachedPack: snapshotPackURL),
+            data: outlinePNG
+        ) else {
+            fail("embedded preview should publish while MapKit is still pending")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
+            fail("a pending MapKit request should not persist the offline fallback")
+        }
+        snapshotContinuation?.resume(returning: snapshotPNG)
+        snapshotContinuation = nil
         let snapshotDeadline = Date().addingTimeInterval(3)
-        while snapshotManager.previewImage(forCachedPack: snapshotPackURL) == nil &&
+        while (!imageMatchesPNG(
+            snapshotManager.previewImage(forCachedPack: snapshotPackURL),
+            data: snapshotPNG
+        ) || SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) != snapshotPNG) &&
             Date() < snapshotDeadline {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
         guard generatedBounds == expectedBounds else {
             fail("snapshot generation should use the downloaded map's exact bounds")
         }
-        guard snapshotManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+        guard imageMatchesPNG(
+            snapshotManager.previewImage(forCachedPack: snapshotPackURL),
+            data: snapshotPNG
+        ) else {
             fail("generated map snapshot should replace the embedded boundary fallback")
         }
         guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == snapshotPNG else {
@@ -252,7 +321,10 @@ struct SavedMapPreviewCatalystTests {
             Date() < restoredDeadline {
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
-        guard restoredManager.previewImage(forCachedPack: snapshotPackURL) != nil else {
+        guard imageMatchesPNG(
+            restoredManager.previewImage(forCachedPack: snapshotPackURL),
+            data: snapshotPNG
+        ) else {
             fail("persisted map snapshot should load after relaunch")
         }
         guard restoredGenerationCount == 0 else {
@@ -316,6 +388,111 @@ struct SavedMapPreviewCatalystTests {
         }
         guard SavedMapSnapshotPreviewStore.imageData(for: cancellationPackURL) == nil else {
             fail("a cancelled snapshot must not recreate a deleted map's thumbnail")
+        }
+
+        let lateMapID = "custom-map-late-snapshot"
+        let latePackURL = cacheDirectory.appendingPathComponent("\(lateMapID).zip")
+        do {
+            let lateManifest = try JSONSerialization.data(withJSONObject: [
+                "schemaVersion": 1,
+                "mapId": lateMapID,
+                "bounds": [120.92, 30.72, 121.93, 31.53],
+            ])
+            try storedZip(entries: [
+                ("manifest.json", lateManifest),
+                (
+                    "VECTMAP/\(lateMapID)/+0000+0000/1.fmb",
+                    Data("map-block".utf8)
+                ),
+            ]).write(to: latePackURL)
+        } catch {
+            fail("late snapshot test pack should write: \(error)")
+        }
+        var lateSnapshotStarted = false
+        var lateSnapshotReturned = false
+        var lateSnapshotContinuation: CheckedContinuation<Data?, Never>?
+        let lateSnapshotManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in
+                lateSnapshotStarted = true
+                let data = await withCheckedContinuation { continuation in
+                    lateSnapshotContinuation = continuation
+                }
+                lateSnapshotReturned = true
+                return data
+            }
+        )
+        lateSnapshotManager.loadPreviewIfNeeded(forCachedPack: latePackURL)
+        let lateStartedDeadline = Date().addingTimeInterval(3)
+        while !lateSnapshotStarted && Date() < lateStartedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard lateSnapshotStarted else {
+            fail("non-cooperative snapshot generation should start")
+        }
+        lateSnapshotManager.deleteCachedPack(at: latePackURL)
+        lateSnapshotContinuation?.resume(returning: snapshotPNG)
+        lateSnapshotContinuation = nil
+        let lateReturnedDeadline = Date().addingTimeInterval(3)
+        while !lateSnapshotReturned && Date() < lateReturnedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard lateSnapshotReturned else {
+            fail("non-cooperative snapshot should finish after deletion")
+        }
+        for _ in 0..<10 {
+            await Task.yield()
+        }
+        guard lateSnapshotManager.previewImage(forCachedPack: latePackURL) == nil else {
+            fail("a late snapshot must not republish a deleted map's thumbnail")
+        }
+        guard SavedMapSnapshotPreviewStore.imageData(for: latePackURL) == nil else {
+            fail("a late snapshot must not persist after its map was deleted")
+        }
+
+        let liveSnapshotTask = Task { @MainActor in
+            try await OfflineMapSnapshotPreviewRenderer.pngData(for: expectedBounds)
+        }
+        let liveSnapshotTimeout = Task {
+            try? await Task.sleep(nanoseconds: 15_000_000_000)
+            liveSnapshotTask.cancel()
+        }
+        let liveSnapshotData: Data
+        do {
+            guard let data = try await liveSnapshotTask.value else {
+                fail("production MapKit renderer should return a cropped PNG")
+            }
+            liveSnapshotData = data
+        } catch {
+            fail("production MapKit renderer should complete: \(error)")
+        }
+        liveSnapshotTimeout.cancel()
+        guard let liveSnapshotImage = UIImage(data: liveSnapshotData) else {
+            fail("production MapKit renderer output should decode")
+        }
+        let northWest = MKMapPoint(CLLocationCoordinate2D(
+            latitude: expectedBounds.maxLatitude,
+            longitude: expectedBounds.minLongitude
+        ))
+        let southEast = MKMapPoint(CLLocationCoordinate2D(
+            latitude: expectedBounds.minLatitude,
+            longitude: expectedBounds.maxLongitude
+        ))
+        let expectedAspectRatio = abs(southEast.x - northWest.x) /
+            abs(southEast.y - northWest.y)
+        let actualAspectRatio = liveSnapshotImage.size.width / liveSnapshotImage.size.height
+        guard abs(actualAspectRatio - expectedAspectRatio) / expectedAspectRatio < 0.05 else {
+            fail("production MapKit renderer should crop to the selected bounds aspect ratio")
+        }
+        guard liveSnapshotImage.size.width <= 160,
+              liveSnapshotImage.size.height <= 96,
+              !imageMatchesPNG(liveSnapshotImage, data: outlinePNG) else {
+            fail(
+                "production MapKit renderer should return map content within thumbnail limits " +
+                    "(size: \(liveSnapshotImage.size), outline: " +
+                    "\(imageMatchesPNG(liveSnapshotImage, data: outlinePNG)))"
+            )
         }
 
         print("SavedMapPreviewCatalystTests passed")


### PR DESCRIPTION
## Summary

- Render a MapKit screenshot for the exact bounds of each downloaded map.
- Crop MapKit output to the downloaded region instead of showing surrounding unavailable geography.
- Show the embedded boundary preview or bounds fallback immediately while MapKit is pending.
- Reject uniform placeholder snapshots, persist valid PNGs beside cached maps, and restore them after relaunch.
- Cancel in-flight snapshot work and prevent late or stale loaders from publishing or deleting replacement thumbnails.
- Add deterministic Catalyst coverage for request geometry, coordinate cropping, different-region and blank-image controls, pixel identity, persistence, fallback timing, and cooperative/non-cooperative races.
- Keep the network-backed MapKit smoke test opt-in with `RUN_LIVE_MAPKIT_SNAPSHOT_TESTS=1`.

## Validation

- `/opt/homebrew/bin/python3.14 -m unittest discover -s ios-app/scripts/tests`
- `ios-app/scripts/run-navigation-tests.sh`
- `RUN_LIVE_MAPKIT_SNAPSHOT_TESTS=1 ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination generic/platform=iOS CODE_SIGNING_ALLOWED=NO build`
- Initial feature build `a211fa9d` installed and launched on iPhone 16 Pro Max “Ultra” running iOS 26.5.2

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.