### PR TITLE
Clarify verified 1.75-inch audio support

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -438,6 +438,13 @@ The production path uses the ES8311 codec and NS4150B amplifier with signed
 both the production `WAVESHARE_AMOLED_175` image and the standalone
 `WAVESHARE_AMOLED_175_SPEAKER_HONK` smoke-test image.
 
+This verified status supersedes older bring-up notes that described the 1.75"
+audio path as TBD/untested or reported that the ES8311 was not detected. The
+current status is backed by the checked-in [1.75 schematic](<reference/1.75 - esp32-s3-touch-amoled-1.75-schematic.pdf>),
+Waveshare's [`08_ES8311` playback example](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.75/tree/main/examples/arduino/08_ES8311),
+the board-specific [production speaker driver](../esp32/lib/speaker/speaker.cpp),
+and the dedicated smoke-test environment in [PlatformIO](../esp32/platformio.ini).
+
 The 1.75 schematic powers the NS4150B from `VCC3V3`, so the firmware models the
 PA and codec DAC rails as 3.3 V for volume calculations. This differs from the
 2.06 path, whose established audio configuration models a 5 V PA rail.

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -440,7 +440,9 @@ both the production `WAVESHARE_AMOLED_175` image and the standalone
 
 This verified status supersedes older bring-up notes that described the 1.75"
 audio path as TBD/untested or reported that the ES8311 was not detected. The
-current status is backed by the checked-in [1.75 schematic](<reference/1.75 - esp32-s3-touch-amoled-1.75-schematic.pdf>),
+current status is backed by the physical production-image and audible-playback
+validation recorded in [PR #62](https://github.com/seichris/open-bike-computer/pull/62),
+the checked-in [1.75 schematic](<reference/1.75 - esp32-s3-touch-amoled-1.75-schematic.pdf>),
 Waveshare's [`08_ES8311` playback example](https://github.com/waveshareteam/ESP32-S3-Touch-AMOLED-1.75/tree/main/examples/arduino/08_ES8311),
 the board-specific [production speaker driver](../esp32/lib/speaker/speaker.cpp),
 and the dedicated smoke-test environment in [PlatformIO](../esp32/platformio.ini).


### PR DESCRIPTION
## Summary

- Explicitly mark the older 1.75-inch audio TBD/untested and ES8311 detection notes as superseded.
- Link the physical production-image and audible-playback validation recorded in PR #62.
- Collect the checked-in schematic, Waveshare playback example, production speaker driver, and dedicated PlatformIO smoke-test environment as the supporting implementation chain.

## Why

PR #62 added working Waveshare 1.75-inch speaker support and changed the hardware guide to `VERIFIED WORKING`, but the guide did not explicitly identify the older bring-up observations as obsolete or link the on-device audible-playback evidence. Historical notes could therefore look like the current hardware status.

## Impact

Documentation only. Firmware and iOS behavior are unchanged.

## Validation

- `git diff --check`
- Confirmed all repository-relative link targets exist.
- Confirmed PR #62 and the Waveshare `08_ES8311` example return HTTP 200.
- Completed a two-iteration deep P0-P2 review/fix loop.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
