### PR TITLE
Use route distance for maneuver guidance

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -17,6 +17,10 @@ navigation-ready.
 | `2A72` | iOS -> ESP32 | Binary GPS position | Current device position and heading for the map view. |
 | `2A73` | iOS -> ESP32 | Binary setting packet | Runtime map-renderer, device-screen, and phone-status values. |
 
+`DistanceMeters` is an unsigned 16-bit decimal value (`0...65535`). The iOS
+sender saturates larger maneuver distances at `65535` instead of allowing the
+firmware field to wrap.
+
 If iOS has cached an older GATT table and does not discover `2A6F`, `2A72`,
 or `2A73`, the app falls back to framed binary writes over authenticated `2A6E`.
 Fallback frame prefixes:

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -296,11 +296,12 @@ class NavigationEngine: NSObject, ObservableObject {
         let currentStep = route.steps[currentStepIndex]
         guard let stepEndLocation = endpointLocation(for: currentStep) else { return }
         
-        // Calculate distance to end of current step
-        let distanceRemaining = Int(location.distance(from: stepEndLocation))
+        // Keep step advancement tied to physical proximity to the endpoint so
+        // an off-route projection beyond the maneuver cannot skip the step.
+        let endpointDistance = Int(location.distance(from: stepEndLocation))
         
         // Check if we should advance to next step (within 20m of step end)
-        if distanceRemaining < 20 && currentStepIndex < route.steps.count - 1 {
+        if endpointDistance < 20 && currentStepIndex < route.steps.count - 1 {
             currentStepIndex += 1
             _ = advanceToNextNavigableStep(in: route)
             print("Advanced to step \(currentStepIndex)")
@@ -311,9 +312,9 @@ class NavigationEngine: NSObject, ObservableObject {
         let newInstruction = extractInstruction(from: newStep)
         let newIconID = mapInstructionToIconID(newInstruction)
 
-        // Recalculate distance to the new step's endpoint after advancement
-        guard let newStepEndLocation = endpointLocation(for: newStep) else { return }
-        let newDistance = Int(location.distance(from: newStepEndLocation))
+        // Recalculate remaining distance along the new step after advancement.
+        guard let remainingDistance = distanceToManeuver(from: location, in: newStep) else { return }
+        let newDistance = Int(remainingDistance)
         let snapshot = NavigationManeuverSnapshot(iconID: newIconID, distance: newDistance, instruction: newInstruction)
         currentSnapshot = snapshot
         
@@ -332,6 +333,17 @@ class NavigationEngine: NSObject, ObservableObject {
 
     private func endpointLocation(for step: MKRoute.Step) -> CLLocation? {
         RoutePolylineEndpoint.location(for: step.polyline)
+    }
+
+    private func distanceToManeuver(
+        from location: CLLocation,
+        in step: MKRoute.Step
+    ) -> CLLocationDistance? {
+        if let remainingDistance = RouteProgress.remainingDistance(from: location, in: step) {
+            return remainingDistance
+        }
+
+        return endpointLocation(for: step).map { location.distance(from: $0) }
     }
 
     private func advanceToNextNavigableStep(in route: MKRoute) -> Bool {

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -28,6 +28,8 @@ class NavigationEngine: NSObject, ObservableObject {
     private var currentRoute: MKRoute?
     private var currentStepIndex: Int = 0
     private var currentSnapshot: NavigationManeuverSnapshot?
+    private var lastManeuverStepIndex: Int?
+    private var lastManeuverRemainingDistance: CLLocationDistance?
     private var sendTracker = NavigationSendTracker(distanceThreshold: 10)
     private var initialNavigationLocation: CLLocation?
     private var lastDeviceGpsLocation: (location: CLLocation, convertFromMapKitRoute: Bool)?
@@ -53,6 +55,7 @@ class NavigationEngine: NSObject, ObservableObject {
     private var bleManager: BLEManager?
     private var cancellables = Set<AnyCancellable>()
     private let liveLocationStartTolerance: CLLocationDistance = 150
+    private let maneuverArrivalRadius: CLLocationDistance = 20
     
     // MARK: - Public Methods
     
@@ -104,6 +107,8 @@ class NavigationEngine: NSObject, ObservableObject {
         isNavigating = true
         
         currentSnapshot = nil
+        lastManeuverStepIndex = nil
+        lastManeuverRemainingDistance = nil
         sendTracker.reset()
         initialNavigationLocation = initialLocation
         hasAcceptedLiveLocation = initialLocation == nil
@@ -131,6 +136,8 @@ class NavigationEngine: NSObject, ObservableObject {
         currentRoute = nil
         currentStepIndex = 0
         currentSnapshot = nil
+        lastManeuverStepIndex = nil
+        lastManeuverRemainingDistance = nil
         sendTracker.reset()
         initialNavigationLocation = nil
         lastDeviceGpsLocation = nil
@@ -295,16 +302,39 @@ class NavigationEngine: NSObject, ObservableObject {
         
         let currentStep = route.steps[currentStepIndex]
         guard let stepEndLocation = endpointLocation(for: currentStep) else { return }
-        
-        // Keep step advancement tied to physical proximity to the endpoint so
-        // an off-route projection beyond the maneuver cannot skip the step.
-        let endpointDistance = Int(location.distance(from: stepEndLocation))
-        
-        // Check if we should advance to next step (within 20m of step end)
-        if endpointDistance < 20 && currentStepIndex < route.steps.count - 1 {
+
+        let preferredRemainingDistance = lastManeuverStepIndex == currentStepIndex
+            ? lastManeuverRemainingDistance
+            : initialRemainingDistance(for: currentStep)
+        guard var remainingDistance = distanceToManeuver(
+            from: location,
+            in: currentStep,
+            preferredRemainingDistance: preferredRemainingDistance
+        ) else { return }
+
+        // Reaching the maneuver requires both physical endpoint proximity and
+        // route progress. The second condition prevents a long U-shaped step
+        // whose endpoint is nearby from being skipped at its start.
+        let endpointDistance = location.distance(from: stepEndLocation)
+        if endpointDistance < maneuverArrivalRadius,
+           remainingDistance < maneuverArrivalRadius,
+           currentStepIndex < route.steps.count - 1 {
             currentStepIndex += 1
-            _ = advanceToNextNavigableStep(in: route)
+            guard advanceToNextNavigableStep(in: route) else {
+                print("Navigation complete!")
+                stopNavigation()
+                return
+            }
             print("Advanced to step \(currentStepIndex)")
+
+            guard let recalculatedDistance = distanceToManeuver(
+                from: location,
+                in: route.steps[currentStepIndex],
+                preferredRemainingDistance: initialRemainingDistance(
+                    for: route.steps[currentStepIndex]
+                )
+            ) else { return }
+            remainingDistance = recalculatedDistance
         }
         
         // Update current navigation data
@@ -312,11 +342,11 @@ class NavigationEngine: NSObject, ObservableObject {
         let newInstruction = extractInstruction(from: newStep)
         let newIconID = mapInstructionToIconID(newInstruction)
 
-        // Recalculate remaining distance along the new step after advancement.
-        guard let remainingDistance = distanceToManeuver(from: location, in: newStep) else { return }
         let newDistance = Int(remainingDistance)
         let snapshot = NavigationManeuverSnapshot(iconID: newIconID, distance: newDistance, instruction: newInstruction)
         currentSnapshot = snapshot
+        lastManeuverStepIndex = currentStepIndex
+        lastManeuverRemainingDistance = remainingDistance
         
         // Update published properties
         currentInstruction = snapshot.instruction
@@ -335,15 +365,35 @@ class NavigationEngine: NSObject, ObservableObject {
         RoutePolylineEndpoint.location(for: step.polyline)
     }
 
+    private func initialRemainingDistance(for step: MKRoute.Step) -> CLLocationDistance? {
+        let distance = step.distance
+        return distance.isFinite && distance > 0 ? distance : nil
+    }
+
     private func distanceToManeuver(
         from location: CLLocation,
-        in step: MKRoute.Step
+        in step: MKRoute.Step,
+        preferredRemainingDistance: CLLocationDistance?
     ) -> CLLocationDistance? {
-        if let remainingDistance = RouteProgress.remainingDistance(from: location, in: step) {
+        guard let endpoint = endpointLocation(for: step) else { return nil }
+        let endpointDistance = location.distance(from: endpoint)
+
+        if let remainingDistance = RouteProgress.remainingDistance(
+            from: location,
+            in: step,
+            preferredRemainingDistance: preferredRemainingDistance,
+            ambiguityTolerance: maneuverArrivalRadius
+        ) {
+            // A projection beyond the final segment clamps to zero. If the
+            // rider is not actually at the maneuver, report the distance back
+            // to its endpoint instead of leaving stale "0 m" guidance.
+            if remainingDistance <= 0, endpointDistance >= maneuverArrivalRadius {
+                return endpointDistance
+            }
             return remainingDistance
         }
 
-        return endpointLocation(for: step).map { location.distance(from: $0) }
+        return endpointDistance
     }
 
     private func advanceToNextNavigableStep(in route: MKRoute) -> Bool {

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -37,19 +37,38 @@ enum RoutePolylineEndpoint {
 
 enum RouteProgress {
     static func remainingDistance(from location: CLLocation, in route: MKRoute) -> CLLocationDistance? {
-        let polyline = route.polyline
+        remainingDistance(
+            from: location,
+            along: route.polyline,
+            referenceDistance: route.distance
+        )
+    }
+
+    static func remainingDistance(from location: CLLocation, in step: MKRoute.Step) -> CLLocationDistance? {
+        remainingDistance(
+            from: location,
+            along: step.polyline,
+            referenceDistance: step.distance
+        )
+    }
+
+    private static func remainingDistance(
+        from location: CLLocation,
+        along polyline: MKPolyline,
+        referenceDistance: CLLocationDistance
+    ) -> CLLocationDistance? {
         let pointCount = polyline.pointCount
         guard pointCount > 1 else { return nil }
 
-        let routePoints = polyline.points()
+        let polylinePoints = polyline.points()
         let target = MKMapPoint(location.coordinate)
         var totalDistance: CLLocationDistance = 0
         var closestDistance = Double.greatestFiniteMagnitude
-        var closestDistanceAlongRoute: CLLocationDistance = 0
+        var closestDistanceAlongPolyline: CLLocationDistance = 0
 
         for index in 0..<(pointCount - 1) {
-            let start = routePoints[index]
-            let end = routePoints[index + 1]
+            let start = polylinePoints[index]
+            let end = polylinePoints[index + 1]
             let dx = end.x - start.x
             let dy = end.y - start.y
             let segmentLengthSquared = dx * dx + dy * dy
@@ -62,7 +81,7 @@ enum RouteProgress {
                 let distanceToSegment = target.distance(to: projected)
                 if distanceToSegment < closestDistance {
                     closestDistance = distanceToSegment
-                    closestDistanceAlongRoute = totalDistance + start.distance(to: projected)
+                    closestDistanceAlongPolyline = totalDistance + start.distance(to: projected)
                 }
             }
 
@@ -71,9 +90,12 @@ enum RouteProgress {
 
         guard totalDistance > 0 else { return nil }
 
-        let routeDistance = route.distance > 0 ? route.distance : totalDistance
-        let scaledDistanceAlongRoute = (closestDistanceAlongRoute / totalDistance) * routeDistance
-        return max(routeDistance - scaledDistanceAlongRoute, 0)
+        let measuredDistance = referenceDistance.isFinite && referenceDistance > 0
+            ? referenceDistance
+            : totalDistance
+        let scaledDistanceAlongPolyline =
+            (closestDistanceAlongPolyline / totalDistance) * measuredDistance
+        return max(measuredDistance - scaledDistanceAlongPolyline, 0)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -36,26 +36,44 @@ enum RoutePolylineEndpoint {
 }
 
 enum RouteProgress {
+    private struct ProjectionCandidate {
+        let crossTrackDistance: CLLocationDistance
+        let distanceAlongPolyline: CLLocationDistance
+    }
+
+    private static let minimumAmbiguityTolerance: CLLocationDistance = 10
+
     static func remainingDistance(from location: CLLocation, in route: MKRoute) -> CLLocationDistance? {
         remainingDistance(
             from: location,
             along: route.polyline,
-            referenceDistance: route.distance
+            referenceDistance: route.distance,
+            preferredRemainingDistance: nil,
+            ambiguityTolerance: minimumAmbiguityTolerance
         )
     }
 
-    static func remainingDistance(from location: CLLocation, in step: MKRoute.Step) -> CLLocationDistance? {
+    static func remainingDistance(
+        from location: CLLocation,
+        in step: MKRoute.Step,
+        preferredRemainingDistance: CLLocationDistance? = nil,
+        ambiguityTolerance: CLLocationDistance = minimumAmbiguityTolerance
+    ) -> CLLocationDistance? {
         remainingDistance(
             from: location,
             along: step.polyline,
-            referenceDistance: step.distance
+            referenceDistance: step.distance,
+            preferredRemainingDistance: preferredRemainingDistance,
+            ambiguityTolerance: ambiguityTolerance
         )
     }
 
     private static func remainingDistance(
         from location: CLLocation,
         along polyline: MKPolyline,
-        referenceDistance: CLLocationDistance
+        referenceDistance: CLLocationDistance,
+        preferredRemainingDistance: CLLocationDistance?,
+        ambiguityTolerance requestedAmbiguityTolerance: CLLocationDistance
     ) -> CLLocationDistance? {
         let pointCount = polyline.pointCount
         guard pointCount > 1 else { return nil }
@@ -63,8 +81,7 @@ enum RouteProgress {
         let polylinePoints = polyline.points()
         let target = MKMapPoint(location.coordinate)
         var totalDistance: CLLocationDistance = 0
-        var closestDistance = Double.greatestFiniteMagnitude
-        var closestDistanceAlongPolyline: CLLocationDistance = 0
+        var candidates: [ProjectionCandidate] = []
 
         for index in 0..<(pointCount - 1) {
             let start = polylinePoints[index]
@@ -79,23 +96,65 @@ enum RouteProgress {
                 let projection = min(max(rawProjection, 0), 1)
                 let projected = MKMapPoint(x: start.x + projection * dx, y: start.y + projection * dy)
                 let distanceToSegment = target.distance(to: projected)
-                if distanceToSegment < closestDistance {
-                    closestDistance = distanceToSegment
-                    closestDistanceAlongPolyline = totalDistance + start.distance(to: projected)
-                }
+                candidates.append(ProjectionCandidate(
+                    crossTrackDistance: distanceToSegment,
+                    distanceAlongPolyline: totalDistance + start.distance(to: projected)
+                ))
             }
 
             totalDistance += segmentLength
         }
 
-        guard totalDistance > 0 else { return nil }
+        guard totalDistance > 0, !candidates.isEmpty else { return nil }
 
         let measuredDistance = referenceDistance.isFinite && referenceDistance > 0
             ? referenceDistance
             : totalDistance
-        let scaledDistanceAlongPolyline =
-            (closestDistanceAlongPolyline / totalDistance) * measuredDistance
-        return max(measuredDistance - scaledDistanceAlongPolyline, 0)
+
+        func remainingDistance(for candidate: ProjectionCandidate) -> CLLocationDistance {
+            let scaledDistanceAlongPolyline =
+                (candidate.distanceAlongPolyline / totalDistance) * measuredDistance
+            return max(measuredDistance - scaledDistanceAlongPolyline, 0)
+        }
+
+        let closestCrossTrackDistance = candidates
+            .map(\.crossTrackDistance)
+            .min() ?? Double.greatestFiniteMagnitude
+        let reportedAccuracy = location.horizontalAccuracy.isFinite && location.horizontalAccuracy >= 0
+            ? location.horizontalAccuracy
+            : 0
+        let sanitizedAmbiguityTolerance = requestedAmbiguityTolerance.isFinite
+            && requestedAmbiguityTolerance >= 0
+            ? requestedAmbiguityTolerance
+            : 0
+        let ambiguityTolerance = max(
+            max(reportedAccuracy, sanitizedAmbiguityTolerance),
+            minimumAmbiguityTolerance
+        )
+        let plausibleCandidates = candidates.filter {
+            $0.crossTrackDistance <= closestCrossTrackDistance + ambiguityTolerance
+        }
+
+        let selectedCandidate: ProjectionCandidate?
+        if let preferredRemainingDistance,
+           preferredRemainingDistance.isFinite,
+           preferredRemainingDistance >= 0 {
+            selectedCandidate = plausibleCandidates.min { lhs, rhs in
+                let lhsProgressDelta = abs(remainingDistance(for: lhs) - preferredRemainingDistance)
+                let rhsProgressDelta = abs(remainingDistance(for: rhs) - preferredRemainingDistance)
+                if lhsProgressDelta == rhsProgressDelta {
+                    return lhs.crossTrackDistance < rhs.crossTrackDistance
+                }
+                return lhsProgressDelta < rhsProgressDelta
+            }
+        } else {
+            selectedCandidate = candidates.min {
+                $0.crossTrackDistance < $1.crossTrackDistance
+            }
+        }
+
+        guard let selectedCandidate else { return nil }
+        return remainingDistance(for: selectedCandidate)
     }
 }
 
@@ -198,12 +257,15 @@ enum NavigationPacketBuilder {
 }
 
 struct NavigationManeuverSnapshot: Equatable {
+    static let maximumTransportDistance = Int(UInt16.max)
+
     let iconID: Int
     let distance: Int
     let instruction: String
 
     var packet: String {
-        "\(iconID)|\(distance)|\(instruction)"
+        let transportDistance = min(max(distance, 0), Self.maximumTransportDistance)
+        return "\(iconID)|\(transportDistance)|\(instruction)"
     }
 }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -353,10 +353,15 @@ final class FirmwareRequestCaptureProtocol: URLProtocol {
 final class TestRouteStep: MKRoute.Step {
     private let storedInstructions: String
     private let storedPolyline: MKPolyline
+    private let storedDistance: CLLocationDistance
 
     init(instructions: String, coordinates: [CLLocationCoordinate2D]) {
         self.storedInstructions = instructions
         self.storedPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+        self.storedDistance = zip(coordinates, coordinates.dropFirst()).reduce(0) { distance, pair in
+            distance + CLLocation(latitude: pair.0.latitude, longitude: pair.0.longitude)
+                .distance(from: CLLocation(latitude: pair.1.latitude, longitude: pair.1.longitude))
+        }
         super.init()
     }
 
@@ -366,6 +371,10 @@ final class TestRouteStep: MKRoute.Step {
 
     override var polyline: MKPolyline {
         storedPolyline
+    }
+
+    override var distance: CLLocationDistance {
+        storedDistance
     }
 }
 
@@ -404,6 +413,7 @@ struct NavigationProtocolTests {
         testIconMapping()
         testRouteEndpointExtraction()
         testRouteRemainingDistance()
+        testStepRemainingDistanceFollowsPolyline()
         testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
         testNonChinaCoordinatesPassThroughUnchanged()
         testSourceEndpointSelection()
@@ -443,6 +453,7 @@ struct NavigationProtocolTests {
         testBLEManagerPersistsNewMapSettings()
         testBLEManagerPersistsDeviceSoundSettings()
         testNavigationSendTrackerReadinessRetry()
+        testNavigationEngineUsesStepPolylineDistance()
         testNavigationEngineResendsWhenBLEBecomesReady()
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
@@ -2039,6 +2050,48 @@ struct NavigationProtocolTests {
 
         let offRouteNearHalfway = CLLocation(latitude: 37.0010, longitude: -122.0005)
         assert(abs((RouteProgress.remainingDistance(from: offRouteNearHalfway, in: route) ?? -1) - totalDistance / 2) < 2, "route remaining projects nearby locations onto closest segment")
+    }
+
+    static func testStepRemainingDistanceFollowsPolyline() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9990)
+        ]
+        let step = TestRouteStep(instructions: "Turn right", coordinates: coordinates)
+        let start = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
+        let endpoint = CLLocation(latitude: coordinates[3].latitude, longitude: coordinates[3].longitude)
+
+        guard let remainingDistance = RouteProgress.remainingDistance(from: start, in: step) else {
+            assert(false, "step remaining distance should be available for valid geometry")
+            return
+        }
+
+        assert(
+            abs(remainingDistance - step.distance) < 2,
+            "step remaining starts at the full polyline distance"
+        )
+        assert(
+            remainingDistance > start.distance(from: endpoint) * 2.5,
+            "curved step distance should not collapse to straight-line endpoint distance"
+        )
+
+        let firstCorner = CLLocation(latitude: coordinates[1].latitude, longitude: coordinates[1].longitude)
+        let expectedAfterCorner = CLLocation(latitude: coordinates[1].latitude, longitude: coordinates[1].longitude)
+            .distance(from: CLLocation(latitude: coordinates[2].latitude, longitude: coordinates[2].longitude))
+            + CLLocation(latitude: coordinates[2].latitude, longitude: coordinates[2].longitude)
+                .distance(from: endpoint)
+        assert(
+            abs((RouteProgress.remainingDistance(from: firstCorner, in: step) ?? -1) - expectedAfterCorner) < 2,
+            "step remaining sums the route geometry after the nearest projection"
+        )
+
+        let offRouteNearCorner = CLLocation(latitude: 37.0010, longitude: -122.0005)
+        assert(
+            abs((RouteProgress.remainingDistance(from: offRouteNearCorner, in: step) ?? -1) - expectedAfterCorner) < 2,
+            "step remaining projects nearby off-route locations onto the step geometry"
+        )
     }
 
     static func testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge() {
@@ -7696,6 +7749,35 @@ struct NavigationProtocolTests {
 
         tracker.resetForReadinessRetry()
         assert(tracker.shouldSend(snapshot), "readiness retry should resend current snapshot without reprocessing route location")
+    }
+
+    static func testNavigationEngineUsesStepPolylineDistance() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9990)
+        ]
+        let route = TestRoute(instructions: "Turn right", coordinates: coordinates)
+        let start = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
+        let endpoint = CLLocation(latitude: coordinates[3].latitude, longitude: coordinates[3].longitude)
+        guard let expectedDistance = RouteProgress.remainingDistance(from: start, in: route.steps[0]) else {
+            assert(false, "navigation test step should have measurable geometry")
+            return
+        }
+
+        let engine = NavigationEngine()
+        engine.startNavigation(with: route, initialLocation: start)
+
+        assertEqual(
+            engine.distanceToManeuver,
+            Int(expectedDistance),
+            "navigation engine publishes remaining step polyline distance"
+        )
+        assert(
+            Double(engine.distanceToManeuver) > start.distance(from: endpoint) * 2.5,
+            "navigation engine should not publish straight-line endpoint distance"
+        )
     }
 
     static func testNavigationEngineResendsWhenBLEBecomesReady() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -246,6 +246,22 @@ func assertCoordinate(
     assert(abs(actual.longitude - expectedLongitude) < 0.000001, "\(message): longitude")
 }
 
+func testLocation(
+    latitude: CLLocationDegrees,
+    longitude: CLLocationDegrees,
+    horizontalAccuracy: CLLocationAccuracy = 5
+) -> CLLocation {
+    CLLocation(
+        coordinate: CLLocationCoordinate2D(latitude: latitude, longitude: longitude),
+        altitude: 0,
+        horizontalAccuracy: horizontalAccuracy,
+        verticalAccuracy: 5,
+        course: -1,
+        speed: -1,
+        timestamp: Date()
+    )
+}
+
 final class TestBLEManager: BLEManager {
     var sentPackets: [String] = []
     var sentRouteGeometry: [Data] = []
@@ -393,6 +409,13 @@ final class TestRoute: MKRoute {
         super.init()
     }
 
+    init(steps: [TestRouteStep], coordinates: [CLLocationCoordinate2D]) {
+        self.storedSteps = steps
+        self.storedPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+        self.storedDistance = steps.reduce(0) { $0 + $1.distance }
+        super.init()
+    }
+
     override var steps: [MKRoute.Step] {
         storedSteps
     }
@@ -414,6 +437,7 @@ struct NavigationProtocolTests {
         testRouteEndpointExtraction()
         testRouteRemainingDistance()
         testStepRemainingDistanceFollowsPolyline()
+        testStepRemainingDistanceResolvesAmbiguousGeometry()
         testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
         testNonChinaCoordinatesPassThroughUnchanged()
         testSourceEndpointSelection()
@@ -452,8 +476,14 @@ struct NavigationProtocolTests {
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
         testBLEManagerPersistsDeviceSoundSettings()
+        testNavigationSnapshotTransportDistanceBounds()
         testNavigationSendTrackerReadinessRetry()
         testNavigationEngineUsesStepPolylineDistance()
+        testNavigationEngineDoesNotSkipNearbyCurvedEndpoint()
+        testNavigationEngineSeedsCurvedProgressAfterStepTransition()
+        testNavigationEngineReportsDistanceAfterPassingManeuver()
+        testNavigationEngineUsesDegenerateStepFallback()
+        testNavigationEngineKeepsProgressAtRouteCrossing()
         testNavigationEngineResendsWhenBLEBecomesReady()
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
@@ -2091,6 +2121,64 @@ struct NavigationProtocolTests {
         assert(
             abs((RouteProgress.remainingDistance(from: offRouteNearCorner, in: step) ?? -1) - expectedAfterCorner) < 2,
             "step remaining projects nearby off-route locations onto the step geometry"
+        )
+    }
+
+    static func testStepRemainingDistanceResolvesAmbiguousGeometry() {
+        let crossingCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000)
+        ]
+        let crossingStep = TestRouteStep(instructions: "Continue", coordinates: crossingCoordinates)
+        let crossing = CLLocation(latitude: 37.0005, longitude: -121.9995)
+        let finalSegmentStart = CLLocation(
+            latitude: crossingCoordinates[2].latitude,
+            longitude: crossingCoordinates[2].longitude
+        )
+        let finalEndpoint = CLLocation(
+            latitude: crossingCoordinates[3].latitude,
+            longitude: crossingCoordinates[3].longitude
+        )
+        let preferredBeforeCrossing = finalSegmentStart.distance(from: finalEndpoint)
+        let expectedAfterCrossing = crossing.distance(from: finalEndpoint)
+
+        let ambiguousRemaining = RouteProgress.remainingDistance(from: crossing, in: crossingStep)
+        let progressAwareRemaining = RouteProgress.remainingDistance(
+            from: crossing,
+            in: crossingStep,
+            preferredRemainingDistance: preferredBeforeCrossing
+        )
+        assert(
+            (ambiguousRemaining ?? 0) > expectedAfterCrossing * 3,
+            "an unqualified crossing projection selects the earlier route occurrence"
+        )
+        assert(
+            abs((progressAwareRemaining ?? -1) - expectedAfterCrossing) < 3,
+            "prior progress keeps a crossing projection on the later route occurrence"
+        )
+
+        let parallelCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9999),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9999)
+        ]
+        let parallelStep = TestRouteStep(instructions: "Continue", coordinates: parallelCoordinates)
+        let noisyFirstLegLocation = CLLocation(latitude: 37.0005, longitude: -121.99994)
+        let nearestOnlyRemaining = RouteProgress.remainingDistance(
+            from: noisyFirstLegLocation,
+            in: parallelStep
+        )
+        let continuousRemaining = RouteProgress.remainingDistance(
+            from: noisyFirstLegLocation,
+            in: parallelStep,
+            preferredRemainingDistance: parallelStep.distance
+        )
+        assert(
+            (continuousRemaining ?? 0) > (nearestOnlyRemaining ?? 0) + 80,
+            "prior progress prevents GPS noise from jumping to a close parallel return leg"
         )
     }
 
@@ -7751,22 +7839,65 @@ struct NavigationProtocolTests {
         assert(tracker.shouldSend(snapshot), "readiness retry should resend current snapshot without reprocessing route location")
     }
 
+    static func testNavigationSnapshotTransportDistanceBounds() {
+        let oversized = NavigationManeuverSnapshot(
+            iconID: NavigationIconID.straight,
+            distance: 70_000,
+            instruction: "Continue"
+        )
+        let negative = NavigationManeuverSnapshot(
+            iconID: NavigationIconID.straight,
+            distance: -10,
+            instruction: "Continue"
+        )
+
+        assertEqual(
+            oversized.packet,
+            "1|65535|Continue",
+            "navigation packet saturates distance to the firmware UInt16 field"
+        )
+        assertEqual(
+            negative.packet,
+            "1|0|Continue",
+            "navigation packet does not transmit a negative distance"
+        )
+    }
+
     static func testNavigationEngineUsesStepPolylineDistance() {
-        let coordinates = [
+        let firstStepCoordinates = [
             CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
             CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
             CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990),
             CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9990)
         ]
-        let route = TestRoute(instructions: "Turn right", coordinates: coordinates)
-        let start = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
-        let endpoint = CLLocation(latitude: coordinates[3].latitude, longitude: coordinates[3].longitude)
+        let secondStepCoordinates = [
+            firstStepCoordinates[3],
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9970)
+        ]
+        let firstStep = TestRouteStep(instructions: "Turn right", coordinates: firstStepCoordinates)
+        let secondStep = TestRouteStep(instructions: "Continue", coordinates: secondStepCoordinates)
+        let route = TestRoute(
+            steps: [firstStep, secondStep],
+            coordinates: firstStepCoordinates + Array(secondStepCoordinates.dropFirst())
+        )
+        let start = CLLocation(
+            latitude: firstStepCoordinates[0].latitude,
+            longitude: firstStepCoordinates[0].longitude
+        )
+        let endpoint = CLLocation(
+            latitude: firstStepCoordinates[3].latitude,
+            longitude: firstStepCoordinates[3].longitude
+        )
         guard let expectedDistance = RouteProgress.remainingDistance(from: start, in: route.steps[0]) else {
             assert(false, "navigation test step should have measurable geometry")
             return
         }
 
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
         let engine = NavigationEngine()
+        engine.setBLEManager(manager)
         engine.startNavigation(with: route, initialLocation: start)
 
         assertEqual(
@@ -7777,6 +7908,216 @@ struct NavigationProtocolTests {
         assert(
             Double(engine.distanceToManeuver) > start.distance(from: endpoint) * 2.5,
             "navigation engine should not publish straight-line endpoint distance"
+        )
+        assert(
+            Double(engine.distanceToManeuver) < route.distance - secondStep.distance / 2,
+            "navigation engine uses only the active step rather than whole-route distance"
+        )
+        assertEqual(manager.sentPackets.count, 1, "initial maneuver is sent to the BLE device")
+        let fields = manager.sentPackets[0].split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+        assertEqual(fields.count, 3, "polyline-distance packet uses firmware fields")
+        assertEqual(
+            String(fields[1]),
+            "\(Int(expectedDistance))",
+            "BLE packet carries the active-step polyline distance"
+        )
+    }
+
+    static func testNavigationEngineDoesNotSkipNearbyCurvedEndpoint() {
+        let firstStepCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0006, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0006, longitude: -121.9998),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9998)
+        ]
+        let secondStepCoordinates = [
+            firstStepCoordinates[3],
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9988)
+        ]
+        let firstStep = TestRouteStep(instructions: "Turn right", coordinates: firstStepCoordinates)
+        let secondStep = TestRouteStep(instructions: "Continue", coordinates: secondStepCoordinates)
+        let route = TestRoute(
+            steps: [firstStep, secondStep],
+            coordinates: firstStepCoordinates + Array(secondStepCoordinates.dropFirst())
+        )
+        let noisyStart = testLocation(latitude: 37.0000, longitude: -121.99979)
+        let routeStart = CLLocation(
+            latitude: firstStepCoordinates[0].latitude,
+            longitude: firstStepCoordinates[0].longitude
+        )
+        let nearbyEndpoint = CLLocation(
+            latitude: firstStepCoordinates[3].latitude,
+            longitude: firstStepCoordinates[3].longitude
+        )
+        let startToEndpointDistance = routeStart.distance(from: nearbyEndpoint)
+        assert(
+            startToEndpointDistance > 10 && startToEndpointDistance < 20,
+            "test curved endpoint is in the 10-to-20-meter arrival band"
+        )
+        assert(
+            noisyStart.distance(from: nearbyEndpoint) < noisyStart.distance(from: routeStart),
+            "test sample is closer to the return-leg endpoint than the route start"
+        )
+        assert(noisyStart.distance(from: nearbyEndpoint) < 20, "test endpoint is inside the arrival radius")
+
+        let engine = NavigationEngine()
+        engine.startNavigation(with: route, initialLocation: noisyStart)
+
+        assertEqual(engine.currentInstruction, "Turn right", "nearby curved endpoint does not skip the active step")
+        assert(
+            Double(engine.distanceToManeuver) > 100,
+            "nearby curved endpoint keeps its substantial along-step distance"
+        )
+    }
+
+    static func testNavigationEngineSeedsCurvedProgressAfterStepTransition() {
+        let curvedStepCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0006, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0006, longitude: -121.9998),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9998)
+        ]
+        let entryStepCoordinates = [
+            CLLocationCoordinate2D(latitude: 36.9995, longitude: -122.0000),
+            curvedStepCoordinates[0]
+        ]
+        let exitStepCoordinates = [
+            curvedStepCoordinates[3],
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9988)
+        ]
+        let entryStep = TestRouteStep(instructions: "Continue", coordinates: entryStepCoordinates)
+        let curvedStep = TestRouteStep(instructions: "Turn right", coordinates: curvedStepCoordinates)
+        let exitStep = TestRouteStep(instructions: "Continue", coordinates: exitStepCoordinates)
+        let route = TestRoute(
+            steps: [entryStep, curvedStep, exitStep],
+            coordinates: entryStepCoordinates
+                + Array(curvedStepCoordinates.dropFirst())
+                + Array(exitStepCoordinates.dropFirst())
+        )
+        let routeStart = CLLocation(
+            latitude: entryStepCoordinates[0].latitude,
+            longitude: entryStepCoordinates[0].longitude
+        )
+        let noisyTransition = testLocation(latitude: 37.0000, longitude: -121.99979)
+        let curvedStart = CLLocation(
+            latitude: curvedStepCoordinates[0].latitude,
+            longitude: curvedStepCoordinates[0].longitude
+        )
+        let curvedEndpoint = CLLocation(
+            latitude: curvedStepCoordinates[3].latitude,
+            longitude: curvedStepCoordinates[3].longitude
+        )
+        let curvedEndpointSeparation = curvedStart.distance(from: curvedEndpoint)
+        assert(
+            curvedEndpointSeparation > 10 && curvedEndpointSeparation < 20,
+            "transition test endpoint is in the 10-to-20-meter arrival band"
+        )
+
+        let engine = NavigationEngine()
+        engine.startNavigation(with: route, initialLocation: routeStart)
+        engine.processExternalLocation(noisyTransition)
+        engine.processExternalLocation(noisyTransition)
+
+        assertEqual(
+            engine.currentInstruction,
+            "Turn right",
+            "noisy transition initializes the curved step at its start rather than its nearby endpoint"
+        )
+        assert(
+            Double(engine.distanceToManeuver) > 100,
+            "noisy transition preserves the curved step's substantial remaining distance"
+        )
+    }
+
+    static func testNavigationEngineReportsDistanceAfterPassingManeuver() {
+        let firstStepCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000)
+        ]
+        let secondStepCoordinates = [
+            firstStepCoordinates[1],
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990)
+        ]
+        let firstStep = TestRouteStep(instructions: "Turn left", coordinates: firstStepCoordinates)
+        let secondStep = TestRouteStep(instructions: "Continue", coordinates: secondStepCoordinates)
+        let route = TestRoute(
+            steps: [firstStep, secondStep],
+            coordinates: firstStepCoordinates + Array(secondStepCoordinates.dropFirst())
+        )
+        let start = CLLocation(
+            latitude: firstStepCoordinates[0].latitude,
+            longitude: firstStepCoordinates[0].longitude
+        )
+        let endpoint = CLLocation(
+            latitude: firstStepCoordinates[1].latitude,
+            longitude: firstStepCoordinates[1].longitude
+        )
+        let pastEndpoint = CLLocation(latitude: 37.0030, longitude: -121.9997)
+        let expectedDistance = Int(pastEndpoint.distance(from: endpoint))
+
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        engine.startNavigation(with: route, initialLocation: start)
+        engine.processExternalLocation(start)
+        engine.processExternalLocation(pastEndpoint)
+
+        assertEqual(engine.currentInstruction, "Turn left", "passing far from the endpoint does not skip the maneuver")
+        assert(
+            abs(engine.distanceToManeuver - expectedDistance) <= 1,
+            "a beyond-endpoint projection reports physical distance back to the maneuver"
+        )
+        let fields = manager.sentPackets.last?.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+        assertEqual(String(fields?[1] ?? ""), "\(expectedDistance)", "BLE packet does not remain at zero after passing the maneuver")
+    }
+
+    static func testNavigationEngineUsesDegenerateStepFallback() {
+        let endpointCoordinate = CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000)
+        let route = TestRoute(instructions: "Arrive", coordinates: [endpointCoordinate])
+        let start = CLLocation(latitude: 37.0005, longitude: -122.0000)
+        let endpoint = CLLocation(latitude: endpointCoordinate.latitude, longitude: endpointCoordinate.longitude)
+        let expectedDistance = Int(start.distance(from: endpoint))
+
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        engine.startNavigation(with: route, initialLocation: start)
+
+        assert(
+            abs(engine.distanceToManeuver - expectedDistance) <= 1,
+            "one-point step falls back to endpoint distance"
+        )
+        let fields = manager.sentPackets.last?.split(separator: "|", maxSplits: 2, omittingEmptySubsequences: false)
+        assertEqual(String(fields?[1] ?? ""), "\(expectedDistance)", "fallback distance is sent to the BLE device")
+    }
+
+    static func testNavigationEngineKeepsProgressAtRouteCrossing() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9990),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000)
+        ]
+        let route = TestRoute(instructions: "Continue", coordinates: coordinates)
+        let start = CLLocation(latitude: coordinates[0].latitude, longitude: coordinates[0].longitude)
+        let finalSegmentStart = CLLocation(latitude: coordinates[2].latitude, longitude: coordinates[2].longitude)
+        let crossing = CLLocation(latitude: 37.0005, longitude: -121.9995)
+        let endpoint = CLLocation(latitude: coordinates[3].latitude, longitude: coordinates[3].longitude)
+        let expectedDistance = Int(crossing.distance(from: endpoint))
+
+        let engine = NavigationEngine()
+        engine.startNavigation(with: route, initialLocation: start)
+        engine.processExternalLocation(start)
+        engine.processExternalLocation(finalSegmentStart)
+        engine.processExternalLocation(crossing)
+
+        assert(
+            abs(engine.distanceToManeuver - expectedDistance) <= 2,
+            "sequential progress keeps the rider on the later segment at a route crossing"
         )
     }
 


### PR DESCRIPTION
## Summary

- Calculate distance to the next maneuver along the active `MKRoute.Step` polyline instead of using straight-line endpoint distance.
- Preserve projection continuity across self-crossing and closely parallel route geometry, including noisy initial and post-transition samples.
- Require both route progress and physical endpoint proximity before advancing a step, and recover to endpoint distance after a missed maneuver instead of leaving stale `0 m` guidance.
- Saturate BLE maneuver distance to the firmware's unsigned 16-bit range and document that transport contract.
- Add multi-step, curved-road, off-route, degenerate-geometry, crossing, parallel-road, noisy-GPS, step-transition, and BLE regression coverage.

## Why

`NavigationEngine` previously measured a straight line from the rider to the maneuver endpoint. That under-reported distance on curved, switchback, and U-shaped road geometry. A nearest-segment-only replacement also needed continuity and arrival-boundary handling to avoid skipping or misidentifying maneuvers on ambiguous geometry.

This is a prerequisite for the spoken turn-by-turn directions plan in #77.

## Impact

The displayed and BLE-transmitted distance to the next maneuver follows active-step route geometry. Missed turns no longer remain at `0 m`, curved steps are not skipped merely because their endpoints are geographically close, and transport values cannot wrap the firmware's `UInt16` field. The BLE packet shape remains unchanged.

## Root cause

The engine reused endpoint proximity as the user-facing distance, had no prior-progress signal for ambiguous polyline projections, and did not bound its decimal distance for the firmware field.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/open-bike-route-polyline-review-derived-data CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- Completed a four-iteration deep P0-P2 review/fix loop.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
