### PR TITLE
Harden device destination picker flow

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -267,9 +267,9 @@ UTF-8 strings of at most 64 bytes, and an empty catalog is valid.
 
 When idle, the picker expands the bottom overlay to two-thirds of the display.
 It shows large, transparent destination rows with a small yellow star before
-each label. Tapping the exposed map or pressing the BOOT/forward button
-dismisses the picker and restores the normal one-third guidance strip; a later
-forward press resumes normal screen cycling.
+each label and no section heading. Tapping the exposed map or pressing the
+BOOT/forward button dismisses the picker and restores the normal one-third
+guidance strip; a later forward press resumes normal screen cycling.
 
 The logical catalog is versioned JSON:
 
@@ -277,8 +277,11 @@ The logical catalog is versioned JSON:
 {"version":1,"generation":17,"items":[{"token":1,"kind":"favorite","label":"Home"},{"token":2,"kind":"favorite","label":"Work"}]}
 ```
 
-`generation` is a non-zero `UInt32`. Each item has a unique non-zero `UInt16`
-token and uses `kind: favorite`. For schema-v1 compatibility, firmware still
+`generation` is a non-zero `UInt32`. iOS starts each process from a randomized
+non-zero generation and advances it after each queued catalog, preventing a
+retained device catalog from aliasing a different token map after app relaunch.
+Each item has a unique non-zero `UInt16` token and uses `kind: favorite`. For
+schema-v1 compatibility, firmware still
 accepts correctly ordered `recent` items from older apps but does not render
 them. Coordinates and search queries remain private to the app; iOS keeps the
 token-to-`SavedDestination` mapping so an exact saved coordinate is used when
@@ -306,25 +309,39 @@ When a row is tapped, firmware notifies iOS on `2A6E`:
 The device immediately displays an animated white spinner with
 `Starting navigation...` and suppresses repeat requests while one is pending.
 iOS accepts the request only when generation and token match its active catalog,
-the device is authenticated, navigation is idle, and current location is
-available. It calculates a cycling route from the current location to the exact
-saved endpoint and replies on either command route:
+the device is authenticated, navigation is idle, and a fresh, reasonably
+accurate current location is available. It calculates a cycling route from that
+location to the exact saved endpoint and replies on either command route. When
+the authenticated picker becomes available, iOS may request Always location
+permission while the app is active, but it does not run continuous GPS merely
+because the device is connected. A row tap starts a request-scoped location
+session and holds it through the complete MapKit route-start outcome. With only
+When In Use permission, that session must start while the app is active; an
+unsupported background start fails instead of pretending the route is pending:
 
 ```text
 "DNST" | Generation: UInt32LE | Token: UInt16LE | State: UInt8 | Message: UTF-8
 ```
 
 State `1` is calculating, `2` started, `3` failed, and `4` stale. Messages are
-at most 64 UTF-8 bytes. Terminal status returns the overlay to the picker after
-five seconds; a request with no terminal response fails locally after 15
-seconds. Active maneuver data always takes precedence over the picker. The
-last valid catalog remains in RAM across disconnects, while tapping it without
-an authenticated app connection shows `Open app to start navigation`.
+at most 64 UTF-8 bytes. iOS cancels location/search/directions work at 13 seconds
+so its terminal response has time to arrive before firmware's 15-second pending
+request timeout. A disconnect also cancels any device-originated route before
+it can start on the phone alone. Terminal status returns the overlay to the
+picker after five seconds. Active maneuver data always takes precedence over
+the picker. The last valid catalog remains in RAM across disconnects, while
+tapping it without an authenticated app connection shows
+`Open app to start navigation`.
 
 iOS republishes the catalog after authenticated capability negotiation, any
 favorite change, reconnect, and navigation stop. The logical catalog is queued
 atomically on iOS so write-queue pressure cannot expose a partial new
-generation.
+generation. A failed acknowledged catalog chunk schedules a forced full-catalog
+retry with a new generation. DNST control responses use a separate bounded
+priority lane so even a bulk queue filled entirely by protected catalog chunks
+cannot starve the device's pending request. An acknowledged DNST write failure
+retries the latest status up to two times; a newer status supersedes stale
+retries.
 
 ## OSM Map Blocks
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -177,7 +177,7 @@ static bool destinationRequestTimedOut(uint32_t nowMs) {
   const bool timedOut = destinationRequestPending &&
                         static_cast<uint32_t>(nowMs -
                                               destinationRequestStartedMs) >
-                            15000;
+                            destination_picker_protocol::REQUEST_TIMEOUT_MS;
   if (timedOut) {
     destinationRequestPending = false;
   }
@@ -190,7 +190,8 @@ static bool destinationStatusShouldExpire(uint32_t nowMs) {
   const bool shouldExpire =
       !destinationRequestPending &&
       destinationPickerStatus.code != DestinationPickerStatusCode::Idle &&
-      static_cast<uint32_t>(nowMs - destinationStatusUpdatedMs) > 5000;
+      static_cast<uint32_t>(nowMs - destinationStatusUpdatedMs) >
+          destination_picker_protocol::TERMINAL_STATUS_DISPLAY_MS;
   portEXIT_CRITICAL(&destinationPickerMux);
   return shouldExpire;
 }

--- a/esp32/lib/ble_navigation/destination_picker_protocol.hpp
+++ b/esp32/lib/ble_navigation/destination_picker_protocol.hpp
@@ -17,6 +17,8 @@ static constexpr uint8_t MAX_RECENTS = 5;
 static constexpr uint8_t MAX_ITEMS = MAX_FAVORITES + MAX_RECENTS;
 static constexpr size_t MAX_LABEL_BYTES = 64;
 static constexpr uint32_t CHUNK_TIMEOUT_MS = 5000;
+static constexpr uint32_t REQUEST_TIMEOUT_MS = 15000;
+static constexpr uint32_t TERMINAL_STATUS_DISPLAY_MS = 5000;
 
 enum class ChunkResult : uint8_t {
   Rejected,

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -422,13 +422,6 @@ static void updateMapGuidanceOverlay() {
         lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
         lv_label_set_text_static(label, "Add saved destinations in the app");
       } else {
-        lv_obj_t *title = lv_label_create(mapGuidanceDestinationPicker);
-        lv_obj_set_width(title, LV_PCT(100));
-        lv_obj_set_style_text_font(title, &lv_font_montserrat_18, 0);
-        lv_obj_set_style_text_color(title, lv_color_white(), 0);
-        lv_obj_set_style_text_align(title, LV_TEXT_ALIGN_CENTER, 0);
-        lv_label_set_text_static(title, "Choose destination");
-
         for (uint8_t i = 0; i < catalog.count; i++) {
           const DeviceDestination &destination = catalog.items[i];
           if (destination.kind != DestinationKind::Favorite) {

--- a/esp32/tools/tests/test_destination_picker_protocol.cpp
+++ b/esp32/tools/tests/test_destination_picker_protocol.cpp
@@ -19,6 +19,9 @@ int main() {
   static_assert(destination_picker_protocol::MAX_FAVORITES == 3);
   static_assert(destination_picker_protocol::MAX_RECENTS == 5);
   static_assert(destination_picker_protocol::MAX_ITEMS == 8);
+  static_assert(destination_picker_protocol::REQUEST_TIMEOUT_MS == 15000);
+  static_assert(destination_picker_protocol::TERMINAL_STATUS_DISPLAY_MS ==
+                5000);
 
   CatalogReassembler reassembler;
   auto first = chunk(7, 0, 2, "{\"version\":1,");

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -106,10 +106,12 @@ struct ContentView: View {
             coordinator.updateSelectedView(newValue)
         }
         .onAppear {
+            coordinator.applicationDidBecomeActive()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: scenePhase) { newValue in
             guard newValue == .active else { return }
+            coordinator.applicationDidBecomeActive()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: coordinator.bleManager.isConnected) { _ in

--- a/ios-app/BikeComputer/BikeComputer/Info.plist
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist
@@ -13,13 +13,13 @@
 
 	<!-- Location Permissions -->
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>BikeComputer needs background location access to continue turn-by-turn navigation and ride tracking while the app is not visible.</string>
+	<string>BikeComputer needs background location access to start and continue navigation from your bike computer and track rides while the app is not visible.</string>
 	
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>BikeComputer needs your location to provide turn-by-turn navigation.</string>
 	
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>BikeComputer needs background location access to continue navigation when the app is not visible.</string>
+	<string>BikeComputer needs background location access to start or continue navigation from your bike computer when the app is not visible.</string>
 
 	<key>OfflineMapAPIToken</key>
 	<string>$(OFFLINE_MAP_API_TOKEN)</string>

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -17,8 +17,21 @@ import UIKit
 
 struct NavigationWriteEndpoint {
     let maximumWriteLength: Int
+    let expectsWriteResponse: Bool
     let canSend: () -> Bool
     let write: (Data) -> Void
+
+    init(
+        maximumWriteLength: Int,
+        expectsWriteResponse: Bool = false,
+        canSend: @escaping () -> Bool,
+        write: @escaping (Data) -> Void
+    ) {
+        self.maximumWriteLength = maximumWriteLength
+        self.expectsWriteResponse = expectsWriteResponse
+        self.canSend = canSend
+        self.write = write
+    }
 }
 
 enum DeviceBLEProtocol {
@@ -57,7 +70,9 @@ enum DeviceBLEProtocol {
     static let batteryStatusScreenCapabilityMask: UInt8 = 1 << 5
     static let destinationPickerCapabilityMask: UInt8 = 1 << 6
     static let deviceCapabilitiesVersion: UInt8 = 5
-    static let fallbackWriteQueueCapacity = 256
+    // Large enough for the worst schema-v1 three-favorite catalog at the
+    // minimum BLE write length, without retaining a long stale GPS backlog.
+    static let fallbackWriteQueueCapacity = 64
 
     static let serviceRoadsVisibilityMask: Int32 = 1 << 10
     static let tracksVisibilityMask: Int32 = 1 << 11
@@ -555,6 +570,7 @@ class BLEManager: NSObject, ObservableObject {
     private var mapTransferStatusChunkCount: UInt8 = 0
     private var mapTransferStatusChunks: [UInt8: Data] = [:]
     private var writeWithResponseInFlight = false
+    private var navigationWriteWithResponseFailureHandler: (() -> Void)?
     private var connectionTimeoutTimer: Timer?
     private var authRetryTimer: Timer?
     private var authTimeoutTimer: Timer?
@@ -562,6 +578,7 @@ class BLEManager: NSObject, ObservableObject {
     private var powerButtonHonkAttempt = 0
     private var nextPowerButtonHonkRequestID: UInt32 = 1
     private var nextDestinationCatalogTransferID: UInt8 = 1
+    private var destinationStatusSequence: UInt64 = 0
     private var powerButtonHonkRetryWorkItem: DispatchWorkItem?
     private var powerButtonHonkAckTimeout: TimeInterval = 1.0
     private var powerButtonHonkFailureRetryDelay: TimeInterval = 0.1
@@ -578,6 +595,7 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     var onDestinationRequest: ((DeviceDestinationRequest) -> Void)?
+    var onDestinationCatalogWriteFailure: (() -> Void)?
     
     // MARK: - UserDefaults Keys
     private enum SettingsKeys {
@@ -1669,7 +1687,10 @@ class BLEManager: NSObject, ObservableObject {
         guard enqueueDestinationFrames(
             frames,
             endpoint: endpoint,
-            label: "destination catalog generation=\(payload.generation)"
+            label: "destination catalog generation=\(payload.generation)",
+            onWriteFailure: { [weak self] in
+                self?.onDestinationCatalogWriteFailure?()
+            }
         ) else { return false }
 
         nextDestinationCatalogTransferID &+= 1
@@ -1685,6 +1706,26 @@ class BLEManager: NSObject, ObservableObject {
         token: UInt16,
         status: DeviceDestinationStatusCode,
         message: String
+    ) -> Bool {
+        destinationStatusSequence &+= 1
+        return enqueueDestinationStatus(
+            generation: generation,
+            token: token,
+            status: status,
+            message: message,
+            sequence: destinationStatusSequence,
+            attempt: 0
+        )
+    }
+
+    @discardableResult
+    private func enqueueDestinationStatus(
+        generation: UInt32,
+        token: UInt16,
+        status: DeviceDestinationStatusCode,
+        message: String,
+        sequence: UInt64,
+        attempt: Int
     ) -> Bool {
         // A DREQ notification itself proves that the connected firmware knows
         // DNST. Allow the reply during the brief post-authentication window
@@ -1708,8 +1749,54 @@ class BLEManager: NSObject, ObservableObject {
         return enqueueDestinationFrames(
             [packet],
             endpoint: endpoint,
-            label: "destination status \(status)"
+            label: "destination status \(status)",
+            prioritized: true,
+            onWriteFailure: { [weak self] in
+                self?.scheduleDestinationStatusRetry(
+                    generation: generation,
+                    token: token,
+                    status: status,
+                    message: message,
+                    sequence: sequence,
+                    failedAttempt: attempt
+                )
+            }
         )
+    }
+
+    private func scheduleDestinationStatusRetry(
+        generation: UInt32,
+        token: UInt16,
+        status: DeviceDestinationStatusCode,
+        message: String,
+        sequence: UInt64,
+        failedAttempt: Int
+    ) {
+        guard DeviceDestinationStatusRetryPolicy.shouldRetry(
+            afterAttempt: failedAttempt
+        ) else {
+            log("Destination status write failed after all retries")
+            return
+        }
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + DeviceDestinationStatusRetryPolicy.retryDelay
+        ) { [weak self] in
+            guard let self,
+                  self.destinationStatusSequence == sequence,
+                  self.isConnected,
+                  self.isNavigationReady else { return }
+            let didRetry = self.enqueueDestinationStatus(
+                generation: generation,
+                token: token,
+                status: status,
+                message: message,
+                sequence: sequence,
+                attempt: failedAttempt + 1
+            )
+            if !didRetry {
+                self.log("Destination status retry could not be queued")
+            }
+        }
     }
 
     func sendDebugNavigationPacket() {
@@ -1790,6 +1877,8 @@ class BLEManager: NSObject, ObservableObject {
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
         authWriteState = .idle
+        writeWithResponseInFlight = false
+        navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
         lastSentPhoneBatteryPercent = nil
         lastSentPhoneBatteryCharging = nil
@@ -1856,6 +1945,7 @@ class BLEManager: NSObject, ObservableObject {
         navigationWriteEndpoint = nil
         isNavigationReady = false
         writeWithResponseInFlight = false
+        navigationWriteWithResponseFailureHandler = nil
         pendingAuthNonce = nil
         authWriteState = .idle
         navigationWriteQueue.removeAll()
@@ -1915,6 +2005,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsDestinationPicker = false
         powerButtonHonkConfigurationError = nil
         nextDestinationCatalogTransferID = 1
+        destinationStatusSequence &+= 1
         hasReceivedDeviceCapabilities = false
         hasSentMapProfileForConnection = false
         hasSentMapNavigationProfileForConnection = false
@@ -2096,6 +2187,7 @@ class BLEManager: NSObject, ObservableObject {
 
         installNavigationWriteEndpoint(NavigationWriteEndpoint(
             maximumWriteLength: peripheral.maximumWriteValueLength(for: navigationWriteType),
+            expectsWriteResponse: navigationWriteType == .withResponse,
             canSend: { [weak self, weak peripheral] in
                 guard let self, let peripheral else { return false }
                 if navigationWriteType == .withResponse {
@@ -2184,14 +2276,16 @@ class BLEManager: NSObject, ObservableObject {
         label: String,
         transportWrite: ((Data) -> Void)? = nil,
         onWrite: (() -> Void)? = nil,
-        onDrop: (() -> Void)? = nil
+        onDrop: (() -> Void)? = nil,
+        onWriteFailure: (() -> Void)? = nil
     ) {
         if navigationWriteQueue.enqueue(NavigationWrite(
             data: data,
             label: label,
             transportWrite: transportWrite,
             onWrite: onWrite,
-            onDrop: onDrop
+            onDrop: onDrop,
+            onWriteFailure: onWriteFailure
         )) {
             log("Navigation write queue full; dropped oldest packet")
         }
@@ -2204,7 +2298,9 @@ class BLEManager: NSObject, ObservableObject {
     private func enqueueDestinationFrames(
         _ frames: [Data],
         endpoint: NavigationWriteEndpoint,
-        label: String
+        label: String,
+        prioritized: Bool = false,
+        onWriteFailure: (() -> Void)? = nil
     ) -> Bool {
         guard !frames.isEmpty,
               frames.allSatisfy({ $0.count <= endpoint.maximumWriteLength }) else {
@@ -2220,10 +2316,17 @@ class BLEManager: NSObject, ObservableObject {
                 transportWrite: characteristic == nil ? nil : { [weak self, weak peripheral, weak characteristic] payload in
                     guard let self, let peripheral, let characteristic else { return }
                     self.writeDeviceData(payload, to: characteristic, on: peripheral)
-                }
+                },
+                onWriteFailure: onWriteFailure
             )
         }
-        guard navigationWriteQueue.enqueueAtomically(writes) else {
+        let didEnqueue: Bool
+        if prioritized {
+            didEnqueue = navigationWriteQueue.enqueuePrioritizedAtomically(writes)
+        } else {
+            didEnqueue = navigationWriteQueue.enqueueAtomically(writes)
+        }
+        guard didEnqueue else {
             log("Destination frames not queued: insufficient write queue capacity")
             return false
         }
@@ -2302,7 +2405,14 @@ class BLEManager: NSObject, ObservableObject {
 
     private func flushPendingNavigationWrites(endpoint: NavigationWriteEndpoint) {
         navigationWriteQueue.flush(canSend: endpoint.canSend, maxWrites: 1) { write in
+            if endpoint.expectsWriteResponse {
+                writeWithResponseInFlight = true
+            }
+            navigationWriteWithResponseFailureHandler = write.onWriteFailure
             write.perform(using: endpoint.write)
+            if !writeWithResponseInFlight {
+                navigationWriteWithResponseFailureHandler = nil
+            }
             log("Sent \(write.label): \(write.data.count) bytes")
         }
         if navigationWriteQueue.count == 0 {
@@ -2314,6 +2424,25 @@ class BLEManager: NSObject, ObservableObject {
             lastNavigationQueuePendingLogAt = Date()
         }
     }
+
+    private func completeNavigationWrite(error: Error?) {
+        writeWithResponseInFlight = false
+        let writeFailureHandler = navigationWriteWithResponseFailureHandler
+        navigationWriteWithResponseFailureHandler = nil
+        if error != nil {
+            writeFailureHandler?()
+        }
+        if let endpoint = navigationWriteEndpoint {
+            flushPendingNavigationWrites(endpoint: endpoint)
+            scheduleNavigationFlushRetryIfNeeded()
+        }
+    }
+
+#if HOST_TESTING
+    func completeNavigationWriteForTesting(error: Error?) {
+        completeNavigationWrite(error: error)
+    }
+#endif
 
     private func writeDeviceData(
         _ data: Data,
@@ -2477,6 +2606,8 @@ extension BLEManager: CBCentralManagerDelegate {
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
         authWriteState = .idle
+        writeWithResponseInFlight = false
+        navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
         lastSentPhoneBatteryPercent = nil
         lastSentPhoneBatteryCharging = nil
@@ -2678,9 +2809,6 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, 
                    didWriteValueFor characteristic: CBCharacteristic, 
                    error: Error?) {
-        if characteristic.uuid != authCharacteristicUUID {
-            writeWithResponseInFlight = false
-        }
         if let error = error {
             log("Error writing characteristic \(characteristic.uuid): \(error.localizedDescription); props=\(characteristic.properties.debugDescription)")
             if characteristic.uuid == authCharacteristicUUID {
@@ -2688,20 +2816,16 @@ extension BLEManager: CBPeripheralDelegate {
                 isPairingMode = false
                 clearConnectionState()
                 centralManager.cancelPeripheralConnection(peripheral)
-            }
-            if characteristic.uuid != authCharacteristicUUID,
-               let endpoint = navigationWriteEndpoint {
-                flushPendingNavigationWrites(endpoint: endpoint)
-                scheduleNavigationFlushRetryIfNeeded()
+            } else {
+                completeNavigationWrite(error: error)
             }
             return
         }
 
         if characteristic.uuid == authCharacteristicUUID {
             authWriteCompleted(for: peripheral, characteristic: characteristic)
-        } else if let endpoint = navigationWriteEndpoint {
-            flushPendingNavigationWrites(endpoint: endpoint)
-            scheduleNavigationFlushRetryIfNeeded()
+        } else {
+            completeNavigationWrite(error: nil)
         }
     }
     
@@ -2858,6 +2982,10 @@ extension BLEManager: CBPeripheralDelegate {
     @discardableResult
     func handleNavigationCharacteristicNotification(_ data: Data) -> Bool {
         if let request = DeviceDestinationRequest.parse(data) {
+            guard isConnected, isNavigationReady else {
+                log("Ignored destination request before authentication completed")
+                return true
+            }
             log("Received destination request generation=\(request.generation) token=\(request.token)")
             onDestinationRequest?(request)
             return true

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -88,10 +88,17 @@ class BikeComputerCoordinator: ObservableObject {
         generation: UInt,
         completion: (NavigationStartOutcome) -> Void
     )?
-    private var destinationCatalogGeneration: UInt32 = 0
-    private var destinationCatalogFingerprint = ""
+    private var destinationCatalogGeneration: UInt32?
+    private var nextDestinationCatalogGeneration =
+        DeviceDestinationCatalogGeneration.initial()
+    private var destinationCatalogFingerprint: String?
     private var destinationCatalogByToken: [UInt16: SavedDestination] = [:]
     private var destinationCatalogRetryWorkItem: DispatchWorkItem?
+    private var pendingDeviceDestinationLocationRequest: DeviceDestinationRequest?
+    private var pendingDeviceDestinationLocationObservation: AnyCancellable?
+    private var pendingDeviceDestinationLocationTimeout: DispatchWorkItem?
+    private var pendingDeviceDestinationRequestDeadline: DispatchWorkItem?
+    private var pendingDeviceDestinationRouteGeneration: UInt?
     private var wasNavigating = false
 
     // MARK: - Initialization
@@ -209,7 +216,10 @@ class BikeComputerCoordinator: ObservableObject {
             .sink { [weak self] isReady in
                 guard let self else { return }
                 self.deviceCapabilityRefreshGeneration &+= 1
-                guard isReady else { return }
+                guard isReady else {
+                    self.cancelPendingDeviceDestinationLocationResolution()
+                    return
+                }
                 let generation = self.deviceCapabilityRefreshGeneration
                 if let location = self.locationManager.currentLocation {
                     self.navEngine.processExternalLocation(location)
@@ -237,6 +247,26 @@ class BikeComputerCoordinator: ObservableObject {
             DispatchQueue.main.async { [weak self] in
                 self?.synchronizeDestinationCatalog(force: true)
             }
+        }
+        .store(in: &cancellables)
+
+        Publishers.CombineLatest3(
+            bleManager.$isNavigationReady,
+            bleManager.$supportsDestinationPicker,
+            destinationStore.$favoriteDestinations
+        )
+        .map { isReady, supportsDestinationPicker, favorites in
+            let hasDeviceDestinations = !DeviceDestinationCatalogBuilder.build(
+                favorites: favorites,
+                generation: 1
+            ).payload.items.isEmpty
+            return isReady && supportsDestinationPicker && hasDeviceDestinations
+        }
+        .removeDuplicates()
+        .sink { [weak self] isEnabled in
+            // Prepare background permission while the app is active, without
+            // running continuous high-accuracy GPS before the rider taps a row.
+            self?.locationManager.setDeviceDestinationRequestsEnabled(isEnabled)
         }
         .store(in: &cancellables)
 
@@ -276,6 +306,11 @@ class BikeComputerCoordinator: ObservableObject {
         bleManager.onDestinationRequest = { [weak self] request in
             Task { @MainActor in
                 self?.handleDestinationRequest(request)
+            }
+        }
+        bleManager.onDestinationCatalogWriteFailure = { [weak self] in
+            Task { @MainActor in
+                self?.scheduleDestinationCatalogRetry()
             }
         }
         locationManager.healthKitManager = healthKitManager
@@ -370,6 +405,10 @@ class BikeComputerCoordinator: ObservableObject {
         locationManager.requestWhenInUseAuthorization()
     }
 
+    func applicationDidBecomeActive() {
+        locationManager.prepareDeviceDestinationRequestsIfNeeded()
+    }
+
     var isLocationAuthorized: Bool {
         locationAuthorizationStatus == .authorizedAlways ||
             locationAuthorizationStatus == .authorizedWhenInUse
@@ -447,13 +486,16 @@ class BikeComputerCoordinator: ObservableObject {
         guard bleManager.isNavigationReady,
               bleManager.supportsDestinationPicker else { return }
 
-        var nextGeneration = destinationCatalogGeneration &+ 1
-        if nextGeneration == 0 { nextGeneration = 1 }
+        let nextGeneration = nextDestinationCatalogGeneration
         let build = DeviceDestinationCatalogBuilder.build(
             favorites: destinationStore.favoriteDestinations,
             generation: nextGeneration
         )
-        guard force || build.sourceFingerprint != destinationCatalogFingerprint else {
+        guard DeviceDestinationCatalogSyncPolicy.shouldPublish(
+            force: force,
+            lastFingerprint: destinationCatalogFingerprint,
+            nextFingerprint: build.sourceFingerprint
+        ) else {
             destinationCatalogRetryWorkItem?.cancel()
             destinationCatalogRetryWorkItem = nil
             return
@@ -466,6 +508,8 @@ class BikeComputerCoordinator: ObservableObject {
         destinationCatalogRetryWorkItem?.cancel()
         destinationCatalogRetryWorkItem = nil
         destinationCatalogGeneration = nextGeneration
+        nextDestinationCatalogGeneration =
+            DeviceDestinationCatalogGeneration.next(after: nextGeneration)
         destinationCatalogFingerprint = build.sourceFingerprint
         destinationCatalogByToken = build.destinationsByToken
     }
@@ -475,40 +519,29 @@ class BikeComputerCoordinator: ObservableObject {
         let workItem = DispatchWorkItem { [weak self] in
             guard let self else { return }
             self.destinationCatalogRetryWorkItem = nil
-            self.synchronizeDestinationCatalog()
+            // A failed enqueue is still unsynchronized even when the source
+            // fingerprint matches the last catalog accepted by the queue.
+            self.synchronizeDestinationCatalog(force: true)
         }
         destinationCatalogRetryWorkItem = workItem
         DispatchQueue.main.asyncAfter(deadline: .now() + 1, execute: workItem)
     }
 
     private func handleDestinationRequest(_ request: DeviceDestinationRequest) {
-        guard request.generation == destinationCatalogGeneration,
-              let destination = destinationCatalogByToken[request.token] else {
-            bleManager.sendDestinationStatus(
-                generation: request.generation,
-                token: request.token,
-                status: .stale,
-                message: "Destination list changed"
-            )
-            synchronizeDestinationCatalog(force: true)
+        guard bleManager.isNavigationReady else { return }
+        guard let destination = destination(for: request) else {
+            rejectStaleDestinationRequest(request)
             return
         }
 
-        guard !isNavigating, !routeCalculation.isCalculating else {
+        guard !isNavigating,
+              !routeCalculation.isCalculating,
+              pendingDeviceDestinationLocationRequest == nil else {
             bleManager.sendDestinationStatus(
                 generation: request.generation,
                 token: request.token,
                 status: .failed,
                 message: "Navigation is already active"
-            )
-            return
-        }
-        guard currentLocation != nil else {
-            bleManager.sendDestinationStatus(
-                generation: request.generation,
-                token: request.token,
-                status: .failed,
-                message: "Current location unavailable"
             )
             return
         }
@@ -519,30 +552,240 @@ class BikeComputerCoordinator: ObservableObject {
             status: .calculating,
             message: "Starting navigation..."
         )
-        startNavigation(
-            from: .currentLocation,
-            to: destination.routeEndpoint,
-            transportType: RouteTransportTypes.cycling
-        ) { [weak self] outcome in
-            guard let self else { return }
-            switch outcome {
-            case .started:
-                self.bleManager.sendDestinationStatus(
-                    generation: request.generation,
-                    token: request.token,
-                    status: .started,
-                    message: "Navigation started"
-                )
-                self.destinationStore.addRecent(destination)
-            case .failed(let message):
-                self.bleManager.sendDestinationStatus(
-                    generation: request.generation,
-                    token: request.token,
-                    status: .failed,
-                    message: message
-                )
+        pendingDeviceDestinationLocationRequest = request
+        scheduleDeviceDestinationRequestDeadline(for: request)
+        resolveFreshDeviceDestinationLocation { [weak self] location in
+            guard let self,
+                  self.pendingDeviceDestinationLocationRequest == request else {
+                return
             }
+            guard self.bleManager.isNavigationReady else {
+                self.cancelPendingDeviceDestinationLocationResolution()
+                return
+            }
+            guard let currentDestination = self.destination(for: request),
+                  currentDestination == destination else {
+                self.finishDeviceDestinationRequest(
+                    request,
+                    status: .stale,
+                    message: "Destination list changed"
+                )
+                self.synchronizeDestinationCatalog(force: true)
+                return
+            }
+            guard !self.isNavigating, !self.routeCalculation.isCalculating else {
+                self.finishDeviceDestinationRequest(
+                    request,
+                    status: .failed,
+                    message: "Navigation is already active"
+                )
+                return
+            }
+            guard let location else {
+                self.finishDeviceDestinationRequest(
+                    request,
+                    status: .failed,
+                    message: "Current location unavailable"
+                )
+                return
+            }
+
+            let routeLocation = CoordinateConverter.mapKitRouteLocation(
+                fromGPSLocation: location
+            )
+            let source = MKMapItem(placemark: MKPlacemark(
+                coordinate: routeLocation.coordinate
+            ))
+            source.name = "Current Location"
+            self.startNavigation(
+                from: .mapItem(source),
+                to: currentDestination.routeEndpoint,
+                transportType: RouteTransportTypes.cycling
+            ) { [weak self] outcome in
+                guard let self,
+                      self.pendingDeviceDestinationLocationRequest == request else {
+                    return
+                }
+                switch outcome {
+                case .started:
+                    self.finishDeviceDestinationRequest(
+                        request,
+                        status: .started,
+                        message: "Navigation started"
+                    )
+                    self.destinationStore.addRecent(currentDestination)
+                case .failed(let message):
+                    self.finishDeviceDestinationRequest(
+                        request,
+                        status: .failed,
+                        message: message
+                    )
+                }
+            }
+            self.pendingDeviceDestinationRouteGeneration =
+                self.pendingNavigationStart?.generation
         }
+    }
+
+    private func scheduleDeviceDestinationRequestDeadline(
+        for request: DeviceDestinationRequest
+    ) {
+        pendingDeviceDestinationRequestDeadline?.cancel()
+        let deadline = DispatchWorkItem { [weak self] in
+            guard let self,
+                  self.pendingDeviceDestinationLocationRequest == request else {
+                return
+            }
+            self.cancelPendingDeviceDestinationRouteCalculation()
+            self.finishDeviceDestinationRequest(
+                request,
+                status: .failed,
+                message: "Route request timed out"
+            )
+        }
+        pendingDeviceDestinationRequestDeadline = deadline
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + DeviceDestinationRequestTiming.appRequestDeadline,
+            execute: deadline
+        )
+    }
+
+    private func finishDeviceDestinationRequest(
+        _ request: DeviceDestinationRequest,
+        status: DeviceDestinationStatusCode,
+        message: String
+    ) {
+        guard pendingDeviceDestinationLocationRequest == request else { return }
+        pendingDeviceDestinationRequestDeadline?.cancel()
+        pendingDeviceDestinationRequestDeadline = nil
+        pendingDeviceDestinationLocationObservation?.cancel()
+        pendingDeviceDestinationLocationObservation = nil
+        pendingDeviceDestinationLocationTimeout?.cancel()
+        pendingDeviceDestinationLocationTimeout = nil
+        pendingDeviceDestinationLocationRequest = nil
+        pendingDeviceDestinationRouteGeneration = nil
+        locationManager.endDeviceDestinationLocationRefresh()
+        bleManager.sendDestinationStatus(
+            generation: request.generation,
+            token: request.token,
+            status: status,
+            message: message
+        )
+    }
+
+    private func destination(
+        for request: DeviceDestinationRequest
+    ) -> SavedDestination? {
+        guard let generation = destinationCatalogGeneration,
+              request.generation == generation,
+              let fingerprint = destinationCatalogFingerprint,
+              let destination = destinationCatalogByToken[request.token] else {
+            return nil
+        }
+        let currentBuild = DeviceDestinationCatalogBuilder.build(
+            favorites: destinationStore.favoriteDestinations,
+            generation: generation
+        )
+        guard currentBuild.sourceFingerprint == fingerprint else { return nil }
+        return destination
+    }
+
+    private func rejectStaleDestinationRequest(
+        _ request: DeviceDestinationRequest
+    ) {
+        bleManager.sendDestinationStatus(
+            generation: request.generation,
+            token: request.token,
+            status: .stale,
+            message: "Destination list changed"
+        )
+        synchronizeDestinationCatalog(force: true)
+    }
+
+    private func resolveFreshDeviceDestinationLocation(
+        completion: @escaping (CLLocation?) -> Void
+    ) {
+        if let currentLocation = locationManager.currentLocation,
+           DeviceDestinationLocationPolicy.isUsable(currentLocation) {
+            guard locationManager.beginDeviceDestinationLocationRefresh(
+                restart: false
+            ) else {
+                completion(nil)
+                return
+            }
+            completion(currentLocation)
+            return
+        }
+
+        pendingDeviceDestinationLocationObservation?.cancel()
+        pendingDeviceDestinationLocationTimeout?.cancel()
+
+        pendingDeviceDestinationLocationObservation = locationManager.$currentLocation
+            .compactMap { $0 }
+            .filter { DeviceDestinationLocationPolicy.isUsable($0) }
+            .first()
+            .sink { [weak self] location in
+                guard let self else { return }
+                self.pendingDeviceDestinationLocationTimeout?.cancel()
+                self.pendingDeviceDestinationLocationTimeout = nil
+                self.pendingDeviceDestinationLocationObservation?.cancel()
+                self.pendingDeviceDestinationLocationObservation = nil
+                completion(location)
+            }
+
+        let timeout = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.pendingDeviceDestinationLocationObservation?.cancel()
+            self.pendingDeviceDestinationLocationObservation = nil
+            self.pendingDeviceDestinationLocationTimeout = nil
+            completion(nil)
+        }
+        pendingDeviceDestinationLocationTimeout = timeout
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + DeviceDestinationRequestTiming.locationRefreshTimeout,
+            execute: timeout
+        )
+        guard locationManager.beginDeviceDestinationLocationRefresh(
+            restart: true
+        ) else {
+            pendingDeviceDestinationLocationObservation?.cancel()
+            pendingDeviceDestinationLocationObservation = nil
+            pendingDeviceDestinationLocationTimeout?.cancel()
+            pendingDeviceDestinationLocationTimeout = nil
+            completion(nil)
+            return
+        }
+    }
+
+    private func cancelPendingDeviceDestinationLocationResolution() {
+        cancelPendingDeviceDestinationRouteCalculation()
+        pendingDeviceDestinationLocationObservation?.cancel()
+        pendingDeviceDestinationLocationObservation = nil
+        pendingDeviceDestinationLocationTimeout?.cancel()
+        pendingDeviceDestinationLocationTimeout = nil
+        pendingDeviceDestinationRequestDeadline?.cancel()
+        pendingDeviceDestinationRequestDeadline = nil
+        pendingDeviceDestinationLocationRequest = nil
+        pendingDeviceDestinationRouteGeneration = nil
+        locationManager.endDeviceDestinationLocationRefresh()
+    }
+
+    private func cancelPendingDeviceDestinationRouteCalculation() {
+        guard let generation = pendingDeviceDestinationRouteGeneration,
+              routeCalculationGeneration == generation else { return }
+        ongoingSourceSearch?.cancel()
+        ongoingSourceSearch = nil
+        ongoingDestinationSearch?.cancel()
+        ongoingDestinationSearch = nil
+        ongoingDirections?.cancel()
+        ongoingDirections = nil
+        if pendingNavigationStart?.generation == generation {
+            pendingNavigationStart = nil
+        }
+        routeCalculationGeneration &+= 1
+        routeCalculation.isCalculating = false
+        routeCalculation.status = ""
+        pendingDeviceDestinationRouteGeneration = nil
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -8,6 +8,9 @@
 import Foundation
 import CoreLocation
 import Combine
+#if canImport(UIKit) && !HOST_TESTING
+import UIKit
+#endif
 
 class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var currentLocation: CLLocation?
@@ -24,6 +27,9 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     private var isNavigating = false
     private var isViewingMap = false
     private var isLocationUpdating = false
+    private var isDeviceDestinationRequestsEnabled = false
+    private var isRefreshingDeviceDestinationLocation = false
+    private var hasRequestedAlwaysAuthorizationForDeviceDestinations = false
     
     weak var healthKitManager: HealthKitManager?
     
@@ -50,6 +56,40 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         locationManager.requestLocation()
     }
 
+    func setDeviceDestinationRequestsEnabled(_ enabled: Bool) {
+        guard isDeviceDestinationRequestsEnabled != enabled else { return }
+        isDeviceDestinationRequestsEnabled = enabled
+        prepareDeviceDestinationRequestsIfNeeded()
+    }
+
+    func prepareDeviceDestinationRequestsIfNeeded() {
+        guard isDeviceDestinationRequestsEnabled,
+              authorizationStatus == .authorizedWhenInUse,
+              Self.applicationIsActive,
+              !hasRequestedAlwaysAuthorizationForDeviceDestinations else {
+            return
+        }
+        hasRequestedAlwaysAuthorizationForDeviceDestinations = true
+        locationManager.requestAlwaysAuthorization()
+    }
+
+    @discardableResult
+    func beginDeviceDestinationLocationRefresh(restart: Bool) -> Bool {
+        guard isLocationAuthorized,
+              authorizationStatus == .authorizedAlways || Self.applicationIsActive else {
+            return false
+        }
+        isRefreshingDeviceDestinationLocation = true
+        updateLocationTracking(restart: restart)
+        return true
+    }
+
+    func endDeviceDestinationLocationRefresh() {
+        guard isRefreshingDeviceDestinationLocation else { return }
+        isRefreshingDeviceDestinationLocation = false
+        updateLocationTracking()
+    }
+
     func requestWhenInUseAuthorization() {
         locationManager.requestWhenInUseAuthorization()
     }
@@ -70,13 +110,18 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         updateLocationTracking()
     }
     
-    public func updateLocationTracking() {
+    public func updateLocationTracking(restart: Bool = false) {
         let shouldTrack = isNavigating || 
                          isViewingMap || 
-                         (healthKitManager?.isWorkoutActive == true)
-        let shouldTrackInBackground = isNavigating || (healthKitManager?.isWorkoutActive == true)
+                         (healthKitManager?.isWorkoutActive == true) ||
+                         isRefreshingDeviceDestinationLocation
+        let shouldTrackInBackground = isNavigating ||
+                                      (healthKitManager?.isWorkoutActive == true) ||
+                                      isRefreshingDeviceDestinationLocation
 
-        if shouldTrackInBackground && locationManager.authorizationStatus == .authorizedWhenInUse {
+        if shouldTrackInBackground &&
+            locationManager.authorizationStatus == .authorizedWhenInUse &&
+            Self.applicationIsActive {
             locationManager.requestAlwaysAuthorization()
         }
 
@@ -84,8 +129,11 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         locationManager.pausesLocationUpdatesAutomatically = !shouldTrackInBackground
         locationManager.showsBackgroundLocationIndicator = shouldTrackInBackground
         
-        if shouldTrack && !isLocationUpdating {
-            print("🌍 Starting location updates (navigating: \(isNavigating), map: \(isViewingMap), workout: \(healthKitManager?.isWorkoutActive == true))")
+        if shouldTrack && (!isLocationUpdating || restart) {
+            if isLocationUpdating {
+                locationManager.stopUpdatingLocation()
+            }
+            print("🌍 Starting location updates (navigating: \(isNavigating), map: \(isViewingMap), workout: \(healthKitManager?.isWorkoutActive == true), device destination request: \(isRefreshingDeviceDestinationLocation))")
             locationManager.startUpdatingLocation()
             isLocationUpdating = true
         } else if !shouldTrack && isLocationUpdating {
@@ -194,6 +242,15 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
 
     func locationManagerDidChangeAuthorization(_ manager: CLLocationManager) {
         authorizationStatus = manager.authorizationStatus
+        prepareDeviceDestinationRequestsIfNeeded()
         updateLocationTracking()
+    }
+
+    private static var applicationIsActive: Bool {
+#if canImport(UIKit) && !HOST_TESTING
+        UIApplication.shared.applicationState == .active
+#else
+        true
+#endif
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -32,6 +32,60 @@ struct DeviceDestinationCatalogBuild {
     let sourceFingerprint: String
 }
 
+enum DeviceDestinationCatalogGeneration {
+    static func initial(
+        randomValue: UInt32 = UInt32.random(in: 1...UInt32.max)
+    ) -> UInt32 {
+        randomValue == 0 ? 1 : randomValue
+    }
+
+    static func next(after current: UInt32) -> UInt32 {
+        current == UInt32.max ? 1 : current + 1
+    }
+}
+
+enum DeviceDestinationCatalogSyncPolicy {
+    static func shouldPublish(
+        force: Bool,
+        lastFingerprint: String?,
+        nextFingerprint: String
+    ) -> Bool {
+        force || lastFingerprint != nextFingerprint
+    }
+}
+
+enum DeviceDestinationLocationPolicy {
+    static let maximumAge: TimeInterval = 5
+    static let maximumHorizontalAccuracy: CLLocationAccuracy = 100
+    static let maximumFutureSkew: TimeInterval = 5
+
+    static func isUsable(_ location: CLLocation, now: Date = Date()) -> Bool {
+        guard location.horizontalAccuracy >= 0,
+              location.horizontalAccuracy <= maximumHorizontalAccuracy else {
+            return false
+        }
+        let age = now.timeIntervalSince(location.timestamp)
+        return age >= -maximumFutureSkew && age <= maximumAge
+    }
+}
+
+enum DeviceDestinationRequestTiming {
+    static let locationRefreshTimeout: TimeInterval = 5
+    static let firmwareRequestTimeout: TimeInterval = 15
+    // Leave enough time for the terminal DNST write to reach firmware before
+    // its own pending-request timeout expires.
+    static let appRequestDeadline: TimeInterval = 13
+}
+
+enum DeviceDestinationStatusRetryPolicy {
+    static let maximumRetryCount = 2
+    static let retryDelay: TimeInterval = 0.15
+
+    static func shouldRetry(afterAttempt attempt: Int) -> Bool {
+        attempt < maximumRetryCount
+    }
+}
+
 enum DeviceDestinationCatalogBuilder {
     static let version: UInt8 = 1
     static let favoriteLimit = 3
@@ -41,26 +95,34 @@ enum DeviceDestinationCatalogBuilder {
         favorites: [SavedDestination],
         generation: UInt32
     ) -> DeviceDestinationCatalogBuild {
-        var selected: [(DeviceDestinationKind, SavedDestination)] = []
+        var selected: [(
+            kind: DeviceDestinationKind,
+            destination: SavedDestination,
+            label: String
+        )] = []
         var seenIdentities = Set<String>()
 
         for destination in favorites where selected.count < favoriteLimit {
+            let label = utf8Prefix(destination.name, maxBytes: labelMaxBytes)
             let identity = destinationIdentity(destination)
-            guard !destination.name.isEmpty, seenIdentities.insert(identity).inserted else { continue }
-            selected.append((.favorite, destination))
+            guard !label.isEmpty,
+                  seenIdentities.insert(identity).inserted else { continue }
+            selected.append((.favorite, destination, label))
         }
 
         var destinationsByToken: [UInt16: SavedDestination] = [:]
         let items = selected.enumerated().map { index, entry in
             let token = UInt16(index + 1)
-            destinationsByToken[token] = entry.1
+            destinationsByToken[token] = entry.destination
             return DeviceDestinationCatalogItem(
                 token: token,
-                kind: entry.0,
-                label: utf8Prefix(entry.1.name, maxBytes: labelMaxBytes)
+                kind: entry.kind,
+                label: entry.label
             )
         }
-        let fingerprintParts: [String] = selected.map { kind, destination in
+        let fingerprintParts: [String] = selected.map { entry in
+            let kind = entry.kind
+            let destination = entry.destination
             let latitude = destination.latitude.map { String($0) } ?? "-"
             let longitude = destination.longitude.map { String($0) } ?? "-"
             return "\(kind.rawValue)|\(destination.id.uuidString)|\(latitude)|\(longitude)|\(destination.name)"

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
@@ -6,6 +6,7 @@ struct NavigationWrite {
     let transportWrite: ((Data) -> Void)?
     let onWrite: (() -> Void)?
     let onDrop: (() -> Void)?
+    let onWriteFailure: (() -> Void)?
     fileprivate let protectedFromEviction: Bool
 
     init(
@@ -14,6 +15,7 @@ struct NavigationWrite {
         transportWrite: ((Data) -> Void)? = nil,
         onWrite: (() -> Void)? = nil,
         onDrop: (() -> Void)? = nil,
+        onWriteFailure: (() -> Void)? = nil,
         protectedFromEviction: Bool = false
     ) {
         self.data = data
@@ -21,6 +23,7 @@ struct NavigationWrite {
         self.transportWrite = transportWrite
         self.onWrite = onWrite
         self.onDrop = onDrop
+        self.onWriteFailure = onWriteFailure
         self.protectedFromEviction = protectedFromEviction
     }
 
@@ -40,6 +43,7 @@ struct NavigationWrite {
             transportWrite: transportWrite,
             onWrite: onWrite,
             onDrop: onDrop,
+            onWriteFailure: onWriteFailure,
             protectedFromEviction: true
         )
     }
@@ -47,18 +51,21 @@ struct NavigationWrite {
 
 struct NavigationWriteQueue {
     let maxCount: Int
+    let priorityMaxCount: Int
     private var pendingWrites: [NavigationWrite] = []
+    private var pendingPriorityWrites: [NavigationWrite] = []
 
     var count: Int {
-        pendingWrites.count
+        pendingPriorityWrites.count + pendingWrites.count
     }
 
     var remainingCapacity: Int {
         max(maxCount - pendingWrites.count, 0)
     }
 
-    init(maxCount: Int) {
+    init(maxCount: Int, priorityMaxCount: Int = 1) {
         self.maxCount = max(1, maxCount)
+        self.priorityMaxCount = max(1, priorityMaxCount)
     }
 
     @discardableResult
@@ -85,7 +92,27 @@ struct NavigationWriteQueue {
         return true
     }
 
+    /// Inserts a small control response into a separate bounded lane ahead of
+    /// bulk traffic. A newer complete response replaces the older priority
+    /// message, without consuming or evicting regular/catalog capacity.
+    @discardableResult
+    mutating func enqueuePrioritizedAtomically(_ writes: [NavigationWrite]) -> Bool {
+        guard !writes.isEmpty, writes.count <= priorityMaxCount else {
+            return false
+        }
+
+        if pendingPriorityWrites.count + writes.count > priorityMaxCount {
+            pendingPriorityWrites.forEach { $0.onDrop?() }
+            pendingPriorityWrites.removeAll()
+        }
+        pendingPriorityWrites.append(contentsOf: writes.map {
+            $0.protectingAtomicBatch()
+        })
+        return true
+    }
+
     mutating func removeAll() {
+        pendingPriorityWrites.removeAll()
         pendingWrites.removeAll()
     }
 
@@ -95,8 +122,12 @@ struct NavigationWriteQueue {
         write: (NavigationWrite) -> Void
     ) {
         var writesRemaining = max(0, maxWrites)
-        while writesRemaining > 0 && !pendingWrites.isEmpty && canSend() {
-            write(pendingWrites.removeFirst())
+        while writesRemaining > 0 && count > 0 && canSend() {
+            if !pendingPriorityWrites.isEmpty {
+                write(pendingPriorityWrites.removeFirst())
+            } else {
+                write(pendingWrites.removeFirst())
+            }
             writesRemaining -= 1
         }
     }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -2319,6 +2319,88 @@ struct NavigationProtocolTests {
                     "AB", "destination labels remove embedded nulls")
         assertEqual(DeviceDestinationCatalogBuilder.utf8Prefix("A\nB", maxBytes: 64),
                     "A B", "destination labels normalize embedded controls")
+        let controlOnlyBuild = DeviceDestinationCatalogBuilder.build(
+            favorites: [
+                SavedDestination(name: "\u{1}\u{2}"),
+                SavedDestination(name: "Valid favorite")
+            ],
+            generation: 17
+        )
+        assertEqual(controlOnlyBuild.payload.items.map(\.label),
+                    ["Valid favorite"],
+                    "favorites whose sanitized label is empty are omitted")
+        assertEqual(DeviceDestinationCatalogGeneration.initial(randomValue: 0), 1,
+                    "catalog generation zero is normalized away")
+        assertEqual(DeviceDestinationCatalogGeneration.initial(randomValue: 99), 99,
+                    "catalog generation preserves a randomized non-zero seed")
+        assertEqual(DeviceDestinationCatalogGeneration.next(after: 99), 100,
+                    "catalog generation advances after publication")
+        assertEqual(DeviceDestinationCatalogGeneration.next(after: UInt32.max), 1,
+                    "catalog generation wraps without emitting zero")
+        assert(DeviceDestinationCatalogSyncPolicy.shouldPublish(
+            force: false,
+            lastFingerprint: nil,
+            nextFingerprint: ""
+        ), "an initial empty catalog is still published")
+        assert(!DeviceDestinationCatalogSyncPolicy.shouldPublish(
+            force: false,
+            lastFingerprint: "",
+            nextFingerprint: ""
+        ), "an unchanged published empty catalog is not repeated")
+        assert(DeviceDestinationCatalogSyncPolicy.shouldPublish(
+            force: true,
+            lastFingerprint: "same",
+            nextFingerprint: "same"
+        ), "a reconnect retry can force an unchanged catalog")
+        assert(DeviceDestinationRequestTiming.locationRefreshTimeout <
+               DeviceDestinationRequestTiming.appRequestDeadline,
+               "location refresh leaves time for route calculation")
+        assert(DeviceDestinationRequestTiming.appRequestDeadline <
+               DeviceDestinationRequestTiming.firmwareRequestTimeout,
+               "iOS terminates before the firmware request timeout")
+        assert(DeviceDestinationStatusRetryPolicy.shouldRetry(afterAttempt: 0),
+               "the first acknowledged status failure is retried")
+        assert(!DeviceDestinationStatusRetryPolicy.shouldRetry(
+            afterAttempt: DeviceDestinationStatusRetryPolicy.maximumRetryCount
+        ), "status retries remain bounded")
+
+        let now = Date()
+        let freshLocation = CLLocation(
+            coordinate: favoriteCoordinate,
+            altitude: 0,
+            horizontalAccuracy: 25,
+            verticalAccuracy: 25,
+            course: -1,
+            speed: -1,
+            timestamp: now.addingTimeInterval(-5)
+        )
+        let staleLocation = CLLocation(
+            coordinate: favoriteCoordinate,
+            altitude: 0,
+            horizontalAccuracy: 25,
+            verticalAccuracy: 25,
+            course: -1,
+            speed: -1,
+            timestamp: now.addingTimeInterval(
+                -(DeviceDestinationLocationPolicy.maximumAge + 1)
+            )
+        )
+        let inaccurateLocation = CLLocation(
+            coordinate: favoriteCoordinate,
+            altitude: 0,
+            horizontalAccuracy:
+                DeviceDestinationLocationPolicy.maximumHorizontalAccuracy + 1,
+            verticalAccuracy: 25,
+            course: -1,
+            speed: -1,
+            timestamp: now
+        )
+        assert(DeviceDestinationLocationPolicy.isUsable(freshLocation, now: now),
+               "a recent accurate fix can start a device route")
+        assert(!DeviceDestinationLocationPolicy.isUsable(staleLocation, now: now),
+               "a stale cached fix cannot start a device route")
+        assert(!DeviceDestinationLocationPolicy.isUsable(inaccurateLocation, now: now),
+               "an inaccurate fix cannot start a device route")
 
         guard let frames = DeviceDestinationCatalogChunker.frames(
             payload: build.payload,
@@ -2366,6 +2448,24 @@ struct NavigationProtocolTests {
             transferID: 1,
             maximumWriteLength: 64
         ) == nil, "the sender enforces the firmware reassembly byte limit")
+
+        let escapeHeavyFavorites = (1...3).map { index in
+            SavedDestination(
+                name: String(repeating: "\"", count: 63) + String(index)
+            )
+        }
+        let escapeHeavyBuild = DeviceDestinationCatalogBuilder.build(
+            favorites: escapeHeavyFavorites,
+            generation: UInt32.max
+        )
+        let escapeHeavyFrames = DeviceDestinationCatalogChunker.frames(
+            payload: escapeHeavyBuild.payload,
+            transferID: 2,
+            maximumWriteLength: 20
+        )
+        assert((escapeHeavyFrames?.count ?? Int.max) <=
+               DeviceBLEProtocol.fallbackWriteQueueCapacity,
+               "the bounded queue fits any valid three-favorite catalog at minimum MTU")
 
         var requestData = Data(DeviceBLEProtocol.destinationRequestPrefix.utf8)
         appendUInt32LE(17, to: &requestData)
@@ -2416,12 +2516,17 @@ struct NavigationProtocolTests {
         manager.onDestinationRequest = { receivedRequest = $0 }
         assert(manager.handleNavigationCharacteristicNotification(requestData),
                "DREQ notification is consumed before other control frames")
-        assertEqual(receivedRequest,
-                    DeviceDestinationRequest(generation: 17, token: 3),
-                    "BLE manager forwards the exact device selection")
+        assert(receivedRequest == nil,
+               "DREQ is not dispatched before authentication completes")
 
         manager.isConnected = true
         manager.isNavigationReady = true
+        assert(manager.handleNavigationCharacteristicNotification(requestData),
+               "authenticated DREQ notification is consumed")
+        assertEqual(receivedRequest,
+                    DeviceDestinationRequest(generation: 17, token: 3),
+                    "BLE manager forwards the exact authenticated device selection")
+
         var writes: [Data] = []
         let managerFrames = DeviceDestinationCatalogChunker.frames(
             payload: build.payload,
@@ -2458,6 +2563,49 @@ struct NavigationProtocolTests {
         ), "a retained-catalog request can be answered before CAPS completes")
         assertEqual(String(data: reconnectWrites.first?.prefix(4) ?? Data(), encoding: .utf8),
                     "DNST", "the pre-capability reconnect reply uses DNST")
+
+        let retryManager = BLEManager()
+        retryManager.isConnected = true
+        retryManager.isNavigationReady = true
+        var retryTransportReady = true
+        var statusRetryWrites: [Data] = []
+        retryManager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 64,
+            expectsWriteResponse: true,
+            canSend: { retryTransportReady },
+            write: { data in
+                statusRetryWrites.append(data)
+                retryTransportReady = false
+            }
+        ))
+        assert(retryManager.sendDestinationStatus(
+            generation: 17,
+            token: 3,
+            status: .failed,
+            message: "Could not start navigation"
+        ), "an acknowledged destination status is initially queued")
+        assertEqual(statusRetryWrites.count, 1,
+                    "the first status attempt reaches the transport")
+        let simulatedWriteError = NSError(
+            domain: "DestinationStatusRetryTests",
+            code: 1
+        )
+        retryTransportReady = true
+        retryManager.completeNavigationWriteForTesting(error: simulatedWriteError)
+        assert(waitForMainLoop(timeout: 3) { statusRetryWrites.count == 2 },
+               "a delegate-equivalent write error retries the latest status")
+        retryTransportReady = true
+        retryManager.completeNavigationWriteForTesting(error: simulatedWriteError)
+        assert(waitForMainLoop(timeout: 3) { statusRetryWrites.count == 3 },
+               "a second acknowledged failure uses the final bounded retry")
+        retryTransportReady = true
+        retryManager.completeNavigationWriteForTesting(error: simulatedWriteError)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.3))
+        assertEqual(statusRetryWrites.count, 3,
+                    "status retry exhaustion does not loop indefinitely")
+        assert(statusRetryWrites.dropFirst().allSatisfy {
+            $0 == statusRetryWrites.first
+        }, "status retries preserve the exact terminal response")
     }
 
     static func testRouteInitialLocationUsesResolvedSource() {
@@ -6441,6 +6589,72 @@ struct NavigationProtocolTests {
                "a later regular write is dropped when only atomic chunks are pending")
         assertEqual(protectedWrites, [Data([1]), Data([2]), Data([3])],
                     "later queue pressure cannot fragment an accepted atomic message")
+
+        var prioritizedQueue = NavigationWriteQueue(maxCount: 3)
+        var droppedRegularWrite = false
+        prioritizedQueue.enqueue(NavigationWrite(
+            data: Data([1]),
+            label: "regular-1",
+            onDrop: { droppedRegularWrite = true }
+        ))
+        prioritizedQueue.enqueue(NavigationWrite(data: Data([2]), label: "regular-2"))
+        prioritizedQueue.enqueue(NavigationWrite(data: Data([3]), label: "regular-3"))
+        assert(prioritizedQueue.enqueuePrioritizedAtomically([
+            NavigationWrite(data: Data([9]), label: "destination-status")
+        ]), "a destination status uses its dedicated lane at bulk capacity")
+        assert(!droppedRegularWrite,
+               "priority admission does not evict ordinary traffic")
+        assertEqual(prioritizedQueue.count, 4,
+                    "the bounded priority lane is separate from bulk capacity")
+        var prioritizedWrites: [Data] = []
+        prioritizedQueue.flush(canSend: { true }) {
+            prioritizedWrites.append($0.data)
+        }
+        assertEqual(prioritizedWrites,
+                    [Data([9]), Data([1]), Data([2]), Data([3])],
+                    "destination status is sent before queued ordinary traffic")
+
+        var catalogAndStatusQueue = NavigationWriteQueue(maxCount: 3)
+        assert(catalogAndStatusQueue.enqueueAtomically([
+            NavigationWrite(data: Data([4]), label: "catalog-1"),
+            NavigationWrite(data: Data([5]), label: "catalog-2"),
+            NavigationWrite(data: Data([6]), label: "catalog-3")
+        ]), "catalog batch can fill bulk capacity before priority traffic")
+        var supersededStatusWasDropped = false
+        assert(catalogAndStatusQueue.enqueuePrioritizedAtomically([
+            NavigationWrite(
+                data: Data([8]),
+                label: "calculating-status",
+                onDrop: { supersededStatusWasDropped = true }
+            )
+        ]), "first priority status is admitted despite a full catalog lane")
+        assert(catalogAndStatusQueue.enqueuePrioritizedAtomically([
+            NavigationWrite(data: Data([9]), label: "terminal-status")
+        ]), "new terminal status replaces an older queued status")
+        assert(supersededStatusWasDropped,
+               "priority replacement reports the superseded status")
+        var catalogAndStatusWrites: [Data] = []
+        catalogAndStatusQueue.flush(canSend: { true }) {
+            catalogAndStatusWrites.append($0.data)
+        }
+        assertEqual(catalogAndStatusWrites,
+                    [Data([9]), Data([4]), Data([5]), Data([6])],
+                    "priority replacement preserves the complete catalog batch")
+
+        var catalogWriteFailureWasReported = false
+        var failureTrackingQueue = NavigationWriteQueue(maxCount: 1)
+        assert(failureTrackingQueue.enqueueAtomically([
+            NavigationWrite(
+                data: Data([7]),
+                label: "catalog",
+                onWriteFailure: { catalogWriteFailureWasReported = true }
+            )
+        ]), "catalog failure callback is accepted with the atomic batch")
+        failureTrackingQueue.flush(canSend: { true }) { write in
+            write.onWriteFailure?()
+        }
+        assert(catalogWriteFailureWasReported,
+               "atomic batch protection preserves the transport failure callback")
     }
 
     static func testDeviceBLEProtocolConstants() {


### PR DESCRIPTION
## What changed

- harden destination catalog generation, queueing, and retry behavior
- keep device-originated route starts atomic across location lookup, MapKit calculation, disconnects, and timeouts
- use request-scoped background location tracking instead of connection-long high-accuracy GPS
- align the device picker UI and protocol documentation with the favorites-only behavior
- add regression coverage for queue pressure, acknowledged write failures, catalog validation, and timeout ordering

## Why

The deep review of PR #75 found lifecycle and transport edge cases that could leave the device spinner waiting, start navigation only on the phone, reuse a stale destination mapping, or keep high-accuracy location active longer than necessary.

## Impact

Selecting a favorite now either starts navigation on both the phone and bike computer or returns a bounded visible failure. Catalog and status messages recover from queue pressure and acknowledged BLE write failures.

## Validation

- five-pass deep review with a final unanimous P0-P2 PASS
- unsigned generic iOS device build
- WAVESHARE_AMOLED_175 and WAVESHARE_AMOLED_206 firmware builds
- NavigationProtocol, DestinationCalloutLayout, and SavedMapPreviewCatalyst suites
- strict destination-picker protocol test and both GUI layout tests
- plist lint and git diff hygiene checks
