### PR TITLE
Prevent map download modal flash

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -21,6 +21,7 @@ struct ContentView: View {
     @State private var showingSettings = false
     @State private var isSearchPanelExpanded = false
     @State private var dismissedOfflineMapOnboarding = false
+    @State private var confirmedDeviceMapMissing = false
     @State private var offlineMapSelectionWidth: CGFloat?
     @State private var offlineMapSelectionHeight: CGFloat?
     @State private var offlineMapSelectionCenterY: CGFloat?
@@ -127,6 +128,21 @@ struct ContentView: View {
                 offlineMapSelectionDragStartFrame = nil
             }
         }
+        .task(id: deviceMapMissingCandidate) {
+            guard deviceMapMissingCandidate else {
+                confirmedDeviceMapMissing = false
+                return
+            }
+
+            do {
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+            } catch {
+                return
+            }
+
+            guard deviceMapMissingCandidate else { return }
+            confirmedDeviceMapMissing = true
+        }
     }
 
     private func schedulePendingMapInstallResume() {
@@ -149,6 +165,13 @@ struct ContentView: View {
         offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
     }
 
+    private var deviceMapMissingCandidate: Bool {
+        coordinator.isLocationAuthorized &&
+            coordinator.bleManager.isNavigationReady &&
+            coordinator.bleManager.deviceHasSDCard == true &&
+            coordinator.bleManager.deviceMapFoundForCurrentLocation == false
+    }
+
     private var shouldShowOfflineMapOnboarding: Bool {
         guard !dismissedOfflineMapOnboarding else { return false }
         guard !offlineMapManager.isMapAreaSelectionActive else { return false }
@@ -160,8 +183,7 @@ struct ContentView: View {
         if !coordinator.isLocationAuthorized {
             return true
         }
-        return coordinator.bleManager.deviceHasSDCard == true &&
-            coordinator.bleManager.deviceMapFoundForCurrentLocation == false
+        return confirmedDeviceMapMissing
     }
 
     private var topOverlay: some View {


### PR DESCRIPTION
## What changed

- require a missing-map status to remain stable for one second before presenting the Download Map onboarding card
- cancel the pending presentation as soon as the device reports that a map is available
- preserve the immediate location-permission onboarding and the existing pending-map recovery flow

## Why

When BLE authentication completes, the first map status can arrive while the device is still applying the phone's GPS position. That transient status reports `mapFound == false`, briefly presenting the Download Map card before the refreshed status correctly reports the existing map.

## Impact

Devices that already contain the current-area map no longer flash the download prompt during connection. Devices that genuinely lack a map still see the prompt after a short confirmation delay.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS' build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`
