### PR TITLE
Reroute navigation after leaving the active route

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -67,6 +67,11 @@ class BikeComputerCoordinator: ObservableObject {
     private var ongoingSourceSearch: MKLocalSearch?
     private var ongoingDestinationSearch: MKLocalSearch?
     private var ongoingDirections: MKDirections?
+    private var ongoingRerouteDirections: MKDirections?
+    private var navigationDestination: MKMapItem?
+    private var routeDeviationDetector = RouteDeviationDetector()
+    private var lastRerouteRequestDate = Date.distantPast
+    private let rerouteCooldown: TimeInterval = 15
     private var transportType: MKDirectionsTransportType = RouteTransportTypes.cycling
     private var deviceCapabilityRefreshGeneration: UInt = 0
     private var routeCalculationGeneration: UInt = 0
@@ -160,7 +165,11 @@ class BikeComputerCoordinator: ObservableObject {
         locationManager.$currentLocation
             .compactMap { $0 }
             .sink { [weak self] location in
-                self?.navEngine.processExternalLocation(location)
+                guard let self else { return }
+                let acceptedForNavigation = self.navEngine.processExternalLocation(location)
+                if acceptedForNavigation {
+                    self.evaluateRerouting(for: location)
+                }
             }
             .store(in: &cancellables)
 
@@ -306,6 +315,11 @@ class BikeComputerCoordinator: ObservableObject {
     }
 
     func stopNavigation() {
+        ongoingRerouteDirections?.cancel()
+        ongoingRerouteDirections = nil
+        navigationDestination = nil
+        routeDeviationDetector.reset()
+        lastRerouteRequestDate = .distantPast
         navEngine.stopNavigation()
         currentRoute = nil
         locationManager.setNavigating(false)
@@ -741,6 +755,11 @@ extension BikeComputerCoordinator {
         ongoingSourceSearch?.cancel()
         ongoingDestinationSearch?.cancel()
         ongoingDirections?.cancel()
+        ongoingRerouteDirections?.cancel()
+        ongoingRerouteDirections = nil
+        navigationDestination = nil
+        routeDeviationDetector.reset()
+        lastRerouteRequestDate = .distantPast
         routeCalculationGeneration &+= 1
         let generation = routeCalculationGeneration
         if let completion {
@@ -930,6 +949,8 @@ extension BikeComputerCoordinator {
 
                 // Store the route for map display
                 self.currentRoute = route
+                self.navigationDestination = destinationItem
+                self.routeDeviationDetector.reset()
 
                 // Start navigation from the same source MapKit used to calculate the route.
                 self.navEngine.startNavigation(
@@ -948,6 +969,83 @@ extension BikeComputerCoordinator {
                     self.routeCalculation.isCalculating = false
                     self.routeCalculation.status = ""
                 }
+            }
+        }
+    }
+
+    private func evaluateRerouting(for gpsLocation: CLLocation) {
+        guard navEngine.isNavigating,
+              !navEngine.isSimulationMode,
+              ongoingRerouteDirections == nil,
+              let route = currentRoute,
+              let destination = navigationDestination else {
+            routeDeviationDetector.reset()
+            return
+        }
+
+        let now = Date()
+        guard now.timeIntervalSince(lastRerouteRequestDate) >= rerouteCooldown else {
+            routeDeviationDetector.reset()
+            return
+        }
+
+        let routeLocation = CoordinateConverter.mapKitRouteLocation(fromGPSLocation: gpsLocation)
+        guard let distanceToRoute = RouteDeviation.distance(from: routeLocation, to: route.polyline),
+              routeDeviationDetector.shouldReroute(
+                distanceToRoute: distanceToRoute,
+                horizontalAccuracy: gpsLocation.horizontalAccuracy
+              ) else {
+            return
+        }
+
+        requestReroute(from: routeLocation, to: destination, distanceToRoute: distanceToRoute)
+    }
+
+    private func requestReroute(
+        from routeLocation: CLLocation,
+        to destination: MKMapItem,
+        distanceToRoute: CLLocationDistance
+    ) {
+        let source = MKMapItem(placemark: MKPlacemark(coordinate: routeLocation.coordinate))
+        source.name = "Current Location"
+
+        let request = MKDirections.Request()
+        request.source = source
+        request.destination = destination
+        request.transportType = transportType
+        request.requestsAlternateRoutes = false
+
+        lastRerouteRequestDate = Date()
+        print("Off route by \(Int(distanceToRoute.rounded()))m; requesting reroute")
+
+        let directions = MKDirections(request: request)
+        ongoingRerouteDirections = directions
+        directions.calculate { [weak self] response, error in
+            MainActor.assumeIsolated {
+                guard let self,
+                      let activeDirections = self.ongoingRerouteDirections,
+                      activeDirections === directions else {
+                    return
+                }
+                self.ongoingRerouteDirections = nil
+
+                if let error {
+                    print("Reroute failed: \(error.localizedDescription)")
+                    return
+                }
+
+                guard self.navEngine.isNavigating,
+                      let route = response?.routes.first else {
+                    print("Reroute returned no route")
+                    return
+                }
+
+                self.currentRoute = route
+                self.routeDeviationDetector.reset()
+                let latestRouteLocation = self.currentLocation
+                    .map(CoordinateConverter.mapKitRouteLocation(fromGPSLocation:)) ?? routeLocation
+                self.navEngine.replaceRoute(with: route, currentLocation: latestRouteLocation)
+                print("Reroute applied: \(Int(route.distance.rounded()))m, \(route.steps.count) steps")
             }
         }
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -80,8 +80,9 @@ class NavigationEngine: NSObject, ObservableObject {
             .store(in: &cancellables)
     }
 
-    func processExternalLocation(_ location: CLLocation) {
-        guard !isSimulationMode else { return }
+    @discardableResult
+    func processExternalLocation(_ location: CLLocation) -> Bool {
+        guard !isSimulationMode else { return false }
         let routeLocation = CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location)
         let acceptedRouteLocation: CLLocation?
         if shouldAcceptLiveLocation(routeLocation) {
@@ -97,6 +98,7 @@ class NavigationEngine: NSObject, ObservableObject {
             lastDeviceGpsLocation = (location, false)
             sendIdleDeviceTimeSyncIfNeeded(location)
         }
+        return acceptedRouteLocation != nil
     }
     
     /// Start navigation with a given route
@@ -127,6 +129,30 @@ class NavigationEngine: NSObject, ObservableObject {
             updateRideTelemetry(gpsLocation: initialLocation, routeLocation: initialLocation)
             sendInitialDeviceGpsPosition(initialLocation, convertFromMapKitRoute: true)
         }
+    }
+
+    /// Replace an active route after rerouting without resetting ride telemetry.
+    func replaceRoute(with route: MKRoute, currentLocation: CLLocation) {
+        guard isNavigating, !isSimulationMode else { return }
+
+        currentRoute = route
+        currentStepIndex = 0
+        currentSnapshot = nil
+        lastManeuverStepIndex = nil
+        lastManeuverRemainingDistance = nil
+        sendTracker.reset()
+        initialNavigationLocation = nil
+        hasAcceptedLiveLocation = true
+        lastSentGeometryHash = 0
+        lastGeometrySendTime = .distantPast
+
+        let remainingDistance = RouteProgress.remainingDistance(from: currentLocation, in: route) ?? route.distance
+        lastRouteRemainingMeters = remainingDistance
+        updateNavigationSummary(route: route, remainingDistance: remainingDistance)
+        processLocation(currentLocation)
+        resendCurrentDeviceGpsPosition()
+
+        print("Navigation route replaced with \(route.steps.count) steps")
     }
     
     /// Stop navigation

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -422,6 +422,85 @@ enum RouteProgress {
     }
 }
 
+enum RouteDeviation {
+    static func distance(from location: CLLocation, to polyline: MKPolyline) -> CLLocationDistance? {
+        let pointCount = polyline.pointCount
+        guard pointCount > 0 else { return nil }
+
+        let routePoints = polyline.points()
+        let target = MKMapPoint(location.coordinate)
+        if pointCount == 1 {
+            return target.distance(to: routePoints[0])
+        }
+
+        var closestDistance = Double.greatestFiniteMagnitude
+        for index in 0..<(pointCount - 1) {
+            let start = routePoints[index]
+            let end = routePoints[index + 1]
+            let dx = end.x - start.x
+            let dy = end.y - start.y
+            let segmentLengthSquared = dx * dx + dy * dy
+
+            guard segmentLengthSquared > 0 else {
+                closestDistance = min(closestDistance, target.distance(to: start))
+                continue
+            }
+
+            let rawProjection = ((target.x - start.x) * dx + (target.y - start.y) * dy) / segmentLengthSquared
+            let projection = min(max(rawProjection, 0), 1)
+            let projected = MKMapPoint(x: start.x + projection * dx, y: start.y + projection * dy)
+            closestDistance = min(closestDistance, target.distance(to: projected))
+        }
+
+        return closestDistance.isFinite ? closestDistance : nil
+    }
+}
+
+struct RouteDeviationDetector {
+    let distanceThreshold: CLLocationDistance
+    let requiredConsecutiveSamples: Int
+    let maxHorizontalAccuracy: CLLocationAccuracy
+    private(set) var consecutiveOffRouteSamples = 0
+
+    init(
+        distanceThreshold: CLLocationDistance = 50,
+        requiredConsecutiveSamples: Int = 3,
+        maxHorizontalAccuracy: CLLocationAccuracy = 50
+    ) {
+        self.distanceThreshold = distanceThreshold
+        self.requiredConsecutiveSamples = max(requiredConsecutiveSamples, 1)
+        self.maxHorizontalAccuracy = maxHorizontalAccuracy
+    }
+
+    mutating func reset() {
+        consecutiveOffRouteSamples = 0
+    }
+
+    mutating func shouldReroute(
+        distanceToRoute: CLLocationDistance,
+        horizontalAccuracy: CLLocationAccuracy
+    ) -> Bool {
+        guard distanceToRoute.isFinite,
+              horizontalAccuracy >= 0,
+              horizontalAccuracy <= maxHorizontalAccuracy else {
+            reset()
+            return false
+        }
+
+        let accuracyAdjustedThreshold = max(distanceThreshold, horizontalAccuracy * 2)
+        guard distanceToRoute > accuracyAdjustedThreshold else {
+            reset()
+            return false
+        }
+
+        consecutiveOffRouteSamples += 1
+        guard consecutiveOffRouteSamples >= requiredConsecutiveSamples else { return false }
+
+        reset()
+        return true
+    }
+}
+
 enum RouteEndpointSelection {
     static func sourceEndpoint(hasSelectedSource: Bool, sourceAddress: String) -> RouteEndpoint {
         hasSelectedSource ? .query(sourceAddress) : .currentLocation

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -463,7 +463,7 @@ struct RouteDeviationDetector {
     private(set) var consecutiveOffRouteSamples = 0
 
     init(
-        distanceThreshold: CLLocationDistance = 50,
+        distanceThreshold: CLLocationDistance = 30,
         requiredConsecutiveSamples: Int = 3,
         maxHorizontalAccuracy: CLLocationAccuracy = 50
     ) {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -436,6 +436,7 @@ struct NavigationProtocolTests {
         testIconMapping()
         testRouteEndpointExtraction()
         testRouteRemainingDistance()
+        testRouteDeviationDetection()
         testStepRemainingDistanceFollowsPolyline()
         testStepRemainingDistanceResolvesAmbiguousGeometry()
         testChinaRouteCoordinatesRoundTripWithoutCalibrationNudge()
@@ -2081,6 +2082,39 @@ struct NavigationProtocolTests {
 
         let offRouteNearHalfway = CLLocation(latitude: 37.0010, longitude: -122.0005)
         assert(abs((RouteProgress.remainingDistance(from: offRouteNearHalfway, in: route) ?? -1) - totalDistance / 2) < 2, "route remaining projects nearby locations onto closest segment")
+    }
+
+    static func testRouteDeviationDetection() {
+        let coordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0020, longitude: -122.0000)
+        ]
+        let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+        let onRoute = CLLocation(latitude: 37.0010, longitude: -122.0000)
+        let offRoute = CLLocation(latitude: 37.0010, longitude: -122.0010)
+
+        assert((RouteDeviation.distance(from: onRoute, to: polyline) ?? -1) < 1,
+               "on-route location has near-zero deviation")
+        assert((RouteDeviation.distance(from: offRoute, to: polyline) ?? 0) > 80,
+               "off-route location reports distance to the nearest segment")
+
+        var detector = RouteDeviationDetector(
+            distanceThreshold: 50,
+            requiredConsecutiveSamples: 3,
+            maxHorizontalAccuracy: 50
+        )
+        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+               "first off-route sample does not reroute")
+        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+               "second off-route sample does not reroute")
+        assert(detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+               "third accurate off-route sample reroutes")
+        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 80),
+               "poor GPS accuracy does not trigger rerouting")
+        assert(!detector.shouldReroute(distanceToRoute: 55, horizontalAccuracy: 30),
+               "accuracy-adjusted threshold avoids marginal deviations")
+        assertEqual(detector.consecutiveOffRouteSamples, 0,
+                    "an on-route or uncertain sample resets the deviation streak")
     }
 
     static func testStepRemainingDistanceFollowsPolyline() {
@@ -8697,8 +8731,9 @@ struct NavigationProtocolTests {
         assertEqual(manager.sentPackets.count, 1, "ready BLE should send initial source-based packet")
 
         let unrelatedDeviceLocation = CLLocation(latitude: 32.2304, longitude: 121.4737)
-        engine.processExternalLocation(unrelatedDeviceLocation)
+        let accepted = engine.processExternalLocation(unrelatedDeviceLocation)
 
+        assert(!accepted, "far live GPS should not be accepted for rerouting")
         assertEqual(manager.sentPackets.count, 1, "far live GPS should not overwrite a route started from another source")
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -2099,17 +2099,17 @@ struct NavigationProtocolTests {
                "off-route location reports distance to the nearest segment")
 
         var detector = RouteDeviationDetector(
-            distanceThreshold: 50,
+            distanceThreshold: 30,
             requiredConsecutiveSamples: 3,
             maxHorizontalAccuracy: 50
         )
-        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+        assert(!detector.shouldReroute(distanceToRoute: 40, horizontalAccuracy: 10),
                "first off-route sample does not reroute")
-        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+        assert(!detector.shouldReroute(distanceToRoute: 40, horizontalAccuracy: 10),
                "second off-route sample does not reroute")
-        assert(detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 10),
+        assert(detector.shouldReroute(distanceToRoute: 40, horizontalAccuracy: 10),
                "third accurate off-route sample reroutes")
-        assert(!detector.shouldReroute(distanceToRoute: 90, horizontalAccuracy: 80),
+        assert(!detector.shouldReroute(distanceToRoute: 40, horizontalAccuracy: 80),
                "poor GPS accuracy does not trigger rerouting")
         assert(!detector.shouldReroute(distanceToRoute: 55, horizontalAccuracy: 30),
                "accuracy-adjusted threshold avoids marginal deviations")


### PR DESCRIPTION
## Summary

- Detect sustained deviation from the active route using GPS-to-polyline distance.
- Request a replacement MapKit route from the rider's current position to the original destination.
- Replace map, maneuver, and BLE route state without restarting navigation or resetting ride telemetry.
- Cancel stale reroute requests when navigation stops or a new destination is selected.

### Root cause

Navigation only advanced maneuver instructions against the original `MKRoute`. No location update path detected that the rider had left the route, and no subsequent `MKDirections` request was made.

### Rerouting policy

- Require three consecutive off-route location samples.
- Trigger beyond `max(30 m, 2 × horizontalAccuracy)`.
- Ignore fixes with horizontal accuracy worse than 50 m.
- Wait at least 15 seconds before retrying another reroute request.

The threshold is app-defined; MapKit does not publish or provide an automatic Apple Maps rerouting threshold.

### User impact

After leaving the active route, riders receive a newly calculated route to the same destination. The updated route is reflected on the iPhone and sent to the bike computer while existing ride telemetry continues uninterrupted.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/open-bike-rerouting-pr-derived CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature. Legal entity represented, if any: none
- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
