### PR TITLE
Keep display awake during navigation

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 import MapKit
+import UIKit
 
 struct ContentView: View {
     
@@ -104,13 +105,21 @@ struct ContentView: View {
             }
         }
         .onAppear {
+            updateIdleTimer()
             coordinator.applicationDidBecomeActive()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: scenePhase) { newValue in
+            updateIdleTimer(for: newValue)
             guard newValue == .active else { return }
             coordinator.applicationDidBecomeActive()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
+        }
+        .onChange(of: coordinator.isNavigating) { _ in
+            updateIdleTimer()
+        }
+        .onDisappear {
+            UIApplication.shared.isIdleTimerDisabled = false
         }
         .onChange(of: coordinator.bleManager.isConnected) { _ in
             schedulePendingMapInstallResume()
@@ -143,6 +152,11 @@ struct ContentView: View {
             guard deviceMapMissingCandidate else { return }
             confirmedDeviceMapMissing = true
         }
+    }
+
+    private func updateIdleTimer(for phase: ScenePhase? = nil) {
+        UIApplication.shared.isIdleTimerDisabled =
+            coordinator.isNavigating && (phase ?? scenePhase) == .active
     }
 
     private func schedulePendingMapInstallResume() {


### PR DESCRIPTION
## Summary

- prevent iOS Auto-Lock while turn-by-turn navigation is active in the foreground
- restore normal Auto-Lock when navigation ends, the app leaves the foreground, or the root view disappears
- preserve the existing scene lifecycle used for pending map recovery

## Root cause

The app never synchronized `UIApplication.shared.isIdleTimerDisabled` with navigation state, so the iPhone could dim and lock during an active route.

## User impact

The navigation display now stays visible throughout a ride without changing the user's normal Auto-Lock behavior outside active navigation.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
