### PR TITLE
Default the 1.75-inch display to 90 degrees

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -99,7 +99,7 @@ Current setting IDs:
 | `1` | Map minimum polygon size | `0...50` |
 | `2` | Map detail level | `0` low, `1` medium, `2` high |
 | `3` | Map route line width | `2...48` |
-| `4` | Display rotation | `0...3` |
+| `4` | Legacy display rotation | Ignored. Rotation is fixed by firmware target: 90° on the 1.75-inch device and 0° on the 2.06-inch device. |
 | `6` | Map rotation mode | `0` north-up, `1` course-up |
 | `7` | Map zoom level | `0...5` |
 | `8` | Map visibility and global navigation-overlay mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/footways, bit 3 major roads, bit 4 residential/other local roads, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker, bit 10 service roads, bit 11 tracks, bit 12 extended-mask marker |

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -21,7 +21,6 @@
 #include "../route_overlay/route_overlay.hpp"
 #include "../speaker/speaker.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-#include "../waveshare_board/display.hpp"
 #include "../waveshare_board/pcf85063.hpp"
 #endif
 #include <NimBLEDevice.h>
@@ -383,28 +382,6 @@ static void initBleIdentityAndSecurity(const char *deviceName) {
                 advertisedAddress[0] == '\0'
                     ? NimBLEDevice::getAddress().toString().c_str()
                     : advertisedAddress);
-}
-
-static uint8_t sanitizeMapDisplayRotation(uint8_t requestedRotation,
-                                          const char *source) {
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  if (requestedRotation > waveshare_board::display::MAX_SUPPORTED_ROTATION) {
-    Serial.printf("BLE Settings: %s displayRotation %u unsupported, clamping "
-                  "to 0\n",
-                  source, requestedRotation);
-    return waveshare_board::display::ROTATION_0;
-  }
-  if (requestedRotation == waveshare_board::display::ROTATION_90 &&
-      !waveshare_board::display::EXPERIMENTAL_90_ROTATION_ENABLED) {
-    Serial.printf("BLE Settings: %s displayRotation 1 disabled on Waveshare "
-                  "until CO5300 window is verified; using 0\n",
-                  source);
-    return waveshare_board::display::ROTATION_0;
-  }
-#else
-  (void)source;
-#endif
-  return requestedRotation;
 }
 
 /**
@@ -1633,15 +1610,8 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     break;
   }
   case 4:
-    mapRenderSettings.displayRotation =
-        (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)3);
-    mapRenderSettings.displayRotation =
-        sanitizeMapDisplayRotation(mapRenderSettings.displayRotation, "write");
-    settingsPrefs.begin("mapSettings", false);
-    settingsPrefs.putUChar("rotation", mapRenderSettings.displayRotation);
-    settingsPrefs.end();
-    Serial.printf("BLE Settings: displayRotation = %d (reboot to apply)\n",
-                  mapRenderSettings.displayRotation);
+    Serial.println("BLE Settings: ignoring legacy displayRotation; rotation "
+                   "is selected by the firmware target");
     break;
   case 5:
     Serial.println("BLE Settings: Reboot command received! Restarting...");
@@ -2071,8 +2041,6 @@ static void loadSettingsFromNVS() {
 
   map_profile_persistence::load(prefs, mapRenderSettings.mapStyle,
                                 mapRenderSettings.mapNavigationStyle);
-  mapRenderSettings.displayRotation =
-      sanitizeMapDisplayRotation(prefs.getUChar("rotation", 0), "NVS");
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
   mapRenderSettings.tapToSwitchScreens = prefs.getUChar("tapSwitch", 0);
   uint8_t storedScreenMask =
@@ -2098,14 +2066,13 @@ static void loadSettingsFromNVS() {
 
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
                 "detailLevel=%d, routeWidth=%d, streetBoost=%d, "
-                "markerScale=%d, rotation=%d, tapSwitch=%d, "
+                "markerScale=%d, tapSwitch=%d, "
                 "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
                 mapRenderSettings.mapStyle.minPolygonSize,
                 mapRenderSettings.mapStyle.detailLevel,
                 mapRenderSettings.mapStyle.routeLineWidth,
                 mapRenderSettings.mapStyle.streetLineWidthBoost,
                 mapRenderSettings.mapStyle.positionMarkerScale,
-                mapRenderSettings.displayRotation,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,
                 mapRenderSettings.defaultScreen,

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -33,9 +33,10 @@ struct NavigationData {
 /**
  * @brief Map rendering settings (configurable via BLE from iOS app)
  * IDs 1,2,3,7,8,9,10 configure the Map screen. IDs 16-22 configure
- * Map + Navigation. IDs 4,6,11-15 configure shared/device behavior, and IDs
+ * Map + Navigation. IDs 6,11-15 configure shared/device behavior, and IDs
  * 23-24 carry the connected phone's transient battery percentage and charging
- * state.
+ * state. Legacy ID 4 is ignored because display rotation is selected by the
+ * hardware target.
  */
 enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
@@ -98,8 +99,6 @@ struct ScreenMapRenderSettings {
 struct MapRenderSettings {
   ScreenMapRenderSettings mapStyle;
   ScreenMapRenderSettings mapNavigationStyle;
-  uint8_t displayRotation =
-      0; // 0-3: Display rotation (0=0°, 1=90°, 2=180°, 3=270°)
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
   uint8_t enabledScreensMask =

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -9,7 +9,6 @@
 #ifdef USE_ARDUINO_GFX
 
 #include <cstring>
-#include <Preferences.h>
 
 // Include HAL for pin definitions
 #include "../../include/hal.hpp"
@@ -59,8 +58,7 @@ Arduino_CO5300 *gfx = new Arduino_CO5300(bus,
 
 extern lv_display_t *display;
 static lv_color_t *disp_draw_buf = NULL;
-static uint8_t displayRotation =
-    0; // Global rotation for touch coordinate transform
+static uint8_t displayRotation = waveshare_board::display::DEFAULT_ROTATION;
 volatile uint32_t displayFlushCount = 0;
 volatile uint32_t lastDisplayFlushMs = 0;
 volatile uint32_t lastDisplayFlushDurationUs = 0;
@@ -75,9 +73,9 @@ static uint8_t sanitizeDisplayRotation(uint8_t requestedRotation) {
     return ROTATION_0;
   }
 
-  if (requestedRotation == ROTATION_90 && !EXPERIMENTAL_90_ROTATION_ENABLED) {
-    Serial.println("CO5300: 90-degree display rotation disabled until the "
-                   "active window is verified; using 0");
+  if (requestedRotation == ROTATION_90 && !ROTATION_90_ENABLED) {
+    Serial.println("CO5300: 90-degree display rotation is only enabled for "
+                   "the 1.75-inch target; using 0");
     return ROTATION_0;
   }
 
@@ -94,15 +92,15 @@ static void applyCo5300Rotation(uint8_t rotation) {
   using namespace waveshare_board::display;
 
   Serial.printf("CO5300: logical=%ux%u active=%ux%u constructorGap=(%u,%u,%u,%u) "
-                "rotation=%u experimental90=%d\n",
+                "rotation=%u rotation90Enabled=%d\n",
                 LOGICAL_WIDTH, LOGICAL_HEIGHT, ACTIVE_WIDTH, ACTIVE_HEIGHT,
                 ARDUINO_CO5300_COL_OFFSET1, ARDUINO_CO5300_ROW_OFFSET1,
                 ARDUINO_CO5300_COL_OFFSET2, ARDUINO_CO5300_ROW_OFFSET2,
-                rotation, EXPERIMENTAL_90_ROTATION_ENABLED ? 1 : 0);
+                rotation, ROTATION_90_ENABLED ? 1 : 0);
 
   switch (rotation) {
   case ROTATION_90:
-    Serial.printf("CO5300: applying experimental MADCTL 0x%02X for 90-degree "
+    Serial.printf("CO5300: applying MADCTL 0x%02X for 90-degree "
                   "rotation\n",
                   CO5300_MADCTL_ROTATION_90);
     writeCo5300Madctl(CO5300_MADCTL_ROTATION_90);
@@ -152,7 +150,7 @@ static void drawDisplayTestPatterns(uint8_t appliedRotation) {
   using namespace waveshare_board::display;
 
   drawDisplayTestPatternForRotation(ROTATION_0);
-  if (EXPERIMENTAL_90_ROTATION_ENABLED) {
+  if (ROTATION_90_ENABLED) {
     drawDisplayTestPatternForRotation(ROTATION_90);
   }
   applyCo5300Rotation(appliedRotation);
@@ -800,15 +798,13 @@ void setupDisplay() {
   gfx->begin();
   delay(100); // Let display stabilize
 
-  // Load rotation from NVS (default to 0 if not set)
-  Preferences prefs;
-  prefs.begin("mapSettings", true); // read-only
-  uint8_t requestedRotation = prefs.getUChar("rotation", 0);
-  prefs.end();
-  uint8_t rotation = sanitizeDisplayRotation(requestedRotation);
+  // Rotation is a hardware-target choice. The square 1.75-inch device boots
+  // at 90 degrees; the rectangular 2.06-inch device remains at 0 degrees.
+  // Ignore legacy NVS values written by older versions of the iOS app.
+  uint8_t rotation = sanitizeDisplayRotation(
+      waveshare_board::display::DEFAULT_ROTATION);
   displayRotation = rotation; // Store globally for touch coordinate rotation
-  Serial.printf("Loaded rotation from NVS: requested=%u applied=%u\n",
-                requestedRotation, rotation);
+  Serial.printf("Loaded target display rotation: %u\n", rotation);
 
   // ============================================================================
   // DISPLAY ROTATION VIA RAW MADCTL COMMAND
@@ -817,9 +813,8 @@ void setupDisplay() {
   // - Standard panels use: 0x80=MY, 0x40=MX, 0x20=MV (row/col exchange)
   // - CO5300 uses different bits: 0x02=X_FLIP, 0x05=Y_FLIP, 0x20=MV
   //
-  // IMPORTANT: current board bring-up only verified 0° for normal firmware.
-  // A 90° MADCTL path exists behind WAVESHARE_ENABLE_EXPERIMENTAL_90_ROTATION
-  // for hardware testing. 180° and 270° attempts all resulted in mirroring or
+  // The 1.75-inch target uses the 90° MADCTL path by default. The 2.06-inch
+  // target remains at 0°. 180° and 270° attempts all resulted in mirroring or
   // wrong direction.
   //
   // === 180° ROTATION ATTEMPTS (all failed): ===
@@ -837,9 +832,9 @@ void setupDisplay() {
   // ============================================================================
   // KNOWN ISSUE: 90° ROTATION HAS GREEN EDGE AT BOTTOM
   // ============================================================================
-  // When 90° rotation is enabled experimentally, a thin green strip appears at
-  // the bottom of the display. The map and touch work correctly, but this visual
-  // artifact persists during all map operations.
+  // On the 1.75-inch target, a thin green strip may appear at the bottom of the
+  // display. The map and touch work correctly, but this visual artifact persisted
+  // during earlier map operations.
   //
   // === WHAT WE TRIED TO FIX THE GREEN EDGE (all failed): ===
   // 1. fillScreen(BLACK) after MADCTL - still shows green
@@ -862,18 +857,15 @@ void setupDisplay() {
   //   render mode configuration
   // - Modify Arduino_CO5300 driver only if software rotation is too slow.
   //
-  // For now, normal Waveshare firmware clamps 90° requests back to 0° so the
-  // shipped build does not expose the known artifact. Use
-  // WAVESHARE_AMOLED_175_DISPLAY_TEST to inspect 0° and the experimental 90°
-  // path on hardware before enabling it in normal firmware.
+  // WAVESHARE_AMOLED_175_DISPLAY_TEST can still be used to inspect both target
+  // orientations on hardware.
   // ============================================================================
   //
   applyCo5300Rotation(rotation);
   if (rotation == waveshare_board::display::ROTATION_90) {
-    gfx->fillScreen(0x0000); // Clear with the experimental rotation applied.
+    gfx->fillScreen(0x0000); // Clear with the target rotation applied.
   }
   // Note: rotation values 2 (180°) and 3 (270°) are not supported by CO5300
-  // The iOS app only offers 0° and 90° options
 
   // Turn on display and set brightness (CRITICAL for AMOLED!)
   Serial.println("Turning on display and setting brightness...");

--- a/esp32/lib/waveshare_board/display.hpp
+++ b/esp32/lib/waveshare_board/display.hpp
@@ -40,6 +40,14 @@ constexpr uint8_t ROTATION_0 = 0;
 constexpr uint8_t ROTATION_90 = 1;
 constexpr uint8_t MAX_SUPPORTED_ROTATION = ROTATION_90;
 
+#ifdef WAVESHARE_AMOLED_175
+constexpr uint8_t DEFAULT_ROTATION = ROTATION_90;
+constexpr bool ROTATION_90_ENABLED = true;
+#else
+constexpr uint8_t DEFAULT_ROTATION = ROTATION_0;
+constexpr bool ROTATION_90_ENABLED = false;
+#endif
+
 constexpr uint8_t CO5300_CASET = 0x2A;
 constexpr uint8_t CO5300_PASET = 0x2B;
 constexpr uint8_t CO5300_MADCTL = 0x36;
@@ -49,11 +57,5 @@ constexpr uint8_t CO5300_MADCTL_RGB = 0x00;
 constexpr uint8_t CO5300_MADCTL_ROTATION_0 = CO5300_MADCTL_RGB;
 constexpr uint8_t CO5300_MADCTL_ROTATION_90 =
     CO5300_MADCTL_RGB | CO5300_MADCTL_MV | CO5300_MADCTL_X_FLIP;
-
-#ifdef WAVESHARE_ENABLE_EXPERIMENTAL_90_ROTATION
-constexpr bool EXPERIMENTAL_90_ROTATION_ENABLED = true;
-#else
-constexpr bool EXPERIMENTAL_90_ROTATION_ENABLED = false;
-#endif
 
 } // namespace waveshare_board::display

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -473,8 +473,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var routeLineWidth: Double = 4
     @Published var streetLineWidthBoost: Double = 0
     @Published var positionMarkerScale: Double = 2
-    @Published var displayRotation: Int = 0 
-    @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up  // 0-3: 0°, 90°, 180°, 270°
+    @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up
     @Published var zoomLevel: Int = 2 // 0-4: 0=super-zoom, 1=closest, 4=farthest
     @Published var mapPlusNavigationMinPolygonSize = MapPlusNavigationDefaults.minPolygonSize
     @Published var mapPlusNavigationDetailLevel = MapPlusNavigationDefaults.detailLevel
@@ -604,7 +603,6 @@ class BLEManager: NSObject, ObservableObject {
         static let routeLineWidth = "mapSettings.routeLineWidth"
         static let streetLineWidthBoost = "mapSettings.streetLineWidthBoost"
         static let positionMarkerScale = "mapSettings.positionMarkerScale"
-        static let displayRotation = "mapSettings.displayRotation"
         static let mapRotationMode = "mapSettings.mapRotationMode"
         static let resetMapRotationModeToNorthUp = "mapSettings.resetMapRotationModeToNorthUp.v1"
         static let zoomLevel = "mapSettings.zoomLevel"
@@ -705,7 +703,6 @@ class BLEManager: NSObject, ObservableObject {
         routeLineWidth = defaults.object(forKey: SettingsKeys.routeLineWidth) as? Double ?? 4.0
         streetLineWidthBoost = defaults.object(forKey: SettingsKeys.streetLineWidthBoost) as? Double ?? 0.0
         positionMarkerScale = defaults.object(forKey: SettingsKeys.positionMarkerScale) as? Double ?? 2.0
-        displayRotation = defaults.object(forKey: SettingsKeys.displayRotation) as? Int ?? 0
         if defaults.bool(forKey: SettingsKeys.resetMapRotationModeToNorthUp) {
             mapRotationMode = defaults.object(forKey: SettingsKeys.mapRotationMode) as? Int ?? 0
         } else {
@@ -875,7 +872,6 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(routeLineWidth, forKey: SettingsKeys.routeLineWidth)
         defaults.set(streetLineWidthBoost, forKey: SettingsKeys.streetLineWidthBoost)
         defaults.set(positionMarkerScale, forKey: SettingsKeys.positionMarkerScale)
-        defaults.set(displayRotation, forKey: SettingsKeys.displayRotation)
         defaults.set(mapRotationMode, forKey: SettingsKeys.mapRotationMode)
         defaults.set(zoomLevel, forKey: SettingsKeys.zoomLevel)
         defaults.set(mapPlusNavigationMinPolygonSize, forKey: SettingsKeys.mapPlusNavigationMinPolygonSize)
@@ -2221,7 +2217,6 @@ class BLEManager: NSObject, ObservableObject {
         updateTrustedPeripheralDescription()
         log("BLE peripheral authenticated")
         requestDeviceCapabilities()
-        sendSetting(id: 4, value: Int32(displayRotation))
         sendSetting(id: 6, value: Int32(mapRotationMode))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
         sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(deviceBrightnessPercent))

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -791,17 +791,6 @@ private struct UICustomizationSettingsView: View {
             .disabled(!bleManager.supportsDeviceSettings ||
                       !bleManager.hasReceivedDeviceCapabilities)
 
-            Section(header: Text("Display Rotation"), footer: Text("Rotate display 90° CCW. Requires reboot.")) {
-                Toggle("Rotate 90°", isOn: Binding(
-                    get: { bleManager.displayRotation == 1 },
-                    set: { newValue in
-                        bleManager.displayRotation = newValue ? 1 : 0
-                        bleManager.sendSetting(id: 4, value: Int32(bleManager.displayRotation))
-                    }
-                ))
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
             Section(header: Text("Map Mode"), footer: Text("Applies only to the Map screen. Map + Navigation automatically uses course-up while navigating.")) {
                 Picker("Rotation", selection: $bleManager.mapRotationMode) {
                     Text("North Up").tag(0)


### PR DESCRIPTION
## Summary

- remove the broken Rotate 90° control and its persisted/transmitted app state
- choose display orientation by firmware target: 90° for 1.75-inch, 0° for 2.06-inch
- ignore legacy BLE setting ID 4 and legacy NVS rotation values

## Why

The app exposed a rotation toggle that normal firmware clamped back to 0°, so the control was misleading. This makes the temporary 1.75-inch workaround explicit and leaves the 2.06-inch target unchanged.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `git diff --check`
- GitHub CI will build the iOS app and all four Waveshare firmware environments