### PR TITLE
Omit redundant text blocks from map streams

### DIFF
--- a/backend/map_platform/map_stream.py
+++ b/backend/map_platform/map_stream.py
@@ -340,6 +340,31 @@ def signed_manifest_payload(manifest: bytes) -> bytes:
     return SIGNATURE_DOMAIN + manifest
 
 
+def _without_redundant_text_fallbacks(manifest: dict[str, Any]) -> dict[str, Any]:
+    normalized = deepcopy(manifest)
+    files = normalized.get("files")
+    if not isinstance(files, list):
+        return normalized
+    binary_stems = {
+        file["path"][:-4]
+        for file in files
+        if isinstance(file, dict)
+        and isinstance(file.get("path"), str)
+        and file["path"].endswith(".fmb")
+    }
+    normalized["files"] = [
+        file
+        for file in files
+        if not (
+            isinstance(file, dict)
+            and isinstance(file.get("path"), str)
+            and file["path"].endswith(".fmp")
+            and file["path"][:-4] in binary_stems
+        )
+    ]
+    return normalized
+
+
 def build_stream_prefix(
     manifest: bytes,
     envelope: MapStreamSignatureEnvelope,
@@ -368,7 +393,9 @@ def write_map_stream_artifact(
     resolved_root = root.resolve()
     destination = Path(output_path)
     canonicalization_started = time.perf_counter()
-    manifest_bytes = canonical_manifest_bytes(manifest)
+    manifest_bytes = canonical_manifest_bytes(
+        _without_redundant_text_fallbacks(manifest)
+    )
     canonical_manifest = json.loads(manifest_bytes)
     files = canonical_manifest["files"]
     file_count = len(files)

--- a/backend/tests/test_map_stream.py
+++ b/backend/tests/test_map_stream.py
@@ -312,6 +312,59 @@ class MapStreamFormatTests(unittest.TestCase):
                 )
             self.assertEqual(raised.exception.code, "map_stream_build_failed")
 
+    def test_artifact_writer_omits_redundant_oversized_text_fallback(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            map_id = "binary-preferred-map"
+            binary_path = f"VECTMAP/{map_id}/+0000+0000/1.fmb"
+            ascii_path = f"VECTMAP/{map_id}/+0000+0000/1.fmp"
+            binary = root / binary_path
+            ascii_fallback = root / ascii_path
+            binary.parent.mkdir(parents=True)
+            binary.write_bytes(b"binary-map-block")
+            ascii_fallback.write_bytes(b"x" * (MAX_BLOCK_BYTES + 1))
+            manifest = {
+                "schemaVersion": 1,
+                "mapId": map_id,
+                "files": [
+                    {
+                        "path": ascii_path,
+                        "bytes": ascii_fallback.stat().st_size,
+                        "sha256": hashlib.sha256(ascii_fallback.read_bytes()).hexdigest(),
+                    },
+                    {
+                        "path": binary_path,
+                        "bytes": binary.stat().st_size,
+                        "sha256": hashlib.sha256(binary.read_bytes()).hexdigest(),
+                    },
+                ],
+            }
+            signer = P256MapArtifactSigner(
+                "map-writer-test",
+                ec.derive_private_key(4, ec.SECP256R1()),
+            )
+
+            build = write_map_stream_artifact(
+                root,
+                manifest,
+                signer,
+                root / "binary-preferred.bmap",
+            )
+
+            stream = build.path.read_bytes()
+            header = MapStreamHeader.decode(stream[:FIXED_HEADER_BYTES])
+            layout = MapStreamLayout.from_header(header, len(stream))
+            stream_manifest = json.loads(
+                stream[layout.manifest_offset : layout.signature_envelope_offset]
+            )
+            self.assertEqual(build.file_count, 1)
+            self.assertEqual(build.payload_bytes, binary.stat().st_size)
+            self.assertEqual(
+                [file["path"] for file in stream_manifest["files"]],
+                [binary_path],
+            )
+            self.assertEqual(stream[layout.payload_offset :], binary.read_bytes())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/backend/tests/test_pipeline_artifacts.py
+++ b/backend/tests/test_pipeline_artifacts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 
 from cryptography.hazmat.primitives.asymmetric import ec
@@ -44,9 +45,10 @@ class FixtureMapBuildPipeline(MapBuildPipeline):
         directory = raw_output_dir / "+0000+0000"
         directory.mkdir(parents=True, exist_ok=True)
         (directory / "1.fmb").write_bytes(b"first-map-block")
+        (directory / "1.fmp").write_bytes(b"redundant-text-fallback")
         (directory / "2.fmp").write_bytes(b"second-map-block")
         if on_progress:
-            on_progress(2, 2)
+            on_progress(3, 3)
 
 
 class PipelineArtifactTests(unittest.TestCase):
@@ -134,6 +136,13 @@ class PipelineArtifactTests(unittest.TestCase):
             self.assertEqual(first.artifact_metrics["streamFileCount"], 2)
             self.assertEqual(first.artifact_metrics["streamPayloadBytes"], 31)
             self.assertEqual(set(pending_keys), {artifact.object_key for artifact in first.artifacts})
+            zip_path = artifact_store.local_path(first_zip.object_key)
+            self.assertIsNotNone(zip_path)
+            with zipfile.ZipFile(zip_path) as archive:
+                self.assertIn(
+                    f"VECTMAP/{job.map_id}/+0000+0000/1.fmp",
+                    archive.namelist(),
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- omit same-stem `.fmp` text fallbacks from signed map streams when a preferred `.fmb` block exists
- keep unmatched `.fmp` blocks supported
- preserve all fallback files in the legacy ZIP artifact

## Production finding

A live map build reached packaging but failed because a redundant `.fmp` fallback exceeded the device stream block limit even though its same-stem `.fmb` block was valid. Firmware already selects `.fmb` before `.fmp`, so transmitting both copies is unnecessary.

## Verification

- targeted map-stream and pipeline artifact tests: 12 passed
- complete backend suite: 184 passed
- regression covers an oversized paired fallback, unmatched fallback support, deterministic stream identity, and legacy ZIP retention
- tracked diff passed whitespace validation

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.