### PR TITLE
Publish latest map worker image

### DIFF
--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -31,15 +31,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - id: metadata
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/open-bike-computer-map-platform
+          tags: |
+            type=raw,value=${{ github.sha }}
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - id: image
-        name: Build and publish immutable image
+        name: Build and publish image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: backend/Dockerfile
           platforms: linux/amd64
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/open-bike-computer-map-platform:${{ github.sha }}
+          tags: ${{ steps.metadata.outputs.tags }}
           provenance: mode=max
           sbom: true
 


### PR DESCRIPTION
## What changed

- keep publishing the map worker image under its immutable commit-SHA tag
- also publish `latest` when the workflow runs from the repository default branch
- keep feature-branch image builds from moving the production-facing `latest` tag

## Why

Coolify can follow a stable `:latest` image reference without requiring a manual environment-variable update for each new worker image.

## Impact

After this merges and the `main` image workflow succeeds, Coolify can use:

```text
ghcr.io/seichris/open-bike-computer-map-platform:latest
```

A Coolify redeploy or force-pull is still required to fetch a newly published mutable tag.

## Validation

- `git diff --check`
- workflow YAML parse
- GitHub Actions image workflow on this branch
