### PR TITLE
Add GitOps map platform deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,10 @@ jobs:
   backend:
     name: Map Backend
     runs-on: ubuntu-latest
+    permissions:
+      attestations: read
+      contents: read
+      packages: read
     defaults:
       run:
         working-directory: backend
@@ -130,6 +134,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+      - uses: docker/setup-buildx-action@v3
       - name: Install backend test dependencies
         run: python -m pip install -e '.[test,object-storage]'
       - name: Python syntax
@@ -156,11 +161,15 @@ jobs:
         run: docker compose config
       - name: GitOps production Compose config
         env:
+          GH_TOKEN: ${{ github.token }}
           MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret
           MAP_PLATFORM_INSTALLATION_SECRET: ci-installation-secret-32-bytes-minimum
           MAP_PLATFORM_TRUSTED_PROXY_CIDRS: "172.16.0.0/12"
           MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS: "86400"
-        run: docker compose -f ../deploy/map-platform/compose.yaml config
+        run: |
+          docker compose -f ../deploy/map-platform/compose.yaml config
+          python ../deploy/map-platform/verify_registry_images.py \
+            ../deploy/map-platform/compose.yaml
       - name: Build backend production image
         run: >-
           docker build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,20 @@ jobs:
       - name: Install backend test dependencies
         run: python -m pip install -e '.[test,object-storage]'
       - name: Python syntax
-        run: python -m py_compile map_platform/*.py tests/*.py
+        run: >-
+          python -m py_compile
+          map_platform/*.py
+          tests/*.py
+          ../deploy/map-platform/*.py
+          ../deploy/map-platform/tests/*.py
       - name: Generated map stream trust registry
         run: |
           python tools/generate_map_stream_trust.py --check
           python tools/check_map_stream_hardware_gate.py --validate-requirements
       - name: Unit tests
-        run: python -m unittest discover -s tests
+        run: |
+          python -m unittest discover -s tests
+          python -m unittest discover -s ../deploy/map-platform/tests
       - name: Production Compose config
         env:
           MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret
@@ -146,6 +153,13 @@ jobs:
           MAP_PLATFORM_TRUSTED_PROXY_CIDRS: "172.16.0.0/12"
           MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS: "86400"
         run: docker compose config
+      - name: GitOps production Compose config
+        env:
+          MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret
+          MAP_PLATFORM_INSTALLATION_SECRET: ci-installation-secret-32-bytes-minimum
+          MAP_PLATFORM_TRUSTED_PROXY_CIDRS: "172.16.0.0/12"
+          MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS: "86400"
+        run: docker compose -f ../deploy/map-platform/compose.yaml config
       - name: Build backend production image
         run: >-
           docker build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   app-store-screenshots:

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -79,6 +79,7 @@ jobs:
       group: map-platform-production-promotion
       cancel-in-progress: false
     permissions:
+      actions: write
       contents: write
       pull-requests: write
     steps:
@@ -187,3 +188,9 @@ jobs:
               --title "$title" \
               --body "$body"
           fi
+
+          # GITHUB_TOKEN-authored pushes and pull requests do not trigger new
+          # workflow runs. Dispatch CI explicitly for the promotion commit.
+          gh workflow run ci.yml \
+            --repo "$GITHUB_REPOSITORY" \
+            --ref "$PROMOTION_BRANCH"

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -4,16 +4,35 @@ on:
   push:
     paths:
       - ".github/workflows/map-platform-image.yml"
+      - ".github/workflows/ci.yml"
       - "backend/**"
       - "tools/OSM_Extract/conf/**"
       - "tools/OSM_Extract/scripts/**"
       - "config/map-stream-hardware-gate.json"
       - "config/map-stream-rollout-approvals.json"
       - "config/map-stream-trust.json"
+      - "deploy/map-platform/detect_worker_change.py"
+      - "deploy/map-platform/select_worker_promotion.py"
+      - "deploy/map-platform/update_image.py"
+      - "deploy/map-platform/verify_registry_images.py"
   workflow_dispatch:
+    inputs:
+      pending_worker:
+        description: How to handle an open worker-moving promotion
+        required: true
+        default: auto
+        type: choice
+        options:
+          - auto
+          - preserve-pending
+          - promote-candidate
 
 permissions:
   contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:
@@ -28,6 +47,8 @@ jobs:
       image_digest: ${{ steps.image.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: docker/setup-buildx-action@v3
 
@@ -41,9 +62,7 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/open-bike-computer-map-platform
-          tags: |
-            type=raw,value=${{ github.sha }}
-            type=raw,value=latest,enable={{is_default_branch}}
+          tags: type=raw,value=${{ github.sha }}
 
       - id: image
         name: Build and publish image
@@ -64,6 +83,29 @@ jobs:
           subject-digest: ${{ steps.image.outputs.digest }}
           push-to-registry: true
 
+      - name: Move latest to the successful default-branch image
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
+        run: |
+          current_sha="$(git ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | cut -f1)"
+          if test "$current_sha" != "$GITHUB_SHA"; then
+            git fetch --no-tags origin "$current_sha"
+            superseded="$(python3 deploy/map-platform/detect_worker_change.py \
+              --before "$GITHUB_SHA" \
+              --after "$current_sha" \
+              --scope promotion)"
+            if test "$superseded" = "true"; then
+              echo "::notice::Skipping latest because a newer main commit changes image or promotion inputs"
+              exit 0
+            fi
+          fi
+          repository="ghcr.io/${GITHUB_REPOSITORY_OWNER}/open-bike-computer-map-platform"
+          docker buildx imagetools create \
+            --tag "${repository}:latest" \
+            "${repository}@${IMAGE_DIGEST}"
+
       - name: Record immutable deployment reference
         env:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -75,37 +117,164 @@ jobs:
     needs: publish
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
     runs-on: ubuntu-latest
-    concurrency:
-      group: map-platform-production-promotion
-      cancel-in-progress: false
     permissions:
       actions: write
+      attestations: read
       contents: write
+      packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
+      - uses: docker/setup-buildx-action@v3
+
+      - id: base
+        name: Reconcile with the live default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          default_sha="$(git ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | cut -f1)"
+          git fetch --no-tags origin "$default_sha"
+          if ! git merge-base --is-ancestor "$GITHUB_SHA" "$default_sha"; then
+            echo "::error::The workflow source is not an ancestor of live ${DEFAULT_BRANCH}"
+            exit 1
+          fi
+          if test "$default_sha" != "$GITHUB_SHA"; then
+            superseded="$(python3 deploy/map-platform/detect_worker_change.py \
+              --before "$GITHUB_SHA" \
+              --after "$default_sha" \
+              --scope promotion)"
+            if test "$superseded" = "true"; then
+              echo "::notice::A newer main commit owns the production proposal"
+              echo "superseded=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          git switch --detach "$default_sha"
+          echo "sha=${default_sha}" >> "$GITHUB_OUTPUT"
+          echo "superseded=false" >> "$GITHUB_OUTPUT"
+
+      - id: pending
+        name: Load the exact repository-owned production promotion
+        if: steps.base.outputs.superseded == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PROMOTION_BRANCH: deploy/map-platform-production
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          promotion_branch_sha="$(git ls-remote --heads origin \
+            "refs/heads/${PROMOTION_BRANCH}" | cut -f1)"
+          echo "branch_sha=${promotion_branch_sha}" >> "$GITHUB_OUTPUT"
+          current_state="$(python3 deploy/map-platform/update_image.py \
+            deploy/map-platform/compose.yaml \
+            --check)"
+          printf '%s\n' "$current_state"
+          current_worker_source="$(printf '%s\n' "$current_state" | awk '$1 == "worker" {print $2}')"
+          current_worker_reference="$(printf '%s\n' "$current_state" | awk '$1 == "worker" {print $3}')"
+          echo "current_worker_source=${current_worker_source}" >> "$GITHUB_OUTPUT"
+          echo "current_worker_reference=${current_worker_reference}" >> "$GITHUB_OUTPUT"
+
+          pending_rows="$(gh api \
+            --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f base="$DEFAULT_BRANCH" \
+            -f head="${GITHUB_REPOSITORY_OWNER}:${PROMOTION_BRANCH}" \
+            --jq '.[] | [.number, .head.sha, .head.repo.full_name, .head.ref] | @tsv')"
+          row_count="$(printf '%s\n' "$pending_rows" | sed '/^$/d' | wc -l | tr -d ' ')"
+          if test "$row_count" -gt 1; then
+            echo "::error::Multiple repository-owned production promotions are open"
+            exit 1
+          fi
+          if test "$row_count" -eq 0; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "moves_worker=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          IFS=$'\t' read -r pending_number pending_sha pending_repository pending_ref \
+            <<< "$pending_rows"
+          if test "$pending_repository" != "$GITHUB_REPOSITORY" \
+            || test "$pending_ref" != "$PROMOTION_BRANCH"; then
+            echo "::error::Promotion pull request head is not repository-owned"
+            exit 1
+          fi
+          if test "$pending_sha" != "$promotion_branch_sha"; then
+            echo "::error::Promotion branch changed while its pull request was loaded"
+            exit 1
+          fi
+          git fetch --no-tags origin "$pending_sha"
+          git show "${pending_sha}:deploy/map-platform/compose.yaml" \
+            > "$RUNNER_TEMP/pending-map-platform-compose.yaml"
+          pending_state="$(python3 deploy/map-platform/update_image.py \
+            "$RUNNER_TEMP/pending-map-platform-compose.yaml" \
+            --check)"
+          printf '%s\n' "$pending_state"
+          pending_worker_source="$(printf '%s\n' "$pending_state" | awk '$1 == "worker" {print $2}')"
+          pending_worker_reference="$(printf '%s\n' "$pending_state" | awk '$1 == "worker" {print $3}')"
+          if test "$pending_worker_source" = "$current_worker_source" \
+            && test "$pending_worker_reference" = "$current_worker_reference"; then
+            moves_worker=false
+          else
+            moves_worker=true
+          fi
+          echo "available=true" >> "$GITHUB_OUTPUT"
+          echo "number=${pending_number}" >> "$GITHUB_OUTPUT"
+          echo "moves_worker=${moves_worker}" >> "$GITHUB_OUTPUT"
+          echo "worker_source=${pending_worker_source}" >> "$GITHUB_OUTPUT"
+          echo "worker_reference=${pending_worker_reference}" >> "$GITHUB_OUTPUT"
+
       - id: scope
-        name: Classify candidate scope
+        name: Select the worker promotion policy
+        if: steps.base.outputs.superseded == 'false'
         env:
           BEFORE_SHA: ${{ github.event.before }}
+          EVENT_NAME: ${{ github.event_name }}
+          PENDING_AVAILABLE: ${{ steps.pending.outputs.available }}
+          PENDING_MOVES_WORKER: ${{ steps.pending.outputs.moves_worker }}
+          PENDING_WORKER_SOURCE: ${{ steps.pending.outputs.worker_source }}
+          PENDING_WORKER_POLICY: ${{ inputs.pending_worker }}
+          CURRENT_WORKER_SOURCE: ${{ steps.pending.outputs.current_worker_source }}
         run: |
-          worker_changed="$(python3 deploy/map-platform/detect_worker_change.py \
+          adjacent_changed="$(python3 deploy/map-platform/detect_worker_change.py \
             --before "$BEFORE_SHA" \
             --after "$GITHUB_SHA")"
-          echo "worker_changed=${worker_changed}" >> "$GITHUB_OUTPUT"
+          accumulated_changed="$(python3 deploy/map-platform/detect_worker_change.py \
+            --before "$CURRENT_WORKER_SOURCE" \
+            --after "$GITHUB_SHA")"
+          pending_worker_changed=false
+          if test "$PENDING_AVAILABLE" = "true"; then
+            pending_worker_changed="$(python3 deploy/map-platform/detect_worker_change.py \
+              --before "$PENDING_WORKER_SOURCE" \
+              --after "$GITHUB_SHA")"
+          fi
+          python3 deploy/map-platform/select_worker_promotion.py \
+            --event-name "$EVENT_NAME" \
+            --requested-policy "$PENDING_WORKER_POLICY" \
+            --pending-available "$PENDING_AVAILABLE" \
+            --pending-moves-worker "$PENDING_MOVES_WORKER" \
+            --pending-worker-changed "$pending_worker_changed" \
+            --adjacent-changed "$adjacent_changed" \
+            --accumulated-changed "$accumulated_changed" \
+            >> "$GITHUB_OUTPUT"
 
       - id: update
         name: Update and validate production lock
+        if: steps.base.outputs.superseded == 'false'
         env:
           IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
           WORKER_CHANGED: ${{ steps.scope.outputs.worker_changed }}
+          PRESERVE_PENDING: ${{ steps.scope.outputs.preserve_pending }}
           MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret
           MAP_PLATFORM_INSTALLATION_SECRET: ci-installation-secret-32-bytes-minimum
           MAP_PLATFORM_TRUSTED_PROXY_CIDRS: 172.16.0.0/12
+          GH_TOKEN: ${{ github.token }}
         run: |
+          base_state="$(python3 deploy/map-platform/update_image.py \
+            deploy/map-platform/compose.yaml \
+            --check)"
+          base_worker="$(printf '%s\n' "$base_state" | awk '$1 == "worker" {print $2 " " $3}')"
           update_args=(
             deploy/map-platform/compose.yaml
             --control-plane-digest "$IMAGE_DIGEST"
@@ -113,12 +282,31 @@ jobs:
           )
           if test "$WORKER_CHANGED" = "true"; then
             update_args+=(--worker-digest "$IMAGE_DIGEST")
+          elif test "$PRESERVE_PENDING" = "true"; then
+            update_args+=(
+              --preserve-worker-from
+              "$RUNNER_TEMP/pending-map-platform-compose.yaml"
+            )
           fi
           python3 deploy/map-platform/update_image.py "${update_args[@]}"
-          python3 deploy/map-platform/update_image.py \
+          final_state="$(python3 deploy/map-platform/update_image.py \
             deploy/map-platform/compose.yaml \
-            --check
+            --check)"
+          printf '%s\n' "$final_state"
+          final_worker="$(printf '%s\n' "$final_state" | awk '$1 == "worker" {print $2 " " $3}')"
+          final_worker_source="$(printf '%s\n' "$final_state" | awk '$1 == "worker" {print $2}')"
+          final_worker_reference="$(printf '%s\n' "$final_state" | awk '$1 == "worker" {print $3}')"
+          if test "$final_worker" = "$base_worker"; then
+            moves_worker=false
+          else
+            moves_worker=true
+          fi
+          echo "moves_worker=${moves_worker}" >> "$GITHUB_OUTPUT"
+          echo "worker_source=${final_worker_source}" >> "$GITHUB_OUTPUT"
+          echo "worker_reference=${final_worker_reference}" >> "$GITHUB_OUTPUT"
           docker compose -f deploy/map-platform/compose.yaml config >/dev/null
+          python3 deploy/map-platform/verify_registry_images.py \
+            deploy/map-platform/compose.yaml
           git diff --check
           if git diff --quiet -- deploy/map-platform/compose.yaml; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
@@ -131,8 +319,14 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
-          WORKER_CHANGED: ${{ steps.scope.outputs.worker_changed }}
+          MOVES_WORKER: ${{ steps.update.outputs.moves_worker }}
+          WORKER_REFERENCE: ${{ steps.update.outputs.worker_reference }}
+          WORKER_SELECTION: ${{ steps.scope.outputs.worker_selection }}
+          WORKER_SOURCE: ${{ steps.update.outputs.worker_source }}
           PROMOTION_BRANCH: deploy/map-platform-production
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          PROPOSAL_BASE_SHA: ${{ steps.base.outputs.sha }}
+          EXPECTED_PROMOTION_SHA: ${{ steps.pending.outputs.branch_sha }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -141,10 +335,34 @@ jobs:
           short_sha="${GITHUB_SHA:0:12}"
           git commit -m "Promote map platform image ${short_sha}"
 
+          latest_default_sha="$(git ls-remote origin "refs/heads/${DEFAULT_BRANCH}" | cut -f1)"
+          if test "$latest_default_sha" != "$PROPOSAL_BASE_SHA"; then
+            git fetch --no-tags origin "$latest_default_sha"
+            if ! git merge-base --is-ancestor "$PROPOSAL_BASE_SHA" "$latest_default_sha"; then
+              echo "::error::Live ${DEFAULT_BRANCH} no longer descends from the proposal base"
+              exit 1
+            fi
+            superseded="$(python3 deploy/map-platform/detect_worker_change.py \
+              --before "$PROPOSAL_BASE_SHA" \
+              --after "$latest_default_sha" \
+              --scope promotion)"
+            if test "$superseded" = "true" \
+              || ! git diff --quiet "$PROPOSAL_BASE_SHA" "$latest_default_sha" \
+                -- deploy/map-platform/compose.yaml; then
+              echo "::error::Live ${DEFAULT_BRANCH} changed production inputs; re-run the workflow"
+              exit 1
+            fi
+            git rebase "$latest_default_sha"
+          fi
+
           remote_sha="$(git ls-remote --heads origin "refs/heads/${PROMOTION_BRANCH}" | cut -f1)"
-          if test -n "$remote_sha"; then
+          if test "$remote_sha" != "$EXPECTED_PROMOTION_SHA"; then
+            echo "::error::Promotion branch changed during candidate validation"
+            exit 1
+          fi
+          if test -n "$EXPECTED_PROMOTION_SHA"; then
             git push \
-              --force-with-lease="refs/heads/${PROMOTION_BRANCH}:${remote_sha}" \
+              --force-with-lease="refs/heads/${PROMOTION_BRANCH}:${EXPECTED_PROMOTION_SHA}" \
               origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
           else
             git push origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
@@ -158,7 +376,10 @@ jobs:
             '' \
             "- Source commit: \`${GITHUB_SHA}\`" \
             "- Image: \`${image_reference}\`" \
-            "- Moves signed worker pin: \`${WORKER_CHANGED}\`" \
+            "- Moves signed worker pin relative to main: \`${MOVES_WORKER}\`" \
+            "- Worker selection: \`${WORKER_SELECTION}\`" \
+            "- Worker source: \`${WORKER_SOURCE}\`" \
+            "- Worker image: \`${WORKER_REFERENCE}\`" \
             "- Build and attestation: ${run_url}" \
             '' \
             '## Deployment' \
@@ -167,12 +388,12 @@ jobs:
             '' \
             'Review the candidate and required hardware rollout gates before merging.')"
 
-          pr_number="$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --head "$PROMOTION_BRANCH" \
-            --base "${{ github.event.repository.default_branch }}" \
-            --state open \
-            --json number \
+          pr_number="$(gh api \
+            --method GET \
+            "repos/${GITHUB_REPOSITORY}/pulls" \
+            -f state=open \
+            -f base="$DEFAULT_BRANCH" \
+            -f head="${GITHUB_REPOSITORY_OWNER}:${PROMOTION_BRANCH}" \
             --jq '.[0].number // empty')"
           if test -n "$pr_number"; then
             gh api \
@@ -183,7 +404,7 @@ jobs:
           else
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
-              --base "${{ github.event.repository.default_branch }}" \
+              --base "$DEFAULT_BRANCH" \
               --head "$PROMOTION_BRANCH" \
               --title "$title" \
               --body "$body"

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -7,19 +7,25 @@ on:
       - "backend/**"
       - "tools/OSM_Extract/conf/**"
       - "tools/OSM_Extract/scripts/**"
+      - "config/map-stream-hardware-gate.json"
+      - "config/map-stream-rollout-approvals.json"
       - "config/map-stream-trust.json"
   workflow_dispatch:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
-  attestations: write
 
 jobs:
   publish:
     name: Publish worker image
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    outputs:
+      image_digest: ${{ steps.image.outputs.digest }}
     steps:
       - uses: actions/checkout@v4
 
@@ -63,3 +69,121 @@ jobs:
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           echo "ghcr.io/${GITHUB_REPOSITORY_OWNER}/open-bike-computer-map-platform@${IMAGE_DIGEST}" >> "$GITHUB_STEP_SUMMARY"
+
+  propose-production:
+    name: Propose production image
+    needs: publish
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    runs-on: ubuntu-latest
+    concurrency:
+      group: map-platform-production-promotion
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - id: scope
+        name: Classify candidate scope
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+        run: |
+          worker_changed="$(python3 deploy/map-platform/detect_worker_change.py \
+            --before "$BEFORE_SHA" \
+            --after "$GITHUB_SHA")"
+          echo "worker_changed=${worker_changed}" >> "$GITHUB_OUTPUT"
+
+      - id: update
+        name: Update and validate production lock
+        env:
+          IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+          WORKER_CHANGED: ${{ steps.scope.outputs.worker_changed }}
+          MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret
+          MAP_PLATFORM_INSTALLATION_SECRET: ci-installation-secret-32-bytes-minimum
+          MAP_PLATFORM_TRUSTED_PROXY_CIDRS: 172.16.0.0/12
+        run: |
+          update_args=(
+            deploy/map-platform/compose.yaml
+            --control-plane-digest "$IMAGE_DIGEST"
+            --source-commit "$GITHUB_SHA"
+          )
+          if test "$WORKER_CHANGED" = "true"; then
+            update_args+=(--worker-digest "$IMAGE_DIGEST")
+          fi
+          python3 deploy/map-platform/update_image.py "${update_args[@]}"
+          python3 deploy/map-platform/update_image.py \
+            deploy/map-platform/compose.yaml \
+            --check
+          docker compose -f deploy/map-platform/compose.yaml config >/dev/null
+          git diff --check
+          if git diff --quiet -- deploy/map-platform/compose.yaml; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Open or refresh production promotion pull request
+        if: steps.update.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          IMAGE_DIGEST: ${{ needs.publish.outputs.image_digest }}
+          WORKER_CHANGED: ${{ steps.scope.outputs.worker_changed }}
+          PROMOTION_BRANCH: deploy/map-platform-production
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$PROMOTION_BRANCH"
+          git add deploy/map-platform/compose.yaml
+          short_sha="${GITHUB_SHA:0:12}"
+          git commit -m "Promote map platform image ${short_sha}"
+
+          remote_sha="$(git ls-remote --heads origin "refs/heads/${PROMOTION_BRANCH}" | cut -f1)"
+          if test -n "$remote_sha"; then
+            git push \
+              --force-with-lease="refs/heads/${PROMOTION_BRANCH}:${remote_sha}" \
+              origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
+          else
+            git push origin "HEAD:refs/heads/${PROMOTION_BRANCH}"
+          fi
+
+          image_reference="ghcr.io/${GITHUB_REPOSITORY_OWNER}/open-bike-computer-map-platform@${IMAGE_DIGEST}"
+          title="Promote map platform image ${short_sha}"
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body="$(printf '%s\n' \
+            '## Production image' \
+            '' \
+            "- Source commit: \`${GITHUB_SHA}\`" \
+            "- Image: \`${image_reference}\`" \
+            "- Moves signed worker pin: \`${WORKER_CHANGED}\`" \
+            "- Build and attestation: ${run_url}" \
+            '' \
+            '## Deployment' \
+            '' \
+            'Merging this pull request updates the digest-pinned production Compose consumed by Coolify. It does not rebuild the image or mutate Coolify environment variables.' \
+            '' \
+            'Review the candidate and required hardware rollout gates before merging.')"
+
+          pr_number="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --head "$PROMOTION_BRANCH" \
+            --base "${{ github.event.repository.default_branch }}" \
+            --state open \
+            --json number \
+            --jq '.[0].number // empty')"
+          if test -n "$pr_number"; then
+            gh api \
+              --method PATCH \
+              "repos/${GITHUB_REPOSITORY}/pulls/${pr_number}" \
+              -f title="$title" \
+              -f body="$body" >/dev/null
+          else
+            gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "${{ github.event.repository.default_branch }}" \
+              --head "$PROMOTION_BRANCH" \
+              --title "$title" \
+              --body "$body"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,25 +89,6 @@ Healthy boot log checkpoints from the Waveshare board:
 
 - Open: `ios-app/BikeComputer/BikeComputer.xcodeproj`
 
-### Map backend production updates
-
-For changes under `backend/` or other image inputs listed in
-`.github/workflows/map-platform-image.yml`:
-
-1. Merge the code through a pull request to `main`; do not deploy `:latest` or
-   change server-side image-selection variables.
-2. Wait for **Map Platform Image** to publish and attest the image, then review
-   the generated `deploy/map-platform-production` pull request. Production is
-   defined by the immutable digest pins in `deploy/map-platform/compose.yaml`.
-3. If the promotion moves the signed worker, complete the worker/hardware gates
-   in `docs/map-stream-rollout-runbook.md`. Merge only after **Map Backend** CI
-   passes; the manifest merge triggers the production deployment.
-4. Verify the deployment and `/healthz`. Roll back through a pull request that
-   restores the complete previous Compose lock (both images and source markers).
-
-If promotion automation needs an explicit pending-worker decision, follow
-`deploy/map-platform/README.md`; never bypass the digest/provenance checks.
-
 ## BLE contract
 
 Current firmware implements BLE service UUID

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,25 @@ Healthy boot log checkpoints from the Waveshare board:
 
 - Open: `ios-app/BikeComputer/BikeComputer.xcodeproj`
 
+### Map backend production updates
+
+For changes under `backend/` or other image inputs listed in
+`.github/workflows/map-platform-image.yml`:
+
+1. Merge the code through a pull request to `main`; do not deploy `:latest` or
+   change server-side image-selection variables.
+2. Wait for **Map Platform Image** to publish and attest the image, then review
+   the generated `deploy/map-platform-production` pull request. Production is
+   defined by the immutable digest pins in `deploy/map-platform/compose.yaml`.
+3. If the promotion moves the signed worker, complete the worker/hardware gates
+   in `docs/map-stream-rollout-runbook.md`. Merge only after **Map Backend** CI
+   passes; the manifest merge triggers the production deployment.
+4. Verify the deployment and `/healthz`. Roll back through a pull request that
+   restores the complete previous Compose lock (both images and source markers).
+
+If promotion automation needs an explicit pending-worker decision, follow
+`deploy/map-platform/README.md`; never bypass the digest/provenance checks.
+
 ## BLE contract
 
 Current firmware implements BLE service UUID

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,9 +85,19 @@ persisted with the job before the worker downloads the matching PBF.
 
 ## Coolify
 
-Use `backend/docker-compose.yml` as the first Coolify deployment shape. The
-service stores mutable state in the `map-platform-data` volume. The host needs
-enough CPU, RAM, and temporary disk for the largest allowed PBF cut-out.
+Use `deploy/map-platform/compose.yaml` for Coolify production. It independently
+pins the API/maintenance control plane and the signed-map worker to immutable
+GHCR digests and is updated by a reviewed image-promotion pull request.
+`backend/docker-compose.yml` remains the local development and image-build
+shape. The service stores mutable state in the `map-platform-data` volume. The
+host needs enough CPU, RAM, and temporary disk for the largest allowed PBF
+cut-out.
+
+Configure the existing Coolify resource with repository base directory `/`,
+Docker Compose location `/deploy/map-platform/compose.yaml`, and watch path
+`deploy/map-platform/compose.yaml`. Keep runtime secrets in Coolify, but do not
+set image-selection variables there; the production Compose is the deployment
+source of truth. See `deploy/map-platform/README.md` for promotion and rollback.
 
 Required Coolify secrets:
 
@@ -157,12 +167,14 @@ Percentage and global modes refuse to start unless the promotion, current
 hardware-requirements hash, and every signing key match the checked-in approval
 and production trust registries. They serve only artifacts whose signed worker
 content, key material, requesting iOS build, and required device firmware
-identity match that approval. Pin `MAP_PLATFORM_WORKER_IMAGE` as the immutable
+identity match that approval. Pin the image anchor in
+`deploy/map-platform/compose.yaml` to the immutable
 `registry/repository@sha256:<digest>` reference used by the hardware run when
-promoting. The same Compose value supplies the worker image and the API/worker
-admission identity, while registry signature/provenance policy verifies that
-digest before deployment. The API image may advance to carry the approval
-record without rebuilding the tested worker. See
+promoting. The worker pin supplies both the worker service image and the
+API/worker admission identity, while the independently pinned control-plane
+image can advance to carry a reviewed approval record without replacing that
+tested worker. Registry signature/provenance policy verifies both digests before
+deployment. See
 `docs/map-stream-rollout-runbook.md` for commissioning, hardware acceptance,
 promotion, rollback, retention, and rotation.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -173,8 +173,10 @@ identity match that approval. Pin the image anchor in
 promoting. The worker pin supplies both the worker service image and the
 API/worker admission identity, while the independently pinned control-plane
 image can advance to carry a reviewed approval record without replacing that
-tested worker. Registry signature/provenance policy verifies both digests before
-deployment. See
+tested worker. CI verifies that both digests resolve for Linux/AMD64 and carry
+GitHub provenance from this repository's image workflow before the promotion
+can merge. Coolify then deploys the reviewed immutable references without
+selecting an image tag at runtime. See
 `docs/map-stream-rollout-runbook.md` for commissioning, hardware acceptance,
 promotion, rollback, retention, and rotation.
 

--- a/deploy/map-platform/README.md
+++ b/deploy/map-platform/README.md
@@ -46,9 +46,10 @@ merge changes `compose.yaml`, which matches the Coolify watch path and deploys
 the exact pinned image. A promotion-only merge does not start another image
 build, so the workflow cannot loop.
 
-GitHub may require a repository maintainer to approve CI on pull requests
-created with `GITHUB_TOKEN`. Do not replace that token with a broadly scoped
-personal token only to remove the approval step.
+GitHub suppresses workflow events caused by `GITHUB_TOKEN`, so the promotion
+job explicitly dispatches `ci.yml` for the promotion commit after opening or
+refreshing the pull request. This keeps the automation on the least-privileged
+repository token without requiring a personal access token.
 
 Validate the lock locally with:
 

--- a/deploy/map-platform/README.md
+++ b/deploy/map-platform/README.md
@@ -7,6 +7,14 @@ may match, but remain separate so an approval-only control-plane release can
 advance without replacing a hardware-tested worker. Coolify secrets remain
 outside Git.
 
+## One-time GitHub configuration
+
+In repository **Settings > Actions > General > Workflow permissions**, enable
+**Allow GitHub Actions to create and approve pull requests**. Keep the default
+`GITHUB_TOKEN` permissions restricted to read access; the image workflow grants
+write access only to its promotion job. GitHub uses this repository switch to
+decide whether `GITHUB_TOKEN` may open the digest-promotion pull request.
+
 ## One-time Coolify configuration
 
 Update the existing `open-bike-computer-map-platform` resource rather than

--- a/deploy/map-platform/README.md
+++ b/deploy/map-platform/README.md
@@ -1,0 +1,72 @@
+# Map Platform Production Deployment
+
+`compose.yaml` is the production deployment lock for the map platform. It pins
+the API/maintenance control plane and the signed-map worker to immutable GHCR
+digests and passes the worker digest into the producer identity. The two pins
+may match, but remain separate so an approval-only control-plane release can
+advance without replacing a hardware-tested worker. Coolify secrets remain
+outside Git.
+
+## One-time Coolify configuration
+
+Update the existing `open-bike-computer-map-platform` resource rather than
+creating a new resource, so its domain and `map-platform-data` volume remain
+attached.
+
+- Build pack: `Docker Compose`
+- Base directory: `/`
+- Docker Compose location: `/deploy/map-platform/compose.yaml`
+- Branch: `main`
+- Auto deploy: enabled
+- Watch path: `deploy/map-platform/compose.yaml`
+
+Keep the existing secret and runtime variables in Coolify. The production
+Compose no longer reads `MAP_PLATFORM_API_IMAGE`,
+`MAP_PLATFORM_WORKER_IMAGE`, or `MAP_PLATFORM_MAINTENANCE_IMAGE`; remove those
+three values after the first successful deployment to avoid presenting stale
+configuration as active.
+
+The initial worker lock points at the image already running successfully in
+production. Its control-plane lock contains the same backend revision currently
+deployed from `main`, so changing the Compose location does not introduce a new
+worker binary.
+
+## Promotion flow
+
+The `Map Platform Image` workflow builds and attests candidate images. After a
+successful build from `main`, it opens or refreshes the automation-owned
+`deploy/map-platform-production` pull request with the new control-plane digest
+and source commit. When the Git range changes an input used by the signed worker
+identity, the same PR also advances the worker pin. Manual workflow dispatches
+conservatively propose both pins for explicit review. The workflow never changes
+production directly.
+
+Review and merge that promotion pull request when the candidate is ready. The
+merge changes `compose.yaml`, which matches the Coolify watch path and deploys
+the exact pinned image. A promotion-only merge does not start another image
+build, so the workflow cannot loop.
+
+GitHub may require a repository maintainer to approve CI on pull requests
+created with `GITHUB_TOKEN`. Do not replace that token with a broadly scoped
+personal token only to remove the approval step.
+
+Validate the lock locally with:
+
+```sh
+python3 deploy/map-platform/update_image.py \
+  deploy/map-platform/compose.yaml \
+  --check
+
+MAP_PLATFORM_DOWNLOAD_SECRET=ci-download-secret \
+MAP_PLATFORM_INSTALLATION_SECRET=ci-installation-secret-32-bytes-minimum \
+MAP_PLATFORM_TRUSTED_PROXY_CIDRS=172.16.0.0/12 \
+docker compose -f deploy/map-platform/compose.yaml config
+```
+
+## Rollback
+
+Revert the promotion commit or open a new promotion pull request restoring a
+previously known-good digest. Git history records the exact source commit and
+image used by every deployment. Coolify's rollback remains available for
+incident response, but follow it with a Git revert so declared production state
+matches the running state.

--- a/deploy/map-platform/README.md
+++ b/deploy/map-platform/README.md
@@ -15,6 +15,18 @@ In repository **Settings > Actions > General > Workflow permissions**, enable
 write access only to its promotion job. GitHub uses this repository switch to
 decide whether `GITHUB_TOKEN` may open the digest-promotion pull request.
 
+Protect `main` with a ruleset or classic branch protection that:
+
+- requires changes to arrive through a pull request (zero required approvals is
+  acceptable for a solo-maintainer repository),
+- requires the `Map Backend` status check before merge, and
+- requires branches to be up to date before merging, and
+- blocks force pushes and branch deletion.
+
+This is the repository-side deployment admission control: without it, a direct
+push could change the watched production Compose without passing pull-request
+CI.
+
 ## One-time Coolify configuration
 
 Update the existing `open-bike-computer-map-platform` resource rather than
@@ -46,8 +58,34 @@ successful build from `main`, it opens or refreshes the automation-owned
 `deploy/map-platform-production` pull request with the new control-plane digest
 and source commit. When the Git range changes an input used by the signed worker
 identity, the same PR also advances the worker pin. Manual workflow dispatches
-conservatively propose both pins for explicit review. The workflow never changes
-production directly.
+from `main` conservatively propose both pins for explicit review; select the
+`main` branch in the dispatch form. A dispatch from another branch publishes a
+candidate image but cannot open a production promotion. `latest` tracks the
+most recent successful image-building commit on `main`; production never reads
+that mutable tag.
+
+The workflow refuses to guess when a control-only push arrives while the open
+promotion moves the worker pin. Re-run **Map Platform Image** manually on `main`
+and choose one of the explicit `pending_worker` policies:
+
+- `preserve-pending` carries the open PR's worker into the new control-plane
+  candidate, for example after intentionally committing its bound approval. It
+  is rejected if later commits changed any worker input.
+- `promote-candidate` replaces the pending worker with the newly built
+  candidate; run the required worker and hardware gates before merging it.
+- `auto` is safe only when no open promotion moves the worker; it fails closed
+  rather than inferring intent. For a manual rebuild with no moving pending
+  worker, it conservatively proposes both the control and worker pins so a
+  dependency-only rebuild can be tested and promoted.
+
+The control plane and worker share backend code and persistent job state, so the
+workflow never offers an unsafe "new API with old worker" override after worker
+inputs have changed. Resolve the pending candidate or build a dedicated,
+reviewed compatibility release instead.
+
+The PR body reports worker movement from the final manifest diff, not merely
+the latest commit's path classification. The workflow never changes production
+directly.
 
 Review and merge that promotion pull request when the candidate is ready. The
 merge changes `compose.yaml`, which matches the Coolify watch path and deploys
@@ -66,16 +104,27 @@ python3 deploy/map-platform/update_image.py \
   deploy/map-platform/compose.yaml \
   --check
 
+python3 deploy/map-platform/verify_registry_images.py \
+  deploy/map-platform/compose.yaml
+
 MAP_PLATFORM_DOWNLOAD_SECRET=ci-download-secret \
 MAP_PLATFORM_INSTALLATION_SECRET=ci-installation-secret-32-bytes-minimum \
 MAP_PLATFORM_TRUSTED_PROXY_CIDRS=172.16.0.0/12 \
 docker compose -f deploy/map-platform/compose.yaml config
 ```
 
+The registry check requires Docker Buildx and an authenticated GitHub CLI. It
+confirms that both immutable references resolve to Linux/AMD64 images and that
+GitHub recorded provenance from this repository's image workflow for each
+adjacent source commit.
+
 ## Rollback
 
-Revert the promotion commit or open a new promotion pull request restoring a
-previously known-good digest. Git history records the exact source commit and
-image used by every deployment. Coolify's rollback remains available for
-incident response, but follow it with a Git revert so declared production state
-matches the running state.
+Revert the promotion commit or restore the complete previously known-good lock
+in a new promotion pull request: both image anchors and both adjacent source
+commit markers. Restoring a digest without its matching marker fails provenance
+verification. The safest manual rollback is to restore the historical
+`compose.yaml` as a unit. Git history records the exact source commit and image
+used by every deployment. Coolify's rollback remains available for incident
+response, but follow it with a Git revert so declared production state matches
+the running state.

--- a/deploy/map-platform/compose.yaml
+++ b/deploy/map-platform/compose.yaml
@@ -1,0 +1,127 @@
+# control-plane-source-commit: 1a2e352f5b157b54009f1a56d4dd90d94b86f86e
+# worker-source-commit: 887a3eaf2e1bec440daec65cdfbfb69361b83314
+
+# These digest-pinned images are the production deployment manifest. The API
+# and maintenance control plane may advance to carry a rollout approval while
+# the hardware-tested worker remains pinned. Keep each source commit and digest
+# in sync through update_image.py; never replace a digest with a mutable tag.
+x-map-platform-images:
+  control-plane: &map-platform-control-plane-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:4e95b298cc02ab5588a1d3b2b9cf70f37fef2cd190faa6a7684a1c4d5db524c5
+  worker: &map-platform-worker-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:4b75542949ddae7e85576eb742910d24637de5dd067fb98bc1fae0b36721af4c
+
+services:
+  map-platform-api:
+    image: *map-platform-control-plane-image
+    environment:
+      MAP_PLATFORM_REPO_ROOT: /app
+      MAP_PLATFORM_DATA_ROOT: /data
+      MAP_PLATFORM_SOURCE_INDEX: /app/backend/config/source-regions.json
+      MAP_PLATFORM_ADMIN_TOKEN: ${MAP_PLATFORM_ADMIN_TOKEN:-}
+      MAP_PLATFORM_DOWNLOAD_SECRET: ${MAP_PLATFORM_DOWNLOAD_SECRET:?set MAP_PLATFORM_DOWNLOAD_SECRET in Coolify secrets}
+      MAP_PLATFORM_INSTALLATION_SECRET: ${MAP_PLATFORM_INSTALLATION_SECRET:?set MAP_PLATFORM_INSTALLATION_SECRET in Coolify secrets}
+      MAP_PLATFORM_INSTALLATION_PREVIOUS_SECRETS: ${MAP_PLATFORM_INSTALLATION_PREVIOUS_SECRETS:-}
+      MAP_PLATFORM_TRUSTED_PROXY_CIDRS: ${MAP_PLATFORM_TRUSTED_PROXY_CIDRS:?set MAP_PLATFORM_TRUSTED_PROXY_CIDRS to the Coolify proxy CIDRs}
+      MAP_PLATFORM_MAX_REQUEST_BODY_BYTES: ${MAP_PLATFORM_MAX_REQUEST_BODY_BYTES:-2097152}
+      MAP_PLATFORM_PUBLIC_REQUEST_LIMIT_PER_MINUTE: ${MAP_PLATFORM_PUBLIC_REQUEST_LIMIT_PER_MINUTE:-240}
+      MAP_PLATFORM_INSTALLATION_ISSUE_LIMIT_PER_DAY: ${MAP_PLATFORM_INSTALLATION_ISSUE_LIMIT_PER_DAY:-3}
+      MAP_PLATFORM_MAP_CREATE_LIMIT_PER_HOUR: ${MAP_PLATFORM_MAP_CREATE_LIMIT_PER_HOUR:-4}
+      MAP_PLATFORM_MAP_CREATE_IP_LIMIT_PER_DAY: ${MAP_PLATFORM_MAP_CREATE_IP_LIMIT_PER_DAY:-20}
+      MAP_PLATFORM_DOWNLOAD_URL_LIMIT_PER_HOUR: ${MAP_PLATFORM_DOWNLOAD_URL_LIMIT_PER_HOUR:-30}
+      MAP_PLATFORM_DOWNLOAD_URL_IP_LIMIT_PER_HOUR: ${MAP_PLATFORM_DOWNLOAD_URL_IP_LIMIT_PER_HOUR:-60}
+      MAP_PLATFORM_MAX_ACTIVE_JOBS: ${MAP_PLATFORM_MAX_ACTIVE_JOBS:-25}
+      MAP_PLATFORM_ARTIFACT_STORE: ${MAP_PLATFORM_ARTIFACT_STORE:-filesystem}
+      MAP_PLATFORM_ARTIFACT_ROOT: ${MAP_PLATFORM_ARTIFACT_ROOT:-/data/artifacts}
+      MAP_PLATFORM_S3_BUCKET: ${MAP_PLATFORM_S3_BUCKET:-}
+      MAP_PLATFORM_S3_PREFIX: ${MAP_PLATFORM_S3_PREFIX:-map-artifacts}
+      MAP_PLATFORM_S3_ENDPOINT_URL: ${MAP_PLATFORM_S3_ENDPOINT_URL:-}
+      AWS_REGION: ${AWS_REGION:-}
+      MAP_PLATFORM_S3_API_ACCESS_KEY_ID: ${MAP_PLATFORM_S3_API_ACCESS_KEY_ID:-}
+      MAP_PLATFORM_S3_API_SECRET_ACCESS_KEY: ${MAP_PLATFORM_S3_API_SECRET_ACCESS_KEY:-}
+      MAP_PLATFORM_S3_API_SESSION_TOKEN: ${MAP_PLATFORM_S3_API_SESSION_TOKEN:-}
+      MAP_PLATFORM_S3_API_USE_DEFAULT_CREDENTIAL_CHAIN: ${MAP_PLATFORM_S3_API_USE_DEFAULT_CREDENTIAL_CHAIN:-0}
+      MAP_PLATFORM_MAP_STREAM_ENABLED: ${MAP_PLATFORM_MAP_STREAM_ENABLED:-0}
+      MAP_PLATFORM_MAP_STREAM_ROLLOUT_MODE: ${MAP_PLATFORM_MAP_STREAM_ROLLOUT_MODE:-disabled}
+      MAP_PLATFORM_MAP_STREAM_ROLLOUT_ALLOWLIST: ${MAP_PLATFORM_MAP_STREAM_ROLLOUT_ALLOWLIST:-}
+      MAP_PLATFORM_MAP_STREAM_ROLLOUT_BASIS_POINTS: ${MAP_PLATFORM_MAP_STREAM_ROLLOUT_BASIS_POINTS:-0}
+      MAP_PLATFORM_MAP_STREAM_ROLLOUT_SECRET: ${MAP_PLATFORM_MAP_STREAM_ROLLOUT_SECRET:-}
+      MAP_PLATFORM_MAP_STREAM_PROMOTION_ID: ${MAP_PLATFORM_MAP_STREAM_PROMOTION_ID:-}
+      MAP_PLATFORM_MAP_STREAM_ROLLOUT_APPROVALS: /app/config/map-stream-rollout-approvals.json
+      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: *map-platform-worker-image
+      MAP_PLATFORM_INLINE_WORKER_ENABLED: "0"
+    volumes:
+      - map-platform-data:/data
+    expose:
+      - "8080"
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/healthz"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+  map-platform-worker:
+    image: *map-platform-worker-image
+    command: ["map-platform", "worker-loop", "--idle-sleep-seconds", "10"]
+    environment:
+      MAP_PLATFORM_REPO_ROOT: /app
+      MAP_PLATFORM_DATA_ROOT: /data
+      MAP_PLATFORM_SOURCE_INDEX: /app/backend/config/source-regions.json
+      MAP_PLATFORM_DOWNLOAD_SECRET: ${MAP_PLATFORM_DOWNLOAD_SECRET:?set MAP_PLATFORM_DOWNLOAD_SECRET in Coolify secrets}
+      MAP_PLATFORM_MAX_ACTIVE_JOBS: ${MAP_PLATFORM_MAX_ACTIVE_JOBS:-25}
+      MAP_PLATFORM_JOB_RETENTION_DAYS: ${MAP_PLATFORM_JOB_RETENTION_DAYS:-30}
+      MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS: ${MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS:-3600}
+      MAP_PLATFORM_ARTIFACT_STORE: ${MAP_PLATFORM_ARTIFACT_STORE:-filesystem}
+      MAP_PLATFORM_ARTIFACT_ROOT: ${MAP_PLATFORM_ARTIFACT_ROOT:-/data/artifacts}
+      MAP_PLATFORM_S3_BUCKET: ${MAP_PLATFORM_S3_BUCKET:-}
+      MAP_PLATFORM_S3_PREFIX: ${MAP_PLATFORM_S3_PREFIX:-map-artifacts}
+      MAP_PLATFORM_S3_ENDPOINT_URL: ${MAP_PLATFORM_S3_ENDPOINT_URL:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+      MAP_PLATFORM_MAP_STREAM_ENABLED: ${MAP_PLATFORM_MAP_STREAM_ENABLED:-0}
+      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: *map-platform-worker-image
+      MAP_PLATFORM_MAP_SIGNING_KEY_ID: ${MAP_PLATFORM_MAP_SIGNING_KEY_ID:-}
+      MAP_PLATFORM_MAP_SIGNING_PRIVATE_KEY_BASE64: ${MAP_PLATFORM_MAP_SIGNING_PRIVATE_KEY_BASE64:-}
+      MAP_PLATFORM_WORKER_HEARTBEAT_PATH: /data/health/worker
+      MAP_PLATFORM_WORKER_HEALTH_MAX_AGE_SECONDS: ${MAP_PLATFORM_WORKER_HEALTH_MAX_AGE_SECONDS:-120}
+    volumes:
+      - map-platform-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,time; from pathlib import Path; assert time.time() - Path('/data/health/worker').stat().st_mtime < float(os.environ['MAP_PLATFORM_WORKER_HEALTH_MAX_AGE_SECONDS'])"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+  map-platform-maintenance:
+    image: *map-platform-control-plane-image
+    command: ["map-platform", "maintenance-loop"]
+    environment:
+      MAP_PLATFORM_REPO_ROOT: /app
+      MAP_PLATFORM_DATA_ROOT: /data
+      MAP_PLATFORM_SOURCE_INDEX: /app/backend/config/source-regions.json
+      MAP_PLATFORM_JOB_RETENTION_DAYS: ${MAP_PLATFORM_JOB_RETENTION_DAYS:-30}
+      MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS: ${MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS:-3600}
+      MAP_PLATFORM_MAINTENANCE_MAX_GC_ITEMS: ${MAP_PLATFORM_MAINTENANCE_MAX_GC_ITEMS:-100}
+      MAP_PLATFORM_MAINTENANCE_HEARTBEAT_PATH: /data/health/maintenance
+      MAP_PLATFORM_ARTIFACT_STORE: ${MAP_PLATFORM_ARTIFACT_STORE:-filesystem}
+      MAP_PLATFORM_ARTIFACT_ROOT: ${MAP_PLATFORM_ARTIFACT_ROOT:-/data/artifacts}
+      MAP_PLATFORM_S3_BUCKET: ${MAP_PLATFORM_S3_BUCKET:-}
+      MAP_PLATFORM_S3_PREFIX: ${MAP_PLATFORM_S3_PREFIX:-map-artifacts}
+      MAP_PLATFORM_S3_ENDPOINT_URL: ${MAP_PLATFORM_S3_ENDPOINT_URL:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+    volumes:
+      - map-platform-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,time; from pathlib import Path; maximum=2*float(os.environ['MAP_PLATFORM_MAINTENANCE_INTERVAL_SECONDS'])+300; assert time.time() - Path('/data/health/maintenance').stat().st_mtime < maximum"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
+volumes:
+  map-platform-data:

--- a/deploy/map-platform/detect_worker_change.py
+++ b/deploy/map-platform/detect_worker_change.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Determine whether a Git range changes signed worker build inputs."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "backend"))
+
+from map_platform.map_stream_build_identity import WORKER_SOURCE_ROOTS  # noqa: E402
+
+
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+
+
+def normalize_repo_path(value: str) -> str:
+    path = PurePosixPath(value.strip())
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"changed path is outside the repository: {value}")
+    return path.as_posix()
+
+
+def worker_inputs_changed(paths: Iterable[str]) -> bool:
+    roots = tuple(root.rstrip("/") for root in WORKER_SOURCE_ROOTS)
+    for raw_path in paths:
+        path = normalize_repo_path(raw_path)
+        if any(path == root or path.startswith(f"{root}/") for root in roots):
+            return True
+    return False
+
+
+def git_changed_paths(repo_root: Path, before: str, after: str) -> list[str] | None:
+    if (
+        COMMIT_PATTERN.fullmatch(before) is None
+        or set(before) == {"0"}
+        or COMMIT_PATTERN.fullmatch(after) is None
+    ):
+        return None
+    ancestor = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", before, after],
+        cwd=repo_root,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+    )
+    if ancestor.returncode != 0:
+        return None
+    completed = subprocess.run(
+        ["git", "diff", "--name-only", "-z", before, after],
+        cwd=repo_root,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return [
+        value.decode("utf-8")
+        for value in completed.stdout.split(b"\0")
+        if value
+    ]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Print true when a Git range changes map worker identity inputs",
+    )
+    parser.add_argument("--before", default="")
+    parser.add_argument("--after", required=True)
+    parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    args = parser.parse_args()
+
+    paths = git_changed_paths(args.repo_root.resolve(), args.before, args.after)
+    # Unknown ranges, including manual dispatches, conservatively propose the
+    # candidate as both control plane and worker for explicit human review.
+    changed = True if paths is None else worker_inputs_changed(paths)
+    print("true" if changed else "false")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/map-platform/detect_worker_change.py
+++ b/deploy/map-platform/detect_worker_change.py
@@ -18,6 +18,22 @@ from map_platform.map_stream_build_identity import WORKER_SOURCE_ROOTS  # noqa: 
 
 
 COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+IMAGE_INPUT_ROOTS = (
+    ".github/workflows/map-platform-image.yml",
+    "backend",
+    "tools/OSM_Extract/conf",
+    "tools/OSM_Extract/scripts",
+    "config/map-stream-hardware-gate.json",
+    "config/map-stream-rollout-approvals.json",
+    "config/map-stream-trust.json",
+)
+PROMOTION_INPUT_ROOTS = IMAGE_INPUT_ROOTS + (
+    ".github/workflows/ci.yml",
+    "deploy/map-platform/detect_worker_change.py",
+    "deploy/map-platform/select_worker_promotion.py",
+    "deploy/map-platform/update_image.py",
+    "deploy/map-platform/verify_registry_images.py",
+)
 
 
 def normalize_repo_path(value: str) -> str:
@@ -29,6 +45,24 @@ def normalize_repo_path(value: str) -> str:
 
 def worker_inputs_changed(paths: Iterable[str]) -> bool:
     roots = tuple(root.rstrip("/") for root in WORKER_SOURCE_ROOTS)
+    for raw_path in paths:
+        path = normalize_repo_path(raw_path)
+        if any(path == root or path.startswith(f"{root}/") for root in roots):
+            return True
+    return False
+
+
+def image_inputs_changed(paths: Iterable[str]) -> bool:
+    roots = tuple(root.rstrip("/") for root in IMAGE_INPUT_ROOTS)
+    for raw_path in paths:
+        path = normalize_repo_path(raw_path)
+        if any(path == root or path.startswith(f"{root}/") for root in roots):
+            return True
+    return False
+
+
+def promotion_inputs_changed(paths: Iterable[str]) -> bool:
+    roots = tuple(root.rstrip("/") for root in PROMOTION_INPUT_ROOTS)
     for raw_path in paths:
         path = normalize_repo_path(raw_path)
         if any(path == root or path.startswith(f"{root}/") for root in roots):
@@ -53,7 +87,7 @@ def git_changed_paths(repo_root: Path, before: str, after: str) -> list[str] | N
     if ancestor.returncode != 0:
         return None
     completed = subprocess.run(
-        ["git", "diff", "--name-only", "-z", before, after],
+        ["git", "diff", "--no-renames", "--name-only", "-z", before, after],
         cwd=repo_root,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -73,12 +107,23 @@ def main() -> int:
     parser.add_argument("--before", default="")
     parser.add_argument("--after", required=True)
     parser.add_argument("--repo-root", type=Path, default=REPO_ROOT)
+    parser.add_argument(
+        "--scope",
+        choices=("worker", "image", "promotion"),
+        default="worker",
+    )
     args = parser.parse_args()
 
     paths = git_changed_paths(args.repo_root.resolve(), args.before, args.after)
     # Unknown ranges, including manual dispatches, conservatively propose the
     # candidate as both control plane and worker for explicit human review.
-    changed = True if paths is None else worker_inputs_changed(paths)
+    classifiers = {
+        "worker": worker_inputs_changed,
+        "image": image_inputs_changed,
+        "promotion": promotion_inputs_changed,
+    }
+    classifier = classifiers[args.scope]
+    changed = True if paths is None else classifier(paths)
     print("true" if changed else "false")
     return 0
 

--- a/deploy/map-platform/select_worker_promotion.py
+++ b/deploy/map-platform/select_worker_promotion.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Select an explicit worker policy for a production image promotion."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WorkerPromotionDecision:
+    worker_changed: bool
+    preserve_pending: bool
+    worker_selection: str
+
+
+def select_worker_promotion(
+    *,
+    event_name: str,
+    requested_policy: str,
+    pending_available: bool,
+    pending_moves_worker: bool,
+    pending_worker_changed: bool,
+    adjacent_changed: bool,
+    accumulated_changed: bool,
+) -> WorkerPromotionDecision:
+    if event_name == "workflow_dispatch":
+        if requested_policy == "preserve-pending":
+            if not pending_available:
+                raise ValueError(
+                    "there is no open repository-owned promotion to preserve"
+                )
+            if pending_worker_changed:
+                raise ValueError(
+                    "the pending worker is incompatible with later worker inputs; "
+                    "promote the new candidate instead"
+                )
+            return WorkerPromotionDecision(False, True, "preserved-pending")
+        if requested_policy == "promote-candidate":
+            return WorkerPromotionDecision(True, False, "candidate")
+        if requested_policy != "auto":
+            raise ValueError(f"unknown pending-worker policy: {requested_policy}")
+        if pending_moves_worker:
+            raise ValueError(
+                "choose preserve-pending or promote-candidate for the open "
+                "worker-moving promotion"
+            )
+        # A manual dispatch intentionally rebuilds both roles, including when
+        # unpinned dependency resolution changes the image without a source diff.
+        return WorkerPromotionDecision(True, False, "candidate")
+
+    if event_name != "push":
+        raise ValueError(f"unsupported workflow event: {event_name}")
+    if pending_moves_worker and not adjacent_changed:
+        raise ValueError(
+            "a control-only change cannot implicitly carry or discard the open "
+            "worker-moving promotion; re-run this workflow manually and choose "
+            "preserve-pending or promote-candidate"
+        )
+    return WorkerPromotionDecision(accumulated_changed, False, "candidate")
+
+
+def _bool(value: str) -> bool:
+    if value not in {"true", "false"}:
+        raise argparse.ArgumentTypeError("expected true or false")
+    return value == "true"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event-name", required=True)
+    parser.add_argument("--requested-policy", default="")
+    parser.add_argument("--pending-available", type=_bool, required=True)
+    parser.add_argument("--pending-moves-worker", type=_bool, required=True)
+    parser.add_argument("--pending-worker-changed", type=_bool, required=True)
+    parser.add_argument("--adjacent-changed", type=_bool, required=True)
+    parser.add_argument("--accumulated-changed", type=_bool, required=True)
+    args = parser.parse_args()
+    decision = select_worker_promotion(
+        event_name=args.event_name,
+        requested_policy=args.requested_policy,
+        pending_available=args.pending_available,
+        pending_moves_worker=args.pending_moves_worker,
+        pending_worker_changed=args.pending_worker_changed,
+        adjacent_changed=args.adjacent_changed,
+        accumulated_changed=args.accumulated_changed,
+    )
+    print(f"worker_changed={str(decision.worker_changed).lower()}")
+    print(f"preserve_pending={str(decision.preserve_pending).lower()}")
+    print(f"worker_selection={decision.worker_selection}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/map-platform/tests/test_detect_worker_change.py
+++ b/deploy/map-platform/tests/test_detect_worker_change.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "detect_worker_change.py"
+SPEC = importlib.util.spec_from_file_location("detect_worker_change", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+detect_worker_change = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = detect_worker_change
+SPEC.loader.exec_module(detect_worker_change)
+
+
+class DetectWorkerChangeTests(unittest.TestCase):
+    def test_all_declared_worker_roots_are_classified_as_worker_changes(self) -> None:
+        for root in detect_worker_change.WORKER_SOURCE_ROOTS:
+            with self.subTest(root=root):
+                self.assertTrue(detect_worker_change.worker_inputs_changed([root]))
+                if "." not in Path(root).name:
+                    self.assertTrue(
+                        detect_worker_change.worker_inputs_changed([f"{root}/child.py"])
+                    )
+
+    def test_control_plane_and_deployment_paths_do_not_move_worker(self) -> None:
+        self.assertFalse(
+            detect_worker_change.worker_inputs_changed(
+                [
+                    ".github/workflows/map-platform-image.yml",
+                    "config/map-stream-rollout-approvals.json",
+                    "config/map-stream-trust.json",
+                    "deploy/map-platform/compose.yaml",
+                    "backend/README.md",
+                    "backend/docker-compose.yml",
+                ]
+            )
+        )
+
+    def test_unknown_git_range_is_conservative(self) -> None:
+        self.assertIsNone(
+            detect_worker_change.git_changed_paths(
+                detect_worker_change.REPO_ROOT,
+                "",
+                "a" * 40,
+            )
+        )
+        self.assertIsNone(
+            detect_worker_change.git_changed_paths(
+                detect_worker_change.REPO_ROOT,
+                "0" * 40,
+                "a" * 40,
+            )
+        )
+
+    def test_repository_escape_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "outside the repository"):
+            detect_worker_change.worker_inputs_changed(["../backend/map_platform/api.py"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/map-platform/tests/test_detect_worker_change.py
+++ b/deploy/map-platform/tests/test_detect_worker_change.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -38,6 +40,32 @@ class DetectWorkerChangeTests(unittest.TestCase):
             )
         )
 
+    def test_image_scope_matches_workflow_build_inputs(self) -> None:
+        for root in detect_worker_change.IMAGE_INPUT_ROOTS:
+            with self.subTest(root=root):
+                self.assertTrue(detect_worker_change.image_inputs_changed([root]))
+                if "." not in Path(root).name:
+                    self.assertTrue(
+                        detect_worker_change.image_inputs_changed([f"{root}/child"])
+                    )
+        self.assertFalse(
+            detect_worker_change.image_inputs_changed(
+                ["docs/readme.md", "deploy/map-platform/compose.yaml"]
+            )
+        )
+
+    def test_promotion_scope_includes_policy_and_ci_inputs(self) -> None:
+        for root in detect_worker_change.PROMOTION_INPUT_ROOTS:
+            with self.subTest(root=root):
+                self.assertTrue(
+                    detect_worker_change.promotion_inputs_changed([root])
+                )
+        self.assertFalse(
+            detect_worker_change.promotion_inputs_changed(
+                ["docs/readme.md", "deploy/map-platform/compose.yaml"]
+            )
+        )
+
     def test_unknown_git_range_is_conservative(self) -> None:
         self.assertIsNone(
             detect_worker_change.git_changed_paths(
@@ -57,6 +85,113 @@ class DetectWorkerChangeTests(unittest.TestCase):
     def test_repository_escape_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "outside the repository"):
             detect_worker_change.worker_inputs_changed(["../backend/map_platform/api.py"])
+
+    def test_rename_out_of_worker_root_reports_removed_source_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "tests@example.com"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Tests"],
+                cwd=repo,
+                check=True,
+            )
+            source = repo / "backend" / "map_platform" / "worker.py"
+            source.parent.mkdir(parents=True)
+            source.write_text("worker = True\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "worker"], cwd=repo, check=True)
+            before = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            destination = repo / "docs" / "worker.py"
+            destination.parent.mkdir()
+            source.rename(destination)
+            subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "move worker"], cwd=repo, check=True)
+            after = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            paths = detect_worker_change.git_changed_paths(repo, before, after)
+            self.assertIsNotNone(paths)
+            self.assertIn("backend/map_platform/worker.py", paths)
+            self.assertTrue(detect_worker_change.worker_inputs_changed(paths or []))
+
+    def test_accumulated_range_keeps_worker_change_before_control_commit(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            repo = Path(directory)
+            subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+            subprocess.run(
+                ["git", "config", "user.email", "tests@example.com"],
+                cwd=repo,
+                check=True,
+            )
+            subprocess.run(
+                ["git", "config", "user.name", "Tests"],
+                cwd=repo,
+                check=True,
+            )
+            worker = repo / "backend" / "map_platform" / "worker.py"
+            worker.parent.mkdir(parents=True)
+            worker.write_text("version = 0\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "production"], cwd=repo, check=True)
+            production = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            worker.write_text("version = 1\n", encoding="utf-8")
+            subprocess.run(["git", "commit", "-qam", "worker candidate"], cwd=repo, check=True)
+            worker_candidate = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            docs = repo / "docs"
+            docs.mkdir()
+            (docs / "control.md").write_text("control only\n", encoding="utf-8")
+            subprocess.run(["git", "add", "."], cwd=repo, check=True)
+            subprocess.run(["git", "commit", "-qm", "control"], cwd=repo, check=True)
+            control = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=repo,
+                check=True,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+
+            adjacent = detect_worker_change.git_changed_paths(
+                repo,
+                worker_candidate,
+                control,
+            )
+            accumulated = detect_worker_change.git_changed_paths(
+                repo,
+                production,
+                control,
+            )
+            self.assertFalse(detect_worker_change.worker_inputs_changed(adjacent or []))
+            self.assertTrue(detect_worker_change.worker_inputs_changed(accumulated or []))
 
 
 if __name__ == "__main__":

--- a/deploy/map-platform/tests/test_select_worker_promotion.py
+++ b/deploy/map-platform/tests/test_select_worker_promotion.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "select_worker_promotion.py"
+SPEC = importlib.util.spec_from_file_location("select_worker_promotion", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+select_worker_promotion = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = select_worker_promotion
+SPEC.loader.exec_module(select_worker_promotion)
+
+
+class SelectWorkerPromotionTests(unittest.TestCase):
+    def decide(self, **overrides: object):
+        values: dict[str, object] = {
+            "event_name": "push",
+            "requested_policy": "",
+            "pending_available": False,
+            "pending_moves_worker": False,
+            "pending_worker_changed": False,
+            "adjacent_changed": False,
+            "accumulated_changed": False,
+        }
+        values.update(overrides)
+        return select_worker_promotion.select_worker_promotion(**values)
+
+    def test_accumulated_worker_change_survives_cancelled_prior_run(self) -> None:
+        decision = self.decide(
+            adjacent_changed=False,
+            accumulated_changed=True,
+        )
+
+        self.assertTrue(decision.worker_changed)
+        self.assertEqual(decision.worker_selection, "candidate")
+
+    def test_control_only_push_cannot_silently_carry_pending_worker(self) -> None:
+        with self.assertRaisesRegex(ValueError, "cannot implicitly carry or discard"):
+            self.decide(
+                pending_available=True,
+                pending_moves_worker=True,
+                adjacent_changed=False,
+                accumulated_changed=True,
+            )
+
+    def test_manual_dispatch_must_resolve_pending_worker_intent(self) -> None:
+        with self.assertRaisesRegex(ValueError, "choose preserve-pending"):
+            self.decide(
+                event_name="workflow_dispatch",
+                requested_policy="auto",
+                pending_available=True,
+                pending_moves_worker=True,
+                accumulated_changed=True,
+            )
+
+        preserved = self.decide(
+            event_name="workflow_dispatch",
+            requested_policy="preserve-pending",
+            pending_available=True,
+            pending_moves_worker=True,
+            accumulated_changed=True,
+        )
+        self.assertFalse(preserved.worker_changed)
+        self.assertTrue(preserved.preserve_pending)
+        self.assertEqual(preserved.worker_selection, "preserved-pending")
+
+        candidate = self.decide(
+            event_name="workflow_dispatch",
+            requested_policy="promote-candidate",
+            pending_available=True,
+            pending_moves_worker=True,
+            accumulated_changed=True,
+        )
+        self.assertTrue(candidate.worker_changed)
+        self.assertFalse(candidate.preserve_pending)
+        self.assertEqual(candidate.worker_selection, "candidate")
+
+    def test_pending_worker_cannot_cross_later_worker_changes(self) -> None:
+        with self.assertRaisesRegex(ValueError, "incompatible with later worker inputs"):
+            self.decide(
+                event_name="workflow_dispatch",
+                requested_policy="preserve-pending",
+                pending_available=True,
+                pending_moves_worker=True,
+                pending_worker_changed=True,
+                adjacent_changed=True,
+                accumulated_changed=True,
+            )
+
+    def test_manual_auto_promotes_same_source_rebuild(self) -> None:
+        decision = self.decide(
+            event_name="workflow_dispatch",
+            requested_policy="auto",
+            accumulated_changed=False,
+        )
+
+        self.assertTrue(decision.worker_changed)
+        self.assertEqual(decision.worker_selection, "candidate")
+
+    def test_worker_changing_push_replaces_pending_candidate(self) -> None:
+        decision = self.decide(
+            pending_available=True,
+            pending_moves_worker=True,
+            adjacent_changed=True,
+            accumulated_changed=True,
+        )
+
+        self.assertTrue(decision.worker_changed)
+        self.assertFalse(decision.preserve_pending)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/map-platform/tests/test_update_image.py
+++ b/deploy/map-platform/tests/test_update_image.py
@@ -70,6 +70,34 @@ class UpdateImageTests(unittest.TestCase):
             self.assertEqual(deployment.worker_digest, digest)
             self.assertNotIn(":latest", target.read_text(encoding="utf-8"))
 
+    def test_pending_worker_can_be_preserved_while_control_plane_advances(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            current = self.copy_compose(directory)
+            pending = Path(directory) / "pending-compose.yaml"
+            pending.write_text(current.read_text(encoding="utf-8"), encoding="utf-8")
+            pending_worker_digest = "sha256:" + "e" * 64
+            pending_worker_commit = "f" * 40
+            update_image.update_manifest(
+                pending,
+                control_plane_digest="sha256:" + "1" * 64,
+                worker_digest=pending_worker_digest,
+                source_commit=pending_worker_commit,
+            )
+
+            preserved = update_image.validate_manifest(pending)
+            deployment = update_image.update_manifest(
+                current,
+                control_plane_digest="sha256:" + "2" * 64,
+                source_commit="3" * 40,
+                worker_digest=preserved.worker_digest,
+                worker_source_commit=preserved.worker_source_commit,
+            )
+
+            self.assertEqual(deployment.control_plane_source_commit, "3" * 40)
+            self.assertEqual(deployment.control_plane_digest, "sha256:" + "2" * 64)
+            self.assertEqual(deployment.worker_source_commit, pending_worker_commit)
+            self.assertEqual(deployment.worker_digest, pending_worker_digest)
+
     def test_update_rejects_mutable_or_malformed_digest(self) -> None:
         for digest in ("latest", "sha256:1234", "sha256:" + "A" * 64):
             with self.subTest(digest=digest), self.assertRaisesRegex(
@@ -99,6 +127,39 @@ class UpdateImageTests(unittest.TestCase):
         for mutated in mutations:
             with self.subTest(), self.assertRaises(ValueError):
                 update_image.validate_manifest_text(mutated)
+
+    def test_validation_rejects_swapped_api_and_worker_aliases(self) -> None:
+        original = self.compose.read_text(encoding="utf-8")
+        api_marker = "  map-platform-api:\n    image: *map-platform-control-plane-image"
+        worker_marker = "  map-platform-worker:\n    image: *map-platform-worker-image"
+        swapped = original.replace(
+            api_marker,
+            "  map-platform-api:\n    image: *map-platform-worker-image",
+        ).replace(
+            worker_marker,
+            "  map-platform-worker:\n    image: *map-platform-control-plane-image",
+        )
+
+        with self.assertRaisesRegex(ValueError, "API service"):
+            update_image.validate_manifest_text(swapped)
+
+    def test_validation_requires_worker_identity_in_environment(self) -> None:
+        original = self.compose.read_text(encoding="utf-8")
+        identity = (
+            "      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: "
+            "*map-platform-worker-image\n"
+        )
+        moved_to_labels = original.replace(identity, "", 1).replace(
+            "    volumes:\n",
+            "    labels:\n"
+            "      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: "
+            "*map-platform-worker-image\n"
+            "    volumes:\n",
+            1,
+        )
+
+        with self.assertRaisesRegex(ValueError, "API service must receive"):
+            update_image.validate_manifest_text(moved_to_labels)
 
 
 if __name__ == "__main__":

--- a/deploy/map-platform/tests/test_update_image.py
+++ b/deploy/map-platform/tests/test_update_image.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "update_image.py"
+SPEC = importlib.util.spec_from_file_location("update_image", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+update_image = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = update_image
+SPEC.loader.exec_module(update_image)
+
+
+class UpdateImageTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.compose = MODULE_PATH.with_name("compose.yaml")
+
+    def copy_compose(self, directory: str) -> Path:
+        target = Path(directory) / "compose.yaml"
+        target.write_text(self.compose.read_text(encoding="utf-8"), encoding="utf-8")
+        return target
+
+    def test_committed_production_compose_is_digest_pinned(self) -> None:
+        deployment = update_image.validate_manifest(self.compose)
+
+        self.assertRegex(deployment.control_plane_source_commit, r"^[0-9a-f]{40}$")
+        self.assertRegex(deployment.worker_source_commit, r"^[0-9a-f]{40}$")
+        self.assertRegex(
+            deployment.control_plane_reference,
+            r"^ghcr\.io/seichris/open-bike-computer-map-platform@sha256:[0-9a-f]{64}$",
+        )
+        self.assertRegex(
+            deployment.worker_reference,
+            r"^ghcr\.io/seichris/open-bike-computer-map-platform@sha256:[0-9a-f]{64}$",
+        )
+
+    def test_control_plane_can_advance_without_worker(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            target = self.copy_compose(directory)
+            before = update_image.validate_manifest(target)
+            deployment = update_image.update_manifest(
+                target,
+                control_plane_digest="sha256:" + "b" * 64,
+                source_commit="a" * 40,
+            )
+
+            self.assertEqual(deployment.control_plane_source_commit, "a" * 40)
+            self.assertEqual(deployment.control_plane_digest, "sha256:" + "b" * 64)
+            self.assertEqual(deployment.worker_source_commit, before.worker_source_commit)
+            self.assertEqual(deployment.worker_reference, before.worker_reference)
+
+    def test_worker_and_control_plane_can_advance_together(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            target = self.copy_compose(directory)
+            digest = "sha256:" + "c" * 64
+            deployment = update_image.update_manifest(
+                target,
+                control_plane_digest=digest,
+                worker_digest=digest,
+                source_commit="d" * 40,
+            )
+
+            self.assertEqual(deployment.control_plane_source_commit, "d" * 40)
+            self.assertEqual(deployment.worker_source_commit, "d" * 40)
+            self.assertEqual(deployment.control_plane_digest, digest)
+            self.assertEqual(deployment.worker_digest, digest)
+            self.assertNotIn(":latest", target.read_text(encoding="utf-8"))
+
+    def test_update_rejects_mutable_or_malformed_digest(self) -> None:
+        for digest in ("latest", "sha256:1234", "sha256:" + "A" * 64):
+            with self.subTest(digest=digest), self.assertRaisesRegex(
+                ValueError,
+                "control-plane digest must be sha256",
+            ):
+                update_image.update_manifest(
+                    self.compose,
+                    control_plane_digest=digest,
+                    source_commit="a" * 40,
+                )
+
+    def test_validation_rejects_service_or_identity_drift(self) -> None:
+        original = self.compose.read_text(encoding="utf-8")
+        mutations = (
+            original.replace(
+                "    image: *map-platform-control-plane-image",
+                "    image: image:latest",
+                1,
+            ),
+            original.replace(
+                "MAP_PLATFORM_WORKER_IMAGE_REFERENCE: *map-platform-worker-image",
+                "MAP_PLATFORM_WORKER_IMAGE_REFERENCE: image:latest",
+                1,
+            ),
+        )
+        for mutated in mutations:
+            with self.subTest(), self.assertRaises(ValueError):
+                update_image.validate_manifest_text(mutated)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/map-platform/tests/test_verify_registry_images.py
+++ b/deploy/map-platform/tests/test_verify_registry_images.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+DEPLOY_DIR = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(DEPLOY_DIR))
+MODULE_PATH = DEPLOY_DIR / "verify_registry_images.py"
+SPEC = importlib.util.spec_from_file_location("verify_registry_images", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+verify_registry_images = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = verify_registry_images
+SPEC.loader.exec_module(verify_registry_images)
+
+
+class VerifyRegistryImagesTests(unittest.TestCase):
+    def test_registry_commands_retry_transient_failures(self) -> None:
+        failure = subprocess.CalledProcessError(
+            1,
+            ["registry", "inspect"],
+            stderr="temporary registry error",
+        )
+        success = subprocess.CompletedProcess(
+            ["registry", "inspect"],
+            0,
+            stdout="manifest",
+            stderr="",
+        )
+        with mock.patch.object(
+            verify_registry_images.subprocess,
+            "run",
+            side_effect=[failure, success],
+        ) as run, mock.patch.object(verify_registry_images.time, "sleep") as sleep:
+            output = verify_registry_images._run(["registry", "inspect"])
+
+        self.assertEqual(output, "manifest")
+        self.assertEqual(run.call_count, 2)
+        sleep.assert_called_once_with(1)
+
+    def test_linux_amd64_platform_is_required(self) -> None:
+        valid = json.dumps(
+            {
+                "manifests": [
+                    {"platform": {"os": "unknown", "architecture": "unknown"}},
+                    {"platform": {"os": "linux", "architecture": "amd64"}},
+                ]
+            }
+        )
+        verify_registry_images.require_linux_amd64(valid, "image@sha256:digest")
+
+        for invalid in (
+            "not-json",
+            json.dumps({"architecture": "amd64", "os": "linux"}),
+            json.dumps(
+                {"manifests": [{"platform": {"os": "linux", "architecture": "arm64"}}]}
+            ),
+        ):
+            with self.subTest(invalid=invalid), self.assertRaises(ValueError):
+                verify_registry_images.require_linux_amd64(
+                    invalid,
+                    "image@sha256:digest",
+                )
+
+    def test_verification_binds_attestation_to_source_and_workflow(self) -> None:
+        manifest = json.dumps(
+            {"manifests": [{"platform": {"os": "linux", "architecture": "amd64"}}]}
+        )
+        reference = "ghcr.io/seichris/open-bike-computer-map-platform@sha256:" + "a" * 64
+        source_commit = "b" * 40
+
+        with mock.patch.object(
+            verify_registry_images,
+            "_run",
+            side_effect=[manifest, "verified"],
+        ) as run:
+            verify_registry_images.verify_image(reference, source_commit)
+
+        self.assertEqual(
+            run.call_args_list[0].args[0],
+            ["docker", "buildx", "imagetools", "inspect", reference, "--raw"],
+        )
+        attestation_command = run.call_args_list[1].args[0]
+        self.assertIn(f"oci://{reference}", attestation_command)
+        self.assertEqual(
+            attestation_command[
+                attestation_command.index("--source-digest") + 1
+            ],
+            source_commit,
+        )
+        self.assertEqual(
+            attestation_command[
+                attestation_command.index("--signer-workflow") + 1
+            ],
+            verify_registry_images.SIGNER_WORKFLOW,
+        )
+        self.assertEqual(
+            attestation_command[
+                attestation_command.index("--source-ref") + 1
+            ],
+            verify_registry_images.REQUIRED_SOURCE_REF,
+        )
+        self.assertIn("--deny-self-hosted-runners", attestation_command)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/map-platform/update_image.py
+++ b/deploy/map-platform/update_image.py
@@ -43,6 +43,10 @@ IDENTITY_ENV_PATTERN = re.compile(
     r"^      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: \*map-platform-worker-image$",
     re.MULTILINE,
 )
+SERVICE_PATTERN_TEMPLATE = r"^  {service}:\n(?P<body>(?:^(?:    |\s*$).*\n?)*)"
+SERVICE_MAPPING_PATTERN_TEMPLATE = (
+    r"^    {mapping}:\n(?P<body>(?:^(?:      |\s*$).*\n?)*)"
+)
 
 
 @dataclass(frozen=True)
@@ -75,6 +79,35 @@ def _single_match(pattern: re.Pattern[str], text: str, description: str) -> re.M
     return matches[0]
 
 
+def _service_body(text: str, service: str) -> str:
+    pattern = re.compile(
+        SERVICE_PATTERN_TEMPLATE.format(service=re.escape(service)),
+        re.MULTILINE,
+    )
+    return _single_match(pattern, text, f"{service} service").group("body")
+
+
+def _require_service_line(
+    body: str,
+    pattern: re.Pattern[str],
+    description: str,
+) -> None:
+    if len(pattern.findall(body)) != 1:
+        raise ValueError(description)
+
+
+def _service_mapping_body(service_body: str, mapping: str, service: str) -> str:
+    pattern = re.compile(
+        SERVICE_MAPPING_PATTERN_TEMPLATE.format(mapping=re.escape(mapping)),
+        re.MULTILINE,
+    )
+    return _single_match(
+        pattern,
+        service_body,
+        f"{service} {mapping} mapping",
+    ).group("body")
+
+
 def validate_manifest_text(text: str) -> DeploymentImages:
     control_source = _single_match(
         CONTROL_SOURCE_PATTERN,
@@ -96,12 +129,42 @@ def validate_manifest_text(text: str) -> DeploymentImages:
         text,
         "pinned worker image anchor",
     )
+    api = _service_body(text, "map-platform-api")
+    worker = _service_body(text, "map-platform-worker")
+    maintenance = _service_body(text, "map-platform-maintenance")
+    api_environment = _service_mapping_body(api, "environment", "API")
+    worker_environment = _service_mapping_body(worker, "environment", "worker")
+    _require_service_line(
+        api,
+        CONTROL_SERVICE_IMAGE_PATTERN,
+        "the API service must use the pinned control-plane image",
+    )
+    _require_service_line(
+        worker,
+        WORKER_SERVICE_IMAGE_PATTERN,
+        "the worker service must use the pinned worker image",
+    )
+    _require_service_line(
+        maintenance,
+        CONTROL_SERVICE_IMAGE_PATTERN,
+        "the maintenance service must use the pinned control-plane image",
+    )
+    _require_service_line(
+        api_environment,
+        IDENTITY_ENV_PATTERN,
+        "the API service must receive the pinned worker image identity",
+    )
+    _require_service_line(
+        worker_environment,
+        IDENTITY_ENV_PATTERN,
+        "the worker service must receive the pinned worker image identity",
+    )
     if len(CONTROL_SERVICE_IMAGE_PATTERN.findall(text)) != 2:
-        raise ValueError("API and maintenance must use the pinned control-plane image")
+        raise ValueError("only API and maintenance may use the control-plane image")
     if len(WORKER_SERVICE_IMAGE_PATTERN.findall(text)) != 1:
-        raise ValueError("the worker service must use the pinned worker image")
+        raise ValueError("only the worker service may use the worker image")
     if len(IDENTITY_ENV_PATTERN.findall(text)) != 2:
-        raise ValueError("API and worker must receive the pinned worker image identity")
+        raise ValueError("only API and worker may receive the worker image identity")
     if "MAP_PLATFORM_WORKER_IMAGE}" in text or "MAP_PLATFORM_WORKER_IMAGE:-" in text:
         raise ValueError("production Compose must not depend on a mutable Coolify image variable")
 
@@ -134,6 +197,7 @@ def update_manifest(
     control_plane_digest: str,
     source_commit: str,
     worker_digest: str | None = None,
+    worker_source_commit: str | None = None,
 ) -> DeploymentImages:
     _validate_update_value(
         control_plane_digest,
@@ -146,11 +210,20 @@ def update_manifest(
             DIGEST_PATTERN,
             "worker digest must be sha256 followed by 64 lowercase hexadecimal characters",
         )
+    if worker_source_commit is not None and worker_digest is None:
+        raise ValueError("worker source commit requires a worker digest")
     _validate_update_value(
         source_commit,
         COMMIT_PATTERN,
         "source commit must be a full 40-character lowercase Git SHA",
     )
+    requested_worker_source = worker_source_commit or source_commit
+    if worker_digest is not None:
+        _validate_update_value(
+            requested_worker_source,
+            COMMIT_PATTERN,
+            "worker source commit must be a full 40-character lowercase Git SHA",
+        )
 
     text = path.read_text(encoding="utf-8")
     validate_manifest_text(text)
@@ -166,7 +239,7 @@ def update_manifest(
     if worker_digest is not None:
         worker_reference = f"{IMAGE_REPOSITORY}@{worker_digest}"
         updated = WORKER_SOURCE_PATTERN.sub(
-            f"# worker-source-commit: {source_commit}",
+            f"# worker-source-commit: {requested_worker_source}",
             updated,
         )
         updated = WORKER_IMAGE_PATTERN.sub(
@@ -181,7 +254,7 @@ def update_manifest(
     ):
         raise ValueError("control-plane update did not persist the requested identity")
     if worker_digest is not None and (
-        deployment.worker_source_commit != source_commit
+        deployment.worker_source_commit != requested_worker_source
         or deployment.worker_digest != worker_digest
     ):
         raise ValueError("worker update did not persist the requested identity")
@@ -198,21 +271,34 @@ def main() -> int:
     mode = parser.add_mutually_exclusive_group(required=True)
     mode.add_argument("--check", action="store_true")
     mode.add_argument("--control-plane-digest")
-    parser.add_argument("--worker-digest")
+    worker_mode = parser.add_mutually_exclusive_group()
+    worker_mode.add_argument("--worker-digest")
+    worker_mode.add_argument("--preserve-worker-from", type=Path)
     parser.add_argument("--source-commit")
     args = parser.parse_args()
 
     if args.check:
-        if args.worker_digest is not None or args.source_commit is not None:
+        if (
+            args.worker_digest is not None
+            or args.preserve_worker_from is not None
+            or args.source_commit is not None
+        ):
             parser.error("update arguments are not valid with --check")
         deployment = validate_manifest(args.compose)
     else:
         if args.source_commit is None:
             parser.error("--source-commit is required with --control-plane-digest")
+        worker_digest = args.worker_digest
+        worker_source_commit = None
+        if args.preserve_worker_from is not None:
+            pending = validate_manifest(args.preserve_worker_from)
+            worker_digest = pending.worker_digest
+            worker_source_commit = pending.worker_source_commit
         deployment = update_manifest(
             args.compose,
             control_plane_digest=args.control_plane_digest,
-            worker_digest=args.worker_digest,
+            worker_digest=worker_digest,
+            worker_source_commit=worker_source_commit,
             source_commit=args.source_commit,
         )
     print(

--- a/deploy/map-platform/update_image.py
+++ b/deploy/map-platform/update_image.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Validate or update immutable map-platform production images."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+IMAGE_REPOSITORY = "ghcr.io/seichris/open-bike-computer-map-platform"
+DIGEST_PATTERN = re.compile(r"sha256:[0-9a-f]{64}")
+REFERENCE_PATTERN = re.compile(
+    rf"{re.escape(IMAGE_REPOSITORY)}@(?P<digest>sha256:[0-9a-f]{{64}})"
+)
+COMMIT_PATTERN = re.compile(r"[0-9a-f]{40}")
+CONTROL_SOURCE_PATTERN = re.compile(
+    r"^# control-plane-source-commit: (?P<commit>[0-9a-f]{40})$",
+    re.MULTILINE,
+)
+WORKER_SOURCE_PATTERN = re.compile(
+    r"^# worker-source-commit: (?P<commit>[0-9a-f]{40})$",
+    re.MULTILINE,
+)
+CONTROL_IMAGE_PATTERN = re.compile(
+    rf"^(?P<prefix>  control-plane: &map-platform-control-plane-image )(?P<reference>{re.escape(IMAGE_REPOSITORY)}@sha256:[0-9a-f]{{64}})$",
+    re.MULTILINE,
+)
+WORKER_IMAGE_PATTERN = re.compile(
+    rf"^(?P<prefix>  worker: &map-platform-worker-image )(?P<reference>{re.escape(IMAGE_REPOSITORY)}@sha256:[0-9a-f]{{64}})$",
+    re.MULTILINE,
+)
+CONTROL_SERVICE_IMAGE_PATTERN = re.compile(
+    r"^    image: \*map-platform-control-plane-image$",
+    re.MULTILINE,
+)
+WORKER_SERVICE_IMAGE_PATTERN = re.compile(
+    r"^    image: \*map-platform-worker-image$",
+    re.MULTILINE,
+)
+IDENTITY_ENV_PATTERN = re.compile(
+    r"^      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: \*map-platform-worker-image$",
+    re.MULTILINE,
+)
+
+
+@dataclass(frozen=True)
+class DeploymentImages:
+    control_plane_source_commit: str
+    control_plane_reference: str
+    worker_source_commit: str
+    worker_reference: str
+
+    @staticmethod
+    def _digest(reference: str) -> str:
+        match = REFERENCE_PATTERN.fullmatch(reference)
+        if match is None:  # pragma: no cover - guarded by validation
+            raise ValueError("production image reference is invalid")
+        return match.group("digest")
+
+    @property
+    def control_plane_digest(self) -> str:
+        return self._digest(self.control_plane_reference)
+
+    @property
+    def worker_digest(self) -> str:
+        return self._digest(self.worker_reference)
+
+
+def _single_match(pattern: re.Pattern[str], text: str, description: str) -> re.Match[str]:
+    matches = list(pattern.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(f"production Compose must contain exactly one {description}")
+    return matches[0]
+
+
+def validate_manifest_text(text: str) -> DeploymentImages:
+    control_source = _single_match(
+        CONTROL_SOURCE_PATTERN,
+        text,
+        "control-plane source-commit marker",
+    )
+    worker_source = _single_match(
+        WORKER_SOURCE_PATTERN,
+        text,
+        "worker source-commit marker",
+    )
+    control_image = _single_match(
+        CONTROL_IMAGE_PATTERN,
+        text,
+        "pinned control-plane image anchor",
+    )
+    worker_image = _single_match(
+        WORKER_IMAGE_PATTERN,
+        text,
+        "pinned worker image anchor",
+    )
+    if len(CONTROL_SERVICE_IMAGE_PATTERN.findall(text)) != 2:
+        raise ValueError("API and maintenance must use the pinned control-plane image")
+    if len(WORKER_SERVICE_IMAGE_PATTERN.findall(text)) != 1:
+        raise ValueError("the worker service must use the pinned worker image")
+    if len(IDENTITY_ENV_PATTERN.findall(text)) != 2:
+        raise ValueError("API and worker must receive the pinned worker image identity")
+    if "MAP_PLATFORM_WORKER_IMAGE}" in text or "MAP_PLATFORM_WORKER_IMAGE:-" in text:
+        raise ValueError("production Compose must not depend on a mutable Coolify image variable")
+
+    control_reference = control_image.group("reference")
+    worker_reference = worker_image.group("reference")
+    if REFERENCE_PATTERN.fullmatch(control_reference) is None:
+        raise ValueError("control-plane image must use the expected repository and OCI digest")
+    if REFERENCE_PATTERN.fullmatch(worker_reference) is None:
+        raise ValueError("worker image must use the expected repository and OCI digest")
+    return DeploymentImages(
+        control_plane_source_commit=control_source.group("commit"),
+        control_plane_reference=control_reference,
+        worker_source_commit=worker_source.group("commit"),
+        worker_reference=worker_reference,
+    )
+
+
+def validate_manifest(path: Path) -> DeploymentImages:
+    return validate_manifest_text(path.read_text(encoding="utf-8"))
+
+
+def _validate_update_value(value: str, pattern: re.Pattern[str], description: str) -> None:
+    if pattern.fullmatch(value) is None:
+        raise ValueError(description)
+
+
+def update_manifest(
+    path: Path,
+    *,
+    control_plane_digest: str,
+    source_commit: str,
+    worker_digest: str | None = None,
+) -> DeploymentImages:
+    _validate_update_value(
+        control_plane_digest,
+        DIGEST_PATTERN,
+        "control-plane digest must be sha256 followed by 64 lowercase hexadecimal characters",
+    )
+    if worker_digest is not None:
+        _validate_update_value(
+            worker_digest,
+            DIGEST_PATTERN,
+            "worker digest must be sha256 followed by 64 lowercase hexadecimal characters",
+        )
+    _validate_update_value(
+        source_commit,
+        COMMIT_PATTERN,
+        "source commit must be a full 40-character lowercase Git SHA",
+    )
+
+    text = path.read_text(encoding="utf-8")
+    validate_manifest_text(text)
+    control_reference = f"{IMAGE_REPOSITORY}@{control_plane_digest}"
+    updated = CONTROL_SOURCE_PATTERN.sub(
+        f"# control-plane-source-commit: {source_commit}",
+        text,
+    )
+    updated = CONTROL_IMAGE_PATTERN.sub(
+        lambda match: f"{match.group('prefix')}{control_reference}",
+        updated,
+    )
+    if worker_digest is not None:
+        worker_reference = f"{IMAGE_REPOSITORY}@{worker_digest}"
+        updated = WORKER_SOURCE_PATTERN.sub(
+            f"# worker-source-commit: {source_commit}",
+            updated,
+        )
+        updated = WORKER_IMAGE_PATTERN.sub(
+            lambda match: f"{match.group('prefix')}{worker_reference}",
+            updated,
+        )
+
+    deployment = validate_manifest_text(updated)
+    if (
+        deployment.control_plane_source_commit != source_commit
+        or deployment.control_plane_reference != control_reference
+    ):
+        raise ValueError("control-plane update did not persist the requested identity")
+    if worker_digest is not None and (
+        deployment.worker_source_commit != source_commit
+        or deployment.worker_digest != worker_digest
+    ):
+        raise ValueError("worker update did not persist the requested identity")
+    if updated != text:
+        path.write_text(updated, encoding="utf-8")
+    return deployment
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Validate or update digest-pinned map-platform production images",
+    )
+    parser.add_argument("compose", type=Path)
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true")
+    mode.add_argument("--control-plane-digest")
+    parser.add_argument("--worker-digest")
+    parser.add_argument("--source-commit")
+    args = parser.parse_args()
+
+    if args.check:
+        if args.worker_digest is not None or args.source_commit is not None:
+            parser.error("update arguments are not valid with --check")
+        deployment = validate_manifest(args.compose)
+    else:
+        if args.source_commit is None:
+            parser.error("--source-commit is required with --control-plane-digest")
+        deployment = update_manifest(
+            args.compose,
+            control_plane_digest=args.control_plane_digest,
+            worker_digest=args.worker_digest,
+            source_commit=args.source_commit,
+        )
+    print(
+        f"control-plane {deployment.control_plane_source_commit} "
+        f"{deployment.control_plane_reference}"
+    )
+    print(f"worker {deployment.worker_source_commit} {deployment.worker_reference}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/deploy/map-platform/verify_registry_images.py
+++ b/deploy/map-platform/verify_registry_images.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Verify production image availability, platform, and GitHub provenance."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Sequence
+
+from update_image import DeploymentImages, validate_manifest
+
+
+SOURCE_REPOSITORY = "seichris/open-bike-computer"
+SIGNER_WORKFLOW = (
+    "seichris/open-bike-computer/.github/workflows/map-platform-image.yml"
+)
+REQUIRED_OS = "linux"
+REQUIRED_ARCHITECTURE = "amd64"
+REQUIRED_SOURCE_REF = "refs/heads/main"
+
+
+def _run(command: Sequence[str], attempts: int = 3) -> str:
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+    for attempt in range(attempts):
+        try:
+            completed = subprocess.run(
+                command,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            return completed.stdout
+        except subprocess.CalledProcessError as error:
+            if attempt + 1 == attempts:
+                detail = (error.stderr or error.stdout or "").strip()
+                message = f"command failed after {attempts} attempts: {' '.join(command)}"
+                if detail:
+                    message = f"{message}: {detail}"
+                raise RuntimeError(message) from error
+            time.sleep(2**attempt)
+    raise AssertionError("retry loop must return or raise")
+
+
+def require_linux_amd64(raw_manifest: str, reference: str) -> None:
+    try:
+        manifest = json.loads(raw_manifest)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"registry returned invalid JSON for {reference}") from error
+    descriptors = manifest.get("manifests")
+    if not isinstance(descriptors, list):
+        raise ValueError(f"{reference} is not a platform-indexed OCI image")
+    for descriptor in descriptors:
+        if not isinstance(descriptor, dict):
+            continue
+        platform = descriptor.get("platform")
+        if not isinstance(platform, dict):
+            continue
+        if (
+            platform.get("os") == REQUIRED_OS
+            and platform.get("architecture") == REQUIRED_ARCHITECTURE
+        ):
+            return
+    raise ValueError(f"{reference} does not contain a linux/amd64 image")
+
+
+def verify_image(reference: str, source_commit: str) -> None:
+    raw_manifest = _run(
+        ["docker", "buildx", "imagetools", "inspect", reference, "--raw"]
+    )
+    require_linux_amd64(raw_manifest, reference)
+    _run(
+        [
+            "gh",
+            "attestation",
+            "verify",
+            f"oci://{reference}",
+            "--repo",
+            SOURCE_REPOSITORY,
+            "--signer-workflow",
+            SIGNER_WORKFLOW,
+            "--source-digest",
+            source_commit,
+            "--source-ref",
+            REQUIRED_SOURCE_REF,
+            "--deny-self-hosted-runners",
+        ]
+    )
+
+
+def verify_deployment(deployment: DeploymentImages) -> None:
+    verify_image(
+        deployment.control_plane_reference,
+        deployment.control_plane_source_commit,
+    )
+    verify_image(deployment.worker_reference, deployment.worker_source_commit)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Verify digest-pinned production images in GHCR",
+    )
+    parser.add_argument("compose", type=Path)
+    args = parser.parse_args()
+    deployment = validate_manifest(args.compose)
+    verify_deployment(deployment)
+    print(
+        "verified control-plane "
+        f"{deployment.control_plane_source_commit} "
+        f"{deployment.control_plane_reference}"
+    )
+    print(
+        f"verified worker {deployment.worker_source_commit} "
+        f"{deployment.worker_reference}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/map-stream-rollout-runbook.md
+++ b/docs/map-stream-rollout-runbook.md
@@ -72,9 +72,10 @@ and native platform/architecture inventory. The worker recomputes it at startup;
 the production image executes from that same hashed source tree and rejects a
 separately installed runtime package. No CI variable or runtime setting can
 assert it. The image reference must be
-digest-pinned as `registry/repository@sha256:<digest>`. Require the deployment
-registry's signature/provenance admission policy to verify that digest, and keep
-the exact image available through approval and rollout.
+digest-pinned as `registry/repository@sha256:<digest>`. Require promotion CI to
+verify registry availability, the required platform, and GitHub provenance from
+the protected `main` branch before merge, and keep the exact image available
+through approval and rollout.
 
 Put these secrets only on the worker service:
 
@@ -187,8 +188,8 @@ alter the derived worker component identity. Keep the worker image anchor in
 `registry/repository@sha256:<digest>` reference exercised by the hardware report
 and deploy it without rebuilding it. The production lock passes that value as
 both the worker service image and the API/worker admission identity; the
-deployment registry policy must verify the image signature/provenance before
-launch. Its separate control-plane image anchor may advance to include the
+promotion CI policy must verify the image platform and `main`-branch provenance
+before merge. Its separate control-plane image anchor may advance to include the
 approval registry. The worker signs its derived content identity into every
 stream manifest and records the exact public-key fingerprint in the
 key-specific artifact identity. The API

--- a/docs/map-stream-rollout-runbook.md
+++ b/docs/map-stream-rollout-runbook.md
@@ -182,12 +182,13 @@ Production delivery modes are:
 For `percentage` and `all`, set `MAP_PLATFORM_MAP_STREAM_PROMOTION_ID` to an ID
 present in the checked-in approval registry. The approval PR is expected to be
 later than the tested source commit; that control-plane-only change does not
-alter the derived worker component identity. Set `MAP_PLATFORM_WORKER_IMAGE` to
-the exact `registry/repository@sha256:<digest>` reference exercised by the
-hardware report and deploy that service without rebuilding it. Compose passes
-the same value as the worker service image and the API/worker admission identity;
-the deployment registry policy must verify the image signature/provenance before
-launch. The API image may advance to include the
+alter the derived worker component identity. Keep the worker image anchor in
+`deploy/map-platform/compose.yaml` on the exact
+`registry/repository@sha256:<digest>` reference exercised by the hardware report
+and deploy it without rebuilding it. The production lock passes that value as
+both the worker service image and the API/worker admission identity; the
+deployment registry policy must verify the image signature/provenance before
+launch. Its separate control-plane image anchor may advance to include the
 approval registry. The worker signs its derived content identity into every
 stream manifest and records the exact public-key fingerprint in the
 key-specific artifact identity. The API


### PR DESCRIPTION
## What changed

- add a digest-pinned production Compose lock with separate control-plane and worker image pins
- keep signed worker identity tied to the exact hardware-approved worker digest
- propose new production digests through a bot-maintained PR after successful `main` image builds
- classify control-plane-only changes so API and maintenance can advance without replacing the tested worker
- validate the production lock in CI and document the one-time Coolify migration and rollback flow

## Why

Production image selection currently lives in mutable Coolify environment variables and requires a manual edit for every release. A mutable `:latest` worker reference is incompatible with the signed worker's fail-closed identity check and previously caused a restart loop.

## Impact

After a one-time Coolify change to `/deploy/map-platform/compose.yaml`, normal releases update a reviewed file in Git instead of Coolify environment variables. API and maintenance can advance independently while the hardware-tested worker stays pinned. Runtime secrets remain in Coolify and no secrets are committed.

## Validation

- 184 backend tests passed
- 9 deployment lock/classifier tests passed
- both GitHub Actions workflows passed `actionlint`
- production Compose rendered successfully with required runtime variables
- current control-plane and worker digests resolve as `linux/amd64` OCI indexes
- live `https://maps.8o.vc/healthz` remained healthy
