### PR TITLE
Disable unused Waveshare GPS and IMU work

### DIFF
--- a/docs/waveshare-gps-imu-power-implementation-plan.md
+++ b/docs/waveshare-gps-imu-power-implementation-plan.md
@@ -1,0 +1,218 @@
+# Waveshare GPS and IMU Power Cleanup Implementation Plan
+
+## Outcome
+
+Reduce normal-navigation power use on both Waveshare AMOLED targets by removing
+two unused hardware paths:
+
+1. Do not initialize the UART GPS receiver or create its FreeRTOS polling task.
+   The iPhone remains the only live GPS source on Waveshare builds.
+2. Keep both QMI8658 sensor engines disabled in production and stop all periodic
+   accelerometer and gyroscope reads.
+
+The shared `Gps` data model remains in place because BLE, maps, navigation, and
+ride telemetry consume it. Hardware-GPS support remains available to the older
+boards that actually use a receiver.
+
+## Scope and invariants
+
+- Production targets: `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206`.
+- Preserve BLE GPS parsing and the existing map/navigation data flow.
+- Preserve UART/NMEA GPS behavior on non-Waveshare targets.
+- Preserve an explicit opt-in IMU diagnostic build path for hardware bring-up.
+- Do not power down the shared Waveshare peripheral rail; the display, touch,
+  RTC, and other devices depend on it.
+- Do not change the BLE protocol or iOS app.
+
+## Current behavior
+
+### Hardware GPS
+
+`setup()` currently creates `gpsMutex`, calls `gps.init()`, and starts
+`initGpsTask()` for every normal firmware build. `gps.init()` opens `Serial2`,
+and `gpsTask()` wakes every RTOS tick to poll the UART and parse NMEA data.
+
+Waveshare navigation does not need that path. The iPhone writes position,
+heading, speed, altitude, distance, elapsed time, and route-remaining data into
+`gps.gpsData` through `ble_navigation.cpp`. Maps and UI read the same structure,
+so removing the UART producer must not remove the model or its consumers.
+
+### IMU
+
+Waveshare setup currently configures the QMI8658 accelerometer and gyroscope,
+the main loop samples them every 500 ms, and the system heartbeat prints their
+derived orientation and movement state. No navigation, screen rotation,
+wake/sleep, or ride feature consumes that state.
+
+Skipping `imu::begin()` alone is insufficient: after a warm ESP restart, the
+QMI8658 may remain powered on the shared rail with sensor engines left enabled
+by the previous firmware. Production boot should therefore explicitly write
+the sensor-enable register to its disabled state once.
+
+## Implementation
+
+### 1. Make hardware GPS an explicit board capability
+
+Add `HAS_HARDWARE_GPS=1` to the non-Waveshare common PlatformIO flags. The
+Waveshare environments use their own common section and intentionally omit the
+flag. This describes the capability directly and avoids scattering negative
+checks for both Waveshare model macros.
+
+Guard the UART-only lifecycle with `HAS_HARDWARE_GPS`:
+
+- declaration, definition, and creation of `gpsMutex`
+- `gpsTask()` and `initGpsTask()` declarations and definitions
+- `gps.init()` and `initGpsTask()` calls in `setup()`
+- GPS baud/rate settings callbacks that can stop, start, or write to `Serial2`
+- hardware-GPS-only checkpoint logging
+
+Keep these pieces unguarded:
+
+- the global `Gps gps` instance and `gps.gpsData`
+- BLE updates to `gps.gpsData`
+- the initial fallback/default latitude and longitude
+- maps, navigation, widgets, and ride-telemetry consumers
+- NMEA implementation needed by hardware-GPS builds
+
+Expected Waveshare boot behavior: no GPS UART start or auto-baud delay, no
+8 KiB GPS task allocation, no GPS mutex, and no once-per-tick polling loop.
+
+Files:
+
+- `esp32/platformio.ini`
+- `esp32/src/main.cpp`
+- `esp32/lib/gps/gps.cpp`
+- `esp32/lib/tasks/tasks.hpp`
+- `esp32/lib/tasks/tasks.cpp`
+- `esp32/lib/settings/settings.hpp`
+- `esp32/lib/settings/settings.cpp`
+
+### 2. Add an explicit production IMU shutdown path
+
+Add `waveshare_board::imu::disable()` in `qmi8658.hpp/.cpp`. It should:
+
+1. Probe the primary `0x6B` and fallback `0x6A` addresses.
+2. Confirm `WHO_AM_I` without enabling or sampling either sensor.
+3. Write `CTRL7 = 0x00` to disable both accelerometer and gyroscope engines.
+4. Read `CTRL7` back and report a single concise success or failure message.
+5. Return harmlessly if no QMI8658 is present so boot can continue.
+
+Do not call the existing diagnostic configuration path from `disable()` because
+that path resets, configures, and re-enables both engines.
+
+Normal Waveshare setup calls `imu::disable()` once after the shared I2C bus and
+power rails are ready. It does not call `imu::begin()` or `imu::process()`, and
+the five-second system heartbeat does not read or print IMU state.
+
+Use `WAVESHARE_IMU_DIAGNOSTICS` as an opt-in build flag. When defined, the
+existing `begin()`, `process()`, sample/status accessors, and IMU heartbeat stay
+available for board bring-up. The standard 1.75-inch and 2.06-inch environments
+must omit this flag. Replace the narrower `WAVESHARE_IMU_DEBUG_LOG` comment and
+behavior so one clearly named flag controls the complete diagnostic path.
+
+Files:
+
+- `esp32/lib/waveshare_board/qmi8658.hpp`
+- `esp32/lib/waveshare_board/qmi8658.cpp`
+- `esp32/src/main.cpp`
+- `esp32/platformio.ini`
+
+### 3. Keep logs aligned with production behavior
+
+Update startup checkpoints and the rate-limited system heartbeat so they do not
+claim that GPS or IMU diagnostics are running in production. Emit at most one
+IMU shutdown result during boot. Keep the existing BLE `gpsFromApp` and position
+fields in the system heartbeat because they verify the active iPhone GPS path.
+
+## Implementation sequence
+
+1. Introduce `HAS_HARDWARE_GPS` and guard the UART task, mutex, initialization,
+   and UART settings operations.
+2. Build one legacy hardware-GPS target to catch missing declarations before
+   changing the IMU path.
+3. Implement and read back `imu::disable()`.
+4. Gate IMU setup, loop processing, and heartbeat output behind
+   `WAVESHARE_IMU_DIAGNOSTICS`.
+5. Build both production Waveshare targets and an opt-in diagnostic variant.
+6. Verify phone-supplied navigation and measure current on physical hardware.
+
+## Verification
+
+### Static checks
+
+- Search the production call graph to confirm Waveshare builds cannot reach
+  `Gps::init()`, `gpsTask()`, or GPS baud/rate UART operations.
+- Confirm normal Waveshare builds have no call to `imu::begin()`,
+  `imu::process()`, `readSample()`, or IMU heartbeat accessors.
+- Confirm `imu::disable()` writes and verifies `CTRL7 = 0x00` only after I2C is
+  initialized.
+- Confirm BLE GPS writes and every `gps.gpsData` map/UI consumer remain intact.
+
+### Build matrix
+
+```sh
+cd esp32
+pio run -e WAVESHARE_AMOLED_175
+pio run -e WAVESHARE_AMOLED_206
+pio run -e MAKERF_ESP32S3
+pio run -e WAVESHARE_AMOLED_175_IMU_DIAGNOSTICS
+```
+
+The dedicated diagnostic environment proves the opt-in bring-up path still
+compiles. `WAVESHARE_AMOLED_206_IMU_DIAGNOSTICS` provides the equivalent path
+for the 2.06-inch target.
+
+### Runtime checks on each Waveshare model
+
+- Boot completes with display, LVGL, SD/FFat, BLE, and touch operational.
+- Serial output contains one verified IMU-disabled result and no periodic IMU
+  samples.
+- Serial output contains no GPS task startup or UART auto-baud activity.
+- The iPhone connects and authenticates over BLE.
+- Starting navigation moves from waiting to map/navigation view after the first
+  phone position update.
+- Position, heading, speed, altitude, distance, elapsed time, and remaining
+  route data continue updating.
+- Disconnect timeout, deep sleep, and BOOT-button wake still work.
+
+### Power measurement
+
+Measure before and after firmware on the same board with the same battery/USB
+setup, brightness, screen, BLE connection state, and navigation route. Record:
+
+- idle current while waiting for the phone
+- connected navigation current after values stabilize
+- at least a five-minute average for each state
+
+The measurement validates the battery impact; functional tests alone only prove
+that the unused work stopped.
+
+## Acceptance criteria
+
+- Production Waveshare firmware never starts `Serial2` for GPS and never creates
+  the GPS mutex or task.
+- BLE from the iPhone remains the sole live position source on Waveshare.
+- Production boot explicitly verifies that both QMI8658 sensor engines are
+  disabled, with no subsequent IMU polling.
+- The standard Waveshare 1.75-inch and 2.06-inch builds pass.
+- A representative non-Waveshare hardware-GPS build passes and retains its UART
+  GPS behavior.
+- An opt-in IMU diagnostic build still compiles and can sample the sensor.
+- Physical navigation, sleep/wake, and peripheral smoke tests pass on both
+  Waveshare models.
+- Before/after current measurements are recorded in the implementation PR.
+
+## Non-goals
+
+- Removing the shared `Gps` class or NMEA support from hardware-GPS boards.
+- Changing iPhone location cadence, BLE payloads, or navigation behavior.
+- Adding motion-based wake, auto-pause, crash detection, or screen rotation.
+- Shutting down a shared PMU rail used by other Waveshare peripherals.
+- Broader Wi-Fi, display, BLE, or CPU-frequency power tuning.
+
+## Rollback
+
+GPS rollback is limited to restoring `HAS_HARDWARE_GPS` for a target that gains
+a physical receiver. IMU diagnostics can be restored for a dedicated build by
+defining `WAVESHARE_IMU_DIAGNOSTICS`; production should not require reverting
+the shutdown implementation to troubleshoot the sensor.

--- a/docs/waveshare-gps-imu-power-implementation-plan.md
+++ b/docs/waveshare-gps-imu-power-implementation-plan.md
@@ -7,8 +7,9 @@ two unused hardware paths:
 
 1. Do not initialize the UART GPS receiver or create its FreeRTOS polling task.
    The iPhone remains the only live GPS source on Waveshare builds.
-2. Keep both QMI8658 sensor engines disabled in production and stop all periodic
-   accelerometer and gyroscope reads.
+2. Put the QMI8658 into power-down in production, disabling every sensor engine
+   and its internal oscillator, and stop all periodic accelerometer and
+   gyroscope reads.
 
 The shared `Gps` data model remains in place because BLE, maps, navigation, and
 ride telemetry consume it. Hardware-GPS support remains available to the older
@@ -45,9 +46,9 @@ derived orientation and movement state. No navigation, screen rotation,
 wake/sleep, or ride feature consumes that state.
 
 Skipping `imu::begin()` alone is insufficient: after a warm ESP restart, the
-QMI8658 may remain powered on the shared rail with sensor engines left enabled
-by the previous firmware. Production boot should therefore explicitly write
-the sensor-enable register to its disabled state once.
+QMI8658 may remain powered on the shared rail with sensor engines or its
+internal oscillator left enabled by the previous firmware. Production boot
+should therefore explicitly enter and verify the sensor's power-down mode once.
 
 ## Implementation
 
@@ -93,9 +94,15 @@ Add `waveshare_board::imu::disable()` in `qmi8658.hpp/.cpp`. It should:
 
 1. Probe the primary `0x6B` and fallback `0x6A` addresses.
 2. Confirm `WHO_AM_I` without enabling or sampling either sensor.
-3. Write `CTRL7 = 0x00` to disable both accelerometer and gyroscope engines.
-4. Read `CTRL7` back and report a single concise success or failure message.
-5. Return harmlessly if no QMI8658 is present so boot can continue.
+3. Write `CTRL7 = 0x00` to disable the accelerometer, gyroscope,
+   magnetometer, and AttitudeEngine.
+4. Wait for the sensor-off transition (`2/ODR`, conservatively 20 ms for the
+   supported 112/125 Hz diagnostic configuration).
+5. Preserve the interface bits in `CTRL1` while setting `SensorDisable = 1` to
+   stop the internal oscillator and enter power-down.
+6. Read both registers back, require the exact disabled state, and report a
+   single concise success or failure message.
+7. Return harmlessly if no QMI8658 is present so boot can continue.
 
 Do not call the existing diagnostic configuration path from `disable()` because
 that path resets, configures, and re-enables both engines.
@@ -108,7 +115,9 @@ Use `WAVESHARE_IMU_DIAGNOSTICS` as an opt-in build flag. When defined, the
 existing `begin()`, `process()`, sample/status accessors, and IMU heartbeat stay
 available for board bring-up. The standard 1.75-inch and 2.06-inch environments
 must omit this flag. Replace the narrower `WAVESHARE_IMU_DEBUG_LOG` comment and
-behavior so one clearly named flag controls the complete diagnostic path.
+behavior so one clearly named flag controls the complete diagnostic path. The
+diagnostic reset path must allow the datasheet's 1.75-second system turn-on time
+so it can recover after production firmware has entered power-down.
 
 Files:
 
@@ -144,8 +153,8 @@ fields in the system heartbeat because they verify the active iPhone GPS path.
   `Gps::init()`, `gpsTask()`, or GPS baud/rate UART operations.
 - Confirm normal Waveshare builds have no call to `imu::begin()`,
   `imu::process()`, `readSample()`, or IMU heartbeat accessors.
-- Confirm `imu::disable()` writes and verifies `CTRL7 = 0x00` only after I2C is
-  initialized.
+- Confirm `imu::disable()` writes and verifies `CTRL7 = 0x00` and
+  `CTRL1.SensorDisable = 1` only after I2C is initialized.
 - Confirm BLE GPS writes and every `gps.gpsData` map/UI consumer remain intact.
 
 ### Build matrix
@@ -192,8 +201,9 @@ that the unused work stopped.
 - Production Waveshare firmware never starts `Serial2` for GPS and never creates
   the GPS mutex or task.
 - BLE from the iPhone remains the sole live position source on Waveshare.
-- Production boot explicitly verifies that both QMI8658 sensor engines are
-  disabled, with no subsequent IMU polling.
+- Production boot explicitly verifies QMI8658 power-down, including every
+  sensor-enable bit and the internal oscillator, with no subsequent IMU
+  polling.
 - The standard Waveshare 1.75-inch and 2.06-inch builds pass.
 - A representative non-Waveshare hardware-GPS build passes and retains its UART
   GPS behavior.

--- a/esp32/lib/gps/gps.cpp
+++ b/esp32/lib/gps/gps.cpp
@@ -29,6 +29,7 @@ Gps::Gps() {}
  */
 void Gps::init()
 {
+#ifdef HAS_HARDWARE_GPS
   gpsPort.setRxBufferSize(1024);
 
   if (gpsBaud != 4)
@@ -68,7 +69,7 @@ void Gps::init()
   gpsPort.flush();
   delay(100);
 #endif
-
+#endif
 }
 
 /**
@@ -232,6 +233,9 @@ long Gps::detectRate(int rxPin)
  */
 long Gps::autoBaud()
 {
+#ifndef HAS_HARDWARE_GPS
+  return 0;
+#else
   long rate = detectRate(GPS_RX) + detectRate(GPS_RX) + detectRate(GPS_RX);
   rate = rate / 3l;
   long baud = 0;
@@ -274,6 +278,7 @@ long Gps::autoBaud()
     baud = 0;
 
   return baud;
+#endif
 }
 
 /**

--- a/esp32/lib/settings/settings.cpp
+++ b/esp32/lib/settings/settings.cpp
@@ -230,6 +230,7 @@ void loadPreferences() {
  * @param gpsBaud
  */
 void saveGPSBaud(uint16_t gpsBaud) {
+#ifdef HAS_HARDWARE_GPS
   cfg.saveShort(PKEYS::KGPS_SPEED, gpsBaud);
   if (gpsBaud != 4) {
 #ifdef AT6558D_GPS
@@ -258,6 +259,9 @@ void saveGPSBaud(uint16_t gpsBaud) {
       delay(500);
     }
   }
+#else
+  (void)gpsBaud;
+#endif
 }
 
 /**
@@ -266,6 +270,7 @@ void saveGPSBaud(uint16_t gpsBaud) {
  * @param gpsUpdateRate
  */
 void saveGPSUpdateRate(uint16_t gpsUpdateRate) {
+#ifdef HAS_HARDWARE_GPS
   cfg.saveShort(PKEYS::KGPS_RATE, gpsUpdateRate);
 #ifdef AT6558D_GPS
   gpsPort.flush();
@@ -274,6 +279,9 @@ void saveGPSUpdateRate(uint16_t gpsUpdateRate) {
   gpsPort.println("$PCAS00*01\r\n");
   gpsPort.flush();
   delay(500);
+#endif
+#else
+  (void)gpsUpdateRate;
 #endif
 }
 

--- a/esp32/lib/tasks/tasks.cpp
+++ b/esp32/lib/tasks/tasks.cpp
@@ -9,11 +9,14 @@
 #include "tasks.hpp"
 
 TaskHandle_t LVGLTaskHandler;
+#ifdef HAS_HARDWARE_GPS
 xSemaphoreHandle gpsMutex;
 extern Gps gps;
+#endif
 
 static const char* TAG PROGMEM = "Task";
 
+#ifdef HAS_HARDWARE_GPS
 /**
  * @brief Read GPS data
  *
@@ -58,6 +61,7 @@ void initGpsTask()
   xTaskCreatePinnedToCore(gpsTask, PSTR("GPS Task"), 8192, NULL, 1, NULL, 0);
   delay(500);
 }
+#endif
 
 /**
  * @brief CLI task
@@ -84,5 +88,4 @@ void cliTask(void *param)
 void initCLITask() { xTaskCreatePinnedToCore(cliTask, "cliTask ", 20000, NULL, 1, NULL, 1); }
 
 #endif
-
 

--- a/esp32/lib/tasks/tasks.hpp
+++ b/esp32/lib/tasks/tasks.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#ifdef HAS_HARDWARE_GPS
 #include "gps.hpp"
+#endif
 #ifdef BME280
 #include "bme.hpp"
 #endif
@@ -26,8 +28,10 @@
 
 #define TASK_SLEEP_PERIOD_MS 5
 
+#ifdef HAS_HARDWARE_GPS
 void gpsTask(void *pvParameters);
 void initGpsTask();
+#endif
 
 #ifndef DISABLE_CLI
 void cliTask(void *param);

--- a/esp32/lib/waveshare_board/qmi8658.cpp
+++ b/esp32/lib/waveshare_board/qmi8658.cpp
@@ -47,6 +47,23 @@ constexpr float MOVING_GYRO_THRESHOLD_DPS = 20.0f;
 constexpr float MOVING_ACCEL_DELTA_MG = 180.0f;
 constexpr float ORIENTATION_THRESHOLD_MG = 650.0f;
 
+bool identifySensorAt(uint8_t address, uint8_t &whoAmI) {
+  if (!i2c::probe(address, "QMI8658", 2)) {
+    return false;
+  }
+  if (!i2c::readRegister8(address, REG_WHO_AM_I, whoAmI, "QMI8658 whoami",
+                          3)) {
+    return false;
+  }
+  if (whoAmI != EXPECTED_WHO_AM_I) {
+    Serial.printf("QMI8658: ignoring addr=0x%02X unexpected whoami=0x%02X\n",
+                  address, whoAmI);
+    return false;
+  }
+  return true;
+}
+
+#ifdef WAVESHARE_IMU_DIAGNOSTICS
 Status imuStatus;
 Sample latestSample;
 uint32_t lastPollMs = 0;
@@ -246,9 +263,42 @@ bool configureSensor() {
   logRawDiagnostic("config-failed");
   return false;
 }
+#endif
 
 } // namespace
 
+bool disable() {
+  uint8_t whoAmI = 0;
+  uint8_t address = waveshare_board::QMI8658_ADDR_PRIMARY;
+  if (!identifySensorAt(address, whoAmI)) {
+    address = waveshare_board::QMI8658_ADDR_FALLBACK;
+    if (!identifySensorAt(address, whoAmI)) {
+      Serial.println("QMI8658: not found; production sensors remain unused");
+      return false;
+    }
+  }
+
+  const bool writeOk = i2c::writeRegister8(
+      address, REG_CTRL7, CTRL7_DISABLE_SENSORS, "QMI8658 power down", 3);
+  delay(1);
+
+  uint8_t ctrl7 = 0xFF;
+  const bool readOk = i2c::readRegister8(address, REG_CTRL7, ctrl7,
+                                         "QMI8658 power-down readback", 3);
+  const bool disabled = writeOk && readOk &&
+                        (ctrl7 & CTRL7_ENABLE_ACCEL_GYRO) == 0;
+  if (disabled) {
+    Serial.printf("QMI8658: accelerometer and gyro disabled addr=0x%02X\n",
+                  address);
+  } else {
+    Serial.printf("QMI8658: failed to disable sensors addr=0x%02X "
+                  "write=%d read=%d ctrl7=0x%02X\n",
+                  address, writeOk, readOk, ctrl7);
+  }
+  return disabled;
+}
+
+#ifdef WAVESHARE_IMU_DIAGNOSTICS
 const Status &status() { return imuStatus; }
 
 const Sample &lastSample() { return latestSample; }
@@ -302,9 +352,7 @@ bool begin() {
   Serial.printf("QMI8658: found addr=0x%02X whoami=0x%02X rev=0x%02X "
                 "accel=8g@125Hz gyro=512dps@112Hz\n",
                 imuStatus.address, imuStatus.whoAmI, imuStatus.revision);
-#ifdef WAVESHARE_IMU_DEBUG_LOG
   logRawDiagnostic("configured");
-#endif
   return true;
 }
 
@@ -380,7 +428,6 @@ void process() {
     logRawDiagnostic("zero-sample");
   }
 
-#ifdef WAVESHARE_IMU_DEBUG_LOG
   static uint32_t lastLogMs = 0;
   if (now - lastLogMs >= 5000) {
     lastLogMs = now;
@@ -393,8 +440,8 @@ void process() {
                   static_cast<unsigned long>(imuStatus.sampleCount),
                   static_cast<unsigned long>(imuStatus.failedReads));
   }
-#endif
 }
+#endif
 
 } // namespace waveshare_board::imu
 

--- a/esp32/lib/waveshare_board/qmi8658.cpp
+++ b/esp32/lib/waveshare_board/qmi8658.cpp
@@ -35,11 +35,14 @@ constexpr uint8_t EXPECTED_WHO_AM_I = 0x05;
 constexpr uint8_t RESET_VALUE = 0xB0;
 constexpr uint8_t RST_RESULT_OK = 0x80;
 constexpr uint8_t CTRL1_LITTLE_ENDIAN_AUTO_INC = 0x40;
+constexpr uint8_t CTRL1_SENSOR_DISABLE = 0x01;
 constexpr uint8_t CTRL2_ACCEL_8G_125HZ = 0x26;
 constexpr uint8_t CTRL3_GYRO_512DPS_112HZ = 0x56;
 constexpr uint8_t CTRL7_ENABLE_ACCEL_GYRO = 0x03;
 constexpr uint8_t CTRL7_DISABLE_SENSORS = 0x00;
 
+constexpr uint32_t SYSTEM_TURN_ON_TIMEOUT_MS = 2000;
+constexpr uint32_t SENSOR_SHUTDOWN_DELAY_MS = 20;
 constexpr float ACCEL_LSB_PER_G = 4096.0f;
 constexpr float GYRO_LSB_PER_DPS = 64.0f;
 constexpr uint32_t SAMPLE_INTERVAL_MS = 500;
@@ -141,7 +144,7 @@ bool softReset(uint8_t address) {
 
   const uint32_t startMs = millis();
   uint8_t resetResult = 0;
-  while (millis() - startMs < 250) {
+  while (millis() - startMs < SYSTEM_TURN_ON_TIMEOUT_MS) {
     delay(10);
     if (i2c::readRegister8(address, REG_RST_RESULT, resetResult,
                            "QMI8658 reset result", 1) &&
@@ -278,22 +281,44 @@ bool disable() {
     }
   }
 
-  const bool writeOk = i2c::writeRegister8(
+  uint8_t ctrl1Before = 0;
+  const bool ctrl1ReadOk =
+      i2c::readRegister8(address, REG_CTRL1, ctrl1Before,
+                         "QMI8658 power-down ctrl1", 3);
+  const bool ctrl7WriteOk = i2c::writeRegister8(
       address, REG_CTRL7, CTRL7_DISABLE_SENSORS, "QMI8658 power down", 3);
+  if (ctrl7WriteOk) {
+    // The datasheet specifies a powered-sensor shutdown transition of up to
+    // 2/ODR. The diagnostic configuration's slowest ODR is 112 Hz.
+    delay(SENSOR_SHUTDOWN_DELAY_MS);
+  }
+  const bool ctrl1WriteOk =
+      ctrl1ReadOk && ctrl7WriteOk &&
+      i2c::writeRegister8(address, REG_CTRL1,
+                          ctrl1Before | CTRL1_SENSOR_DISABLE,
+                          "QMI8658 disable oscillator", 3);
   delay(1);
 
   uint8_t ctrl7 = 0xFF;
-  const bool readOk = i2c::readRegister8(address, REG_CTRL7, ctrl7,
-                                         "QMI8658 power-down readback", 3);
-  const bool disabled = writeOk && readOk &&
-                        (ctrl7 & CTRL7_ENABLE_ACCEL_GYRO) == 0;
+  const bool ctrl7ReadOk = i2c::readRegister8(
+      address, REG_CTRL7, ctrl7, "QMI8658 power-down ctrl7 readback", 3);
+  uint8_t ctrl1 = 0;
+  const bool ctrl1VerifyOk = i2c::readRegister8(
+      address, REG_CTRL1, ctrl1, "QMI8658 power-down ctrl1 readback", 3);
+  const bool disabled =
+      ctrl7WriteOk && ctrl1WriteOk && ctrl7ReadOk && ctrl1VerifyOk &&
+      ctrl7 == CTRL7_DISABLE_SENSORS &&
+      (ctrl1 & CTRL1_SENSOR_DISABLE) == CTRL1_SENSOR_DISABLE;
   if (disabled) {
-    Serial.printf("QMI8658: accelerometer and gyro disabled addr=0x%02X\n",
-                  address);
+    Serial.printf("QMI8658: powered down addr=0x%02X ctrl1=0x%02X "
+                  "ctrl7=0x%02X\n",
+                  address, ctrl1, ctrl7);
   } else {
-    Serial.printf("QMI8658: failed to disable sensors addr=0x%02X "
-                  "write=%d read=%d ctrl7=0x%02X\n",
-                  address, writeOk, readOk, ctrl7);
+    Serial.printf("QMI8658: power-down failed addr=0x%02X "
+                  "ctrl1Read=%d ctrl1Write=%d ctrl1Verify=%d ctrl1=0x%02X "
+                  "ctrl7Write=%d ctrl7Read=%d ctrl7=0x%02X\n",
+                  address, ctrl1ReadOk, ctrl1WriteOk, ctrl1VerifyOk, ctrl1,
+                  ctrl7WriteOk, ctrl7ReadOk, ctrl7);
   }
   return disabled;
 }

--- a/esp32/lib/waveshare_board/qmi8658.hpp
+++ b/esp32/lib/waveshare_board/qmi8658.hpp
@@ -11,6 +11,9 @@
 
 namespace waveshare_board::imu {
 
+bool disable();
+
+#ifdef WAVESHARE_IMU_DIAGNOSTICS
 enum class Orientation : uint8_t {
   Unknown,
   FaceUp,
@@ -52,6 +55,7 @@ bool readSample(Sample &sample);
 const Status &status();
 const Sample &lastSample();
 const char *orientationName(Orientation orientation);
+#endif
 
 } // namespace waveshare_board::imu
 

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -33,6 +33,7 @@ build_flags =
   -D DISABLE_RADIO=1
   -D BAUDRATE=115200
   -D DEBUG=1
+  -D HAS_HARDWARE_GPS=1
   -D SHELLMINATOR_BUFF_LEN=70
   -D SHELLMINATOR_BUFF_DIM=70
   -D SHELLMINATOR_LOGO_COLOR=BLUE
@@ -211,9 +212,8 @@ build_flags =
   ; identity and makes iOS see a fresh peripheral after each firmware boot.
   ; Keep disabled for normal reconnect behavior.
   ; -DBLE_DEV_RANDOM_IDENTITY=1
-  ; Optional QMI8658 sample logging; normal builds expose IMU state through the
-  ; compact rate-limited IMU heartbeat instead.
-  ; -DWAVESHARE_IMU_DEBUG_LOG=1
+  ; Production builds explicitly disable the QMI8658 accelerometer and gyro.
+  ; Use one of the dedicated *_IMU_DIAGNOSTICS environments for bring-up.
   ; SD Card uses dedicated HSPI. Verified pins: CS=41, MOSI=1, MISO=3, SCK=2.
   ; SD SPI tuning defaults to the PR6/PR7 known-good 4 MHz baseline.
   ; Test candidates: 8000000, 12000000, 16000000.
@@ -261,6 +261,12 @@ build_flags =
   ${env:WAVESHARE_AMOLED_175.build_flags}
   -DWAVESHARE_DISPLAY_TEST=1
 
+[env:WAVESHARE_AMOLED_175_IMU_DIAGNOSTICS]
+extends = env:WAVESHARE_AMOLED_175
+build_flags =
+  ${env:WAVESHARE_AMOLED_175.build_flags}
+  -DWAVESHARE_IMU_DIAGNOSTICS=1
+
 [env:WAVESHARE_AMOLED_175_SPEAKER_HONK]
 extends = env:WAVESHARE_AMOLED_175
 build_src_filter =
@@ -284,6 +290,12 @@ build_flags =
   ${env:WAVESHARE_AMOLED_206.build_flags}
   -DWAVESHARE_DISPLAY_TEST=1
   -DWAVESHARE_DISPLAY_PROBE=1
+
+[env:WAVESHARE_AMOLED_206_IMU_DIAGNOSTICS]
+extends = env:WAVESHARE_AMOLED_206
+build_flags =
+  ${env:WAVESHARE_AMOLED_206.build_flags}
+  -DWAVESHARE_IMU_DIAGNOSTICS=1
 
 [env:WAVESHARE_AMOLED_206_VENDOR_HELLO]
 extends = waveshare_amoled_common

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -47,7 +47,9 @@
 #include "imu.hpp"
 #endif
 
+#ifdef HAS_HARDWARE_GPS
 extern xSemaphoreHandle gpsMutex;
+#endif
 
 #ifndef DISABLE_WEB_SERVER
 #include "webpage.h"
@@ -284,7 +286,8 @@ static void logSystemDebugHeartbeat() {
   lastLogMs = now;
 
   BLEDebugStats bleStats = bleNavServer.getDebugStats();
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#if (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)) &&       \
+    defined(WAVESHARE_IMU_DIAGNOSTICS)
   const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
   const waveshare_board::rtc::Status &rtcStatus =
       waveshare_board::rtc::status();
@@ -292,6 +295,10 @@ static void logSystemDebugHeartbeat() {
       waveshare_board::imu::status();
   const waveshare_board::imu::Sample &imuSample =
       waveshare_board::imu::lastSample();
+#elif defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
+  const waveshare_board::rtc::Status &rtcStatus =
+      waveshare_board::rtc::status();
 #endif
   const char *screenName = "unknown";
   lv_obj_t *activeScreen = lv_scr_act();
@@ -301,7 +308,8 @@ static void logSystemDebugHeartbeat() {
     screenName = "main";
   }
 
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#if (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)) &&       \
+    defined(WAVESHARE_IMU_DIAGNOSTICS)
   Serial.printf("IMU: p=%d cfg=%d valid=%d addr=0x%02X n=%lu zero=%lu fail=%lu "
                 "a=%.0f,%.0f,%.0f g=%.1f,%.1f,%.1f mag=%.0f vib=%.1f "
                 "orient=%s moving=%d\n",
@@ -316,7 +324,9 @@ static void logSystemDebugHeartbeat() {
                 imuStatus.vibrationDps,
                 waveshare_board::imu::orientationName(imuStatus.orientation),
                 imuStatus.moving);
+#endif
 
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   Serial.printf("SYS: up=%lus heap=%lu psram=%lu screen=%s tile=%s "
                 "waitRefresh=%d gpsFromApp=%d pendingMap=%d lat=%.6f "
                 "lon=%.6f heading=%u routePts=%u mapFound=%d mapBlocks=%u "
@@ -447,7 +457,9 @@ static void processDisconnectedShutdown() {
  *
  */
 void setup() {
+#ifdef HAS_HARDWARE_GPS
   gpsMutex = xSemaphoreCreateMutex();
+#endif
   esp_log_level_set("*", ESP_LOG_DEBUG);
   esp_log_level_set("storage", ESP_LOG_DEBUG);
 
@@ -530,7 +542,11 @@ void setup() {
   Serial.println("Waveshare display probe: skipping RTC and IMU init");
 #else
   waveshare_board::rtc::restoreSystemTimeFromRtc();
+#ifdef WAVESHARE_IMU_DIAGNOSTICS
   waveshare_board::imu::begin();
+#else
+  waveshare_board::imu::disable();
+#endif
 #endif
 #endif
 
@@ -629,17 +645,21 @@ void setup() {
                   TFT_HEIGHT);
 
   loadPreferences();
+#ifdef HAS_HARDWARE_GPS
   gps.init();
+#endif
   initLVGL();
   log_i("Checkpoint A: LVGL Init Done");
 
   // Get init Latitude and Longitude
   gps.gpsData.latitude = gps.getLat();
   gps.gpsData.longitude = gps.getLon();
-  log_i("Checkpoint B: GPS Data Retrieved");
+  log_i("Checkpoint B: Position Data Initialized");
 
+#ifdef HAS_HARDWARE_GPS
   initGpsTask();
   log_i("Checkpoint C: GPS Task Init Done");
+#endif
 
 #ifndef DISABLE_CLI
   initCLI();
@@ -751,7 +771,8 @@ void loop() {
   bleNavServer.process();
   processDisconnectedShutdown();
 
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#if (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)) &&       \
+    defined(WAVESHARE_IMU_DIAGNOSTICS)
   waveshare_board::imu::process();
 #endif
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)


### PR DESCRIPTION
## Summary

- omit the unused UART GPS initialization, mutex, and RTOS polling task from Waveshare production builds while retaining the shared phone-fed GPS data model
- put the QMI8658 into verified power-down at boot and remove IMU sampling/heartbeat work from production firmware
- retain hardware GPS for legacy targets and add opt-in IMU diagnostic environments for both Waveshare models
- document the implementation and physical validation plan

This addresses the GPS/IMU portion of #95.

## Why

The iPhone is the live position source on Waveshare navigation builds, but firmware still initialized `Serial2` and ran a GPS parser task every RTOS tick. The accelerometer and gyroscope were also configured and sampled only for diagnostics; no production feature consumed their state.

The production IMU path writes and verifies `CTRL7 = 0x00`, then preserves the interface configuration while setting and verifying `CTRL1.SensorDisable = 1`. This prevents a warm restart from leaving any sensor engine or the internal oscillator enabled.

## Verification

- `pio run -e WAVESHARE_AMOLED_175` — passed
- `pio run -e WAVESHARE_AMOLED_206` — passed
- `pio run -e WAVESHARE_AMOLED_175_IMU_DIAGNOSTICS` — passed
- `pio run -e WAVESHARE_AMOLED_206_IMU_DIAGNOSTICS` — passed
- temporary `HAS_HARDWARE_GPS` compatibility build using the current Waveshare toolchain — passed
- ELF symbol audit: production builds contain `imu::disable()` and omit `Gps::init()`, `gpsTask()`, `initGpsTask()`, `imu::begin()`, `imu::process()`, and `imu::readSample()`
- ELF symbol audit: diagnostic builds retain `imu::begin()`, `imu::process()`, and `imu::readSample()` while omitting the GPS task
- production image size decreased by about 35.5 KB on each Waveshare target
- exact pushed head `0eb5a1dcd3f74f85eb456ac44be45246c88654ce`: all 18 GitHub checks passed
- iOS app built, signed, installed, launched, and verified on iPhone as `LetItRide.BikeComputer` version `1.0 (3)`

## 1.75-inch physical validation

Tested over USB as VID:PID `303A:1001`, serial `28:84:85:57:44:10`.

- production boot verified `QMI8658: powered down addr=0x6B ctrl1=0x41 ctrl7=0x00`
- display power, RTC, display, LVGL, SD, speaker task, BLE, and touch initialized
- no hardware-GPS UART/task startup and no periodic IMU samples appeared in production logs
- iPhone connected and authenticated; phone GPS transitioned the device from waiting to the map
- route geometry parsed 27 points and navigation rendered `MAP_GUIDANCE`; the user confirmed navigation was visible on both app and device
- diagnostic firmware recovered from production power-down, configured accel/gyro, and reached 59 samples with zero failures
- production firmware was restored and immediately verified QMI8658 power-down again
- terminating the iOS app caused BLE disconnect; after exactly 120 seconds firmware disabled display/peripheral rails and entered deep sleep
- physical BOOT wake restored the display/USB device; the app relaunched, reauthenticated, and resumed phone GPS/map updates

## 2.06-inch physical validation

Tested over USB as VID:PID `303A:1001`, serial `3C:DC:75:6E:F0:10`.

- the pre-change installed firmware initialized the QMI8658 at accel `8g@125Hz` / gyro `512dps@112Hz` and continuously sampled it, establishing the hardware baseline
- production boot verified `QMI8658: powered down addr=0x6B ctrl1=0x41 ctrl7=0x00`
- display power, PCF85063 RTC, 410x502 display, LVGL, speaker task, BLE, and FT3168 touch initialized
- no hardware-GPS UART/task startup and no periodic IMU samples appeared in production logs
- iPhone connected and authenticated, then supplied GPS and route data; the user confirmed navigation works
- diagnostic firmware recovered from production power-down, configured accel/gyro, and reached 53 samples with zero failures
- production firmware was restored and immediately verified QMI8658 power-down again
- terminating the iOS app produced BLE disconnect and the expected 120-second shutdown announcement; USB disappeared at the deadline and remained absent
- physical BOOT wake restored USB/display; the relaunched app reauthenticated and resumed phone GPS and route delivery
- the attached SD card was absent or unreadable, so firmware correctly fell back to internal storage but map tiles were unavailable; this is a device/setup condition unrelated to the GPS/IMU change

## Deep review

The adversarial review/fix loop found and fixed four P2 power-sequencing issues:

- disable the QMI8658 oscillator as well as its sensor engines
- verify the exact all-engines-off register state
- honor the datasheet sensor-shutdown delay before stopping the oscillator
- allow the datasheet reset recovery time when switching back to diagnostics

Fresh correctness, integration, security, claims/reachability, test, and maintenance passes found no remaining P0/P1/P2 issues.

## Validation limitations

Quantitative before/after current measurements could not be recorded. The inline USB meter reported `5.1 V` but `0 A` while the screen was on, even though the AXP2101 reported no battery and valid VBUS power, proving the current reading was invalid. Functional power-state validation was completed on both models, but a working meter is still required for numeric idle/navigation current comparisons.

The `MAKERF_ESP32S3` dependency download now completes, but the target fails before reaching this change because the unchanged IceNav-derived baseline only selects Waveshare panels and the legacy `compass.hpp` implementation is absent. `ICENAV_BOARD` is also blocked by its unknown custom PlatformIO board ID. Restoring either legacy target requires separate display/board-support work; the compatibility build above exercises the guarded hardware-GPS lifecycle with the current supported toolchain.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
