### PR TITLE
Add secure per-device ownership and multi-device pairing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -237,6 +237,17 @@ jobs:
             $(pkg-config --cflags --libs mbedcrypto) \
             -o /tmp/test_device_ownership_crypto
           /tmp/test_device_ownership_crypto
+      - name: Device ownership state host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            -DDEVICE_OWNERSHIP_HOST_TEST \
+            -Itools/tests/host_stubs \
+            lib/ble_navigation/device_ownership.cpp \
+            lib/ble_navigation/device_ownership_crypto.cpp \
+            tools/tests/test_device_ownership.cpp \
+            $(pkg-config --cflags --libs mbedcrypto) \
+            -o /tmp/test_device_ownership
+          /tmp/test_device_ownership
       - name: Destination picker protocol host tests
         run: |
           g++ -std=c++17 -Wall -Wextra -Werror \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,15 @@ jobs:
             tools/tests/test_device_screen_protocol.cpp \
             -o /tmp/test_device_screen_protocol
           /tmp/test_device_screen_protocol
+      - name: Device ownership crypto host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            -DDEVICE_OWNERSHIP_HOST_TEST \
+            lib/ble_navigation/device_ownership_crypto.cpp \
+            tools/tests/test_device_ownership_crypto.cpp \
+            $(pkg-config --cflags --libs mbedcrypto) \
+            -o /tmp/test_device_ownership_crypto
+          /tmp/test_device_ownership_crypto
       - name: Destination picker protocol host tests
         run: |
           g++ -std=c++17 -Wall -Wextra -Werror \

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -3,7 +3,7 @@
 The ESP32 advertises BLE service UUID
 `9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800` under its user-assigned device name.
 An unregistered device uses `BikeComputer XXYY`, where `XXYY` is derived from
-its stable random device ID.
+its stable hardware-derived device ID.
 
 The advertisement carries an eight-byte manufacturer payload:
 
@@ -12,7 +12,8 @@ FF FF | ProtocolVersion: UInt8 | Flags: UInt8 | DeviceID suffix: 4 bytes
 ```
 
 Protocol version is currently `2`; flag bit `0` means the device already has an
-owner. The suffix lets the app and device show the same short identifier when
+owner and the remaining flag bits are reserved. The suffix lets the app and
+device show the same short identifier when
 several Bike Computers are nearby without advertising the complete identity.
 
 All navigation/map writes require the authenticated session established through
@@ -45,8 +46,12 @@ Fallback frame prefixes:
 
 ## Device ownership and authentication
 
-Every ownership-capable ESP32 creates a random 128-bit device ID on first boot
-and keeps it in NVS. The iOS installation similarly creates a random 128-bit
+Every ownership-capable ESP32 derives its stable 128-bit device ID as the first
+16 bytes of `SHA-256("BikeComputer device ID v2" || eFuseBaseMAC)` and caches it
+in NVS. A missing/corrupt cached ID is recreated only when no owner artifacts
+exist; otherwise firmware remains physically recoverable but fail-locked rather
+than binding an existing credential to a new identity. The iOS installation
+similarly creates a random 128-bit
 owner ID and stores it in the Keychain. iOS may register multiple Bike
 Computers, but maintains one current BLE connection at a time. Automatic
 reconnect targets only the current device; changing devices is explicit in
@@ -62,10 +67,13 @@ BLE.
 All binary fields below are lowercase hex. `AppPublicKey` and
 `DevicePublicKey` are 65-byte uncompressed X9.63 P-256 keys.
 
-1. iOS writes `INFO`.
+1. iOS writes `INFO` after the user selects the nearby Bike Computer and taps
+   Continue. No device-button press is required yet.
 2. ESP32 notifies
    `DEVICE|2|<DeviceID>|<Claimed 0-or-1>|<UTF8NameHex>`.
-3. iOS writes `PAIR|<OwnerID>|<AppPublicKey>`.
+3. iOS writes `PAIR|<OwnerID>|<AppPublicKey>`. Firmware accepts at most one
+   valid `PAIR` request per BLE connection, limiting unattended clients to one
+   expensive P-256 operation before they must reconnect.
 4. ESP32 derives the owner key and notifies
    `PAIRING|<DeviceID>|<DevicePublicKey>`.
 5. Both sides hash `"BikeComputer ownership v2" || DeviceID || OwnerID ||
@@ -73,13 +81,25 @@ All binary fields below are lowercase hex. `AppPublicKey` and
    HKDF salt and `BikeComputer owner key v2` as HKDF info.
 6. Both show the six-digit big-endian value from the first four bytes of
    `HMAC-SHA256(OwnerKey, "compare|" || TranscriptHash)`, modulo `1,000,000`.
-7. After verifying that the displays match, the user presses BOOT on the Bike
-   Computer. ESP32 notifies `PAIR_READY|<DeviceID>`. This physical action is
-   required so a nearby client cannot silently claim an unattended device.
-8. iOS writes
+7. After verifying that the displays match, the user presses either button on
+   the Bike Computer. ESP32 arms confirmation only after the comparison screen
+   has been rendered, discards older BOOT/PWR events, and requires a fresh
+   press for the active pairing generation before notifying
+   `PAIR_READY|<DeviceID>`. This physical action is required so a nearby client
+   cannot silently claim an unattended device.
+8. The user also taps the matching-code confirmation on iPhone. Replacing a
+   stale credential uses a separate destructive “Replace Registration” action.
+   iOS then writes
    `CONFIRM|<OwnerID>|<HMAC-SHA256(OwnerKey, "claim|" || TranscriptHash)>|<UTF8NameHex>`.
 9. ESP32 persists the owner ID, owner key, and name, then notifies
    `PAIRED|<DeviceID>|<UTF8NameHex>`.
+
+iOS keeps the derived key in a provisional Keychain entry through these steps.
+`PAIRED` is not itself trusted: the app promotes the key and mutates the device
+registry only after the subsequent owner-session handshake proves the hardware
+committed that same key. Automatic promotion never overwrites a different final
+credential; the explicit replacement action is persisted so recovery remains
+possible if the final notification is lost.
 
 Pairing expires after 120 seconds. Names are non-empty UTF-8, exclude control
 characters and `|`, and are limited to 24 bytes. The app starts with the
@@ -88,38 +108,123 @@ owner name to apps.
 
 ### Owner session authentication
 
-Every BLE connection performs a fresh mutual challenge using a random 16-byte
-nonce. No navigation, map, settings, rename, or deregistration command is
-accepted before this completes.
+Every BLE connection performs a fresh mutual challenge using independent
+random 16-byte nonces from iOS and the ESP32. The device-generated nonce makes
+a captured handshake unusable on a later connection. No navigation, map,
+settings, rename, or deregistration command is accepted before this completes.
 
-1. iOS writes `OWNER|<OwnerID>|<Nonce>`.
+1. iOS writes `OWNER|<OwnerID>|<ClientNonce>`.
 2. ESP32 notifies
-   `SERVER2|<DeviceID>|<Nonce>|<HMAC-SHA256(OwnerKey, "server2|<DeviceID>|<OwnerID>|<Nonce>")>`.
+   `SERVER2|<DeviceID>|<ClientNonce>|<ServerNonce>|<HMAC-SHA256(OwnerKey, "server2|<DeviceID>|<OwnerID>|<ClientNonce>|<ServerNonce>")>`.
 3. iOS verifies the server proof, then writes
-   `PROOF|<OwnerID>|<Nonce>|<HMAC-SHA256(OwnerKey, "client2|<DeviceID>|<OwnerID>|<Nonce>")>`.
-4. ESP32 verifies the owner and nonce, then notifies
-   `OK2|<DeviceID>|<Nonce>` and opens the authenticated session.
+   `PROOF|<OwnerID>|<ClientNonce>|<ServerNonce>|<HMAC-SHA256(OwnerKey, "client2|<DeviceID>|<OwnerID>|<ClientNonce>|<ServerNonce>")>`.
+4. ESP32 verifies the owner and both nonces, then notifies
+   `OK2|<DeviceID>|<ClientNonce>|<ServerNonce>` and opens the authenticated session.
+
+### Protected session frames
+
+After `OK2`, all app-to-device writes on the auth, navigation, route, GPS, and
+settings characteristics use AES-256-GCM. Auth replies and every
+device-to-app navigation notification—including destination requests,
+capabilities, acknowledgements, and transfer status—use the reverse protected
+direction. Plaintext notifications are rejected while a v2 session exists. The
+two directional keys are:
+
+```text
+WriteKey  = HMAC-SHA256(OwnerKey, "session2-write|<DeviceID>|<ClientNonce>|<ServerNonce>")
+NotifyKey = HMAC-SHA256(OwnerKey, "session2-notify|<DeviceID>|<ClientNonce>|<ServerNonce>")
+```
+
+App-to-device frame (`S2`) and device-to-app notification (`R2`):
+
+```text
+Magic: 2 bytes (ASCII S2 or R2)
+Sequence: UInt32 big-endian
+Ciphertext: 0 or more bytes
+Tag: 16-byte AES-GCM tag
+```
+
+Channels are `1=auth`, `2=navigation`, `3=route`, `4=GPS`, and `5=settings`.
+Each direction has an independent strictly increasing sequence per channel.
+Receivers reject zero, replayed, out-of-order, wrong-channel, or invalid-tag
+frames. The 12-byte nonce is `Channel || 7 zero bytes || Sequence`. Additional
+authenticated data is ASCII `write2|` for `S2` or `notify2|` for `R2`, followed
+by the one-byte channel and four-byte sequence. The frame adds 22 bytes, so iOS
+subtracts that overhead before packet sizing.
+
+Ownership setup messages are each at most 182 bytes and require an ATT MTU of
+at least 185. Firmware checks the negotiated MTU before notifying. Swift and
+mbedTLS tests share exact `S2` and `R2` golden vectors to prevent wire-format
+drift.
 
 An owned device replies `OWNED|<DeviceID>` or `DENIED|<DeviceID>` to an
 unauthorized client and does not fall back to the global legacy key.
 
 ### Rename, deregistration, and recovery
 
-After owner authentication, iOS can rename with `NAME|<UTF8NameHex>`; ESP32
-persists the name and replies `NAME_OK|<UTF8NameHex>`. `UNPAIR` removes the
-owner ID, owner key, and name from the hardware; ESP32 replies
-`UNPAIRED|<DeviceID>` before restarting its BLE state. iOS deletes its Keychain
-credential only after that acknowledgement.
+Inside protected `S2` frames, iOS can rename with `NAME|<UTF8NameHex>`; ESP32
+persists the name and returns a protected `NAME_OK|<UTF8NameHex>`. `UNPAIR`
+first persists a signed revocation tombstone, removes the owner ID, owner key,
+and name, then returns protected
+`UNPAIRED2|<DeviceID>|<ReceiptNonce>|<ReceiptProof>`, where:
+
+```text
+ReceiptProof = HMAC-SHA256(
+  OwnerKey,
+  "revoked2|<DeviceID>|<OwnerID>|<ReceiptNonce>"
+)
+```
+
+After every owner authentication, iOS sends protected `GET_NAME`; ESP32 returns
+protected `NAME_INFO|<UTF8NameHex>`. Registry name changes are committed only
+from this authenticated response (or `NAME_OK`), so a dropped rename response
+reconciles on reconnect without trusting plaintext `INFO` metadata.
+
+iOS verifies this receipt with its stored credential before deleting that
+credential. If the notification is dropped, the device retains and exposes the
+same compact receipt on subsequent `INFO` responses as
+`DEVICE|2|<DeviceID>|<Claimed>||<ReceiptNonce>|<ReceiptProof>`, including after
+a new owner registers. This lets the prior iPhone reconcile a missed handoff
+without retaining the old secret on the device. Both receipt forms fit the
+supported notification value limit. A disconnected Settings entry also offers
+an explicit local Forget action for devices that were reset, transferred more
+than once, lost, or destroyed.
+
+At boot, firmware distinguishes an interrupted `UNPAIR` from an older handoff
+receipt by verifying the tombstone with the currently committed owner key. If
+it matches, firmware completes owner-record cleanup before advertising. If the
+same iPhone later re-pairs with a different per-device key, the old receipt no
+longer validates under the current credential and remains available to
+reconcile the earlier handoff. A receipt from any historical owner never makes
+an invalid current-owner record appear unclaimed; current-record corruption
+always fails locked until the eight-second physical recovery action.
 
 If the owner iPhone is lost, holding the ESP32 BOOT button for eight seconds
 clears ownership locally and makes the device available for registration again.
 The stable device ID remains unchanged.
 
+### Hardware security boundary
+
+This ownership layer prevents remote/nearby phones from controlling or
+impersonating a registered Bike Computer. Physical possession of the hardware
+is intentionally a recovery authority through the BOOT action; the current
+development firmware does not claim resistance to invasive flash extraction or
+malicious reflashing. Its per-device owner key is stored in ordinary NVS.
+
+A production SKU whose threat model includes stolen-hardware key extraction
+must add a separately provisioned hardware-security profile: NVS encryption,
+flash encryption, Secure Boot, protected signing/encryption keys, disabled or
+controlled debug/download paths, and a tested OTA/recovery ceremony. Those
+eFuse and key-management operations are manufacturing decisions and are not
+enabled implicitly by this application protocol.
+
 ### Legacy compatibility
 
-Older firmware and an unclaimed ownership-capable device still accept the v1
-shared-key handshake so existing app/firmware combinations can connect during
-migration. An owned v2 device rejects this path.
+Only genuinely older firmware accepts the v1 shared-key handshake. Protocol-v2
+firmware never accepts the app-wide key, including when pristine, reset, or
+unclaimed; unreadable or partial ownership storage also fails closed. iOS keeps
+the legacy client path solely for a previously known legacy peripheral that
+does not expose v2 identity information.
 
 The legacy shared local key is `BikeComputer BLE v1 local pairing key`:
 

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -300,7 +300,7 @@ Current setting IDs:
 | `12` | Device brightness | `5...100` percent on supported hardware |
 | `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation, bit 4 Battery Status. Invalid or empty masks fall back to all supported screens. Existing four-screen configurations enable Battery Status once during migration, after which it remains user-toggleable. |
 | `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation, `4` Battery Status. Invalid or disabled defaults prefer Map + Navigation, then the first enabled fallback screen. |
-| `15` | Disconnected sleep timeout | seconds before deep sleep while not connected to the app: `60`, `120`, `300`, `600`; `0` disables automatic disconnected sleep. |
+| `15` | Disconnected sleep timeout | seconds before deep sleep while not connected to the app: `60`, `120`, `300`, `600`; `0` disables automatic disconnected sleep. An unclaimed device waiting to be added applies a minimum 600-second registration grace period; `0` still disables automatic disconnected sleep. |
 | `16` | Map + Navigation minimum polygon size | `0...50` |
 | `17` | Map + Navigation detail level | `0` low, `1` medium, `2` high |
 | `18` | Map + Navigation route line width | `2...48` |

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -1,7 +1,19 @@
 # BLE Protocol
 
 The ESP32 advertises BLE service UUID
-`9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800` as `BikeComputer`.
+`9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800` under its user-assigned device name.
+An unregistered device uses `BikeComputer XXYY`, where `XXYY` is derived from
+its stable random device ID.
+
+The advertisement carries an eight-byte manufacturer payload:
+
+```text
+FF FF | ProtocolVersion: UInt8 | Flags: UInt8 | DeviceID suffix: 4 bytes
+```
+
+Protocol version is currently `2`; flag bit `0` means the device already has an
+owner. The suffix lets the app and device show the same short identifier when
+several Bike Computers are nearby without advertising the complete identity.
 
 All navigation/map writes require the authenticated session established through
 the auth characteristic. The iOS app completes auth before it marks the device as
@@ -31,13 +43,87 @@ Fallback frame prefixes:
 | `GPSP` | GPS position packet |
 | `MSET` | map setting packet |
 
-## Auth
+## Device ownership and authentication
 
-The shared local key is `BikeComputer BLE v1 local pairing key`.
+Every ownership-capable ESP32 creates a random 128-bit device ID on first boot
+and keeps it in NVS. The iOS installation similarly creates a random 128-bit
+owner ID and stores it in the Keychain. iOS may register multiple Bike
+Computers, but maintains one current BLE connection at a time. Automatic
+reconnect targets only the current device; changing devices is explicit in
+Settings.
 
-Handshake:
+### Initial registration
 
-1. iOS writes `HELLO|<nonce>` to auth characteristic.
+Registration is allowed only while the device is unclaimed. The two sides use
+ephemeral P-256 ECDH, HKDF-SHA256, and a comparison code shown independently on
+the iPhone and Bike Computer. The derived 256-bit owner key is never sent over
+BLE.
+
+All binary fields below are lowercase hex. `AppPublicKey` and
+`DevicePublicKey` are 65-byte uncompressed X9.63 P-256 keys.
+
+1. iOS writes `INFO`.
+2. ESP32 notifies
+   `DEVICE|2|<DeviceID>|<Claimed 0-or-1>|<UTF8NameHex>`.
+3. iOS writes `PAIR|<OwnerID>|<AppPublicKey>`.
+4. ESP32 derives the owner key and notifies
+   `PAIRING|<DeviceID>|<DevicePublicKey>`.
+5. Both sides hash `"BikeComputer ownership v2" || DeviceID || OwnerID ||
+   AppPublicKey || DevicePublicKey`, then derive the owner key with that hash as
+   HKDF salt and `BikeComputer owner key v2` as HKDF info.
+6. Both show the six-digit big-endian value from the first four bytes of
+   `HMAC-SHA256(OwnerKey, "compare|" || TranscriptHash)`, modulo `1,000,000`.
+7. After verifying that the displays match, the user presses BOOT on the Bike
+   Computer. ESP32 notifies `PAIR_READY|<DeviceID>`. This physical action is
+   required so a nearby client cannot silently claim an unattended device.
+8. iOS writes
+   `CONFIRM|<OwnerID>|<HMAC-SHA256(OwnerKey, "claim|" || TranscriptHash)>|<UTF8NameHex>`.
+9. ESP32 persists the owner ID, owner key, and name, then notifies
+   `PAIRED|<DeviceID>|<UTF8NameHex>`.
+
+Pairing expires after 120 seconds. Names are non-empty UTF-8, exclude control
+characters and `|`, and are limited to 24 bytes. The app starts with the
+privacy-safe editable suggestion `My bike`; iOS does not expose the Apple ID
+owner name to apps.
+
+### Owner session authentication
+
+Every BLE connection performs a fresh mutual challenge using a random 16-byte
+nonce. No navigation, map, settings, rename, or deregistration command is
+accepted before this completes.
+
+1. iOS writes `OWNER|<OwnerID>|<Nonce>`.
+2. ESP32 notifies
+   `SERVER2|<DeviceID>|<Nonce>|<HMAC-SHA256(OwnerKey, "server2|<DeviceID>|<OwnerID>|<Nonce>")>`.
+3. iOS verifies the server proof, then writes
+   `PROOF|<OwnerID>|<Nonce>|<HMAC-SHA256(OwnerKey, "client2|<DeviceID>|<OwnerID>|<Nonce>")>`.
+4. ESP32 verifies the owner and nonce, then notifies
+   `OK2|<DeviceID>|<Nonce>` and opens the authenticated session.
+
+An owned device replies `OWNED|<DeviceID>` or `DENIED|<DeviceID>` to an
+unauthorized client and does not fall back to the global legacy key.
+
+### Rename, deregistration, and recovery
+
+After owner authentication, iOS can rename with `NAME|<UTF8NameHex>`; ESP32
+persists the name and replies `NAME_OK|<UTF8NameHex>`. `UNPAIR` removes the
+owner ID, owner key, and name from the hardware; ESP32 replies
+`UNPAIRED|<DeviceID>` before restarting its BLE state. iOS deletes its Keychain
+credential only after that acknowledgement.
+
+If the owner iPhone is lost, holding the ESP32 BOOT button for eight seconds
+clears ownership locally and makes the device available for registration again.
+The stable device ID remains unchanged.
+
+### Legacy compatibility
+
+Older firmware and an unclaimed ownership-capable device still accept the v1
+shared-key handshake so existing app/firmware combinations can connect during
+migration. An owned v2 device rejects this path.
+
+The legacy shared local key is `BikeComputer BLE v1 local pairing key`:
+
+1. iOS writes `HELLO|<nonce>`.
 2. ESP32 notifies `SERVER|<nonce>|<hmac_sha256_hex("server|<nonce>")>`.
 3. iOS writes `CLIENT|<nonce>|<hmac_sha256_hex("client|<nonce>")>`.
 4. ESP32 notifies `OK|<nonce>` and accepts navigation/map writes.

--- a/docs/device-ownership-test-vectors.json
+++ b/docs/device-ownership-test-vectors.json
@@ -1,0 +1,6 @@
+{
+  "hardwareMAC": "020000123456",
+  "deviceID": "0a4c573db1f4810069ecdc5bfa85158d",
+  "advertisementUnclaimed": "ffff0200fa85158d",
+  "advertisementClaimed": "ffff0201fa85158d"
+}

--- a/esp32/include/nimble_connection_config.h
+++ b/esp32/include/nimble_connection_config.h
@@ -1,0 +1,12 @@
+#pragma once
+
+// PlatformIO preincludes this file before NimBLE-Arduino and application
+// sources. Including sdkconfig.h first consumes its generated definition; the
+// project-wide replacement below therefore remains authoritative for the rest
+// of each translation unit.
+#include <sdkconfig.h>
+
+#ifdef CONFIG_BT_NIMBLE_MAX_CONNECTIONS
+#undef CONFIG_BT_NIMBLE_MAX_CONNECTIONS
+#endif
+#define CONFIG_BT_NIMBLE_MAX_CONNECTIONS 1

--- a/esp32/lib/ble_navigation/ble_connection_policy.hpp
+++ b/esp32/lib/ble_navigation/ble_connection_policy.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ble_connection_policy {
+
+constexpr uint16_t noConnection = 0xFFFF;
+
+inline bool accepts(uint16_t activeHandle, uint16_t candidateHandle) {
+  return activeHandle == noConnection || activeHandle == candidateHandle;
+}
+
+inline bool tearsDownSession(uint16_t activeHandle,
+                             uint16_t disconnectedHandle) {
+  return activeHandle != noConnection && activeHandle == disconnectedHandle;
+}
+
+template <typename ResetSession>
+bool beginSession(uint16_t &activeHandle, uint16_t candidateHandle,
+                  ResetSession resetSession) {
+  if (!accepts(activeHandle, candidateHandle) || !resetSession()) {
+    return false;
+  }
+  activeHandle = candidateHandle;
+  return true;
+}
+
+template <typename ResetSession>
+bool endSession(uint16_t &activeHandle, uint16_t disconnectedHandle,
+                ResetSession resetSession) {
+  if (!tearsDownSession(activeHandle, disconnectedHandle) ||
+      !resetSession()) {
+    return false;
+  }
+  activeHandle = noConnection;
+  return true;
+}
+
+} // namespace ble_connection_policy

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -6,7 +6,9 @@
  */
 
 #include "ble_navigation.hpp"
+#include "ble_connection_policy.hpp"
 #include "device_ownership.hpp"
+#include "ownership_button_policy.hpp"
 #include "device_screen_protocol.hpp"
 #include "map_profile_persistence.hpp"
 #include "transfer_control_dispatch.hpp"
@@ -35,6 +37,11 @@
 #include <host/ble_hs_id.h>
 #include <mbedtls/md.h>
 #include <WiFi.h>
+
+#if !defined(CONFIG_BT_NIMBLE_MAX_CONNECTIONS) || \
+    CONFIG_BT_NIMBLE_MAX_CONNECTIONS != 1
+#error "Bike Computer ownership requires CONFIG_BT_NIMBLE_MAX_CONNECTIONS=1"
+#endif
 
 extern Gps gps;
 extern device_transfer::HttpTransferServer deviceTransferHttp;
@@ -75,11 +82,19 @@ static char pendingAuthNonce[33] = "";
 static NimBLECharacteristic *authCharacteristic = nullptr;
 static NimBLECharacteristic *mapTransferStatusCharacteristic = nullptr;
 static BLEDebugStats bleDebugStats;
+static_assert(BLE_HS_CONN_HANDLE_NONE == ble_connection_policy::noConnection,
+              "single-connection policy must match NimBLE's empty handle");
 static uint16_t activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
 static bool unauthTimeoutDisconnectRequested = false;
 static device_ownership::DeviceOwnership deviceOwnership;
 static bool deviceOwnershipReady = false;
+static bool ownershipPairingActiveSnapshot = false;
+static StaticSemaphore_t deviceOwnershipMutexStorage;
+static SemaphoreHandle_t deviceOwnershipMutex = nullptr;
+static StaticSemaphore_t notificationTransportMutexStorage;
+static SemaphoreHandle_t notificationTransportMutex = nullptr;
 static bool ownershipAdvertisingDirty = false;
+static bool ownershipDisconnectPending = false;
 static bool ownershipRestartRequested = false;
 static uint32_t ownershipRestartRequestedMs = 0;
 static portMUX_TYPE ownershipUiMux = portMUX_INITIALIZER_UNLOCKED;
@@ -87,6 +102,9 @@ static bool ownershipUiUpdatePending = false;
 static char ownershipUiName[device_ownership::MAX_DEVICE_NAME_BYTES + 1] = "";
 static bool ownershipUiClaimed = false;
 static int32_t ownershipUiPairingCode = -1;
+static uint32_t ownershipUiPairingGeneration = 0;
+static ownership_button_policy::ComparisonRenderGate
+    ownershipComparisonRenderGate;
 static ble_transfer::PendingRequest pendingTransferControl;
 static portMUX_TYPE destinationPickerMux = portMUX_INITIALIZER_UNLOCKED;
 static DestinationCatalogSnapshot destinationCatalog;
@@ -98,16 +116,24 @@ static bool destinationRequestPending = false;
 static uint32_t destinationRequestStartedMs = 0;
 static uint32_t destinationStatusUpdatedMs = 0;
 
-static void queueOwnershipUiUpdate(int32_t pairingCode = -1) {
-  if (!deviceOwnershipReady) {
+static bool notifyAuthenticatedNavigation(NimBLECharacteristic *characteristic,
+                                          const uint8_t *data, size_t length);
+
+static void queueOwnershipUiUpdate(int32_t pairingCode = -1,
+                                   uint32_t pairingGeneration = 0) {
+  if (!deviceOwnershipReady || deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
     return;
   }
+  const std::string name = deviceOwnership.deviceName();
+  const bool claimed = deviceOwnership.isClaimed();
+  xSemaphoreGive(deviceOwnershipMutex);
   portENTER_CRITICAL(&ownershipUiMux);
-  strncpy(ownershipUiName, deviceOwnership.deviceName().c_str(),
-          sizeof(ownershipUiName) - 1);
+  strncpy(ownershipUiName, name.c_str(), sizeof(ownershipUiName) - 1);
   ownershipUiName[sizeof(ownershipUiName) - 1] = '\0';
-  ownershipUiClaimed = deviceOwnership.isClaimed();
+  ownershipUiClaimed = claimed;
   ownershipUiPairingCode = pairingCode;
+  ownershipUiPairingGeneration = pairingGeneration;
   ownershipUiUpdatePending = true;
   portEXIT_CRITICAL(&ownershipUiMux);
 }
@@ -116,29 +142,42 @@ static void applyPendingOwnershipUiUpdate() {
   char name[sizeof(ownershipUiName)] = "";
   bool claimed = false;
   int32_t pairingCode = -1;
+  uint32_t pairingGeneration = 0;
   portENTER_CRITICAL(&ownershipUiMux);
   const bool pending = ownershipUiUpdatePending;
   if (pending) {
     strncpy(name, ownershipUiName, sizeof(name) - 1);
     claimed = ownershipUiClaimed;
     pairingCode = ownershipUiPairingCode;
+    pairingGeneration = ownershipUiPairingGeneration;
     ownershipUiUpdatePending = false;
   }
   portEXIT_CRITICAL(&ownershipUiMux);
   if (pending) {
     updateWaitingOwnershipStatus(name, claimed, pairingCode);
+    portENTER_CRITICAL(&ownershipUiMux);
+    if (pairingCode >= 0) {
+      ownershipComparisonRenderGate.request(pairingGeneration);
+    } else {
+      ownershipComparisonRenderGate.cancel();
+    }
+    portEXIT_CRITICAL(&ownershipUiMux);
   }
 }
 
 static void applyOwnershipAdvertisingData() {
-  if (!deviceOwnershipReady) {
+  if (!deviceOwnershipReady || deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
     return;
   }
-  NimBLEDevice::setDeviceName(deviceOwnership.advertisedName());
+  const std::string name = deviceOwnership.advertisedName();
+  const std::vector<uint8_t> manufacturerData =
+      deviceOwnership.advertisementManufacturerData();
+  xSemaphoreGive(deviceOwnershipMutex);
+  NimBLEDevice::setDeviceName(name);
   NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();
-  advertising->setName(deviceOwnership.advertisedName());
-  advertising->setManufacturerData(
-      deviceOwnership.advertisementManufacturerData());
+  advertising->setName(name);
+  advertising->setManufacturerData(manufacturerData);
   ownershipAdvertisingDirty = false;
 }
 
@@ -286,8 +325,13 @@ bool requestDestinationRoute(uint32_t generation, uint16_t token) {
   destination_picker_protocol::writeUInt16LE(token, request + 8);
   setDestinationPickerStatus(DestinationPickerStatusCode::Calculating,
                              generation, token, "Starting navigation...");
-  mapTransferStatusCharacteristic->setValue(request, sizeof(request));
-  mapTransferStatusCharacteristic->notify();
+  if (!notifyAuthenticatedNavigation(mapTransferStatusCharacteristic, request,
+                                     sizeof(request))) {
+    finishDestinationRequestIfPending();
+    setDestinationPickerStatus(DestinationPickerStatusCode::Failed, generation,
+                               token, "Secure notification failed");
+    return false;
+  }
   Serial.printf("BLE Destination: requested generation=%lu token=%u\n",
                 (unsigned long)generation, token);
   return true;
@@ -479,6 +523,40 @@ static bool requireAuthenticated(const char *payloadName) {
   return false;
 }
 
+static bool unwrapOwnerAuthenticatedPayload(
+    device_ownership::AuthenticatedChannel channel, const std::string &frame,
+    std::string &payload, const char *payloadName) {
+  if (!deviceOwnershipReady || deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+    payload = frame;
+    return !deviceOwnershipReady;
+  }
+  const bool requiresFrame = deviceOwnership.isSessionAuthenticated();
+  const bool authenticationStateDiverged =
+      bleSessionAuthenticated && !requiresFrame;
+  const bool accepted = !authenticationStateDiverged &&
+                        (!requiresFrame ||
+                         deviceOwnership.unwrapAuthenticatedPayload(
+                             channel, frame, payload));
+  if (!requiresFrame) {
+    payload = frame;
+  }
+  xSemaphoreGive(deviceOwnershipMutex);
+  if (authenticationStateDiverged) {
+    bleSessionAuthenticated = false;
+    bleDebugStats.authenticated = false;
+    ownershipDisconnectPending = true;
+    Serial.println("BLE: Ownership session was lost; disconnect requested");
+  }
+  if (!accepted) {
+    bleDebugStats.rejectedUnauthenticatedCount++;
+    bleDebugStats.lastRejectedUnauthenticatedMs = millis();
+    Serial.printf("BLE: Rejected %s: invalid authenticated frame\n",
+                  payloadName == nullptr ? "payload" : payloadName);
+  }
+  return accepted;
+}
+
 static bool isHexNonce(const char *nonce) {
   if (nonce == nullptr || strlen(nonce) != 32) {
     return false;
@@ -539,13 +617,81 @@ static bool constantTimeEquals(const char *a, const char *b) {
   return diff == 0;
 }
 
-static void notifyAuthResponse(const char *response) {
-  if (authCharacteristic == nullptr || response == nullptr) {
+static void notifyAuthResponse(const std::string &response) {
+  if (authCharacteristic == nullptr || response.empty() ||
+      notificationTransportMutex == nullptr ||
+      xSemaphoreTake(notificationTransportMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
     return;
   }
-
-  authCharacteristic->setValue((uint8_t *)response, strlen(response));
+  constexpr size_t kMaximumOwnershipNotificationBytes = 182;
+  if (response.size() > kMaximumOwnershipNotificationBytes) {
+    Serial.printf("BLE: Ownership response too large: %u bytes\n",
+                  static_cast<unsigned>(response.size()));
+    xSemaphoreGive(notificationTransportMutex);
+    return;
+  }
+  uint16_t peerMtu = 23;
+  NimBLEService *service = authCharacteristic->getService();
+  NimBLEServer *server = service == nullptr ? nullptr : service->getServer();
+  if (server != nullptr && activeConnHandle != BLE_HS_CONN_HANDLE_NONE) {
+    peerMtu = server->getPeerMTU(activeConnHandle);
+  }
+  if (response.size() > static_cast<size_t>(peerMtu - 3)) {
+    Serial.printf(
+        "BLE: Ownership response needs ATT MTU %u; peer negotiated %u\n",
+        static_cast<unsigned>(response.size() + 3), peerMtu);
+    xSemaphoreGive(notificationTransportMutex);
+    return;
+  }
+  authCharacteristic->setValue(
+      reinterpret_cast<const uint8_t *>(response.data()), response.size());
   authCharacteristic->notify();
+  xSemaphoreGive(notificationTransportMutex);
+}
+
+static void notifyAuthResponse(const char *response) {
+  if (response != nullptr) notifyAuthResponse(std::string(response));
+}
+
+static bool notifyAuthenticatedNavigation(NimBLECharacteristic *characteristic,
+                                          const uint8_t *data, size_t length) {
+  if (characteristic == nullptr || data == nullptr ||
+      !bleSessionAuthenticated || !deviceOwnershipReady ||
+      deviceOwnershipMutex == nullptr || notificationTransportMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+    return false;
+  }
+  std::string frame;
+  const std::string payload(reinterpret_cast<const char *>(data), length);
+  const bool protectedPayload = deviceOwnership.protectAuthenticatedPayload(
+      device_ownership::AuthenticatedChannel::Navigation, payload, frame);
+  if (!protectedPayload || activeConnHandle == BLE_HS_CONN_HANDLE_NONE) {
+    xSemaphoreGive(deviceOwnershipMutex);
+    return false;
+  }
+  if (xSemaphoreTake(notificationTransportMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
+    xSemaphoreGive(deviceOwnershipMutex);
+    return false;
+  }
+  NimBLEService *service = characteristic->getService();
+  NimBLEServer *server = service == nullptr ? nullptr : service->getServer();
+  if (server == nullptr ||
+      frame.size() > static_cast<size_t>(server->getPeerMTU(activeConnHandle) - 3)) {
+    Serial.printf("BLE: Protected navigation notification too large: %u bytes\n",
+                  static_cast<unsigned>(frame.size()));
+    xSemaphoreGive(notificationTransportMutex);
+    xSemaphoreGive(deviceOwnershipMutex);
+    return false;
+  }
+  // Keep sequence assignment, characteristic value publication, and notify in
+  // one critical section. Calls arrive from both NimBLE and application tasks;
+  // splitting these operations can publish R2 sequence N+1 before N.
+  characteristic->setValue(
+      reinterpret_cast<const uint8_t *>(frame.data()), frame.size());
+  characteristic->notify();
+  xSemaphoreGive(notificationTransportMutex);
+  xSemaphoreGive(deviceOwnershipMutex);
+  return true;
 }
 
 static void logAuthPayloadPreview(const std::string &value) {
@@ -565,7 +711,13 @@ static void logAuthPayloadPreview(const std::string &value) {
                 (unsigned)value.length(), ascii, hex);
 }
 
-static void handleAuthPayload(const std::string &value) {
+static void handleAuthPayload(const std::string &frame) {
+  std::string value;
+  if (!unwrapOwnerAuthenticatedPayload(
+          device_ownership::AuthenticatedChannel::Auth, frame, value,
+          "ownership command")) {
+    return;
+  }
   if (value.length() == 2 &&
       (((uint8_t)value[0] == 0x01 && (uint8_t)value[1] == 0x00) ||
        ((uint8_t)value[0] == 0x00 && (uint8_t)value[1] == 0x00))) {
@@ -579,16 +731,63 @@ static void handleAuthPayload(const std::string &value) {
   }
 
   if (deviceOwnershipReady) {
-    const device_ownership::CommandResult ownershipResult =
-        deviceOwnership.handle(value, millis());
+    device_ownership::CommandResult ownershipResult;
+    uint32_t pairingCode = 0;
+    uint32_t pairingGeneration = 0;
+    bool ownershipLockAcquired = false;
+    bool ownershipSessionAuthenticated = false;
+    if (deviceOwnershipMutex != nullptr &&
+        xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(250)) == pdTRUE) {
+      ownershipLockAcquired = true;
+      ownershipResult = deviceOwnership.handle(value, millis());
+      pairingCode = deviceOwnership.pairingCode();
+      pairingGeneration = deviceOwnership.pairingGeneration();
+      if (frame.size() >= 2 && frame[0] == 'S' && frame[1] == '2' &&
+          !ownershipResult.response.empty() &&
+          !(ownershipResult.response.size() >= 2 &&
+            ownershipResult.response[0] == 'R' &&
+            ownershipResult.response[1] == '2') &&
+          deviceOwnership.isSessionAuthenticated()) {
+        std::string protectedResponse;
+        if (deviceOwnership.protectAuthenticatedPayload(
+                device_ownership::AuthenticatedChannel::Auth,
+                ownershipResult.response, protectedResponse)) {
+          ownershipResult.response = std::move(protectedResponse);
+        } else {
+          ownershipResult.response.clear();
+        }
+      }
+      ownershipSessionAuthenticated =
+          deviceOwnership.isSessionAuthenticated();
+      if (!ownershipResult.response.empty()) {
+        // Publish before releasing the ownership lock. This keeps the state
+        // transition, R2 sequence assignment, and transport order atomic with
+        // respect to both a following BLE write and a physical BOOT action.
+        notifyAuthResponse(ownershipResult.response);
+      }
+      xSemaphoreGive(deviceOwnershipMutex);
+    }
+    if (!ownershipLockAcquired) {
+      Serial.println("BLE: Rejected ownership command: state lock unavailable");
+      return;
+    }
+    if (bleSessionAuthenticated && !ownershipSessionAuthenticated) {
+      bleSessionAuthenticated = false;
+      bleDebugStats.authenticated = false;
+      ownershipDisconnectPending = true;
+      Serial.println("BLE: Ownership command invalidated session; disconnect requested");
+    }
     if (ownershipResult.matched) {
       switch (ownershipResult.event) {
       case device_ownership::Event::PairingStarted:
+        ownershipPairingActiveSnapshot = true;
         queueOwnershipUiUpdate(
-            static_cast<int32_t>(deviceOwnership.pairingCode()));
+            static_cast<int32_t>(pairingCode),
+            pairingGeneration);
         Serial.println("BLE: Secure ownership comparison started");
         break;
       case device_ownership::Event::Paired:
+        ownershipPairingActiveSnapshot = false;
         ownershipAdvertisingDirty = true;
         queueOwnershipUiUpdate();
         Serial.println("BLE: Device ownership registered");
@@ -618,9 +817,6 @@ static void handleAuthPayload(const std::string &value) {
       case device_ownership::Event::None:
         break;
       }
-      if (!ownershipResult.response.empty()) {
-        notifyAuthResponse(ownershipResult.response.c_str());
-      }
       return;
     }
   }
@@ -641,10 +837,22 @@ static void handleAuthPayload(const std::string &value) {
     return;
   }
 
-  if (deviceOwnershipReady && deviceOwnership.isClaimed()) {
-    const std::string response = "OWNED|" + deviceOwnership.deviceIdHex();
+  bool legacyAllowed = false;
+  bool claimed = true;
+  std::string stableDeviceId;
+  if (deviceOwnershipReady && deviceOwnershipMutex != nullptr &&
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(100)) == pdTRUE) {
+    legacyAllowed = deviceOwnership.allowsLegacyAuthentication();
+    claimed = deviceOwnership.isClaimed();
+    stableDeviceId = deviceOwnership.deviceIdHex();
+    xSemaphoreGive(deviceOwnershipMutex);
+  }
+  if (!deviceOwnershipReady || !legacyAllowed) {
+    const std::string response =
+        (deviceOwnershipReady && claimed ? "OWNED|" : "ERROR|") +
+        (deviceOwnershipReady ? stableDeviceId : "ownership_unavailable");
     notifyAuthResponse(response.c_str());
-    Serial.println("BLE: Rejected legacy shared-key auth on an owned device");
+    Serial.println("BLE: Rejected legacy shared-key authentication");
     return;
   }
 
@@ -960,15 +1168,13 @@ static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
   uint16_t peerMtu = 23;
   NimBLEService *service = pChar->getService();
   NimBLEServer *server = service == nullptr ? nullptr : service->getServer();
-  if (server != nullptr) {
-    const std::vector<uint16_t> peers = server->getPeerDevices();
-    if (!peers.empty())
-      peerMtu = server->getPeerMTU(peers.front());
+  if (server != nullptr && activeConnHandle != BLE_HS_CONN_HANDLE_NONE) {
+    peerMtu = server->getPeerMTU(activeConnHandle);
   }
-  if (peerMtu >= 3 && legacy.size() <= peerMtu - 3) {
-    pChar->setValue(reinterpret_cast<const uint8_t *>(legacy.data()),
-                    legacy.size());
-    pChar->notify();
+  if (peerMtu >= 25 && legacy.size() <= peerMtu - 25 &&
+      notifyAuthenticatedNavigation(
+          pChar, reinterpret_cast<const uint8_t *>(legacy.data()),
+          legacy.size())) {
     Serial.printf("BLE Map Transfer: status notified (%u bytes, MTU %u)\n",
                   (unsigned)legacy.size(), (unsigned)peerMtu);
     return;
@@ -988,9 +1194,12 @@ static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
     frame.push_back(static_cast<char>(index));
     frame.push_back(static_cast<char>(chunkCount));
     frame.append(body.data() + offset, length);
-    pChar->setValue(reinterpret_cast<const uint8_t *>(frame.data()),
-                    frame.size());
-    pChar->notify();
+    if (!notifyAuthenticatedNavigation(
+            pChar, reinterpret_cast<const uint8_t *>(frame.data()),
+            frame.size())) {
+      Serial.println("BLE Map Transfer: protected status chunk failed");
+      return;
+    }
     delay(2);
   }
   Serial.printf("BLE Map Transfer: status notified (%u bytes, %u chunks)\n",
@@ -1005,11 +1214,40 @@ static void notifyGenericTransferStatus(NimBLECharacteristic *pChar) {
     return;
   }
 
-  std::string response = "DSTS" + genericTransferStatusJson();
-  pChar->setValue((uint8_t *)response.data(), response.size());
-  pChar->notify();
-  Serial.printf("BLE Device Transfer: status notified (%u bytes)\n",
-                (unsigned)response.size());
+  constexpr size_t kChunkBytes = 128;
+  static uint8_t transferId = 0;
+  const std::string body = genericTransferStatusJson();
+  const std::string response = "DSTS" + body;
+  if (notifyAuthenticatedNavigation(
+          pChar, reinterpret_cast<const uint8_t *>(response.data()),
+          response.size())) {
+    Serial.printf("BLE Device Transfer: status notified (%u bytes)\n",
+                  static_cast<unsigned>(response.size()));
+    return;
+  }
+  const size_t chunkCount = (body.size() + kChunkBytes - 1) / kChunkBytes;
+  if (chunkCount == 0 || chunkCount > 255) {
+    Serial.printf("BLE Device Transfer: status too large (%u bytes)\n",
+                  static_cast<unsigned>(body.size()));
+    return;
+  }
+  transferId++;
+  for (size_t index = 0; index < chunkCount; index++) {
+    const size_t offset = index * kChunkBytes;
+    const size_t chunkLength = std::min(kChunkBytes, body.size() - offset);
+    std::string chunk = "DSTC";
+    chunk.push_back(static_cast<char>(transferId));
+    chunk.push_back(static_cast<char>(index));
+    chunk.push_back(static_cast<char>(chunkCount));
+    chunk.append(body.data() + offset, chunkLength);
+    if (!notifyAuthenticatedNavigation(
+            pChar, reinterpret_cast<const uint8_t *>(chunk.data()),
+            chunk.size())) {
+      Serial.println("BLE Device Transfer: protected status chunk failed");
+      return;
+    }
+    delay(2);
+  }
 }
 
 static void queueTransferControl(ble_transfer::Action action,
@@ -1139,8 +1377,10 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
     }
     responseSize += waveshare_board::speaker::POWER_BUTTON_HONK_PAYLOAD_SIZE;
   }
-  pChar->setValue(response, responseSize);
-  pChar->notify();
+  if (!notifyAuthenticatedNavigation(pChar, response, responseSize)) {
+    Serial.println("BLE Capabilities: protected notification failed");
+    return;
+  }
   Serial.printf("BLE Capabilities: notified flags=0x%02X config=%d\n",
                 response[4], responseSize > 5 ? 1 : 0);
 }
@@ -1163,8 +1403,10 @@ static void notifyPowerButtonHonkStatus(
           command, applied, response, responseSize)) {
     return;
   }
-  pChar->setValue(response, responseSize);
-  pChar->notify();
+  if (!notifyAuthenticatedNavigation(pChar, response, responseSize)) {
+    Serial.println("BLE Sound: protected PWR status notification failed");
+    return;
+  }
   Serial.printf("BLE Sound: PWR honk apply status notified success=%d\n",
                 applied ? 1 : 0);
 }
@@ -1858,6 +2100,20 @@ static void handleMapSettingPayload(const uint8_t *data, size_t len,
 // NimBLE Callbacks
 // ============================================================================
 
+static bool resetOwnershipConnectionState() {
+  if (!deviceOwnershipReady) {
+    return true;
+  }
+  if (deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, portMAX_DELAY) != pdTRUE) {
+    return false;
+  }
+  deviceOwnership.resetConnection();
+  ownershipPairingActiveSnapshot = false;
+  xSemaphoreGive(deviceOwnershipMutex);
+  return true;
+}
+
 class MyBLEServerCallbacks : public NimBLEServerCallbacks {
 public:
   BLENavigationServer *server;
@@ -1865,20 +2121,46 @@ public:
   MyBLEServerCallbacks(BLENavigationServer *srv) : server(srv) {}
 
   void onConnect(NimBLEServer *pServer) override {
-    activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
+    // NimBLE-Arduino 1.4 invokes both overloads for the same event. The
+    // descriptor overload below is the only one allowed to mutate state.
+    (void)pServer;
+  }
+
+  void onConnect(NimBLEServer *pServer, ble_gap_conn_desc *desc) override {
+    if (desc == nullptr) {
+      Serial.println("BLE: Rejected connection without a handle");
+      return;
+    }
+    if (activeConnHandle == desc->conn_handle && server->connected) {
+      Serial.printf("BLE: Ignoring duplicate connection callback handle=%u\n",
+                    desc->conn_handle);
+      return;
+    }
+    if (!ble_connection_policy::beginSession(
+            activeConnHandle, desc->conn_handle,
+            [] { return resetOwnershipConnectionState(); })) {
+      Serial.printf("BLE: Rejecting connection handle=%u (busy or ownership reset unavailable)\n",
+                    desc->conn_handle);
+      pServer->disconnect(desc->conn_handle);
+      return;
+    }
+    acceptConnection();
+  }
+
+  void acceptConnection() {
     server->connected = true;
     bleSessionAuthenticated = false;
     bleSessionUsesIndependentMapProfiles = false;
     phoneBatteryLevelPercent = -1;
     phoneBatteryCharging = false;
     unauthTimeoutDisconnectRequested = false;
+    ownershipDisconnectPending = false;
     bleDebugStats.connected = true;
     bleDebugStats.authenticated = false;
     bleDebugStats.connectCount++;
     bleDebugStats.lastConnectMs = millis();
     pendingAuthNonce[0] = '\0';
     if (deviceOwnershipReady) {
-      deviceOwnership.resetConnection();
       queueOwnershipUiUpdate();
     }
     if (destinationCatalogReassemblerMutex != nullptr &&
@@ -1892,14 +2174,28 @@ public:
     NimBLEDevice::stopAdvertising();
   }
 
-  void onConnect(NimBLEServer *pServer, ble_gap_conn_desc *desc) override {
-    onConnect(pServer);
-    if (desc != nullptr) {
-      activeConnHandle = desc->conn_handle;
+  void onDisconnect(NimBLEServer *pServer,
+                    ble_gap_conn_desc *desc) override {
+    if (desc == nullptr || !ble_connection_policy::endSession(
+                               activeConnHandle, desc->conn_handle,
+                               [] { return resetOwnershipConnectionState(); })) {
+      Serial.printf("BLE: Secondary connection handle=%u disconnected\n",
+                    desc == nullptr ? BLE_HS_CONN_HANDLE_NONE
+                                    : desc->conn_handle);
+      return;
     }
+    disconnectActive();
   }
 
   void onDisconnect(NimBLEServer *pServer) override {
+    // See onConnect(NimBLEServer*): the pinned NimBLE version invokes both.
+    (void)pServer;
+  }
+
+  void disconnectActive() {
+    if (activeConnHandle == BLE_HS_CONN_HANDLE_NONE && !server->connected) {
+      return;
+    }
     queueTransferControl(ble_transfer::Action::DisableMap,
                          ble_transfer::NotifyNone);
     server->connected = false;
@@ -1908,14 +2204,13 @@ public:
     phoneBatteryLevelPercent = -1;
     phoneBatteryCharging = false;
     unauthTimeoutDisconnectRequested = false;
-    activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
+    ownershipDisconnectPending = false;
     bleDebugStats.connected = false;
     bleDebugStats.authenticated = false;
     bleDebugStats.disconnectCount++;
     bleDebugStats.lastDisconnectMs = millis();
     pendingAuthNonce[0] = '\0';
     if (deviceOwnershipReady) {
-      deviceOwnership.resetConnection();
       if (ownershipAdvertisingDirty) {
         applyOwnershipAdvertisingData();
       }
@@ -1938,8 +2233,14 @@ public:
 class MyNavCharacteristicCallbacks : public NimBLECharacteristicCallbacks {
 public:
   void onWrite(NimBLECharacteristic *pChar) override {
-    std::string value = pChar->getValue();
-    if (value.empty()) {
+    const std::string frame = pChar->getValue();
+    if (frame.empty()) {
+      return;
+    }
+    std::string value;
+    if (!unwrapOwnerAuthenticatedPayload(
+            device_ownership::AuthenticatedChannel::Navigation, frame, value,
+            "navigation characteristic")) {
       return;
     }
 
@@ -2038,7 +2339,13 @@ public:
 class MyRouteCharacteristicCallbacks : public NimBLECharacteristicCallbacks {
 public:
   void onWrite(NimBLECharacteristic *pChar) override {
-    std::string value = pChar->getValue();
+    const std::string frame = pChar->getValue();
+    std::string value;
+    if (!unwrapOwnerAuthenticatedPayload(
+            device_ownership::AuthenticatedChannel::Route, frame, value,
+            "route characteristic")) {
+      return;
+    }
     if (!requireAuthenticated("route geometry")) {
       return;
     }
@@ -2051,7 +2358,13 @@ public:
 class MyGPSCharacteristicCallbacks : public NimBLECharacteristicCallbacks {
 public:
   void onWrite(NimBLECharacteristic *pChar) override {
-    std::string value = pChar->getValue();
+    const std::string frame = pChar->getValue();
+    std::string value;
+    if (!unwrapOwnerAuthenticatedPayload(
+            device_ownership::AuthenticatedChannel::Gps, frame, value,
+            "GPS characteristic")) {
+      return;
+    }
     if (!requireAuthenticated("GPS position")) {
       return;
     }
@@ -2069,7 +2382,13 @@ public:
 class MySettingsCharacteristicCallbacks : public NimBLECharacteristicCallbacks {
 public:
   void onWrite(NimBLECharacteristic *pChar) override {
-    std::string value = pChar->getValue();
+    const std::string frame = pChar->getValue();
+    std::string value;
+    if (!unwrapOwnerAuthenticatedPayload(
+            device_ownership::AuthenticatedChannel::Settings, frame, value,
+            "settings characteristic")) {
+      return;
+    }
 
     if (handleDestinationPickerPayload(value, "native destination picker")) {
       return;
@@ -2216,16 +2535,41 @@ void BLENavigationServer::init(const char *deviceName) {
         &destinationCatalogReassemblerMutexStorage);
   }
 
-  deviceOwnershipReady = deviceOwnership.begin();
-  const std::string effectiveDeviceName =
-      deviceOwnershipReady ? deviceOwnership.advertisedName() : deviceName;
+  if (deviceOwnershipMutex == nullptr) {
+    deviceOwnershipMutex =
+        xSemaphoreCreateMutexStatic(&deviceOwnershipMutexStorage);
+  }
+
+  if (notificationTransportMutex == nullptr) {
+    notificationTransportMutex =
+        xSemaphoreCreateMutexStatic(&notificationTransportMutexStorage);
+  }
+
+  deviceOwnershipReady = deviceOwnershipMutex != nullptr &&
+                         notificationTransportMutex != nullptr &&
+                         xSemaphoreTake(deviceOwnershipMutex,
+                                        pdMS_TO_TICKS(250)) == pdTRUE;
+  std::string effectiveDeviceName = deviceName;
+  std::string stableDeviceId;
+  bool ownershipClaimed = true;
+  std::vector<uint8_t> manufacturerData;
+  if (deviceOwnershipReady) {
+    deviceOwnershipReady = deviceOwnership.begin();
+    if (deviceOwnershipReady) {
+      effectiveDeviceName = deviceOwnership.advertisedName();
+      stableDeviceId = deviceOwnership.deviceIdHex();
+      ownershipClaimed = deviceOwnership.isClaimed();
+      manufacturerData = deviceOwnership.advertisementManufacturerData();
+    }
+    xSemaphoreGive(deviceOwnershipMutex);
+  }
   if (deviceOwnershipReady) {
     Serial.printf("BLE: Ownership identity=%s claimed=%d name='%s'\n",
-                  deviceOwnership.deviceIdHex().c_str(),
-                  deviceOwnership.isClaimed(), effectiveDeviceName.c_str());
+                  stableDeviceId.c_str(), ownershipClaimed,
+                  effectiveDeviceName.c_str());
     queueOwnershipUiUpdate();
   } else {
-    Serial.println("BLE: Ownership storage unavailable; using legacy identity");
+    Serial.println("BLE: Ownership storage unavailable; authentication locked");
   }
 
   initBleIdentityAndSecurity(effectiveDeviceName.c_str());
@@ -2285,9 +2629,8 @@ void BLENavigationServer::init(const char *deviceName) {
   NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
   pAdvertising->addServiceUUID(SERVICE_UUID);
   if (deviceOwnershipReady) {
-    pAdvertising->setName(deviceOwnership.advertisedName());
-    pAdvertising->setManufacturerData(
-        deviceOwnership.advertisementManufacturerData());
+    pAdvertising->setName(effectiveDeviceName);
+    pAdvertising->setManufacturerData(manufacturerData);
   }
   pAdvertising->setScanResponse(true);
   pAdvertising->start();
@@ -2302,9 +2645,16 @@ void BLENavigationServer::init(const char *deviceName) {
 
 void BLENavigationServer::process() {
   if (deviceOwnershipReady) {
-    const bool wasPairing = deviceOwnership.hasPairingCode();
-    deviceOwnership.process(millis());
-    if (wasPairing && !deviceOwnership.hasPairingCode()) {
+    bool pairingExpired = false;
+    if (deviceOwnershipMutex != nullptr &&
+        xSemaphoreTake(deviceOwnershipMutex, 0) == pdTRUE) {
+      const bool wasPairing = deviceOwnership.hasPairingCode();
+      deviceOwnership.process(millis());
+      ownershipPairingActiveSnapshot = deviceOwnership.hasPairingCode();
+      pairingExpired = wasPairing && !ownershipPairingActiveSnapshot;
+      xSemaphoreGive(deviceOwnershipMutex);
+    }
+    if (pairingExpired) {
       queueOwnershipUiUpdate();
     }
     applyPendingOwnershipUiUpdate();
@@ -2340,10 +2690,23 @@ void BLENavigationServer::process() {
   }
 
   static uint32_t lastLog = 0;
+  if (deviceOwnershipReady && deviceOwnershipMutex != nullptr &&
+      xSemaphoreTake(deviceOwnershipMutex, 0) == pdTRUE) {
+    ownershipPairingActiveSnapshot = deviceOwnership.hasPairingCode();
+    xSemaphoreGive(deviceOwnershipMutex);
+  }
+  const uint32_t unauthenticatedLimitMs =
+      ownershipPairingActiveSnapshot ? 120000 : 12000;
+  if (connected && ownershipDisconnectPending) {
+    ownershipDisconnectPending = false;
+    unauthTimeoutDisconnectRequested = true;
+    if (pServer != nullptr && activeConnHandle != BLE_HS_CONN_HANDLE_NONE) {
+      pServer->disconnect(activeConnHandle);
+    }
+  }
   if (connected && !bleSessionAuthenticated &&
-      !(deviceOwnershipReady && deviceOwnership.hasPairingCode()) &&
       !unauthTimeoutDisconnectRequested &&
-      millis() - bleDebugStats.lastConnectMs > 12000) {
+      millis() - bleDebugStats.lastConnectMs > unauthenticatedLimitMs) {
     Serial.println("BLE: Disconnecting unauthenticated client after timeout");
     unauthTimeoutDisconnectRequested = true;
     if (pServer != nullptr && activeConnHandle != BLE_HS_CONN_HANDLE_NONE) {
@@ -2395,8 +2758,13 @@ BLEDebugStats BLENavigationServer::getDebugStats() const {
 }
 
 bool BLENavigationServer::forgetOwner() {
-  if (!deviceOwnershipReady || !deviceOwnership.isClaimed() ||
-      !deviceOwnership.clearOwner()) {
+  bool cleared = false;
+  if (deviceOwnershipReady && deviceOwnershipMutex != nullptr &&
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(250)) == pdTRUE) {
+    cleared = deviceOwnership.isClaimed() && deviceOwnership.clearOwner();
+    xSemaphoreGive(deviceOwnershipMutex);
+  }
+  if (!cleared) {
     return false;
   }
   bleSessionAuthenticated = false;
@@ -2409,16 +2777,71 @@ bool BLENavigationServer::forgetOwner() {
   return true;
 }
 
-bool BLENavigationServer::confirmOwnershipPairing() {
-  if (!deviceOwnershipReady || !deviceOwnership.confirmPairingOnDevice()) {
+void BLENavigationServer::noteOwnershipDisplayFlushCompleted() {
+  portENTER_CRITICAL(&ownershipUiMux);
+  ownershipComparisonRenderGate.displayFlushed();
+  portEXIT_CRITICAL(&ownershipUiMux);
+}
+
+bool BLENavigationServer::ownershipPairingRenderedRequest(
+    uint32_t &pairingGeneration) {
+  portENTER_CRITICAL(&ownershipUiMux);
+  pairingGeneration = ownershipComparisonRenderGate.renderedGeneration();
+  portEXIT_CRITICAL(&ownershipUiMux);
+  return pairingGeneration != 0;
+}
+
+bool BLENavigationServer::armOwnershipPairingConfirmation(
+    uint32_t pairingGeneration) {
+  portENTER_CRITICAL(&ownershipUiMux);
+  const bool requestMatches = pairingGeneration != 0 &&
+      ownershipComparisonRenderGate.renderedGeneration() ==
+          pairingGeneration;
+  portEXIT_CRITICAL(&ownershipUiMux);
+  if (!requestMatches || !deviceOwnershipReady ||
+      deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(250)) != pdTRUE) {
     return false;
   }
-  const std::string response =
-      "PAIR_READY|" + deviceOwnership.deviceIdHex();
+  const bool armed =
+      deviceOwnership.armPairingConfirmation(pairingGeneration);
+  xSemaphoreGive(deviceOwnershipMutex);
+  portENTER_CRITICAL(&ownershipUiMux);
+  ownershipComparisonRenderGate.consumeRendered(pairingGeneration);
+  portEXIT_CRITICAL(&ownershipUiMux);
+  return armed;
+}
+
+bool BLENavigationServer::hasOwnershipPairingCode() {
+  if (!deviceOwnershipReady || deviceOwnershipMutex == nullptr ||
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(50)) != pdTRUE) {
+    return ownershipPairingActiveSnapshot;
+  }
+  const bool active = deviceOwnership.hasPairingCode();
+  xSemaphoreGive(deviceOwnershipMutex);
+  return active;
+}
+
+bool BLENavigationServer::confirmOwnershipPairing() {
+  bool confirmed = false;
+  uint32_t pairingCode = 0;
+  std::string stableDeviceId;
+  if (deviceOwnershipReady && deviceOwnershipMutex != nullptr &&
+      xSemaphoreTake(deviceOwnershipMutex, pdMS_TO_TICKS(250)) == pdTRUE) {
+    confirmed = deviceOwnership.confirmPairingOnDevice();
+    if (confirmed) {
+      stableDeviceId = deviceOwnership.deviceIdHex();
+      pairingCode = deviceOwnership.pairingCode();
+    }
+    xSemaphoreGive(deviceOwnershipMutex);
+  }
+  if (!confirmed) {
+    return false;
+  }
+  const std::string response = "PAIR_READY|" + stableDeviceId;
   notifyAuthResponse(response.c_str());
-  queueOwnershipUiUpdate(
-      static_cast<int32_t>(deviceOwnership.pairingCode()));
-  Serial.println("BLE: Ownership pairing confirmed with physical BOOT press");
+  queueOwnershipUiUpdate(static_cast<int32_t>(pairingCode));
+  Serial.println("BLE: Ownership pairing confirmed with physical button press");
   return true;
 }
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -2569,6 +2569,9 @@ void BLENavigationServer::init(const char *deviceName) {
                   effectiveDeviceName.c_str());
     queueOwnershipUiUpdate();
   } else {
+    portENTER_CRITICAL(&ownershipUiMux);
+    ownershipUiClaimed = true;
+    portEXIT_CRITICAL(&ownershipUiMux);
     Serial.println("BLE: Ownership storage unavailable; authentication locked");
   }
 
@@ -2820,6 +2823,13 @@ bool BLENavigationServer::hasOwnershipPairingCode() {
   const bool active = deviceOwnership.hasPairingCode();
   xSemaphoreGive(deviceOwnershipMutex);
   return active;
+}
+
+bool BLENavigationServer::isOwnershipClaimed() {
+  portENTER_CRITICAL(&ownershipUiMux);
+  const bool claimed = ownershipUiClaimed;
+  portEXIT_CRITICAL(&ownershipUiMux);
+  return claimed;
 }
 
 bool BLENavigationServer::confirmOwnershipPairing() {

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -6,6 +6,7 @@
  */
 
 #include "ble_navigation.hpp"
+#include "device_ownership.hpp"
 #include "device_screen_protocol.hpp"
 #include "map_profile_persistence.hpp"
 #include "transfer_control_dispatch.hpp"
@@ -76,6 +77,16 @@ static NimBLECharacteristic *mapTransferStatusCharacteristic = nullptr;
 static BLEDebugStats bleDebugStats;
 static uint16_t activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
 static bool unauthTimeoutDisconnectRequested = false;
+static device_ownership::DeviceOwnership deviceOwnership;
+static bool deviceOwnershipReady = false;
+static bool ownershipAdvertisingDirty = false;
+static bool ownershipRestartRequested = false;
+static uint32_t ownershipRestartRequestedMs = 0;
+static portMUX_TYPE ownershipUiMux = portMUX_INITIALIZER_UNLOCKED;
+static bool ownershipUiUpdatePending = false;
+static char ownershipUiName[device_ownership::MAX_DEVICE_NAME_BYTES + 1] = "";
+static bool ownershipUiClaimed = false;
+static int32_t ownershipUiPairingCode = -1;
 static ble_transfer::PendingRequest pendingTransferControl;
 static portMUX_TYPE destinationPickerMux = portMUX_INITIALIZER_UNLOCKED;
 static DestinationCatalogSnapshot destinationCatalog;
@@ -86,6 +97,50 @@ static SemaphoreHandle_t destinationCatalogReassemblerMutex = nullptr;
 static bool destinationRequestPending = false;
 static uint32_t destinationRequestStartedMs = 0;
 static uint32_t destinationStatusUpdatedMs = 0;
+
+static void queueOwnershipUiUpdate(int32_t pairingCode = -1) {
+  if (!deviceOwnershipReady) {
+    return;
+  }
+  portENTER_CRITICAL(&ownershipUiMux);
+  strncpy(ownershipUiName, deviceOwnership.deviceName().c_str(),
+          sizeof(ownershipUiName) - 1);
+  ownershipUiName[sizeof(ownershipUiName) - 1] = '\0';
+  ownershipUiClaimed = deviceOwnership.isClaimed();
+  ownershipUiPairingCode = pairingCode;
+  ownershipUiUpdatePending = true;
+  portEXIT_CRITICAL(&ownershipUiMux);
+}
+
+static void applyPendingOwnershipUiUpdate() {
+  char name[sizeof(ownershipUiName)] = "";
+  bool claimed = false;
+  int32_t pairingCode = -1;
+  portENTER_CRITICAL(&ownershipUiMux);
+  const bool pending = ownershipUiUpdatePending;
+  if (pending) {
+    strncpy(name, ownershipUiName, sizeof(name) - 1);
+    claimed = ownershipUiClaimed;
+    pairingCode = ownershipUiPairingCode;
+    ownershipUiUpdatePending = false;
+  }
+  portEXIT_CRITICAL(&ownershipUiMux);
+  if (pending) {
+    updateWaitingOwnershipStatus(name, claimed, pairingCode);
+  }
+}
+
+static void applyOwnershipAdvertisingData() {
+  if (!deviceOwnershipReady) {
+    return;
+  }
+  NimBLEDevice::setDeviceName(deviceOwnership.advertisedName());
+  NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();
+  advertising->setName(deviceOwnership.advertisedName());
+  advertising->setManufacturerData(
+      deviceOwnership.advertisementManufacturerData());
+  ownershipAdvertisingDirty = false;
+}
 
 NavigationData getCurrentNavigationData() { return currentNavData; }
 
@@ -517,13 +572,60 @@ static void handleAuthPayload(const std::string &value) {
     return;
   }
 
-  if (value.length() > 128) {
+  if (value.length() > 256) {
     Serial.println("BLE: Rejected auth payload: too large");
     logAuthPayloadPreview(value);
     return;
   }
 
-  char payload[129];
+  if (deviceOwnershipReady) {
+    const device_ownership::CommandResult ownershipResult =
+        deviceOwnership.handle(value, millis());
+    if (ownershipResult.matched) {
+      switch (ownershipResult.event) {
+      case device_ownership::Event::PairingStarted:
+        queueOwnershipUiUpdate(
+            static_cast<int32_t>(deviceOwnership.pairingCode()));
+        Serial.println("BLE: Secure ownership comparison started");
+        break;
+      case device_ownership::Event::Paired:
+        ownershipAdvertisingDirty = true;
+        queueOwnershipUiUpdate();
+        Serial.println("BLE: Device ownership registered");
+        break;
+      case device_ownership::Event::Authenticated:
+        bleSessionAuthenticated = true;
+        bleDebugStats.authenticated = true;
+        bleDebugStats.authSuccessCount++;
+        bleDebugStats.lastAuthSuccessMs = millis();
+        queueOwnershipUiUpdate();
+        Serial.println("BLE: Owner session authenticated");
+        break;
+      case device_ownership::Event::Renamed:
+        ownershipAdvertisingDirty = true;
+        queueOwnershipUiUpdate();
+        Serial.println("BLE: Device name updated");
+        break;
+      case device_ownership::Event::Unpaired:
+        bleSessionAuthenticated = false;
+        bleDebugStats.authenticated = false;
+        ownershipAdvertisingDirty = true;
+        queueOwnershipUiUpdate();
+        ownershipRestartRequested = true;
+        ownershipRestartRequestedMs = millis();
+        Serial.println("BLE: Device ownership removed; restart scheduled");
+        break;
+      case device_ownership::Event::None:
+        break;
+      }
+      if (!ownershipResult.response.empty()) {
+        notifyAuthResponse(ownershipResult.response.c_str());
+      }
+      return;
+    }
+  }
+
+  char payload[257];
   memcpy(payload, value.data(), value.length());
   payload[value.length()] = '\0';
 
@@ -536,6 +638,13 @@ static void handleAuthPayload(const std::string &value) {
       !isHexNonce(nonce)) {
     Serial.println("BLE: Rejected auth payload: invalid format");
     logAuthPayloadPreview(value);
+    return;
+  }
+
+  if (deviceOwnershipReady && deviceOwnership.isClaimed()) {
+    const std::string response = "OWNED|" + deviceOwnership.deviceIdHex();
+    notifyAuthResponse(response.c_str());
+    Serial.println("BLE: Rejected legacy shared-key auth on an owned device");
     return;
   }
 
@@ -1768,6 +1877,10 @@ public:
     bleDebugStats.connectCount++;
     bleDebugStats.lastConnectMs = millis();
     pendingAuthNonce[0] = '\0';
+    if (deviceOwnershipReady) {
+      deviceOwnership.resetConnection();
+      queueOwnershipUiUpdate();
+    }
     if (destinationCatalogReassemblerMutex != nullptr &&
         xSemaphoreTake(destinationCatalogReassemblerMutex,
                        pdMS_TO_TICKS(100)) == pdTRUE) {
@@ -1801,6 +1914,13 @@ public:
     bleDebugStats.disconnectCount++;
     bleDebugStats.lastDisconnectMs = millis();
     pendingAuthNonce[0] = '\0';
+    if (deviceOwnershipReady) {
+      deviceOwnership.resetConnection();
+      if (ownershipAdvertisingDirty) {
+        applyOwnershipAdvertisingData();
+      }
+      queueOwnershipUiUpdate();
+    }
     if (finishDestinationRequestIfPending()) {
       const DestinationPickerStatusSnapshot status =
           getDestinationPickerStatusSnapshot();
@@ -2096,7 +2216,19 @@ void BLENavigationServer::init(const char *deviceName) {
         &destinationCatalogReassemblerMutexStorage);
   }
 
-  initBleIdentityAndSecurity(deviceName);
+  deviceOwnershipReady = deviceOwnership.begin();
+  const std::string effectiveDeviceName =
+      deviceOwnershipReady ? deviceOwnership.advertisedName() : deviceName;
+  if (deviceOwnershipReady) {
+    Serial.printf("BLE: Ownership identity=%s claimed=%d name='%s'\n",
+                  deviceOwnership.deviceIdHex().c_str(),
+                  deviceOwnership.isClaimed(), effectiveDeviceName.c_str());
+    queueOwnershipUiUpdate();
+  } else {
+    Serial.println("BLE: Ownership storage unavailable; using legacy identity");
+  }
+
+  initBleIdentityAndSecurity(effectiveDeviceName.c_str());
   NimBLEDevice::setPower(ESP_PWR_LVL_P9); // Maximum power
   NimBLEDevice::setMTU(512);              // Increase MTU for route geometry
 
@@ -2152,6 +2284,11 @@ void BLENavigationServer::init(const char *deviceName) {
   // Start advertising
   NimBLEAdvertising *pAdvertising = NimBLEDevice::getAdvertising();
   pAdvertising->addServiceUUID(SERVICE_UUID);
+  if (deviceOwnershipReady) {
+    pAdvertising->setName(deviceOwnership.advertisedName());
+    pAdvertising->setManufacturerData(
+        deviceOwnership.advertisementManufacturerData());
+  }
   pAdvertising->setScanResponse(true);
   pAdvertising->start();
 
@@ -2159,10 +2296,25 @@ void BLENavigationServer::init(const char *deviceName) {
   bleDebugStats.initialized = true;
   bleDebugStats.connected = connected;
   bleDebugStats.authenticated = bleSessionAuthenticated;
-  Serial.printf("BLE: Server started, advertising as '%s'\n", deviceName);
+  Serial.printf("BLE: Server started, advertising as '%s'\n",
+                effectiveDeviceName.c_str());
 }
 
 void BLENavigationServer::process() {
+  if (deviceOwnershipReady) {
+    const bool wasPairing = deviceOwnership.hasPairingCode();
+    deviceOwnership.process(millis());
+    if (wasPairing && !deviceOwnership.hasPairingCode()) {
+      queueOwnershipUiUpdate();
+    }
+    applyPendingOwnershipUiUpdate();
+  }
+  if (ownershipRestartRequested &&
+      static_cast<uint32_t>(millis() - ownershipRestartRequestedMs) >= 500) {
+    Serial.println("BLE: Restarting after ownership removal");
+    Serial.flush();
+    ESP.restart();
+  }
   processPendingTransferControl();
   const uint32_t nowMs = millis();
   if (destinationCatalogReassemblerMutex != nullptr &&
@@ -2189,6 +2341,7 @@ void BLENavigationServer::process() {
 
   static uint32_t lastLog = 0;
   if (connected && !bleSessionAuthenticated &&
+      !(deviceOwnershipReady && deviceOwnership.hasPairingCode()) &&
       !unauthTimeoutDisconnectRequested &&
       millis() - bleDebugStats.lastConnectMs > 12000) {
     Serial.println("BLE: Disconnecting unauthenticated client after timeout");
@@ -2239,6 +2392,34 @@ BLEDebugStats BLENavigationServer::getDebugStats() const {
   stats.connected = connected;
   stats.authenticated = bleSessionAuthenticated;
   return stats;
+}
+
+bool BLENavigationServer::forgetOwner() {
+  if (!deviceOwnershipReady || !deviceOwnership.isClaimed() ||
+      !deviceOwnership.clearOwner()) {
+    return false;
+  }
+  bleSessionAuthenticated = false;
+  bleDebugStats.authenticated = false;
+  ownershipAdvertisingDirty = true;
+  queueOwnershipUiUpdate();
+  ownershipRestartRequested = true;
+  ownershipRestartRequestedMs = millis();
+  Serial.println("BLE: Owner cleared by physical recovery action");
+  return true;
+}
+
+bool BLENavigationServer::confirmOwnershipPairing() {
+  if (!deviceOwnershipReady || !deviceOwnership.confirmPairingOnDevice()) {
+    return false;
+  }
+  const std::string response =
+      "PAIR_READY|" + deviceOwnership.deviceIdHex();
+  notifyAuthResponse(response.c_str());
+  queueOwnershipUiUpdate(
+      static_cast<int32_t>(deviceOwnership.pairingCode()));
+  Serial.println("BLE: Ownership pairing confirmed with physical BOOT press");
+  return true;
 }
 
 // ============================================================================

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -208,6 +208,7 @@ public:
   void noteOwnershipDisplayFlushCompleted();
   bool ownershipPairingRenderedRequest(uint32_t &pairingGeneration);
   bool armOwnershipPairingConfirmation(uint32_t pairingGeneration);
+  bool isOwnershipClaimed();
   bool hasOwnershipPairingCode();
   bool confirmOwnershipPairing();
 

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -205,6 +205,10 @@ public:
    * @brief Clear the registered iPhone owner after physical recovery input.
    */
   bool forgetOwner();
+  void noteOwnershipDisplayFlushCompleted();
+  bool ownershipPairingRenderedRequest(uint32_t &pairingGeneration);
+  bool armOwnershipPairingConfirmation(uint32_t pairingGeneration);
+  bool hasOwnershipPairingCode();
   bool confirmOwnershipPairing();
 
   BLEDebugStats getDebugStats() const;

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -201,6 +201,12 @@ public:
    */
   void process();
 
+  /**
+   * @brief Clear the registered iPhone owner after physical recovery input.
+   */
+  bool forgetOwner();
+  bool confirmOwnershipPairing();
+
   BLEDebugStats getDebugStats() const;
 
 private:

--- a/esp32/lib/ble_navigation/device_ownership.cpp
+++ b/esp32/lib/ble_navigation/device_ownership.cpp
@@ -2,6 +2,8 @@
 
 #include <Preferences.h>
 #include <esp_system.h>
+#include <esp_mac.h>
+#include <mbedtls/gcm.h>
 
 #include <algorithm>
 #include <array>
@@ -18,7 +20,12 @@ constexpr char OWNER_VERSION_KEY[] = "version";
 constexpr char OWNER_ID_KEY[] = "ownerId";
 constexpr char OWNER_KEY_KEY[] = "ownerKey";
 constexpr char DEVICE_NAME_KEY[] = "name";
+constexpr char REVOCATION_VERSION_KEY[] = "revVersion";
+constexpr char REVOKED_OWNER_ID_KEY[] = "revOwner";
+constexpr char REVOCATION_NONCE_KEY[] = "revNonce";
+constexpr char REVOCATION_PROOF_KEY[] = "revProof";
 constexpr uint8_t OWNER_VERSION = 2;
+constexpr uint8_t REVOCATION_VERSION = 1;
 
 std::vector<std::string> split(const std::string &value) {
   std::vector<std::string> parts;
@@ -42,36 +49,120 @@ bool isHexNonce(const std::string &nonce) {
          });
 }
 
-std::array<uint8_t, 32>
-proofFor(const OwnerKey &key, const char *prefix,
-         const TranscriptHash &transcriptHash) {
-  std::array<uint8_t, 32> proof{};
+bool proofFor(const OwnerKey &key, const char *prefix,
+              const TranscriptHash &transcriptHash,
+              std::array<uint8_t, 32> &proof) {
+  proof.fill(0);
   std::array<uint8_t, 7 + TRANSCRIPT_HASH_SIZE> message{};
   const size_t prefixLength = strlen(prefix);
   if (prefixLength > 7) {
-    return proof;
+    return false;
   }
   memcpy(message.data(), prefix, prefixLength);
   memcpy(message.data() + prefixLength, transcriptHash.data(),
          transcriptHash.size());
-  hmacSha256(key.data(), key.size(), message.data(),
-             prefixLength + transcriptHash.size(), proof.data());
-  return proof;
+  return hmacSha256(key.data(), key.size(), message.data(),
+                    prefixLength + transcriptHash.size(), proof.data());
 }
 
-std::array<uint8_t, 32> stringProofFor(const OwnerKey &key,
-                                       const std::string &message) {
-  std::array<uint8_t, 32> proof{};
-  hmacSha256(key.data(), key.size(),
-             reinterpret_cast<const uint8_t *>(message.data()), message.size(),
-             proof.data());
-  return proof;
+bool stringProofFor(const OwnerKey &key, const std::string &message,
+                    std::array<uint8_t, 32> &proof) {
+  proof.fill(0);
+  return hmacSha256(key.data(), key.size(),
+                    reinterpret_cast<const uint8_t *>(message.data()),
+                    message.size(), proof.data());
 }
 
 bool ownerMatches(const OwnerId &expected, const std::string &candidateHex) {
   OwnerId candidate{};
   return hexDecode(candidateHex, candidate.data(), candidate.size()) &&
          constantTimeEquals(expected.data(), candidate.data(), expected.size());
+}
+
+void makeFrameNonce(AuthenticatedChannel channel, uint32_t sequence,
+                    std::array<uint8_t, 12> &nonce) {
+  nonce.fill(0);
+  nonce[0] = static_cast<uint8_t>(channel);
+  nonce[8] = static_cast<uint8_t>(sequence >> 24);
+  nonce[9] = static_cast<uint8_t>(sequence >> 16);
+  nonce[10] = static_cast<uint8_t>(sequence >> 8);
+  nonce[11] = static_cast<uint8_t>(sequence);
+}
+
+bool decryptFrame(const OwnerKey &key, AuthenticatedChannel channel,
+                  uint32_t sequence, const uint8_t *ciphertext, size_t length,
+                  const uint8_t tag[16], const char *aadPrefix,
+                  std::string &plaintext) {
+  std::array<uint8_t, 12> nonce{};
+  makeFrameNonce(channel, sequence, nonce);
+  std::vector<uint8_t> aad(aadPrefix, aadPrefix + strlen(aadPrefix));
+  aad.push_back(static_cast<uint8_t>(channel));
+  aad.push_back(static_cast<uint8_t>(sequence >> 24));
+  aad.push_back(static_cast<uint8_t>(sequence >> 16));
+  aad.push_back(static_cast<uint8_t>(sequence >> 8));
+  aad.push_back(static_cast<uint8_t>(sequence));
+  std::vector<uint8_t> output(length);
+  uint8_t emptyInput = 0;
+  uint8_t emptyOutput = 0;
+  const uint8_t *safeCiphertext = length == 0 ? &emptyInput : ciphertext;
+  uint8_t *safeOutput = length == 0 ? &emptyOutput : output.data();
+  mbedtls_gcm_context context;
+  mbedtls_gcm_init(&context);
+  const int result =
+      mbedtls_gcm_setkey(&context, MBEDTLS_CIPHER_ID_AES, key.data(), 256) == 0
+          ? mbedtls_gcm_auth_decrypt(
+                &context, length, nonce.data(), nonce.size(), aad.data(),
+                aad.size(), tag, 16, safeCiphertext, safeOutput)
+                         : -1;
+  mbedtls_gcm_free(&context);
+  if (result != 0) return false;
+  if (output.empty()) {
+    plaintext.clear();
+  } else {
+    plaintext.assign(reinterpret_cast<const char *>(output.data()),
+                     output.size());
+  }
+  return true;
+}
+
+bool encryptFrame(const OwnerKey &key, AuthenticatedChannel channel,
+                  uint32_t sequence, const std::string &plaintext,
+                  const char *aadPrefix, std::string &ciphertext,
+                  std::array<uint8_t, 16> &tag) {
+  std::array<uint8_t, 12> nonce{};
+  makeFrameNonce(channel, sequence, nonce);
+  std::vector<uint8_t> aad(aadPrefix, aadPrefix + strlen(aadPrefix));
+  aad.push_back(static_cast<uint8_t>(channel));
+  aad.push_back(static_cast<uint8_t>(sequence >> 24));
+  aad.push_back(static_cast<uint8_t>(sequence >> 16));
+  aad.push_back(static_cast<uint8_t>(sequence >> 8));
+  aad.push_back(static_cast<uint8_t>(sequence));
+  std::vector<uint8_t> output(plaintext.size());
+  uint8_t emptyInput = 0;
+  uint8_t emptyOutput = 0;
+  const uint8_t *safePlaintext =
+      plaintext.empty()
+          ? &emptyInput
+          : reinterpret_cast<const uint8_t *>(plaintext.data());
+  uint8_t *safeOutput = plaintext.empty() ? &emptyOutput : output.data();
+  mbedtls_gcm_context context;
+  mbedtls_gcm_init(&context);
+  const int result =
+      mbedtls_gcm_setkey(&context, MBEDTLS_CIPHER_ID_AES, key.data(), 256) == 0
+          ? mbedtls_gcm_crypt_and_tag(
+                &context, MBEDTLS_GCM_ENCRYPT, plaintext.size(), nonce.data(),
+                nonce.size(), aad.data(), aad.size(),
+                safePlaintext, safeOutput, tag.size(), tag.data())
+                         : -1;
+  mbedtls_gcm_free(&context);
+  if (result != 0) return false;
+  if (output.empty()) {
+    ciphertext.clear();
+  } else {
+    ciphertext.assign(reinterpret_cast<const char *>(output.data()),
+                      output.size());
+  }
+  return true;
 }
 
 } // namespace
@@ -117,10 +208,42 @@ bool isValidDeviceName(const std::string &name) {
   if (name.empty() || name.size() > MAX_DEVICE_NAME_BYTES) {
     return false;
   }
-  for (const unsigned char byte : name) {
+  for (size_t index = 0; index < name.size();) {
+    const uint8_t byte = static_cast<uint8_t>(name[index]);
     if (byte == 0 || byte == '|' || byte < 0x20 || byte == 0x7F) {
       return false;
     }
+    if (byte <= 0x7F) {
+      index++;
+      continue;
+    }
+    size_t continuationCount = 0;
+    if (byte >= 0xC2 && byte <= 0xDF) {
+      continuationCount = 1;
+    } else if (byte >= 0xE0 && byte <= 0xEF) {
+      continuationCount = 2;
+    } else if (byte >= 0xF0 && byte <= 0xF4) {
+      continuationCount = 3;
+    } else {
+      return false;
+    }
+    if (index + continuationCount >= name.size()) {
+      return false;
+    }
+    const uint8_t second = static_cast<uint8_t>(name[index + 1]);
+    if ((second & 0xC0) != 0x80 ||
+        (byte == 0xE0 && second < 0xA0) ||
+        (byte == 0xED && second > 0x9F) ||
+        (byte == 0xF0 && second < 0x90) ||
+        (byte == 0xF4 && second > 0x8F)) {
+      return false;
+    }
+    for (size_t offset = 2; offset <= continuationCount; offset++) {
+      if ((static_cast<uint8_t>(name[index + offset]) & 0xC0) != 0x80) {
+        return false;
+      }
+    }
+    index += continuationCount + 1;
   }
   return true;
 }
@@ -129,7 +252,21 @@ bool DeviceOwnership::begin() {
   if (!loadOrCreateDeviceId()) {
     return false;
   }
-  loadOwner();
+  if (!loadOwner()) {
+    // If ownership storage cannot be read, keep the device locked. Treating an
+    // I/O failure as "unclaimed" would silently re-enable the shared v1 key.
+    claimed_ = true;
+    ownerRecordValid_ = false;
+    legacyAuthenticationAllowed_ = false;
+  }
+  if (!deviceIdIntegrityValid_) {
+    // Never bind an otherwise valid owner record to a newly minted identity.
+    // Stay recoverably locked until the physical owner-reset action removes
+    // the orphaned record.
+    claimed_ = true;
+    ownerRecordValid_ = false;
+    legacyAuthenticationAllowed_ = false;
+  }
   if (deviceName_.empty()) {
     deviceName_ = defaultDeviceName();
   }
@@ -138,8 +275,14 @@ bool DeviceOwnership::begin() {
 
 void DeviceOwnership::resetConnection() {
   sessionAuthenticated_ = false;
+  sessionWriteKey_.fill(0);
+  sessionNotifyKey_.fill(0);
+  lastInboundSequence_.fill(0);
+  nextOutboundSequence_.fill(0);
   pendingAuthNonce_[0] = '\0';
+  pendingServerAuthNonce_[0] = '\0';
   clearPairing();
+  pairingAttemptedOnConnection_ = false;
 }
 
 void DeviceOwnership::process(uint32_t nowMs) {
@@ -165,6 +308,20 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
                       hexEncode(reinterpret_cast<const uint8_t *>(
                                     deviceName_.data()),
                                 deviceName_.size());
+    if (revocationReceiptValid_ && (!claimed_ || ownerRecordValid_)) {
+      // Keep the prior owner's signed receipt visible even after a new owner
+      // registers. Omitting the name and already-known owner ID keeps this
+      // durable reconciliation record within the supported 182-byte ATT value.
+      // A claimed but invalid owner record is a storage failure, not a completed
+      // handoff; suppress its receipt so iOS cannot delete the only usable key.
+      result.response = "DEVICE|2|" + deviceIdHex() + "|" +
+                         (claimed_ ? "1" : "0") + "||" +
+                         hexEncode(revocationNonce_.data(),
+                                   revocationNonce_.size()) +
+                         "|" +
+                         hexEncode(revocationProof_.data(),
+                                   revocationProof_.size());
+    }
     return result;
   }
 
@@ -174,7 +331,15 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
       result.response = "OWNED|" + deviceIdHex();
       return result;
     }
+    if (pairingAttemptedOnConnection_) {
+      result.response = "ERROR|pairing_attempt_already_used";
+      return result;
+    }
 
+    // Bound unauthenticated P-256 work to one valid request per BLE connection.
+    // A new transcript requires a reconnect, and claiming the device still
+    // requires an explicit physical confirmation after the comparison code is
+    // visible on both sides.
     OwnerId requestedOwner{};
     PublicKey appPublicKey{};
     if (!hexDecode(parts[1], requestedOwner.data(), requestedOwner.size()) ||
@@ -182,6 +347,8 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
       result.response = "ERROR|invalid_pairing_request";
       return result;
     }
+    pairingAttemptedOnConnection_ = true;
+    clearPairing();
     if (!pairingKey_.generate() ||
         !pairingKey_.publicKey(pendingDevicePublicKey_) ||
         !pairingKey_.derive(appPublicKey, deviceId_, requestedOwner,
@@ -196,6 +363,11 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
     pendingAppPublicKey_ = appPublicKey;
     pendingDeviceName_.clear();
     pairingStartedMs_ = nowMs;
+    pairingGeneration_++;
+    if (pairingGeneration_ == 0) {
+      pairingGeneration_++;
+    }
+    armedPairingGeneration_ = 0;
     pairingActive_ = true;
     result.event = Event::PairingStarted;
     result.response = "PAIRING|" + deviceIdHex() + "|" +
@@ -212,12 +384,12 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
     }
     std::array<uint8_t, 32> suppliedProof{};
     std::array<uint8_t, MAX_DEVICE_NAME_BYTES> nameBytes{};
-    const std::array<uint8_t, 32> expectedProof =
-        proofFor(pendingPairing_.ownerKey, "claim|",
-                 pendingPairing_.transcriptHash);
+    std::array<uint8_t, 32> expectedProof{};
     if (!pairingActive_ ||
         static_cast<uint32_t>(nowMs - pairingStartedMs_) >
             PAIRING_SESSION_TIMEOUT_MS ||
+        !proofFor(pendingPairing_.ownerKey, "claim|",
+                  pendingPairing_.transcriptHash, expectedProof) ||
         !ownerMatches(pendingOwnerId_, parts[1]) ||
         !hexDecode(parts[2], suppliedProof.data(), suppliedProof.size()) ||
         !constantTimeEquals(expectedProof.data(), suppliedProof.data(),
@@ -241,15 +413,24 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
     ownerId_ = pendingOwnerId_;
     ownerKey_ = pendingPairing_.ownerKey;
     deviceName_ = pendingDeviceName_;
-    claimed_ = persistOwner();
-    if (!claimed_) {
+    if (!persistOwner()) {
       result.response = "ERROR|pairing_persistence_failed";
-      ownerId_.fill(0);
-      ownerKey_.fill(0);
-      deviceName_ = defaultDeviceName();
+      // Best-effort rollback. If cleanup cannot be proven, remain locked in
+      // memory so a partial record can never downgrade to the legacy key. A
+      // durable revocation receipt belongs to the prior owner and must survive
+      // every failed new-owner write boundary.
+      if (!clearOwnerStorage(false, true)) {
+        claimed_ = true;
+        ownerRecordValid_ = false;
+        legacyAuthenticationAllowed_ = false;
+        sessionAuthenticated_ = false;
+      }
       clearPairing();
       return result;
     }
+    claimed_ = true;
+    ownerRecordValid_ = true;
+    legacyAuthenticationAllowed_ = false;
     result.event = Event::Paired;
     result.response = "PAIRED|" + deviceIdHex() + "|" +
                       hexEncode(reinterpret_cast<const uint8_t *>(
@@ -262,7 +443,10 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
   if (parts[0] == "OWNER" && parts.size() == 3) {
     result.matched = true;
     sessionAuthenticated_ = false;
-    if (!claimed_ || !ownerMatches(ownerId_, parts[1]) ||
+    pendingAuthNonce_[0] = '\0';
+    pendingServerAuthNonce_[0] = '\0';
+    if (!claimed_ || !ownerRecordValid_ ||
+        !ownerMatches(ownerId_, parts[1]) ||
         !isHexNonce(parts[2])) {
       result.response = "DENIED|" + deviceIdHex();
       return result;
@@ -270,21 +454,36 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
     strncpy(pendingAuthNonce_, parts[2].c_str(),
             sizeof(pendingAuthNonce_) - 1);
     pendingAuthNonce_[sizeof(pendingAuthNonce_) - 1] = '\0';
+    std::array<uint8_t, 16> serverNonce{};
+    esp_fill_random(serverNonce.data(), serverNonce.size());
+    const std::string serverNonceHex =
+        hexEncode(serverNonce.data(), serverNonce.size());
+    strncpy(pendingServerAuthNonce_, serverNonceHex.c_str(),
+            sizeof(pendingServerAuthNonce_) - 1);
+    pendingServerAuthNonce_[sizeof(pendingServerAuthNonce_) - 1] = '\0';
     const std::string message = "server2|" + deviceIdHex() + "|" + parts[1] +
-                                "|" + parts[2];
-    const auto proof = stringProofFor(ownerKey_, message);
+                                "|" + parts[2] + "|" + serverNonceHex;
+    std::array<uint8_t, 32> proof{};
+    if (!stringProofFor(ownerKey_, message, proof)) {
+      pendingAuthNonce_[0] = '\0';
+      pendingServerAuthNonce_[0] = '\0';
+      result.response = "DENIED|" + deviceIdHex();
+      return result;
+    }
     result.response = "SERVER2|" + deviceIdHex() + "|" + parts[2] + "|" +
+                      serverNonceHex + "|" +
                       hexEncode(proof.data(), proof.size());
     return result;
   }
 
-  if (parts[0] == "PROOF" && parts.size() == 4) {
+  if (parts[0] == "PROOF" && parts.size() == 5) {
     result.matched = true;
     std::array<uint8_t, 32> suppliedProof{};
     const std::string message = "client2|" + deviceIdHex() + "|" + parts[1] +
-                                "|" + parts[2];
-    const auto expectedProof = stringProofFor(ownerKey_, message);
-    if (!claimed_ || parts[2].size() != 32 ||
+                                "|" + parts[2] + "|" + parts[3];
+    std::array<uint8_t, 32> expectedProof{};
+    if (!claimed_ || !ownerRecordValid_ || parts[2].size() != 32 ||
+        parts[3].size() != 32 ||
         !ownerMatches(ownerId_, parts[1]) ||
         !constantTimeEquals(reinterpret_cast<const uint8_t *>(
                                 pendingAuthNonce_),
@@ -292,17 +491,42 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
                                 parts[2].c_str()),
                             32) ||
         pendingAuthNonce_[32] != '\0' ||
-        !hexDecode(parts[3], suppliedProof.data(), suppliedProof.size()) ||
+        !constantTimeEquals(reinterpret_cast<const uint8_t *>(
+                                pendingServerAuthNonce_),
+                            reinterpret_cast<const uint8_t *>(
+                                parts[3].c_str()),
+                            32) ||
+        pendingServerAuthNonce_[32] != '\0' ||
+        !stringProofFor(ownerKey_, message, expectedProof) ||
+        !hexDecode(parts[4], suppliedProof.data(), suppliedProof.size()) ||
         !constantTimeEquals(expectedProof.data(), suppliedProof.data(),
                             expectedProof.size())) {
       result.response = "DENIED|" + deviceIdHex();
       pendingAuthNonce_[0] = '\0';
+      pendingServerAuthNonce_[0] = '\0';
+      return result;
+    }
+    const std::string sessionContext =
+        deviceIdHex() + "|" + parts[2] + "|" + parts[3];
+    if (!stringProofFor(ownerKey_, "session2-write|" + sessionContext,
+                        sessionWriteKey_) ||
+        !stringProofFor(ownerKey_, "session2-notify|" + sessionContext,
+                        sessionNotifyKey_)) {
+      result.response = "DENIED|" + deviceIdHex();
+      pendingAuthNonce_[0] = '\0';
+      pendingServerAuthNonce_[0] = '\0';
+      sessionWriteKey_.fill(0);
+      sessionNotifyKey_.fill(0);
       return result;
     }
     pendingAuthNonce_[0] = '\0';
+    pendingServerAuthNonce_[0] = '\0';
+    lastInboundSequence_.fill(0);
+    nextOutboundSequence_.fill(0);
     sessionAuthenticated_ = true;
     result.event = Event::Authenticated;
-    result.response = "OK2|" + deviceIdHex() + "|" + parts[2];
+    result.response = "OK2|" + deviceIdHex() + "|" + parts[2] + "|" +
+                      parts[3];
     return result;
   }
 
@@ -323,7 +547,29 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
       return result;
     }
     result.event = Event::Renamed;
-    result.response = "NAME_OK|" + parts[1];
+    const std::string response = "NAME_OK|" + parts[1];
+    if (!protectAuthenticatedPayload(AuthenticatedChannel::Auth, response,
+                                     result.response)) {
+      result.response = "ERROR|response_authentication_failed";
+      result.event = Event::None;
+    }
+    return result;
+  }
+
+  if (parts[0] == "GET_NAME" && parts.size() == 1) {
+    result.matched = true;
+    if (!sessionAuthenticated_) {
+      result.response = "ERROR|name_read_rejected";
+      return result;
+    }
+    const std::string response =
+        "NAME_INFO|" +
+        hexEncode(reinterpret_cast<const uint8_t *>(deviceName_.data()),
+                  deviceName_.size());
+    if (!protectAuthenticatedPayload(AuthenticatedChannel::Auth, response,
+                                     result.response)) {
+      result.response = "ERROR|response_authentication_failed";
+    }
     return result;
   }
 
@@ -334,47 +580,215 @@ CommandResult DeviceOwnership::handle(const std::string &payload,
       return result;
     }
     const std::string id = deviceIdHex();
-    if (!clearOwner()) {
+    const std::string ownerIdHex =
+        hexEncode(ownerId_.data(), ownerId_.size());
+    std::array<uint8_t, 16> receiptNonce{};
+    std::array<uint8_t, 32> receiptProof{};
+    esp_fill_random(receiptNonce.data(), receiptNonce.size());
+    const std::string receiptNonceHex =
+        hexEncode(receiptNonce.data(), receiptNonce.size());
+    if (!stringProofFor(ownerKey_,
+                        "revoked2|" + id + "|" + ownerIdHex + "|" +
+                            receiptNonceHex,
+                        receiptProof) ||
+        !persistRevocationReceipt(ownerId_, receiptNonce, receiptProof)) {
+      result.response = "ERROR|unpair_persistence_failed";
+      return result;
+    }
+    std::string protectedResponse;
+    if (!protectAuthenticatedPayload(AuthenticatedChannel::Auth,
+                                     "UNPAIRED2|" + id + "|" +
+                                         receiptNonceHex + "|" +
+                                         hexEncode(receiptProof.data(),
+                                                   receiptProof.size()),
+                                     protectedResponse) ||
+        !clearOwnerStorage(false, true)) {
       result.response = "ERROR|unpair_persistence_failed";
       return result;
     }
     result.event = Event::Unpaired;
-    result.response = "UNPAIRED|" + id;
+    result.response = protectedResponse;
     return result;
   }
 
   return result;
 }
 
+bool DeviceOwnership::armPairingConfirmation(uint32_t pairingGeneration) {
+  if (!pairingActive_ || pairingGeneration == 0 ||
+      pairingGeneration != pairingGeneration_) {
+    return false;
+  }
+  armedPairingGeneration_ = pairingGeneration;
+  return true;
+}
+
 bool DeviceOwnership::confirmPairingOnDevice() {
-  if (!pairingActive_) {
+  if (!pairingActive_ || pairingConfirmedOnDevice_ ||
+      armedPairingGeneration_ != pairingGeneration_) {
     return false;
   }
   pairingConfirmedOnDevice_ = true;
   return true;
 }
 
+bool DeviceOwnership::unwrapAuthenticatedPayload(
+    AuthenticatedChannel channel, const std::string &frame,
+    std::string &payload) {
+  constexpr size_t headerSize = 6;
+  constexpr size_t tagSize = 16;
+  const size_t channelIndex = static_cast<size_t>(channel);
+  payload.clear();
+  if (!sessionAuthenticated_ || channelIndex == 0 ||
+      channelIndex >= lastInboundSequence_.size() ||
+      frame.size() < headerSize + tagSize || frame[0] != 'S' ||
+      frame[1] != '2') {
+    return false;
+  }
+  const auto *bytes = reinterpret_cast<const uint8_t *>(frame.data());
+  const uint32_t sequence = (static_cast<uint32_t>(bytes[2]) << 24) |
+                            (static_cast<uint32_t>(bytes[3]) << 16) |
+                            (static_cast<uint32_t>(bytes[4]) << 8) |
+                            static_cast<uint32_t>(bytes[5]);
+  if (sequence == 0 || sequence <= lastInboundSequence_[channelIndex]) {
+    return false;
+  }
+  const size_t payloadSize = frame.size() - headerSize - tagSize;
+  if (!decryptFrame(sessionWriteKey_, channel, sequence, bytes + headerSize,
+                    payloadSize, bytes + headerSize + payloadSize, "write2|",
+                    payload)) {
+    return false;
+  }
+  lastInboundSequence_[channelIndex] = sequence;
+  return true;
+}
+
+bool DeviceOwnership::protectAuthenticatedPayload(
+    AuthenticatedChannel channel, const std::string &payload,
+    std::string &frame) {
+  constexpr size_t headerSize = 6;
+  constexpr size_t tagSize = 16;
+  const size_t channelIndex = static_cast<size_t>(channel);
+  frame.clear();
+  if (!sessionAuthenticated_ || channelIndex == 0 ||
+      channelIndex >= nextOutboundSequence_.size() ||
+      nextOutboundSequence_[channelIndex] == UINT32_MAX) {
+    return false;
+  }
+  const uint32_t sequence = ++nextOutboundSequence_[channelIndex];
+  const uint8_t sequenceBytes[4] = {
+      static_cast<uint8_t>(sequence >> 24),
+      static_cast<uint8_t>(sequence >> 16),
+      static_cast<uint8_t>(sequence >> 8), static_cast<uint8_t>(sequence)};
+  std::array<uint8_t, 16> tag{};
+  std::string ciphertext;
+  if (!encryptFrame(sessionNotifyKey_, channel, sequence, payload, "notify2|",
+                    ciphertext, tag)) {
+    return false;
+  }
+  frame.reserve(headerSize + payload.size() + tagSize);
+  frame.append("R2", 2);
+  frame.append(reinterpret_cast<const char *>(sequenceBytes),
+               sizeof(sequenceBytes));
+  frame.append(ciphertext);
+  frame.append(reinterpret_cast<const char *>(tag.data()), tagSize);
+  return true;
+}
+
 bool DeviceOwnership::clearOwner() {
+  return clearOwnerStorage(false, false);
+}
+
+bool DeviceOwnership::clearOwnerStorage(bool preserveSession,
+                                        bool preserveRevocationReceipt) {
   Preferences preferences;
   if (!preferences.begin(NVS_NAMESPACE, false)) {
     return false;
   }
-  const bool markerRemoved = !preferences.isKey(OWNER_VERSION_KEY) ||
-                             preferences.remove(OWNER_VERSION_KEY);
-  preferences.remove(OWNER_ID_KEY);
-  preferences.remove(OWNER_KEY_KEY);
-  preferences.remove(DEVICE_NAME_KEY);
+  const auto removeIfPresent = [&preferences](const char *key) {
+    return !preferences.isKey(key) || preferences.remove(key);
+  };
+  // Remove the validity marker last. A power loss during cleanup therefore
+  // leaves a locked/corrupt record instead of silently enabling the v1 key.
+  const bool ownerIdRemoved = removeIfPresent(OWNER_ID_KEY);
+  const bool ownerKeyRemoved = removeIfPresent(OWNER_KEY_KEY);
+  const bool nameRemoved = removeIfPresent(DEVICE_NAME_KEY);
+  const bool markerRemoved = removeIfPresent(OWNER_VERSION_KEY);
+  const bool receiptRemoved =
+      preserveRevocationReceipt || clearRevocationReceipt(preferences);
   preferences.end();
-  if (!markerRemoved) {
+  if (!ownerIdRemoved || !ownerKeyRemoved || !nameRemoved || !markerRemoved ||
+      !receiptRemoved) {
+    claimed_ = true;
+    ownerRecordValid_ = false;
+    legacyAuthenticationAllowed_ = false;
+    sessionAuthenticated_ = false;
     return false;
   }
   ownerId_.fill(0);
   ownerKey_.fill(0);
+  if (!preserveSession) {
+    sessionWriteKey_.fill(0);
+    sessionNotifyKey_.fill(0);
+    lastInboundSequence_.fill(0);
+    nextOutboundSequence_.fill(0);
+    sessionAuthenticated_ = false;
+  }
   claimed_ = false;
-  sessionAuthenticated_ = false;
+  ownerRecordValid_ = false;
+  legacyAuthenticationAllowed_ = false;
   deviceName_ = defaultDeviceName();
   clearPairing();
   return true;
+}
+
+bool DeviceOwnership::persistRevocationReceipt(
+    const OwnerId &ownerId, const std::array<uint8_t, 16> &nonce,
+    const std::array<uint8_t, 32> &proof) {
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  if (preferences.isKey(REVOCATION_VERSION_KEY) &&
+      !preferences.remove(REVOCATION_VERSION_KEY)) {
+    preferences.end();
+    return false;
+  }
+  const bool stored =
+      preferences.putBytes(REVOKED_OWNER_ID_KEY, ownerId.data(),
+                           ownerId.size()) == ownerId.size() &&
+      preferences.putBytes(REVOCATION_NONCE_KEY, nonce.data(), nonce.size()) ==
+          nonce.size() &&
+      preferences.putBytes(REVOCATION_PROOF_KEY, proof.data(), proof.size()) ==
+          proof.size() &&
+      preferences.putUChar(REVOCATION_VERSION_KEY, REVOCATION_VERSION) ==
+          sizeof(uint8_t);
+  preferences.end();
+  if (stored) {
+    revokedOwnerId_ = ownerId;
+    revocationNonce_ = nonce;
+    revocationProof_ = proof;
+    revocationReceiptValid_ = true;
+  }
+  return stored;
+}
+
+bool DeviceOwnership::clearRevocationReceipt(Preferences &preferences) {
+  const auto removeIfPresent = [&preferences](const char *key) {
+    return !preferences.isKey(key) || preferences.remove(key);
+  };
+  const bool ownerRemoved = removeIfPresent(REVOKED_OWNER_ID_KEY);
+  const bool nonceRemoved = removeIfPresent(REVOCATION_NONCE_KEY);
+  const bool proofRemoved = removeIfPresent(REVOCATION_PROOF_KEY);
+  const bool markerRemoved = removeIfPresent(REVOCATION_VERSION_KEY);
+  if (ownerRemoved && nonceRemoved && proofRemoved && markerRemoved) {
+    revokedOwnerId_.fill(0);
+    revocationNonce_.fill(0);
+    revocationProof_.fill(0);
+    revocationReceiptValid_ = false;
+    return true;
+  }
+  return false;
 }
 
 std::string DeviceOwnership::deviceIdHex() const {
@@ -384,8 +798,9 @@ std::string DeviceOwnership::deviceIdHex() const {
 std::string DeviceOwnership::advertisedName() const { return deviceName_; }
 
 std::vector<uint8_t> DeviceOwnership::advertisementManufacturerData() const {
+  const uint8_t flags = static_cast<uint8_t>(claimed_ ? 0x01 : 0x00);
   return {0xFF, 0xFF, PROTOCOL_VERSION,
-          static_cast<uint8_t>(claimed_ ? 1 : 0), deviceId_[12], deviceId_[13],
+          flags, deviceId_[12], deviceId_[13],
           deviceId_[14], deviceId_[15]};
 }
 
@@ -394,13 +809,51 @@ bool DeviceOwnership::loadOrCreateDeviceId() {
   if (!preferences.begin(NVS_NAMESPACE, false)) {
     return false;
   }
-  if (preferences.getBytesLength(DEVICE_ID_KEY) == deviceId_.size() &&
-      preferences.getBytes(DEVICE_ID_KEY, deviceId_.data(), deviceId_.size()) ==
-          deviceId_.size()) {
+  const bool hasOwnerArtifacts = preferences.isKey(OWNER_VERSION_KEY) ||
+                                 preferences.isKey(OWNER_ID_KEY) ||
+                                 preferences.isKey(OWNER_KEY_KEY) ||
+                                 preferences.isKey(DEVICE_NAME_KEY);
+  uint8_t hardwareMac[6]{};
+  std::array<uint8_t, 32> identityDigest{};
+  static constexpr char identityDomain[] = "BikeComputer device ID v2";
+  std::array<uint8_t, sizeof(identityDomain) - 1 + sizeof(hardwareMac)>
+      identityInput{};
+  memcpy(identityInput.data(), identityDomain, sizeof(identityDomain) - 1);
+  if (esp_efuse_mac_get_default(hardwareMac) != ESP_OK) {
+    preferences.end();
+    return false;
+  }
+  memcpy(identityInput.data() + sizeof(identityDomain) - 1, hardwareMac,
+         sizeof(hardwareMac));
+  if (!sha256(identityInput.data(), identityInput.size(),
+              identityDigest.data())) {
+    preferences.end();
+    return false;
+  }
+
+  std::array<uint8_t, 16> storedDeviceId{};
+  const bool hasStoredDeviceId =
+      preferences.getBytesLength(DEVICE_ID_KEY) == storedDeviceId.size() &&
+      preferences.getBytes(DEVICE_ID_KEY, storedDeviceId.data(),
+                           storedDeviceId.size()) == storedDeviceId.size();
+  memcpy(deviceId_.data(), identityDigest.data(), deviceId_.size());
+  if (hasStoredDeviceId &&
+      constantTimeEquals(storedDeviceId.data(), deviceId_.data(),
+                         deviceId_.size())) {
     preferences.end();
     return true;
   }
-  esp_fill_random(deviceId_.data(), deviceId_.size());
+
+  if (hasOwnerArtifacts) {
+    // Device identity is derived from immutable eFuse material. Never bind an
+    // existing owner credential to a missing or same-length corrupted cache.
+    deviceIdIntegrityValid_ = false;
+    preferences.end();
+    return true;
+  }
+
+  // An unclaimed device can safely repair a missing/corrupt cache from the
+  // deterministic hardware identity.
   const bool stored = preferences.putBytes(DEVICE_ID_KEY, deviceId_.data(),
                                            deviceId_.size()) == deviceId_.size();
   preferences.end();
@@ -408,11 +861,48 @@ bool DeviceOwnership::loadOrCreateDeviceId() {
 }
 
 bool DeviceOwnership::loadOwner() {
+  revokedOwnerId_.fill(0);
+  revocationNonce_.fill(0);
+  revocationProof_.fill(0);
+  revocationReceiptValid_ = false;
   Preferences preferences;
   if (!preferences.begin(NVS_NAMESPACE, false)) {
     return false;
   }
-  const bool valid = preferences.getUChar(OWNER_VERSION_KEY, 0) ==
+  const bool hasMarker = preferences.isKey(OWNER_VERSION_KEY);
+  const bool hasOwnerId = preferences.isKey(OWNER_ID_KEY);
+  const bool hasOwnerKey = preferences.isKey(OWNER_KEY_KEY);
+  const bool hasName = preferences.isKey(DEVICE_NAME_KEY);
+  const bool hasRevocationReceipt =
+      preferences.getUChar(REVOCATION_VERSION_KEY, 0) ==
+          REVOCATION_VERSION &&
+      preferences.getBytesLength(REVOKED_OWNER_ID_KEY) ==
+          revokedOwnerId_.size() &&
+      preferences.getBytesLength(REVOCATION_NONCE_KEY) ==
+          revocationNonce_.size() &&
+      preferences.getBytesLength(REVOCATION_PROOF_KEY) ==
+          revocationProof_.size();
+  if (hasRevocationReceipt) {
+    revocationReceiptValid_ =
+        preferences.getBytes(REVOKED_OWNER_ID_KEY, revokedOwnerId_.data(),
+                             revokedOwnerId_.size()) == revokedOwnerId_.size() &&
+        preferences.getBytes(REVOCATION_NONCE_KEY, revocationNonce_.data(),
+                             revocationNonce_.size()) == revocationNonce_.size() &&
+        preferences.getBytes(REVOCATION_PROOF_KEY, revocationProof_.data(),
+                             revocationProof_.size()) == revocationProof_.size();
+  }
+  if (!hasMarker && !hasOwnerId && !hasOwnerKey && !hasName) {
+    preferences.end();
+    claimed_ = false;
+    ownerRecordValid_ = false;
+    // Protocol-v2 firmware never falls back to the app-wide v1 key. iOS may
+    // still support genuinely old firmware that does not expose INFO v2.
+    legacyAuthenticationAllowed_ = false;
+    return true;
+  }
+
+  const bool valid = hasMarker && hasOwnerId && hasOwnerKey && hasName &&
+                     preferences.getUChar(OWNER_VERSION_KEY, 0) ==
                          OWNER_VERSION &&
                      preferences.getBytesLength(OWNER_ID_KEY) ==
                          ownerId_.size() &&
@@ -425,11 +915,51 @@ bool DeviceOwnership::loadOwner() {
                                     ownerKey_.size()) == ownerKey_.size();
     deviceName_ = preferences.getString(DEVICE_NAME_KEY, "").c_str();
     if (!isValidDeviceName(deviceName_)) {
-      deviceName_ = defaultDeviceName();
+      claimed_ = false;
     }
   }
   preferences.end();
-  return claimed_;
+  if (!valid || !claimed_) {
+    ownerId_.fill(0);
+    ownerKey_.fill(0);
+    deviceName_ = defaultDeviceName();
+    // A historical receipt can belong to a superseded owner and therefore
+    // cannot prove that corruption in the current record is an interrupted
+    // deregistration. Invalid current-owner storage always fails locked until
+    // the explicit eight-second physical recovery action.
+    claimed_ = true;
+    ownerRecordValid_ = false;
+    legacyAuthenticationAllowed_ = false;
+    return true;
+  }
+  if (revocationReceiptValid_ &&
+      constantTimeEquals(revokedOwnerId_.data(), ownerId_.data(),
+                         ownerId_.size())) {
+    std::array<uint8_t, 32> expectedProof{};
+    const std::string receiptMessage =
+        "revoked2|" + deviceIdHex() + "|" +
+        hexEncode(ownerId_.data(), ownerId_.size()) + "|" +
+        hexEncode(revocationNonce_.data(), revocationNonce_.size());
+    if (stringProofFor(ownerKey_, receiptMessage, expectedProof) &&
+        constantTimeEquals(expectedProof.data(), revocationProof_.data(),
+                           expectedProof.size())) {
+      // The current credential itself signed this tombstone, so power was lost
+      // after durable UNPAIR intent but before owner cleanup. Complete that
+      // transaction before advertising or answering INFO. A receipt from an
+      // older key (even with the same installation OwnerID) remains a handoff
+      // receipt and must not erase a newly committed owner.
+      if (!clearOwnerStorage(false, true)) {
+        // Do not expose a claimed receipt that the current iPhone can verify
+        // while its owner record is still present. Taking ownership offline is
+        // the only fail-closed state until storage cleanup succeeds.
+        return false;
+      }
+      return true;
+    }
+  }
+  ownerRecordValid_ = true;
+  legacyAuthenticationAllowed_ = false;
+  return true;
 }
 
 bool DeviceOwnership::persistOwner() {
@@ -437,7 +967,15 @@ bool DeviceOwnership::persistOwner() {
   if (!preferences.begin(NVS_NAMESPACE, false)) {
     return false;
   }
-  preferences.remove(OWNER_VERSION_KEY);
+  // A revocation receipt is the old phone's durable acknowledgement. Retain it
+  // before, during, and after a new owner-record commit so the prior iPhone can
+  // reconcile a lost handoff. The validity marker keeps partial new-owner
+  // writes from becoming authoritative.
+  if (preferences.isKey(OWNER_VERSION_KEY) &&
+      !preferences.remove(OWNER_VERSION_KEY)) {
+    preferences.end();
+    return false;
+  }
   const bool stored =
       preferences.putBytes(OWNER_ID_KEY, ownerId_.data(), ownerId_.size()) ==
           ownerId_.size() &&
@@ -458,6 +996,7 @@ void DeviceOwnership::clearPairing() {
   pendingDevicePublicKey_.fill(0);
   pendingDeviceName_.clear();
   pairingStartedMs_ = 0;
+  armedPairingGeneration_ = 0;
   pairingActive_ = false;
   pairingConfirmedOnDevice_ = false;
 }

--- a/esp32/lib/ble_navigation/device_ownership.cpp
+++ b/esp32/lib/ble_navigation/device_ownership.cpp
@@ -1,0 +1,490 @@
+#include "device_ownership.hpp"
+
+#include <Preferences.h>
+#include <esp_system.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+
+namespace device_ownership {
+namespace {
+
+constexpr char NVS_NAMESPACE[] = "bleOwner";
+constexpr char DEVICE_ID_KEY[] = "deviceId";
+constexpr char OWNER_VERSION_KEY[] = "version";
+constexpr char OWNER_ID_KEY[] = "ownerId";
+constexpr char OWNER_KEY_KEY[] = "ownerKey";
+constexpr char DEVICE_NAME_KEY[] = "name";
+constexpr uint8_t OWNER_VERSION = 2;
+
+std::vector<std::string> split(const std::string &value) {
+  std::vector<std::string> parts;
+  size_t start = 0;
+  while (start <= value.size()) {
+    const size_t separator = value.find('|', start);
+    if (separator == std::string::npos) {
+      parts.push_back(value.substr(start));
+      break;
+    }
+    parts.push_back(value.substr(start, separator - start));
+    start = separator + 1;
+  }
+  return parts;
+}
+
+bool isHexNonce(const std::string &nonce) {
+  return nonce.size() == 32 &&
+         std::all_of(nonce.begin(), nonce.end(), [](unsigned char character) {
+           return std::isxdigit(character) != 0;
+         });
+}
+
+std::array<uint8_t, 32>
+proofFor(const OwnerKey &key, const char *prefix,
+         const TranscriptHash &transcriptHash) {
+  std::array<uint8_t, 32> proof{};
+  std::array<uint8_t, 7 + TRANSCRIPT_HASH_SIZE> message{};
+  const size_t prefixLength = strlen(prefix);
+  if (prefixLength > 7) {
+    return proof;
+  }
+  memcpy(message.data(), prefix, prefixLength);
+  memcpy(message.data() + prefixLength, transcriptHash.data(),
+         transcriptHash.size());
+  hmacSha256(key.data(), key.size(), message.data(),
+             prefixLength + transcriptHash.size(), proof.data());
+  return proof;
+}
+
+std::array<uint8_t, 32> stringProofFor(const OwnerKey &key,
+                                       const std::string &message) {
+  std::array<uint8_t, 32> proof{};
+  hmacSha256(key.data(), key.size(),
+             reinterpret_cast<const uint8_t *>(message.data()), message.size(),
+             proof.data());
+  return proof;
+}
+
+bool ownerMatches(const OwnerId &expected, const std::string &candidateHex) {
+  OwnerId candidate{};
+  return hexDecode(candidateHex, candidate.data(), candidate.size()) &&
+         constantTimeEquals(expected.data(), candidate.data(), expected.size());
+}
+
+} // namespace
+
+std::string hexEncode(const uint8_t *data, size_t length) {
+  static const char digits[] = "0123456789abcdef";
+  if (data == nullptr) {
+    return "";
+  }
+  std::string result(length * 2, '0');
+  for (size_t index = 0; index < length; index++) {
+    result[index * 2] = digits[(data[index] >> 4) & 0x0F];
+    result[index * 2 + 1] = digits[data[index] & 0x0F];
+  }
+  return result;
+}
+
+bool hexDecode(const std::string &hex, uint8_t *out, size_t length) {
+  if (out == nullptr || hex.size() != length * 2) {
+    return false;
+  }
+  auto nibble = [](char value) -> int {
+    if (value >= '0' && value <= '9')
+      return value - '0';
+    if (value >= 'a' && value <= 'f')
+      return value - 'a' + 10;
+    if (value >= 'A' && value <= 'F')
+      return value - 'A' + 10;
+    return -1;
+  };
+  for (size_t index = 0; index < length; index++) {
+    const int high = nibble(hex[index * 2]);
+    const int low = nibble(hex[index * 2 + 1]);
+    if (high < 0 || low < 0) {
+      return false;
+    }
+    out[index] = static_cast<uint8_t>((high << 4) | low);
+  }
+  return true;
+}
+
+bool isValidDeviceName(const std::string &name) {
+  if (name.empty() || name.size() > MAX_DEVICE_NAME_BYTES) {
+    return false;
+  }
+  for (const unsigned char byte : name) {
+    if (byte == 0 || byte == '|' || byte < 0x20 || byte == 0x7F) {
+      return false;
+    }
+  }
+  return true;
+}
+
+bool DeviceOwnership::begin() {
+  if (!loadOrCreateDeviceId()) {
+    return false;
+  }
+  loadOwner();
+  if (deviceName_.empty()) {
+    deviceName_ = defaultDeviceName();
+  }
+  return true;
+}
+
+void DeviceOwnership::resetConnection() {
+  sessionAuthenticated_ = false;
+  pendingAuthNonce_[0] = '\0';
+  clearPairing();
+}
+
+void DeviceOwnership::process(uint32_t nowMs) {
+  if (pairingActive_ &&
+      static_cast<uint32_t>(nowMs - pairingStartedMs_) >
+          PAIRING_SESSION_TIMEOUT_MS) {
+    clearPairing();
+  }
+}
+
+CommandResult DeviceOwnership::handle(const std::string &payload,
+                                      uint32_t nowMs) {
+  const std::vector<std::string> parts = split(payload);
+  CommandResult result;
+  if (parts.empty()) {
+    return result;
+  }
+
+  if (parts[0] == "INFO" && parts.size() == 1) {
+    result.matched = true;
+    result.response = "DEVICE|2|" + deviceIdHex() + "|" +
+                      (claimed_ ? "1" : "0") + "|" +
+                      hexEncode(reinterpret_cast<const uint8_t *>(
+                                    deviceName_.data()),
+                                deviceName_.size());
+    return result;
+  }
+
+  if (parts[0] == "PAIR" && parts.size() == 3) {
+    result.matched = true;
+    if (claimed_) {
+      result.response = "OWNED|" + deviceIdHex();
+      return result;
+    }
+
+    OwnerId requestedOwner{};
+    PublicKey appPublicKey{};
+    if (!hexDecode(parts[1], requestedOwner.data(), requestedOwner.size()) ||
+        !hexDecode(parts[2], appPublicKey.data(), appPublicKey.size())) {
+      result.response = "ERROR|invalid_pairing_request";
+      return result;
+    }
+    if (!pairingKey_.generate() ||
+        !pairingKey_.publicKey(pendingDevicePublicKey_) ||
+        !pairingKey_.derive(appPublicKey, deviceId_, requestedOwner,
+                            appPublicKey, pendingDevicePublicKey_,
+                            pendingPairing_)) {
+      clearPairing();
+      result.response = "ERROR|pairing_setup_failed";
+      return result;
+    }
+
+    pendingOwnerId_ = requestedOwner;
+    pendingAppPublicKey_ = appPublicKey;
+    pendingDeviceName_.clear();
+    pairingStartedMs_ = nowMs;
+    pairingActive_ = true;
+    result.event = Event::PairingStarted;
+    result.response = "PAIRING|" + deviceIdHex() + "|" +
+                      hexEncode(pendingDevicePublicKey_.data(),
+                                pendingDevicePublicKey_.size());
+    return result;
+  }
+
+  if (parts[0] == "CONFIRM" && parts.size() == 4) {
+    result.matched = true;
+    if (pairingActive_ && !pairingConfirmedOnDevice_) {
+      result.response = "ERROR|physical_confirmation_required";
+      return result;
+    }
+    std::array<uint8_t, 32> suppliedProof{};
+    std::array<uint8_t, MAX_DEVICE_NAME_BYTES> nameBytes{};
+    const std::array<uint8_t, 32> expectedProof =
+        proofFor(pendingPairing_.ownerKey, "claim|",
+                 pendingPairing_.transcriptHash);
+    if (!pairingActive_ ||
+        static_cast<uint32_t>(nowMs - pairingStartedMs_) >
+            PAIRING_SESSION_TIMEOUT_MS ||
+        !ownerMatches(pendingOwnerId_, parts[1]) ||
+        !hexDecode(parts[2], suppliedProof.data(), suppliedProof.size()) ||
+        !constantTimeEquals(expectedProof.data(), suppliedProof.data(),
+                            expectedProof.size()) ||
+        parts[3].empty() || parts[3].size() > MAX_DEVICE_NAME_BYTES * 2 ||
+        parts[3].size() % 2 != 0 ||
+        !hexDecode(parts[3], nameBytes.data(), parts[3].size() / 2)) {
+      result.response = "ERROR|pairing_confirmation_failed";
+      clearPairing();
+      return result;
+    }
+
+    pendingDeviceName_ = std::string(
+        reinterpret_cast<const char *>(nameBytes.data()), parts[3].size() / 2);
+    if (!isValidDeviceName(pendingDeviceName_)) {
+      result.response = "ERROR|pairing_confirmation_failed";
+      clearPairing();
+      return result;
+    }
+
+    ownerId_ = pendingOwnerId_;
+    ownerKey_ = pendingPairing_.ownerKey;
+    deviceName_ = pendingDeviceName_;
+    claimed_ = persistOwner();
+    if (!claimed_) {
+      result.response = "ERROR|pairing_persistence_failed";
+      ownerId_.fill(0);
+      ownerKey_.fill(0);
+      deviceName_ = defaultDeviceName();
+      clearPairing();
+      return result;
+    }
+    result.event = Event::Paired;
+    result.response = "PAIRED|" + deviceIdHex() + "|" +
+                      hexEncode(reinterpret_cast<const uint8_t *>(
+                                    deviceName_.data()),
+                                deviceName_.size());
+    clearPairing();
+    return result;
+  }
+
+  if (parts[0] == "OWNER" && parts.size() == 3) {
+    result.matched = true;
+    sessionAuthenticated_ = false;
+    if (!claimed_ || !ownerMatches(ownerId_, parts[1]) ||
+        !isHexNonce(parts[2])) {
+      result.response = "DENIED|" + deviceIdHex();
+      return result;
+    }
+    strncpy(pendingAuthNonce_, parts[2].c_str(),
+            sizeof(pendingAuthNonce_) - 1);
+    pendingAuthNonce_[sizeof(pendingAuthNonce_) - 1] = '\0';
+    const std::string message = "server2|" + deviceIdHex() + "|" + parts[1] +
+                                "|" + parts[2];
+    const auto proof = stringProofFor(ownerKey_, message);
+    result.response = "SERVER2|" + deviceIdHex() + "|" + parts[2] + "|" +
+                      hexEncode(proof.data(), proof.size());
+    return result;
+  }
+
+  if (parts[0] == "PROOF" && parts.size() == 4) {
+    result.matched = true;
+    std::array<uint8_t, 32> suppliedProof{};
+    const std::string message = "client2|" + deviceIdHex() + "|" + parts[1] +
+                                "|" + parts[2];
+    const auto expectedProof = stringProofFor(ownerKey_, message);
+    if (!claimed_ || parts[2].size() != 32 ||
+        !ownerMatches(ownerId_, parts[1]) ||
+        !constantTimeEquals(reinterpret_cast<const uint8_t *>(
+                                pendingAuthNonce_),
+                            reinterpret_cast<const uint8_t *>(
+                                parts[2].c_str()),
+                            32) ||
+        pendingAuthNonce_[32] != '\0' ||
+        !hexDecode(parts[3], suppliedProof.data(), suppliedProof.size()) ||
+        !constantTimeEquals(expectedProof.data(), suppliedProof.data(),
+                            expectedProof.size())) {
+      result.response = "DENIED|" + deviceIdHex();
+      pendingAuthNonce_[0] = '\0';
+      return result;
+    }
+    pendingAuthNonce_[0] = '\0';
+    sessionAuthenticated_ = true;
+    result.event = Event::Authenticated;
+    result.response = "OK2|" + deviceIdHex() + "|" + parts[2];
+    return result;
+  }
+
+  if (parts[0] == "NAME" && parts.size() == 2) {
+    result.matched = true;
+    std::array<uint8_t, MAX_DEVICE_NAME_BYTES> nameBytes{};
+    if (!sessionAuthenticated_ || parts[1].empty() ||
+        parts[1].size() > MAX_DEVICE_NAME_BYTES * 2 ||
+        parts[1].size() % 2 != 0 ||
+        !hexDecode(parts[1], nameBytes.data(), parts[1].size() / 2)) {
+      result.response = "ERROR|rename_rejected";
+      return result;
+    }
+    const std::string name(reinterpret_cast<const char *>(nameBytes.data()),
+                           parts[1].size() / 2);
+    if (!setDeviceName(name)) {
+      result.response = "ERROR|rename_rejected";
+      return result;
+    }
+    result.event = Event::Renamed;
+    result.response = "NAME_OK|" + parts[1];
+    return result;
+  }
+
+  if (parts[0] == "UNPAIR" && parts.size() == 1) {
+    result.matched = true;
+    if (!sessionAuthenticated_) {
+      result.response = "ERROR|unpair_rejected";
+      return result;
+    }
+    const std::string id = deviceIdHex();
+    if (!clearOwner()) {
+      result.response = "ERROR|unpair_persistence_failed";
+      return result;
+    }
+    result.event = Event::Unpaired;
+    result.response = "UNPAIRED|" + id;
+    return result;
+  }
+
+  return result;
+}
+
+bool DeviceOwnership::confirmPairingOnDevice() {
+  if (!pairingActive_) {
+    return false;
+  }
+  pairingConfirmedOnDevice_ = true;
+  return true;
+}
+
+bool DeviceOwnership::clearOwner() {
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  const bool markerRemoved = !preferences.isKey(OWNER_VERSION_KEY) ||
+                             preferences.remove(OWNER_VERSION_KEY);
+  preferences.remove(OWNER_ID_KEY);
+  preferences.remove(OWNER_KEY_KEY);
+  preferences.remove(DEVICE_NAME_KEY);
+  preferences.end();
+  if (!markerRemoved) {
+    return false;
+  }
+  ownerId_.fill(0);
+  ownerKey_.fill(0);
+  claimed_ = false;
+  sessionAuthenticated_ = false;
+  deviceName_ = defaultDeviceName();
+  clearPairing();
+  return true;
+}
+
+std::string DeviceOwnership::deviceIdHex() const {
+  return hexEncode(deviceId_.data(), deviceId_.size());
+}
+
+std::string DeviceOwnership::advertisedName() const { return deviceName_; }
+
+std::vector<uint8_t> DeviceOwnership::advertisementManufacturerData() const {
+  return {0xFF, 0xFF, PROTOCOL_VERSION,
+          static_cast<uint8_t>(claimed_ ? 1 : 0), deviceId_[12], deviceId_[13],
+          deviceId_[14], deviceId_[15]};
+}
+
+bool DeviceOwnership::loadOrCreateDeviceId() {
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  if (preferences.getBytesLength(DEVICE_ID_KEY) == deviceId_.size() &&
+      preferences.getBytes(DEVICE_ID_KEY, deviceId_.data(), deviceId_.size()) ==
+          deviceId_.size()) {
+    preferences.end();
+    return true;
+  }
+  esp_fill_random(deviceId_.data(), deviceId_.size());
+  const bool stored = preferences.putBytes(DEVICE_ID_KEY, deviceId_.data(),
+                                           deviceId_.size()) == deviceId_.size();
+  preferences.end();
+  return stored;
+}
+
+bool DeviceOwnership::loadOwner() {
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  const bool valid = preferences.getUChar(OWNER_VERSION_KEY, 0) ==
+                         OWNER_VERSION &&
+                     preferences.getBytesLength(OWNER_ID_KEY) ==
+                         ownerId_.size() &&
+                     preferences.getBytesLength(OWNER_KEY_KEY) ==
+                         ownerKey_.size();
+  if (valid) {
+    claimed_ = preferences.getBytes(OWNER_ID_KEY, ownerId_.data(),
+                                    ownerId_.size()) == ownerId_.size() &&
+               preferences.getBytes(OWNER_KEY_KEY, ownerKey_.data(),
+                                    ownerKey_.size()) == ownerKey_.size();
+    deviceName_ = preferences.getString(DEVICE_NAME_KEY, "").c_str();
+    if (!isValidDeviceName(deviceName_)) {
+      deviceName_ = defaultDeviceName();
+    }
+  }
+  preferences.end();
+  return claimed_;
+}
+
+bool DeviceOwnership::persistOwner() {
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  preferences.remove(OWNER_VERSION_KEY);
+  const bool stored =
+      preferences.putBytes(OWNER_ID_KEY, ownerId_.data(), ownerId_.size()) ==
+          ownerId_.size() &&
+      preferences.putBytes(OWNER_KEY_KEY, ownerKey_.data(), ownerKey_.size()) ==
+          ownerKey_.size() &&
+      preferences.putString(DEVICE_NAME_KEY, deviceName_.c_str()) ==
+          deviceName_.size() &&
+      preferences.putUChar(OWNER_VERSION_KEY, OWNER_VERSION) == sizeof(uint8_t);
+  preferences.end();
+  return stored;
+}
+
+void DeviceOwnership::clearPairing() {
+  pairingKey_.clear();
+  pendingPairing_ = {};
+  pendingOwnerId_.fill(0);
+  pendingAppPublicKey_.fill(0);
+  pendingDevicePublicKey_.fill(0);
+  pendingDeviceName_.clear();
+  pairingStartedMs_ = 0;
+  pairingActive_ = false;
+  pairingConfirmedOnDevice_ = false;
+}
+
+std::string DeviceOwnership::defaultDeviceName() const {
+  char name[24];
+  snprintf(name, sizeof(name), "BikeComputer %02X%02X", deviceId_[14],
+           deviceId_[15]);
+  return name;
+}
+
+bool DeviceOwnership::setDeviceName(const std::string &name) {
+  if (!isValidDeviceName(name)) {
+    return false;
+  }
+  Preferences preferences;
+  if (!preferences.begin(NVS_NAMESPACE, false)) {
+    return false;
+  }
+  const bool stored = preferences.putString(DEVICE_NAME_KEY, name.c_str()) ==
+                      name.size();
+  preferences.end();
+  if (!stored) {
+    return false;
+  }
+  deviceName_ = name;
+  return true;
+}
+
+} // namespace device_ownership

--- a/esp32/lib/ble_navigation/device_ownership.hpp
+++ b/esp32/lib/ble_navigation/device_ownership.hpp
@@ -7,11 +7,22 @@
 #include <string>
 #include <vector>
 
+class Preferences;
+
 namespace device_ownership {
 
 constexpr uint8_t PROTOCOL_VERSION = 2;
 constexpr size_t MAX_DEVICE_NAME_BYTES = 24;
 constexpr uint32_t PAIRING_SESSION_TIMEOUT_MS = 120000;
+constexpr size_t AUTHENTICATED_FRAME_OVERHEAD = 22;
+
+enum class AuthenticatedChannel : uint8_t {
+  Auth = 1,
+  Navigation = 2,
+  Route = 3,
+  Gps = 4,
+  Settings = 5,
+};
 
 enum class Event {
   None,
@@ -35,10 +46,30 @@ public:
   void process(uint32_t nowMs);
 
   CommandResult handle(const std::string &payload, uint32_t nowMs);
+  bool armPairingConfirmation(uint32_t pairingGeneration);
   bool confirmPairingOnDevice();
   bool clearOwner();
+  bool unwrapAuthenticatedPayload(AuthenticatedChannel channel,
+                                  const std::string &frame,
+                                  std::string &payload);
+  bool protectAuthenticatedPayload(AuthenticatedChannel channel,
+                                   const std::string &payload,
+                                   std::string &frame);
+#ifdef DEVICE_OWNERSHIP_HOST_TEST
+  void setAuthenticatedSessionKeysForTesting(const OwnerKey &writeKey,
+                                             const OwnerKey &notifyKey) {
+    sessionWriteKey_ = writeKey;
+    sessionNotifyKey_ = notifyKey;
+    lastInboundSequence_.fill(0);
+    nextOutboundSequence_.fill(0);
+    sessionAuthenticated_ = true;
+  }
+#endif
 
   bool isClaimed() const { return claimed_; }
+  bool allowsLegacyAuthentication() const {
+    return legacyAuthenticationAllowed_;
+  }
   bool isSessionAuthenticated() const { return sessionAuthenticated_; }
   const DeviceId &deviceId() const { return deviceId_; }
   const std::string &deviceName() const { return deviceName_; }
@@ -48,11 +79,17 @@ public:
 
   bool hasPairingCode() const { return pairingActive_; }
   uint32_t pairingCode() const { return pendingPairing_.comparisonCode; }
+  uint32_t pairingGeneration() const { return pairingGeneration_; }
 
 private:
   bool loadOrCreateDeviceId();
   bool loadOwner();
   bool persistOwner();
+  bool clearOwnerStorage(bool preserveSession, bool preserveRevocationReceipt);
+  bool persistRevocationReceipt(const OwnerId &ownerId,
+                                const std::array<uint8_t, 16> &nonce,
+                                const std::array<uint8_t, 32> &proof);
+  bool clearRevocationReceipt(Preferences &preferences);
   void clearPairing();
   std::string defaultDeviceName() const;
   bool setDeviceName(const std::string &name);
@@ -60,9 +97,14 @@ private:
   DeviceId deviceId_{};
   OwnerId ownerId_{};
   OwnerKey ownerKey_{};
+  OwnerKey sessionWriteKey_{};
+  OwnerKey sessionNotifyKey_{};
   std::string deviceName_;
   bool claimed_ = false;
+  bool ownerRecordValid_ = false;
+  bool legacyAuthenticationAllowed_ = false;
   bool sessionAuthenticated_ = false;
+  bool deviceIdIntegrityValid_ = true;
 
   PairingKeyAgreement pairingKey_;
   PairingMaterial pendingPairing_{};
@@ -71,10 +113,21 @@ private:
   PublicKey pendingDevicePublicKey_{};
   std::string pendingDeviceName_;
   uint32_t pairingStartedMs_ = 0;
+  uint32_t pairingGeneration_ = 0;
+  uint32_t armedPairingGeneration_ = 0;
   bool pairingActive_ = false;
   bool pairingConfirmedOnDevice_ = false;
+  bool pairingAttemptedOnConnection_ = false;
+
+  OwnerId revokedOwnerId_{};
+  std::array<uint8_t, 16> revocationNonce_{};
+  std::array<uint8_t, 32> revocationProof_{};
+  bool revocationReceiptValid_ = false;
 
   char pendingAuthNonce_[33] = "";
+  char pendingServerAuthNonce_[33] = "";
+  std::array<uint32_t, 6> lastInboundSequence_{};
+  std::array<uint32_t, 6> nextOutboundSequence_{};
 };
 
 std::string hexEncode(const uint8_t *data, size_t length);

--- a/esp32/lib/ble_navigation/device_ownership.hpp
+++ b/esp32/lib/ble_navigation/device_ownership.hpp
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "device_ownership_crypto.hpp"
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace device_ownership {
+
+constexpr uint8_t PROTOCOL_VERSION = 2;
+constexpr size_t MAX_DEVICE_NAME_BYTES = 24;
+constexpr uint32_t PAIRING_SESSION_TIMEOUT_MS = 120000;
+
+enum class Event {
+  None,
+  PairingStarted,
+  Paired,
+  Authenticated,
+  Renamed,
+  Unpaired,
+};
+
+struct CommandResult {
+  bool matched = false;
+  Event event = Event::None;
+  std::string response;
+};
+
+class DeviceOwnership {
+public:
+  bool begin();
+  void resetConnection();
+  void process(uint32_t nowMs);
+
+  CommandResult handle(const std::string &payload, uint32_t nowMs);
+  bool confirmPairingOnDevice();
+  bool clearOwner();
+
+  bool isClaimed() const { return claimed_; }
+  bool isSessionAuthenticated() const { return sessionAuthenticated_; }
+  const DeviceId &deviceId() const { return deviceId_; }
+  const std::string &deviceName() const { return deviceName_; }
+  std::string deviceIdHex() const;
+  std::string advertisedName() const;
+  std::vector<uint8_t> advertisementManufacturerData() const;
+
+  bool hasPairingCode() const { return pairingActive_; }
+  uint32_t pairingCode() const { return pendingPairing_.comparisonCode; }
+
+private:
+  bool loadOrCreateDeviceId();
+  bool loadOwner();
+  bool persistOwner();
+  void clearPairing();
+  std::string defaultDeviceName() const;
+  bool setDeviceName(const std::string &name);
+
+  DeviceId deviceId_{};
+  OwnerId ownerId_{};
+  OwnerKey ownerKey_{};
+  std::string deviceName_;
+  bool claimed_ = false;
+  bool sessionAuthenticated_ = false;
+
+  PairingKeyAgreement pairingKey_;
+  PairingMaterial pendingPairing_{};
+  OwnerId pendingOwnerId_{};
+  PublicKey pendingAppPublicKey_{};
+  PublicKey pendingDevicePublicKey_{};
+  std::string pendingDeviceName_;
+  uint32_t pairingStartedMs_ = 0;
+  bool pairingActive_ = false;
+  bool pairingConfirmedOnDevice_ = false;
+
+  char pendingAuthNonce_[33] = "";
+};
+
+std::string hexEncode(const uint8_t *data, size_t length);
+bool hexDecode(const std::string &hex, uint8_t *out, size_t length);
+bool isValidDeviceName(const std::string &name);
+
+} // namespace device_ownership

--- a/esp32/lib/ble_navigation/device_ownership_crypto.cpp
+++ b/esp32/lib/ble_navigation/device_ownership_crypto.cpp
@@ -1,0 +1,238 @@
+#include "device_ownership_crypto.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+
+#include <mbedtls/hkdf.h>
+#include <mbedtls/ecdh.h>
+#include <mbedtls/md.h>
+#include <mbedtls/version.h>
+#ifdef DEVICE_OWNERSHIP_HOST_TEST
+#include <random>
+#else
+#include <esp_system.h>
+#endif
+
+namespace device_ownership {
+namespace {
+
+#if MBEDTLS_VERSION_MAJOR >= 3
+#define OWNERSHIP_KEY_FIELD(key, member) ((key).MBEDTLS_PRIVATE(member))
+#else
+#define OWNERSHIP_KEY_FIELD(key, member) ((key).member)
+#endif
+
+constexpr char TRANSCRIPT_PREFIX[] = "BikeComputer ownership v2";
+constexpr char OWNER_KEY_INFO[] = "BikeComputer owner key v2";
+constexpr char COMPARISON_PREFIX[] = "compare|";
+
+int fillRandom(void *, unsigned char *output, size_t length) {
+#ifdef DEVICE_OWNERSHIP_HOST_TEST
+  static std::random_device random;
+  for (size_t index = 0; index < length; index++) {
+    output[index] = static_cast<unsigned char>(random());
+  }
+#else
+  esp_fill_random(output, length);
+#endif
+  return 0;
+}
+
+template <size_t Size>
+void append(std::array<uint8_t, Size> &buffer, size_t &offset,
+            const uint8_t *value, size_t length) {
+  if (value == nullptr || offset + length > buffer.size()) {
+    return;
+  }
+  memcpy(buffer.data() + offset, value, length);
+  offset += length;
+}
+
+bool makeTranscriptHash(const DeviceId &deviceId, const OwnerId &ownerId,
+                        const PublicKey &appPublicKey,
+                        const PublicKey &devicePublicKey,
+                        TranscriptHash &out) {
+  constexpr size_t transcriptSize = sizeof(TRANSCRIPT_PREFIX) - 1 +
+                                    DEVICE_ID_SIZE + OWNER_ID_SIZE +
+                                    (PUBLIC_KEY_SIZE * 2);
+  std::array<uint8_t, transcriptSize> transcript{};
+  size_t offset = 0;
+  append(transcript, offset,
+         reinterpret_cast<const uint8_t *>(TRANSCRIPT_PREFIX),
+         sizeof(TRANSCRIPT_PREFIX) - 1);
+  append(transcript, offset, deviceId.data(), deviceId.size());
+  append(transcript, offset, ownerId.data(), ownerId.size());
+  append(transcript, offset, appPublicKey.data(), appPublicKey.size());
+  append(transcript, offset, devicePublicKey.data(), devicePublicKey.size());
+  return offset == transcript.size() &&
+         sha256(transcript.data(), transcript.size(), out.data());
+}
+
+} // namespace
+
+bool constantTimeEquals(const uint8_t *left, const uint8_t *right,
+                        size_t length) {
+  if (left == nullptr || right == nullptr) {
+    return false;
+  }
+  uint8_t difference = 0;
+  for (size_t index = 0; index < length; index++) {
+    difference |= left[index] ^ right[index];
+  }
+  return difference == 0;
+}
+
+bool sha256(const uint8_t *data, size_t length, uint8_t out[32]) {
+  if (data == nullptr || out == nullptr) {
+    return false;
+  }
+  const mbedtls_md_info_t *info =
+      mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  return info != nullptr && mbedtls_md(info, data, length, out) == 0;
+}
+
+bool hmacSha256(const uint8_t *key, size_t keyLength, const uint8_t *data,
+                size_t dataLength, uint8_t out[32]) {
+  if (key == nullptr || data == nullptr || out == nullptr) {
+    return false;
+  }
+  const mbedtls_md_info_t *info =
+      mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+  return info != nullptr &&
+         mbedtls_md_hmac(info, key, keyLength, data, dataLength, out) == 0;
+}
+
+PairingKeyAgreement::PairingKeyAgreement() { mbedtls_ecp_keypair_init(&key_); }
+
+PairingKeyAgreement::~PairingKeyAgreement() { clear(); }
+
+bool PairingKeyAgreement::generate() {
+  clear();
+  mbedtls_ecp_keypair_init(&key_);
+  ready_ = mbedtls_ecp_gen_key(MBEDTLS_ECP_DP_SECP256R1, &key_, fillRandom,
+                               nullptr) == 0;
+  return ready_;
+}
+
+bool PairingKeyAgreement::setPrivateKeyForTesting(
+    const uint8_t privateKey[32]) {
+  if (privateKey == nullptr) {
+    return false;
+  }
+  clear();
+  mbedtls_ecp_keypair_init(&key_);
+  if (mbedtls_ecp_group_load(&OWNERSHIP_KEY_FIELD(key_, grp),
+                             MBEDTLS_ECP_DP_SECP256R1) != 0 ||
+      mbedtls_mpi_read_binary(&OWNERSHIP_KEY_FIELD(key_, d), privateKey, 32) !=
+          0 ||
+      mbedtls_ecp_check_privkey(&OWNERSHIP_KEY_FIELD(key_, grp),
+                                &OWNERSHIP_KEY_FIELD(key_, d)) != 0 ||
+      mbedtls_ecp_mul(&OWNERSHIP_KEY_FIELD(key_, grp),
+                      &OWNERSHIP_KEY_FIELD(key_, Q),
+                      &OWNERSHIP_KEY_FIELD(key_, d),
+                      &OWNERSHIP_KEY_FIELD(key_, grp).G, fillRandom,
+                      nullptr) != 0) {
+    clear();
+    return false;
+  }
+  ready_ = true;
+  return true;
+}
+
+bool PairingKeyAgreement::publicKey(PublicKey &out) const {
+  if (!ready_) {
+    return false;
+  }
+  size_t written = 0;
+  return mbedtls_ecp_point_write_binary(
+             &OWNERSHIP_KEY_FIELD(key_, grp),
+             &OWNERSHIP_KEY_FIELD(key_, Q),
+             MBEDTLS_ECP_PF_UNCOMPRESSED, &written, out.data(), out.size()) ==
+             0 &&
+         written == out.size();
+}
+
+bool PairingKeyAgreement::derive(const PublicKey &peerPublicKey,
+                                 const DeviceId &deviceId,
+                                 const OwnerId &ownerId,
+                                 const PublicKey &appPublicKey,
+                                 const PublicKey &devicePublicKey,
+                                 PairingMaterial &out) {
+  if (!ready_) {
+    return false;
+  }
+
+  mbedtls_ecp_point peer;
+  mbedtls_mpi shared;
+  mbedtls_ecp_point_init(&peer);
+  mbedtls_mpi_init(&shared);
+  bool ok = false;
+
+  do {
+    if (mbedtls_ecp_point_read_binary(&OWNERSHIP_KEY_FIELD(key_, grp), &peer,
+                                      peerPublicKey.data(),
+                                      peerPublicKey.size()) != 0 ||
+        mbedtls_ecp_check_pubkey(&OWNERSHIP_KEY_FIELD(key_, grp), &peer) != 0 ||
+        mbedtls_ecdh_compute_shared(&OWNERSHIP_KEY_FIELD(key_, grp), &shared,
+                                    &peer, &OWNERSHIP_KEY_FIELD(key_, d),
+                                    fillRandom,
+                                    nullptr) != 0) {
+      break;
+    }
+
+    std::array<uint8_t, 32> sharedBytes{};
+    if (mbedtls_mpi_write_binary(&shared, sharedBytes.data(),
+                                 sharedBytes.size()) != 0 ||
+        !makeTranscriptHash(deviceId, ownerId, appPublicKey, devicePublicKey,
+                            out.transcriptHash)) {
+      break;
+    }
+
+    const mbedtls_md_info_t *info =
+        mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
+    if (info == nullptr ||
+        mbedtls_hkdf(
+            info, out.transcriptHash.data(), out.transcriptHash.size(),
+            sharedBytes.data(), sharedBytes.size(),
+            reinterpret_cast<const uint8_t *>(OWNER_KEY_INFO),
+            sizeof(OWNER_KEY_INFO) - 1, out.ownerKey.data(),
+            out.ownerKey.size()) != 0) {
+      break;
+    }
+
+    std::array<uint8_t,
+               sizeof(COMPARISON_PREFIX) - 1 + TRANSCRIPT_HASH_SIZE>
+        comparisonMessage{};
+    memcpy(comparisonMessage.data(), COMPARISON_PREFIX,
+           sizeof(COMPARISON_PREFIX) - 1);
+    memcpy(comparisonMessage.data() + sizeof(COMPARISON_PREFIX) - 1,
+           out.transcriptHash.data(), out.transcriptHash.size());
+    uint8_t digest[32]{};
+    if (!hmacSha256(out.ownerKey.data(), out.ownerKey.size(),
+                    comparisonMessage.data(), comparisonMessage.size(),
+                    digest)) {
+      break;
+    }
+    const uint32_t value = (static_cast<uint32_t>(digest[0]) << 24) |
+                           (static_cast<uint32_t>(digest[1]) << 16) |
+                           (static_cast<uint32_t>(digest[2]) << 8) |
+                           static_cast<uint32_t>(digest[3]);
+    out.comparisonCode = value % 1000000U;
+    ok = true;
+  } while (false);
+
+  mbedtls_mpi_free(&shared);
+  mbedtls_ecp_point_free(&peer);
+  return ok;
+}
+
+void PairingKeyAgreement::clear() {
+  mbedtls_ecp_keypair_free(&key_);
+  memset(&key_, 0, sizeof(key_));
+  ready_ = false;
+}
+
+} // namespace device_ownership
+
+#undef OWNERSHIP_KEY_FIELD

--- a/esp32/lib/ble_navigation/device_ownership_crypto.cpp
+++ b/esp32/lib/ble_navigation/device_ownership_crypto.cpp
@@ -11,7 +11,7 @@
 #ifdef DEVICE_OWNERSHIP_HOST_TEST
 #include <random>
 #else
-#include <esp_system.h>
+#include <esp_random.h>
 #endif
 
 namespace device_ownership {

--- a/esp32/lib/ble_navigation/device_ownership_crypto.hpp
+++ b/esp32/lib/ble_navigation/device_ownership_crypto.hpp
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+#include <mbedtls/ecp.h>
+
+namespace device_ownership {
+
+constexpr size_t DEVICE_ID_SIZE = 16;
+constexpr size_t OWNER_ID_SIZE = 16;
+constexpr size_t OWNER_KEY_SIZE = 32;
+constexpr size_t PUBLIC_KEY_SIZE = 65;
+constexpr size_t TRANSCRIPT_HASH_SIZE = 32;
+
+using DeviceId = std::array<uint8_t, DEVICE_ID_SIZE>;
+using OwnerId = std::array<uint8_t, OWNER_ID_SIZE>;
+using OwnerKey = std::array<uint8_t, OWNER_KEY_SIZE>;
+using PublicKey = std::array<uint8_t, PUBLIC_KEY_SIZE>;
+using TranscriptHash = std::array<uint8_t, TRANSCRIPT_HASH_SIZE>;
+
+struct PairingMaterial {
+  OwnerKey ownerKey{};
+  TranscriptHash transcriptHash{};
+  uint32_t comparisonCode = 0;
+};
+
+bool constantTimeEquals(const uint8_t *left, const uint8_t *right,
+                        size_t length);
+bool sha256(const uint8_t *data, size_t length, uint8_t out[32]);
+bool hmacSha256(const uint8_t *key, size_t keyLength, const uint8_t *data,
+                size_t dataLength, uint8_t out[32]);
+
+class PairingKeyAgreement {
+public:
+  PairingKeyAgreement();
+  ~PairingKeyAgreement();
+
+  PairingKeyAgreement(const PairingKeyAgreement &) = delete;
+  PairingKeyAgreement &operator=(const PairingKeyAgreement &) = delete;
+
+  bool generate();
+  bool setPrivateKeyForTesting(const uint8_t privateKey[32]);
+  bool publicKey(PublicKey &out) const;
+  bool derive(const PublicKey &peerPublicKey, const DeviceId &deviceId,
+              const OwnerId &ownerId, const PublicKey &appPublicKey,
+              const PublicKey &devicePublicKey, PairingMaterial &out);
+  void clear();
+
+private:
+  mbedtls_ecp_keypair key_;
+  bool ready_ = false;
+};
+
+} // namespace device_ownership

--- a/esp32/lib/ble_navigation/disconnected_shutdown_policy.hpp
+++ b/esp32/lib/ble_navigation/disconnected_shutdown_policy.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <cstdint>
+
+namespace disconnected_shutdown_policy {
+
+constexpr uint32_t registrationGraceSeconds = 10 * 60;
+
+enum class Action : uint8_t {
+  None,
+  CountdownStarted,
+  ShutdownDue,
+  ShutdownRetry,
+};
+
+struct UpdateResult {
+  Action action = Action::None;
+  uint32_t timeoutSeconds = 0;
+  bool waitingForRegistration = false;
+};
+
+inline uint32_t effectiveTimeoutSeconds(uint32_t configuredTimeoutSeconds,
+                                        bool ownershipClaimed) {
+  if (configuredTimeoutSeconds == 0 || ownershipClaimed ||
+      configuredTimeoutSeconds >= registrationGraceSeconds) {
+    return configuredTimeoutSeconds;
+  }
+  return registrationGraceSeconds;
+}
+
+class Tracker {
+public:
+  UpdateResult update(uint32_t nowMs, bool connected,
+                      uint32_t configuredTimeoutSeconds,
+                      bool ownershipClaimed) {
+    const uint32_t timeoutSeconds = effectiveTimeoutSeconds(
+        configuredTimeoutSeconds, ownershipClaimed);
+    const bool waitingForRegistration = !ownershipClaimed;
+
+    if (connected || timeoutSeconds == 0) {
+      reset();
+      return {Action::None, timeoutSeconds, waitingForRegistration};
+    }
+
+    if (!counting_ || timeoutSeconds != activeTimeoutSeconds_ ||
+        ownershipClaimed != activeOwnershipClaimed_) {
+      counting_ = true;
+      countdownStartedMs_ = nowMs;
+      activeTimeoutSeconds_ = timeoutSeconds;
+      activeOwnershipClaimed_ = ownershipClaimed;
+      shutdownAnnounced_ = false;
+      return {Action::CountdownStarted, timeoutSeconds,
+              waitingForRegistration};
+    }
+
+    const uint32_t elapsedMs = nowMs - countdownStartedMs_;
+    const uint64_t deadlineMs =
+        static_cast<uint64_t>(timeoutSeconds) * 1000ULL;
+    if (static_cast<uint64_t>(elapsedMs) < deadlineMs) {
+      return {Action::None, timeoutSeconds, waitingForRegistration};
+    }
+
+    if (!shutdownAnnounced_) {
+      shutdownAnnounced_ = true;
+      return {Action::ShutdownDue, timeoutSeconds, waitingForRegistration};
+    }
+    return {Action::ShutdownRetry, timeoutSeconds, waitingForRegistration};
+  }
+
+private:
+  void reset() {
+    counting_ = false;
+    countdownStartedMs_ = 0;
+    activeTimeoutSeconds_ = 0;
+    activeOwnershipClaimed_ = false;
+    shutdownAnnounced_ = false;
+  }
+
+  bool counting_ = false;
+  uint32_t countdownStartedMs_ = 0;
+  uint32_t activeTimeoutSeconds_ = 0;
+  bool activeOwnershipClaimed_ = false;
+  bool shutdownAnnounced_ = false;
+};
+
+} // namespace disconnected_shutdown_policy

--- a/esp32/lib/ble_navigation/ownership_button_policy.hpp
+++ b/esp32/lib/ble_navigation/ownership_button_policy.hpp
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ownership_button_policy {
+
+class ComparisonRenderGate {
+public:
+  void request(uint32_t pairingGeneration) {
+    pendingGeneration_ = pairingGeneration;
+    renderedGeneration_ = 0;
+  }
+
+  void cancel() {
+    pendingGeneration_ = 0;
+    renderedGeneration_ = 0;
+  }
+
+  void displayFlushed() {
+    if (pendingGeneration_ != 0) {
+      renderedGeneration_ = pendingGeneration_;
+    }
+  }
+
+  uint32_t renderedGeneration() const { return renderedGeneration_; }
+
+  bool consumeRendered(uint32_t pairingGeneration) {
+    if (pairingGeneration == 0 ||
+        pairingGeneration != pendingGeneration_ ||
+        pairingGeneration != renderedGeneration_) {
+      return false;
+    }
+    cancel();
+    return true;
+  }
+
+private:
+  uint32_t pendingGeneration_ = 0;
+  uint32_t renderedGeneration_ = 0;
+};
+
+class FreshBootButtonGate {
+public:
+  void arm() {
+    requiresStableRelease_ = true;
+    releaseStartMs_ = 0;
+  }
+
+  bool blocksInput(bool pressed, uint32_t nowMs, uint32_t debounceMs) {
+    if (!requiresStableRelease_) {
+      return false;
+    }
+    if (pressed) {
+      releaseStartMs_ = 0;
+      return true;
+    }
+    if (releaseStartMs_ == 0) {
+      releaseStartMs_ = nowMs;
+      return true;
+    }
+    if (nowMs - releaseStartMs_ < debounceMs) {
+      return true;
+    }
+    requiresStableRelease_ = false;
+    releaseStartMs_ = 0;
+    return true;
+  }
+
+private:
+  bool requiresStableRelease_ = false;
+  uint32_t releaseStartMs_ = 0;
+};
+
+class FreshPowerButtonGate {
+public:
+  void arm(uint32_t pairingGeneration) {
+    pairingGeneration_ = pairingGeneration;
+    sawPressEdge_ = false;
+  }
+
+  void cancel() {
+    pairingGeneration_ = 0;
+    sawPressEdge_ = false;
+  }
+
+  bool acceptEvents(uint32_t pairingGeneration, bool negativeEdge,
+                    bool positiveEdge, bool shortPress) {
+    if (pairingGeneration == 0 || pairingGeneration != pairingGeneration_) {
+      return false;
+    }
+    if (negativeEdge) {
+      sawPressEdge_ = true;
+    }
+    if (!sawPressEdge_ || (!positiveEdge && !shortPress)) {
+      return false;
+    }
+    // Consume the tap, but retain the generation so a transient failure in
+    // the confirmation handler can be retried only with another fresh tap.
+    sawPressEdge_ = false;
+    return true;
+  }
+
+private:
+  uint32_t pairingGeneration_ = 0;
+  bool sawPressEdge_ = false;
+};
+
+template <typename ConfirmPairing, typename Fallback>
+bool handleShortPress(ConfirmPairing confirmPairing, Fallback fallback) {
+  if (confirmPairing()) {
+    return true;
+  }
+  fallback();
+  return false;
+}
+
+inline bool shouldRecoverOwner(uint32_t pressDurationMs,
+                               bool handledPairingConfirmation) {
+  return pressDurationMs >= 8000 && !handledPairingConfirmation;
+}
+
+} // namespace ownership_button_policy

--- a/esp32/lib/gui/src/waitingScr.cpp
+++ b/esp32/lib/gui/src/waitingScr.cpp
@@ -83,7 +83,7 @@ void updateWaitingOwnershipStatus(const char *deviceName, bool claimed,
                         ? "Bike Computer"
                         : deviceName);
   if (pairingCode >= 0) {
-    lv_label_set_text_fmt(waitingMessage, "Match %06ld\nthen press BOOT.",
+    lv_label_set_text_fmt(waitingMessage, "Match %06ld\nthen press a button.",
                           static_cast<long>(pairingCode));
   } else if (claimed) {
     lv_label_set_text(waitingMessage, "Waiting for\nyour iPhone.");

--- a/esp32/lib/gui/src/waitingScr.cpp
+++ b/esp32/lib/gui/src/waitingScr.cpp
@@ -11,6 +11,8 @@
 lv_obj_t *waitingScreen = nullptr;
 volatile bool gpsReceivedFromApp = false;
 volatile bool pendingTransitionToMap = false;
+static lv_obj_t *waitingTitle = nullptr;
+static lv_obj_t *waitingMessage = nullptr;
 
 // Forward declaration
 void loadMainScreen();
@@ -41,12 +43,15 @@ void createWaitingScr() {
   lv_obj_set_style_bg_color(waitingScreen, lv_color_black(), 0);
 
   // Title: "Bike Computer"
-  lv_obj_t *title = lv_label_create(waitingScreen);
-  lv_obj_set_style_text_font(title, &lv_font_montserrat_42, 0);
-  lv_obj_set_style_text_color(title, lv_color_white(), 0);
-  lv_label_set_text(title, "Bike Computer");
-  lv_obj_set_align(title, LV_ALIGN_CENTER);
-  lv_obj_set_y(title, -105);
+  waitingTitle = lv_label_create(waitingScreen);
+  lv_obj_set_style_text_font(waitingTitle, &lv_font_montserrat_42, 0);
+  lv_obj_set_style_text_color(waitingTitle, lv_color_white(), 0);
+  lv_obj_set_style_text_align(waitingTitle, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_long_mode(waitingTitle, LV_LABEL_LONG_DOT);
+  lv_obj_set_width(waitingTitle, TFT_WIDTH - 24);
+  lv_label_set_text(waitingTitle, "Bike Computer");
+  lv_obj_set_align(waitingTitle, LV_ALIGN_CENTER);
+  lv_obj_set_y(waitingTitle, -105);
 
   // Spinner (animated loading indicator)
   lv_obj_t *spinner = lv_spinner_create(waitingScreen);
@@ -55,14 +60,34 @@ void createWaitingScr() {
   lv_obj_center(spinner);
 
   // Message: "Start the app to start navigation."
-  lv_obj_t *message = lv_label_create(waitingScreen);
-  lv_obj_set_style_text_font(message, &lv_font_montserrat_42, 0);
-  lv_obj_set_style_text_color(message, lv_color_hex(0xAAAAAA), 0);
-  lv_obj_set_style_text_align(message, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_text(message, "Start the app\nto start navigation.");
-  lv_obj_set_width(message, TFT_WIDTH - 24);
-  lv_obj_set_align(message, LV_ALIGN_CENTER);
-  lv_obj_set_y(message, 125);
+  waitingMessage = lv_label_create(waitingScreen);
+  lv_obj_set_style_text_font(waitingMessage, &lv_font_montserrat_42, 0);
+  lv_obj_set_style_text_color(waitingMessage, lv_color_hex(0xAAAAAA), 0);
+  lv_obj_set_style_text_align(waitingMessage, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_text(waitingMessage, "Start the app\nto start navigation.");
+  lv_obj_set_width(waitingMessage, TFT_WIDTH - 24);
+  lv_obj_set_align(waitingMessage, LV_ALIGN_CENTER);
+  lv_obj_set_y(waitingMessage, 125);
 
   log_i("waitingScreen created at 0x%p", waitingScreen);
+}
+
+void updateWaitingOwnershipStatus(const char *deviceName, bool claimed,
+                                  int32_t pairingCode) {
+  if (waitingTitle == nullptr || waitingMessage == nullptr) {
+    return;
+  }
+
+  lv_label_set_text(waitingTitle,
+                    deviceName == nullptr || deviceName[0] == '\0'
+                        ? "Bike Computer"
+                        : deviceName);
+  if (pairingCode >= 0) {
+    lv_label_set_text_fmt(waitingMessage, "Match %06ld\nthen press BOOT.",
+                          static_cast<long>(pairingCode));
+  } else if (claimed) {
+    lv_label_set_text(waitingMessage, "Waiting for\nyour iPhone.");
+  } else {
+    lv_label_set_text(waitingMessage, "Open the app\nand add this device.");
+  }
 }

--- a/esp32/lib/gui/src/waitingScr.hpp
+++ b/esp32/lib/gui/src/waitingScr.hpp
@@ -15,3 +15,5 @@ extern volatile bool pendingTransitionToMap; // Flag: Transition to map pending
 
 void createWaitingScr();
 void checkPendingMapTransition(); // Called from main loop
+void updateWaitingOwnershipStatus(const char *deviceName, bool claimed,
+                                  int32_t pairingCode = -1);

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -17,6 +17,8 @@
 #include "touch.hpp"
 #include "waveshare_board.hpp"
 
+extern void appDisplayFlushCompleted();
+
 // Define Global Variables declared extern in hal.hpp
 uint8_t GPS_TX = GPIO_NUM_43;
 uint8_t GPS_RX = GPIO_NUM_44;
@@ -190,6 +192,10 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
   gfx->fillRect(area->x1, area->y1, 1, 1,
                 reinterpret_cast<uint16_t *>(px_map)[0]);
 #endif
+
+  // Notify application policy only after the physical panel write (including
+  // the 2.06-inch commit write) has completed.
+  appDisplayFlushCompleted();
 
   // Inform LVGL 9 that flushing is complete
   lv_display_flush_ready(disp);

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -88,10 +88,8 @@ float currentDacGainDb = 0.0f;
 speaker_limiter_t playbackLimiter{};
 PowerButtonHonkConfig powerButtonHonkConfig{
     false, Sound::PlasticBicycleHorn, DEFAULT_VOLUME_PERCENT};
-uint32_t lastPowerButtonPollMs = 0;
 uint32_t lastPowerButtonConfigureAttemptMs = 0;
 
-constexpr uint32_t POWER_BUTTON_POLL_INTERVAL_MS = 100;
 constexpr uint32_t POWER_BUTTON_CONFIGURE_RETRY_MS = 5000;
 constexpr uint32_t POWER_BUTTON_CONFIG_LOCK_TIMEOUT_MS = 250;
 constexpr char POWER_BUTTON_PREFERENCES_NAMESPACE[] = "deviceSounds";
@@ -189,8 +187,7 @@ bool configurePowerButtonMonitoringLocked() {
     return false;
   }
   powerButtonMonitoringConfigured =
-      axp2101::setPowerButtonShortPressMonitoring(
-          powerButtonHonkConfig.enabled);
+      axp2101::setPowerButtonEventMonitoring(true);
   lastPowerButtonConfigureAttemptMs = millis();
   return powerButtonMonitoringConfigured;
 }
@@ -682,7 +679,7 @@ bool configurePowerButtonHonk(const PowerButtonHonkConfig &config) {
   return true;
 }
 
-void processPowerButtonHonk() {
+void handlePowerButtonHonkPress() {
   if (!isPowerButtonHonkAvailable()) {
     return;
   }
@@ -692,22 +689,15 @@ void processPowerButtonHonk() {
     return;
   }
 
-  const uint32_t now = millis();
   if (!powerButtonMonitoringConfigured) {
+    const uint32_t now = millis();
     if (now - lastPowerButtonConfigureAttemptMs >=
         POWER_BUTTON_CONFIGURE_RETRY_MS) {
       configurePowerButtonMonitoringLocked();
     }
     return;
   }
-  if (!powerButtonHonkConfig.enabled ||
-      now - lastPowerButtonPollMs < POWER_BUTTON_POLL_INTERVAL_MS) {
-    return;
-  }
-  lastPowerButtonPollMs = now;
-
-  bool pressed = false;
-  if (!axp2101::readAndClearPowerButtonShortPress(pressed) || !pressed) {
+  if (!powerButtonHonkConfig.enabled) {
     return;
   }
   if (!requestPlay(powerButtonHonkConfig.sound,
@@ -731,7 +721,7 @@ bool isSupported(Sound) { return false; }
 bool isPowerButtonHonkAvailable() { return false; }
 bool getPowerButtonHonkConfig(PowerButtonHonkConfig &) { return false; }
 bool configurePowerButtonHonk(const PowerButtonHonkConfig &) { return false; }
-void processPowerButtonHonk() {}
+void handlePowerButtonHonkPress() {}
 
 } // namespace waveshare_board::speaker
 

--- a/esp32/lib/speaker/speaker.hpp
+++ b/esp32/lib/speaker/speaker.hpp
@@ -14,6 +14,6 @@ bool isSupported(Sound sound);
 bool isPowerButtonHonkAvailable();
 bool getPowerButtonHonkConfig(PowerButtonHonkConfig &config);
 bool configurePowerButtonHonk(const PowerButtonHonkConfig &config);
-void processPowerButtonHonk();
+void handlePowerButtonHonkPress();
 
 } // namespace waveshare_board::speaker

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -26,9 +26,15 @@ constexpr uint8_t AXP2101_BATTERY_CURRENT_DIRECTION_MASK = 0x03;
 constexpr uint8_t AXP2101_SYSTEM_ON_MASK = 0x10;
 constexpr uint8_t AXP2101_VINDPM_ACTIVE_MASK = 0x08;
 constexpr uint8_t AXP2101_CHARGING_STATUS_MASK = 0x07;
-constexpr uint8_t AXP2101_INTERRUPT_ENABLE_2_REG = 0x41;
-constexpr uint8_t AXP2101_INTERRUPT_STATUS_2_REG = 0x49;
+constexpr uint8_t AXP2101_INTERRUPT_ENABLE_1_REG = 0x41;
+constexpr uint8_t AXP2101_INTERRUPT_STATUS_1_REG = 0x49;
 constexpr uint8_t AXP2101_POWER_BUTTON_SHORT_PRESS_MASK = 0x08;
+constexpr uint8_t AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK = 0x02;
+constexpr uint8_t AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK = 0x01;
+constexpr uint8_t AXP2101_POWER_BUTTON_EVENT_MASK =
+    AXP2101_POWER_BUTTON_SHORT_PRESS_MASK |
+    AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK |
+    AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK;
 
 constexpr uint8_t peripheralRailRegs[] = {
     AXP2101_ALDO1_VOLTAGE_REG, AXP2101_ALDO2_VOLTAGE_REG,
@@ -135,50 +141,56 @@ bool readBatteryPercentage(uint8_t &percentage) {
   return readBatteryStatus(percentage, charging);
 }
 
-bool setPowerButtonShortPressMonitoring(bool enabled) {
+bool setPowerButtonEventMonitoring(bool enabled) {
   if (!pmuAvailable) {
     return false;
   }
 
   uint8_t interruptEnable = 0;
-  if (!readRegister(AXP2101_INTERRUPT_ENABLE_2_REG, interruptEnable)) {
+  if (!readRegister(AXP2101_INTERRUPT_ENABLE_1_REG, interruptEnable)) {
     return false;
   }
 
   const uint8_t updatedInterruptEnable =
-      enabled ? interruptEnable | AXP2101_POWER_BUTTON_SHORT_PRESS_MASK
-              : interruptEnable & ~AXP2101_POWER_BUTTON_SHORT_PRESS_MASK;
+      enabled ? interruptEnable | AXP2101_POWER_BUTTON_EVENT_MASK
+              : interruptEnable & ~AXP2101_POWER_BUTTON_EVENT_MASK;
   if (updatedInterruptEnable != interruptEnable &&
-      !writeRegister(AXP2101_INTERRUPT_ENABLE_2_REG,
+      !writeRegister(AXP2101_INTERRUPT_ENABLE_1_REG,
                      updatedInterruptEnable)) {
     return false;
   }
 
   // AXP2101 interrupt status is write-one-to-clear. Remove any stale press so
   // enabling the feature cannot immediately trigger playback.
-  return writeRegister(AXP2101_INTERRUPT_STATUS_2_REG,
-                       AXP2101_POWER_BUTTON_SHORT_PRESS_MASK);
+  return writeRegister(AXP2101_INTERRUPT_STATUS_1_REG,
+                       AXP2101_POWER_BUTTON_EVENT_MASK);
 }
 
-bool readAndClearPowerButtonShortPress(bool &pressed) {
-  pressed = false;
+bool readAndClearPowerButtonEvents(PowerButtonEvents &events) {
+  events = {};
   if (!pmuAvailable) {
     return false;
   }
 
   uint8_t interruptStatus = 0;
-  if (!readRegister(AXP2101_INTERRUPT_STATUS_2_REG, interruptStatus)) {
+  if (!readRegister(AXP2101_INTERRUPT_STATUS_1_REG, interruptStatus)) {
     return false;
   }
-  if ((interruptStatus & AXP2101_POWER_BUTTON_SHORT_PRESS_MASK) == 0) {
+  const uint8_t pendingEvents =
+      interruptStatus & AXP2101_POWER_BUTTON_EVENT_MASK;
+  if (pendingEvents == 0) {
     return true;
   }
-  if (!writeRegister(AXP2101_INTERRUPT_STATUS_2_REG,
-                     AXP2101_POWER_BUTTON_SHORT_PRESS_MASK)) {
+  if (!writeRegister(AXP2101_INTERRUPT_STATUS_1_REG, pendingEvents)) {
     return false;
   }
 
-  pressed = true;
+  events.shortPress =
+      (pendingEvents & AXP2101_POWER_BUTTON_SHORT_PRESS_MASK) != 0;
+  events.negativeEdge =
+      (pendingEvents & AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK) != 0;
+  events.positiveEdge =
+      (pendingEvents & AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK) != 0;
   return true;
 }
 

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -22,6 +22,12 @@ struct PowerStatus {
   uint8_t chargingStatus = 0;
 };
 
+struct PowerButtonEvents {
+  bool shortPress = false;
+  bool negativeEdge = false;
+  bool positiveEdge = false;
+};
+
 bool begin();
 bool isAvailable();
 bool readRegister(uint8_t reg, uint8_t &value);
@@ -29,8 +35,8 @@ bool writeRegister(uint8_t reg, uint8_t value);
 bool readPowerStatus(PowerStatus &status);
 bool readBatteryStatus(uint8_t &percentage, bool &charging);
 bool readBatteryPercentage(uint8_t &percentage);
-bool setPowerButtonShortPressMonitoring(bool enabled);
-bool readAndClearPowerButtonShortPress(bool &pressed);
+bool setPowerButtonEventMonitoring(bool enabled);
+bool readAndClearPowerButtonEvents(PowerButtonEvents &events);
 
 bool enableDisplayRails();
 bool enablePeripheralRails();

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -33,6 +33,7 @@ build_flags =
   -D DISABLE_RADIO=1
   -D BAUDRATE=115200
   -D DEBUG=1
+  -include include/nimble_connection_config.h
   -D HAS_HARDWARE_GPS=1
   -D SHELLMINATOR_BUFF_LEN=70
   -D SHELLMINATOR_BUFF_DIM=70
@@ -241,6 +242,10 @@ build_flags =
   -D CORE_DEBUG_LEVEL=2
   -D BAUDRATE=115200
   -D DEBUG=1
+  ; Arduino's sdkconfig.h defines NimBLE's connection limit after command-line
+  ; macros. Preinclude our override so every locally built NimBLE source agrees
+  ; that the ownership protocol permits exactly one central.
+  -include include/nimble_connection_config.h
   ; AMOLEDs need high brightness commands, usually handled in driver, 
   ; but we define a default here just in case.
   -DTFT_BL=-1

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -68,6 +68,7 @@ extern xSemaphoreHandle gpsMutex;
 
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
+#include "disconnected_shutdown_policy.hpp"
 #include "ownership_button_policy.hpp"
 #include "guiLayout.hpp"
 #include "mainScr.hpp"
@@ -504,50 +505,34 @@ static void logSystemDebugHeartbeat() {
 }
 
 static void processDisconnectedShutdown() {
-  static uint32_t disconnectedSinceMs = 0;
-  static uint32_t lastTimeoutSeconds = 120;
-  static bool shutdownAnnounced = false;
+  static disconnected_shutdown_policy::Tracker shutdownTracker;
+  const bool connected = bleNavServer.isConnected();
+  const bool ownershipClaimed = bleNavServer.isOwnershipClaimed();
+  const disconnected_shutdown_policy::UpdateResult result =
+      shutdownTracker.update(
+          millis(), connected,
+          mapRenderSettings.disconnectedSleepTimeoutSeconds,
+          ownershipClaimed);
 
-  if (bleNavServer.isConnected()) {
-    disconnectedSinceMs = 0;
-    lastTimeoutSeconds = mapRenderSettings.disconnectedSleepTimeoutSeconds;
-    shutdownAnnounced = false;
+  if (result.action ==
+      disconnected_shutdown_policy::Action::CountdownStarted) {
+    Serial.printf(
+        "Power: app not connected; shutdown in %lu seconds if still "
+        "disconnected%s\n",
+        (unsigned long)result.timeoutSeconds,
+        result.waitingForRegistration ? " (registration grace)" : "");
     return;
   }
 
-  const uint32_t timeoutSeconds =
-      mapRenderSettings.disconnectedSleepTimeoutSeconds;
-  if (timeoutSeconds == 0) {
-    disconnectedSinceMs = 0;
-    lastTimeoutSeconds = 0;
-    shutdownAnnounced = false;
+  if (result.action != disconnected_shutdown_policy::Action::ShutdownDue &&
+      result.action != disconnected_shutdown_policy::Action::ShutdownRetry) {
     return;
   }
 
-  if (timeoutSeconds != lastTimeoutSeconds) {
-    disconnectedSinceMs = 0;
-    lastTimeoutSeconds = timeoutSeconds;
-    shutdownAnnounced = false;
-  }
-
-  const uint32_t now = millis();
-  if (disconnectedSinceMs == 0) {
-    disconnectedSinceMs = now;
-    Serial.printf("Power: app not connected; shutdown in %lu seconds if still "
-                  "disconnected\n",
-                  (unsigned long)timeoutSeconds);
-    return;
-  }
-
-  if (now - disconnectedSinceMs < timeoutSeconds * 1000UL) {
-    return;
-  }
-
-  if (!shutdownAnnounced) {
-    shutdownAnnounced = true;
+  if (result.action == disconnected_shutdown_policy::Action::ShutdownDue) {
     Serial.printf("Power: app was disconnected for %lu seconds; entering deep "
                   "sleep\n",
-                  (unsigned long)timeoutSeconds);
+                  (unsigned long)result.timeoutSeconds);
     Serial.println("Power: press BOOT to wake the device");
     Serial.flush();
   }

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -68,12 +68,14 @@ extern xSemaphoreHandle gpsMutex;
 
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
+#include "ownership_button_policy.hpp"
 #include "guiLayout.hpp"
 #include "mainScr.hpp"
 #include "route_overlay.hpp"
 #include "waitingScr.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "WAVESHARE_AMOLED_175.hpp"
+#include "axp2101.hpp"
 #include "i2c_bus.hpp"
 #include "pcf85063.hpp"
 #include "qmi8658.hpp"
@@ -154,6 +156,20 @@ static void updateMapActivationProgressOverlay() {
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 volatile bool waveshareBootScreenCyclePending = false;
 static portMUX_TYPE waveshareBootButtonMux = portMUX_INITIALIZER_UNLOCKED;
+static ownership_button_policy::FreshBootButtonGate waveshareBootPairingGate;
+static bool waveshareBootWaitingForRelease = false;
+static bool waveshareBootHandledPairingConfirmation = false;
+static uint32_t waveshareBootReleaseStartMs = 0;
+static uint32_t waveshareBootPressStartMs = 0;
+static ownership_button_policy::FreshPowerButtonGate
+    wavesharePowerPairingGate;
+static uint32_t wavesharePowerPairingGeneration = 0;
+
+// Called by the panel driver only after a frame has reached the display. This
+// keeps physical confirmation disabled until the comparison code is visible.
+void appDisplayFlushCompleted() {
+  bleNavServer.noteOwnershipDisplayFlushCompleted();
+}
 
 static void IRAM_ATTR latchWaveshareBootScreenCycle() {
   portENTER_CRITICAL_ISR(&waveshareBootButtonMux);
@@ -172,58 +188,131 @@ static bool takeWaveshareBootScreenCycle() {
 static void processWaveshareBootButton() {
   constexpr uint32_t DEBOUNCE_MS = 50;
 
-  static bool waitingForRelease = false;
-  static bool handledPairingConfirmation = false;
-  static uint32_t releaseStartMs = 0;
-  static uint32_t pressStartMs = 0;
-
   const uint32_t now = millis();
   const bool pressed = digitalRead(BOARD_BOOT_PIN) == LOW;
   const bool latchedPress = takeWaveshareBootScreenCycle();
 
-  if (!waitingForRelease) {
+  if (waveshareBootPairingGate.blocksInput(pressed, now, DEBOUNCE_MS)) {
+    return;
+  }
+
+  if (!waveshareBootWaitingForRelease) {
     if (!latchedPress && !pressed) {
       return;
     }
 
-    waitingForRelease = true;
-    handledPairingConfirmation = false;
-    releaseStartMs = 0;
-    pressStartMs = now;
-    if (bleNavServer.confirmOwnershipPairing()) {
-      handledPairingConfirmation = true;
-      log_i("Waveshare BOOT pressed; confirmed ownership pairing");
+    waveshareBootWaitingForRelease = true;
+    waveshareBootHandledPairingConfirmation = false;
+    waveshareBootReleaseStartMs = 0;
+    waveshareBootPressStartMs = now;
+    waveshareBootHandledPairingConfirmation =
+        ownership_button_policy::handleShortPress(
+            [] { return bleNavServer.confirmOwnershipPairing(); },
+            [] {
+              if (!bleNavServer.hasOwnershipPairingCode()) {
+                toggleNavigationScreen();
+              }
+            });
+    if (waveshareBootHandledPairingConfirmation) {
+      log_i("Waveshare BOOT pressed; handled ownership pairing");
+    } else if (bleNavServer.hasOwnershipPairingCode()) {
+      log_i("Waveshare BOOT press ignored until comparison is ready");
     } else {
       log_i("Waveshare BOOT pressed; handling forward action");
-      toggleNavigationScreen();
     }
     return;
   }
 
   if (pressed) {
-    releaseStartMs = 0;
+    waveshareBootReleaseStartMs = 0;
     return;
   }
 
-  if (releaseStartMs == 0) {
-    releaseStartMs = now;
+  if (waveshareBootReleaseStartMs == 0) {
+    waveshareBootReleaseStartMs = now;
     return;
   }
 
-  if (now - releaseStartMs < DEBOUNCE_MS) {
+  if (now - waveshareBootReleaseStartMs < DEBOUNCE_MS) {
     return;
   }
 
-  waitingForRelease = false;
-  const uint32_t pressDurationMs = now - pressStartMs;
+  waveshareBootWaitingForRelease = false;
+  const uint32_t pressDurationMs = now - waveshareBootPressStartMs;
   log_i("Waveshare BOOT released after %lu ms",
         static_cast<unsigned long>(pressDurationMs));
-  if (pressDurationMs >= 8000 && !handledPairingConfirmation) {
+  if (ownership_button_policy::shouldRecoverOwner(
+          pressDurationMs, waveshareBootHandledPairingConfirmation)) {
     if (bleNavServer.forgetOwner()) {
       log_i("Waveshare BOOT long press cleared the registered iPhone");
     } else {
       log_i("Waveshare BOOT long press: no registered iPhone to clear");
     }
+  }
+}
+
+static void processWavesharePowerButton() {
+  constexpr uint32_t POLL_INTERVAL_MS = 100;
+  static uint32_t lastPollMs = 0;
+
+  const uint32_t now = millis();
+  if (now - lastPollMs < POLL_INTERVAL_MS) {
+    return;
+  }
+  lastPollMs = now;
+
+  waveshare_board::axp2101::PowerButtonEvents events;
+  if (!waveshare_board::axp2101::readAndClearPowerButtonEvents(events)) {
+    return;
+  }
+
+  if (bleNavServer.hasOwnershipPairingCode()) {
+    if (wavesharePowerPairingGate.acceptEvents(
+            wavesharePowerPairingGeneration, events.negativeEdge,
+            events.positiveEdge, events.shortPress) &&
+        bleNavServer.confirmOwnershipPairing()) {
+      log_i("Waveshare PWR pressed; handled ownership pairing");
+    }
+    // Never honk while a pairing comparison is active, including before the
+    // screen has flushed and the fresh-edge gate has been armed.
+    return;
+  }
+
+  wavesharePowerPairingGate.cancel();
+  wavesharePowerPairingGeneration = 0;
+  if (events.shortPress) {
+    waveshare_board::speaker::handlePowerButtonHonkPress();
+  }
+}
+
+static void armOwnershipPairingAfterRenderedComparison() {
+  uint32_t pairingGeneration = 0;
+  if (!bleNavServer.ownershipPairingRenderedRequest(pairingGeneration)) {
+    return;
+  }
+
+  // A registration can only consume input generated after this comparison
+  // screen was rendered. Discard both hardware latches and require BOOT to be
+  // observed released before its next press.
+  (void)takeWaveshareBootScreenCycle();
+  waveshareBootPairingGate.arm();
+  waveshareBootWaitingForRelease = false;
+  waveshareBootHandledPairingConfirmation = false;
+  waveshareBootReleaseStartMs = 0;
+  waveshareBootPressStartMs = 0;
+  waveshare_board::axp2101::PowerButtonEvents stalePowerButtonEvents;
+  if (!waveshare_board::axp2101::readAndClearPowerButtonEvents(
+          stalePowerButtonEvents)) {
+    return;
+  }
+
+  wavesharePowerPairingGate.arm(pairingGeneration);
+  wavesharePowerPairingGeneration = pairingGeneration;
+  if (bleNavServer.armOwnershipPairingConfirmation(pairingGeneration)) {
+    log_i("Ownership pairing buttons armed after comparison render");
+  } else {
+    wavesharePowerPairingGate.cancel();
+    wavesharePowerPairingGeneration = 0;
   }
 }
 #endif
@@ -706,6 +795,9 @@ void setup() {
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::speaker::begin();
+  if (!waveshare_board::axp2101::setPowerButtonEventMonitoring(true)) {
+    Serial.println("AXP2101: PWR button-event monitoring unavailable");
+  }
 #endif
 
   // Initialize BLE early so device is discoverable while showing waiting screen
@@ -779,6 +871,9 @@ void loop() {
     lvglHandlerCount++;
     lastLvglHandlerMs = millis();
     vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+    armOwnershipPairingAfterRenderedComparison();
+#endif
   }
 
   // Process BLE events
@@ -790,7 +885,7 @@ void loop() {
   waveshare_board::imu::process();
 #endif
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  waveshare_board::speaker::processPowerButtonHonk();
+  processWavesharePowerButton();
 #endif
 
   logSystemDebugHeartbeat();

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -173,6 +173,7 @@ static void processWaveshareBootButton() {
   constexpr uint32_t DEBOUNCE_MS = 50;
 
   static bool waitingForRelease = false;
+  static bool handledPairingConfirmation = false;
   static uint32_t releaseStartMs = 0;
   static uint32_t pressStartMs = 0;
 
@@ -186,10 +187,16 @@ static void processWaveshareBootButton() {
     }
 
     waitingForRelease = true;
+    handledPairingConfirmation = false;
     releaseStartMs = 0;
     pressStartMs = now;
-    log_i("Waveshare BOOT pressed; handling forward action");
-    toggleNavigationScreen();
+    if (bleNavServer.confirmOwnershipPairing()) {
+      handledPairingConfirmation = true;
+      log_i("Waveshare BOOT pressed; confirmed ownership pairing");
+    } else {
+      log_i("Waveshare BOOT pressed; handling forward action");
+      toggleNavigationScreen();
+    }
     return;
   }
 
@@ -211,6 +218,13 @@ static void processWaveshareBootButton() {
   const uint32_t pressDurationMs = now - pressStartMs;
   log_i("Waveshare BOOT released after %lu ms",
         static_cast<unsigned long>(pressDurationMs));
+  if (pressDurationMs >= 8000 && !handledPairingConfirmation) {
+    if (bleNavServer.forgetOwner()) {
+      log_i("Waveshare BOOT long press cleared the registered iPhone");
+    } else {
+      log_i("Waveshare BOOT long press: no registered iPhone to clear");
+    }
+  }
 }
 #endif
 extern Gps gps;

--- a/esp32/tools/tests/host_stubs/Preferences.h
+++ b/esp32/tools/tests/host_stubs/Preferences.h
@@ -1,0 +1,104 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace preferences_test {
+using Bytes = std::vector<uint8_t>;
+inline std::unordered_map<std::string, std::unordered_map<std::string, Bytes>> stores;
+inline bool failBegin = false;
+inline std::string failPutKey;
+inline std::string failRemoveKey;
+
+inline void reset() {
+  stores.clear();
+  failBegin = false;
+  failPutKey.clear();
+  failRemoveKey.clear();
+}
+
+inline void put(const std::string &nameSpace, const std::string &key,
+                const Bytes &value) {
+  stores[nameSpace][key] = value;
+}
+} // namespace preferences_test
+
+class Preferences {
+public:
+  bool begin(const char *nameSpace, bool) {
+    if (preferences_test::failBegin) return false;
+    nameSpace_ = nameSpace == nullptr ? "" : nameSpace;
+    open_ = true;
+    return true;
+  }
+
+  void end() { open_ = false; }
+
+  bool isKey(const char *key) const { return find(key) != nullptr; }
+
+  size_t getBytesLength(const char *key) const {
+    const auto *value = find(key);
+    return value == nullptr ? 0 : value->size();
+  }
+
+  size_t getBytes(const char *key, void *out, size_t length) const {
+    const auto *value = find(key);
+    if (value == nullptr || out == nullptr) return 0;
+    const size_t copied = value->size() < length ? value->size() : length;
+    std::memcpy(out, value->data(), copied);
+    return copied;
+  }
+
+  size_t putBytes(const char *key, const void *data, size_t length) {
+    if (!open_ || key == nullptr || data == nullptr) return 0;
+    if (preferences_test::failPutKey == key) return 0;
+    const auto *bytes = static_cast<const uint8_t *>(data);
+    preferences_test::stores[nameSpace_][key] =
+        preferences_test::Bytes(bytes, bytes + length);
+    return length;
+  }
+
+  uint8_t getUChar(const char *key, uint8_t fallback) const {
+    const auto *value = find(key);
+    return value != nullptr && value->size() == 1 ? (*value)[0] : fallback;
+  }
+
+  size_t putUChar(const char *key, uint8_t value) {
+    return putBytes(key, &value, 1);
+  }
+
+  std::string getString(const char *key, const char *fallback) const {
+    const auto *value = find(key);
+    if (value == nullptr) return fallback == nullptr ? "" : fallback;
+    return std::string(value->begin(), value->end());
+  }
+
+  size_t putString(const char *key, const char *value) {
+    if (value == nullptr) return 0;
+    const size_t length = std::strlen(value);
+    return putBytes(key, value, length);
+  }
+
+  bool remove(const char *key) {
+    if (!open_ || key == nullptr) return false;
+    if (preferences_test::failRemoveKey == key) return false;
+    auto store = preferences_test::stores.find(nameSpace_);
+    return store != preferences_test::stores.end() && store->second.erase(key) == 1;
+  }
+
+private:
+  const preferences_test::Bytes *find(const char *key) const {
+    if (!open_ || key == nullptr) return nullptr;
+    const auto store = preferences_test::stores.find(nameSpace_);
+    if (store == preferences_test::stores.end()) return nullptr;
+    const auto value = store->second.find(key);
+    return value == store->second.end() ? nullptr : &value->second;
+  }
+
+  std::string nameSpace_;
+  bool open_ = false;
+};

--- a/esp32/tools/tests/host_stubs/esp_mac.h
+++ b/esp32/tools/tests/host_stubs/esp_mac.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <cstdint>
+#include <cstddef>
+
+using esp_err_t = int;
+constexpr esp_err_t ESP_OK = 0;
+
+inline esp_err_t esp_efuse_mac_get_default(uint8_t mac[6]) {
+  if (mac == nullptr) return -1;
+  const uint8_t fixed[6] = {0x02, 0x00, 0x00, 0x12, 0x34, 0x56};
+  for (size_t index = 0; index < 6; index++) mac[index] = fixed[index];
+  return ESP_OK;
+}

--- a/esp32/tools/tests/host_stubs/esp_system.h
+++ b/esp32/tools/tests/host_stubs/esp_system.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+inline void esp_fill_random(void *output, size_t length) {
+  static uint8_t next = 1;
+  auto *bytes = static_cast<uint8_t *>(output);
+  for (size_t index = 0; index < length; index++) bytes[index] = next++;
+}

--- a/esp32/tools/tests/test_device_ownership.cpp
+++ b/esp32/tools/tests/test_device_ownership.cpp
@@ -1,5 +1,6 @@
 #include "../../lib/ble_navigation/device_ownership.hpp"
 #include "../../lib/ble_navigation/ble_connection_policy.hpp"
+#include "../../lib/ble_navigation/disconnected_shutdown_policy.hpp"
 #include "../../lib/ble_navigation/ownership_button_policy.hpp"
 #include "host_stubs/Preferences.h"
 
@@ -155,6 +156,53 @@ struct AppPairing {
 };
 
 int main() {
+  assert(disconnected_shutdown_policy::effectiveTimeoutSeconds(120, true) ==
+         120);
+  assert(disconnected_shutdown_policy::effectiveTimeoutSeconds(120, false) ==
+         600);
+  assert(disconnected_shutdown_policy::effectiveTimeoutSeconds(600, false) ==
+         600);
+  assert(disconnected_shutdown_policy::effectiveTimeoutSeconds(0, false) ==
+         0);
+  disconnected_shutdown_policy::Tracker shutdownTracker;
+  auto shutdownResult = shutdownTracker.update(100, false, 120, false);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
+  assert(shutdownResult.timeoutSeconds == 600);
+  assert(shutdownResult.waitingForRegistration);
+  shutdownResult = shutdownTracker.update(600099, false, 120, false);
+  assert(shutdownResult.action == disconnected_shutdown_policy::Action::None);
+  shutdownResult = shutdownTracker.update(600100, false, 120, false);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::ShutdownDue);
+  shutdownResult = shutdownTracker.update(600101, false, 120, false);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::ShutdownRetry);
+
+  shutdownResult = shutdownTracker.update(700000, true, 120, false);
+  assert(shutdownResult.action == disconnected_shutdown_policy::Action::None);
+  shutdownResult = shutdownTracker.update(700001, false, 120, true);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
+  assert(shutdownResult.timeoutSeconds == 120);
+  assert(!shutdownResult.waitingForRegistration);
+  shutdownResult = shutdownTracker.update(800001, false, 0, true);
+  assert(shutdownResult.action == disconnected_shutdown_policy::Action::None);
+  shutdownResult = shutdownTracker.update(900001, false, 120, true);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
+  shutdownResult = shutdownTracker.update(950001, false, 300, true);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
+  shutdownResult = shutdownTracker.update(1250001, false, 300, true);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::ShutdownDue);
+  shutdownResult = shutdownTracker.update(1300000, false, 600, false);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
+  shutdownResult = shutdownTracker.update(1400000, false, 600, true);
+  assert(shutdownResult.action ==
+         disconnected_shutdown_policy::Action::CountdownStarted);
   assert(ble_connection_policy::accepts(
       ble_connection_policy::noConnection, 7));
   assert(ble_connection_policy::accepts(7, 7));

--- a/esp32/tools/tests/test_device_ownership.cpp
+++ b/esp32/tools/tests/test_device_ownership.cpp
@@ -1,0 +1,757 @@
+#include "../../lib/ble_navigation/device_ownership.hpp"
+#include "../../lib/ble_navigation/ble_connection_policy.hpp"
+#include "../../lib/ble_navigation/ownership_button_policy.hpp"
+#include "host_stubs/Preferences.h"
+
+#include <array>
+#include <cassert>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <iterator>
+#include <mbedtls/gcm.h>
+#include <string>
+#include <vector>
+
+using namespace device_ownership;
+
+static std::string sharedFixtureValue(const std::string &key) {
+  std::ifstream fixture("../docs/device-ownership-test-vectors.json");
+  assert(fixture.good());
+  const std::string json((std::istreambuf_iterator<char>(fixture)),
+                         std::istreambuf_iterator<char>());
+  const std::string prefix = "\"" + key + "\": \"";
+  const size_t start = json.find(prefix);
+  assert(start != std::string::npos);
+  const size_t valueStart = start + prefix.size();
+  const size_t end = json.find('"', valueStart);
+  assert(end != std::string::npos);
+  return json.substr(valueStart, end - valueStart);
+}
+
+static std::vector<std::string> split(const std::string &value) {
+  std::vector<std::string> parts;
+  size_t start = 0;
+  while (start <= value.size()) {
+    const size_t end = value.find('|', start);
+    parts.push_back(value.substr(start, end - start));
+    if (end == std::string::npos) break;
+    start = end + 1;
+  }
+  return parts;
+}
+
+static std::string proof(const OwnerKey &key, const std::string &message) {
+  std::array<uint8_t, 32> digest{};
+  assert(hmacSha256(key.data(), key.size(),
+                    reinterpret_cast<const uint8_t *>(message.data()),
+                    message.size(), digest.data()));
+  return hexEncode(digest.data(), digest.size());
+}
+
+static std::string binary(const std::string &hex) {
+  std::string result(hex.size() / 2, '\0');
+  assert(hexDecode(hex, reinterpret_cast<uint8_t *>(result.data()),
+                   result.size()));
+  return result;
+}
+
+static OwnerKey keyFromHex(const std::string &hex) {
+  OwnerKey result{};
+  assert(hexDecode(hex, result.data(), result.size()));
+  return result;
+}
+
+static OwnerKey sessionKey(const OwnerKey &ownerKey, const char *label,
+                           const std::string &context) {
+  OwnerKey result{};
+  const std::string message = std::string(label) + "|" + context;
+  assert(hmacSha256(ownerKey.data(), ownerKey.size(),
+                    reinterpret_cast<const uint8_t *>(message.data()),
+                    message.size(), result.data()));
+  return result;
+}
+
+static std::string writeFrame(const OwnerKey &writeKey,
+                              AuthenticatedChannel channel, uint32_t sequence,
+                              const std::string &plaintext) {
+  const uint8_t channelByte = static_cast<uint8_t>(channel);
+  const uint8_t sequenceBytes[4] = {
+      static_cast<uint8_t>(sequence >> 24),
+      static_cast<uint8_t>(sequence >> 16),
+      static_cast<uint8_t>(sequence >> 8), static_cast<uint8_t>(sequence)};
+  const std::array<uint8_t, 12> nonce = {
+      channelByte, 0, 0, 0, 0, 0, 0, 0, sequenceBytes[0], sequenceBytes[1],
+      sequenceBytes[2], sequenceBytes[3]};
+  std::string aad = "write2|";
+  aad.push_back(static_cast<char>(channelByte));
+  aad.append(reinterpret_cast<const char *>(sequenceBytes), 4);
+  std::string ciphertext(plaintext.size(), '\0');
+  std::array<uint8_t, 16> tag{};
+  mbedtls_gcm_context context;
+  mbedtls_gcm_init(&context);
+  assert(mbedtls_gcm_setkey(&context, MBEDTLS_CIPHER_ID_AES, writeKey.data(),
+                            256) == 0);
+  assert(mbedtls_gcm_crypt_and_tag(
+             &context, MBEDTLS_GCM_ENCRYPT, plaintext.size(), nonce.data(),
+             nonce.size(), reinterpret_cast<const uint8_t *>(aad.data()),
+             aad.size(), reinterpret_cast<const uint8_t *>(plaintext.data()),
+             reinterpret_cast<uint8_t *>(ciphertext.data()), tag.size(),
+             tag.data()) == 0);
+  mbedtls_gcm_free(&context);
+  std::string frame = "S2";
+  frame.append(reinterpret_cast<const char *>(sequenceBytes), 4);
+  frame.append(ciphertext);
+  frame.append(reinterpret_cast<const char *>(tag.data()), tag.size());
+  return frame;
+}
+
+struct AppPairing {
+  PairingKeyAgreement agreement;
+  OwnerId ownerId{};
+  PublicKey publicKey{};
+
+  explicit AppPairing(uint8_t privateTail) {
+    uint8_t privateKey[32]{};
+    privateKey[31] = privateTail;
+    assert(agreement.setPrivateKeyForTesting(privateKey));
+    assert(agreement.publicKey(publicKey));
+    for (size_t index = 0; index < ownerId.size(); index++)
+      ownerId[index] = static_cast<uint8_t>(0xA0 + index);
+  }
+
+  std::string command() const {
+    return "PAIR|" + hexEncode(ownerId.data(), ownerId.size()) + "|" +
+           hexEncode(publicKey.data(), publicKey.size());
+  }
+
+  PairingMaterial material(const CommandResult &response) {
+    const auto parts = split(response.response);
+    assert(parts.size() == 3 && parts[0] == "PAIRING");
+    DeviceId deviceId{};
+    PublicKey devicePublic{};
+    assert(hexDecode(parts[1], deviceId.data(), deviceId.size()));
+    assert(hexDecode(parts[2], devicePublic.data(), devicePublic.size()));
+    PairingMaterial result{};
+    assert(agreement.derive(devicePublic, deviceId, ownerId, publicKey,
+                            devicePublic, result));
+    return result;
+  }
+
+  std::string confirm(const PairingMaterial &material,
+                      const std::string &name) const {
+    std::array<uint8_t, 32> digest{};
+    std::array<uint8_t, 6 + TRANSCRIPT_HASH_SIZE> message{};
+    std::memcpy(message.data(), "claim|", 6);
+    std::memcpy(message.data() + 6, material.transcriptHash.data(),
+                material.transcriptHash.size());
+    assert(hmacSha256(material.ownerKey.data(), material.ownerKey.size(),
+                      message.data(), message.size(), digest.data()));
+    return "CONFIRM|" + hexEncode(ownerId.data(), ownerId.size()) + "|" +
+           hexEncode(digest.data(), digest.size()) + "|" +
+           hexEncode(reinterpret_cast<const uint8_t *>(name.data()),
+                     name.size());
+  }
+};
+
+int main() {
+  assert(ble_connection_policy::accepts(
+      ble_connection_policy::noConnection, 7));
+  assert(ble_connection_policy::accepts(7, 7));
+  assert(!ble_connection_policy::accepts(7, 8));
+  assert(ble_connection_policy::tearsDownSession(7, 7));
+  assert(!ble_connection_policy::tearsDownSession(7, 8));
+  uint16_t activeHandle = ble_connection_policy::noConnection;
+  int sessionResets = 0;
+  assert(ble_connection_policy::beginSession(
+      activeHandle, 7, [&] {
+        sessionResets++;
+        return true;
+      }));
+  assert(activeHandle == 7 && sessionResets == 1);
+  assert(!ble_connection_policy::beginSession(
+      activeHandle, 8, [&] {
+        sessionResets++;
+        return true;
+      }));
+  assert(activeHandle == 7 && sessionResets == 1);
+  assert(!ble_connection_policy::endSession(
+      activeHandle, 8, [&] {
+        sessionResets++;
+        return true;
+      }));
+  assert(activeHandle == 7 && sessionResets == 1);
+  assert(ble_connection_policy::endSession(
+      activeHandle, 7, [&] {
+        sessionResets++;
+        return true;
+      }));
+  assert(activeHandle == ble_connection_policy::noConnection &&
+         sessionResets == 2);
+  int bootConfirmations = 0;
+  int bootFallbacks = 0;
+  assert(ownership_button_policy::handleShortPress(
+      [&] {
+        bootConfirmations++;
+        return true;
+      },
+      [&] { bootFallbacks++; }));
+  assert(bootConfirmations == 1 && bootFallbacks == 0);
+  int powerConfirmations = 0;
+  int powerFallbacks = 0;
+  assert(ownership_button_policy::handleShortPress(
+      [&] {
+        powerConfirmations++;
+        return true;
+      },
+      [&] { powerFallbacks++; }));
+  assert(powerConfirmations == 1 && powerFallbacks == 0);
+  assert(!ownership_button_policy::handleShortPress(
+      [] { return false; }, [&] { powerFallbacks++; }));
+  assert(powerFallbacks == 1);
+  assert(!ownership_button_policy::shouldRecoverOwner(7999, false));
+  assert(ownership_button_policy::shouldRecoverOwner(8000, false));
+  assert(!ownership_button_policy::shouldRecoverOwner(9000, true));
+
+  ownership_button_policy::ComparisonRenderGate renderGate;
+  renderGate.request(7);
+  assert(renderGate.renderedGeneration() == 0);
+  assert(!renderGate.consumeRendered(7));
+  renderGate.displayFlushed();
+  assert(renderGate.renderedGeneration() == 7);
+  assert(!renderGate.consumeRendered(8));
+  assert(renderGate.consumeRendered(7));
+  assert(renderGate.renderedGeneration() == 0);
+
+  ownership_button_policy::FreshBootButtonGate bootGate;
+  bootGate.arm();
+  assert(bootGate.blocksInput(true, 100, 50));
+  assert(bootGate.blocksInput(false, 110, 50));
+  assert(bootGate.blocksInput(false, 159, 50));
+  assert(bootGate.blocksInput(false, 160, 50));
+  // After the stale press is released and debounced, the very next fresh
+  // press passes the gate and can confirm pairing.
+  assert(!bootGate.blocksInput(true, 200, 50));
+
+  ownership_button_policy::FreshPowerButtonGate powerGate;
+  powerGate.arm(7);
+  // Releasing a button held before arming must not confirm pairing.
+  assert(!powerGate.acceptEvents(7, false, true, true));
+  assert(!powerGate.acceptEvents(8, true, true, true));
+  assert(!powerGate.acceptEvents(7, true, false, false));
+  assert(powerGate.acceptEvents(7, false, true, true));
+  assert(!powerGate.acceptEvents(7, false, true, true));
+  assert(powerGate.acceptEvents(7, true, true, true));
+  powerGate.arm(8);
+  // A complete fresh tap can be reported in one PMU status read.
+  assert(powerGate.acceptEvents(8, true, true, true));
+
+  assert(isValidDeviceName("Chris' bike"));
+  assert(isValidDeviceName("Chris' \xF0\x9F\x9A\xB2"));
+  assert(!isValidDeviceName(std::string("\xC0\xAF", 2)));
+  assert(!isValidDeviceName(std::string("\xED\xA0\x80", 3)));
+  preferences_test::reset();
+  DeviceOwnership device;
+  assert(device.begin());
+  assert(!device.isClaimed());
+  assert(!device.allowsLegacyAuthentication());
+  assert(!device.confirmPairingOnDevice());
+  const auto unclaimedAdvertisement = device.advertisementManufacturerData();
+  assert(unclaimedAdvertisement.size() == 8);
+  assert(hexEncode(unclaimedAdvertisement.data(),
+                   unclaimedAdvertisement.size()) ==
+         sharedFixtureValue("advertisementUnclaimed"));
+  const std::string stableId = device.deviceIdHex();
+  assert(stableId == sharedFixtureValue("deviceID"));
+
+  AppPairing firstApp(1);
+  assert(device.handle("PAIR|bad|bad", 9).response ==
+         "ERROR|invalid_pairing_request");
+  const auto firstPair = device.handle(firstApp.command(), 10);
+  assert(firstPair.event == Event::PairingStarted);
+  const uint32_t firstPairingGeneration = device.pairingGeneration();
+  assert(firstPairingGeneration != 0);
+
+  // A BOOT/PWR event latched before the comparison is rendered cannot confirm
+  // the new pairing generation. Only a fresh post-render press can do so.
+  assert(!device.confirmPairingOnDevice());
+  assert(!device.armPairingConfirmation(firstPairingGeneration + 1));
+  assert(!device.confirmPairingOnDevice());
+
+  AppPairing replacement(2);
+  const auto replacementPair = device.handle(replacement.command(), 20);
+  assert(replacementPair.response == "ERROR|pairing_attempt_already_used");
+  const auto firstMaterial = firstApp.material(firstPair);
+  const auto premature =
+      device.handle(firstApp.confirm(firstMaterial, "Cargo bike"), 21);
+  assert(premature.response == "ERROR|physical_confirmation_required");
+
+  assert(device.armPairingConfirmation(firstPairingGeneration));
+  assert(device.confirmPairingOnDevice());
+  assert(!device.confirmPairingOnDevice());
+  const auto paired =
+      device.handle(firstApp.confirm(firstMaterial, "Cargo bike"), 22);
+  assert(paired.event == Event::Paired);
+  assert(device.isClaimed());
+  assert(!device.allowsLegacyAuthentication());
+  const auto claimedAdvertisement = device.advertisementManufacturerData();
+  assert(hexEncode(claimedAdvertisement.data(),
+                   claimedAdvertisement.size()) ==
+         sharedFixtureValue("advertisementClaimed"));
+
+  const std::string ownerHex =
+      hexEncode(firstApp.ownerId.data(), firstApp.ownerId.size());
+  const std::string clientNonce = "00112233445566778899aabbccddeeff";
+  const auto server =
+      device.handle("OWNER|" + ownerHex + "|" + clientNonce, 30);
+  const auto serverParts = split(server.response);
+  assert(serverParts.size() == 5 && serverParts[0] == "SERVER2");
+  const std::string serverMessage = "server2|" + stableId + "|" + ownerHex +
+                                    "|" + clientNonce + "|" + serverParts[3];
+  assert(serverParts[4] == proof(firstMaterial.ownerKey, serverMessage));
+  const std::string clientMessage = "client2|" + stableId + "|" + ownerHex +
+                                    "|" + clientNonce + "|" + serverParts[3];
+  const std::string oldProof = "PROOF|" + ownerHex + "|" + clientNonce + "|" +
+                               serverParts[3] + "|" +
+                               proof(firstMaterial.ownerKey, clientMessage);
+  assert(device.handle(oldProof, 31).event == Event::Authenticated);
+
+  device.resetConnection();
+  const auto freshServer =
+      device.handle("OWNER|" + ownerHex + "|" + clientNonce, 40);
+  assert(split(freshServer.response)[3] != serverParts[3]);
+  assert(device.handle(oldProof, 41).response == "DENIED|" + stableId);
+
+  DeviceOwnership rebooted;
+  assert(rebooted.begin());
+  assert(rebooted.deviceIdHex() == stableId);
+  assert(rebooted.isClaimed());
+  assert(!rebooted.allowsLegacyAuthentication());
+
+  const auto rebootServer =
+      rebooted.handle("OWNER|" + ownerHex + "|" + clientNonce, 50);
+  const auto rebootServerParts = split(rebootServer.response);
+  assert(rebootServerParts.size() == 5);
+  const std::string rebootContext =
+      stableId + "|" + clientNonce + "|" + rebootServerParts[3];
+  const std::string rebootClientMessage =
+      "client2|" + stableId + "|" + ownerHex + "|" + clientNonce + "|" +
+      rebootServerParts[3];
+  assert(rebooted
+             .handle("PROOF|" + ownerHex + "|" + clientNonce + "|" +
+                         rebootServerParts[3] + "|" +
+                         proof(firstMaterial.ownerKey, rebootClientMessage),
+                     51)
+             .event == Event::Authenticated);
+  const OwnerKey rebootWriteKey =
+      sessionKey(firstMaterial.ownerKey, "session2-write", rebootContext);
+  std::string command;
+  assert(rebooted.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(rebootWriteKey, AuthenticatedChannel::Auth, 1,
+                 "NAME|526f61642062696b65"),
+      command));
+  const auto renamed = rebooted.handle(command, 52);
+  assert(renamed.event == Event::Renamed);
+  assert(renamed.response.size() <= 182);
+
+  assert(rebooted.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(rebootWriteKey, AuthenticatedChannel::Auth, 2, "GET_NAME"),
+      command));
+  const auto currentName = rebooted.handle(command, 53);
+  assert(currentName.matched && currentName.event == Event::None &&
+         currentName.response.size() >= AUTHENTICATED_FRAME_OVERHEAD &&
+         currentName.response[0] == 'R' && currentName.response[1] == '2');
+  assert(rebooted.deviceName() == "Road bike");
+
+  assert(rebooted.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(rebootWriteKey, AuthenticatedChannel::Auth, 3, "UNPAIR"),
+      command));
+  const auto unpaired = rebooted.handle(command, 54);
+  assert(unpaired.event == Event::Unpaired);
+  assert(unpaired.response.size() <= 182);
+  assert(!rebooted.isClaimed());
+  assert(!rebooted.allowsLegacyAuthentication());
+
+  DeviceOwnership afterUnpair;
+  assert(afterUnpair.begin());
+  const auto receiptInfo = split(afterUnpair.handle("INFO", 55).response);
+  assert(receiptInfo.size() == 7 && receiptInfo[3] == "0" &&
+         receiptInfo[4].empty());
+  assert(receiptInfo[5].size() == 32 && receiptInfo[6].size() == 64);
+  const std::string receiptMessage =
+      "revoked2|" + stableId + "|" + ownerHex + "|" + receiptInfo[5];
+  assert(receiptInfo[6] == proof(firstMaterial.ownerKey, receiptMessage));
+
+  const auto receiptStore = preferences_test::stores;
+  const auto assertReceiptSurvives = [&](uint32_t nowMs) {
+    DeviceOwnership recovered;
+    assert(recovered.begin());
+    assert(!recovered.isClaimed());
+    const auto recoveredInfo = split(recovered.handle("INFO", nowMs).response);
+    assert(recoveredInfo.size() == 7 && recoveredInfo[3] == "0");
+    assert(recoveredInfo[5].size() == 32 &&
+           recoveredInfo[6] ==
+               proof(firstMaterial.ownerKey,
+                     "revoked2|" + stableId + "|" + ownerHex + "|" +
+                         recoveredInfo[5]));
+  };
+
+  // Model reset after the UNPAIR tombstone commits but before owner cleanup.
+  // Because the current key signed this receipt, boot must finish revocation
+  // before exposing any claimed state to the iPhone.
+  preferences_test::stores = receiptStore;
+  preferences_test::put("bleOwner", "version", {2});
+  preferences_test::put(
+      "bleOwner", "ownerId",
+      preferences_test::Bytes(firstApp.ownerId.begin(), firstApp.ownerId.end()));
+  preferences_test::put(
+      "bleOwner", "ownerKey",
+      preferences_test::Bytes(firstMaterial.ownerKey.begin(),
+                              firstMaterial.ownerKey.end()));
+  preferences_test::put("bleOwner", "name", {'C', 'a', 'r', 'g', 'o'});
+  const auto interruptedUnpairStore = preferences_test::stores;
+  preferences_test::failRemoveKey = "ownerKey";
+  DeviceOwnership blockedInterruptedUnpair;
+  assert(blockedInterruptedUnpair.begin());
+  assert(blockedInterruptedUnpair.isClaimed());
+  assert(split(blockedInterruptedUnpair.handle("INFO", 899).response).size() ==
+         5);
+  assert(!blockedInterruptedUnpair.allowsLegacyAuthentication());
+  preferences_test::failRemoveKey.clear();
+  preferences_test::stores = interruptedUnpairStore;
+  assertReceiptSurvives(900);
+
+  // Every failed owner-record write must roll back without deleting the prior
+  // owner's durable deregistration acknowledgement.
+  const std::array<const char *, 4> ownerWriteKeys = {
+      "ownerId", "ownerKey", "name", "version"};
+  for (size_t index = 0; index < ownerWriteKeys.size(); index++) {
+    preferences_test::stores = receiptStore;
+    preferences_test::failPutKey.clear();
+    preferences_test::failRemoveKey.clear();
+    DeviceOwnership retry;
+    assert(retry.begin());
+    AppPairing retryApp(static_cast<uint8_t>(10 + index));
+    const auto retryPair = retry.handle(
+        retryApp.command(), 1001 + static_cast<uint32_t>(index * 10));
+    const auto retryMaterial = retryApp.material(retryPair);
+    assert(retry.armPairingConfirmation(retry.pairingGeneration()));
+    assert(retry.confirmPairingOnDevice());
+    preferences_test::failPutKey = ownerWriteKeys[index];
+    assert(retry
+               .handle(retryApp.confirm(retryMaterial, "Retry bike"),
+                       1002 + static_cast<uint32_t>(index * 10))
+               .response == "ERROR|pairing_persistence_failed");
+    preferences_test::failPutKey.clear();
+    assertReceiptSurvives(1003 + static_cast<uint32_t>(index * 10));
+  }
+
+  // Without a transaction marker bound to the replacement credential, a
+  // historical receipt cannot distinguish these partial writes from arbitrary
+  // corruption of a later owner. Every partial owner record must fail locked.
+  for (size_t completedWrites = 1; completedWrites <= 3; completedWrites++) {
+    preferences_test::stores = receiptStore;
+    preferences_test::put(
+        "bleOwner", "ownerId",
+        preferences_test::Bytes(firstApp.ownerId.begin(),
+                                firstApp.ownerId.end()));
+    if (completedWrites >= 2) {
+      preferences_test::put(
+          "bleOwner", "ownerKey",
+          preferences_test::Bytes(firstMaterial.ownerKey.begin(),
+                                  firstMaterial.ownerKey.end()));
+    }
+    if (completedWrites >= 3) {
+      preferences_test::put("bleOwner", "name",
+                            {'R', 'e', 't', 'r', 'y', ' ', 'b', 'i', 'k', 'e'});
+    }
+    DeviceOwnership interruptedReplacement;
+    assert(interruptedReplacement.begin());
+    assert(interruptedReplacement.isClaimed());
+    assert(interruptedReplacement
+               .handle(firstApp.command(),
+                       1100 + static_cast<uint32_t>(completedWrites))
+               .response == "OWNED|" + interruptedReplacement.deviceIdHex());
+  }
+
+  // A committed replacement owner keeps exposing the prior signed receipt so
+  // the old iPhone can converge even when its direct UNPAIRED2 was lost.
+  preferences_test::stores = receiptStore;
+  preferences_test::failPutKey.clear();
+  preferences_test::failRemoveKey.clear();
+  DeviceOwnership committedRetry;
+  assert(committedRetry.begin());
+  AppPairing committedApp(20);
+  const auto committedPair = committedRetry.handle(committedApp.command(), 1201);
+  const auto committedMaterial = committedApp.material(committedPair);
+  assert(committedRetry.armPairingConfirmation(
+      committedRetry.pairingGeneration()));
+  assert(committedRetry.confirmPairingOnDevice());
+  const auto committed = committedRetry.handle(
+      committedApp.confirm(committedMaterial, "Committed bike"), 1202);
+  assert(committed.event == Event::Paired);
+  DeviceOwnership committedReboot;
+  assert(committedReboot.begin());
+  assert(committedReboot.isClaimed());
+  const auto claimedReceipt =
+      split(committedReboot.handle("INFO", 1203).response);
+  assert(claimedReceipt.size() == 7 && claimedReceipt[3] == "1" &&
+         claimedReceipt[4].empty());
+  assert(claimedReceipt[6] ==
+         proof(firstMaterial.ownerKey,
+               "revoked2|" + stableId + "|" + ownerHex + "|" +
+                   claimedReceipt[5]));
+  const auto committedOwnerStore = preferences_test::stores;
+  preferences_test::put("bleOwner", "name", {0xFF});
+  DeviceOwnership corruptedReplacement;
+  assert(corruptedReplacement.begin());
+  assert(corruptedReplacement.isClaimed());
+  assert(corruptedReplacement
+             .handle(committedApp.command(), 1203)
+             .response == "OWNED|" + corruptedReplacement.deviceIdHex());
+  preferences_test::stores = committedOwnerStore;
+  const auto committedServer = committedReboot.handle(
+      "OWNER|" + ownerHex + "|00112233445566778899aabbccddeeff",
+      1204);
+  const auto committedServerParts = split(committedServer.response);
+  assert(committedServerParts.size() == 5 &&
+         committedServerParts[0] == "SERVER2");
+  const std::string committedClientMessage =
+      "client2|" + stableId + "|" + ownerHex +
+      "|00112233445566778899aabbccddeeff|" + committedServerParts[3];
+  assert(committedReboot
+             .handle("PROOF|" + ownerHex +
+                         "|00112233445566778899aabbccddeeff|" +
+                         committedServerParts[3] + "|" +
+                         proof(committedMaterial.ownerKey,
+                               committedClientMessage),
+                     1205)
+             .event == Event::Authenticated);
+  const OwnerKey committedWriteKey = sessionKey(
+      committedMaterial.ownerKey, "session2-write",
+      stableId + "|00112233445566778899aabbccddeeff|" +
+          committedServerParts[3]);
+  assert(committedReboot.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(committedWriteKey, AuthenticatedChannel::Auth, 1, "UNPAIR"),
+      command));
+  preferences_test::failRemoveKey = "revVersion";
+  assert(committedReboot.handle(command, 1206).response ==
+         "ERROR|unpair_persistence_failed");
+  assert(committedReboot.isClaimed() &&
+         committedReboot.isSessionAuthenticated());
+  preferences_test::failRemoveKey.clear();
+
+  preferences_test::reset();
+  preferences_test::put("bleOwner", "version", {2});
+  DeviceOwnership corrupt;
+  assert(corrupt.begin());
+  assert(corrupt.isClaimed());
+  assert(!corrupt.allowsLegacyAuthentication());
+
+  preferences_test::reset();
+  preferences_test::failBegin = true;
+  DeviceOwnership unavailable;
+  assert(!unavailable.begin());
+  assert(!unavailable.allowsLegacyAuthentication());
+
+  preferences_test::reset();
+  DeviceOwnership expiring;
+  assert(expiring.begin());
+  const auto expiringPair = expiring.handle(firstApp.command(), 100);
+  const auto expiringMaterial = firstApp.material(expiringPair);
+  assert(expiring.armPairingConfirmation(expiring.pairingGeneration()));
+  assert(expiring.confirmPairingOnDevice());
+  expiring.process(100 + PAIRING_SESSION_TIMEOUT_MS + 1);
+  assert(expiring.handle(firstApp.confirm(expiringMaterial, "Bike"),
+                         100 + PAIRING_SESSION_TIMEOUT_MS + 2)
+             .response == "ERROR|pairing_confirmation_failed");
+  assert(expiring
+             .handle(firstApp.command(),
+                     100 + PAIRING_SESSION_TIMEOUT_MS + 3)
+             .response == "ERROR|pairing_attempt_already_used");
+  expiring.resetConnection();
+  assert(expiring
+             .handle(firstApp.command(),
+                     100 + PAIRING_SESSION_TIMEOUT_MS + 4)
+             .event == Event::PairingStarted);
+
+  preferences_test::reset();
+  DeviceOwnership persistFailure;
+  assert(persistFailure.begin());
+  AppPairing failingApp(3);
+  const auto failingPair = persistFailure.handle(failingApp.command(), 201);
+  const auto failingMaterial = failingApp.material(failingPair);
+  assert(persistFailure.armPairingConfirmation(
+      persistFailure.pairingGeneration()));
+  assert(persistFailure.confirmPairingOnDevice());
+  preferences_test::failPutKey = "ownerKey";
+  assert(persistFailure
+             .handle(failingApp.confirm(failingMaterial, "Bike"), 202)
+             .response == "ERROR|pairing_persistence_failed");
+  assert(!persistFailure.isClaimed());
+  assert(!persistFailure.allowsLegacyAuthentication());
+
+  preferences_test::reset();
+  preferences_test::put("bleOwner", "version", {2});
+  preferences_test::put(
+      "bleOwner", "ownerId",
+      preferences_test::Bytes(firstApp.ownerId.begin(), firstApp.ownerId.end()));
+  preferences_test::put(
+      "bleOwner", "ownerKey",
+      preferences_test::Bytes(firstMaterial.ownerKey.begin(),
+                              firstMaterial.ownerKey.end()));
+  preferences_test::put("bleOwner", "name", {'B', 'i', 'k', 'e'});
+  DeviceOwnership missingIdentity;
+  assert(missingIdentity.begin());
+  assert(missingIdentity.isClaimed());
+  assert(!missingIdentity.allowsLegacyAuthentication());
+  assert(missingIdentity.handle(
+             "OWNER|" + ownerHex + "|" + clientNonce, 205).response ==
+         "DENIED|" + missingIdentity.deviceIdHex());
+  assert(missingIdentity.clearOwner());
+  DeviceOwnership recoveredIdentity;
+  assert(recoveredIdentity.begin());
+  assert(!recoveredIdentity.isClaimed());
+  assert(recoveredIdentity.deviceIdHex() == missingIdentity.deviceIdHex());
+
+  preferences_test::reset();
+  DeviceOwnership identitySeed;
+  assert(identitySeed.begin());
+  preferences_test::put("bleOwner", "version", {2});
+  preferences_test::put(
+      "bleOwner", "ownerId",
+      preferences_test::Bytes(firstApp.ownerId.begin(), firstApp.ownerId.end()));
+  preferences_test::put(
+      "bleOwner", "ownerKey",
+      preferences_test::Bytes(firstMaterial.ownerKey.begin(),
+                              firstMaterial.ownerKey.end()));
+  preferences_test::put("bleOwner", "name", {'B', 'i', 'k', 'e'});
+  const auto deterministicOwnerStore = preferences_test::stores;
+  const std::string deterministicIdentity = identitySeed.deviceIdHex();
+  preferences_test::put("bleOwner", "deviceId",
+                        preferences_test::Bytes(16, 0xA5));
+  DeviceOwnership sameLengthCorruptIdentity;
+  assert(sameLengthCorruptIdentity.begin());
+  assert(sameLengthCorruptIdentity.isClaimed());
+  assert(sameLengthCorruptIdentity.deviceIdHex() == deterministicIdentity);
+  assert(sameLengthCorruptIdentity
+             .handle("OWNER|" + ownerHex + "|" + clientNonce, 209)
+             .response == "DENIED|" + deterministicIdentity);
+  preferences_test::stores = deterministicOwnerStore;
+  DeviceOwnership storageFailure;
+  assert(storageFailure.begin() && storageFailure.isClaimed());
+  const std::string storageId = storageFailure.deviceIdHex();
+  const auto storageServer =
+      storageFailure.handle("OWNER|" + ownerHex + "|" + clientNonce, 210);
+  const auto storageServerParts = split(storageServer.response);
+  const std::string storageClientMessage =
+      "client2|" + storageId + "|" + ownerHex + "|" + clientNonce + "|" +
+      storageServerParts[3];
+  assert(storageFailure
+             .handle("PROOF|" + ownerHex + "|" + clientNonce + "|" +
+                         storageServerParts[3] + "|" +
+                         proof(firstMaterial.ownerKey, storageClientMessage),
+                     211)
+             .event == Event::Authenticated);
+  const OwnerKey storageWriteKey = sessionKey(
+      firstMaterial.ownerKey, "session2-write",
+      storageId + "|" + clientNonce + "|" + storageServerParts[3]);
+  preferences_test::failPutKey = "name";
+  assert(storageFailure.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(storageWriteKey, AuthenticatedChannel::Auth, 1,
+                 "NAME|4e6577206e616d65"),
+      command));
+  assert(storageFailure.handle(command, 212).response ==
+         "ERROR|rename_rejected");
+  assert(storageFailure.isSessionAuthenticated());
+  preferences_test::failPutKey = "revProof";
+  assert(storageFailure.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(storageWriteKey, AuthenticatedChannel::Auth, 2, "UNPAIR"),
+      command));
+  assert(storageFailure.handle(command, 213).response ==
+         "ERROR|unpair_persistence_failed");
+  assert(storageFailure.isClaimed() &&
+         storageFailure.isSessionAuthenticated());
+  preferences_test::failPutKey.clear();
+  preferences_test::failRemoveKey = "ownerKey";
+  assert(storageFailure.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Auth,
+      writeFrame(storageWriteKey, AuthenticatedChannel::Auth, 3, "UNPAIR"),
+      command));
+  assert(storageFailure.handle(command, 214).response ==
+         "ERROR|unpair_persistence_failed");
+  assert(storageFailure.isClaimed());
+  assert(!storageFailure.isSessionAuthenticated());
+  assert(!storageFailure.allowsLegacyAuthentication());
+
+  const OwnerKey goldenWriteKey = keyFromHex(
+      "fc52403d7ec42e7b3b7ecf64e6e496655930b1d175249e3447c670f59147304d");
+  const OwnerKey goldenNotifyKey = keyFromHex(
+      "54a70b224da51f29d318ddaa4e9d3cddb5b5fde0ee1a9da5361debc26f7bdc06");
+  const std::string goldenWriteFrame = binary(
+      "533200000001c486d6a2464da1600aab2af46a3ae0e00442af910dcdc23c8164d0336842cfaa426b31");
+  const std::string goldenNotifyFrame = binary(
+      "523200000001f19f6c8cd9263269e34a54aa910f37738270d42cb7d8632c8f0e20bfa6a4588d369304ab9662");
+
+  DeviceOwnership wire;
+  wire.setAuthenticatedSessionKeysForTesting(goldenWriteKey, goldenNotifyKey);
+  std::string plaintext;
+  assert(wire.unwrapAuthenticatedPayload(AuthenticatedChannel::Auth,
+                                         goldenWriteFrame, plaintext));
+  assert(plaintext == "NAME|4d792062696b65");
+  assert(!wire.unwrapAuthenticatedPayload(AuthenticatedChannel::Auth,
+                                          goldenWriteFrame, plaintext));
+
+  DeviceOwnership tamperedWire;
+  tamperedWire.setAuthenticatedSessionKeysForTesting(goldenWriteKey,
+                                                      goldenNotifyKey);
+  std::string tampered = goldenWriteFrame;
+  tampered.back() ^= 0x01;
+  assert(!tamperedWire.unwrapAuthenticatedPayload(AuthenticatedChannel::Auth,
+                                                  tampered, plaintext));
+  assert(tamperedWire.unwrapAuthenticatedPayload(AuthenticatedChannel::Auth,
+                                                  goldenWriteFrame,
+                                                  plaintext));
+
+  DeviceOwnership wrongChannel;
+  wrongChannel.setAuthenticatedSessionKeysForTesting(goldenWriteKey,
+                                                      goldenNotifyKey);
+  assert(!wrongChannel.unwrapAuthenticatedPayload(AuthenticatedChannel::Route,
+                                                   goldenWriteFrame,
+                                                   plaintext));
+
+  DeviceOwnership emptyRoute;
+  emptyRoute.setAuthenticatedSessionKeysForTesting(goldenWriteKey,
+                                                   goldenNotifyKey);
+  assert(emptyRoute.unwrapAuthenticatedPayload(
+      AuthenticatedChannel::Route,
+      binary("533200000001c981669fdeb1b029019459478ef19ff6"),
+      plaintext));
+  assert(plaintext.empty());
+
+  DeviceOwnership notifier;
+  notifier.setAuthenticatedSessionKeysForTesting(goldenWriteKey,
+                                                  goldenNotifyKey);
+  std::string notification;
+  assert(notifier.protectAuthenticatedPayload(
+      AuthenticatedChannel::Auth, "NAME_OK|4d792062696b65", notification));
+  assert(notification == goldenNotifyFrame);
+
+  DeviceOwnership navigationNotifier;
+  navigationNotifier.setAuthenticatedSessionKeysForTesting(goldenWriteKey,
+                                                            goldenNotifyKey);
+  const std::string destinationRequest("DREQ\x01\x00\x00\x00\x02\x00", 10);
+  assert(navigationNotifier.protectAuthenticatedPayload(
+      AuthenticatedChannel::Navigation, destinationRequest, notification));
+  assert(notification == binary(
+      "523200000001a0d24a5355c7de1683c4a586dd2fb19a8c19b6a6c0afe3b4f62e"));
+
+  std::cout << "device ownership state tests passed\n";
+  return 0;
+}

--- a/esp32/tools/tests/test_device_ownership_crypto.cpp
+++ b/esp32/tools/tests/test_device_ownership_crypto.cpp
@@ -1,0 +1,81 @@
+#include "../../lib/ble_navigation/device_ownership_crypto.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <sstream>
+
+template <typename Container> std::string hex(const Container &value) {
+  std::ostringstream stream;
+  stream << std::hex << std::setfill('0');
+  for (uint8_t byte : value) {
+    stream << std::setw(2) << static_cast<unsigned int>(byte);
+  }
+  return stream.str();
+}
+
+int main() {
+  using namespace device_ownership;
+
+  uint8_t appPrivate[32]{};
+  uint8_t devicePrivate[32]{};
+  appPrivate[31] = 1;
+  devicePrivate[31] = 2;
+
+  PairingKeyAgreement app;
+  PairingKeyAgreement device;
+  assert(app.setPrivateKeyForTesting(appPrivate));
+  assert(device.setPrivateKeyForTesting(devicePrivate));
+
+  PublicKey appPublic{};
+  PublicKey devicePublic{};
+  assert(app.publicKey(appPublic));
+  assert(device.publicKey(devicePublic));
+  assert(appPublic[0] == 0x04);
+  assert(devicePublic[0] == 0x04);
+
+  DeviceId deviceId{};
+  OwnerId ownerId{};
+  for (size_t index = 0; index < deviceId.size(); index++) {
+    deviceId[index] = static_cast<uint8_t>(index);
+    ownerId[index] = static_cast<uint8_t>(0xF0 + index);
+  }
+
+  PairingMaterial appMaterial{};
+  PairingMaterial deviceMaterial{};
+  assert(app.derive(devicePublic, deviceId, ownerId, appPublic, devicePublic,
+                    appMaterial));
+  assert(device.derive(appPublic, deviceId, ownerId, appPublic, devicePublic,
+                       deviceMaterial));
+  assert(appMaterial.ownerKey == deviceMaterial.ownerKey);
+  assert(appMaterial.transcriptHash == deviceMaterial.transcriptHash);
+  assert(appMaterial.comparisonCode == deviceMaterial.comparisonCode);
+  assert(hex(appMaterial.ownerKey) ==
+         "024d0fb0b003b6d22569ef8e5a382eaa9bbd29ebeaee683d93992ae1399900cf");
+  assert(hex(appMaterial.transcriptHash) ==
+         "9d0aa8a0aa3fb676d1a80412b522ca25047e52a59dde1bedcf18f3dc583b2072");
+  assert(appMaterial.comparisonCode == 983668);
+
+  DeviceId differentDeviceId = deviceId;
+  differentDeviceId[0] ^= 0xFF;
+  PairingMaterial differentMaterial{};
+  assert(app.derive(devicePublic, differentDeviceId, ownerId, appPublic,
+                    devicePublic, differentMaterial));
+  assert(differentMaterial.ownerKey != appMaterial.ownerKey);
+  assert(differentMaterial.transcriptHash != appMaterial.transcriptHash);
+
+  uint8_t digest[32]{};
+  const uint8_t key[] = {1, 2, 3};
+  const uint8_t message[] = {4, 5, 6};
+  assert(hmacSha256(key, sizeof(key), message, sizeof(message), digest));
+  assert(constantTimeEquals(digest, digest, sizeof(digest)));
+  uint8_t changed[32]{};
+  std::copy(std::begin(digest), std::end(digest), std::begin(changed));
+  changed[31] ^= 1;
+  assert(!constantTimeEquals(digest, changed, sizeof(digest)));
+
+  std::cout << "device ownership crypto tests passed\n";
+  return 0;
+}

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -269,13 +269,16 @@ and `Speaker: playing sound N at V% volume`.
 
 The same settings group can enable the PWR button as a honk control. The app
 sends the authenticated configuration as `"SNDH" | Enabled | SoundID | Volume`
-and firmware persists it in NVS. On the 2.06 board, a short PWR press is read
-from AXP2101 interrupt-enable/status register pair `0x41`/`0x49`, bit `3`.
-Firmware polls the latched status only while honk mode is enabled and queues
-playback on the existing speaker task; the PMU's six-second hard power-off is
-unchanged. Versioned capability discovery also returns this persisted
-configuration, so reconnecting from a fresh app does not overwrite device
-state with app defaults.
+and firmware persists it in NVS. PWR button activity is read from the AXP2101
+interrupt-enable/status register pair `0x41`/`0x49`: bit `3` reports a short
+press, while bits `1` and `0` report the press and release edges. Firmware polls
+the latched status while awake and gives an active ownership comparison first
+refusal to confirm physical access. At all other times an enabled honk is queued
+on the existing
+speaker task. The PMU's six-second hard power-off is unchanged. Versioned
+capability discovery also returns the persisted honk configuration, so
+reconnecting from a fresh app does not overwrite device state with app
+defaults.
 
 ### Buttons, External Pads, And Power
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -55,6 +55,7 @@ enum DeviceBLEProtocol {
     static let mapTransferStatusChunkPrefix = "MSTC"
     static let deviceTransferControlPrefix = "DTRN"
     static let deviceTransferStatusPrefix = "DSTS"
+    static let deviceTransferStatusChunkPrefix = "DSTC"
     static let deviceCapabilitiesPrefix = "CAPS"
     static let soundPlayPrefix = "SNDP"
     static let powerButtonHonkPrefix = "SNDH"
@@ -436,12 +437,16 @@ class BLEManager: NSObject, ObservableObject {
     @Published var trustedPeripheralDescription: String = "none"
     @Published private(set) var knownDevices: [KnownBikeComputerDevice] = []
     @Published private(set) var discoveredDevices: [DiscoveredBikeComputerDevice] = []
+    @Published private(set) var observedIdentityMismatchDeviceIDs: Set<String> = []
     @Published private(set) var activeDeviceID: String?
     @Published private(set) var connectedDeviceID: String?
     @Published private(set) var pairingPrompt: BikeComputerPairingPrompt?
     @Published private(set) var isPairingConfirmedOnDevice = false
+    @Published private(set) var isPairingConfirmationSubmitting = false
     @Published private(set) var pairingStatusMessage: String?
     @Published private(set) var pairingError: String?
+    @Published private(set) var deviceOperationDeviceID: String?
+    @Published private(set) var deviceFeedbackDeviceID: String?
     @Published var debugEvents: [String] = []
     @Published var mapTransferModeEnabled: Bool = false
     @Published var mapTransferBaseURL: URL?
@@ -558,29 +563,36 @@ class BLEManager: NSObject, ObservableObject {
         case legacy(nonce: String)
         case pairing
         case awaitingPairingConfirmation
-        case owner(nonce: String, deviceID: String, ownerID: Data, ownerKey: Data)
+        case owner(clientNonce: String, serverNonce: String?, deviceID: String, ownerID: Data, ownerKey: Data)
         case authenticated
     }
     private var authFlowState: AuthFlowState = .idle
+    private var authenticatedWriteSession: AuthenticatedBLEWriteSession?
     private var authWriteInFlight = false
     private var queuedAuthMessages: [Data] = []
     private var authInfoFallbackTimer: Timer?
+    private var authInfoAttempts = 0
     private let deviceRegistry = BikeComputerDeviceRegistry()
     private var pendingPairingSession: DevicePairingSession?
     private var pendingPairingMaterial: DevicePairingMaterial?
     private var pendingPairingCandidate: DiscoveredBikeComputerDevice?
+    private var ownershipLifecycle = BLEOwnershipLifecycle()
+    private var ownerAuthenticationUsesProvisionalKey = false
     private var pendingDeregistrationDeviceID: String?
     private var pendingRenameDeviceID: String?
+    private var deviceOperationTimeoutTimer: Timer?
     private var isDiscoveringDevices = false
     private var pendingConnectionAfterDisconnect: UUID?
+    private var pendingScannedConnectionIdentifier: UUID?
     private var discoveredPeripherals: [UUID: CBPeripheral] = [:]
+    private var discoveryFreshnessTimer: Timer?
+    private var locallyForgottenPeripheralIdentifiers: Set<UUID> = []
     
     private var autoReconnect: Bool = true
     private var lastConnectedPeripheralIdentifier: UUID?
     
     // MARK: - Reconnection with Exponential Backoff (Optimization #14)
     private var reconnectAttempts: Int = 0
-    private var maxReconnectAttempts: Int = 10
     private var baseReconnectDelay: TimeInterval = 1.0 // Start with 1 second
     private var maxReconnectDelay: TimeInterval = 60.0 // Cap at 60 seconds
     private var reconnectTimer: Timer?
@@ -589,6 +601,9 @@ class BLEManager: NSObject, ObservableObject {
     private var mapTransferStatusChunkTransferID: UInt8?
     private var mapTransferStatusChunkCount: UInt8 = 0
     private var mapTransferStatusChunks: [UInt8: Data] = [:]
+    private var deviceTransferStatusChunkTransferID: UInt8?
+    private var deviceTransferStatusChunkCount: UInt8 = 0
+    private var deviceTransferStatusChunks: [UInt8: Data] = [:]
     private var writeWithResponseInFlight = false
     private var navigationWriteWithResponseFailureHandler: (() -> Void)?
     private var connectionTimeoutTimer: Timer?
@@ -687,13 +702,25 @@ class BLEManager: NSObject, ObservableObject {
             name: UIDevice.batteryStateDidChangeNotification,
             object: UIDevice.current
         )
-        centralManager = CBCentralManager(delegate: self, queue: nil)
 #endif
         loadSettings()
         loadLastPeripheralIdentifier()
         migrateLegacyPeripheralIfNeeded()
         refreshKnownDevices()
         updateTrustedPeripheralDescription()
+#if canImport(UIKit) && !HOST_TESTING
+        // Load the active-device registry before CoreBluetooth can deliver a
+        // restoration callback, so an old peripheral can never replace the
+        // user's current Bike Computer during app launch.
+        centralManager = CBCentralManager(
+            delegate: self,
+            queue: nil,
+            options: [
+                CBCentralManagerOptionRestoreIdentifierKey:
+                    "BikeComputer.central.v2"
+            ]
+        )
+#endif
         log("BLE debug session started")
     }
 
@@ -902,6 +929,9 @@ class BLEManager: NSObject, ObservableObject {
 
     private func refreshKnownDevices() {
         knownDevices = deviceRegistry.devices
+        observedIdentityMismatchDeviceIDs.formIntersection(
+            Set(knownDevices.map(\.deviceID))
+        )
         activeDeviceID = deviceRegistry.activeDeviceID
         if let activeDeviceID,
            let active = knownDevices.first(where: { $0.deviceID == activeDeviceID }) {
@@ -915,6 +945,10 @@ class BLEManager: NSObject, ObservableObject {
             UserDefaults.standard.removeObject(forKey: SettingsKeys.lastPeripheralIdentifier)
         }
         updateTrustedPeripheralDescription()
+    }
+
+    func hasObservedIdentityMismatch(for device: KnownBikeComputerDevice) -> Bool {
+        observedIdentityMismatchDeviceIDs.contains(device.deviceID)
     }
     
     func saveSettings() {
@@ -998,7 +1032,10 @@ class BLEManager: NSObject, ObservableObject {
         // Scan for devices advertising the navigation service
         centralManager.scanForPeripherals(
             withServices: [serviceUUID],
-            options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+            options: [
+                CBCentralManagerScanOptionAllowDuplicatesKey:
+                    isDiscoveringDevices
+            ]
         )
     }
     
@@ -1040,34 +1077,67 @@ class BLEManager: NSObject, ObservableObject {
         }
     }
 
+    func resumeAutoReconnectIfNeeded() {
+        guard autoReconnect, !isConnected, !isConnecting,
+              pendingPairingSession == nil else { return }
+        reconnectTimer?.invalidate()
+        reconnectToLastDevice()
+    }
+
     func startDeviceDiscovery() {
+        guard BLEDeviceOperationPolicy.canStartPairing(
+            operationDeviceID: deviceOperationDeviceID
+        ) else {
+            pairingError = "Wait for the current Bike Computer change to finish."
+            return
+        }
         guard centralManager.state == .poweredOn else {
             pairingError = "Turn on Bluetooth to add a Bike Computer."
             return
         }
         pairingError = nil
+        ownershipLifecycle.beginDiscovery()
         pairingStatusMessage = "Looking for nearby Bike Computers…"
         discoveredDevices = []
         discoveredPeripherals = [:]
+        if isScanning { stopScanning() }
         isDiscoveringDevices = true
         isPairingMode = true
+        startDiscoveryFreshnessTimer()
         startScanning()
     }
 
-    func cancelDeviceDiscovery() {
+    func cancelDeviceDiscovery(resumeAutoReconnect: Bool = false) {
+        let shouldResumeAutoReconnect = ownershipLifecycle.endDiscovery(
+            resumeAutoReconnect: resumeAutoReconnect
+        )
         if isScanning {
             stopScanning()
         }
         isDiscoveringDevices = false
         isPairingMode = false
+        discoveryFreshnessTimer?.invalidate()
+        discoveryFreshnessTimer = nil
+        discoveredDevices = []
+        discoveredPeripherals = [:]
         pairingStatusMessage = nil
+        if shouldResumeAutoReconnect {
+            resumeAutoReconnectIfNeeded()
+        }
     }
 
     func pair(with candidate: DiscoveredBikeComputerDevice, name: String) {
+        guard BLEDeviceOperationPolicy.canStartPairing(
+            operationDeviceID: deviceOperationDeviceID
+        ) else {
+            pairingError = "Wait for the current Bike Computer change to finish."
+            return
+        }
         guard let ownerID = deviceRegistry.installationOwnerID() else {
             pairingError = "Could not create a secure owner identity on this iPhone."
             return
         }
+        locallyForgottenPeripheralIdentifiers.remove(candidate.peripheralIdentifier)
         do {
             pendingPairingSession = try DevicePairingSession(
                 peripheralIdentifier: candidate.peripheralIdentifier,
@@ -1079,18 +1149,24 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
         pendingPairingCandidate = candidate
+        let requiresConnectedDeviceHandoff = ownershipLifecycle.beginPairing(
+            candidateIdentifier: candidate.peripheralIdentifier,
+            connectedIdentifier: connectedPeripheral?.identifier
+        )
         pendingPairingMaterial = nil
         pairingPrompt = nil
         isPairingConfirmedOnDevice = false
+        isPairingConfirmationSubmitting = false
         pairingError = nil
         pairingStatusMessage = "Connecting to \(candidate.advertisedName)…"
         isPairingMode = true
         isDiscoveringDevices = false
+        discoveryFreshnessTimer?.invalidate()
+        discoveryFreshnessTimer = nil
         autoReconnect = false
         if isScanning { stopScanning() }
 
-        if let connectedPeripheral,
-           connectedPeripheral.identifier != candidate.peripheralIdentifier {
+        if requiresConnectedDeviceHandoff, let connectedPeripheral {
             pendingConnectionAfterDisconnect = candidate.peripheralIdentifier
             autoReconnect = false
             centralManager.cancelPeripheralConnection(connectedPeripheral)
@@ -1099,29 +1175,122 @@ class BLEManager: NSObject, ObservableObject {
         connectDiscoveredPeripheral(identifier: candidate.peripheralIdentifier)
     }
 
-    func confirmPairing() {
+    func confirmPairingAfterCodeMatch() {
         guard let material = pendingPairingMaterial,
-              let peripheral = connectedPeripheral else { return }
+              let peripheral = connectedPeripheral,
+              isPairingConfirmedOnDevice,
+              !isPairingConfirmationSubmitting,
+              ownershipLifecycle.beginConfirmation(
+                for: peripheral.identifier
+              ) else { return }
+        isPairingConfirmationSubmitting = true
+        // Persist recovery eligibility only after both the hardware button
+        // confirmation and the user's matching-code confirmation on iPhone.
+        deviceRegistry.markProvisionalOwnerKeyConfirmed(
+            deviceID: material.deviceID
+        )
+        if pairingPrompt?.isReplacingExistingRegistration == true {
+            deviceRegistry.authorizeProvisionalCredentialReplacement(
+                deviceID: material.deviceID
+            )
+        }
         pairingStatusMessage = "Registering this iPhone…"
         startAuthenticationTimeout(for: peripheral)
         enqueueAuthMessage(material.confirmationCommand)
     }
 
     func cancelPairing() {
+        guard pendingPairingSession != nil || pendingPairingMaterial != nil ||
+                pairingPrompt != nil || isPairingMode else { return }
+        let hasActivePairing = pendingPairingSession != nil ||
+            pendingPairingMaterial != nil || pairingPrompt != nil
+
+        // Closing the naming sheet is not a transport cancellation. Keep the
+        // automatic Nearby scan alive and, especially, do not disconnect a
+        // currently selected Bike Computer before Continue has been tapped.
+        guard hasActivePairing else {
+            pairingError = nil
+            return
+        }
+        let cancellation = ownershipLifecycle.cancel(
+            connectedIdentifier: connectedPeripheral?.identifier
+        )
+        if let deviceID = pendingPairingMaterial?.deviceID,
+           !deviceRegistry.isProvisionalOwnerKeyConfirmed(deviceID: deviceID) {
+            deviceRegistry.removeProvisionalOwnerKey(deviceID: deviceID)
+        }
         pendingPairingSession = nil
         pendingPairingMaterial = nil
         pendingPairingCandidate = nil
         pairingPrompt = nil
         isPairingConfirmedOnDevice = false
+        isPairingConfirmationSubmitting = false
         pairingStatusMessage = nil
         pairingError = nil
         authFlowState = .idle
-        if let peripheral = connectedPeripheral, !isConnected {
+        pendingConnectionAfterDisconnect = nil
+        pendingScannedConnectionIdentifier = nil
+        isPairingMode = true
+        isDiscoveringDevices = true
+        autoReconnect = true
+        startDiscoveryFreshnessTimer()
+        startScanning()
+        if let peripheral = connectedPeripheral,
+           cancellation.shouldDisconnectPairingPeripheral {
             centralManager.cancelPeripheralConnection(peripheral)
+        } else if connectedPeripheral == nil {
+            reconnectToLastDevice()
+        }
+    }
+
+    private func interruptPendingPairing(_ message: String) {
+        guard pendingPairingSession != nil || pendingPairingMaterial != nil ||
+                isPairingMode else { return }
+        pendingPairingSession = nil
+        ownershipLifecycle.interrupt()
+        pendingPairingMaterial = nil
+        pendingPairingCandidate = nil
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        isPairingConfirmationSubmitting = false
+        pendingConnectionAfterDisconnect = nil
+        pendingScannedConnectionIdentifier = nil
+        isPairingMode = false
+        isDiscoveringDevices = false
+        discoveryFreshnessTimer?.invalidate()
+        discoveryFreshnessTimer = nil
+        pairingStatusMessage = nil
+        pairingError = message
+        authFlowState = .idle
+        autoReconnect = true
+    }
+
+    private func startDiscoveryFreshnessTimer() {
+        discoveryFreshnessTimer?.invalidate()
+        discoveryFreshnessTimer = Timer.scheduledTimer(
+            withTimeInterval: 2,
+            repeats: true
+        ) { [weak self] _ in
+            guard let self, self.isDiscoveringDevices else { return }
+            let retained = BLEDiscoveryFreshnessPolicy.retained(
+                self.discoveredDevices
+            )
+            let retainedIdentifiers = Set(retained.map(\.peripheralIdentifier))
+            self.discoveredDevices = retained
+            self.discoveredPeripherals = self.discoveredPeripherals.filter {
+                retainedIdentifiers.contains($0.key)
+            }
+            self.pairingStatusMessage = retained.isEmpty
+                ? "Looking for nearby Bike Computers…"
+                : nil
         }
     }
 
     func connect(to device: KnownBikeComputerDevice) {
+        guard deviceOperationDeviceID == nil else {
+            pairingError = "Wait for the current Bike Computer change to finish."
+            return
+        }
         deviceRegistry.activeDeviceID = device.deviceID
         refreshKnownDevices()
         autoReconnect = true
@@ -1135,6 +1304,10 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     func rename(device: KnownBikeComputerDevice, to proposedName: String) {
+        guard deviceOperationDeviceID == nil else {
+            pairingError = "Another Bike Computer change is still in progress."
+            return
+        }
         guard connectedDeviceID == device.deviceID, isConnected else {
             pairingError = "Connect to this Bike Computer before renaming it."
             return
@@ -1143,19 +1316,115 @@ class BLEManager: NSObject, ObservableObject {
         pairingError = nil
         pairingStatusMessage = "Saving Bike Computer name…"
         pendingRenameDeviceID = device.deviceID
+        deviceOperationDeviceID = device.deviceID
+        deviceFeedbackDeviceID = device.deviceID
+        startDeviceOperationTimeout(kind: "rename")
         enqueueAuthMessage("NAME|\(Data(name.utf8).ownershipHex)")
     }
 
     func deregister(device: KnownBikeComputerDevice) {
+        guard deviceOperationDeviceID == nil else {
+            pairingError = "Another Bike Computer change is still in progress."
+            return
+        }
         guard connectedDeviceID == device.deviceID, isConnected, !device.isLegacy else {
             pairingError = "Connect to this Bike Computer before deregistering it."
             return
         }
         pendingDeregistrationDeviceID = device.deviceID
+        deviceOperationDeviceID = device.deviceID
+        deviceFeedbackDeviceID = device.deviceID
         pairingError = nil
         pairingStatusMessage = "Deregistering \(device.name)…"
         autoReconnect = false
+        startDeviceOperationTimeout(kind: "deregister")
         enqueueAuthMessage("UNPAIR")
+    }
+
+    func forgetLocally(device: KnownBikeComputerDevice) {
+        guard deviceOperationDeviceID == nil else {
+            pairingError = "Another Bike Computer change is still in progress."
+            return
+        }
+        guard !isConnected(to: device) || device.isLegacy else {
+            pairingError = "Deregister the connected Bike Computer to remove ownership from both devices."
+            return
+        }
+        let wasActive = deviceRegistry.activeDeviceID == device.deviceID
+        let wasPendingPeripheral = connectedPeripheral?.identifier == device.peripheralIdentifier
+        guard deviceRegistry.remove(deviceID: device.deviceID) else {
+            pairingError = "Could not remove this Bike Computer’s secure credential from the iPhone. Try again."
+            return
+        }
+
+        locallyForgottenPeripheralIdentifiers.insert(device.peripheralIdentifier)
+        if pendingScannedConnectionIdentifier == device.peripheralIdentifier {
+            pendingScannedConnectionIdentifier = nil
+        }
+        discoveredPeripherals.removeValue(forKey: device.peripheralIdentifier)
+        discoveredDevices.removeAll {
+            $0.peripheralIdentifier == device.peripheralIdentifier
+        }
+        refreshKnownDevices()
+        pairingError = nil
+        pairingStatusMessage = nil
+        deviceFeedbackDeviceID = nil
+
+        let successorIdentifier = deviceRegistry.devices.first(where: {
+            $0.deviceID == deviceRegistry.activeDeviceID
+        })?.peripheralIdentifier
+        if wasActive || wasPendingPeripheral {
+            resetReconnectionState()
+        }
+        if BLELocalForgetPolicy.shouldStopScanning(
+            wasActive: wasActive,
+            hadPendingTransport: wasPendingPeripheral,
+            hasSuccessor: successorIdentifier != nil
+        ) {
+            autoReconnect = false
+            pendingConnectionAfterDisconnect = nil
+            pendingScannedConnectionIdentifier = nil
+            if isScanning { stopScanning() }
+            isDiscoveringDevices = false
+            isPairingMode = false
+        }
+        if wasPendingPeripheral, let peripheral = connectedPeripheral {
+            autoReconnect = successorIdentifier != nil
+            invalidateAuthenticationForLocalForget()
+            pendingConnectionAfterDisconnect = successorIdentifier
+            centralManager.cancelPeripheralConnection(peripheral)
+        } else if wasActive, successorIdentifier != nil {
+            autoReconnect = true
+            reconnectToLastDevice()
+        } else if wasActive {
+            autoReconnect = false
+        }
+    }
+
+    private func invalidateAuthenticationForLocalForget() {
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
+        authRetryTimer?.invalidate()
+        authRetryTimer = nil
+        authTimeoutTimer?.invalidate()
+        authTimeoutTimer = nil
+        pendingAuthNonce = nil
+        authFlowState = .idle
+        authenticatedWriteSession = nil
+        ownerAuthenticationUsesProvisionalKey = false
+        authWriteInFlight = false
+        queuedAuthMessages.removeAll()
+        pendingPairingSession = nil
+        pendingPairingMaterial = nil
+        pendingPairingCandidate = nil
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        isPairingConfirmationSubmitting = false
+        navigationWriteEndpoint = nil
+        navigationWriteQueue.removeAll()
+        isConnected = false
+        isNavigationReady = false
+        connectedDeviceID = nil
     }
 
     func isConnected(to device: KnownBikeComputerDevice) -> Bool {
@@ -1167,8 +1436,28 @@ class BLEManager: NSObject, ObservableObject {
             centralManager.retrievePeripherals(withIdentifiers: [identifier]).first {
             connectToPeripheral(peripheral)
         } else {
-            pairingError = "That Bike Computer is no longer nearby."
-            startDeviceDiscovery()
+            pendingScannedConnectionIdentifier = identifier
+            pairingError = nil
+            pairingStatusMessage = "Looking for the selected Bike Computer…"
+            isDiscoveringDevices = false
+            isPairingMode = false
+            startScanning()
+        }
+    }
+
+    private func startDeviceOperationTimeout(kind: String) {
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 12, repeats: false) { [weak self] _ in
+            guard let self,
+                  self.pendingRenameDeviceID != nil || self.pendingDeregistrationDeviceID != nil else { return }
+            self.pendingRenameDeviceID = nil
+            self.pendingDeregistrationDeviceID = nil
+            self.deviceOperationDeviceID = nil
+            self.deviceOperationTimeoutTimer = nil
+            self.pairingStatusMessage = nil
+            self.pairingError = "The Bike Computer did not confirm the \(kind). Reconnect and try again."
+            self.autoReconnect = true
+            self.scheduleReconnectWithBackoff()
         }
     }
     
@@ -1203,10 +1492,10 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        let maxLength = peripheral.maximumWriteValueLength(for: .withoutResponse)
+        let maxLength = navigationWriteEndpoint?.maximumWriteLength ?? 0
         if let characteristic = routeGeometryCharacteristic,
            let endpoint = navigationWriteEndpoint {
-            guard data.count <= maxLength else {
+            guard data.count <= endpoint.maximumWriteLength else {
                 log("Cannot send geometry: \(data.count) bytes exceeds write limit \(maxLength)")
                 return
             }
@@ -2048,10 +2337,15 @@ class BLEManager: NSObject, ObservableObject {
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
         authFlowState = .idle
+        authenticatedWriteSession = nil
+        ownerAuthenticationUsesProvisionalKey = false
         authWriteInFlight = false
         queuedAuthMessages.removeAll()
         authInfoFallbackTimer?.invalidate()
         authInfoFallbackTimer = nil
+        authInfoAttempts = 0
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = nil
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
@@ -2065,7 +2359,11 @@ class BLEManager: NSObject, ObservableObject {
         isConnecting = true
         centralManager.connect(peripheral, options: nil)
         log("Connecting to: \(peripheral.name ?? "Unknown")")
-        startConnectionTimeout(for: peripheral)
+        if BLEConnectionPersistence.shouldCancelTimedOutConnection(
+            isPairing: pendingPairingSession != nil
+        ) {
+            startConnectionTimeout(for: peripheral)
+        }
     }
 
     private func startConnectionTimeout(for peripheral: CBPeripheral) {
@@ -2104,10 +2402,15 @@ class BLEManager: NSObject, ObservableObject {
         navigationWriteWithResponseFailureHandler = nil
         pendingAuthNonce = nil
         authFlowState = .idle
+        authenticatedWriteSession = nil
+        ownerAuthenticationUsesProvisionalKey = false
         authWriteInFlight = false
         queuedAuthMessages.removeAll()
         authInfoFallbackTimer?.invalidate()
         authInfoFallbackTimer = nil
+        authInfoAttempts = 0
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = nil
         navigationWriteQueue.removeAll()
         lastSentPhoneBatteryPercent = nil
         lastSentPhoneBatteryCharging = nil
@@ -2120,6 +2423,14 @@ class BLEManager: NSObject, ObservableObject {
         authRetryTimer = nil
         authTimeoutTimer?.invalidate()
         authTimeoutTimer = nil
+        if pendingRenameDeviceID != nil || pendingDeregistrationDeviceID != nil {
+            pendingRenameDeviceID = nil
+            pendingDeregistrationDeviceID = nil
+            deviceOperationDeviceID = nil
+            pairingStatusMessage = nil
+            pairingError = "The Bike Computer disconnected before confirming the change. Reconnect to verify and try again if needed."
+            autoReconnect = true
+        }
         clearTransferState()
         stopMonitoringRSSI()
     }
@@ -2143,6 +2454,9 @@ class BLEManager: NSObject, ObservableObject {
         mapTransferStatusChunkTransferID = nil
         mapTransferStatusChunkCount = 0
         mapTransferStatusChunks.removeAll()
+        deviceTransferStatusChunkTransferID = nil
+        deviceTransferStatusChunkCount = 0
+        deviceTransferStatusChunks.removeAll()
         deviceTransferMode = ""
         deviceTransferBaseURL = nil
         deviceTransferAccessPointSSID = nil
@@ -2274,13 +2588,43 @@ class BLEManager: NSObject, ObservableObject {
         }
         guard case .idle = authFlowState else { return }
         authFlowState = .waitingForInfo
+        authInfoAttempts = 1
         enqueueAuthMessage("INFO")
-        authInfoFallbackTimer?.invalidate()
-        authInfoFallbackTimer = Timer.scheduledTimer(withTimeInterval: 0.8, repeats: false) { [weak self] _ in
-            guard let self, case .waitingForInfo = self.authFlowState else { return }
-            self.beginLegacyAuthentication()
-        }
+        scheduleOwnershipInfoRetry(for: peripheral)
         log("Requested Bike Computer ownership information from \(source)")
+    }
+
+    private func scheduleOwnershipInfoRetry(for peripheral: CBPeripheral) {
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = Timer.scheduledTimer(withTimeInterval: 0.8, repeats: false) { [weak self, weak peripheral] _ in
+            guard let self, let peripheral,
+                  self.connectedPeripheral?.identifier == peripheral.identifier,
+                  case .waitingForInfo = self.authFlowState else { return }
+            if self.authInfoAttempts < 3 {
+                self.authInfoAttempts += 1
+                self.enqueueAuthMessage("INFO")
+                self.scheduleOwnershipInfoRetry(for: peripheral)
+                return
+            }
+            let knownDevice = self.deviceRegistry.devices.first {
+                $0.peripheralIdentifier == peripheral.identifier
+            }
+            let observedCandidate = self.pendingPairingCandidate ??
+                self.discoveredDevices.first {
+                    $0.peripheralIdentifier == peripheral.identifier
+                }
+            if DeviceOwnershipFlowPolicy.allowsLegacyFallback(
+                knownDevice: knownDevice,
+                pairingCandidate: observedCandidate
+            ) {
+                self.beginLegacyAuthentication()
+            } else {
+                self.failAuthentication(
+                    "The Bike Computer did not return its secure identity. Reconnect and try again.",
+                    peripheral: peripheral
+                )
+            }
+        }
     }
 
     private func preferredWriteType(
@@ -2296,7 +2640,25 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     private func handleAuthResponse(_ data: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic) {
-        guard let message = BLEPairingAuthenticator.authMessage(from: data) else {
+        let responseData: Data
+        if data.count >= 2, data[0] == 0x52, data[1] == 0x32 {
+            guard let authenticatedWriteSession,
+                  let plaintext = authenticatedWriteSession.notificationPayload(
+                    from: data,
+                    channel: .auth
+                  ) else {
+                log("Rejected invalid protected ownership response")
+                return
+            }
+            responseData = plaintext
+        } else {
+            if authenticatedWriteSession != nil {
+                log("Rejected unauthenticated ownership response")
+                return
+            }
+            responseData = data
+        }
+        guard let message = BLEPairingAuthenticator.authMessage(from: responseData) else {
             log("Received undecodable BLE auth response: \(data.count) bytes hex=\(data.hexPreview)")
             return
         }
@@ -2308,20 +2670,48 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
         if message.hasPrefix("PAIRING|") {
-            guard let session = pendingPairingSession else {
+            guard let session = pendingPairingSession,
+                  session.matches(peripheralIdentifier: peripheral.identifier) else {
                 failAuthentication("Received an unexpected pairing response.", peripheral: peripheral)
                 return
             }
             do {
                 let material = try session.material(from: message)
+                if let candidate = pendingPairingCandidate,
+                   let advertisedIdentitySuffix = candidate.identitySuffix,
+                   String(material.deviceID.suffix(8)).uppercased() != advertisedIdentitySuffix.uppercased() {
+                    failAuthentication("The Bike Computer identity did not match its nearby code.", peripheral: peripheral)
+                    return
+                }
+                // Commit the credential before the physical confirmation can
+                // commit ownership on the Bike Computer. This makes a lost
+                // PAIRED notification recoverable on the next connection.
+                guard deviceRegistry.saveProvisionalOwnerKey(
+                    material.ownerKey,
+                    deviceID: material.deviceID
+                ) else {
+                    failAuthentication("The secure owner credential could not be saved.", peripheral: peripheral)
+                    return
+                }
                 pendingPairingMaterial = material
+                guard ownershipLifecycle.markComparisonReady(
+                    for: peripheral.identifier
+                ) else {
+                    failAuthentication(
+                        "The secure-pairing response arrived outside the active registration.",
+                        peripheral: peripheral
+                    )
+                    return
+                }
                 authFlowState = .awaitingPairingConfirmation
                 startPairingConfirmationTimeout(for: peripheral)
                 pairingPrompt = BikeComputerPairingPrompt(
                     peripheralIdentifier: peripheral.identifier,
                     deviceName: session.deviceName,
-                    shortIdentifier: pendingPairingCandidate?.shortIdentifier ?? String(material.deviceID.suffix(8)).uppercased(),
-                    comparisonCode: material.comparisonCode
+                    shortIdentifier: pendingPairingCandidate?.shortIdentifier ?? String(material.deviceID.suffix(4)).uppercased(),
+                    comparisonCode: material.comparisonCode,
+                    isReplacingExistingRegistration:
+                        deviceRegistry.ownerKey(deviceID: material.deviceID) != nil
                 )
                 pairingStatusMessage = nil
             } catch {
@@ -2342,7 +2732,7 @@ class BLEManager: NSObject, ObservableObject {
                 return
             }
             isPairingConfirmedOnDevice = true
-            confirmPairing()
+            pairingStatusMessage = "Confirm the matching code on this iPhone."
             return
         }
         if message.hasPrefix("SERVER2|") {
@@ -2350,15 +2740,23 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
         if message.hasPrefix("OK2|") {
-            guard case .owner(let nonce, let deviceID, _, _) = authFlowState else {
+            guard case .owner(let clientNonce, let serverNonce, let deviceID, _, let ownerKey) = authFlowState,
+                  let serverNonce else {
                 failAuthentication("Received an unexpected owner confirmation.", peripheral: peripheral)
                 return
             }
             let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
-            guard parts.count == 3, parts[1] == deviceID, parts[2] == nonce else {
+            guard parts.count == 4, parts[1] == deviceID,
+                  parts[2] == clientNonce, parts[3] == serverNonce else {
                 failAuthentication("The owner confirmation did not match this connection.", peripheral: peripheral)
                 return
             }
+            authenticatedWriteSession = AuthenticatedBLEWriteSession(
+                ownerKey: ownerKey,
+                deviceID: deviceID,
+                clientNonce: clientNonce,
+                serverNonce: serverNonce
+            )
             completeAuthentication(for: peripheral)
             return
         }
@@ -2366,16 +2764,22 @@ class BLEManager: NSObject, ObservableObject {
             handleRenameResponse(message)
             return
         }
-        if message.hasPrefix("UNPAIRED|") {
+        if message.hasPrefix("NAME_INFO|") {
+            handleDeviceNameResponse(message)
+            return
+        }
+        if message.hasPrefix("UNPAIRED2|") {
             let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
-            guard parts.count == 2, pendingDeregistrationDeviceID == parts[1] else { return }
-            deviceRegistry.remove(deviceID: parts[1])
-            pendingDeregistrationDeviceID = nil
-            connectedDeviceID = nil
-            refreshKnownDevices()
-            pairingError = nil
-            pairingStatusMessage = "Bike Computer deregistered."
-            centralManager.cancelPeripheralConnection(peripheral)
+            guard parts.count == 4,
+                  pendingDeregistrationDeviceID == parts[1],
+                  verifyRevocationReceipt(parts: parts) else {
+                log("Rejected invalid deregistration receipt")
+                return
+            }
+            completeDeregistration(
+                deviceID: parts[1],
+                peripheral: peripheral
+            )
             return
         }
         if message.hasPrefix("OWNED|") || message.hasPrefix("DENIED|") {
@@ -2389,16 +2793,29 @@ class BLEManager: NSObject, ObservableObject {
         if message.hasPrefix("ERROR|") {
             let detail = message.split(separator: "|", maxSplits: 1).last.map(String.init) ?? "unknown error"
             if pendingRenameDeviceID != nil {
+                deviceOperationTimeoutTimer?.invalidate()
+                deviceOperationTimeoutTimer = nil
                 pendingRenameDeviceID = nil
+                deviceOperationDeviceID = nil
                 pairingStatusMessage = nil
                 pairingError = "Could not rename the Bike Computer: \(detail.replacingOccurrences(of: "_", with: " "))."
                 return
             }
             if pendingDeregistrationDeviceID != nil {
+                deviceOperationTimeoutTimer?.invalidate()
+                deviceOperationTimeoutTimer = nil
                 pendingDeregistrationDeviceID = nil
+                deviceOperationDeviceID = nil
                 pairingStatusMessage = nil
                 pairingError = "Could not deregister the Bike Computer: \(detail.replacingOccurrences(of: "_", with: " "))."
                 autoReconnect = true
+                return
+            }
+            if detail == "pairing_attempt_already_used" {
+                failAuthentication(
+                    "Cancel and add this Bike Computer again to start a new secure pairing attempt.",
+                    peripheral: peripheral
+                )
                 return
             }
             failAuthentication(
@@ -2428,7 +2845,7 @@ class BLEManager: NSObject, ObservableObject {
         authInfoFallbackTimer?.invalidate()
         authInfoFallbackTimer = nil
         let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
-        guard parts.count == 5, parts[1] == "2",
+        guard (parts.count == 5 || parts.count == 7), parts[1] == "2",
               let deviceID = Data(ownershipHex: parts[2]),
               deviceID.count == DeviceOwnershipProtocol.deviceIDLength,
               let nameData = Data(ownershipHex: parts[4]),
@@ -2438,14 +2855,72 @@ class BLEManager: NSObject, ObservableObject {
         }
         let deviceIDHex = parts[2].lowercased()
         let isClaimed = parts[3] == "1"
+        let conflictingDeviceIDs = BLEIdentityObservationPolicy.conflictingDeviceIDs(
+            knownDevices: knownDevices,
+            peripheralIdentifier: peripheral.identifier,
+            observedDeviceID: deviceIDHex
+        )
+        if !conflictingDeviceIDs.isEmpty {
+            observedIdentityMismatchDeviceIDs.formUnion(conflictingDeviceIDs)
+            log(
+                "Observed Device \(String(deviceIDHex.suffix(8)).uppercased()) " +
+                "on a peripheral saved with a different identity"
+            )
+        }
+        let existingDevice = knownDevices.first(where: {
+            $0.deviceID == deviceIDHex
+        })
+        let resolvedName = DeviceOwnershipProtocol.resolvedInfoName(
+            reportedName: reportedName,
+            isClaimed: isClaimed,
+            existingName: existingDevice?.name,
+            peripheralName: peripheral.name
+        )
         connectedDeviceID = deviceIDHex
-        peripheralName = reportedName
+        peripheralName = resolvedName
+
+        if parts.count == 7,
+           verifyRevocationReceipt(parts: [
+               "UNPAIRED2", deviceIDHex, parts[5], parts[6]
+           ]) {
+            // A retained receipt is signed by the superseded key. Once the
+            // user has confirmed a replacement credential, recover that new
+            // credential first; deleting it here would strand a device that
+            // has already committed the replacement owner.
+            if deviceRegistry.hasConfirmedReplacementCredential(
+                deviceID: deviceIDHex
+            ) {
+                log("Ignoring a receipt for the superseded owner during confirmed replacement recovery")
+            } else {
+                guard deviceRegistry.remove(deviceID: deviceIDHex) else {
+                    failAuthentication(
+                        "The Bike Computer was deregistered, but its secure credential could not be removed from this iPhone. Try again.",
+                        peripheral: peripheral
+                    )
+                    return
+                }
+                refreshKnownDevices()
+                if pendingPairingSession == nil {
+                    completeDeregistration(
+                        deviceID: deviceIDHex,
+                        peripheral: peripheral,
+                        registryAlreadyRemoved: true
+                    )
+                    return
+                }
+            }
+        }
 
         if let session = pendingPairingSession {
+            guard session.matches(peripheralIdentifier: peripheral.identifier) else {
+                failAuthentication("The pairing response came from a different Bike Computer.", peripheral: peripheral)
+                return
+            }
             guard !isClaimed else {
-                if let ownerKey = deviceRegistry.ownerKey(deviceID: deviceIDHex),
+                if let credential = ownerCredential(deviceID: deviceIDHex),
                    let ownerID = deviceRegistry.installationOwnerID() {
-                    beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: ownerKey)
+                    ownerAuthenticationUsesProvisionalKey = credential.isProvisional
+                    beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: credential.key)
                 } else {
                     autoReconnect = false
                     failAuthentication("This Bike Computer is already registered to another iPhone.", peripheral: peripheral)
@@ -2459,17 +2934,12 @@ class BLEManager: NSObject, ObservableObject {
         }
 
         if isClaimed,
-           let ownerKey = deviceRegistry.ownerKey(deviceID: deviceIDHex),
+           let credential = ownerCredential(deviceID: deviceIDHex),
            let ownerID = deviceRegistry.installationOwnerID() {
-            deviceRegistry.upsert(KnownBikeComputerDevice(
-                deviceID: deviceIDHex,
-                peripheralIdentifier: peripheral.identifier,
-                name: reportedName,
-                lastConnectedAt: Date(),
-                isLegacy: false
-            ))
-            refreshKnownDevices()
-            beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: ownerKey)
+            // INFO is plaintext discovery data. Do not mutate the trusted
+            // registry until OWNER proof succeeds in completeAuthentication.
+            ownerAuthenticationUsesProvisionalKey = credential.isProvisional
+            beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: credential.key)
         } else if isClaimed {
             autoReconnect = false
             failAuthentication(
@@ -2478,10 +2948,11 @@ class BLEManager: NSObject, ObservableObject {
             )
         } else {
             autoReconnect = false
-            failAuthentication(
-                "This Bike Computer is not registered yet. Add it from Settings → Bike Computers.",
-                peripheral: peripheral
-            )
+            let shortIdentifier = String(deviceIDHex.suffix(4)).uppercased()
+            let message = conflictingDeviceIDs.isEmpty
+                ? "This Bike Computer is not registered yet. Add Device \(shortIdentifier) from Settings → Bike Computers."
+                : "Saved registration does not match this hardware. Tap Add Bike Computer and choose Device \(shortIdentifier)."
+            failAuthentication(message, peripheral: peripheral)
         }
     }
 
@@ -2490,26 +2961,27 @@ class BLEManager: NSObject, ObservableObject {
         guard parts.count == 3,
               let material = pendingPairingMaterial,
               let session = pendingPairingSession,
+              session.matches(peripheralIdentifier: peripheral.identifier),
               parts[1].lowercased() == material.deviceID,
               let nameData = Data(ownershipHex: parts[2]),
               let name = String(data: nameData, encoding: .utf8),
-              deviceRegistry.saveOwnerKey(material.ownerKey, deviceID: material.deviceID) else {
-            failAuthentication("The secure owner credential could not be saved.", peripheral: peripheral)
+              deviceRegistry.provisionalOwnerKey(deviceID: material.deviceID) == material.ownerKey,
+              deviceRegistry.isProvisionalOwnerKeyConfirmed(deviceID: material.deviceID) else {
+            failAuthentication("The provisional owner credential is unavailable.", peripheral: peripheral)
             return
         }
-        deviceRegistry.upsert(KnownBikeComputerDevice(
-            deviceID: material.deviceID,
-            peripheralIdentifier: peripheral.identifier,
-            name: name,
-            lastConnectedAt: Date(),
-            isLegacy: false
-        ), makeActive: true)
-        refreshKnownDevices()
+        // PAIRED is still pre-authentication. Keep the asserted identity and
+        // name in memory until OWNER authentication proves possession of the
+        // committed key; only then may this device alter the persistent
+        // registry or active-device selection.
         connectedDeviceID = material.deviceID
-        pairingPrompt = nil
-        isPairingConfirmedOnDevice = false
+        peripheralName = name
         pairingStatusMessage = "Finishing secure connection…"
         startAuthenticationTimeout(for: peripheral)
+        // PAIRED is not authenticated. Keep the new key provisional until the
+        // following OWNER/SERVER2/PROOF/OK2 exchange proves the hardware
+        // committed the same credential.
+        ownerAuthenticationUsesProvisionalKey = true
         beginOwnerAuthentication(
             deviceID: material.deviceID,
             ownerID: session.ownerID,
@@ -2517,33 +2989,122 @@ class BLEManager: NSObject, ObservableObject {
         )
     }
 
+    private func verifyRevocationReceipt(parts: [String]) -> Bool {
+        guard parts.count == 4,
+              parts[0] == "UNPAIRED2",
+              Data(ownershipHex: parts[2])?.count == 16,
+              Data(ownershipHex: parts[3])?.count == 32,
+              let ownerID = deviceRegistry.installationOwnerID(),
+              let ownerKey = deviceRegistry.ownerKey(deviceID: parts[1]) else {
+            return false
+        }
+        return DeviceOwnerAuthenticator.isValidRevocationReceipt(
+            suppliedProof: parts[3],
+            key: ownerKey,
+            deviceID: parts[1],
+            ownerID: ownerID,
+            nonce: parts[2]
+        )
+    }
+
+    private func completeDeregistration(
+        deviceID: String,
+        peripheral: CBPeripheral,
+        registryAlreadyRemoved: Bool = false
+    ) {
+        if !registryAlreadyRemoved && !deviceRegistry.remove(deviceID: deviceID) {
+            deviceOperationTimeoutTimer?.invalidate()
+            deviceOperationTimeoutTimer = nil
+            pendingDeregistrationDeviceID = nil
+            deviceOperationDeviceID = nil
+            pairingStatusMessage = nil
+            pairingError = "The Bike Computer was deregistered, but its secure credential could not be removed from this iPhone. Try removing it again."
+            autoReconnect = false
+            centralManager.cancelPeripheralConnection(peripheral)
+            return
+        }
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = nil
+        pendingDeregistrationDeviceID = nil
+        deviceOperationDeviceID = nil
+        connectedDeviceID = nil
+        refreshKnownDevices()
+        pairingError = nil
+        pairingStatusMessage = "Bike Computer deregistered."
+        if let successor = deviceRegistry.devices.first(where: {
+            $0.deviceID == deviceRegistry.activeDeviceID
+        }) {
+            pendingConnectionAfterDisconnect = successor.peripheralIdentifier
+            autoReconnect = true
+        } else {
+            autoReconnect = false
+        }
+        centralManager.cancelPeripheralConnection(peripheral)
+    }
+
     private func beginOwnerAuthentication(deviceID: String, ownerID: Data, ownerKey: Data) {
         guard let nonce = BLEPairingAuthenticator.makeNonce() else { return }
+        authenticatedWriteSession = nil
         pendingAuthNonce = nonce
-        authFlowState = .owner(nonce: nonce, deviceID: deviceID, ownerID: ownerID, ownerKey: ownerKey)
+        authFlowState = .owner(clientNonce: nonce, serverNonce: nil, deviceID: deviceID, ownerID: ownerID, ownerKey: ownerKey)
         enqueueAuthMessage("OWNER|\(ownerID.ownershipHex)|\(nonce)")
     }
 
+    private func ownerCredential(deviceID: String) -> (key: Data, isProvisional: Bool)? {
+        if deviceRegistry.isProvisionalOwnerKeyConfirmed(deviceID: deviceID),
+           let key = deviceRegistry.provisionalOwnerKey(deviceID: deviceID) {
+            return (key, true)
+        }
+        if let key = deviceRegistry.ownerKey(deviceID: deviceID) {
+            return (key, false)
+        }
+        return nil
+    }
+
     private func handleOwnerServerProof(_ message: String, peripheral: CBPeripheral) {
-        guard case .owner(let nonce, let deviceID, let ownerID, let ownerKey) = authFlowState else {
+        guard case .owner(let clientNonce, _, let deviceID, let ownerID, let ownerKey) = authFlowState else {
             failAuthentication("Received an unexpected owner challenge.", peripheral: peripheral)
             return
         }
         let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 5,
+              parts[1] == deviceID,
+              parts[2] == clientNonce,
+              Data(ownershipHex: parts[3])?.count == 16 else {
+            failAuthentication("The Bike Computer owner challenge was invalid.", peripheral: peripheral)
+            return
+        }
+        let serverNonce = parts[3]
         let expected = DeviceOwnerAuthenticator.proof(
             key: ownerKey,
-            message: DeviceOwnerAuthenticator.serverMessage(deviceID: deviceID, ownerID: ownerID, nonce: nonce)
+            message: DeviceOwnerAuthenticator.serverMessage(
+                deviceID: deviceID,
+                ownerID: ownerID,
+                clientNonce: clientNonce,
+                serverNonce: serverNonce
+            )
         )
-        guard parts.count == 4, parts[1] == deviceID, parts[2] == nonce,
-              DeviceOwnerAuthenticator.isValidProof(parts[3], expected: expected) else {
+        guard DeviceOwnerAuthenticator.isValidProof(parts[4], expected: expected) else {
             failAuthentication("The Bike Computer owner proof was invalid.", peripheral: peripheral)
             return
         }
         let clientProof = DeviceOwnerAuthenticator.proof(
             key: ownerKey,
-            message: DeviceOwnerAuthenticator.clientMessage(deviceID: deviceID, ownerID: ownerID, nonce: nonce)
+            message: DeviceOwnerAuthenticator.clientMessage(
+                deviceID: deviceID,
+                ownerID: ownerID,
+                clientNonce: clientNonce,
+                serverNonce: serverNonce
+            )
         )
-        enqueueAuthMessage("PROOF|\(ownerID.ownershipHex)|\(nonce)|\(clientProof)")
+        authFlowState = .owner(
+            clientNonce: clientNonce,
+            serverNonce: serverNonce,
+            deviceID: deviceID,
+            ownerID: ownerID,
+            ownerKey: ownerKey
+        )
+        enqueueAuthMessage("PROOF|\(ownerID.ownershipHex)|\(clientNonce)|\(serverNonce)|\(clientProof)")
     }
 
     private func beginLegacyAuthentication() {
@@ -2566,7 +3127,20 @@ class BLEManager: NSObject, ObservableObject {
               let peripheral = connectedPeripheral,
               let authCharacteristic,
               let writeType = preferredWriteType(for: authCharacteristic) else { return }
-        let data = queuedAuthMessages.removeFirst()
+        let message = queuedAuthMessages.removeFirst()
+        let data: Data
+        if let authenticatedWriteSession {
+            guard let frame = authenticatedWriteSession.frame(
+                payload: message,
+                channel: .auth
+            ) else {
+                failAuthentication("Could not protect the ownership command.", peripheral: peripheral)
+                return
+            }
+            data = frame
+        } else {
+            data = message
+        }
         authWriteInFlight = writeType == .withResponse
         peripheral.writeValue(data, for: authCharacteristic, type: writeType)
         log("Sent ownership command via \(authWriteLabel(writeType))")
@@ -2587,7 +3161,7 @@ class BLEManager: NSObject, ObservableObject {
         pairingStatusMessage = nil
         pairingPrompt = nil
         isPairingConfirmedOnDevice = false
-        pendingPairingMaterial = nil
+        isPairingConfirmationSubmitting = false
         authInfoFallbackTimer?.invalidate()
         authInfoFallbackTimer = nil
         log("BLE auth failed: \(message)")
@@ -2604,10 +3178,34 @@ class BLEManager: NSObject, ObservableObject {
               var device = knownDevices.first(where: { $0.deviceID == deviceID }) else { return }
         device.name = name
         deviceRegistry.upsert(device)
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = nil
         pendingRenameDeviceID = nil
+        deviceOperationDeviceID = nil
         peripheralName = name
         pairingStatusMessage = nil
         pairingError = nil
+        refreshKnownDevices()
+    }
+
+    private func handleDeviceNameResponse(_ message: String) {
+        let parts = message.split(
+            separator: "|",
+            omittingEmptySubsequences: false
+        ).map(String.init)
+        guard parts.count == 2,
+              let nameData = Data(ownershipHex: parts[1]),
+              let name = String(data: nameData, encoding: .utf8),
+              DeviceOwnershipProtocol.normalizedName(name) == name,
+              let deviceID = connectedDeviceID,
+              var device = knownDevices.first(where: {
+                  $0.deviceID == deviceID
+              }) else {
+            return
+        }
+        device.name = name
+        deviceRegistry.upsert(device)
+        peripheralName = name
         refreshKnownDevices()
     }
 
@@ -2618,8 +3216,19 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
+        let transportMaximum = peripheral.maximumWriteValueLength(for: navigationWriteType)
+        let payloadMaximum = max(
+            0,
+            transportMaximum - (authenticatedWriteSession == nil
+                ? 0
+                : AuthenticatedBLEWriteSession.frameOverhead)
+        )
+        guard payloadMaximum > 0 else {
+            failAuthentication("The BLE connection is too small for protected device commands.", peripheral: peripheral)
+            return
+        }
         installNavigationWriteEndpoint(NavigationWriteEndpoint(
-            maximumWriteLength: peripheral.maximumWriteValueLength(for: navigationWriteType),
+            maximumWriteLength: payloadMaximum,
             expectsWriteResponse: navigationWriteType == .withResponse,
             canSend: { [weak self, weak peripheral] in
                 guard let self, let peripheral else { return false }
@@ -2649,6 +3258,19 @@ class BLEManager: NSObject, ObservableObject {
         UserDefaults.standard.set(peripheral.identifier.uuidString, forKey: SettingsKeys.lastPeripheralIdentifier)
 
         if let connectedDeviceID {
+            if ownerAuthenticationUsesProvisionalKey,
+               !deviceRegistry.promoteProvisionalOwnerKey(
+                    deviceID: connectedDeviceID,
+                    allowReplacingExisting:
+                        deviceRegistry
+                            .isProvisionalCredentialReplacementAuthorized(
+                                deviceID: connectedDeviceID
+                            )
+               ) {
+                failAuthentication("The recovered owner credential could not be finalized.", peripheral: peripheral)
+                return
+            }
+            ownerAuthenticationUsesProvisionalKey = false
             var device = knownDevices.first(where: { $0.deviceID == connectedDeviceID })
                 ?? KnownBikeComputerDevice(
                     deviceID: connectedDeviceID,
@@ -2659,7 +3281,11 @@ class BLEManager: NSObject, ObservableObject {
                 )
             device.peripheralIdentifier = peripheral.identifier
             device.lastConnectedAt = Date()
-            deviceRegistry.upsert(device, makeActive: deviceRegistry.activeDeviceID == nil)
+            deviceRegistry.upsert(
+                device,
+                makeActive: pendingPairingSession != nil ||
+                    deviceRegistry.activeDeviceID == nil
+            )
         } else if connectedDeviceID == nil {
             let legacyID = "legacy:\(peripheral.identifier.uuidString.lowercased())"
             connectedDeviceID = legacyID
@@ -2669,18 +3295,21 @@ class BLEManager: NSObject, ObservableObject {
                 name: peripheralName.isEmpty ? DeviceOwnershipProtocol.defaultDeviceName : peripheralName,
                 lastConnectedAt: Date(),
                 isLegacy: true
-            ), makeActive: knownDevices.isEmpty)
+            ), makeActive: pendingPairingSession != nil || knownDevices.isEmpty)
         }
         refreshKnownDevices()
         pairingPrompt = nil
         isPairingConfirmedOnDevice = false
+        isPairingConfirmationSubmitting = false
         pairingStatusMessage = nil
         pairingError = nil
         pendingPairingSession = nil
+        ownershipLifecycle.complete()
         pendingPairingMaterial = nil
         pendingPairingCandidate = nil
         autoReconnect = true
         log("BLE peripheral authenticated")
+        enqueueAuthMessage("GET_NAME")
         requestDeviceCapabilities()
         sendSetting(id: 6, value: Int32(mapRotationMode))
         sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
@@ -2875,10 +3504,33 @@ class BLEManager: NSObject, ObservableObject {
             log("Cannot write characteristic \(characteristic.uuid): unsupported properties")
             return
         }
+        let payload: Data
+        if let authenticatedWriteSession {
+            guard let channel = authenticatedChannel(for: characteristic.uuid),
+                  let frame = authenticatedWriteSession.frame(
+                    payload: data,
+                    channel: channel
+                  ) else {
+                log("Cannot protect write for characteristic \(characteristic.uuid)")
+                return
+            }
+            payload = frame
+        } else {
+            payload = data
+        }
         if writeType == .withResponse {
             writeWithResponseInFlight = true
         }
-        peripheral.writeValue(data, for: characteristic, type: writeType)
+        peripheral.writeValue(payload, for: characteristic, type: writeType)
+    }
+
+    private func authenticatedChannel(for uuid: CBUUID) -> AuthenticatedBLEChannel? {
+        if uuid == authCharacteristicUUID { return .auth }
+        if uuid == characteristicUUID { return .navigation }
+        if uuid == routeGeometryCharacteristicUUID { return .route }
+        if uuid == gpsPositionCharacteristicUUID { return .gps }
+        if uuid == settingsCharacteristicUUID { return .settings }
+        return nil
     }
 
     private func scheduleNavigationFlushRetryIfNeeded() {
@@ -2900,14 +3552,85 @@ class BLEManager: NSObject, ObservableObject {
 // MARK: - CBCentralManagerDelegate
 
 extension BLEManager: CBCentralManagerDelegate {
+
+    func centralManager(
+        _ central: CBCentralManager,
+        willRestoreState dict: [String: Any]
+    ) {
+        guard let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey]
+                as? [CBPeripheral],
+              !peripherals.isEmpty else {
+            log("CoreBluetooth restored without a Bike Computer peripheral")
+            return
+        }
+        guard let selectedIdentifier = BLERestorationPolicy.selectedIdentifier(
+            from: peripherals.map(\.identifier),
+            trustedIdentifier: lastConnectedPeripheralIdentifier
+        ), let restored = peripherals.first(where: {
+            $0.identifier == selectedIdentifier
+        }) else {
+            log("Ignoring restored connection for a non-current Bike Computer")
+            for peripheral in peripherals {
+                central.cancelPeripheralConnection(peripheral)
+            }
+            return
+        }
+        restored.delegate = self
+        log("Restored Bike Computer connection state: \(restored.state.rawValue)")
+        switch restored.state {
+        case .connected:
+            connectedPeripheral = restored
+            isConnecting = false
+            isConnected = false
+            isNavigationReady = false
+            peripheralName = restored.name ?? "BikeComputer"
+            startMonitoringRSSI()
+            startAuthenticationTimeout(for: restored)
+            restored.discoverServices([serviceUUID, deviceInformationServiceUUID])
+        case .connecting:
+            connectedPeripheral = restored
+            isConnecting = true
+        case .disconnected:
+            connectToPeripheral(restored)
+        case .disconnecting:
+            connectedPeripheral = restored
+            pendingConnectionAfterDisconnect = restored.identifier
+        @unknown default:
+            connectedPeripheral = restored
+            pendingConnectionAfterDisconnect = restored.identifier
+        }
+        let restoredIdentifiersToCancel = Set(
+            BLERestorationPolicy.identifiersToCancel(
+                from: peripherals.map(\.identifier),
+                keeping: selectedIdentifier
+            )
+        )
+        for peripheral in peripherals
+        where restoredIdentifiersToCancel.contains(peripheral.identifier) {
+            central.cancelPeripheralConnection(peripheral)
+        }
+    }
     
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state != .poweredOn {
+            interruptPendingPairing("Pairing was interrupted because Bluetooth became unavailable. Start again when Bluetooth is on.")
+            pendingConnectionAfterDisconnect = nil
+            pendingScannedConnectionIdentifier = nil
+            isDiscoveringDevices = false
+            isPairingMode = false
+            discoveryFreshnessTimer?.invalidate()
+            discoveryFreshnessTimer = nil
+            discoveredDevices = []
+            discoveredPeripherals = [:]
+        }
         switch central.state {
         case .poweredOn:
             centralStateDescription = "powered on"
             log("Bluetooth powered on")
             // Attempt to reconnect to last device, or start scanning
-            if lastConnectedPeripheralIdentifier != nil {
+            if hasActiveBLESession {
+                log("Using restored Bike Computer connection")
+            } else if lastConnectedPeripheralIdentifier != nil {
                 reconnectToLastDevice()
             } else {
                 log("No Bike Computer saved; add one from Settings")
@@ -2975,6 +3698,14 @@ extension BLEManager: CBCentralManagerDelegate {
         }
         discoveredDevices.sort { $0.rssi > $1.rssi }
 
+        if pendingScannedConnectionIdentifier == peripheral.identifier {
+            pendingScannedConnectionIdentifier = nil
+            pairingStatusMessage = nil
+            stopScanning()
+            connectToPeripheral(peripheral)
+            return
+        }
+
         if isDiscoveringDevices {
             pairingStatusMessage = discoveredDevices.isEmpty ? "Looking for nearby Bike Computers…" : nil
             return
@@ -2998,6 +3729,20 @@ extension BLEManager: CBCentralManagerDelegate {
     }
     
     func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            log("Cancelling a late connection for a locally forgotten Bike Computer")
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
+        guard connectedPeripheral?.identifier == peripheral.identifier else {
+            log("Ignoring connection callback for a non-current Bike Computer")
+            central.cancelPeripheralConnection(peripheral)
+            return
+        }
         log("Connected to: \(peripheral.name ?? "Unknown")")
         
         connectionTimeoutTimer?.invalidate()
@@ -3021,6 +3766,11 @@ extension BLEManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, 
                        didDisconnectPeripheral peripheral: CBPeripheral, 
                        error: Error?) {
+        guard connectedPeripheral?.identifier == peripheral.identifier else {
+            log("Ignoring disconnect callback for a non-current Bike Computer")
+            return
+        }
+        locallyForgottenPeripheralIdentifiers.remove(peripheral.identifier)
         log("Disconnected from: \(peripheral.name ?? "Unknown")")
         
         if let error = error {
@@ -3046,10 +3796,15 @@ extension BLEManager: CBCentralManagerDelegate {
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
         authFlowState = .idle
+        authenticatedWriteSession = nil
+        ownerAuthenticationUsesProvisionalKey = false
         authWriteInFlight = false
         queuedAuthMessages.removeAll()
         authInfoFallbackTimer?.invalidate()
         authInfoFallbackTimer = nil
+        authInfoAttempts = 0
+        deviceOperationTimeoutTimer?.invalidate()
+        deviceOperationTimeoutTimer = nil
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
@@ -3060,8 +3815,18 @@ extension BLEManager: CBCentralManagerDelegate {
         stopMonitoringRSSI()
         connectedDeviceID = nil
 
-        if let nextIdentifier = pendingConnectionAfterDisconnect {
-            pendingConnectionAfterDisconnect = nil
+        if pendingRenameDeviceID != nil || pendingDeregistrationDeviceID != nil {
+            pendingRenameDeviceID = nil
+            pendingDeregistrationDeviceID = nil
+            deviceOperationDeviceID = nil
+            pairingStatusMessage = nil
+            pairingError = "The Bike Computer disconnected before confirming the change. Reconnect to verify and try again if needed."
+            autoReconnect = true
+        }
+
+        if let nextIdentifier = BLEPendingHandoffPolicy.consume(
+            &pendingConnectionAfterDisconnect
+        ) {
             connectDiscoveredPeripheral(identifier: nextIdentifier)
             return
         }
@@ -3089,18 +3854,21 @@ extension BLEManager: CBCentralManagerDelegate {
     
     private func scheduleReconnectWithBackoff() {
         reconnectTimer?.invalidate()
-        
-        guard reconnectAttempts < maxReconnectAttempts else {
-            log("Max reconnection attempts reached (\(maxReconnectAttempts))")
-            reconnectAttempts = 0
-            return
+
+        guard autoReconnect else { return }
+        // Keep a CoreBluetooth operation active while the app is suspended;
+        // run-loop timers alone cannot provide durable background reconnect.
+        if centralManager.state == .poweredOn, !isScanning {
+            startScanning()
         }
+        let delay = BLEReconnectBackoff.delay(
+            attempt: reconnectAttempts,
+            base: baseReconnectDelay,
+            maximum: maxReconnectDelay
+        )
+        reconnectAttempts = min(reconnectAttempts + 1, 30)
         
-        // Calculate delay with exponential backoff: base * 2^attempts
-        let delay = min(baseReconnectDelay * pow(2.0, Double(reconnectAttempts)), maxReconnectDelay)
-        reconnectAttempts += 1
-        
-        log("Reconnection attempt \(reconnectAttempts)/\(maxReconnectAttempts) in \(String(format: "%.1f", delay))s")
+        log("Reconnection attempt \(reconnectAttempts) in \(String(format: "%.1f", delay))s")
         
         reconnectTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
             self?.reconnectToLastDevice()
@@ -3121,11 +3889,23 @@ extension BLEManager: CBCentralManagerDelegate {
     func centralManager(_ central: CBCentralManager, 
                        didFailToConnect peripheral: CBPeripheral, 
                        error: Error?) {
+        guard connectedPeripheral?.identifier == peripheral.identifier else {
+            log("Ignoring connection failure for a non-current Bike Computer")
+            return
+        }
+        locallyForgottenPeripheralIdentifiers.remove(peripheral.identifier)
         log("Failed to connect to: \(peripheral.name ?? "Unknown")")
         clearConnectionState()
         
         if let error = error {
             log("Connection error: \(error.localizedDescription)")
+        }
+
+        if let nextIdentifier = BLEPendingHandoffPolicy.consume(
+            &pendingConnectionAfterDisconnect
+        ) {
+            connectDiscoveredPeripheral(identifier: nextIdentifier)
+            return
         }
         
         if pendingPairingSession != nil {
@@ -3141,6 +3921,13 @@ extension BLEManager: CBCentralManagerDelegate {
 extension BLEManager: CBPeripheralDelegate {
     
     func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         if let error = error {
             log("Error discovering services: \(error.localizedDescription)")
             return
@@ -3170,6 +3957,13 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, 
                    didDiscoverCharacteristicsFor service: CBService, 
                    error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         if let error = error {
             log("Error discovering characteristics: \(error.localizedDescription)")
             return
@@ -3241,6 +4035,13 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral,
                    didUpdateNotificationStateFor characteristic: CBCharacteristic,
                    error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         if let error = error {
             log("Error updating notifications: \(error.localizedDescription)")
             return
@@ -3252,6 +4053,13 @@ extension BLEManager: CBPeripheralDelegate {
     }
 
     func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         guard isNavigationReady, let endpoint = navigationWriteEndpoint else { return }
         log("BLE transport ready; pending writes=\(navigationWriteQueue.count)")
         flushPendingNavigationWrites(endpoint: endpoint)
@@ -3261,6 +4069,13 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, 
                    didWriteValueFor characteristic: CBCharacteristic, 
                    error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         if let error = error {
             log("Error writing characteristic \(characteristic.uuid): \(error.localizedDescription); props=\(characteristic.properties.debugDescription)")
             if characteristic.uuid == authCharacteristicUUID {
@@ -3281,6 +4096,14 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, 
                    didUpdateValueFor characteristic: CBCharacteristic, 
                    error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            log("Ignored late value from a locally forgotten Bike Computer")
+            return
+        }
         if let error = error {
             log("Error reading characteristic: \(error.localizedDescription)")
             return
@@ -3293,9 +4116,41 @@ extension BLEManager: CBPeripheralDelegate {
             return
         }
 
-        if characteristic.uuid == characteristicUUID,
-           handleNavigationCharacteristicNotification(data) {
-            return
+        if characteristic.uuid == characteristicUUID {
+            let isProtectedFrame = data.count >= 2 && data[0] == 0x52 && data[1] == 0x32
+            let isAuthenticated: Bool
+            if case .authenticated = authFlowState {
+                isAuthenticated = true
+            } else {
+                isAuthenticated = false
+            }
+            guard BLENavigationNotificationPolicy.accepts(
+                isAuthenticated: isAuthenticated,
+                isLegacyDevice: connectedDeviceID?.hasPrefix("legacy:") == true,
+                hasProtectedSession: authenticatedWriteSession != nil,
+                isProtectedFrame: isProtectedFrame
+            ) else {
+                log("Rejected navigation notification outside its authenticated transport")
+                return
+            }
+            let notificationData: Data
+            if let authenticatedWriteSession {
+                guard isProtectedFrame,
+                      let plaintext = authenticatedWriteSession
+                        .notificationPayload(
+                            from: data,
+                            channel: .navigation
+                        ) else {
+                    log("Rejected unauthenticated navigation notification")
+                    return
+                }
+                notificationData = plaintext
+            } else {
+                notificationData = data
+            }
+            if handleNavigationCharacteristicNotification(notificationData) {
+                return
+            }
         }
 
         if [modelNumberCharacteristicUUID,
@@ -3508,12 +4363,58 @@ extension BLEManager: CBPeripheralDelegate {
     @discardableResult
     func handleDeviceTransferStatusNotification(_ data: Data) -> Bool {
         guard data.count >= 4,
-              String(data: data.prefix(4), encoding: .utf8) == DeviceBLEProtocol.deviceTransferStatusPrefix else {
+              let prefix = String(data: data.prefix(4), encoding: .utf8) else {
             return false
         }
 
-        let body = data.dropFirst(4)
-        guard let object = try? JSONSerialization.jsonObject(with: Data(body)) as? [String: Any] else {
+        if prefix == DeviceBLEProtocol.deviceTransferStatusChunkPrefix {
+            return handleDeviceTransferStatusChunk(data)
+        }
+        guard prefix == DeviceBLEProtocol.deviceTransferStatusPrefix else {
+            return false
+        }
+
+        return applyDeviceTransferStatusBody(Data(data.dropFirst(4)))
+    }
+
+    private func handleDeviceTransferStatusChunk(_ data: Data) -> Bool {
+        guard data.count >= 7 else {
+            firmwareUpdateStatus = "invalid status"
+            return true
+        }
+        let transferID = data[4]
+        let index = data[5]
+        let count = data[6]
+        guard count > 0, index < count else {
+            firmwareUpdateStatus = "invalid status"
+            return true
+        }
+        if deviceTransferStatusChunkTransferID != transferID ||
+            deviceTransferStatusChunkCount != count {
+            deviceTransferStatusChunkTransferID = transferID
+            deviceTransferStatusChunkCount = count
+            deviceTransferStatusChunks.removeAll(keepingCapacity: true)
+        }
+        deviceTransferStatusChunks[index] = Data(data.dropFirst(7))
+        guard deviceTransferStatusChunks.count == Int(count) else {
+            return true
+        }
+        var body = Data()
+        for chunkIndex in UInt8(0)..<count {
+            guard let chunk = deviceTransferStatusChunks[chunkIndex] else {
+                return true
+            }
+            body.append(chunk)
+        }
+        deviceTransferStatusChunkTransferID = nil
+        deviceTransferStatusChunkCount = 0
+        deviceTransferStatusChunks.removeAll(keepingCapacity: true)
+        return applyDeviceTransferStatusBody(body)
+    }
+
+    private func applyDeviceTransferStatusBody(_ body: Data) -> Bool {
+
+        guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
             firmwareUpdateStatus = "invalid status"
             log("Received invalid device transfer status payload")
             return true
@@ -3668,6 +4569,13 @@ extension BLEManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, 
                    didReadRSSI RSSI: NSNumber, 
                    error: Error?) {
+        guard BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheral.identifier,
+            currentIdentifier: connectedPeripheral?.identifier,
+            forgottenIdentifiers: locallyForgottenPeripheralIdentifiers
+        ) else {
+            return
+        }
         if error == nil {
             signalStrength = RSSI.intValue
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -437,12 +437,14 @@ class BLEManager: NSObject, ObservableObject {
     @Published var trustedPeripheralDescription: String = "none"
     @Published private(set) var knownDevices: [KnownBikeComputerDevice] = []
     @Published private(set) var discoveredDevices: [DiscoveredBikeComputerDevice] = []
+    @Published private(set) var isDiscoveringDevices = false
     @Published private(set) var observedIdentityMismatchDeviceIDs: Set<String> = []
     @Published private(set) var activeDeviceID: String?
     @Published private(set) var connectedDeviceID: String?
     @Published private(set) var pairingPrompt: BikeComputerPairingPrompt?
     @Published private(set) var isPairingConfirmedOnDevice = false
     @Published private(set) var isPairingConfirmationSubmitting = false
+    @Published private(set) var completedPairingGeneration: UInt64 = 0
     @Published private(set) var pairingStatusMessage: String?
     @Published private(set) var pairingError: String?
     @Published private(set) var deviceOperationDeviceID: String?
@@ -581,7 +583,6 @@ class BLEManager: NSObject, ObservableObject {
     private var pendingDeregistrationDeviceID: String?
     private var pendingRenameDeviceID: String?
     private var deviceOperationTimeoutTimer: Timer?
-    private var isDiscoveringDevices = false
     private var pendingConnectionAfterDisconnect: UUID?
     private var pendingScannedConnectionIdentifier: UUID?
     private var discoveredPeripherals: [UUID: CBPeripheral] = [:]
@@ -607,6 +608,7 @@ class BLEManager: NSObject, ObservableObject {
     private var writeWithResponseInFlight = false
     private var navigationWriteWithResponseFailureHandler: (() -> Void)?
     private var connectionTimeoutTimer: Timer?
+    private var pendingScannedConnectionTimeoutTimer: Timer?
     private var authRetryTimer: Timer?
     private var authTimeoutTimer: Timer?
     private var pendingPowerButtonHonkPacket: Data?
@@ -1133,6 +1135,10 @@ class BLEManager: NSObject, ObservableObject {
             pairingError = "Wait for the current Bike Computer change to finish."
             return
         }
+        guard centralManager.state == .poweredOn else {
+            pairingError = "Turn on Bluetooth to add a Bike Computer."
+            return
+        }
         guard let ownerID = deviceRegistry.installationOwnerID() else {
             pairingError = "Could not create a secure owner identity on this iPhone."
             return
@@ -1230,6 +1236,8 @@ class BLEManager: NSObject, ObservableObject {
         authFlowState = .idle
         pendingConnectionAfterDisconnect = nil
         pendingScannedConnectionIdentifier = nil
+        pendingScannedConnectionTimeoutTimer?.invalidate()
+        pendingScannedConnectionTimeoutTimer = nil
         isPairingMode = true
         isDiscoveringDevices = true
         autoReconnect = true
@@ -1255,6 +1263,8 @@ class BLEManager: NSObject, ObservableObject {
         isPairingConfirmationSubmitting = false
         pendingConnectionAfterDisconnect = nil
         pendingScannedConnectionIdentifier = nil
+        pendingScannedConnectionTimeoutTimer?.invalidate()
+        pendingScannedConnectionTimeoutTimer = nil
         isPairingMode = false
         isDiscoveringDevices = false
         discoveryFreshnessTimer?.invalidate()
@@ -1440,8 +1450,31 @@ class BLEManager: NSObject, ObservableObject {
             pairingError = nil
             pairingStatusMessage = "Looking for the selected Bike Computer…"
             isDiscoveringDevices = false
-            isPairingMode = false
+            // Keep pairing mode active: startScanning() intentionally rejects
+            // untrusted peripherals outside an explicit pairing operation.
+            startPendingScannedConnectionTimeout(for: identifier)
             startScanning()
+        }
+    }
+
+    private func startPendingScannedConnectionTimeout(for identifier: UUID) {
+        pendingScannedConnectionTimeoutTimer?.invalidate()
+        pendingScannedConnectionTimeoutTimer = Timer.scheduledTimer(
+            withTimeInterval: BLEPendingScanPolicy.timeout,
+            repeats: false
+        ) { [weak self] _ in
+            guard let self,
+                  self.pendingScannedConnectionIdentifier == identifier else {
+                return
+            }
+            self.pendingScannedConnectionIdentifier = nil
+            self.pendingScannedConnectionTimeoutTimer = nil
+            if self.isScanning {
+                self.stopScanning()
+            }
+            self.isPairingMode = false
+            self.pairingStatusMessage = nil
+            self.pairingError = "Could not find that Bike Computer. Move closer and try again."
         }
     }
 
@@ -3297,12 +3330,16 @@ class BLEManager: NSObject, ObservableObject {
                 isLegacy: true
             ), makeActive: pendingPairingSession != nil || knownDevices.isEmpty)
         }
+        let completedPairing = pendingPairingSession != nil
         refreshKnownDevices()
         pairingPrompt = nil
         isPairingConfirmedOnDevice = false
         isPairingConfirmationSubmitting = false
         pairingStatusMessage = nil
         pairingError = nil
+        if completedPairing {
+            completedPairingGeneration &+= 1
+        }
         pendingPairingSession = nil
         ownershipLifecycle.complete()
         pendingPairingMaterial = nil
@@ -3616,6 +3653,8 @@ extension BLEManager: CBCentralManagerDelegate {
             interruptPendingPairing("Pairing was interrupted because Bluetooth became unavailable. Start again when Bluetooth is on.")
             pendingConnectionAfterDisconnect = nil
             pendingScannedConnectionIdentifier = nil
+            pendingScannedConnectionTimeoutTimer?.invalidate()
+            pendingScannedConnectionTimeoutTimer = nil
             isDiscoveringDevices = false
             isPairingMode = false
             discoveryFreshnessTimer?.invalidate()
@@ -3698,8 +3737,17 @@ extension BLEManager: CBCentralManagerDelegate {
         }
         discoveredDevices.sort { $0.rssi > $1.rssi }
 
-        if pendingScannedConnectionIdentifier == peripheral.identifier {
+        if let pendingIdentifier = pendingScannedConnectionIdentifier {
+            guard BLEPendingScanPolicy.accepts(
+                discoveredIdentifier: peripheral.identifier,
+                pendingIdentifier: pendingIdentifier
+            ) else {
+                log("Ignoring non-selected Bike Computer while awaiting the chosen device")
+                return
+            }
             pendingScannedConnectionIdentifier = nil
+            pendingScannedConnectionTimeoutTimer?.invalidate()
+            pendingScannedConnectionTimeoutTimer = nil
             pairingStatusMessage = nil
             stopScanning()
             connectToPeripheral(peripheral)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -434,6 +434,14 @@ class BLEManager: NSObject, ObservableObject {
     @Published var signalStrength: Int = 0
     @Published var centralStateDescription: String = "unknown"
     @Published var trustedPeripheralDescription: String = "none"
+    @Published private(set) var knownDevices: [KnownBikeComputerDevice] = []
+    @Published private(set) var discoveredDevices: [DiscoveredBikeComputerDevice] = []
+    @Published private(set) var activeDeviceID: String?
+    @Published private(set) var connectedDeviceID: String?
+    @Published private(set) var pairingPrompt: BikeComputerPairingPrompt?
+    @Published private(set) var isPairingConfirmedOnDevice = false
+    @Published private(set) var pairingStatusMessage: String?
+    @Published private(set) var pairingError: String?
     @Published var debugEvents: [String] = []
     @Published var mapTransferModeEnabled: Bool = false
     @Published var mapTransferBaseURL: URL?
@@ -544,15 +552,28 @@ class BLEManager: NSObject, ObservableObject {
     private var isConnecting: Bool = false
     private var isPairingMode: Bool = false
     private var pendingAuthNonce: String?
-    private enum AuthWriteState {
+    private enum AuthFlowState {
         case idle
-        case helloInFlight
-        case waitingForServer
-        case clientProofPending(Data)
-        case clientProofInFlight
-        case waitingForOK
+        case waitingForInfo
+        case legacy(nonce: String)
+        case pairing
+        case awaitingPairingConfirmation
+        case owner(nonce: String, deviceID: String, ownerID: Data, ownerKey: Data)
+        case authenticated
     }
-    private var authWriteState: AuthWriteState = .idle
+    private var authFlowState: AuthFlowState = .idle
+    private var authWriteInFlight = false
+    private var queuedAuthMessages: [Data] = []
+    private var authInfoFallbackTimer: Timer?
+    private let deviceRegistry = BikeComputerDeviceRegistry()
+    private var pendingPairingSession: DevicePairingSession?
+    private var pendingPairingMaterial: DevicePairingMaterial?
+    private var pendingPairingCandidate: DiscoveredBikeComputerDevice?
+    private var pendingDeregistrationDeviceID: String?
+    private var pendingRenameDeviceID: String?
+    private var isDiscoveringDevices = false
+    private var pendingConnectionAfterDisconnect: UUID?
+    private var discoveredPeripherals: [UUID: CBPeripheral] = [:]
     
     private var autoReconnect: Bool = true
     private var lastConnectedPeripheralIdentifier: UUID?
@@ -587,7 +608,6 @@ class BLEManager: NSObject, ObservableObject {
     private var isSendingNegotiatedMapProfiles = false
     private var lastSentPhoneBatteryPercent: Int32?
     private var lastSentPhoneBatteryCharging: Bool?
-    private var shouldPairAfterDisconnect: Bool = false
     private var suppressNextReconnect: Bool = false
     private var hasActiveBLESession: Bool {
         isConnected || isConnecting || connectedPeripheral != nil
@@ -671,6 +691,8 @@ class BLEManager: NSObject, ObservableObject {
 #endif
         loadSettings()
         loadLastPeripheralIdentifier()
+        migrateLegacyPeripheralIfNeeded()
+        refreshKnownDevices()
         updateTrustedPeripheralDescription()
         log("BLE debug session started")
     }
@@ -864,6 +886,36 @@ class BLEManager: NSObject, ObservableObject {
         lastConnectedPeripheralIdentifier = UUID(uuidString: uuidString)
         updateTrustedPeripheralDescription()
     }
+
+    private func migrateLegacyPeripheralIfNeeded() {
+        guard deviceRegistry.devices.isEmpty,
+              let identifier = lastConnectedPeripheralIdentifier else { return }
+        let legacy = KnownBikeComputerDevice(
+            deviceID: "legacy:\(identifier.uuidString.lowercased())",
+            peripheralIdentifier: identifier,
+            name: DeviceOwnershipProtocol.defaultDeviceName,
+            lastConnectedAt: .distantPast,
+            isLegacy: true
+        )
+        deviceRegistry.upsert(legacy, makeActive: true)
+    }
+
+    private func refreshKnownDevices() {
+        knownDevices = deviceRegistry.devices
+        activeDeviceID = deviceRegistry.activeDeviceID
+        if let activeDeviceID,
+           let active = knownDevices.first(where: { $0.deviceID == activeDeviceID }) {
+            lastConnectedPeripheralIdentifier = active.peripheralIdentifier
+            UserDefaults.standard.set(
+                active.peripheralIdentifier.uuidString,
+                forKey: SettingsKeys.lastPeripheralIdentifier
+            )
+        } else if knownDevices.isEmpty {
+            lastConnectedPeripheralIdentifier = nil
+            UserDefaults.standard.removeObject(forKey: SettingsKeys.lastPeripheralIdentifier)
+        }
+        updateTrustedPeripheralDescription()
+    }
     
     func saveSettings() {
         let defaults = UserDefaults.standard
@@ -927,7 +979,7 @@ class BLEManager: NSObject, ObservableObject {
             log("Bluetooth not powered on")
             return
         }
-        guard !hasActiveBLESession else {
+        guard !hasActiveBLESession || isDiscoveringDevices else {
             log("Skipping BLE scan: connection already active")
             return
         }
@@ -935,7 +987,7 @@ class BLEManager: NSObject, ObservableObject {
             log("Skipping BLE scan: scan already active")
             return
         }
-        guard lastConnectedPeripheralIdentifier != nil || isPairingMode else {
+        guard lastConnectedPeripheralIdentifier != nil || isPairingMode || isDiscoveringDevices else {
             log("Skipping BLE scan: no trusted peripheral saved and pairing mode is not active")
             return
         }
@@ -974,15 +1026,150 @@ class BLEManager: NSObject, ObservableObject {
         resetReconnectionState()
 
         if let peripheral = connectedPeripheral {
-            log("Restarting active BLE connection with fresh pairing scan")
-            shouldPairAfterDisconnect = true
+            log("Restarting connection to the active Bike Computer")
+            pendingConnectionAfterDisconnect = peripheral.identifier
             stopMonitoringRSSI()
             centralManager.cancelPeripheralConnection(peripheral)
             return
         }
 
-        forgetTrustedPeripheralForFreshScan()
-        beginPairing()
+        if lastConnectedPeripheralIdentifier == nil {
+            startDeviceDiscovery()
+        } else {
+            reconnectToLastDevice()
+        }
+    }
+
+    func startDeviceDiscovery() {
+        guard centralManager.state == .poweredOn else {
+            pairingError = "Turn on Bluetooth to add a Bike Computer."
+            return
+        }
+        pairingError = nil
+        pairingStatusMessage = "Looking for nearby Bike Computers…"
+        discoveredDevices = []
+        discoveredPeripherals = [:]
+        isDiscoveringDevices = true
+        isPairingMode = true
+        startScanning()
+    }
+
+    func cancelDeviceDiscovery() {
+        if isScanning {
+            stopScanning()
+        }
+        isDiscoveringDevices = false
+        isPairingMode = false
+        pairingStatusMessage = nil
+    }
+
+    func pair(with candidate: DiscoveredBikeComputerDevice, name: String) {
+        guard let ownerID = deviceRegistry.installationOwnerID() else {
+            pairingError = "Could not create a secure owner identity on this iPhone."
+            return
+        }
+        do {
+            pendingPairingSession = try DevicePairingSession(
+                peripheralIdentifier: candidate.peripheralIdentifier,
+                ownerID: ownerID,
+                deviceName: name
+            )
+        } catch {
+            pairingError = "Could not begin secure pairing."
+            return
+        }
+        pendingPairingCandidate = candidate
+        pendingPairingMaterial = nil
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        pairingError = nil
+        pairingStatusMessage = "Connecting to \(candidate.advertisedName)…"
+        isPairingMode = true
+        isDiscoveringDevices = false
+        autoReconnect = false
+        if isScanning { stopScanning() }
+
+        if let connectedPeripheral,
+           connectedPeripheral.identifier != candidate.peripheralIdentifier {
+            pendingConnectionAfterDisconnect = candidate.peripheralIdentifier
+            autoReconnect = false
+            centralManager.cancelPeripheralConnection(connectedPeripheral)
+            return
+        }
+        connectDiscoveredPeripheral(identifier: candidate.peripheralIdentifier)
+    }
+
+    func confirmPairing() {
+        guard let material = pendingPairingMaterial,
+              let peripheral = connectedPeripheral else { return }
+        pairingStatusMessage = "Registering this iPhone…"
+        startAuthenticationTimeout(for: peripheral)
+        enqueueAuthMessage(material.confirmationCommand)
+    }
+
+    func cancelPairing() {
+        pendingPairingSession = nil
+        pendingPairingMaterial = nil
+        pendingPairingCandidate = nil
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        pairingStatusMessage = nil
+        pairingError = nil
+        authFlowState = .idle
+        if let peripheral = connectedPeripheral, !isConnected {
+            centralManager.cancelPeripheralConnection(peripheral)
+        }
+    }
+
+    func connect(to device: KnownBikeComputerDevice) {
+        deviceRegistry.activeDeviceID = device.deviceID
+        refreshKnownDevices()
+        autoReconnect = true
+        if let peripheral = connectedPeripheral {
+            if peripheral.identifier == device.peripheralIdentifier, isConnected { return }
+            pendingConnectionAfterDisconnect = device.peripheralIdentifier
+            centralManager.cancelPeripheralConnection(peripheral)
+            return
+        }
+        reconnectToLastDevice()
+    }
+
+    func rename(device: KnownBikeComputerDevice, to proposedName: String) {
+        guard connectedDeviceID == device.deviceID, isConnected else {
+            pairingError = "Connect to this Bike Computer before renaming it."
+            return
+        }
+        let name = DeviceOwnershipProtocol.normalizedName(proposedName)
+        pairingError = nil
+        pairingStatusMessage = "Saving Bike Computer name…"
+        pendingRenameDeviceID = device.deviceID
+        enqueueAuthMessage("NAME|\(Data(name.utf8).ownershipHex)")
+    }
+
+    func deregister(device: KnownBikeComputerDevice) {
+        guard connectedDeviceID == device.deviceID, isConnected, !device.isLegacy else {
+            pairingError = "Connect to this Bike Computer before deregistering it."
+            return
+        }
+        pendingDeregistrationDeviceID = device.deviceID
+        pairingError = nil
+        pairingStatusMessage = "Deregistering \(device.name)…"
+        autoReconnect = false
+        enqueueAuthMessage("UNPAIR")
+    }
+
+    func isConnected(to device: KnownBikeComputerDevice) -> Bool {
+        isConnected && connectedDeviceID == device.deviceID
+    }
+
+    private func connectDiscoveredPeripheral(identifier: UUID) {
+        if let peripheral = discoveredPeripherals[identifier] ??
+            centralManager.retrievePeripherals(withIdentifiers: [identifier]).first {
+            connectToPeripheral(peripheral)
+        } else {
+            pairingError = "That Bike Computer is no longer nearby."
+            startDeviceDiscovery()
+        }
     }
     
     /// Send navigation data to ESP32
@@ -1805,19 +1992,6 @@ class BLEManager: NSObject, ObservableObject {
         log("Sent debug navigation packet")
     }
 
-    func forgetTrustedPeripheral() {
-        autoReconnect = false
-        lastConnectedPeripheralIdentifier = nil
-        UserDefaults.standard.removeObject(forKey: SettingsKeys.lastPeripheralIdentifier)
-        updateTrustedPeripheralDescription()
-        log("Forgot trusted BikeComputer peripheral")
-        if let peripheral = connectedPeripheral {
-            centralManager.cancelPeripheralConnection(peripheral)
-        } else {
-            clearConnectionState()
-        }
-    }
-
     var debugLogText: String {
         debugEvents.joined(separator: "\n")
     }
@@ -1860,6 +2034,7 @@ class BLEManager: NSObject, ObservableObject {
 
         stopScanning()
         connectedPeripheral = peripheral
+        connectedDeviceID = nil
         navigationCharacteristic = nil
         authCharacteristic = nil
         routeGeometryCharacteristic = nil
@@ -1872,7 +2047,11 @@ class BLEManager: NSObject, ObservableObject {
         deviceMapFoundForCurrentLocation = nil
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
-        authWriteState = .idle
+        authFlowState = .idle
+        authWriteInFlight = false
+        queuedAuthMessages.removeAll()
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
@@ -1889,27 +2068,6 @@ class BLEManager: NSObject, ObservableObject {
         startConnectionTimeout(for: peripheral)
     }
 
-    private func beginPairing() {
-        guard centralManager.state == .poweredOn else {
-            log("Cannot pair: Bluetooth not powered on")
-            return
-        }
-
-        isPairingMode = true
-        log("Starting pairing scan")
-        startScanning()
-    }
-
-    private func forgetTrustedPeripheralForFreshScan() {
-        if lastConnectedPeripheralIdentifier != nil {
-            log("Forgetting trusted BikeComputer peripheral for fresh scan")
-        }
-
-        lastConnectedPeripheralIdentifier = nil
-        UserDefaults.standard.removeObject(forKey: SettingsKeys.lastPeripheralIdentifier)
-        updateTrustedPeripheralDescription()
-    }
-
     private func startConnectionTimeout(for peripheral: CBPeripheral) {
         connectionTimeoutTimer?.invalidate()
         connectionTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 8.0, repeats: false) { [weak self, weak peripheral] _ in
@@ -1920,11 +2078,12 @@ class BLEManager: NSObject, ObservableObject {
                 return
             }
 
-            self.log("BLE connection timed out; starting fresh pairing scan")
+            self.log("BLE connection timed out")
+            if self.pendingPairingSession != nil {
+                self.pairingError = "Could not connect to that Bike Computer."
+                self.suppressNextReconnect = true
+            }
             self.centralManager.cancelPeripheralConnection(peripheral)
-            self.clearConnectionState()
-            self.forgetTrustedPeripheralForFreshScan()
-            self.beginPairing()
         }
     }
 
@@ -1933,6 +2092,7 @@ class BLEManager: NSObject, ObservableObject {
         isConnecting = false
         supportsDeviceSettings = false
         connectedPeripheral = nil
+        connectedDeviceID = nil
         navigationCharacteristic = nil
         authCharacteristic = nil
         routeGeometryCharacteristic = nil
@@ -1943,7 +2103,11 @@ class BLEManager: NSObject, ObservableObject {
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         pendingAuthNonce = nil
-        authWriteState = .idle
+        authFlowState = .idle
+        authWriteInFlight = false
+        queuedAuthMessages.removeAll()
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
         navigationWriteQueue.removeAll()
         lastSentPhoneBatteryPercent = nil
         lastSentPhoneBatteryCharging = nil
@@ -2011,7 +2175,12 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     private func updateTrustedPeripheralDescription() {
-        trustedPeripheralDescription = lastConnectedPeripheralIdentifier?.uuidString ?? "none"
+        if let activeDeviceID,
+           let active = knownDevices.first(where: { $0.deviceID == activeDeviceID }) {
+            trustedPeripheralDescription = "\(active.name) (\(active.shortIdentifier))"
+        } else {
+            trustedPeripheralDescription = lastConnectedPeripheralIdentifier?.uuidString ?? "none"
+        }
     }
 
     private func log(_ message: String) {
@@ -2071,15 +2240,26 @@ class BLEManager: NSObject, ObservableObject {
             guard let self,
                   let peripheral,
                   self.connectedPeripheral?.identifier == peripheral.identifier,
-                  !self.isNavigationReady else {
-                return
+                  !self.isNavigationReady else { return }
+            self.log("BLE authentication timed out")
+            if self.pendingPairingSession != nil {
+                self.pairingError = "Pairing timed out. Bring the Bike Computer closer and try again."
             }
-
-            self.log("BLE auth timed out; restarting fresh pairing scan")
-            self.clearConnectionState()
-            self.forgetTrustedPeripheralForFreshScan()
             self.centralManager.cancelPeripheralConnection(peripheral)
-            self.beginPairing()
+        }
+    }
+
+    private func startPairingConfirmationTimeout(for peripheral: CBPeripheral) {
+        authTimeoutTimer?.invalidate()
+        authTimeoutTimer = Timer.scheduledTimer(withTimeInterval: 115.0, repeats: false) { [weak self, weak peripheral] _ in
+            guard let self,
+                  let peripheral,
+                  self.connectedPeripheral?.identifier == peripheral.identifier,
+                  case .awaitingPairingConfirmation = self.authFlowState else { return }
+            self.failAuthentication(
+                "The pairing code expired. Start again to generate a new code.",
+                peripheral: peripheral
+            )
         }
     }
 
@@ -2088,41 +2268,26 @@ class BLEManager: NSObject, ObservableObject {
             log("BLE auth not ready from \(source): navigation characteristic missing")
             return
         }
-        guard let authCharacteristic else {
+        guard authCharacteristic != nil else {
             log("BLE auth not ready from \(source): auth characteristic missing")
             return
         }
-        guard pendingAuthNonce == nil, case .idle = authWriteState else {
-            return
+        guard case .idle = authFlowState else { return }
+        authFlowState = .waitingForInfo
+        enqueueAuthMessage("INFO")
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = Timer.scheduledTimer(withTimeInterval: 0.8, repeats: false) { [weak self] _ in
+            guard let self, case .waitingForInfo = self.authFlowState else { return }
+            self.beginLegacyAuthentication()
         }
-
-        guard let writeType = preferredWriteType(for: authCharacteristic) else {
-            log("Auth characteristic does not support writes; props=\(authCharacteristic.properties.debugDescription)")
-            return
-        }
-
-        guard let nonce = BLEPairingAuthenticator.makeNonce() else {
-            log("Failed to generate BLE auth nonce")
-            return
-        }
-
-        let challenge = "HELLO|\(nonce)"
-        guard let challengeData = challenge.data(using: .utf8) else { return }
-        pendingAuthNonce = nonce
-        authWriteState = writeType == .withResponse ? .helloInFlight : .waitingForServer
-        peripheral.writeValue(challengeData, for: authCharacteristic, type: writeType)
-        log("Sent BLE auth challenge via \(authWriteLabel(writeType)); props=\(authCharacteristic.properties.debugDescription)")
+        log("Requested Bike Computer ownership information from \(source)")
     }
 
     private func preferredWriteType(
         for characteristic: CBCharacteristic
     ) -> CBCharacteristicWriteType? {
-        if characteristic.properties.contains(.write) {
-            return .withResponse
-        }
-        if characteristic.properties.contains(.writeWithoutResponse) {
-            return .withoutResponse
-        }
+        if characteristic.properties.contains(.write) { return .withResponse }
+        if characteristic.properties.contains(.writeWithoutResponse) { return .withoutResponse }
         return nil
     }
 
@@ -2137,46 +2302,318 @@ class BLEManager: NSObject, ObservableObject {
         }
         log("Received BLE auth response: \(message.prefix(16))... (\(data.count) bytes)")
 
-        if message == "LOCKED" {
-            log("Ignoring initial BLE auth state")
+        if message == "LOCKED" { return }
+        if message.hasPrefix("DEVICE|") {
+            handleDeviceInformation(message, peripheral: peripheral)
             return
         }
-
-        guard let nonce = pendingAuthNonce else {
-            log("Ignoring BLE auth response without a pending challenge")
-            return
-        }
-
-        if message.hasPrefix("SERVER|") {
-            guard BLEPairingAuthenticator.isValidServerResponse(message, nonce: nonce) else {
-                log("BLE auth failed: invalid server proof")
-                isPairingMode = false
-                clearConnectionState()
-                centralManager.cancelPeripheralConnection(peripheral)
+        if message.hasPrefix("PAIRING|") {
+            guard let session = pendingPairingSession else {
+                failAuthentication("Received an unexpected pairing response.", peripheral: peripheral)
                 return
             }
-
-            let clientProof = BLEPairingAuthenticator.clientProof(nonce: nonce)
-            let proofMessage = "CLIENT|\(nonce)|\(clientProof)"
-            guard let proofData = proofMessage.data(using: .utf8) else { return }
-            sendOrQueueClientProof(proofData, peripheral: peripheral, characteristic: characteristic)
+            do {
+                let material = try session.material(from: message)
+                pendingPairingMaterial = material
+                authFlowState = .awaitingPairingConfirmation
+                startPairingConfirmationTimeout(for: peripheral)
+                pairingPrompt = BikeComputerPairingPrompt(
+                    peripheralIdentifier: peripheral.identifier,
+                    deviceName: session.deviceName,
+                    shortIdentifier: pendingPairingCandidate?.shortIdentifier ?? String(material.deviceID.suffix(8)).uppercased(),
+                    comparisonCode: material.comparisonCode
+                )
+                pairingStatusMessage = nil
+            } catch {
+                failAuthentication("The Bike Computer returned an invalid secure-pairing response.", peripheral: peripheral)
+            }
             return
         }
-
-        if message == "OK|\(nonce)" {
+        if message.hasPrefix("PAIRED|") {
+            handlePairedResponse(message, peripheral: peripheral)
+            return
+        }
+        if message.hasPrefix("PAIR_READY|") {
+            let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 2,
+                  let material = pendingPairingMaterial,
+                  parts[1].lowercased() == material.deviceID else {
+                failAuthentication("The physical pairing confirmation did not match this device.", peripheral: peripheral)
+                return
+            }
+            isPairingConfirmedOnDevice = true
+            confirmPairing()
+            return
+        }
+        if message.hasPrefix("SERVER2|") {
+            handleOwnerServerProof(message, peripheral: peripheral)
+            return
+        }
+        if message.hasPrefix("OK2|") {
+            guard case .owner(let nonce, let deviceID, _, _) = authFlowState else {
+                failAuthentication("Received an unexpected owner confirmation.", peripheral: peripheral)
+                return
+            }
+            let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 3, parts[1] == deviceID, parts[2] == nonce else {
+                failAuthentication("The owner confirmation did not match this connection.", peripheral: peripheral)
+                return
+            }
             completeAuthentication(for: peripheral)
             return
         }
+        if message.hasPrefix("NAME_OK|") {
+            handleRenameResponse(message)
+            return
+        }
+        if message.hasPrefix("UNPAIRED|") {
+            let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+            guard parts.count == 2, pendingDeregistrationDeviceID == parts[1] else { return }
+            deviceRegistry.remove(deviceID: parts[1])
+            pendingDeregistrationDeviceID = nil
+            connectedDeviceID = nil
+            refreshKnownDevices()
+            pairingError = nil
+            pairingStatusMessage = "Bike Computer deregistered."
+            centralManager.cancelPeripheralConnection(peripheral)
+            return
+        }
+        if message.hasPrefix("OWNED|") || message.hasPrefix("DENIED|") {
+            autoReconnect = false
+            failAuthentication(
+                "This Bike Computer belongs to another iPhone. Hold BOOT for 8 seconds to reset ownership.",
+                peripheral: peripheral
+            )
+            return
+        }
+        if message.hasPrefix("ERROR|") {
+            let detail = message.split(separator: "|", maxSplits: 1).last.map(String.init) ?? "unknown error"
+            if pendingRenameDeviceID != nil {
+                pendingRenameDeviceID = nil
+                pairingStatusMessage = nil
+                pairingError = "Could not rename the Bike Computer: \(detail.replacingOccurrences(of: "_", with: " "))."
+                return
+            }
+            if pendingDeregistrationDeviceID != nil {
+                pendingDeregistrationDeviceID = nil
+                pairingStatusMessage = nil
+                pairingError = "Could not deregister the Bike Computer: \(detail.replacingOccurrences(of: "_", with: " "))."
+                autoReconnect = true
+                return
+            }
+            failAuthentication(
+                "Bike Computer pairing failed: \(detail.replacingOccurrences(of: "_", with: " ")).",
+                peripheral: peripheral
+            )
+            return
+        }
+        if message.hasPrefix("SERVER|") {
+            guard case .legacy(let nonce) = authFlowState,
+                  BLEPairingAuthenticator.isValidServerResponse(message, nonce: nonce) else {
+                failAuthentication("The Bike Computer failed authentication.", peripheral: peripheral)
+                return
+            }
+            let proof = BLEPairingAuthenticator.clientProof(nonce: nonce)
+            enqueueAuthMessage("CLIENT|\(nonce)|\(proof)")
+            return
+        }
+        if case .legacy(let nonce) = authFlowState, message == "OK|\(nonce)" {
+            completeAuthentication(for: peripheral)
+            return
+        }
+        log("Ignoring unexpected BLE auth response: \(message.prefix(24))")
+    }
 
-        log("BLE auth failed: unexpected response")
-        isPairingMode = false
-        clearConnectionState()
+    private func handleDeviceInformation(_ message: String, peripheral: CBPeripheral) {
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
+        let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 5, parts[1] == "2",
+              let deviceID = Data(ownershipHex: parts[2]),
+              deviceID.count == DeviceOwnershipProtocol.deviceIDLength,
+              let nameData = Data(ownershipHex: parts[4]),
+              let reportedName = String(data: nameData, encoding: .utf8) else {
+            failAuthentication("The Bike Computer returned invalid identity information.", peripheral: peripheral)
+            return
+        }
+        let deviceIDHex = parts[2].lowercased()
+        let isClaimed = parts[3] == "1"
+        connectedDeviceID = deviceIDHex
+        peripheralName = reportedName
+
+        if let session = pendingPairingSession {
+            guard !isClaimed else {
+                if let ownerKey = deviceRegistry.ownerKey(deviceID: deviceIDHex),
+                   let ownerID = deviceRegistry.installationOwnerID() {
+                    beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: ownerKey)
+                } else {
+                    autoReconnect = false
+                    failAuthentication("This Bike Computer is already registered to another iPhone.", peripheral: peripheral)
+                }
+                return
+            }
+            authFlowState = .pairing
+            enqueueAuthMessage(session.pairingCommand)
+            pairingStatusMessage = "Preparing secure comparison…"
+            return
+        }
+
+        if isClaimed,
+           let ownerKey = deviceRegistry.ownerKey(deviceID: deviceIDHex),
+           let ownerID = deviceRegistry.installationOwnerID() {
+            deviceRegistry.upsert(KnownBikeComputerDevice(
+                deviceID: deviceIDHex,
+                peripheralIdentifier: peripheral.identifier,
+                name: reportedName,
+                lastConnectedAt: Date(),
+                isLegacy: false
+            ))
+            refreshKnownDevices()
+            beginOwnerAuthentication(deviceID: deviceIDHex, ownerID: ownerID, ownerKey: ownerKey)
+        } else if isClaimed {
+            autoReconnect = false
+            failAuthentication(
+                "This Bike Computer belongs to another iPhone. Hold BOOT for 8 seconds to reset ownership.",
+                peripheral: peripheral
+            )
+        } else {
+            autoReconnect = false
+            failAuthentication(
+                "This Bike Computer is not registered yet. Add it from Settings → Bike Computers.",
+                peripheral: peripheral
+            )
+        }
+    }
+
+    private func handlePairedResponse(_ message: String, peripheral: CBPeripheral) {
+        let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 3,
+              let material = pendingPairingMaterial,
+              let session = pendingPairingSession,
+              parts[1].lowercased() == material.deviceID,
+              let nameData = Data(ownershipHex: parts[2]),
+              let name = String(data: nameData, encoding: .utf8),
+              deviceRegistry.saveOwnerKey(material.ownerKey, deviceID: material.deviceID) else {
+            failAuthentication("The secure owner credential could not be saved.", peripheral: peripheral)
+            return
+        }
+        deviceRegistry.upsert(KnownBikeComputerDevice(
+            deviceID: material.deviceID,
+            peripheralIdentifier: peripheral.identifier,
+            name: name,
+            lastConnectedAt: Date(),
+            isLegacy: false
+        ), makeActive: true)
+        refreshKnownDevices()
+        connectedDeviceID = material.deviceID
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        pairingStatusMessage = "Finishing secure connection…"
+        startAuthenticationTimeout(for: peripheral)
+        beginOwnerAuthentication(
+            deviceID: material.deviceID,
+            ownerID: session.ownerID,
+            ownerKey: material.ownerKey
+        )
+    }
+
+    private func beginOwnerAuthentication(deviceID: String, ownerID: Data, ownerKey: Data) {
+        guard let nonce = BLEPairingAuthenticator.makeNonce() else { return }
+        pendingAuthNonce = nonce
+        authFlowState = .owner(nonce: nonce, deviceID: deviceID, ownerID: ownerID, ownerKey: ownerKey)
+        enqueueAuthMessage("OWNER|\(ownerID.ownershipHex)|\(nonce)")
+    }
+
+    private func handleOwnerServerProof(_ message: String, peripheral: CBPeripheral) {
+        guard case .owner(let nonce, let deviceID, let ownerID, let ownerKey) = authFlowState else {
+            failAuthentication("Received an unexpected owner challenge.", peripheral: peripheral)
+            return
+        }
+        let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        let expected = DeviceOwnerAuthenticator.proof(
+            key: ownerKey,
+            message: DeviceOwnerAuthenticator.serverMessage(deviceID: deviceID, ownerID: ownerID, nonce: nonce)
+        )
+        guard parts.count == 4, parts[1] == deviceID, parts[2] == nonce,
+              DeviceOwnerAuthenticator.isValidProof(parts[3], expected: expected) else {
+            failAuthentication("The Bike Computer owner proof was invalid.", peripheral: peripheral)
+            return
+        }
+        let clientProof = DeviceOwnerAuthenticator.proof(
+            key: ownerKey,
+            message: DeviceOwnerAuthenticator.clientMessage(deviceID: deviceID, ownerID: ownerID, nonce: nonce)
+        )
+        enqueueAuthMessage("PROOF|\(ownerID.ownershipHex)|\(nonce)|\(clientProof)")
+    }
+
+    private func beginLegacyAuthentication() {
+        guard let nonce = BLEPairingAuthenticator.makeNonce() else { return }
+        pendingAuthNonce = nonce
+        authFlowState = .legacy(nonce: nonce)
+        enqueueAuthMessage("HELLO|\(nonce)")
+        log("Ownership protocol unavailable; trying legacy authentication")
+    }
+
+    private func enqueueAuthMessage(_ message: String) {
+        guard let data = message.data(using: .utf8) else { return }
+        queuedAuthMessages.append(data)
+        flushAuthMessageQueue()
+    }
+
+    private func flushAuthMessageQueue() {
+        guard !authWriteInFlight,
+              !queuedAuthMessages.isEmpty,
+              let peripheral = connectedPeripheral,
+              let authCharacteristic,
+              let writeType = preferredWriteType(for: authCharacteristic) else { return }
+        let data = queuedAuthMessages.removeFirst()
+        authWriteInFlight = writeType == .withResponse
+        peripheral.writeValue(data, for: authCharacteristic, type: writeType)
+        log("Sent ownership command via \(authWriteLabel(writeType))")
+        if writeType == .withoutResponse { flushAuthMessageQueue() }
+    }
+
+    private func authWriteCompleted(error: Error?, peripheral: CBPeripheral) {
+        authWriteInFlight = false
+        if let error {
+            failAuthentication("Could not send secure ownership data: \(error.localizedDescription)", peripheral: peripheral)
+            return
+        }
+        flushAuthMessageQueue()
+    }
+
+    private func failAuthentication(_ message: String, peripheral: CBPeripheral) {
+        pairingError = message
+        pairingStatusMessage = nil
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        pendingPairingMaterial = nil
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
+        log("BLE auth failed: \(message)")
+        suppressNextReconnect = pendingPairingSession != nil
         centralManager.cancelPeripheralConnection(peripheral)
     }
 
+    private func handleRenameResponse(_ message: String) {
+        guard let deviceID = pendingRenameDeviceID else { return }
+        let parts = message.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 2,
+              let nameData = Data(ownershipHex: parts[1]),
+              let name = String(data: nameData, encoding: .utf8),
+              var device = knownDevices.first(where: { $0.deviceID == deviceID }) else { return }
+        device.name = name
+        deviceRegistry.upsert(device)
+        pendingRenameDeviceID = nil
+        peripheralName = name
+        pairingStatusMessage = nil
+        pairingError = nil
+        refreshKnownDevices()
+    }
+
     private func completeAuthentication(for peripheral: CBPeripheral) {
-        guard let characteristic = navigationCharacteristic else { return }
-        guard let navigationWriteType = preferredWriteType(for: characteristic) else {
+        guard let characteristic = navigationCharacteristic,
+              let navigationWriteType = preferredWriteType(for: characteristic) else {
             log("Navigation characteristic is not writable after authentication")
             return
         }
@@ -2186,24 +2623,20 @@ class BLEManager: NSObject, ObservableObject {
             expectsWriteResponse: navigationWriteType == .withResponse,
             canSend: { [weak self, weak peripheral] in
                 guard let self, let peripheral else { return false }
-                if navigationWriteType == .withResponse {
-                    return !self.writeWithResponseInFlight
-                }
-                return peripheral.canSendWriteWithoutResponse
+                return navigationWriteType == .withResponse
+                    ? !self.writeWithResponseInFlight
+                    : peripheral.canSendWriteWithoutResponse
             },
             write: { [weak self, weak peripheral, weak characteristic] data in
                 guard let self, let peripheral, let characteristic else { return }
-                self.writeDeviceData(
-                    data,
-                    to: characteristic,
-                    on: peripheral,
-                    type: navigationWriteType
-                )
+                self.writeDeviceData(data, to: characteristic, on: peripheral, type: navigationWriteType)
             }
         ))
 
         pendingAuthNonce = nil
-        authWriteState = .idle
+        authFlowState = .authenticated
+        authWriteInFlight = false
+        queuedAuthMessages.removeAll()
         isPairingMode = false
         isConnected = true
         isNavigationReady = true
@@ -2214,7 +2647,39 @@ class BLEManager: NSObject, ObservableObject {
         authTimeoutTimer = nil
         lastConnectedPeripheralIdentifier = peripheral.identifier
         UserDefaults.standard.set(peripheral.identifier.uuidString, forKey: SettingsKeys.lastPeripheralIdentifier)
-        updateTrustedPeripheralDescription()
+
+        if let connectedDeviceID {
+            var device = knownDevices.first(where: { $0.deviceID == connectedDeviceID })
+                ?? KnownBikeComputerDevice(
+                    deviceID: connectedDeviceID,
+                    peripheralIdentifier: peripheral.identifier,
+                    name: peripheralName.isEmpty ? DeviceOwnershipProtocol.defaultDeviceName : peripheralName,
+                    lastConnectedAt: Date(),
+                    isLegacy: connectedDeviceID.hasPrefix("legacy:")
+                )
+            device.peripheralIdentifier = peripheral.identifier
+            device.lastConnectedAt = Date()
+            deviceRegistry.upsert(device, makeActive: deviceRegistry.activeDeviceID == nil)
+        } else if connectedDeviceID == nil {
+            let legacyID = "legacy:\(peripheral.identifier.uuidString.lowercased())"
+            connectedDeviceID = legacyID
+            deviceRegistry.upsert(KnownBikeComputerDevice(
+                deviceID: legacyID,
+                peripheralIdentifier: peripheral.identifier,
+                name: peripheralName.isEmpty ? DeviceOwnershipProtocol.defaultDeviceName : peripheralName,
+                lastConnectedAt: Date(),
+                isLegacy: true
+            ), makeActive: knownDevices.isEmpty)
+        }
+        refreshKnownDevices()
+        pairingPrompt = nil
+        isPairingConfirmedOnDevice = false
+        pairingStatusMessage = nil
+        pairingError = nil
+        pendingPairingSession = nil
+        pendingPairingMaterial = nil
+        pendingPairingCandidate = nil
+        autoReconnect = true
         log("BLE peripheral authenticated")
         requestDeviceCapabilities()
         sendSetting(id: 6, value: Int32(mapRotationMode))
@@ -2224,45 +2689,6 @@ class BLEManager: NSObject, ObservableObject {
                     value: disconnectedSleepTimeout.settingValue)
         requestDeviceTransferStatus()
         requestMapTransferStatus()
-    }
-
-    private func sendOrQueueClientProof(_ proofData: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic) {
-        switch authWriteState {
-        case .helloInFlight:
-            authWriteState = .clientProofPending(proofData)
-            log("Queued BLE client auth proof until challenge write completes")
-        case .waitingForServer:
-            writeClientAuthProof(proofData, peripheral: peripheral, characteristic: characteristic)
-        default:
-            log("Ignoring duplicate BLE server auth response")
-        }
-    }
-
-    private func writeClientAuthProof(_ proofData: Data, peripheral: CBPeripheral, characteristic: CBCharacteristic) {
-        guard let writeType = preferredWriteType(for: characteristic) else {
-            log("Cannot send BLE client auth proof: auth characteristic is not writable")
-            isPairingMode = false
-            clearConnectionState()
-            centralManager.cancelPeripheralConnection(peripheral)
-            return
-        }
-
-        authWriteState = writeType == .withResponse ? .clientProofInFlight : .waitingForOK
-        peripheral.writeValue(proofData, for: characteristic, type: writeType)
-        log("Sent BLE client auth proof via \(authWriteLabel(writeType))")
-    }
-
-    private func authWriteCompleted(for peripheral: CBPeripheral, characteristic: CBCharacteristic) {
-        switch authWriteState {
-        case .helloInFlight:
-            authWriteState = .waitingForServer
-        case .clientProofPending(let proofData):
-            writeClientAuthProof(proofData, peripheral: peripheral, characteristic: characteristic)
-        case .clientProofInFlight:
-            authWriteState = .waitingForOK
-        default:
-            break
-        }
     }
 
     private func enqueueNavigationWrite(
@@ -2484,7 +2910,7 @@ extension BLEManager: CBCentralManagerDelegate {
             if lastConnectedPeripheralIdentifier != nil {
                 reconnectToLastDevice()
             } else {
-                log("No trusted BikeComputer peripheral saved; tap reconnect to pair")
+                log("No Bike Computer saved; add one from Settings")
             }
             
         case .poweredOff:
@@ -2528,12 +2954,31 @@ extension BLEManager: CBCentralManagerDelegate {
         }
     }
     
-    func centralManager(_ central: CBCentralManager, 
-                       didDiscover peripheral: CBPeripheral, 
-                       advertisementData: [String : Any], 
+    func centralManager(_ central: CBCentralManager,
+                       didDiscover peripheral: CBPeripheral,
+                       advertisementData: [String : Any],
                        rssi RSSI: NSNumber) {
         
         log("Discovered: \(peripheral.name ?? "Unknown") (RSSI: \(RSSI))")
+
+        discoveredPeripherals[peripheral.identifier] = peripheral
+        let candidate = DiscoveredBikeComputerDevice.parse(
+            peripheralIdentifier: peripheral.identifier,
+            localName: advertisementData[CBAdvertisementDataLocalNameKey] as? String ?? peripheral.name,
+            manufacturerData: advertisementData[CBAdvertisementDataManufacturerDataKey] as? Data,
+            rssi: RSSI.intValue
+        )
+        if let index = discoveredDevices.firstIndex(where: { $0.id == candidate.id }) {
+            discoveredDevices[index] = candidate
+        } else {
+            discoveredDevices.append(candidate)
+        }
+        discoveredDevices.sort { $0.rssi > $1.rssi }
+
+        if isDiscoveringDevices {
+            pairingStatusMessage = discoveredDevices.isEmpty ? "Looking for nearby Bike Computers…" : nil
+            return
+        }
 
         if let trustedIdentifier = lastConnectedPeripheralIdentifier,
            peripheral.identifier != trustedIdentifier {
@@ -2600,7 +3045,11 @@ extension BLEManager: CBCentralManagerDelegate {
         deviceMapFoundForCurrentLocation = nil
         deviceMapBlockCount = 0
         pendingAuthNonce = nil
-        authWriteState = .idle
+        authFlowState = .idle
+        authWriteInFlight = false
+        queuedAuthMessages.removeAll()
+        authInfoFallbackTimer?.invalidate()
+        authInfoFallbackTimer = nil
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         navigationWriteQueue.removeAll()
@@ -2609,12 +3058,19 @@ extension BLEManager: CBCentralManagerDelegate {
         connectionTimeoutTimer?.invalidate()
         connectionTimeoutTimer = nil
         stopMonitoringRSSI()
+        connectedDeviceID = nil
 
-        if shouldPairAfterDisconnect {
-            shouldPairAfterDisconnect = false
-            forgetTrustedPeripheralForFreshScan()
-            beginPairing()
+        if let nextIdentifier = pendingConnectionAfterDisconnect {
+            pendingConnectionAfterDisconnect = nil
+            connectDiscoveredPeripheral(identifier: nextIdentifier)
             return
+        }
+
+        if pendingPairingSession != nil && pairingError == nil {
+            pairingPrompt = nil
+            isPairingConfirmedOnDevice = false
+            pairingStatusMessage = nil
+            pairingError = "Pairing was interrupted. Cancel and add the Bike Computer again."
         }
 
         if suppressNextReconnect {
@@ -2672,8 +3128,9 @@ extension BLEManager: CBCentralManagerDelegate {
             log("Connection error: \(error.localizedDescription)")
         }
         
-        // Retry after delay
-        if autoReconnect {
+        if pendingPairingSession != nil {
+            pairingError = "Could not connect to that Bike Computer."
+        } else if autoReconnect {
             scheduleReconnectWithBackoff()
         }
     }
@@ -2807,10 +3264,7 @@ extension BLEManager: CBPeripheralDelegate {
         if let error = error {
             log("Error writing characteristic \(characteristic.uuid): \(error.localizedDescription); props=\(characteristic.properties.debugDescription)")
             if characteristic.uuid == authCharacteristicUUID {
-                suppressNextReconnect = true
-                isPairingMode = false
-                clearConnectionState()
-                centralManager.cancelPeripheralConnection(peripheral)
+                authWriteCompleted(error: error, peripheral: peripheral)
             } else {
                 completeNavigationWrite(error: error)
             }
@@ -2818,7 +3272,7 @@ extension BLEManager: CBPeripheralDelegate {
         }
 
         if characteristic.uuid == authCharacteristicUUID {
-            authWriteCompleted(for: peripheral, characteristic: characteristic)
+            authWriteCompleted(error: nil, peripheral: peripheral)
         } else {
             completeNavigationWrite(error: nil)
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -440,6 +440,7 @@ class BikeComputerCoordinator: ObservableObject {
 
     func applicationDidBecomeActive() {
         locationManager.prepareDeviceDestinationRequestsIfNeeded()
+        bleManager.resumeAutoReconnectIfNeeded()
     }
 
     var isLocationAuthorized: Bool {

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
@@ -153,6 +153,48 @@ enum BLEDiscoveryFreshnessPolicy {
     }
 }
 
+enum BikeComputersMenuPolicy {
+    static func title(knownDeviceCount: Int) -> String {
+        switch knownDeviceCount {
+        case 0:
+            return "Connect Bike Computer"
+        case 1:
+            return "My Bike Computer"
+        default:
+            return "My Bike Computers"
+        }
+    }
+
+    static func shouldStartDiscoveryOnEntry(knownDeviceCount: Int) -> Bool {
+        knownDeviceCount == 0
+    }
+
+    static func shouldShowConnectNewDeviceAction(knownDeviceCount: Int) -> Bool {
+        knownDeviceCount > 0
+    }
+
+    static func shouldResumeOwnedDiscovery(
+        ownsDiscoveryLifecycle: Bool,
+        isBluetoothPoweredOn: Bool,
+        isDiscoveringDevices: Bool,
+        pairingCompletedDuringPresentation: Bool
+    ) -> Bool {
+        ownsDiscoveryLifecycle && isBluetoothPoweredOn &&
+            !isDiscoveringDevices && !pairingCompletedDuringPresentation
+    }
+}
+
+enum BLEPendingScanPolicy {
+    static let timeout: TimeInterval = 8
+
+    static func accepts(
+        discoveredIdentifier: UUID,
+        pendingIdentifier: UUID
+    ) -> Bool {
+        discoveredIdentifier == pendingIdentifier
+    }
+}
+
 enum BLEPairingCancellationPolicy {
     static func shouldDisconnect(
         connectedPeripheralIdentifier: UUID?,

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
@@ -16,7 +16,7 @@ struct KnownBikeComputerDevice: Codable, Equatable, Identifiable {
         guard !isLegacy, deviceID.count >= 8 else {
             return String(peripheralIdentifier.uuidString.prefix(4)).uppercased()
         }
-        return String(deviceID.suffix(8)).uppercased()
+        return String(deviceID.suffix(4)).uppercased()
     }
 }
 
@@ -24,6 +24,7 @@ struct DiscoveredBikeComputerDevice: Equatable, Identifiable {
     let peripheralIdentifier: UUID
     var advertisedName: String
     var shortIdentifier: String
+    var identitySuffix: String?
     var isClaimed: Bool?
     var rssi: Int
     var lastSeenAt: Date
@@ -38,6 +39,7 @@ struct DiscoveredBikeComputerDevice: Equatable, Identifiable {
         now: Date = Date()
     ) -> DiscoveredBikeComputerDevice {
         var shortIdentifier = String(peripheralIdentifier.uuidString.prefix(4)).uppercased()
+        var identitySuffix: String?
         var isClaimed: Bool?
         if let data = manufacturerData,
            data.count == DeviceOwnershipProtocol.advertisementLength,
@@ -45,12 +47,15 @@ struct DiscoveredBikeComputerDevice: Equatable, Identifiable {
            data[1] == 0xFF,
            data[2] == DeviceOwnershipProtocol.version {
             isClaimed = data[3] & DeviceOwnershipProtocol.claimedFlag != 0
-            shortIdentifier = data.subdata(in: 4..<8).ownershipHex.uppercased()
+            let parsedIdentitySuffix = data.subdata(in: 4..<8).ownershipHex.uppercased()
+            identitySuffix = parsedIdentitySuffix
+            shortIdentifier = String(parsedIdentitySuffix.suffix(4))
         }
         return DiscoveredBikeComputerDevice(
             peripheralIdentifier: peripheralIdentifier,
             advertisedName: localName.nilIfEmpty ?? "BikeComputer \(shortIdentifier.suffix(4))",
             shortIdentifier: shortIdentifier,
+            identitySuffix: identitySuffix,
             isClaimed: isClaimed,
             rssi: rssi,
             lastSeenAt: now
@@ -63,6 +68,7 @@ struct BikeComputerPairingPrompt: Equatable, Identifiable {
     let deviceName: String
     let shortIdentifier: String
     let comparisonCode: Int
+    let isReplacingExistingRegistration: Bool
 
     var id: UUID { peripheralIdentifier }
     var formattedCode: String { String(format: "%06d", comparisonCode) }
@@ -94,6 +100,258 @@ enum DeviceOwnershipProtocol {
             result = candidate
         }
         return result.isEmpty ? defaultDeviceName : result
+    }
+
+    static func resolvedName(
+        reportedName: String,
+        existingName: String?,
+        peripheralName: String?
+    ) -> String {
+        if !reportedName.isEmpty { return normalizedName(reportedName) }
+        if let existingName, !existingName.isEmpty {
+            return normalizedName(existingName)
+        }
+        if let peripheralName, !peripheralName.isEmpty {
+            return normalizedName(peripheralName)
+        }
+        return defaultDeviceName
+    }
+
+    static func resolvedInfoName(
+        reportedName: String,
+        isClaimed: Bool,
+        existingName: String?,
+        peripheralName: String?
+    ) -> String {
+        resolvedName(
+            reportedName: isClaimed && existingName != nil ? "" : reportedName,
+            existingName: existingName,
+            peripheralName: peripheralName
+        )
+    }
+}
+
+enum DeviceOwnershipFlowPolicy {
+    static func allowsLegacyFallback(
+        knownDevice: KnownBikeComputerDevice?,
+        pairingCandidate: DiscoveredBikeComputerDevice?
+    ) -> Bool {
+        guard pairingCandidate?.isClaimed == nil else { return false }
+        return knownDevice?.isLegacy == true
+    }
+}
+
+enum BLEDiscoveryFreshnessPolicy {
+    static let maximumAge: TimeInterval = 6
+
+    static func retained(
+        _ devices: [DiscoveredBikeComputerDevice],
+        now: Date = Date(),
+        maximumAge: TimeInterval = maximumAge
+    ) -> [DiscoveredBikeComputerDevice] {
+        devices.filter { now.timeIntervalSince($0.lastSeenAt) <= maximumAge }
+    }
+}
+
+enum BLEPairingCancellationPolicy {
+    static func shouldDisconnect(
+        connectedPeripheralIdentifier: UUID?,
+        pairingPeripheralIdentifier: UUID?,
+        hasActivePairing: Bool
+    ) -> Bool {
+        hasActivePairing && connectedPeripheralIdentifier != nil &&
+            connectedPeripheralIdentifier == pairingPeripheralIdentifier
+    }
+}
+
+enum BLEOwnershipLifecyclePhase: Equatable {
+    case idle
+    case discovering
+    case pairing(UUID)
+    case comparisonReady(UUID)
+    case submitting(UUID)
+}
+
+struct BLEOwnershipCancellation: Equatable {
+    let pairingPeripheralIdentifier: UUID?
+    let shouldDisconnectPairingPeripheral: Bool
+}
+
+/// Owns the user-driven registration lifecycle independently of CoreBluetooth.
+/// BLEManager uses every transition below, while host tests can exercise the
+/// same handoff, cancellation, and single-submit decisions deterministically.
+struct BLEOwnershipLifecycle {
+    private(set) var phase: BLEOwnershipLifecyclePhase = .idle
+
+    mutating func beginDiscovery() {
+        phase = .discovering
+    }
+
+    mutating func endDiscovery(resumeAutoReconnect: Bool) -> Bool {
+        phase = .idle
+        return resumeAutoReconnect
+    }
+
+    mutating func beginPairing(
+        candidateIdentifier: UUID,
+        connectedIdentifier: UUID?
+    ) -> Bool {
+        phase = .pairing(candidateIdentifier)
+        return connectedIdentifier != nil &&
+            connectedIdentifier != candidateIdentifier
+    }
+
+    mutating func markComparisonReady(for candidateIdentifier: UUID) -> Bool {
+        guard phase == .pairing(candidateIdentifier) else { return false }
+        phase = .comparisonReady(candidateIdentifier)
+        return true
+    }
+
+    mutating func beginConfirmation(for candidateIdentifier: UUID) -> Bool {
+        guard phase == .comparisonReady(candidateIdentifier) else { return false }
+        phase = .submitting(candidateIdentifier)
+        return true
+    }
+
+    mutating func cancel(connectedIdentifier: UUID?) -> BLEOwnershipCancellation {
+        let candidateIdentifier: UUID?
+        switch phase {
+        case .pairing(let identifier),
+             .comparisonReady(let identifier),
+             .submitting(let identifier):
+            candidateIdentifier = identifier
+        case .idle, .discovering:
+            candidateIdentifier = nil
+        }
+        let cancellation = BLEOwnershipCancellation(
+            pairingPeripheralIdentifier: candidateIdentifier,
+            shouldDisconnectPairingPeripheral:
+                BLEPairingCancellationPolicy.shouldDisconnect(
+                    connectedPeripheralIdentifier: connectedIdentifier,
+                    pairingPeripheralIdentifier: candidateIdentifier,
+                    hasActivePairing: candidateIdentifier != nil
+                )
+        )
+        phase = .discovering
+        return cancellation
+    }
+
+    mutating func interrupt() {
+        phase = .idle
+    }
+
+    mutating func complete() {
+        phase = .idle
+    }
+}
+
+enum BLEIdentityObservationPolicy {
+    static func conflictingDeviceIDs(
+        knownDevices: [KnownBikeComputerDevice],
+        peripheralIdentifier: UUID,
+        observedDeviceID: String
+    ) -> Set<String> {
+        Set(knownDevices.compactMap { device in
+            guard device.peripheralIdentifier == peripheralIdentifier,
+                  device.deviceID != observedDeviceID else { return nil }
+            return device.deviceID
+        })
+    }
+}
+
+enum BLEReconnectBackoff {
+    static func delay(
+        attempt: Int,
+        base: TimeInterval = 1,
+        maximum: TimeInterval = 60
+    ) -> TimeInterval {
+        let boundedAttempt = min(max(attempt, 0), 30)
+        return min(base * pow(2, Double(boundedAttempt)), maximum)
+    }
+}
+
+enum BLEConnectionPersistence {
+    // Trusted-device connects intentionally remain pending in CoreBluetooth so
+    // iOS can complete them when the accessory reappears, including while the
+    // app is suspended. Interactive pairing attempts remain bounded.
+    static func shouldCancelTimedOutConnection(isPairing: Bool) -> Bool {
+        isPairing
+    }
+}
+
+enum BLEPendingHandoffPolicy {
+    static func consume(_ pendingIdentifier: inout UUID?) -> UUID? {
+        defer { pendingIdentifier = nil }
+        return pendingIdentifier
+    }
+}
+
+enum BLEDeviceOperationPolicy {
+    static func canStartPairing(operationDeviceID: String?) -> Bool {
+        operationDeviceID == nil
+    }
+}
+
+enum BikeComputerRemovalAction: Equatable {
+    case deregister
+    case forget
+}
+
+enum BikeComputerRemovalPolicy {
+    static func action(
+        isConnected: Bool,
+        isLegacy: Bool
+    ) -> BikeComputerRemovalAction {
+        isConnected && !isLegacy ? .deregister : .forget
+    }
+}
+
+enum BLELocalForgetPolicy {
+    static func acceptsCallback(
+        peripheralIdentifier: UUID,
+        currentIdentifier: UUID?,
+        forgottenIdentifiers: Set<UUID>
+    ) -> Bool {
+        currentIdentifier == peripheralIdentifier &&
+            !forgottenIdentifiers.contains(peripheralIdentifier)
+    }
+
+    static func shouldStopScanning(
+        wasActive: Bool,
+        hadPendingTransport: Bool,
+        hasSuccessor: Bool
+    ) -> Bool {
+        (wasActive || hadPendingTransport) && !hasSuccessor
+    }
+}
+
+enum BLENavigationNotificationPolicy {
+    static func accepts(
+        isAuthenticated: Bool,
+        isLegacyDevice: Bool,
+        hasProtectedSession: Bool,
+        isProtectedFrame: Bool
+    ) -> Bool {
+        guard isAuthenticated else { return false }
+        if hasProtectedSession { return isProtectedFrame }
+        return isLegacyDevice && !isProtectedFrame
+    }
+}
+
+enum BLERestorationPolicy {
+    static func selectedIdentifier(
+        from available: [UUID],
+        trustedIdentifier: UUID?
+    ) -> UUID? {
+        guard let trustedIdentifier else { return nil }
+        return available.contains(trustedIdentifier) ? trustedIdentifier : nil
+    }
+
+    static func identifiersToCancel(
+        from available: [UUID],
+        keeping selectedIdentifier: UUID
+    ) -> [UUID] {
+        available.filter { $0 != selectedIdentifier }
     }
 }
 
@@ -144,6 +402,10 @@ struct DevicePairingSession {
 
     var pairingCommand: String {
         "PAIR|\(ownerID.ownershipHex)|\(privateKey.publicKey.x963Representation.ownershipHex)"
+    }
+
+    func matches(peripheralIdentifier: UUID) -> Bool {
+        self.peripheralIdentifier == peripheralIdentifier
     }
 
     func material(from response: String) throws -> DevicePairingMaterial {
@@ -220,17 +482,27 @@ enum DeviceOwnerAuthenticator {
     static func serverMessage(
         deviceID: String,
         ownerID: Data,
-        nonce: String
+        clientNonce: String,
+        serverNonce: String
     ) -> String {
-        "server2|\(deviceID)|\(ownerID.ownershipHex)|\(nonce)"
+        "server2|\(deviceID)|\(ownerID.ownershipHex)|\(clientNonce)|\(serverNonce)"
     }
 
     static func clientMessage(
         deviceID: String,
         ownerID: Data,
+        clientNonce: String,
+        serverNonce: String
+    ) -> String {
+        "client2|\(deviceID)|\(ownerID.ownershipHex)|\(clientNonce)|\(serverNonce)"
+    }
+
+    static func revocationMessage(
+        deviceID: String,
+        ownerID: Data,
         nonce: String
     ) -> String {
-        "client2|\(deviceID)|\(ownerID.ownershipHex)|\(nonce)"
+        "revoked2|\(deviceID)|\(ownerID.ownershipHex)|\(nonce)"
     }
 
     static func proof(key: Data, message: String) -> String {
@@ -251,6 +523,155 @@ enum DeviceOwnerAuthenticator {
             difference |= suppliedData[index] ^ expectedData[index]
         }
         return difference == 0
+    }
+
+    static func isValidRevocationReceipt(
+        suppliedProof: String,
+        key: Data,
+        deviceID: String,
+        ownerID: Data,
+        nonce: String
+    ) -> Bool {
+        guard Data(ownershipHex: nonce)?.count == 16,
+              Data(ownershipHex: suppliedProof)?.count == 32 else {
+            return false
+        }
+        return isValidProof(
+            suppliedProof,
+            expected: proof(
+                key: key,
+                message: revocationMessage(
+                    deviceID: deviceID,
+                    ownerID: ownerID,
+                    nonce: nonce
+                )
+            )
+        )
+    }
+}
+
+enum AuthenticatedBLEChannel: UInt8 {
+    case auth = 1
+    case navigation = 2
+    case route = 3
+    case gps = 4
+    case settings = 5
+}
+
+final class AuthenticatedBLEWriteSession {
+    static let frameOverhead = 22
+
+    private let writeKey: SymmetricKey
+    private let notifyKey: SymmetricKey
+    private var nextSequence: [AuthenticatedBLEChannel: UInt32] = [:]
+    private var lastNotificationSequence: [AuthenticatedBLEChannel: UInt32] = [:]
+
+    init(
+        ownerKey: Data,
+        deviceID: String,
+        clientNonce: String,
+        serverNonce: String
+    ) {
+        let context = "\(deviceID)|\(clientNonce)|\(serverNonce)"
+        writeKey = SymmetricKey(data: HMAC<SHA256>.authenticationCode(
+            for: Data("session2-write|\(context)".utf8),
+            using: SymmetricKey(data: ownerKey)
+        ))
+        notifyKey = SymmetricKey(data: HMAC<SHA256>.authenticationCode(
+            for: Data("session2-notify|\(context)".utf8),
+            using: SymmetricKey(data: ownerKey)
+        ))
+    }
+
+    func frame(payload: Data, channel: AuthenticatedBLEChannel) -> Data? {
+        let (sequence, overflow) = (nextSequence[channel] ?? 0)
+            .addingReportingOverflow(1)
+        guard !overflow else { return nil }
+        nextSequence[channel] = sequence
+        let sequenceBytes: [UInt8] = [
+            UInt8((sequence >> 24) & 0xFF),
+            UInt8((sequence >> 16) & 0xFF),
+            UInt8((sequence >> 8) & 0xFF),
+            UInt8(sequence & 0xFF)
+        ]
+        guard let nonce = try? AES.GCM.Nonce(data: nonceData(
+            channel: channel,
+            sequenceBytes: sequenceBytes
+        )) else { return nil }
+        let aad = authenticatedData(
+            prefix: "write2|",
+            channel: channel,
+            sequenceBytes: sequenceBytes
+        )
+        guard let sealed = try? AES.GCM.seal(
+            payload,
+            using: writeKey,
+            nonce: nonce,
+            authenticating: aad
+        ) else { return nil }
+        var frame = Data([0x53, 0x32])
+        frame.append(contentsOf: sequenceBytes)
+        frame.append(sealed.ciphertext)
+        frame.append(sealed.tag)
+        return frame
+    }
+
+    func notificationPayload(
+        from frame: Data,
+        channel: AuthenticatedBLEChannel
+    ) -> Data? {
+        guard frame.count >= Self.frameOverhead,
+              frame[0] == 0x52, frame[1] == 0x32 else { return nil }
+        let sequenceBytes = Array(frame[2..<6])
+        let sequence = sequenceBytes.reduce(UInt32(0)) {
+            ($0 << 8) | UInt32($1)
+        }
+        guard sequence > (lastNotificationSequence[channel] ?? 0),
+              let nonce = try? AES.GCM.Nonce(data: nonceData(
+                channel: channel,
+                sequenceBytes: sequenceBytes
+              )) else { return nil }
+        let ciphertext = frame.subdata(in: 6..<(frame.count - 16))
+        let tag = frame.suffix(16)
+        let box: AES.GCM.SealedBox
+        do {
+            box = try AES.GCM.SealedBox(
+                nonce: nonce,
+                ciphertext: ciphertext,
+                tag: tag
+            )
+            let plaintext = try AES.GCM.open(
+                box,
+                using: notifyKey,
+                authenticating: authenticatedData(
+                    prefix: "notify2|",
+                    channel: channel,
+                    sequenceBytes: sequenceBytes
+                )
+            )
+            lastNotificationSequence[channel] = sequence
+            return plaintext
+        } catch {
+            return nil
+        }
+    }
+
+    private func nonceData(
+        channel: AuthenticatedBLEChannel,
+        sequenceBytes: [UInt8]
+    ) -> Data {
+        Data([channel.rawValue, 0, 0, 0, 0, 0, 0, 0] + sequenceBytes)
+    }
+
+    private func authenticatedData(
+        prefix: String,
+        channel: AuthenticatedBLEChannel,
+        sequenceBytes: [UInt8]
+    ) -> Data {
+        var data = Data(prefix.utf8)
+        data.append(channel.rawValue)
+        data.append(contentsOf: sequenceBytes)
+        return data
     }
 }
 
@@ -306,12 +727,14 @@ final class KeychainDeviceCredentialStore: DeviceCredentialStoring {
 #if HOST_TESTING
 final class InMemoryDeviceCredentialStore: DeviceCredentialStoring {
     private var values: [String: Data] = [:]
+    var shouldFailRemoval = false
     func data(account: String) -> Data? { values[account] }
     func set(_ data: Data, account: String) -> Bool {
         values[account] = data
         return true
     }
     func remove(account: String) -> Bool {
+        if shouldFailRemoval { return false }
         values.removeValue(forKey: account)
         return true
     }
@@ -322,8 +745,17 @@ final class BikeComputerDeviceRegistry {
     private enum Keys {
         static let devices = "ble.knownDevices.v2"
         static let activeDeviceID = "ble.activeDeviceID.v2"
+        static func provisionalConfirmed(deviceID: String) -> String {
+            "ble.provisionalOwnerConfirmed.\(deviceID)"
+        }
+        static func provisionalReplacementAuthorized(deviceID: String) -> String {
+            "ble.provisionalReplacementAuthorized.\(deviceID)"
+        }
         static let installationOwnerID = "installation-owner-id"
         static func ownerKey(deviceID: String) -> String { "owner-key-\(deviceID)" }
+        static func provisionalOwnerKey(deviceID: String) -> String {
+            "provisional-owner-key-\(deviceID)"
+        }
     }
 
     private let defaults: UserDefaults
@@ -389,21 +821,140 @@ final class BikeComputerDeviceRegistry {
         return credentialStore.set(key, account: Keys.ownerKey(deviceID: deviceID))
     }
 
+    func provisionalOwnerKey(deviceID: String) -> Data? {
+        credentialStore.data(account: Keys.provisionalOwnerKey(deviceID: deviceID))
+    }
+
+    @discardableResult
+    func saveProvisionalOwnerKey(_ key: Data, deviceID: String) -> Bool {
+        guard key.count == DeviceOwnershipProtocol.ownerKeyLength else { return false }
+        defaults.removeObject(forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+        defaults.removeObject(
+            forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+        )
+        return credentialStore.set(
+            key,
+            account: Keys.provisionalOwnerKey(deviceID: deviceID)
+        )
+    }
+
+    func markProvisionalOwnerKeyConfirmed(deviceID: String) {
+        defaults.set(true, forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+    }
+
+    func isProvisionalOwnerKeyConfirmed(deviceID: String) -> Bool {
+        defaults.bool(forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+    }
+
+    func authorizeProvisionalCredentialReplacement(deviceID: String) {
+        defaults.set(
+            true,
+            forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+        )
+    }
+
+    func isProvisionalCredentialReplacementAuthorized(
+        deviceID: String
+    ) -> Bool {
+        defaults.bool(
+            forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+        )
+    }
+
+    func hasConfirmedReplacementCredential(deviceID: String) -> Bool {
+        isProvisionalOwnerKeyConfirmed(deviceID: deviceID) &&
+            isProvisionalCredentialReplacementAuthorized(deviceID: deviceID) &&
+            provisionalOwnerKey(deviceID: deviceID) != nil
+    }
+
+    @discardableResult
+    func promoteProvisionalOwnerKey(
+        deviceID: String,
+        allowReplacingExisting: Bool = false
+    ) -> Bool {
+        guard let key = provisionalOwnerKey(deviceID: deviceID) else {
+            return false
+        }
+        // A stable DeviceID is an identifier, not proof of continuity. Never
+        // let an ordinary pairing flow replace a different credential for the
+        // same ID; that requires an explicit recovery/reset flow.
+        if let existing = ownerKey(deviceID: deviceID),
+           existing != key,
+           !allowReplacingExisting {
+            return false
+        }
+        guard saveOwnerKey(key, deviceID: deviceID) else { return false }
+        let removed = credentialStore.remove(
+            account: Keys.provisionalOwnerKey(deviceID: deviceID)
+        )
+        if removed {
+            defaults.removeObject(forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+            defaults.removeObject(
+                forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+            )
+        }
+        return removed
+    }
+
+    func removeProvisionalOwnerKey(deviceID: String) {
+        credentialStore.remove(
+            account: Keys.provisionalOwnerKey(deviceID: deviceID)
+        )
+        defaults.removeObject(forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+        defaults.removeObject(
+            forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+        )
+    }
+
     func upsert(_ device: KnownBikeComputerDevice, makeActive: Bool = false) {
-        var current = devices.filter { $0.deviceID != device.deviceID }
+        let previous = devices
+        let replacedActiveAlias = previous.contains {
+            $0.peripheralIdentifier == device.peripheralIdentifier &&
+                $0.deviceID == activeDeviceID
+        }
+        var current = previous.filter {
+            $0.deviceID != device.deviceID &&
+                $0.peripheralIdentifier != device.peripheralIdentifier
+        }
         current.append(device)
         devices = current
-        if makeActive || activeDeviceID == nil {
+        if makeActive || activeDeviceID == nil || replacedActiveAlias ||
+            !current.contains(where: { $0.deviceID == activeDeviceID }) {
             activeDeviceID = device.deviceID
         }
     }
 
-    func remove(deviceID: String) {
+    @discardableResult
+    func remove(deviceID: String) -> Bool {
+        let ownerAccount = Keys.ownerKey(deviceID: deviceID)
+        let provisionalAccount = Keys.provisionalOwnerKey(deviceID: deviceID)
+        let ownerKey = credentialStore.data(account: ownerAccount)
+        let provisionalKey = credentialStore.data(account: provisionalAccount)
+
+        let removedOwner = credentialStore.remove(account: ownerAccount)
+        let removedProvisional = credentialStore.remove(account: provisionalAccount)
+        guard removedOwner && removedProvisional else {
+            // Keychain has no transaction primitive. Restore whichever secrets
+            // were present so a partial deletion cannot hide a device while
+            // leaving the registry and credentials out of sync.
+            if let ownerKey {
+                _ = credentialStore.set(ownerKey, account: ownerAccount)
+            }
+            if let provisionalKey {
+                _ = credentialStore.set(provisionalKey, account: provisionalAccount)
+            }
+            return false
+        }
+
         devices = devices.filter { $0.deviceID != deviceID }
-        credentialStore.remove(account: Keys.ownerKey(deviceID: deviceID))
+        defaults.removeObject(forKey: Keys.provisionalConfirmed(deviceID: deviceID))
+        defaults.removeObject(
+            forKey: Keys.provisionalReplacementAuthorized(deviceID: deviceID)
+        )
         if activeDeviceID == deviceID {
             activeDeviceID = devices.first?.deviceID
         }
+        return true
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
@@ -1,0 +1,435 @@
+import Foundation
+import CoreBluetooth
+import CryptoKit
+import Security
+
+struct KnownBikeComputerDevice: Codable, Equatable, Identifiable {
+    let deviceID: String
+    var peripheralIdentifier: UUID
+    var name: String
+    var lastConnectedAt: Date
+    var isLegacy: Bool
+
+    var id: String { deviceID }
+
+    var shortIdentifier: String {
+        guard !isLegacy, deviceID.count >= 8 else {
+            return String(peripheralIdentifier.uuidString.prefix(4)).uppercased()
+        }
+        return String(deviceID.suffix(8)).uppercased()
+    }
+}
+
+struct DiscoveredBikeComputerDevice: Equatable, Identifiable {
+    let peripheralIdentifier: UUID
+    var advertisedName: String
+    var shortIdentifier: String
+    var isClaimed: Bool?
+    var rssi: Int
+    var lastSeenAt: Date
+
+    var id: UUID { peripheralIdentifier }
+
+    static func parse(
+        peripheralIdentifier: UUID,
+        localName: String?,
+        manufacturerData: Data?,
+        rssi: Int,
+        now: Date = Date()
+    ) -> DiscoveredBikeComputerDevice {
+        var shortIdentifier = String(peripheralIdentifier.uuidString.prefix(4)).uppercased()
+        var isClaimed: Bool?
+        if let data = manufacturerData,
+           data.count == DeviceOwnershipProtocol.advertisementLength,
+           data[0] == 0xFF,
+           data[1] == 0xFF,
+           data[2] == DeviceOwnershipProtocol.version {
+            isClaimed = data[3] & DeviceOwnershipProtocol.claimedFlag != 0
+            shortIdentifier = data.subdata(in: 4..<8).ownershipHex.uppercased()
+        }
+        return DiscoveredBikeComputerDevice(
+            peripheralIdentifier: peripheralIdentifier,
+            advertisedName: localName.nilIfEmpty ?? "BikeComputer \(shortIdentifier.suffix(4))",
+            shortIdentifier: shortIdentifier,
+            isClaimed: isClaimed,
+            rssi: rssi,
+            lastSeenAt: now
+        )
+    }
+}
+
+struct BikeComputerPairingPrompt: Equatable, Identifiable {
+    let peripheralIdentifier: UUID
+    let deviceName: String
+    let shortIdentifier: String
+    let comparisonCode: Int
+
+    var id: UUID { peripheralIdentifier }
+    var formattedCode: String { String(format: "%06d", comparisonCode) }
+}
+
+enum DeviceOwnershipProtocol {
+    static let version: UInt8 = 2
+    static let advertisementLength = 8
+    static let claimedFlag: UInt8 = 1
+    static let ownerIDLength = 16
+    static let deviceIDLength = 16
+    static let ownerKeyLength = 32
+    static let publicKeyLength = 65
+    static let maximumNameBytes = 24
+    static let defaultDeviceName = "My bike"
+
+    static func normalizedName(_ proposedName: String) -> String {
+        let trimmed = proposedName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return defaultDeviceName }
+        var result = ""
+        for character in trimmed {
+            let characterText = String(character)
+            let bytes = characterText.utf8
+            guard !bytes.contains(where: { $0 == 0 || $0 == 0x7C || $0 < 0x20 || $0 == 0x7F }) else {
+                continue
+            }
+            let candidate = result + characterText
+            guard candidate.utf8.count <= maximumNameBytes else { break }
+            result = candidate
+        }
+        return result.isEmpty ? defaultDeviceName : result
+    }
+}
+
+enum DeviceOwnershipCryptoError: Error, Equatable {
+    case invalidOwnerID
+    case invalidDeviceID
+    case invalidPublicKey
+    case invalidResponse
+}
+
+struct DevicePairingMaterial {
+    let deviceID: String
+    let ownerKey: Data
+    let comparisonCode: Int
+    let confirmationCommand: String
+}
+
+struct DevicePairingSession {
+    let peripheralIdentifier: UUID
+    let ownerID: Data
+    let deviceName: String
+    private let privateKey: P256.KeyAgreement.PrivateKey
+
+    init(peripheralIdentifier: UUID, ownerID: Data, deviceName: String) throws {
+        guard ownerID.count == DeviceOwnershipProtocol.ownerIDLength else {
+            throw DeviceOwnershipCryptoError.invalidOwnerID
+        }
+        self.peripheralIdentifier = peripheralIdentifier
+        self.ownerID = ownerID
+        self.deviceName = DeviceOwnershipProtocol.normalizedName(deviceName)
+        privateKey = P256.KeyAgreement.PrivateKey()
+    }
+
+    init(
+        peripheralIdentifier: UUID,
+        ownerID: Data,
+        deviceName: String,
+        privateKeyRawRepresentation: Data
+    ) throws {
+        guard ownerID.count == DeviceOwnershipProtocol.ownerIDLength else {
+            throw DeviceOwnershipCryptoError.invalidOwnerID
+        }
+        self.peripheralIdentifier = peripheralIdentifier
+        self.ownerID = ownerID
+        self.deviceName = DeviceOwnershipProtocol.normalizedName(deviceName)
+        privateKey = try P256.KeyAgreement.PrivateKey(rawRepresentation: privateKeyRawRepresentation)
+    }
+
+    var pairingCommand: String {
+        "PAIR|\(ownerID.ownershipHex)|\(privateKey.publicKey.x963Representation.ownershipHex)"
+    }
+
+    func material(from response: String) throws -> DevicePairingMaterial {
+        let parts = response.split(separator: "|", omittingEmptySubsequences: false).map(String.init)
+        guard parts.count == 3, parts[0] == "PAIRING",
+              let deviceID = Data(ownershipHex: parts[1]),
+              deviceID.count == DeviceOwnershipProtocol.deviceIDLength,
+              let devicePublicData = Data(ownershipHex: parts[2]),
+              devicePublicData.count == DeviceOwnershipProtocol.publicKeyLength else {
+            throw DeviceOwnershipCryptoError.invalidResponse
+        }
+        let devicePublicKey: P256.KeyAgreement.PublicKey
+        do {
+            devicePublicKey = try P256.KeyAgreement.PublicKey(x963Representation: devicePublicData)
+        } catch {
+            throw DeviceOwnershipCryptoError.invalidPublicKey
+        }
+        let appPublicData = privateKey.publicKey.x963Representation
+        let transcriptHash = Self.transcriptHash(
+            deviceID: deviceID,
+            ownerID: ownerID,
+            appPublicKey: appPublicData,
+            devicePublicKey: devicePublicData
+        )
+        let sharedSecret = try privateKey.sharedSecretFromKeyAgreement(with: devicePublicKey)
+        let ownerKey = sharedSecret.hkdfDerivedSymmetricKey(
+            using: SHA256.self,
+            salt: transcriptHash,
+            sharedInfo: Data("BikeComputer owner key v2".utf8),
+            outputByteCount: DeviceOwnershipProtocol.ownerKeyLength
+        )
+        let ownerKeyData = ownerKey.withUnsafeBytes { Data($0) }
+        var comparisonMessage = Data("compare|".utf8)
+        comparisonMessage.append(transcriptHash)
+        let comparisonDigest = Self.hmac(key: ownerKeyData, message: comparisonMessage)
+        let comparisonValue = comparisonDigest.prefix(4).reduce(UInt32(0)) {
+            ($0 << 8) | UInt32($1)
+        }
+        var confirmationMessage = Data("claim|".utf8)
+        confirmationMessage.append(transcriptHash)
+        let proof = Self.hmac(key: ownerKeyData, message: confirmationMessage)
+        return DevicePairingMaterial(
+            deviceID: parts[1].lowercased(),
+            ownerKey: ownerKeyData,
+            comparisonCode: Int(comparisonValue % 1_000_000),
+            confirmationCommand: "CONFIRM|\(ownerID.ownershipHex)|\(proof.ownershipHex)|\(Data(deviceName.utf8).ownershipHex)"
+        )
+    }
+
+    private static func transcriptHash(
+        deviceID: Data,
+        ownerID: Data,
+        appPublicKey: Data,
+        devicePublicKey: Data
+    ) -> Data {
+        var transcript = Data("BikeComputer ownership v2".utf8)
+        transcript.append(deviceID)
+        transcript.append(ownerID)
+        transcript.append(appPublicKey)
+        transcript.append(devicePublicKey)
+        return Data(SHA256.hash(data: transcript))
+    }
+
+    private static func hmac(key: Data, message: Data) -> Data {
+        let code = HMAC<SHA256>.authenticationCode(
+            for: message,
+            using: SymmetricKey(data: key)
+        )
+        return Data(code)
+    }
+}
+
+enum DeviceOwnerAuthenticator {
+    static func serverMessage(
+        deviceID: String,
+        ownerID: Data,
+        nonce: String
+    ) -> String {
+        "server2|\(deviceID)|\(ownerID.ownershipHex)|\(nonce)"
+    }
+
+    static func clientMessage(
+        deviceID: String,
+        ownerID: Data,
+        nonce: String
+    ) -> String {
+        "client2|\(deviceID)|\(ownerID.ownershipHex)|\(nonce)"
+    }
+
+    static func proof(key: Data, message: String) -> String {
+        Data(HMAC<SHA256>.authenticationCode(
+            for: Data(message.utf8),
+            using: SymmetricKey(data: key)
+        )).ownershipHex
+    }
+
+    static func isValidProof(_ supplied: String, expected: String) -> Bool {
+        guard let suppliedData = Data(ownershipHex: supplied),
+              let expectedData = Data(ownershipHex: expected),
+              suppliedData.count == expectedData.count else {
+            return false
+        }
+        var difference: UInt8 = 0
+        for index in suppliedData.indices {
+            difference |= suppliedData[index] ^ expectedData[index]
+        }
+        return difference == 0
+    }
+}
+
+protocol DeviceCredentialStoring {
+    func data(account: String) -> Data?
+    @discardableResult func set(_ data: Data, account: String) -> Bool
+    @discardableResult func remove(account: String) -> Bool
+}
+
+final class KeychainDeviceCredentialStore: DeviceCredentialStoring {
+    private let service = "LetItRide.BikeComputer.device-ownership.v2"
+
+    func data(account: String) -> Data? {
+        var query = baseQuery(account: account)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+        var item: CFTypeRef?
+        guard SecItemCopyMatching(query as CFDictionary, &item) == errSecSuccess else {
+            return nil
+        }
+        return item as? Data
+    }
+
+    @discardableResult
+    func set(_ data: Data, account: String) -> Bool {
+        let query = baseQuery(account: account)
+        let attributes: [String: Any] = [kSecValueData as String: data]
+        let updateStatus = SecItemUpdate(query as CFDictionary, attributes as CFDictionary)
+        if updateStatus == errSecSuccess { return true }
+        guard updateStatus == errSecItemNotFound else { return false }
+        var addition = query
+        addition[kSecValueData as String] = data
+        addition[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        return SecItemAdd(addition as CFDictionary, nil) == errSecSuccess
+    }
+
+    @discardableResult
+    func remove(account: String) -> Bool {
+        let status = SecItemDelete(baseQuery(account: account) as CFDictionary)
+        return status == errSecSuccess || status == errSecItemNotFound
+    }
+
+    private func baseQuery(account: String) -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: false
+        ]
+    }
+}
+
+#if HOST_TESTING
+final class InMemoryDeviceCredentialStore: DeviceCredentialStoring {
+    private var values: [String: Data] = [:]
+    func data(account: String) -> Data? { values[account] }
+    func set(_ data: Data, account: String) -> Bool {
+        values[account] = data
+        return true
+    }
+    func remove(account: String) -> Bool {
+        values.removeValue(forKey: account)
+        return true
+    }
+}
+#endif
+
+final class BikeComputerDeviceRegistry {
+    private enum Keys {
+        static let devices = "ble.knownDevices.v2"
+        static let activeDeviceID = "ble.activeDeviceID.v2"
+        static let installationOwnerID = "installation-owner-id"
+        static func ownerKey(deviceID: String) -> String { "owner-key-\(deviceID)" }
+    }
+
+    private let defaults: UserDefaults
+    private let credentialStore: DeviceCredentialStoring
+
+    init(
+        defaults: UserDefaults = .standard,
+        credentialStore: DeviceCredentialStoring? = nil
+    ) {
+        self.defaults = defaults
+#if HOST_TESTING
+        self.credentialStore = credentialStore ?? InMemoryDeviceCredentialStore()
+#else
+        self.credentialStore = credentialStore ?? KeychainDeviceCredentialStore()
+#endif
+    }
+
+    var devices: [KnownBikeComputerDevice] {
+        get {
+            guard let data = defaults.data(forKey: Keys.devices),
+                  let devices = try? JSONDecoder().decode([KnownBikeComputerDevice].self, from: data) else {
+                return []
+            }
+            return devices.sorted { $0.lastConnectedAt > $1.lastConnectedAt }
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else { return }
+            defaults.set(data, forKey: Keys.devices)
+        }
+    }
+
+    var activeDeviceID: String? {
+        get { defaults.string(forKey: Keys.activeDeviceID) }
+        set {
+            if let newValue {
+                defaults.set(newValue, forKey: Keys.activeDeviceID)
+            } else {
+                defaults.removeObject(forKey: Keys.activeDeviceID)
+            }
+        }
+    }
+
+    func installationOwnerID() -> Data? {
+        if let existing = credentialStore.data(account: Keys.installationOwnerID),
+           existing.count == DeviceOwnershipProtocol.ownerIDLength {
+            return existing
+        }
+        var bytes = [UInt8](repeating: 0, count: DeviceOwnershipProtocol.ownerIDLength)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return nil
+        }
+        let ownerID = Data(bytes)
+        return credentialStore.set(ownerID, account: Keys.installationOwnerID) ? ownerID : nil
+    }
+
+    func ownerKey(deviceID: String) -> Data? {
+        credentialStore.data(account: Keys.ownerKey(deviceID: deviceID))
+    }
+
+    @discardableResult
+    func saveOwnerKey(_ key: Data, deviceID: String) -> Bool {
+        guard key.count == DeviceOwnershipProtocol.ownerKeyLength else { return false }
+        return credentialStore.set(key, account: Keys.ownerKey(deviceID: deviceID))
+    }
+
+    func upsert(_ device: KnownBikeComputerDevice, makeActive: Bool = false) {
+        var current = devices.filter { $0.deviceID != device.deviceID }
+        current.append(device)
+        devices = current
+        if makeActive || activeDeviceID == nil {
+            activeDeviceID = device.deviceID
+        }
+    }
+
+    func remove(deviceID: String) {
+        devices = devices.filter { $0.deviceID != deviceID }
+        credentialStore.remove(account: Keys.ownerKey(deviceID: deviceID))
+        if activeDeviceID == deviceID {
+            activeDeviceID = devices.first?.deviceID
+        }
+    }
+}
+
+extension Data {
+    init?(ownershipHex: String) {
+        guard ownershipHex.count.isMultiple(of: 2) else { return nil }
+        self.init(capacity: ownershipHex.count / 2)
+        var index = ownershipHex.startIndex
+        while index < ownershipHex.endIndex {
+            let next = ownershipHex.index(index, offsetBy: 2)
+            guard let byte = UInt8(ownershipHex[index..<next], radix: 16) else {
+                return nil
+            }
+            append(byte)
+            index = next
+        }
+    }
+
+    var ownershipHex: String {
+        map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+private extension Optional where Wrapped == String {
+    var nilIfEmpty: String? {
+        guard let self, !self.isEmpty else { return nil }
+        return self
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -3,10 +3,18 @@ import SwiftUI
 struct BikeComputersSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
     @State private var selectedCandidate: DiscoveredBikeComputerDevice?
+    @State private var presentedPairingCompletionGeneration: UInt64?
+    @State private var ownsDiscoveryLifecycle = false
+
+    private var menuTitle: String {
+        BikeComputersMenuPolicy.title(
+            knownDeviceCount: bleManager.knownDevices.count
+        )
+    }
 
     var body: some View {
         Form {
-            Section("My Bike Computers") {
+            Section {
                 if bleManager.knownDevices.isEmpty {
                     VStack(alignment: .leading, spacing: 6) {
                         Label("No Bike Computers", systemImage: "bicycle")
@@ -23,9 +31,14 @@ struct BikeComputersSettingsView: View {
                         }
                     }
                 }
+            } header: {
+                if !bleManager.knownDevices.isEmpty {
+                    Text(menuTitle)
+                }
             }
 
-            if bleManager.isScanning || !bleManager.discoveredDevices.isEmpty {
+            if bleManager.isDiscoveringDevices ||
+                !bleManager.discoveredDevices.isEmpty {
                 Section {
                     if bleManager.discoveredDevices.isEmpty {
                         HStack(spacing: 12) {
@@ -36,6 +49,8 @@ struct BikeComputersSettingsView: View {
                     } else {
                         ForEach(bleManager.discoveredDevices) { device in
                             Button {
+                                presentedPairingCompletionGeneration =
+                                    bleManager.completedPairingGeneration
                                 selectedCandidate = device
                             } label: {
                                 DiscoveredBikeComputerRow(device: device)
@@ -51,16 +66,17 @@ struct BikeComputersSettingsView: View {
                 }
             }
 
-            Section {
-                if bleManager.isScanning {
-                    Button("Stop Looking", role: .cancel) {
-                        bleManager.cancelDeviceDiscovery()
-                    }
-                } else {
+            if BikeComputersMenuPolicy.shouldShowConnectNewDeviceAction(
+                knownDeviceCount: bleManager.knownDevices.count
+            ), !bleManager.isDiscoveringDevices {
+                Section {
                     Button {
-                        bleManager.startDeviceDiscovery()
+                        beginDiscovery()
                     } label: {
-                        Label("Add Bike Computer", systemImage: "plus.circle")
+                        Label(
+                            "Connect a new Bike Computer",
+                            systemImage: "plus.circle"
+                        )
                     }
                     .disabled(bleManager.deviceOperationDeviceID != nil)
                 }
@@ -71,7 +87,8 @@ struct BikeComputersSettingsView: View {
                     Label(error, systemImage: "exclamationmark.triangle.fill")
                         .foregroundStyle(.red)
                 }
-            } else if let status = bleManager.pairingStatusMessage {
+            } else if let status = bleManager.pairingStatusMessage,
+                      !bleManager.isDiscoveringDevices {
                 Section {
                     HStack(spacing: 12) {
                         if !status.contains("deregistered") {
@@ -82,29 +99,75 @@ struct BikeComputersSettingsView: View {
                 }
             }
 
-            Section {
-                Text("A registered Bike Computer only accepts this iPhone. To recover after losing the phone, hold the device’s BOOT button for 8 seconds.")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
-            }
         }
-        .navigationTitle("Bike Computers")
+        .navigationTitle(menuTitle)
         .navigationBarTitleDisplayMode(.inline)
-        .sheet(item: $selectedCandidate) { candidate in
+        .sheet(item: $selectedCandidate, onDismiss: {
+            resumeOwnedDiscoveryIfNeeded()
+        }) { candidate in
             PairBikeComputerSheet(candidate: candidate)
                 .environmentObject(bleManager)
         }
         .onAppear {
-            bleManager.startDeviceDiscovery()
+            if BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+                knownDeviceCount: bleManager.knownDevices.count
+            ) {
+                beginDiscovery()
+            } else if bleManager.isDiscoveringDevices {
+                bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
+            }
         }
         .onChange(of: bleManager.centralStateDescription) { state in
-            if state == "powered on", selectedCandidate == nil {
+            if state == "powered on", ownsDiscoveryLifecycle,
+               selectedCandidate == nil {
                 bleManager.startDeviceDiscovery()
             }
         }
-        .onDisappear {
-            bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
+        .onChange(of: bleManager.knownDevices.count) { count in
+            if BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+                knownDeviceCount: count
+            ) {
+                if !ownsDiscoveryLifecycle {
+                    beginDiscovery()
+                }
+            } else if ownsDiscoveryLifecycle {
+                ownsDiscoveryLifecycle = false
+                bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
+            }
         }
+        .onDisappear {
+            if ownsDiscoveryLifecycle || bleManager.isDiscoveringDevices {
+                ownsDiscoveryLifecycle = false
+                bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
+            }
+        }
+    }
+
+    private func beginDiscovery() {
+        ownsDiscoveryLifecycle = true
+        bleManager.startDeviceDiscovery()
+    }
+
+    private func resumeOwnedDiscoveryIfNeeded() {
+        let pairingCompletedDuringPresentation =
+            presentedPairingCompletionGeneration.map {
+                bleManager.completedPairingGeneration != $0
+            } ?? false
+        presentedPairingCompletionGeneration = nil
+        guard BikeComputersMenuPolicy.shouldResumeOwnedDiscovery(
+            ownsDiscoveryLifecycle: ownsDiscoveryLifecycle,
+            isBluetoothPoweredOn:
+                bleManager.centralStateDescription == "powered on",
+            isDiscoveringDevices: bleManager.isDiscoveringDevices,
+            pairingCompletedDuringPresentation:
+                pairingCompletedDuringPresentation
+        ) else {
+            if pairingCompletedDuringPresentation {
+                ownsDiscoveryLifecycle = false
+            }
+            return
+        }
+        bleManager.startDeviceDiscovery()
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -41,6 +41,7 @@ struct BikeComputersSettingsView: View {
                                 DiscoveredBikeComputerRow(device: device)
                             }
                             .buttonStyle(.plain)
+                            .disabled(bleManager.deviceOperationDeviceID != nil)
                         }
                     }
                 } header: {
@@ -61,6 +62,7 @@ struct BikeComputersSettingsView: View {
                     } label: {
                         Label("Add Bike Computer", systemImage: "plus.circle")
                     }
+                    .disabled(bleManager.deviceOperationDeviceID != nil)
                 }
             }
 
@@ -92,10 +94,16 @@ struct BikeComputersSettingsView: View {
             PairBikeComputerSheet(candidate: candidate)
                 .environmentObject(bleManager)
         }
-        .onDisappear {
-            if bleManager.isScanning {
-                bleManager.cancelDeviceDiscovery()
+        .onAppear {
+            bleManager.startDeviceDiscovery()
+        }
+        .onChange(of: bleManager.centralStateDescription) { state in
+            if state == "powered on", selectedCandidate == nil {
+                bleManager.startDeviceDiscovery()
             }
+        }
+        .onDisappear {
+            bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
         }
     }
 }
@@ -120,6 +128,10 @@ private struct KnownBikeComputerRow: View {
                 Text("Connected")
                     .font(.caption)
                     .foregroundStyle(.green)
+            } else if bleManager.hasObservedIdentityMismatch(for: device) {
+                Text("Needs Setup")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
             } else if bleManager.activeDeviceID == device.deviceID {
                 Text("Current")
                     .font(.caption)
@@ -190,18 +202,35 @@ private struct PairBikeComputerSheet: View {
                     } header: {
                         Text("Confirm the Code")
                     } footer: {
-                        Text("If this exact code is also displayed on your Bike Computer, press its BOOT button to confirm physical access.")
+                        if prompt.isReplacingExistingRegistration {
+                            Text("This Bike Computer was reset. Match this code, then press either button on the device to replace its old registration on this iPhone.")
+                        } else {
+                            Text("If this exact code is also displayed on your Bike Computer, press either button on the device to confirm physical access.")
+                        }
                     }
 
-                    if bleManager.isPairingConfirmedOnDevice {
+                    if bleManager.isPairingConfirmationSubmitting {
                         Section {
                             HStack(spacing: 12) {
                                 ProgressView()
                                 Text("Registering this iPhone…")
                             }
                         }
+                    } else if bleManager.isPairingConfirmedOnDevice {
+                        Section {
+                            Button(
+                                prompt.isReplacingExistingRegistration
+                                    ? "Codes Match — Replace Registration"
+                                    : "Codes Match — Register This iPhone",
+                                role: prompt.isReplacingExistingRegistration
+                                    ? .destructive
+                                    : nil
+                            ) {
+                                bleManager.confirmPairingAfterCodeMatch()
+                            }
+                        }
                     }
-                } else if didStart {
+                } else if didStart, bleManager.pairingError == nil {
                     Section {
                         HStack(spacing: 12) {
                             ProgressView()
@@ -230,6 +259,10 @@ private struct PairBikeComputerSheet: View {
                     Section {
                         Label(error, systemImage: "exclamationmark.triangle.fill")
                             .foregroundStyle(.red)
+                        Button("Try Again") {
+                            bleManager.cancelPairing()
+                            didStart = false
+                        }
                     }
                 }
             }
@@ -249,6 +282,9 @@ private struct PairBikeComputerSheet: View {
                           $0.peripheralIdentifier == candidate.peripheralIdentifier
                       }) else { return }
                 dismiss()
+            }
+            .onDisappear {
+                bleManager.cancelPairing()
             }
         }
     }
@@ -272,6 +308,7 @@ private struct BikeComputerDetailView: View {
     let deviceID: String
     @State private var editedName = ""
     @State private var showingDeregisterConfirmation = false
+    @State private var showingForgetConfirmation = false
 
     private var device: KnownBikeComputerDevice? {
         bleManager.knownDevices.first { $0.deviceID == deviceID }
@@ -290,32 +327,63 @@ private struct BikeComputerDetailView: View {
                     )
                 }
 
-                Section {
-                    if bleManager.isConnected(to: device) {
-                        Button("Save Name") {
-                            bleManager.rename(device: device, to: editedName)
+                if !bleManager.isConnected(to: device) || !device.isLegacy {
+                    Section {
+                        if bleManager.isConnected(to: device) {
+                            Button("Save Name") {
+                                bleManager.rename(device: device, to: editedName)
+                            }
+                            .disabled(
+                                bleManager.deviceOperationDeviceID != nil ||
+                                DeviceOwnershipProtocol.normalizedName(editedName) == device.name
+                            )
+                        } else {
+                            Button("Set as Current and Connect") {
+                                bleManager.connect(to: device)
+                            }
                         }
-                        .disabled(
-                            device.isLegacy ||
-                            DeviceOwnershipProtocol.normalizedName(editedName) == device.name
-                        )
-                    } else {
-                        Button("Set as Current and Connect") {
-                            bleManager.connect(to: device)
+                    }
+                }
+
+                if bleManager.deviceFeedbackDeviceID == device.deviceID,
+                   let error = bleManager.pairingError {
+                    Section {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                } else if bleManager.deviceFeedbackDeviceID == device.deviceID,
+                          let status = bleManager.pairingStatusMessage {
+                    Section {
+                        HStack(spacing: 12) {
+                            if !status.contains("deregistered") { ProgressView() }
+                            Text(status)
                         }
                     }
                 }
 
                 Section {
-                    Button("Deregister from This iPhone", role: .destructive) {
-                        showingDeregisterConfirmation = true
+                    if BikeComputerRemovalPolicy.action(
+                        isConnected: bleManager.isConnected(to: device),
+                        isLegacy: device.isLegacy
+                    ) == .deregister {
+                        Button("Deregister from This iPhone", role: .destructive) {
+                            showingDeregisterConfirmation = true
+                        }
+                        .disabled(
+                            device.isLegacy ||
+                            bleManager.deviceOperationDeviceID != nil
+                        )
+                    } else {
+                        Button("Forget on This iPhone", role: .destructive) {
+                            showingForgetConfirmation = true
+                        }
+                        .disabled(bleManager.deviceOperationDeviceID != nil)
                     }
-                    .disabled(!bleManager.isConnected(to: device) || device.isLegacy)
                 } footer: {
                     if device.isLegacy {
-                        Text("Install ownership-capable firmware, then add this device again to enable secure registration.")
+                        Text("You can forget this legacy entry here, or install ownership-capable firmware and add it again.")
                     } else if !bleManager.isConnected(to: device) {
-                        Text("Connect to this device before deregistering so ownership is removed from both the iPhone and Bike Computer.")
+                        Text("Forgetting removes this iPhone’s local credential only. Use this if the Bike Computer was reset, transferred, or is no longer available.")
                     } else {
                         Text("The Bike Computer will restart and become available for another iPhone.")
                     }
@@ -331,6 +399,18 @@ private struct BikeComputerDetailView: View {
                     Button("Cancel", role: .cancel) { }
                 } message: {
                     Text("This removes the secure owner credential from both devices.")
+                }
+                .confirmationDialog(
+                    "Forget \(device.name) on this iPhone?",
+                    isPresented: $showingForgetConfirmation,
+                    titleVisibility: .visible
+                ) {
+                    Button("Forget", role: .destructive) {
+                        bleManager.forgetLocally(device: device)
+                    }
+                    Button("Cancel", role: .cancel) { }
+                } message: {
+                    Text("This removes the saved credential from this iPhone. It does not change the Bike Computer.")
                 }
             }
         }

--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -1,0 +1,362 @@
+import SwiftUI
+
+struct BikeComputersSettingsView: View {
+    @EnvironmentObject private var bleManager: BLEManager
+    @State private var selectedCandidate: DiscoveredBikeComputerDevice?
+
+    var body: some View {
+        Form {
+            Section("My Bike Computers") {
+                if bleManager.knownDevices.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("No Bike Computers", systemImage: "bicycle")
+                        Text("Add a nearby device and choose a name for it.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(bleManager.knownDevices) { device in
+                        NavigationLink {
+                            BikeComputerDetailView(deviceID: device.deviceID)
+                        } label: {
+                            KnownBikeComputerRow(device: device)
+                        }
+                    }
+                }
+            }
+
+            if bleManager.isScanning || !bleManager.discoveredDevices.isEmpty {
+                Section {
+                    if bleManager.discoveredDevices.isEmpty {
+                        HStack(spacing: 12) {
+                            ProgressView()
+                            Text("Looking nearby…")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        ForEach(bleManager.discoveredDevices) { device in
+                            Button {
+                                selectedCandidate = device
+                            } label: {
+                                DiscoveredBikeComputerRow(device: device)
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                } header: {
+                    Text("Nearby")
+                } footer: {
+                    Text("Choose the device whose short code matches the one shown on your Bike Computer.")
+                }
+            }
+
+            Section {
+                if bleManager.isScanning {
+                    Button("Stop Looking", role: .cancel) {
+                        bleManager.cancelDeviceDiscovery()
+                    }
+                } else {
+                    Button {
+                        bleManager.startDeviceDiscovery()
+                    } label: {
+                        Label("Add Bike Computer", systemImage: "plus.circle")
+                    }
+                }
+            }
+
+            if let error = bleManager.pairingError {
+                Section {
+                    Label(error, systemImage: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.red)
+                }
+            } else if let status = bleManager.pairingStatusMessage {
+                Section {
+                    HStack(spacing: 12) {
+                        if !status.contains("deregistered") {
+                            ProgressView()
+                        }
+                        Text(status)
+                    }
+                }
+            }
+
+            Section {
+                Text("A registered Bike Computer only accepts this iPhone. To recover after losing the phone, hold the device’s BOOT button for 8 seconds.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .navigationTitle("Bike Computers")
+        .navigationBarTitleDisplayMode(.inline)
+        .sheet(item: $selectedCandidate) { candidate in
+            PairBikeComputerSheet(candidate: candidate)
+                .environmentObject(bleManager)
+        }
+        .onDisappear {
+            if bleManager.isScanning {
+                bleManager.cancelDeviceDiscovery()
+            }
+        }
+    }
+}
+
+private struct KnownBikeComputerRow: View {
+    @EnvironmentObject private var bleManager: BLEManager
+    let device: KnownBikeComputerDevice
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bicycle.circle.fill")
+                .font(.title2)
+                .foregroundStyle(bleManager.isConnected(to: device) ? Color.green : Color.accentColor)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(device.name)
+                Text("Device \(device.shortIdentifier)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if bleManager.isConnected(to: device) {
+                Text("Connected")
+                    .font(.caption)
+                    .foregroundStyle(.green)
+            } else if bleManager.activeDeviceID == device.deviceID {
+                Text("Current")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct DiscoveredBikeComputerRow: View {
+    let device: DiscoveredBikeComputerDevice
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "bicycle")
+                .font(.title3)
+                .foregroundStyle(Color.accentColor)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(device.advertisedName)
+                Text("Device \(device.shortIdentifier)")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            if device.isClaimed == true {
+                Text("Registered")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Image(systemName: signalImage)
+                .foregroundStyle(.secondary)
+                .accessibilityLabel("Signal \(device.rssi) dBm")
+        }
+        .contentShape(Rectangle())
+    }
+
+    private var signalImage: String {
+        if device.rssi >= -60 { return "wifi" }
+        if device.rssi >= -75 { return "wifi.exclamationmark" }
+        return "antenna.radiowaves.left.and.right.slash"
+    }
+}
+
+private struct PairBikeComputerSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var bleManager: BLEManager
+    let candidate: DiscoveredBikeComputerDevice
+
+    @State private var deviceName = DeviceOwnershipProtocol.defaultDeviceName
+    @State private var didStart = false
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    DeviceValueRow(title: "Device", value: candidate.shortIdentifier)
+                    DeviceValueRow(title: "Signal", value: "\(candidate.rssi) dBm")
+                }
+
+                if let prompt = matchingPrompt {
+                    Section {
+                        Text(prompt.formattedCode)
+                            .font(.system(size: 44, weight: .semibold, design: .rounded))
+                            .monospacedDigit()
+                            .frame(maxWidth: .infinity)
+                            .accessibilityLabel("Pairing code \(prompt.formattedCode)")
+                    } header: {
+                        Text("Confirm the Code")
+                    } footer: {
+                        Text("If this exact code is also displayed on your Bike Computer, press its BOOT button to confirm physical access.")
+                    }
+
+                    if bleManager.isPairingConfirmedOnDevice {
+                        Section {
+                            HStack(spacing: 12) {
+                                ProgressView()
+                                Text("Registering this iPhone…")
+                            }
+                        }
+                    }
+                } else if didStart {
+                    Section {
+                        HStack(spacing: 12) {
+                            ProgressView()
+                            Text(bleManager.pairingStatusMessage ?? "Preparing secure pairing…")
+                        }
+                    }
+                } else {
+                    Section {
+                        TextField("Bike name", text: $deviceName)
+                            .textInputAutocapitalization(.words)
+                            .submitLabel(.continue)
+                            .onSubmit(startPairing)
+                    } header: {
+                        Text("Name Your Bike")
+                    } footer: {
+                        Text("You can change this later. iOS does not expose the owner’s Apple ID name, so the app starts with “My bike.”")
+                    }
+
+                    Section {
+                        Button("Continue") { startPairing() }
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+
+                if let error = bleManager.pairingError {
+                    Section {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .foregroundStyle(.red)
+                    }
+                }
+            }
+            .navigationTitle("Add Bike Computer")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        bleManager.cancelPairing()
+                        dismiss()
+                    }
+                }
+            }
+            .onChange(of: bleManager.isConnected) { isConnected in
+                guard isConnected,
+                      bleManager.knownDevices.contains(where: {
+                          $0.peripheralIdentifier == candidate.peripheralIdentifier
+                      }) else { return }
+                dismiss()
+            }
+        }
+    }
+
+    private var matchingPrompt: BikeComputerPairingPrompt? {
+        guard bleManager.pairingPrompt?.peripheralIdentifier == candidate.peripheralIdentifier else {
+            return nil
+        }
+        return bleManager.pairingPrompt
+    }
+
+    private func startPairing() {
+        didStart = true
+        bleManager.pair(with: candidate, name: deviceName)
+    }
+}
+
+private struct BikeComputerDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var bleManager: BLEManager
+    let deviceID: String
+    @State private var editedName = ""
+    @State private var showingDeregisterConfirmation = false
+
+    private var device: KnownBikeComputerDevice? {
+        bleManager.knownDevices.first { $0.deviceID == deviceID }
+    }
+
+    var body: some View {
+        Form {
+            if let device {
+                Section("Bike Computer") {
+                    TextField("Name", text: $editedName)
+                        .disabled(!bleManager.isConnected(to: device) || device.isLegacy)
+                    DeviceValueRow(title: "Device ID", value: device.shortIdentifier)
+                    DeviceValueRow(
+                        title: "Status",
+                        value: bleManager.isConnected(to: device) ? "Connected" : "Disconnected"
+                    )
+                }
+
+                Section {
+                    if bleManager.isConnected(to: device) {
+                        Button("Save Name") {
+                            bleManager.rename(device: device, to: editedName)
+                        }
+                        .disabled(
+                            device.isLegacy ||
+                            DeviceOwnershipProtocol.normalizedName(editedName) == device.name
+                        )
+                    } else {
+                        Button("Set as Current and Connect") {
+                            bleManager.connect(to: device)
+                        }
+                    }
+                }
+
+                Section {
+                    Button("Deregister from This iPhone", role: .destructive) {
+                        showingDeregisterConfirmation = true
+                    }
+                    .disabled(!bleManager.isConnected(to: device) || device.isLegacy)
+                } footer: {
+                    if device.isLegacy {
+                        Text("Install ownership-capable firmware, then add this device again to enable secure registration.")
+                    } else if !bleManager.isConnected(to: device) {
+                        Text("Connect to this device before deregistering so ownership is removed from both the iPhone and Bike Computer.")
+                    } else {
+                        Text("The Bike Computer will restart and become available for another iPhone.")
+                    }
+                }
+                .confirmationDialog(
+                    "Deregister \(device.name)?",
+                    isPresented: $showingDeregisterConfirmation,
+                    titleVisibility: .visible
+                ) {
+                    Button("Deregister", role: .destructive) {
+                        bleManager.deregister(device: device)
+                    }
+                    Button("Cancel", role: .cancel) { }
+                } message: {
+                    Text("This removes the secure owner credential from both devices.")
+                }
+            }
+        }
+        .navigationTitle(device?.name ?? "Bike Computer")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { editedName = device?.name ?? "" }
+        .onChange(of: device?.name) { newName in
+            if let newName { editedName = newName }
+        }
+        .onChange(of: device) { newDevice in
+            if newDevice == nil { dismiss() }
+        }
+    }
+}
+
+private struct DeviceValueRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -52,16 +52,6 @@ struct SettingsView: View {
                     }
                 }
 
-                Section {
-                    NavigationLink {
-                        BikeComputersSettingsView()
-                    } label: {
-                        Label("Bike Computers", systemImage: "bicycle")
-                    }
-                } footer: {
-                    Text("Choose, name, and securely register the Bike Computers that belong to this iPhone.")
-                }
-
                 MainFirmwareUpdateSection(manager: firmwareUpdateManager)
                 DeviceScreensSettingsSection()
                 SavedMapsSettingsSection(
@@ -78,6 +68,17 @@ struct SettingsView: View {
                 }
 
                 Section {
+                    NavigationLink {
+                        BikeComputersSettingsView()
+                    } label: {
+                        Label(
+                            BikeComputersMenuPolicy.title(
+                                knownDeviceCount: bleManager.knownDevices.count
+                            ),
+                            systemImage: "bicycle"
+                        )
+                    }
+
                     NavigationLink {
                         UICustomizationSettingsView()
                     } label: {
@@ -1094,14 +1095,6 @@ private struct HardwareCustomizationSettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Screen Navigation")) {
-                Toggle("Tap to Switch Screens", isOn: $bleManager.tapToSwitchScreens)
-                    .onChange(of: bleManager.tapToSwitchScreens) { newValue in
-                        bleManager.sendSetting(id: 11, value: newValue ? 1 : 0)
-                    }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
             Section(header: Text("Device Brightness")) {
                 VStack(alignment: .leading) {
                     HStack {
@@ -1133,6 +1126,14 @@ private struct HardwareCustomizationSettingsView: View {
                         value: newValue.settingValue
                     )
                 }
+            }
+            .disabled(!bleManager.supportsDeviceSettings)
+
+            Section(header: Text("Screen Navigation")) {
+                Toggle("Tap to Switch Screens", isOn: $bleManager.tapToSwitchScreens)
+                    .onChange(of: bleManager.tapToSwitchScreens) { newValue in
+                        bleManager.sendSetting(id: 11, value: newValue ? 1 : 0)
+                    }
             }
             .disabled(!bleManager.supportsDeviceSettings)
         }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -52,6 +52,16 @@ struct SettingsView: View {
                     }
                 }
 
+                Section {
+                    NavigationLink {
+                        BikeComputersSettingsView()
+                    } label: {
+                        Label("Bike Computers", systemImage: "bicycle")
+                    }
+                } footer: {
+                    Text("Choose, name, and securely register the Bike Computers that belong to this iPhone.")
+                }
+
                 MainFirmwareUpdateSection(manager: firmwareUpdateManager)
                 DeviceScreensSettingsSection()
                 SavedMapsSettingsSection(
@@ -1285,10 +1295,10 @@ private struct DeveloperSettingsView: View {
                     Label("Reconnect", systemImage: "antenna.radiowaves.left.and.right")
                 }
 
-                Button(role: .destructive, action: {
-                    bleManager.forgetTrustedPeripheral()
-                }) {
-                    Label("Forget Device", systemImage: "trash")
+                NavigationLink {
+                    BikeComputersSettingsView()
+                } label: {
+                    Label("Manage Bike Computers", systemImage: "bicycle")
                 }
 
                 Button(action: {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8456,6 +8456,62 @@ struct NavigationProtocolTests {
             hasActivePairing: false
         ), "closing the pre-Continue naming sheet never disconnects hardware")
 
+        assertEqual(
+            BikeComputersMenuPolicy.title(knownDeviceCount: 0),
+            "Connect Bike Computer",
+            "an empty registry presents the connect menu"
+        )
+        assertEqual(
+            BikeComputersMenuPolicy.title(knownDeviceCount: 1),
+            "My Bike Computer",
+            "one registered device uses the singular menu title"
+        )
+        assertEqual(
+            BikeComputersMenuPolicy.title(knownDeviceCount: 2),
+            "My Bike Computers",
+            "multiple registered devices use the plural menu title"
+        )
+        assert(BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+            knownDeviceCount: 0
+        ), "an empty registry starts discovery on menu entry")
+        assert(!BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+            knownDeviceCount: 1
+        ), "a registered device keeps discovery opt-in")
+        assert(!BikeComputersMenuPolicy.shouldShowConnectNewDeviceAction(
+            knownDeviceCount: 0
+        ), "the empty state does not duplicate its automatic discovery action")
+        assert(BikeComputersMenuPolicy.shouldShowConnectNewDeviceAction(
+            knownDeviceCount: 1
+        ), "a registered device offers an explicit add-another action")
+        assert(BikeComputersMenuPolicy.shouldResumeOwnedDiscovery(
+            ownsDiscoveryLifecycle: true,
+            isBluetoothPoweredOn: true,
+            isDiscoveringDevices: false,
+            pairingCompletedDuringPresentation: false
+        ), "an interrupted owned discovery resumes after its sheet closes")
+        assert(!BikeComputersMenuPolicy.shouldResumeOwnedDiscovery(
+            ownsDiscoveryLifecycle: true,
+            isBluetoothPoweredOn: true,
+            isDiscoveringDevices: false,
+            pairingCompletedDuringPresentation: true
+        ), "successful pairing does not restart Nearby discovery")
+        assert(!BikeComputersMenuPolicy.shouldResumeOwnedDiscovery(
+            ownsDiscoveryLifecycle: true,
+            isBluetoothPoweredOn: false,
+            isDiscoveringDevices: false,
+            pairingCompletedDuringPresentation: false
+        ), "discovery waits for Bluetooth to become available")
+        assert(BLEPendingScanPolicy.accepts(
+            discoveredIdentifier: peripheralID,
+            pendingIdentifier: peripheralID
+        ), "fallback scanning accepts only the selected Bike Computer")
+        assert(!BLEPendingScanPolicy.accepts(
+            discoveredIdentifier: otherPeripheralID,
+            pendingIdentifier: peripheralID
+        ), "fallback scanning ignores a different nearby Bike Computer")
+        assertEqual(BLEPendingScanPolicy.timeout, 8,
+                    "fallback scanning has a bounded retry window")
+
         var lifecycle = BLEOwnershipLifecycle()
         lifecycle.beginDiscovery()
         assertEqual(lifecycle.phase, .discovering,

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8379,6 +8379,8 @@ struct NavigationProtocolTests {
         let deviceKey = try! P256.KeyAgreement.PrivateKey(rawRepresentation: devicePrivate)
         let response = "PAIRING|\(deviceID.ownershipHex)|\(deviceKey.publicKey.x963Representation.ownershipHex)"
         let material = try! session.material(from: response)
+        assert(session.matches(peripheralIdentifier: peripheralID), "pairing sessions bind to their selected peripheral")
+        assert(!session.matches(peripheralIdentifier: UUID()), "pairing sessions reject a different peripheral")
 
         assertEqual(
             material.ownerKey.ownershipHex,
@@ -8386,26 +8388,429 @@ struct NavigationProtocolTests {
             "P-256 and HKDF owner key matches the firmware vector"
         )
         assertEqual(material.comparisonCode, 983668, "pairing comparison code matches the firmware vector")
+        let leadingZeroPrompt = BikeComputerPairingPrompt(
+            peripheralIdentifier: peripheralID,
+            deviceName: "My bike",
+            shortIdentifier: "1234",
+            comparisonCode: 42,
+            isReplacingExistingRegistration: false
+        )
+        assertEqual(leadingZeroPrompt.formattedCode, "000042",
+                    "comparison codes always display all six digits")
         assert(material.confirmationCommand.hasPrefix("CONFIRM|f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff|"),
                "confirmation binds the installation owner ID")
         assert(material.confirmationCommand.hasSuffix("|4368726973e280992062696b65"),
                "confirmation transmits the normalized device name as UTF-8 hex")
 
-        let advertisement = Data([0xFF, 0xFF, 2, 1, 0xAB, 0xCD, 0x12, 0x34])
+        let ownershipFixtureURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent("docs/device-ownership-test-vectors.json")
+        let ownershipFixture = try! JSONSerialization.jsonObject(
+            with: Data(contentsOf: ownershipFixtureURL)
+        ) as! [String: String]
+        let advertisement = Data(
+            ownershipHex: ownershipFixture["advertisementClaimed"]!
+        )!
         let discovered = DiscoveredBikeComputerDevice.parse(
             peripheralIdentifier: peripheralID,
             localName: "Chris’ bike",
             manufacturerData: advertisement,
             rssi: -55
         )
-        assertEqual(discovered.shortIdentifier, "ABCD1234", "advertising exposes the short device identifier")
+        assertEqual(discovered.identitySuffix, "FA85158D", "iOS consumes the firmware-generated identity suffix fixture")
+        assertEqual(discovered.shortIdentifier, "158D", "the UI presents the same short device identifier as firmware")
         assertEqual(discovered.isClaimed, true, "advertising exposes ownership state")
         assertEqual(discovered.advertisedName, "Chris’ bike", "advertising exposes the user-assigned name")
+        assertEqual(
+            BLEDiscoveryFreshnessPolicy.retained(
+                [discovered],
+                now: discovered.lastSeenAt.addingTimeInterval(5)
+            ).count,
+            1,
+            "recent Nearby observations remain visible"
+        )
+        assertEqual(
+            BLEDiscoveryFreshnessPolicy.retained(
+                [discovered],
+                now: discovered.lastSeenAt.addingTimeInterval(7)
+            ).count,
+            0,
+            "Nearby observations expire after the freshness window"
+        )
+        let otherPeripheralID = UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!
+        assert(!BLEPairingCancellationPolicy.shouldDisconnect(
+            connectedPeripheralIdentifier: peripheralID,
+            pairingPeripheralIdentifier: otherPeripheralID,
+            hasActivePairing: true
+        ), "canceling a handoff to another device preserves the current connection")
+        assert(BLEPairingCancellationPolicy.shouldDisconnect(
+            connectedPeripheralIdentifier: otherPeripheralID,
+            pairingPeripheralIdentifier: otherPeripheralID,
+            hasActivePairing: true
+        ), "canceling an active candidate connection disconnects only that candidate")
+        assert(!BLEPairingCancellationPolicy.shouldDisconnect(
+            connectedPeripheralIdentifier: peripheralID,
+            pairingPeripheralIdentifier: otherPeripheralID,
+            hasActivePairing: false
+        ), "closing the pre-Continue naming sheet never disconnects hardware")
+
+        var lifecycle = BLEOwnershipLifecycle()
+        lifecycle.beginDiscovery()
+        assertEqual(lifecycle.phase, .discovering,
+                    "opening Bike Computers begins Nearby discovery")
+        assert(lifecycle.beginPairing(
+            candidateIdentifier: otherPeripheralID,
+            connectedIdentifier: peripheralID
+        ), "selecting another Bike Computer requests a connected-device handoff")
+        assertEqual(lifecycle.phase, .pairing(otherPeripheralID),
+                    "Continue, not the naming screen, begins pairing")
+        assert(lifecycle.markComparisonReady(for: otherPeripheralID),
+               "the selected Bike Computer can advance to code comparison")
+        assert(lifecycle.beginConfirmation(for: otherPeripheralID),
+               "the matching-code action can submit once")
+        assert(!lifecycle.beginConfirmation(for: otherPeripheralID),
+               "a matching-code confirmation cannot be submitted twice")
+        let handoffCancellation = lifecycle.cancel(
+            connectedIdentifier: peripheralID
+        )
+        assertEqual(handoffCancellation.pairingPeripheralIdentifier, otherPeripheralID,
+                    "cancel clears the selected handoff target")
+        assert(!handoffCancellation.shouldDisconnectPairingPeripheral,
+               "cancel preserves the already-connected Bike Computer")
+        assertEqual(lifecycle.phase, .discovering,
+                    "cancel returns to Nearby discovery")
+
+        assert(lifecycle.beginPairing(
+            candidateIdentifier: otherPeripheralID,
+            connectedIdentifier: nil
+        ) == false, "pairing without a current connection needs no handoff")
+        let candidateCancellation = lifecycle.cancel(
+            connectedIdentifier: otherPeripheralID
+        )
+        assert(candidateCancellation.shouldDisconnectPairingPeripheral,
+               "cancel disconnects an actively connected candidate")
+        assert(lifecycle.endDiscovery(resumeAutoReconnect: true),
+               "leaving Bike Computers resumes trusted-device reconnect")
+        assertEqual(lifecycle.phase, .idle,
+                    "leaving Bike Computers closes the discovery lifecycle")
+        lifecycle.beginDiscovery()
+        lifecycle.interrupt()
+        assertEqual(lifecycle.phase, .idle,
+                    "Bluetooth interruption clears the ownership lifecycle")
+        lifecycle.beginDiscovery()
+        lifecycle.complete()
+        assertEqual(lifecycle.phase, .idle,
+                    "successful ownership completion clears the lifecycle")
+
+        let staleDevice = KnownBikeComputerDevice(
+            deviceID: String(repeating: "4", count: 24) + "00004f7b",
+            peripheralIdentifier: peripheralID,
+            name: "BikeComputer",
+            lastConnectedAt: .distantPast,
+            isLegacy: false
+        )
+        let differentPeripheralDevice = KnownBikeComputerDevice(
+            deviceID: String(repeating: "5", count: 24) + "00005555",
+            peripheralIdentifier: UUID(),
+            name: "Cargo bike",
+            lastConnectedAt: .distantPast,
+            isLegacy: false
+        )
+        assertEqual(
+            BLEIdentityObservationPolicy.conflictingDeviceIDs(
+                knownDevices: [staleDevice, differentPeripheralDevice],
+                peripheralIdentifier: peripheralID,
+                observedDeviceID: deviceID.ownershipHex
+            ),
+            [staleDevice.deviceID],
+            "a changed stable identity marks only the saved alias for the same BLE peripheral"
+        )
+        assertEqual(
+            BLEIdentityObservationPolicy.conflictingDeviceIDs(
+                knownDevices: [staleDevice],
+                peripheralIdentifier: peripheralID,
+                observedDeviceID: staleDevice.deviceID
+            ),
+            [],
+            "an unchanged stable identity remains current"
+        )
 
         assertEqual(DeviceOwnershipProtocol.normalizedName("   "), "My bike", "empty names use the privacy-safe default")
         assertEqual(DeviceOwnershipProtocol.normalizedName("Road|Bike"), "RoadBike", "names remove protocol delimiters")
         assert(DeviceOwnershipProtocol.normalizedName(String(repeating: "🚲", count: 10)).utf8.count <= 24,
                "device names are truncated on Character boundaries to the firmware limit")
+        assertEqual(
+            DeviceOwnershipProtocol.resolvedInfoName(
+                reportedName: "Spoofed name",
+                isClaimed: true,
+                existingName: "Cargo bike",
+                peripheralName: "BikeComputer"
+            ),
+            "Cargo bike",
+            "a compact claimed receipt does not erase the current owner's saved name"
+        )
+
+        let clientNonce = "00112233445566778899aabbccddeeff"
+        let serverNonceA = "102132435465768798a9bacbdcedfe0f"
+        let serverNonceB = "ffeeddccbbaa99887766554433221100"
+        let serverMessageA = DeviceOwnerAuthenticator.serverMessage(
+            deviceID: deviceID.ownershipHex,
+            ownerID: ownerID,
+            clientNonce: clientNonce,
+            serverNonce: serverNonceA
+        )
+        let serverMessageB = DeviceOwnerAuthenticator.serverMessage(
+            deviceID: deviceID.ownershipHex,
+            ownerID: ownerID,
+            clientNonce: clientNonce,
+            serverNonce: serverNonceB
+        )
+        assert(
+            DeviceOwnerAuthenticator.proof(key: material.ownerKey, message: serverMessageA) !=
+                DeviceOwnerAuthenticator.proof(key: material.ownerKey, message: serverMessageB),
+            "device-generated nonces make captured owner challenges non-replayable"
+        )
+        assertEqual(BLEReconnectBackoff.delay(attempt: 0), 1, "reconnect starts promptly")
+        assertEqual(BLEReconnectBackoff.delay(attempt: 100), 60, "reconnect continues indefinitely at the cap")
+        assert(BLEConnectionPersistence.shouldCancelTimedOutConnection(isPairing: true),
+               "interactive pairing connections remain time-bounded")
+        assert(!BLEConnectionPersistence.shouldCancelTimedOutConnection(isPairing: false),
+               "trusted reconnects remain pending for CoreBluetooth background wake")
+        var pendingHandoff: UUID? = peripheralID
+        assertEqual(
+            BLEPendingHandoffPolicy.consume(&pendingHandoff),
+            peripheralID,
+            "a terminal connection failure consumes its pending successor"
+        )
+        assertEqual(pendingHandoff, nil, "consumed handoffs cannot fire again later")
+        assert(BLEDeviceOperationPolicy.canStartPairing(operationDeviceID: nil),
+               "pairing can start when no device mutation is pending")
+        assert(!BLEDeviceOperationPolicy.canStartPairing(operationDeviceID: material.deviceID),
+               "pairing cannot interrupt a rename or deregistration")
+        assertEqual(
+            BikeComputerRemovalPolicy.action(isConnected: true, isLegacy: false),
+            .deregister,
+            "connected ownership-capable devices deregister both sides"
+        )
+        assertEqual(
+            BikeComputerRemovalPolicy.action(isConnected: true, isLegacy: true),
+            .forget,
+            "connected legacy devices remain locally removable"
+        )
+        assertEqual(
+            BikeComputerRemovalPolicy.action(isConnected: false, isLegacy: false),
+            .forget,
+            "disconnected devices expose local Forget"
+        )
+        assert(!BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheralID,
+            currentIdentifier: peripheralID,
+            forgottenIdentifiers: [peripheralID]
+        ), "late callbacks cannot recreate a locally forgotten device")
+        assert(BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheralID,
+            currentIdentifier: peripheralID,
+            forgottenIdentifiers: []
+        ), "ordinary current-device callbacks remain enabled")
+        assert(!BLELocalForgetPolicy.acceptsCallback(
+            peripheralIdentifier: peripheralID,
+            currentIdentifier: UUID(),
+            forgottenIdentifiers: []
+        ), "late callbacks from a replaced peripheral cannot mutate the current session")
+        assert(BLELocalForgetPolicy.shouldStopScanning(
+            wasActive: true,
+            hadPendingTransport: false,
+            hasSuccessor: false
+        ), "forgetting the sole active device stops fallback scanning")
+        assert(!BLELocalForgetPolicy.shouldStopScanning(
+            wasActive: true,
+            hadPendingTransport: true,
+            hasSuccessor: true
+        ), "forgetting with a successor keeps reconnection available")
+        assert(!BLENavigationNotificationPolicy.accepts(
+            isAuthenticated: false,
+            isLegacyDevice: false,
+            hasProtectedSession: false,
+            isProtectedFrame: false
+        ), "pre-authentication navigation notifications are rejected")
+        assert(!BLENavigationNotificationPolicy.accepts(
+            isAuthenticated: true,
+            isLegacyDevice: false,
+            hasProtectedSession: true,
+            isProtectedFrame: false
+        ), "v2 sessions reject plaintext navigation notifications")
+        assert(BLENavigationNotificationPolicy.accepts(
+            isAuthenticated: true,
+            isLegacyDevice: false,
+            hasProtectedSession: true,
+            isProtectedFrame: true
+        ), "v2 sessions admit protected navigation notifications for AEAD verification")
+        assert(BLENavigationNotificationPolicy.accepts(
+            isAuthenticated: true,
+            isLegacyDevice: true,
+            hasProtectedSession: false,
+            isProtectedFrame: false
+        ), "authenticated legacy sessions retain plaintext notifications")
+        assert(!BLENavigationNotificationPolicy.accepts(
+            isAuthenticated: true,
+            isLegacyDevice: false,
+            hasProtectedSession: false,
+            isProtectedFrame: false
+        ), "v2 sessions fail closed if their protected transport is missing")
+
+        let restoredA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+        let restoredB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000002")!
+        let restoredMissing = UUID(uuidString: "CCCCCCCC-0000-0000-0000-000000000003")!
+        assertEqual(
+            BLERestorationPolicy.selectedIdentifier(
+                from: [restoredA, restoredB],
+                trustedIdentifier: restoredB
+            ),
+            restoredB,
+            "restoration selects the trusted current peripheral"
+        )
+        assertEqual(
+            BLERestorationPolicy.selectedIdentifier(
+                from: [restoredA, restoredB],
+                trustedIdentifier: restoredMissing
+            ),
+            nil,
+            "restoration rejects stale peripherals when the trusted device is absent"
+        )
+        assertEqual(
+            BLERestorationPolicy.selectedIdentifier(
+                from: [restoredA, restoredB],
+                trustedIdentifier: nil
+            ),
+            nil,
+            "restoration never trusts an arbitrary peripheral without a saved current device"
+        )
+        assertEqual(
+            BLERestorationPolicy.identifiersToCancel(
+                from: [restoredA, restoredB],
+                keeping: restoredB
+            ),
+            [restoredA],
+            "restoration cancels every non-current peripheral"
+        )
+
+        let goldenOwnerKey = Data((0..<32).map(UInt8.init))
+        let goldenDeviceID = "00112233445566778899aabbccddeeff"
+        let goldenClientNonce = "102132435465768798a9babbdcddedef"
+        let goldenServerNonce = "ffeeddccbbaa99887766554433221100"
+        let revocationProof = DeviceOwnerAuthenticator.proof(
+            key: goldenOwnerKey,
+            message: DeviceOwnerAuthenticator.revocationMessage(
+                deviceID: goldenDeviceID,
+                ownerID: ownerID,
+                nonce: goldenServerNonce
+            )
+        )
+        assert(DeviceOwnerAuthenticator.isValidRevocationReceipt(
+            suppliedProof: revocationProof,
+            key: goldenOwnerKey,
+            deviceID: goldenDeviceID,
+            ownerID: ownerID,
+            nonce: goldenServerNonce
+        ), "a signed deregistration receipt is accepted")
+        let invalidRevocationProof = String(revocationProof.dropLast()) +
+            (revocationProof.last == "0" ? "1" : "0")
+        assert(!DeviceOwnerAuthenticator.isValidRevocationReceipt(
+            suppliedProof: invalidRevocationProof,
+            key: goldenOwnerKey,
+            deviceID: goldenDeviceID,
+            ownerID: ownerID,
+            nonce: goldenServerNonce
+        ), "a forged deregistration receipt is rejected")
+        assert(!DeviceOwnerAuthenticator.isValidRevocationReceipt(
+            suppliedProof: revocationProof,
+            key: Data(repeating: 0x5A, count: DeviceOwnershipProtocol.ownerKeyLength),
+            deviceID: goldenDeviceID,
+            ownerID: ownerID,
+            nonce: goldenServerNonce
+        ), "a retained prior-owner receipt cannot delete the current owner's credential")
+        let protectedSession = AuthenticatedBLEWriteSession(
+            ownerKey: goldenOwnerKey,
+            deviceID: goldenDeviceID,
+            clientNonce: goldenClientNonce,
+            serverNonce: goldenServerNonce
+        )
+        let goldenWriteFrame = Data(ownershipHex:
+            "533200000001c486d6a2464da1600aab2af46a3ae0e00442af910dcdc23c8164d0336842cfaa426b31")!
+        assertEqual(
+            protectedSession.frame(
+                payload: Data("NAME|4d792062696b65".utf8),
+                channel: .auth
+            ),
+            goldenWriteFrame,
+            "AES-GCM app write frame matches the shared mbedTLS vector"
+        )
+        assertEqual(
+            protectedSession.frame(payload: Data(), channel: .route),
+            Data(ownershipHex: "533200000001c981669fdeb1b029019459478ef19ff6"),
+            "empty protected route payload has a valid authenticated frame"
+        )
+        let goldenNotifyFrame = Data(ownershipHex:
+            "523200000001f19f6c8cd9263269e34a54aa910f37738270d42cb7d8632c8f0e20bfa6a4588d369304ab9662")!
+        assertEqual(
+            protectedSession.notificationPayload(
+                from: goldenNotifyFrame,
+                channel: .auth
+            ),
+            Data("NAME_OK|4d792062696b65".utf8),
+            "AES-GCM device notification matches the shared mbedTLS vector"
+        )
+        assertEqual(
+            protectedSession.notificationPayload(
+                from: goldenNotifyFrame,
+                channel: .auth
+            ),
+            nil,
+            "protected notification replay is rejected"
+        )
+        var tamperedNotification = goldenNotifyFrame
+        tamperedNotification[tamperedNotification.index(before: tamperedNotification.endIndex)] ^= 1
+        let tamperSession = AuthenticatedBLEWriteSession(
+            ownerKey: goldenOwnerKey,
+            deviceID: goldenDeviceID,
+            clientNonce: goldenClientNonce,
+            serverNonce: goldenServerNonce
+        )
+        assertEqual(
+            tamperSession.notificationPayload(
+                from: tamperedNotification,
+                channel: .auth
+            ),
+            nil,
+            "tampered protected notification is rejected"
+        )
+        let navigationNotifySession = AuthenticatedBLEWriteSession(
+            ownerKey: goldenOwnerKey,
+            deviceID: goldenDeviceID,
+            clientNonce: goldenClientNonce,
+            serverNonce: goldenServerNonce
+        )
+        let destinationRequest = Data([0x44, 0x52, 0x45, 0x51,
+                                       1, 0, 0, 0, 2, 0])
+        assertEqual(
+            navigationNotifySession.notificationPayload(
+                from: Data(ownershipHex:
+                    "523200000001a0d24a5355c7de1683c4a586dd2fb19a8c19b6a6c0afe3b4f62e")!,
+                channel: .navigation
+            ),
+            destinationRequest,
+            "device-originated navigation action matches the protected vector"
+        )
+        assertEqual(
+            navigationNotifySession.notificationPayload(
+                from: destinationRequest,
+                channel: .navigation
+            ),
+            nil,
+            "plaintext device actions are rejected once a secure session exists"
+        )
 
         let suiteName = "DeviceOwnershipProtocolTests.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
@@ -8431,14 +8836,75 @@ struct NavigationProtocolTests {
             lastConnectedAt: Date(timeIntervalSince1970: 20),
             isLegacy: false
         )
-        registry.upsert(first, makeActive: true)
+        let legacyAlias = KnownBikeComputerDevice(
+            deviceID: "legacy:\(peripheralID.uuidString.lowercased())",
+            peripheralIdentifier: peripheralID,
+            name: "Old identity",
+            lastConnectedAt: Date(timeIntervalSince1970: 5),
+            isLegacy: true
+        )
+        registry.upsert(legacyAlias, makeActive: true)
+        registry.upsert(first)
         registry.upsert(second)
         assertEqual(registry.devices.count, 2, "registry supports multiple Bike Computers")
+        assert(!registry.devices.contains(where: { $0.isLegacy && $0.peripheralIdentifier == peripheralID }),
+               "a stable v2 identity replaces its legacy peripheral alias")
         assertEqual(registry.activeDeviceID, first.deviceID, "adding another device does not silently switch the current device")
         assertEqual(registry.ownerKey(deviceID: first.deviceID), material.ownerKey, "owner key can be retrieved for authentication")
-        registry.remove(deviceID: first.deviceID)
+        let secondKey = Data(repeating: 0xA5, count: DeviceOwnershipProtocol.ownerKeyLength)
+        assert(registry.saveOwnerKey(secondKey, deviceID: second.deviceID), "each device stores an independent owner credential")
+        assertEqual(registry.ownerKey(deviceID: second.deviceID), secondKey, "second device credential is independently addressable")
+        let replacementKey = Data(repeating: 0x5A, count: DeviceOwnershipProtocol.ownerKeyLength)
+        assert(registry.saveProvisionalOwnerKey(replacementKey, deviceID: first.deviceID),
+               "replacement pairing stores a separate provisional credential")
+        registry.markProvisionalOwnerKeyConfirmed(deviceID: first.deviceID)
+        assert(!registry.hasConfirmedReplacementCredential(deviceID: first.deviceID),
+               "confirmation alone does not authorize overwriting a prior credential")
+        assert(!registry.promoteProvisionalOwnerKey(deviceID: first.deviceID),
+               "ordinary promotion cannot overwrite a different existing credential")
+        assertEqual(registry.ownerKey(deviceID: first.deviceID), material.ownerKey,
+                    "rejected promotion preserves the existing credential")
+        registry.authorizeProvisionalCredentialReplacement(deviceID: first.deviceID)
+        assert(registry.hasConfirmedReplacementCredential(deviceID: first.deviceID),
+               "confirmed authorized replacement recovery takes priority over an old receipt")
+        assert(registry.promoteProvisionalOwnerKey(
+            deviceID: first.deviceID,
+            allowReplacingExisting: true
+        ), "explicit recovery authorization can replace a stale credential")
+        assertEqual(registry.ownerKey(deviceID: first.deviceID), replacementKey,
+                    "authorized recovery promotes the verified provisional key")
+        assert(!DeviceOwnershipFlowPolicy.allowsLegacyFallback(knownDevice: first, pairingCandidate: nil),
+               "known v2 devices never downgrade after an INFO timeout")
+        assert(DeviceOwnershipFlowPolicy.allowsLegacyFallback(knownDevice: legacyAlias, pairingCandidate: nil),
+               "known legacy firmware can use the migration handshake")
+        assert(!DeviceOwnershipFlowPolicy.allowsLegacyFallback(knownDevice: nil, pairingCandidate: discovered),
+               "advertised v2 pairing candidates never downgrade")
+        assert(!DeviceOwnershipFlowPolicy.allowsLegacyFallback(knownDevice: nil, pairingCandidate: nil),
+               "an unknown first-time Add never falls back to the shared legacy credential")
+        assert(registry.remove(deviceID: first.deviceID),
+               "credential removal succeeds before the visible registry entry is deleted")
         assertEqual(registry.activeDeviceID, second.deviceID, "removing the current device selects the remaining device")
         assertEqual(registry.ownerKey(deviceID: first.deviceID), nil, "deregistering deletes the owner key")
+        assertEqual(registry.ownerKey(deviceID: second.deviceID), secondKey, "deregistering one device preserves another device credential")
+
+        let failureSuiteName = "DeviceOwnershipRemovalFailureTests.\(UUID().uuidString)"
+        let failureDefaults = UserDefaults(suiteName: failureSuiteName)!
+        defer { failureDefaults.removePersistentDomain(forName: failureSuiteName) }
+        let failingCredentials = InMemoryDeviceCredentialStore()
+        let failureRegistry = BikeComputerDeviceRegistry(
+            defaults: failureDefaults,
+            credentialStore: failingCredentials
+        )
+        failureRegistry.upsert(first, makeActive: true)
+        assert(failureRegistry.saveOwnerKey(material.ownerKey, deviceID: first.deviceID),
+               "removal regression fixture stores an owner key")
+        failingCredentials.shouldFailRemoval = true
+        assert(!failureRegistry.remove(deviceID: first.deviceID),
+               "credential deletion failure is surfaced")
+        assertEqual(failureRegistry.devices, [first],
+                    "credential deletion failure keeps the device visible")
+        assertEqual(failureRegistry.ownerKey(deviceID: first.deviceID), material.ownerKey,
+                    "credential deletion failure preserves the owner key")
     }
 
     static func testBLEManagerRequiresNavigationReadinessForWrites() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -531,6 +531,7 @@ struct NavigationProtocolTests {
         testDeviceScreenValidation()
         testHardwareLabelPreference()
         testBLEPairingAuthenticator()
+        testDeviceOwnershipProtocol()
         testBLEManagerRequiresNavigationReadinessForWrites()
         testBLEManagerSendsFallbackMapSettings()
         testBLEManagerSendsSeparateMapProfileSettings()
@@ -8359,6 +8360,85 @@ struct NavigationProtocolTests {
         )
         assertEqual(BLEPairingAuthenticator.clientProof(nonce: nonce), clientProof, "client proof matches firmware vector")
         assertEqual(BLEPairingAuthenticator.makeNonce()?.count, 32, "generated nonce uses 16 random bytes encoded as hex")
+    }
+
+    static func testDeviceOwnershipProtocol() {
+        var appPrivate = Data(repeating: 0, count: 32)
+        appPrivate[31] = 1
+        var devicePrivate = Data(repeating: 0, count: 32)
+        devicePrivate[31] = 2
+        let ownerID = Data((0..<16).map { UInt8(0xF0 + $0) })
+        let deviceID = Data((0..<16).map(UInt8.init))
+        let peripheralID = UUID(uuidString: "11111111-2222-3333-4444-555555555555")!
+        let session = try! DevicePairingSession(
+            peripheralIdentifier: peripheralID,
+            ownerID: ownerID,
+            deviceName: "Chris’ bike",
+            privateKeyRawRepresentation: appPrivate
+        )
+        let deviceKey = try! P256.KeyAgreement.PrivateKey(rawRepresentation: devicePrivate)
+        let response = "PAIRING|\(deviceID.ownershipHex)|\(deviceKey.publicKey.x963Representation.ownershipHex)"
+        let material = try! session.material(from: response)
+
+        assertEqual(
+            material.ownerKey.ownershipHex,
+            "024d0fb0b003b6d22569ef8e5a382eaa9bbd29ebeaee683d93992ae1399900cf",
+            "P-256 and HKDF owner key matches the firmware vector"
+        )
+        assertEqual(material.comparisonCode, 983668, "pairing comparison code matches the firmware vector")
+        assert(material.confirmationCommand.hasPrefix("CONFIRM|f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff|"),
+               "confirmation binds the installation owner ID")
+        assert(material.confirmationCommand.hasSuffix("|4368726973e280992062696b65"),
+               "confirmation transmits the normalized device name as UTF-8 hex")
+
+        let advertisement = Data([0xFF, 0xFF, 2, 1, 0xAB, 0xCD, 0x12, 0x34])
+        let discovered = DiscoveredBikeComputerDevice.parse(
+            peripheralIdentifier: peripheralID,
+            localName: "Chris’ bike",
+            manufacturerData: advertisement,
+            rssi: -55
+        )
+        assertEqual(discovered.shortIdentifier, "ABCD1234", "advertising exposes the short device identifier")
+        assertEqual(discovered.isClaimed, true, "advertising exposes ownership state")
+        assertEqual(discovered.advertisedName, "Chris’ bike", "advertising exposes the user-assigned name")
+
+        assertEqual(DeviceOwnershipProtocol.normalizedName("   "), "My bike", "empty names use the privacy-safe default")
+        assertEqual(DeviceOwnershipProtocol.normalizedName("Road|Bike"), "RoadBike", "names remove protocol delimiters")
+        assert(DeviceOwnershipProtocol.normalizedName(String(repeating: "🚲", count: 10)).utf8.count <= 24,
+               "device names are truncated on Character boundaries to the firmware limit")
+
+        let suiteName = "DeviceOwnershipProtocolTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let credentials = InMemoryDeviceCredentialStore()
+        let registry = BikeComputerDeviceRegistry(defaults: defaults, credentialStore: credentials)
+        let generatedOwnerID = registry.installationOwnerID()
+        assertEqual(generatedOwnerID?.count, 16, "registry creates a 128-bit installation owner ID")
+        assertEqual(registry.installationOwnerID(), generatedOwnerID, "installation owner ID is stable")
+        assert(registry.saveOwnerKey(material.ownerKey, deviceID: material.deviceID), "registry stores device owner key")
+
+        let first = KnownBikeComputerDevice(
+            deviceID: material.deviceID,
+            peripheralIdentifier: peripheralID,
+            name: "Chris’ bike",
+            lastConnectedAt: Date(timeIntervalSince1970: 10),
+            isLegacy: false
+        )
+        let second = KnownBikeComputerDevice(
+            deviceID: String(repeating: "a", count: 32),
+            peripheralIdentifier: UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE")!,
+            name: "Cargo bike",
+            lastConnectedAt: Date(timeIntervalSince1970: 20),
+            isLegacy: false
+        )
+        registry.upsert(first, makeActive: true)
+        registry.upsert(second)
+        assertEqual(registry.devices.count, 2, "registry supports multiple Bike Computers")
+        assertEqual(registry.activeDeviceID, first.deviceID, "adding another device does not silently switch the current device")
+        assertEqual(registry.ownerKey(deviceID: first.deviceID), material.ownerKey, "owner key can be retrieved for authentication")
+        registry.remove(deviceID: first.deviceID)
+        assertEqual(registry.activeDeviceID, second.deviceID, "removing the current device selects the remaining device")
+        assertEqual(registry.ownerKey(deviceID: first.deviceID), nil, "deregistering deletes the owner key")
     }
 
     static func testBLEManagerRequiresNavigationReadinessForWrites() {

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -11,6 +11,7 @@ cd "${REPO_DIR}"
 xcrun swiftc \
   -D HOST_TESTING \
   -o "${OUT}" \
+  ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift \
   ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift \
   ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift \
@@ -62,6 +63,7 @@ xcrun swiftc \
   -I "${IOS_SUPPORT}/usr/lib/swift" \
   -L "${IOS_SUPPORT}/usr/lib/swift" \
   -o "${PREVIEW_CATALYST_OUT}" \
+  ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift \
   ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift \
   ios-app/BikeComputer/BikeComputer/Managers/FirmwareUpdateManager.swift \


### PR DESCRIPTION
## Summary

- replace the app-wide shared BLE key with a stable eFuse-derived hardware ID and a unique per-device owner credential established through ephemeral P-256 ECDH
- store the iPhone installation identity and per-device credentials in the non-synchronizing Keychain
- support multiple named Bike Computers, an explicit current device, authenticated reconnect/rename/deregistration, and owner-only connections
- keep unregistered hardware available for pairing for at least 10 minutes while preserving the configured timeout for registered devices and `0 = never`
- auto-discover nearby hardware when the Bike Computers menu has no registered devices; otherwise require the explicit **Connect a new Bike Computer** action
- stop discovery when leaving the menu, remove the duplicate discovery status and stop button, and recover cleanly across Bluetooth interruptions and stale selected peripherals
- use dynamic menu titles: **Connect Bike Computer**, **My Bike Computer**, or **My Bike Computers**
- place the Bike Computer entry immediately above UI Customization and move Screen Navigation to the bottom of Hardware Customization
- keep the first Add Bike Computer step to device details, naming, and Continue—no physical button press
- show the six-digit comparison code in the second step, then accept a fresh press of either BOOT or PWR
- arm confirmation only after the code has physically flushed to the panel; reject held or stale pre-code input
- retain the eight-second BOOT ownership-recovery action for a lost owner iPhone
- permit legacy authentication only for devices already recorded as legacy, never as an unknown-device downgrade
- document the v2 protocol and share deterministic cross-platform fixtures between CryptoKit and mbedTLS tests

## User experience

With no registered hardware, opening **Connect Bike Computer** starts discovery immediately. With one or more registered devices, the menu becomes **My Bike Computer(s)** and discovery starts only after **Connect a new Bike Computer** is tapped. Discovery ends when the user leaves the menu.

Adding a device starts with an editable `My bike` name because iOS does not expose the Apple ID owner name to ordinary apps. After Continue, the iPhone and Bike Computer show the same six-digit code; the user confirms it with either physical button. Once registered, that Bike Computer accepts only this iPhone installation until authenticated deregistration or the eight-second BOOT recovery action.

## Validation

- `cd ios-app && ./scripts/run-navigation-tests.sh`
- unsigned generic-iOS build
- signed physical-iPhone build, install, launch, and live BLE logging on an iPhone 16 Pro Max
  - no unsolicited scan at app launch with an empty registry
  - automatic scan begins when entering **Connect Bike Computer**
- ownership crypto and state host tests with `-Wall -Wextra -Werror`
- shared advertisement/crypto fixtures consumed by firmware and Swift tests
- PlatformIO builds:
  - `WAVESHARE_AMOLED_175`
  - `WAVESHARE_AMOLED_175_SPEAKER_HONK`
  - `WAVESHARE_AMOLED_206`
  - `WAVESHARE_AMOLED_206_SPEAKER_HONK`
- exact 1.75-inch firmware flashed and verified on `/dev/cu.usbmodem2101`
  - unregistered device remained available beyond the old 120-second timeout
  - device slept near the new 600-second registration-grace boundary
- deep claim, security, and test review/fix loop converged with no remaining P0/P1/P2 findings
- `git diff --check`

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
