### PR TITLE
Keep Start Workout label visible

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -352,7 +352,7 @@ struct ContentView: View {
                     )
                 }
             )
-            .layoutPriority(1)
+            .layoutPriority(0)
 
             if !isSearchPanelExpanded,
                workoutStore.presentation.canStartNewWorkout {
@@ -361,6 +361,7 @@ struct ContentView: View {
                     action: workoutMirrorManager.startOutdoorCyclingOnWatch
                 ) {
                     Label("Start Workout", systemImage: "figure.outdoor.cycle")
+                        .labelStyle(.titleAndIcon)
                         .font(.subheadline.weight(.semibold))
                         .lineLimit(1)
                         .minimumScaleFactor(0.72)
@@ -376,6 +377,8 @@ struct ContentView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .fixedSize(horizontal: true, vertical: false)
+                .layoutPriority(1)
                 .accessibilityLabel("Start workout on Apple Watch")
             }
         }

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5061,8 +5061,14 @@ private struct WorkoutContractTestSuite {
                 )
                 && compactContent.contains(
                     "WorkoutStartButton(watchAvailability:watchAvailability,action:workoutMirrorManager.startOutdoorCyclingOnWatch)"
+                )
+                && compactContent.contains(
+                    "Label(\"StartWorkout\",systemImage:\"figure.outdoor.cycle\").labelStyle(.titleAndIcon)"
+                )
+                && compactContent.contains(
+                    ".buttonStyle(.plain).fixedSize(horizontal:true,vertical:false).layoutPriority(1).accessibilityLabel(\"StartworkoutonAppleWatch\")"
                 ),
-            "the collapsed destination row must include the blue Watch-gated start button"
+            "the collapsed destination row must keep the full blue Watch-gated Start Workout label visible"
         )
         expect(
             compactContent.contains(


### PR DESCRIPTION
## Summary
- let the workout action keep its intrinsic width instead of being compressed by the destination search field
- explicitly render both the bike icon and Start Workout title
- extend the UI composition contract test to cover the non-collapsing label

## Verification
- `ios-app/scripts/run-workout-contract-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme WorkoutContractiOSTests -configuration Debug -destination "platform=iOS Simulator,id=5D476B06-CB16-40E2-BEC9-02B26ABF7431" test`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- physical iPhone build, install, and launch succeeded (version 1.1 build 6, git SHA df9b5878a316a6d3458c757e3ce227932c9e0b23)