### PR TITLE
Guide first-run setup through device pairing

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -545,6 +545,7 @@ struct ContentView: View {
             simulatedPosition: coordinator.simulatedPosition,
             isSimulationMode: coordinator.isSimulationMode,
             isNavigating: coordinator.isNavigating,
+            isUserLocationAuthorized: coordinator.isLocationAuthorized,
             offlineMapSelectionFrame: selectionFrame,
             onMapTapped: {
                 if isSearchPanelExpanded {

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -23,10 +23,18 @@ struct ContentView: View {
     @State private var sourceAddress = ""
     @State private var destinationAddress = ""
     @State private var showingSettings = false
+    @State private var showingBikeComputerSetup = false
     @State private var showingWorkoutDashboard = false
     @State private var isSearchPanelExpanded = false
     @State private var dismissedOfflineMapOnboarding = false
     @State private var confirmedDeviceMapMissing = false
+    @State private var isOfflineMapOnboardingStatePrepared = false
+    @AppStorage("offlineMapOnboarding.firstRunCompleted.v1")
+    private var hasCompletedFirstRunMapOnboarding = false
+    @AppStorage("offlineMapOnboarding.locationStepCompleted.v1")
+    private var hasAdvancedPastMapOnboardingLocation = false
+    @AppStorage("offlineMapOnboarding.existingInstallMigrationCompleted.v1")
+    private var hasMigratedExistingInstallOnboarding = false
     @State private var offlineMapSelectionWidth: CGFloat?
     @State private var offlineMapSelectionHeight: CGFloat?
     @State private var offlineMapSelectionCenterY: CGFloat?
@@ -96,25 +104,32 @@ struct ContentView: View {
 
                 if coordinator.bleManager.supportsDeviceSounds &&
                     !offlineMapManager.isMapAreaSelectionActive &&
-                    !shouldShowOfflineMapOnboarding {
+                    visibleOfflineMapOnboardingStep == nil {
                     DeviceSoundMapButton(bleManager: coordinator.bleManager)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .trailing)
                         .padding(.trailing, 16)
                         .zIndex(9)
                 }
 
-                if shouldShowOfflineMapOnboarding {
+                if let onboardingStep = visibleOfflineMapOnboardingStep {
                     Color.black.opacity(0.18)
                         .ignoresSafeArea()
 
                     OfflineMapOnboardingView(
                         manager: offlineMapManager,
                         bleManager: coordinator.bleManager,
+                        step: onboardingStep,
                         location: coordinator.currentLocation,
                         isLocationAuthorized: coordinator.isLocationAuthorized,
-                        onRequestLocation: { coordinator.requestLocationAuthorization() },
-                        onChooseArea: { offlineMapManager.beginMapAreaSelection() },
-                        onClose: { dismissedOfflineMapOnboarding = true }
+                        onRequestLocation: advancePastLocationAndRequestAccess,
+                        onSkipLocation: advancePastLocation,
+                        onConnectDevice: { showingBikeComputerSetup = true },
+                        onCheckDeviceMaps: {
+                            _ = coordinator.bleManager.requestMapTransferStatus()
+                            _ = coordinator.bleManager.requestDeviceTransferStatus()
+                        },
+                        onChooseArea: beginOnboardingMapSelection,
+                        onClose: dismissOfflineMapOnboarding
                     )
                     .transition(.scale(scale: 0.96).combined(with: .opacity))
                     .zIndex(20)
@@ -142,6 +157,19 @@ struct ContentView: View {
                 )
                     .environmentObject(coordinator.bleManager)
             }
+            .sheet(isPresented: $showingBikeComputerSetup) {
+                NavigationView {
+                    BikeComputersSettingsView()
+                        .toolbar {
+                            ToolbarItem(placement: .cancellationAction) {
+                                Button("Close") {
+                                    showingBikeComputerSetup = false
+                                }
+                            }
+                        }
+                }
+                .environmentObject(coordinator.bleManager)
+            }
             .sheet(isPresented: $showingWorkoutDashboard) {
                 WorkoutDashboardView(
                     store: workoutStore,
@@ -156,6 +184,8 @@ struct ContentView: View {
             }
         }
         .onAppear {
+            migrateExistingInstallOnboardingIfNeeded()
+            isOfflineMapOnboardingStatePrepared = true
             watchAvailability.activate()
             updateIdleTimer()
             coordinator.applicationDidBecomeActive()
@@ -180,6 +210,9 @@ struct ContentView: View {
         }
         .onChange(of: coordinator.bleManager.isNavigationReady) { _ in
             schedulePendingMapInstallResume()
+            if coordinator.bleManager.isNavigationReady {
+                showingBikeComputerSetup = false
+            }
         }
         .onChange(of: offlineMapManager.isMapAreaSelectionActive) { isActive in
             if isActive {
@@ -205,6 +238,12 @@ struct ContentView: View {
 
             guard deviceMapMissingCandidate else { return }
             confirmedDeviceMapMissing = true
+        }
+        .task(id: offlineMapOnboardingPresentation) {
+            guard offlineMapOnboardingPresentation == .completeFirstRun else {
+                return
+            }
+            hasCompletedFirstRunMapOnboarding = true
         }
     }
 
@@ -243,18 +282,58 @@ struct ContentView: View {
         )
     }
 
-    private var shouldShowOfflineMapOnboarding: Bool {
-        guard !dismissedOfflineMapOnboarding else { return false }
-        guard !offlineMapManager.isMapAreaSelectionActive else { return false }
+    private var offlineMapOnboardingPresentation: OfflineMapOnboardingPresentation {
+        OfflineMapOnboardingPolicy.presentation(
+            hasCompletedFirstRun: hasCompletedFirstRunMapOnboarding,
+            hasAdvancedPastLocation: hasAdvancedPastMapOnboardingLocation,
+            isLocationAuthorized: coordinator.isLocationAuthorized,
+            isNavigationReady: coordinator.bleManager.isNavigationReady,
+            hasSDCard: coordinator.bleManager.deviceHasSDCard,
+            activeMapId: coordinator.bleManager.mapTransferActiveMapId,
+            confirmedDeviceMapMissing: confirmedDeviceMapMissing
+        )
+    }
+
+    private var visibleOfflineMapOnboardingStep: OfflineMapOnboardingStep? {
+        guard isOfflineMapOnboardingStatePrepared else { return nil }
+        guard !dismissedOfflineMapOnboarding else { return nil }
+        guard !offlineMapManager.isMapAreaSelectionActive else { return nil }
         guard !offlineMapManager.isBusy,
               !offlineMapManager.hasPendingMapJob,
               offlineMapManager.currentJob == nil,
               offlineMapManager.downloadedPackURL == nil,
-              offlineMapManager.errorMessage == nil else { return false }
-        if !coordinator.isLocationAuthorized {
-            return true
+              offlineMapManager.errorMessage == nil else { return nil }
+        guard case .step(let step) = offlineMapOnboardingPresentation else {
+            return nil
         }
-        return confirmedDeviceMapMissing
+        return step
+    }
+
+    private func advancePastLocationAndRequestAccess() {
+        advancePastLocation()
+        coordinator.requestLocationAuthorization()
+    }
+
+    private func advancePastLocation() {
+        hasAdvancedPastMapOnboardingLocation = true
+    }
+
+    private func beginOnboardingMapSelection() {
+        hasCompletedFirstRunMapOnboarding = true
+        offlineMapManager.beginMapAreaSelection()
+    }
+
+    private func dismissOfflineMapOnboarding() {
+        dismissedOfflineMapOnboarding = true
+    }
+
+    private func migrateExistingInstallOnboardingIfNeeded() {
+        guard !hasMigratedExistingInstallOnboarding else { return }
+        hasMigratedExistingInstallOnboarding = true
+
+        guard !coordinator.bleManager.knownDevices.isEmpty else { return }
+        hasAdvancedPastMapOnboardingLocation = true
+        hasCompletedFirstRunMapOnboarding = true
     }
 
     private var topOverlay: some View {

--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -41,8 +41,8 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
 #if !os(macOS)
         locationManager.showsBackgroundLocationIndicator = false
 #endif
-        locationManager.requestWhenInUseAuthorization()
-        // Don't start by default - wait for explicit need
+        // First-run onboarding owns the permission prompt so the user can read
+        // the rationale or skip location before iOS asks for access.
     }
     
     func requestLocation() {
@@ -123,14 +123,14 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         locationManager.showsBackgroundLocationIndicator = shouldTrackInBackground
 #endif
         
-        if shouldTrack && (!isLocationUpdating || restart) {
+        if shouldTrack && isLocationAuthorized && (!isLocationUpdating || restart) {
             if isLocationUpdating {
                 locationManager.stopUpdatingLocation()
             }
             print("🌍 Starting location updates (navigating: \(isNavigating), map: \(isViewingMap), device destination request: \(isRefreshingDeviceDestinationLocation))")
             locationManager.startUpdatingLocation()
             isLocationUpdating = true
-        } else if !shouldTrack && isLocationUpdating {
+        } else if (!shouldTrack || !isLocationAuthorized) && isLocationUpdating {
             print("🌍 Stopping location updates (not needed)")
             locationManager.stopUpdatingLocation()
             isLocationUpdating = false
@@ -138,7 +138,7 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     }
     
     func startUpdatingLocation() {
-        if !isLocationUpdating {
+        if isLocationAuthorized && !isLocationUpdating {
             locationManager.startUpdatingLocation()
             isLocationUpdating = true
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -803,7 +803,52 @@ nonisolated enum OfflineMapPollingRetryPolicy {
     }
 }
 
+nonisolated enum OfflineMapOnboardingStep: Equatable {
+    case location
+    case device
+    case checkingDevice
+    case download
+    case storageUnavailable
+}
+
+nonisolated enum OfflineMapOnboardingPresentation: Equatable {
+    case hidden
+    case step(OfflineMapOnboardingStep)
+    case completeFirstRun
+}
+
 nonisolated enum OfflineMapOnboardingPolicy {
+    static func presentation(
+        hasCompletedFirstRun: Bool,
+        hasAdvancedPastLocation: Bool,
+        isLocationAuthorized: Bool,
+        isNavigationReady: Bool,
+        hasSDCard: Bool?,
+        activeMapId: String,
+        confirmedDeviceMapMissing: Bool
+    ) -> OfflineMapOnboardingPresentation {
+        if !hasCompletedFirstRun {
+            if !isLocationAuthorized && !hasAdvancedPastLocation {
+                return .step(.location)
+            }
+            guard isNavigationReady else {
+                return .step(.device)
+            }
+            guard let hasSDCard else {
+                return .step(.checkingDevice)
+            }
+            guard hasSDCard else {
+                return .step(.storageUnavailable)
+            }
+            guard !activeMapId.isEmpty else {
+                return .step(.download)
+            }
+            return .completeFirstRun
+        }
+
+        return confirmedDeviceMapMissing ? .step(.download) : .hidden
+    }
+
     static func shouldOfferDownload(
         isLocationAuthorized: Bool,
         isNavigationReady: Bool,

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -50,6 +50,7 @@ struct MapViewContainer: UIViewRepresentable {
     let simulatedPosition: CLLocationCoordinate2D?
     let isSimulationMode: Bool
     let isNavigating: Bool
+    let isUserLocationAuthorized: Bool
     let offlineMapSelectionFrame: CGRect?
     let onMapTapped: (() -> Void)?
     let onOfflineMapSelectionBoundsChanged: ((OfflineMapBounds) -> Void)?
@@ -58,8 +59,8 @@ struct MapViewContainer: UIViewRepresentable {
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
         mapView.delegate = context.coordinator
-        mapView.showsUserLocation = true
-        mapView.userTrackingMode = .follow
+        mapView.showsUserLocation = isUserLocationAuthorized
+        mapView.userTrackingMode = isUserLocationAuthorized ? .follow : .none
         
         // Configure map appearance
         mapView.showsCompass = false
@@ -158,9 +159,10 @@ struct MapViewContainer: UIViewRepresentable {
             let simAnnotations = uiView.annotations.filter { $0 is SimulatedPositionAnnotation }
             uiView.removeAnnotations(simAnnotations)
             
-            // Re-enable user tracking when navigation stops
-            uiView.userTrackingMode = .follow
-            uiView.showsUserLocation = true 
+            // Re-enable user tracking when navigation stops and location access
+            // has been granted explicitly through onboarding.
+            uiView.userTrackingMode = isUserLocationAuthorized ? .follow : .none
+            uiView.showsUserLocation = isUserLocationAuthorized
             context.coordinator.hasSetInitialRegion = false
             context.coordinator.resetNavigationCamera()
         }
@@ -192,14 +194,22 @@ struct MapViewContainer: UIViewRepresentable {
                 uiView.addAnnotation(annotation)
             }
         } else {
-            // Show real user location if not simulating
-            if !uiView.showsUserLocation {
-                uiView.showsUserLocation = true
-            }
-            if isNavigating && uiView.userTrackingMode != .followWithHeading {
-                uiView.setUserTrackingMode(.followWithHeading, animated: true)
-            } else if !isNavigating && uiView.userTrackingMode == .followWithHeading {
-                uiView.setUserTrackingMode(.follow, animated: true)
+            if isUserLocationAuthorized {
+                if !uiView.showsUserLocation {
+                    uiView.showsUserLocation = true
+                }
+                if isNavigating && uiView.userTrackingMode != .followWithHeading {
+                    uiView.setUserTrackingMode(.followWithHeading, animated: true)
+                } else if !isNavigating && uiView.userTrackingMode == .followWithHeading {
+                    uiView.setUserTrackingMode(.follow, animated: true)
+                }
+            } else {
+                if uiView.showsUserLocation {
+                    uiView.showsUserLocation = false
+                }
+                if uiView.userTrackingMode != .none {
+                    uiView.setUserTrackingMode(.none, animated: false)
+                }
             }
             // Remove sim annotation if present
             if !existingSimAnnotations.isEmpty {

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
@@ -12,23 +12,17 @@ import UIKit
 struct OfflineMapOnboardingView: View {
     @ObservedObject var manager: OfflineMapManager
     @ObservedObject var bleManager: BLEManager
+    let step: OfflineMapOnboardingStep
     let location: CLLocation?
     let isLocationAuthorized: Bool
     let onRequestLocation: () -> Void
+    let onSkipLocation: () -> Void
+    let onConnectDevice: () -> Void
+    let onCheckDeviceMaps: () -> Void
     let onChooseArea: () -> Void
     let onClose: () -> Void
 
     @Environment(\.openURL) private var openURL
-
-    private var currentStep: OfflineMapOnboardingStep {
-        if !isLocationAuthorized {
-            return .location
-        }
-        if !bleManager.isNavigationReady {
-            return .device
-        }
-        return .download
-    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -43,21 +37,23 @@ struct OfflineMapOnboardingView: View {
 
                 Spacer()
 
-                Button("Skip", action: onClose)
-                    .font(.subheadline.weight(.semibold))
+                if step == .location {
+                    Button("Skip", action: onSkipLocation)
+                        .font(.subheadline.weight(.semibold))
+                }
             }
 
             VStack(spacing: 18) {
-                Image(systemName: currentStep.symbol)
+                Image(systemName: step.symbol)
                     .font(.system(size: 42, weight: .semibold))
                     .foregroundColor(.accentColor)
                     .frame(height: 48)
 
-                Text(currentStep.title)
+                Text(step.title)
                     .font(.title2.weight(.semibold))
                     .multilineTextAlignment(.center)
 
-                Text(currentStep.message)
+                Text(step.message)
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -80,7 +76,7 @@ struct OfflineMapOnboardingView: View {
 
     @ViewBuilder
     private var actionContent: some View {
-        switch currentStep {
+        switch step {
         case .location:
             VStack(spacing: 10) {
                 Button(action: onRequestLocation) {
@@ -101,9 +97,22 @@ struct OfflineMapOnboardingView: View {
             }
 
         case .device:
+            VStack(spacing: 10) {
+                Button(action: onConnectDevice) {
+                    Label("Connect Bike Computer", systemImage: "bicycle")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+                Text(bleManager.centralStateDescription)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+        case .checkingDevice:
             VStack(spacing: 8) {
                 ProgressView()
-                Text(bleManager.centralStateDescription)
+                Text("Checking map storage…")
                     .font(.caption)
                     .foregroundColor(.secondary)
             }
@@ -116,13 +125,19 @@ struct OfflineMapOnboardingView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
+                } else if !isLocationAuthorized {
+                    locationActions
+                } else if location == nil {
+                    ProgressView()
+                    Text("Finding your location…")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
                 } else {
                     Button(action: onChooseArea) {
                         Label("Choose Area", systemImage: "rectangle.dashed")
                             .frame(maxWidth: .infinity)
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(location == nil)
                 }
 
                 if let error = manager.errorMessage {
@@ -132,23 +147,50 @@ struct OfflineMapOnboardingView: View {
                         .multilineTextAlignment(.center)
                 }
             }
+
+        case .storageUnavailable:
+            Button(action: onCheckDeviceMaps) {
+                Label("Check Again", systemImage: "arrow.clockwise")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+        }
+    }
+
+    private var locationActions: some View {
+        VStack(spacing: 10) {
+            Button(action: onRequestLocation) {
+                Label("Enable Location", systemImage: "location")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.borderedProminent)
+
+            Button {
+                if let url = URL(string: UIApplication.openSettingsURLString) {
+                    openURL(url)
+                }
+            } label: {
+                Text("Open iPhone Settings")
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
         }
     }
 }
 
-private enum OfflineMapOnboardingStep {
-    case location
-    case device
-    case download
-
+private extension OfflineMapOnboardingStep {
     var symbol: String {
         switch self {
         case .location:
             return "location.circle"
         case .device:
             return "antenna.radiowaves.left.and.right.circle"
+        case .checkingDevice:
+            return "externaldrive.badge.questionmark"
         case .download:
             return "map.circle"
+        case .storageUnavailable:
+            return "sdcard"
         }
     }
 
@@ -158,8 +200,12 @@ private enum OfflineMapOnboardingStep {
             return "Enable Location"
         case .device:
             return "Connect Your Bike Computer"
+        case .checkingDevice:
+            return "Checking Your Bike Computer"
         case .download:
             return "Download Map"
+        case .storageUnavailable:
+            return "Insert an SD Card"
         }
     }
 
@@ -168,9 +214,13 @@ private enum OfflineMapOnboardingStep {
         case .location:
             return "Bike Computer needs your current location to prepare the right offline map."
         case .device:
-            return "Boot the device and keep it nearby. The app will continue when BLE is connected."
+            return "Connect your Bike Computer before downloading its first map."
+        case .checkingDevice:
+            return "The app is checking whether your Bike Computer already has a map."
         case .download:
-            return "Download your current area to your Bike Computer."
+            return "Choose an area to download to your Bike Computer."
+        case .storageUnavailable:
+            return "Insert an SD card in your Bike Computer, then check again."
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
@@ -110,11 +110,17 @@ struct OfflineMapOnboardingView: View {
             }
 
         case .checkingDevice:
-            VStack(spacing: 8) {
+            VStack(spacing: 12) {
                 ProgressView()
                 Text("Checking map storage…")
                     .font(.caption)
                     .foregroundColor(.secondary)
+
+                Button(action: onCheckDeviceMaps) {
+                    Label("Check Again", systemImage: "arrow.clockwise")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
             }
 
         case .download:

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -3878,6 +3878,124 @@ struct NavigationProtocolTests {
     }
 
     static func testOfflineMapOnboardingPolicy() {
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: false,
+                isLocationAuthorized: false,
+                isNavigationReady: false,
+                hasSDCard: nil,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.location),
+            "first launch starts with location"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: false,
+                isNavigationReady: false,
+                hasSDCard: nil,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.device),
+            "skipping location advances directly to device connection"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: false,
+                isLocationAuthorized: true,
+                isNavigationReady: false,
+                hasSDCard: nil,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.device),
+            "authorizing location advances directly to device connection"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: false,
+                isNavigationReady: true,
+                hasSDCard: nil,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.checkingDevice),
+            "the modal remains visible while connected map status loads"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: false,
+                isNavigationReady: true,
+                hasSDCard: true,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.download),
+            "a connected device with no map advances to download even when location was skipped"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: true,
+                isNavigationReady: true,
+                hasSDCard: false,
+                activeMapId: "",
+                confirmedDeviceMapMissing: false
+            ),
+            .step(.storageUnavailable),
+            "missing storage keeps onboarding visible with recovery guidance"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: false,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: true,
+                isNavigationReady: true,
+                hasSDCard: true,
+                activeMapId: "installed-map",
+                confirmedDeviceMapMissing: false
+            ),
+            .completeFirstRun,
+            "an installed map completes first-run onboarding"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: true,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: true,
+                isNavigationReady: true,
+                hasSDCard: true,
+                activeMapId: "",
+                confirmedDeviceMapMissing: true
+            ),
+            .step(.download),
+            "later confirmed map loss still offers download"
+        )
+        assertEqual(
+            OfflineMapOnboardingPolicy.presentation(
+                hasCompletedFirstRun: true,
+                hasAdvancedPastLocation: true,
+                isLocationAuthorized: true,
+                isNavigationReady: true,
+                hasSDCard: true,
+                activeMapId: "installed-map",
+                confirmedDeviceMapMissing: false
+            ),
+            .hidden,
+            "completed onboarding stays hidden while maps are available"
+        )
+
         assert(
             OfflineMapOnboardingPolicy.shouldOfferDownload(
                 isLocationAuthorized: true,


### PR DESCRIPTION
## Summary

- keep first-run onboarding visible as an explicit, persisted sequence: location, Bike Computer connection, device map check, then map download
- make both Enable Location and Skip advance to the Bike Computer connection prompt
- open the real Bike Computers pairing flow from onboarding and continue automatically after authentication
- handle delayed device status, missing SD storage, and skipped location without dropping back to the ordinary map screen
- migrate existing paired installs so the new first-run flow only affects genuinely unconfigured installs

## Why

The onboarding overlay was derived directly from location authorization and a confirmed missing-map state. Granting location therefore removed the overlay before the device connection step could be shown, while Skip dismissed the entire flow. The app could reach the ordinary map UI without first connecting the Bike Computer or checking whether it already had a map.

## Impact

First-time users now move through one continuous setup flow. Existing users with a registered Bike Computer keep their current behavior, and later confirmed map loss still presents the existing download recovery step.

## Checks

- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' -derivedDataPath /tmp/first-run-onboarding-derived CODE_SIGNING_ALLOWED=NO build`
- `ios-app/scripts/run-navigation-tests.sh`
- `git diff --check`

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
