### PR TITLE
Keep GPS centered and current in dot mode

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -227,6 +227,14 @@ class NavigationEngine: NSObject, ObservableObject {
         isSimulationMode = false
         simulatedPosition = nil
     }
+
+    #if HOST_TESTING
+    func updateSimulationForTesting(timeInterval: TimeInterval) {
+        guard isSimulationMode else { return }
+        lastSimulationUpdate = Date().addingTimeInterval(-timeInterval)
+        updateSimulation()
+    }
+    #endif
     
     private func updateSimulation() {
         guard let route = currentRoute, let lastUpdate = lastSimulationUpdate else { return }
@@ -266,6 +274,7 @@ class NavigationEngine: NSObject, ObservableObject {
 
             // Also process location for navigation instructions
             processLocation(location)
+            guard isNavigating, isSimulationMode else { return }
             updateRideTelemetry(gpsLocation: location, routeLocation: location)
             sendDeviceGpsPosition(location, convertFromMapKitRoute: true)
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -33,6 +33,7 @@ class NavigationEngine: NSObject, ObservableObject {
     private var sendTracker = NavigationSendTracker(distanceThreshold: 10)
     private var initialNavigationLocation: CLLocation?
     private var lastDeviceGpsLocation: (location: CLLocation, convertFromMapKitRoute: Bool)?
+    private var latestExternalGpsLocation: CLLocation?
     private var hasAcceptedLiveLocation = false
     private var lastSentGeometryHash: Int = 0
     private var geometrySendInterval: TimeInterval = 2.0
@@ -86,6 +87,7 @@ class NavigationEngine: NSObject, ObservableObject {
 
     @discardableResult
     func processExternalLocation(_ location: CLLocation) -> Bool {
+        latestExternalGpsLocation = location
         guard !isSimulationMode else { return false }
         let routeLocation = CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location)
         let acceptedRouteLocation: CLLocation?
@@ -177,6 +179,7 @@ class NavigationEngine: NSObject, ObservableObject {
     
     /// Stop navigation
     func stopNavigation() {
+        let externalLocationToRestore = isSimulationMode ? latestExternalGpsLocation : nil
         bleManager?.clearRouteGeometry()
         isNavigating = false
         currentRoute = nil
@@ -195,6 +198,11 @@ class NavigationEngine: NSObject, ObservableObject {
         expectedArrivalDate = nil
         resetRideTelemetry(startingAt: nil)
         stopSimulation()
+        if let externalLocationToRestore {
+            sendDeviceGpsPosition(externalLocationToRestore,
+                                  convertFromMapKitRoute: false,
+                                  includeRideTelemetry: false)
+        }
         print("Navigation stopped")
     }
     
@@ -238,7 +246,6 @@ class NavigationEngine: NSObject, ObservableObject {
         if simulationProgress >= 1.0 {
             simulationProgress = 1.0
             print("Simulation complete")
-            stopSimulation()
             stopNavigation()
             return
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -38,8 +38,6 @@ class NavigationEngine: NSObject, ObservableObject {
     private var geometrySendInterval: TimeInterval = 2.0
     private var lastGeometrySendTime: Date = .distantPast
     private let geometryWindowSize: Int = 30
-    private let idleGpsSyncInterval: TimeInterval = 10 * 60
-    private var lastIdleGpsSyncTime: Date = .distantPast
     private var rideStartDate: Date?
     @Published private(set) var rideDistanceMeters: CLLocationDistance = 0
     private var lastRideLocation: CLLocation?
@@ -101,8 +99,9 @@ class NavigationEngine: NSObject, ObservableObject {
             updateRideTelemetry(gpsLocation: location, routeLocation: acceptedRouteLocation)
             sendDeviceGpsPosition(location, convertFromMapKitRoute: false)
         } else {
-            lastDeviceGpsLocation = (location, false)
-            sendIdleDeviceTimeSyncIfNeeded(location)
+            sendDeviceGpsPosition(location,
+                                  convertFromMapKitRoute: false,
+                                  includeRideTelemetry: false)
         }
         return acceptedRouteLocation != nil
     }
@@ -191,7 +190,6 @@ class NavigationEngine: NSObject, ObservableObject {
         hasAcceptedLiveLocation = false
         lastSentGeometryHash = 0
         lastGeometrySendTime = .distantPast
-        lastIdleGpsSyncTime = .distantPast
         routeRemainingDistance = nil
         routeRemainingTime = nil
         expectedArrivalDate = nil
@@ -501,15 +499,6 @@ class NavigationEngine: NSObject, ObservableObject {
         sendDeviceGpsPosition(lastDeviceGpsLocation.location,
                               convertFromMapKitRoute: lastDeviceGpsLocation.convertFromMapKitRoute,
                               includeRideTelemetry: isNavigating)
-    }
-
-    private func sendIdleDeviceTimeSyncIfNeeded(_ location: CLLocation) {
-        let now = Date()
-        guard now.timeIntervalSince(lastIdleGpsSyncTime) >= idleGpsSyncInterval else { return }
-        guard let bleManager, bleManager.isConnected, bleManager.isNavigationReady else { return }
-
-        sendDeviceGpsPosition(location, convertFromMapKitRoute: false, includeRideTelemetry: false)
-        lastIdleGpsSyncTime = now
     }
 
     private func resetRideTelemetry(startingAt location: CLLocation?) {

--- a/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+enum MapTrackingBehavior: Equatable {
+    case follow
+    case followWithHeading
+}
+
+enum MapTrackingPolicy {
+    static func desiredMode(
+        isNavigating: Bool,
+        isOfflineMapSelectionActive: Bool
+    ) -> MapTrackingBehavior? {
+        guard !isOfflineMapSelectionActive else { return nil }
+        return isNavigating ? .followWithHeading : .follow
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum MapTrackingBehavior: Equatable {
+    case none
     case follow
     case followWithHeading
 }
@@ -10,9 +11,9 @@ enum MapTrackingPolicy {
         isNavigating: Bool,
         isOfflineMapSelectionActive: Bool,
         isDestinationSelectionActive: Bool
-    ) -> MapTrackingBehavior? {
+    ) -> MapTrackingBehavior {
         guard !isOfflineMapSelectionActive,
-              !isDestinationSelectionActive else { return nil }
+              !isDestinationSelectionActive else { return .none }
         return isNavigating ? .followWithHeading : .follow
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
@@ -8,9 +8,11 @@ enum MapTrackingBehavior: Equatable {
 enum MapTrackingPolicy {
     static func desiredMode(
         isNavigating: Bool,
-        isOfflineMapSelectionActive: Bool
+        isOfflineMapSelectionActive: Bool,
+        isDestinationSelectionActive: Bool
     ) -> MapTrackingBehavior? {
-        guard !isOfflineMapSelectionActive else { return nil }
+        guard !isOfflineMapSelectionActive,
+              !isDestinationSelectionActive else { return nil }
         return isNavigating ? .followWithHeading : .follow
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -198,10 +198,15 @@ struct MapViewContainer: UIViewRepresentable {
                 if !uiView.showsUserLocation {
                     uiView.showsUserLocation = true
                 }
-                if isNavigating && uiView.userTrackingMode != .followWithHeading {
-                    uiView.setUserTrackingMode(.followWithHeading, animated: true)
-                } else if !isNavigating && uiView.userTrackingMode == .followWithHeading {
-                    uiView.setUserTrackingMode(.follow, animated: true)
+                if let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
+                    isNavigating: isNavigating,
+                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+                ) {
+                    let desiredTrackingMode: MKUserTrackingMode =
+                        desiredTrackingBehavior == .followWithHeading ? .followWithHeading : .follow
+                    if uiView.userTrackingMode != desiredTrackingMode {
+                        uiView.setUserTrackingMode(desiredTrackingMode, animated: true)
+                    }
                 }
             } else {
                 if uiView.showsUserLocation {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -286,14 +286,21 @@ struct MapViewContainer: UIViewRepresentable {
             let isDestinationSelectionActive = mapView.selectedAnnotations.contains {
                 $0 is DestinationAnnotation
             }
-            guard let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
+            let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
                 isNavigating: isNavigating,
                 isOfflineMapSelectionActive: isOfflineMapSelectionActive,
                 isDestinationSelectionActive: isDestinationSelectionActive
-            ) else { return }
+            )
 
-            let desiredTrackingMode: MKUserTrackingMode =
-                desiredTrackingBehavior == .followWithHeading ? .followWithHeading : .follow
+            let desiredTrackingMode: MKUserTrackingMode
+            switch desiredTrackingBehavior {
+            case .none:
+                desiredTrackingMode = .none
+            case .follow:
+                desiredTrackingMode = .follow
+            case .followWithHeading:
+                desiredTrackingMode = .followWithHeading
+            }
             if mapView.userTrackingMode != desiredTrackingMode {
                 mapView.setUserTrackingMode(desiredTrackingMode, animated: animated)
             }

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -198,19 +198,11 @@ struct MapViewContainer: UIViewRepresentable {
                 if !uiView.showsUserLocation {
                     uiView.showsUserLocation = true
                 }
-                if let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
+                context.coordinator.updateUserTrackingMode(
+                    mapView: uiView,
                     isNavigating: isNavigating,
-                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil,
-                    isDestinationSelectionActive: uiView.selectedAnnotations.contains {
-                        $0 is DestinationAnnotation
-                    }
-                ) {
-                    let desiredTrackingMode: MKUserTrackingMode =
-                        desiredTrackingBehavior == .followWithHeading ? .followWithHeading : .follow
-                    if uiView.userTrackingMode != desiredTrackingMode {
-                        uiView.setUserTrackingMode(desiredTrackingMode, animated: true)
-                    }
-                }
+                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+                )
             } else {
                 if uiView.showsUserLocation {
                     uiView.showsUserLocation = false
@@ -283,6 +275,28 @@ struct MapViewContainer: UIViewRepresentable {
         func updateControlVisibility(isNavigating: Bool) {
             compassButton?.compassVisibility = isNavigating ? .visible : .adaptive
             trackingButton?.isHidden = !isNavigating
+        }
+
+        func updateUserTrackingMode(
+            mapView: MKMapView,
+            isNavigating: Bool,
+            isOfflineMapSelectionActive: Bool,
+            animated: Bool = true
+        ) {
+            let isDestinationSelectionActive = mapView.selectedAnnotations.contains {
+                $0 is DestinationAnnotation
+            }
+            guard let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
+                isNavigating: isNavigating,
+                isOfflineMapSelectionActive: isOfflineMapSelectionActive,
+                isDestinationSelectionActive: isDestinationSelectionActive
+            ) else { return }
+
+            let desiredTrackingMode: MKUserTrackingMode =
+                desiredTrackingBehavior == .followWithHeading ? .followWithHeading : .follow
+            if mapView.userTrackingMode != desiredTrackingMode {
+                mapView.setUserTrackingMode(desiredTrackingMode, animated: animated)
+            }
         }
 
         func updateOfflineMapSelectionBounds() {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -87,6 +87,10 @@ struct MapViewContainer: UIViewRepresentable {
         context.coordinator.onMapTapped = onMapTapped
         context.coordinator.onOfflineMapSelectionBoundsChanged = onOfflineMapSelectionBoundsChanged
         context.coordinator.onDestinationSelected = onDestinationSelected
+        context.coordinator.isNavigating = isNavigating
+        context.coordinator.isSimulationMode = isSimulationMode
+        context.coordinator.isUserLocationAuthorized = isUserLocationAuthorized
+        context.coordinator.simulatedPosition = simulatedPosition
         
         return mapView
     }
@@ -104,6 +108,10 @@ struct MapViewContainer: UIViewRepresentable {
         context.coordinator.offlineMapSelectionFrame = offlineMapSelectionFrame
         context.coordinator.onOfflineMapSelectionBoundsChanged = onOfflineMapSelectionBoundsChanged
         context.coordinator.onDestinationSelected = onDestinationSelected
+        context.coordinator.isNavigating = isNavigating
+        context.coordinator.isSimulationMode = isSimulationMode
+        context.coordinator.isUserLocationAuthorized = isUserLocationAuthorized
+        context.coordinator.simulatedPosition = simulatedPosition
         context.coordinator.updateControlVisibility(isNavigating: isNavigating)
         context.coordinator.updateOfflineMapSelectionBounds()
         
@@ -223,6 +231,10 @@ struct MapViewContainer: UIViewRepresentable {
         var offlineMapSelectionFrame: CGRect?
         var onOfflineMapSelectionBoundsChanged: ((OfflineMapBounds) -> Void)?
         var onDestinationSelected: ((SavedDestination, CLLocation?) -> Void)?
+        var isNavigating = false
+        var isSimulationMode = false
+        var isUserLocationAuthorized = false
+        var simulatedPosition: CLLocationCoordinate2D?
         var hasSetInitialRegion = false
         private var compassButton: MKCompassButton?
         private var trackingButton: MKUserTrackingButton?
@@ -461,6 +473,35 @@ struct MapViewContainer: UIViewRepresentable {
 
         func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
             updateOfflineMapSelectionBounds()
+        }
+
+        func mapView(_ mapView: MKMapView, didDeselect view: MKAnnotationView) {
+            guard view.annotation is DestinationAnnotation else { return }
+
+            // MapKit reports the temporary deselection used to rebuild a
+            // reverse-geocoded callout too. Defer until a synchronous reselect
+            // has completed, then only resume tracking if free pan truly ended.
+            DispatchQueue.main.async { [weak self, weak mapView] in
+                guard let self, let mapView,
+                      !self.isFreePanActive(
+                          mapView: mapView,
+                          isOfflineMapSelectionActive: self.offlineMapSelectionFrame != nil
+                      ) else { return }
+
+                if self.isSimulationMode, let simulatedPosition = self.simulatedPosition {
+                    self.updateNavigationCamera(
+                        mapView: mapView,
+                        coordinate: simulatedPosition,
+                        animated: true
+                    )
+                } else if self.isUserLocationAuthorized {
+                    self.updateUserTrackingMode(
+                        mapView: mapView,
+                        isNavigating: self.isNavigating,
+                        isOfflineMapSelectionActive: false
+                    )
+                }
+            }
         }
 
         @objc func handleTap(_ gestureRecognizer: UITapGestureRecognizer) {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -92,6 +92,8 @@ struct MapViewContainer: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
+        let isOfflineMapSelectionActive = offlineMapSelectionFrame != nil
+
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
         context.coordinator.onMapTapped = onMapTapped
@@ -137,7 +139,8 @@ struct MapViewContainer: UIViewRepresentable {
                 location: location,
                 simulatedPosition: simulatedPosition,
                 isSimulationMode: isSimulationMode,
-                isNavigating: isNavigating
+                isNavigating: isNavigating,
+                isOfflineMapSelectionActive: isOfflineMapSelectionActive
             )
             
             // Handle simulated position annotation
@@ -175,9 +178,10 @@ struct MapViewContainer: UIViewRepresentable {
             if uiView.showsUserLocation {
                 uiView.showsUserLocation = false
             }
-            context.coordinator.updateNavigationCamera(
+            context.coordinator.updateSimulatedNavigationCamera(
                 mapView: uiView,
                 coordinate: simPos,
+                isOfflineMapSelectionActive: isOfflineMapSelectionActive,
                 animated: true
             )
             
@@ -201,7 +205,7 @@ struct MapViewContainer: UIViewRepresentable {
                 context.coordinator.updateUserTrackingMode(
                     mapView: uiView,
                     isNavigating: isNavigating,
-                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+                    isOfflineMapSelectionActive: isOfflineMapSelectionActive
                 )
             } else {
                 if uiView.showsUserLocation {
@@ -334,8 +338,16 @@ struct MapViewContainer: UIViewRepresentable {
             location: CLLocation?,
             simulatedPosition: CLLocationCoordinate2D?,
             isSimulationMode: Bool,
-            isNavigating: Bool
+            isNavigating: Bool,
+            isOfflineMapSelectionActive: Bool
         ) {
+            guard !isOfflineMapSelectionActive else {
+                if mapView.userTrackingMode != .none {
+                    mapView.setUserTrackingMode(.none, animated: false)
+                }
+                return
+            }
+
             guard isNavigating else {
                 mapView.setVisibleMapRect(
                     route.polyline.boundingMapRect,
@@ -350,6 +362,26 @@ struct MapViewContainer: UIViewRepresentable {
             } else {
                 mapView.setUserTrackingMode(.followWithHeading, animated: true)
             }
+        }
+
+        func updateSimulatedNavigationCamera(
+            mapView: MKMapView,
+            coordinate: CLLocationCoordinate2D,
+            isOfflineMapSelectionActive: Bool,
+            animated: Bool
+        ) {
+            guard !isOfflineMapSelectionActive else {
+                if mapView.userTrackingMode != .none {
+                    mapView.setUserTrackingMode(.none, animated: false)
+                }
+                return
+            }
+
+            updateNavigationCamera(
+                mapView: mapView,
+                coordinate: coordinate,
+                animated: animated
+            )
         }
 
         func updateNavigationCamera(

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -93,10 +93,10 @@ struct MapViewContainer: UIViewRepresentable {
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
         let isOfflineMapSelectionActive = offlineMapSelectionFrame != nil
-        let isDestinationSelectionActive = uiView.selectedAnnotations.contains {
-            $0 is DestinationAnnotation
-        }
-        let isFreePanActive = isOfflineMapSelectionActive || isDestinationSelectionActive
+        let isFreePanActive = context.coordinator.isFreePanActive(
+            mapView: uiView,
+            isOfflineMapSelectionActive: isOfflineMapSelectionActive
+        )
 
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
@@ -129,7 +129,7 @@ struct MapViewContainer: UIViewRepresentable {
                 simulatedPosition: simulatedPosition,
                 isSimulationMode: isSimulationMode,
                 isNavigating: isNavigating,
-                isOfflineMapSelectionActive: isOfflineMapSelectionActive
+                isFreePanActive: isFreePanActive
             )
             
             // Handle simulated position annotation
@@ -169,7 +169,7 @@ struct MapViewContainer: UIViewRepresentable {
             context.coordinator.updateSimulatedNavigationCamera(
                 mapView: uiView,
                 coordinate: simPos,
-                isOfflineMapSelectionActive: isOfflineMapSelectionActive,
+                isFreePanActive: isFreePanActive,
                 animated: true
             )
             
@@ -298,6 +298,15 @@ struct MapViewContainer: UIViewRepresentable {
             }
         }
 
+        func isFreePanActive(
+            mapView: MKMapView,
+            isOfflineMapSelectionActive: Bool
+        ) -> Bool {
+            isOfflineMapSelectionActive || mapView.selectedAnnotations.contains {
+                $0 is DestinationAnnotation
+            }
+        }
+
         func updateInitialRegionIfNeeded(
             mapView: MKMapView,
             location: CLLocation?,
@@ -378,9 +387,9 @@ struct MapViewContainer: UIViewRepresentable {
             simulatedPosition: CLLocationCoordinate2D?,
             isSimulationMode: Bool,
             isNavigating: Bool,
-            isOfflineMapSelectionActive: Bool
+            isFreePanActive: Bool
         ) {
-            guard !isOfflineMapSelectionActive else {
+            guard !isFreePanActive else {
                 if mapView.userTrackingMode != .none {
                     mapView.setUserTrackingMode(.none, animated: false)
                 }
@@ -406,10 +415,10 @@ struct MapViewContainer: UIViewRepresentable {
         func updateSimulatedNavigationCamera(
             mapView: MKMapView,
             coordinate: CLLocationCoordinate2D,
-            isOfflineMapSelectionActive: Bool,
+            isFreePanActive: Bool,
             animated: Bool
         ) {
-            guard !isOfflineMapSelectionActive else {
+            guard !isFreePanActive else {
                 if mapView.userTrackingMode != .none {
                     mapView.setUserTrackingMode(.none, animated: false)
                 }

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -201,7 +201,7 @@ struct MapViewContainer: UIViewRepresentable {
                 if let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
                     isNavigating: isNavigating,
                     isOfflineMapSelectionActive: offlineMapSelectionFrame != nil,
-                    isDestinationSelectionActive: uiView.annotations.contains {
+                    isDestinationSelectionActive: uiView.selectedAnnotations.contains {
                         $0 is DestinationAnnotation
                     }
                 ) {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -93,6 +93,10 @@ struct MapViewContainer: UIViewRepresentable {
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
         let isOfflineMapSelectionActive = offlineMapSelectionFrame != nil
+        let isDestinationSelectionActive = uiView.selectedAnnotations.contains {
+            $0 is DestinationAnnotation
+        }
+        let isFreePanActive = isOfflineMapSelectionActive || isDestinationSelectionActive
 
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
@@ -103,28 +107,13 @@ struct MapViewContainer: UIViewRepresentable {
         context.coordinator.updateControlVisibility(isNavigating: isNavigating)
         context.coordinator.updateOfflineMapSelectionBounds()
         
-        // Only set initial region once if not already set
-        if let location = location, 
-           !context.coordinator.hasSetInitialRegion,
-           context.coordinator.lastRoute == nil {
-             // Use simulated position if available and in simulation mode
-             var center = (isSimulationMode && simulatedPosition != nil) ? simulatedPosition! : location.coordinate
-             
-             // In China, Apple Maps uses GCJ-02 for its view region
-             // Convert WGS-84 -> GCJ-02 so the map centers correctly on the visual location (blue dot)
-             // Only convert for REAL GPS (which is WGS-84). Simulated position (from MKRoute) is already GCJ-02.
-             if !isSimulationMode && CoordinateConverter.isInChina(lat: center.latitude, lon: center.longitude) {
-                 let converted = CoordinateConverter.wgs84ToGCJ02(coordinate: center)
-                 center = converted
-             }
-             
-            let region = MKCoordinateRegion(
-                center: center,
-                span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-            )
-            uiView.setRegion(region, animated: false)
-            context.coordinator.hasSetInitialRegion = true
-        }
+        context.coordinator.updateInitialRegionIfNeeded(
+            mapView: uiView,
+            location: location,
+            simulatedPosition: simulatedPosition,
+            isSimulationMode: isSimulationMode,
+            isFreePanActive: isFreePanActive
+        )
         
         // Update route overlay
         if let route = route, context.coordinator.lastRoute !== route {
@@ -162,12 +151,11 @@ struct MapViewContainer: UIViewRepresentable {
             let simAnnotations = uiView.annotations.filter { $0 is SimulatedPositionAnnotation }
             uiView.removeAnnotations(simAnnotations)
             
-            // Re-enable user tracking when navigation stops and location access
-            // has been granted explicitly through onboarding.
-            uiView.userTrackingMode = isUserLocationAuthorized ? .follow : .none
-            uiView.showsUserLocation = isUserLocationAuthorized
-            context.coordinator.hasSetInitialRegion = false
-            context.coordinator.resetNavigationCamera()
+            context.coordinator.finishNavigationTracking(
+                mapView: uiView,
+                isUserLocationAuthorized: isUserLocationAuthorized,
+                isFreePanActive: isFreePanActive
+            )
         }
         
         // Update simulated position
@@ -308,6 +296,57 @@ struct MapViewContainer: UIViewRepresentable {
             if mapView.userTrackingMode != desiredTrackingMode {
                 mapView.setUserTrackingMode(desiredTrackingMode, animated: animated)
             }
+        }
+
+        func updateInitialRegionIfNeeded(
+            mapView: MKMapView,
+            location: CLLocation?,
+            simulatedPosition: CLLocationCoordinate2D?,
+            isSimulationMode: Bool,
+            isFreePanActive: Bool
+        ) {
+            guard !isFreePanActive,
+                  let location,
+                  !hasSetInitialRegion,
+                  lastRoute == nil else { return }
+
+            var center = isSimulationMode ? (simulatedPosition ?? location.coordinate) : location.coordinate
+
+            // Apple Maps displays mainland-China coordinates in GCJ-02. Simulated
+            // route positions already use MapKit's coordinate space.
+            if !isSimulationMode,
+               CoordinateConverter.isInChina(lat: center.latitude, lon: center.longitude) {
+                center = CoordinateConverter.wgs84ToGCJ02(coordinate: center)
+            }
+
+            let region = MKCoordinateRegion(
+                center: center,
+                span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
+            )
+            mapView.setRegion(region, animated: false)
+            hasSetInitialRegion = true
+        }
+
+        func finishNavigationTracking(
+            mapView: MKMapView,
+            isUserLocationAuthorized: Bool,
+            isFreePanActive: Bool
+        ) {
+            mapView.showsUserLocation = isUserLocationAuthorized
+
+            if isFreePanActive {
+                if mapView.userTrackingMode != .none {
+                    mapView.setUserTrackingMode(.none, animated: false)
+                }
+            } else {
+                let desiredMode: MKUserTrackingMode = isUserLocationAuthorized ? .follow : .none
+                if mapView.userTrackingMode != desiredMode {
+                    mapView.setUserTrackingMode(desiredMode, animated: false)
+                }
+                hasSetInitialRegion = false
+            }
+
+            resetNavigationCamera()
         }
 
         func updateOfflineMapSelectionBounds() {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -200,7 +200,10 @@ struct MapViewContainer: UIViewRepresentable {
                 }
                 if let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
                     isNavigating: isNavigating,
-                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+                    isOfflineMapSelectionActive: offlineMapSelectionFrame != nil,
+                    isDestinationSelectionActive: uiView.annotations.contains {
+                        $0 is DestinationAnnotation
+                    }
                 ) {
                     let desiredTrackingMode: MKUserTrackingMode =
                         desiredTrackingBehavior == .followWithHeading ? .followWithHeading : .follow

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -162,6 +162,17 @@ struct DestinationCalloutLayoutTests {
             mapView.userTrackingMode == .followWithHeading,
             "navigation heading-follow should resume with a dismissed destination pin"
         )
+
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: true,
+            isOfflineMapSelectionActive: true,
+            animated: false
+        )
+        precondition(
+            mapView.userTrackingMode == .none,
+            "offline map selection should disable heading-follow during navigation"
+        )
     }
 
     @MainActor

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -147,6 +147,33 @@ struct DestinationCalloutLayoutTests {
             "a selected destination callout should preserve free panning"
         )
 
+        let destinationFreePanActive = coordinator.isFreePanActive(
+            mapView: mapView,
+            isOfflineMapSelectionActive: false
+        )
+        let cameraUpdatesBeforeDestinationRoute = mapView.cameraUpdateCount
+        let destinationRouteCoordinate = CLLocationCoordinate2D(latitude: 1.3525, longitude: 103.8202)
+        coordinator.configureRouteCamera(
+            mapView: mapView,
+            route: RecordingRoute(),
+            location: nil,
+            simulatedPosition: destinationRouteCoordinate,
+            isSimulationMode: true,
+            isNavigating: true,
+            isFreePanActive: destinationFreePanActive
+        )
+        coordinator.updateSimulatedNavigationCamera(
+            mapView: mapView,
+            coordinate: destinationRouteCoordinate,
+            isFreePanActive: destinationFreePanActive,
+            animated: false
+        )
+        precondition(
+            destinationFreePanActive &&
+                mapView.cameraUpdateCount == cameraUpdatesBeforeDestinationRoute,
+            "route start and simulation ticks should preserve a selected destination callout"
+        )
+
         mapView.deselectAnnotation(annotation, animated: false)
 
         precondition(
@@ -191,7 +218,7 @@ struct DestinationCalloutLayoutTests {
         coordinator.updateSimulatedNavigationCamera(
             mapView: mapView,
             coordinate: simulatedCoordinate,
-            isOfflineMapSelectionActive: true,
+            isFreePanActive: true,
             animated: false
         )
         precondition(
@@ -207,7 +234,7 @@ struct DestinationCalloutLayoutTests {
             simulatedPosition: simulatedCoordinate,
             isSimulationMode: false,
             isNavigating: true,
-            isOfflineMapSelectionActive: true
+            isFreePanActive: true
         )
         precondition(
             mapView.cameraUpdateCount == cameraUpdatesBeforeSelection &&
@@ -218,7 +245,7 @@ struct DestinationCalloutLayoutTests {
         coordinator.updateSimulatedNavigationCamera(
             mapView: mapView,
             coordinate: simulatedCoordinate,
-            isOfflineMapSelectionActive: false,
+            isFreePanActive: false,
             animated: false
         )
         precondition(

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -16,6 +16,7 @@ private final class RecordingMapView: MKMapView {
     var convertedCoordinate: CLLocationCoordinate2D?
     private(set) var selectionCount = 0
     private(set) var deselectionCount = 0
+    private(set) var cameraUpdateCount = 0
     private var recordedSelectedAnnotations: [MKAnnotation] = []
     private var recordedUserTrackingMode: MKUserTrackingMode = .none
 
@@ -31,6 +32,10 @@ private final class RecordingMapView: MKMapView {
 
     override func setUserTrackingMode(_ mode: MKUserTrackingMode, animated: Bool) {
         recordedUserTrackingMode = mode
+    }
+
+    override func setCamera(_ camera: MKMapCamera, animated: Bool) {
+        cameraUpdateCount += 1
     }
 
     override func view(for annotation: MKAnnotation) -> MKAnnotationView? {
@@ -83,6 +88,8 @@ private final class RecordingLongPressGestureRecognizer: UILongPressGestureRecog
         recordedLocation
     }
 }
+
+private final class RecordingRoute: MKRoute {}
 
 @main
 struct DestinationCalloutLayoutTests {
@@ -172,6 +179,57 @@ struct DestinationCalloutLayoutTests {
         precondition(
             mapView.userTrackingMode == .none,
             "offline map selection should disable heading-follow during navigation"
+        )
+
+        let cameraUpdatesBeforeSelection = mapView.cameraUpdateCount
+        let simulatedCoordinate = CLLocationCoordinate2D(latitude: 1.353, longitude: 103.82)
+        coordinator.updateSimulatedNavigationCamera(
+            mapView: mapView,
+            coordinate: simulatedCoordinate,
+            isOfflineMapSelectionActive: true,
+            animated: false
+        )
+        precondition(
+            mapView.cameraUpdateCount == cameraUpdatesBeforeSelection,
+            "simulated navigation updates should not recenter an offline selection"
+        )
+
+        mapView.userTrackingMode = .followWithHeading
+        coordinator.configureRouteCamera(
+            mapView: mapView,
+            route: RecordingRoute(),
+            location: nil,
+            simulatedPosition: simulatedCoordinate,
+            isSimulationMode: false,
+            isNavigating: true,
+            isOfflineMapSelectionActive: true
+        )
+        precondition(
+            mapView.cameraUpdateCount == cameraUpdatesBeforeSelection &&
+                mapView.userTrackingMode == .none,
+            "route replacement should not move a navigating offline selection"
+        )
+
+        coordinator.updateSimulatedNavigationCamera(
+            mapView: mapView,
+            coordinate: simulatedCoordinate,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
+        precondition(
+            mapView.cameraUpdateCount == cameraUpdatesBeforeSelection + 1,
+            "simulated navigation camera updates should resume after selection"
+        )
+
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: true,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
+        precondition(
+            mapView.userTrackingMode == .followWithHeading,
+            "real navigation heading-follow should resume after offline selection"
         )
     }
 

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -101,7 +101,7 @@ struct DestinationCalloutLayoutTests {
     @MainActor
     static func main() async {
         testLabelExpansion()
-        testDestinationSelectionTrackingIntegration()
+        await testDestinationSelectionTrackingIntegration()
         await testResolvedAddressCallbackAndRecentInsertion()
         await testFallbackAddress()
         await testStaleResolutionCancellation()
@@ -110,11 +110,12 @@ struct DestinationCalloutLayoutTests {
     }
 
     @MainActor
-    private static func testDestinationSelectionTrackingIntegration() {
+    private static func testDestinationSelectionTrackingIntegration() async {
         let coordinate = CLLocationCoordinate2D(latitude: 1.35210, longitude: 103.81980)
         let mapView = RecordingMapView()
         let coordinator = MapViewContainer.Coordinator(addressResolver: { _ in nil })
         coordinator.mapView = mapView
+        coordinator.isUserLocationAuthorized = true
         mapView.convertedCoordinate = coordinate
         mapView.annotationViewProvider = { annotation in
             coordinator.mapView(mapView, viewFor: annotation)
@@ -174,32 +175,36 @@ struct DestinationCalloutLayoutTests {
             "route start and simulation ticks should preserve a selected destination callout"
         )
 
+        guard let annotationView = mapView.view(for: annotation) else {
+            preconditionFailure("the selected destination should have an annotation view")
+        }
+        coordinator.mapView(mapView, didDeselect: annotationView)
+        await waitForMainQueue()
+        precondition(
+            mapView.userTrackingMode == .none,
+            "a temporary callout refresh must not resume tracking after the pin is reselected"
+        )
+
         mapView.deselectAnnotation(annotation, animated: false)
+        coordinator.mapView(mapView, didDeselect: annotationView)
+        await waitForMainQueue()
 
         precondition(
             !mapView.selectedAnnotations.contains { $0 is DestinationAnnotation },
             "dismissing the callout should end destination selection"
         )
-        coordinator.updateUserTrackingMode(
-            mapView: mapView,
-            isNavigating: false,
-            isOfflineMapSelectionActive: false,
-            animated: false
-        )
         precondition(
             mapView.userTrackingMode == .follow,
-            "dot-mode follow should resume after destination selection ends"
+            "the MapKit deselection callback should resume dot-mode follow"
         )
 
-        coordinator.updateUserTrackingMode(
-            mapView: mapView,
-            isNavigating: true,
-            isOfflineMapSelectionActive: false,
-            animated: false
-        )
+        coordinator.isNavigating = true
+        mapView.userTrackingMode = .none
+        coordinator.mapView(mapView, didDeselect: annotationView)
+        await waitForMainQueue()
         precondition(
             mapView.userTrackingMode == .followWithHeading,
-            "navigation heading-follow should resume with a dismissed destination pin"
+            "the MapKit deselection callback should resume navigation heading-follow"
         )
 
         coordinator.updateUserTrackingMode(
@@ -314,6 +319,15 @@ struct DestinationCalloutLayoutTests {
             mapView.userTrackingMode == .follow,
             "dot-mode follow should resume when free-pan selection exits"
         )
+    }
+
+    @MainActor
+    private static func waitForMainQueue() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
     }
 
     @MainActor

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -17,10 +17,20 @@ private final class RecordingMapView: MKMapView {
     private(set) var selectionCount = 0
     private(set) var deselectionCount = 0
     private var recordedSelectedAnnotations: [MKAnnotation] = []
+    private var recordedUserTrackingMode: MKUserTrackingMode = .none
 
     override var selectedAnnotations: [MKAnnotation] {
         get { recordedSelectedAnnotations }
         set { recordedSelectedAnnotations = newValue }
+    }
+
+    override var userTrackingMode: MKUserTrackingMode {
+        get { recordedUserTrackingMode }
+        set { recordedUserTrackingMode = newValue }
+    }
+
+    override func setUserTrackingMode(_ mode: MKUserTrackingMode, animated: Bool) {
+        recordedUserTrackingMode = mode
     }
 
     override func view(for annotation: MKAnnotation) -> MKAnnotationView? {
@@ -79,7 +89,7 @@ struct DestinationCalloutLayoutTests {
     @MainActor
     static func main() async {
         testLabelExpansion()
-        testDestinationSelectionTrackingPolicy()
+        testDestinationSelectionTrackingIntegration()
         await testResolvedAddressCallbackAndRecentInsertion()
         await testFallbackAddress()
         await testStaleResolutionCancellation()
@@ -88,26 +98,40 @@ struct DestinationCalloutLayoutTests {
     }
 
     @MainActor
-    private static func testDestinationSelectionTrackingPolicy() {
+    private static func testDestinationSelectionTrackingIntegration() {
         let coordinate = CLLocationCoordinate2D(latitude: 1.35210, longitude: 103.81980)
         let mapView = RecordingMapView()
         let coordinator = MapViewContainer.Coordinator(addressResolver: { _ in nil })
+        coordinator.mapView = mapView
+        mapView.convertedCoordinate = coordinate
         mapView.annotationViewProvider = { annotation in
             coordinator.mapView(mapView, viewFor: annotation)
         }
         coordinator.onDestinationSelected = { _, _ in }
+        mapView.userTrackingMode = .follow
 
-        coordinator.selectDestination(at: coordinate, on: mapView)
+        let longPress = RecordingLongPressGestureRecognizer(
+            state: .began,
+            location: CGPoint(x: 100, y: 100)
+        )
+        coordinator.handleLongPress(longPress)
 
         guard let annotation = mapView.selectedAnnotations.first as? DestinationAnnotation else {
             preconditionFailure("a newly dropped destination should be selected")
         }
         precondition(
-            MapTrackingPolicy.desiredMode(
-                isNavigating: false,
-                isOfflineMapSelectionActive: false,
-                isDestinationSelectionActive: true
-            ) == nil,
+            mapView.userTrackingMode == .none,
+            "long-press destination selection should disable tracking"
+        )
+
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: false,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
+        precondition(
+            mapView.userTrackingMode == .none,
             "a selected destination callout should preserve free panning"
         )
 
@@ -117,13 +141,26 @@ struct DestinationCalloutLayoutTests {
             !mapView.selectedAnnotations.contains { $0 is DestinationAnnotation },
             "dismissing the callout should end destination selection"
         )
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: false,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
         precondition(
-            MapTrackingPolicy.desiredMode(
-                isNavigating: false,
-                isOfflineMapSelectionActive: false,
-                isDestinationSelectionActive: false
-            ) == .follow,
+            mapView.userTrackingMode == .follow,
             "dot-mode follow should resume after destination selection ends"
+        )
+
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: true,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
+        precondition(
+            mapView.userTrackingMode == .followWithHeading,
+            "navigation heading-follow should resume with a dismissed destination pin"
         )
     }
 

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -17,6 +17,7 @@ private final class RecordingMapView: MKMapView {
     private(set) var selectionCount = 0
     private(set) var deselectionCount = 0
     private(set) var cameraUpdateCount = 0
+    private(set) var regionUpdateCount = 0
     private var recordedSelectedAnnotations: [MKAnnotation] = []
     private var recordedUserTrackingMode: MKUserTrackingMode = .none
 
@@ -36,6 +37,10 @@ private final class RecordingMapView: MKMapView {
 
     override func setCamera(_ camera: MKMapCamera, animated: Bool) {
         cameraUpdateCount += 1
+    }
+
+    override func setRegion(_ region: MKCoordinateRegion, animated: Bool) {
+        regionUpdateCount += 1
     }
 
     override func view(for annotation: MKAnnotation) -> MKAnnotationView? {
@@ -230,6 +235,57 @@ struct DestinationCalloutLayoutTests {
         precondition(
             mapView.userTrackingMode == .followWithHeading,
             "real navigation heading-follow should resume after offline selection"
+        )
+
+        let liveLocation = CLLocation(latitude: 1.354, longitude: 103.821)
+        coordinator.hasSetInitialRegion = false
+        let regionUpdatesBeforeLateLocation = mapView.regionUpdateCount
+        coordinator.updateInitialRegionIfNeeded(
+            mapView: mapView,
+            location: liveLocation,
+            simulatedPosition: nil,
+            isSimulationMode: false,
+            isFreePanActive: true
+        )
+        precondition(
+            mapView.regionUpdateCount == regionUpdatesBeforeLateLocation &&
+                !coordinator.hasSetInitialRegion,
+            "a late first location should not recenter an active free-pan selection"
+        )
+
+        coordinator.hasSetInitialRegion = true
+        mapView.userTrackingMode = .followWithHeading
+        coordinator.finishNavigationTracking(
+            mapView: mapView,
+            isUserLocationAuthorized: true,
+            isFreePanActive: true
+        )
+        precondition(
+            mapView.userTrackingMode == .none && coordinator.hasSetInitialRegion,
+            "stopping navigation should preserve the selected map region"
+        )
+
+        coordinator.updateInitialRegionIfNeeded(
+            mapView: mapView,
+            location: liveLocation,
+            simulatedPosition: nil,
+            isSimulationMode: false,
+            isFreePanActive: true
+        )
+        precondition(
+            mapView.regionUpdateCount == regionUpdatesBeforeLateLocation,
+            "the next GPS update should not recenter after navigation stops during selection"
+        )
+
+        coordinator.updateUserTrackingMode(
+            mapView: mapView,
+            isNavigating: false,
+            isOfflineMapSelectionActive: false,
+            animated: false
+        )
+        precondition(
+            mapView.userTrackingMode == .follow,
+            "dot-mode follow should resume when free-pan selection exits"
         )
     }
 

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -16,6 +16,12 @@ private final class RecordingMapView: MKMapView {
     var convertedCoordinate: CLLocationCoordinate2D?
     private(set) var selectionCount = 0
     private(set) var deselectionCount = 0
+    private var recordedSelectedAnnotations: [MKAnnotation] = []
+
+    override var selectedAnnotations: [MKAnnotation] {
+        get { recordedSelectedAnnotations }
+        set { recordedSelectedAnnotations = newValue }
+    }
 
     override func view(for annotation: MKAnnotation) -> MKAnnotationView? {
         let identifier = ObjectIdentifier(annotation as AnyObject)
@@ -34,12 +40,14 @@ private final class RecordingMapView: MKMapView {
 
     override func selectAnnotation(_ annotation: MKAnnotation, animated: Bool) {
         selectionCount += 1
+        recordedSelectedAnnotations = [annotation]
         view(for: annotation)?.setSelected(true, animated: false)
     }
 
     override func deselectAnnotation(_ annotation: MKAnnotation?, animated: Bool) {
         deselectionCount += 1
         if let annotation {
+            recordedSelectedAnnotations.removeAll { $0 === annotation }
             view(for: annotation)?.setSelected(false, animated: false)
         }
     }
@@ -71,11 +79,52 @@ struct DestinationCalloutLayoutTests {
     @MainActor
     static func main() async {
         testLabelExpansion()
+        testDestinationSelectionTrackingPolicy()
         await testResolvedAddressCallbackAndRecentInsertion()
         await testFallbackAddress()
         await testStaleResolutionCancellation()
 
         print("DestinationCalloutLayoutTests passed")
+    }
+
+    @MainActor
+    private static func testDestinationSelectionTrackingPolicy() {
+        let coordinate = CLLocationCoordinate2D(latitude: 1.35210, longitude: 103.81980)
+        let mapView = RecordingMapView()
+        let coordinator = MapViewContainer.Coordinator(addressResolver: { _ in nil })
+        mapView.annotationViewProvider = { annotation in
+            coordinator.mapView(mapView, viewFor: annotation)
+        }
+        coordinator.onDestinationSelected = { _, _ in }
+
+        coordinator.selectDestination(at: coordinate, on: mapView)
+
+        guard let annotation = mapView.selectedAnnotations.first as? DestinationAnnotation else {
+            preconditionFailure("a newly dropped destination should be selected")
+        }
+        precondition(
+            MapTrackingPolicy.desiredMode(
+                isNavigating: false,
+                isOfflineMapSelectionActive: false,
+                isDestinationSelectionActive: true
+            ) == nil,
+            "a selected destination callout should preserve free panning"
+        )
+
+        mapView.deselectAnnotation(annotation, animated: false)
+
+        precondition(
+            !mapView.selectedAnnotations.contains { $0 is DestinationAnnotation },
+            "dismissing the callout should end destination selection"
+        )
+        precondition(
+            MapTrackingPolicy.desiredMode(
+                isNavigating: false,
+                isOfflineMapSelectionActive: false,
+                isDestinationSelectionActive: false
+            ) == .follow,
+            "dot-mode follow should resume after destination selection ends"
+        )
     }
 
     @MainActor

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -571,6 +571,7 @@ struct NavigationProtocolTests {
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
         testNavigationEngineRestoresPhysicalGPSAfterSimulation()
+        testNavigationEngineKeepsPhysicalGPSAfterSimulationStepCompletion()
         testNavigationEngineOmitsRideTelemetryWhenIdle()
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testNavigationEngineReplacesRouteWithoutResettingTelemetry()
@@ -11649,7 +11650,15 @@ struct NavigationProtocolTests {
         )
         engine.startNavigation(with: route, isTestMode: true)
 
-        let latestPhysicalLocation = CLLocation(latitude: 37.2, longitude: -122.2)
+        let latestPhysicalLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.2, longitude: -122.2),
+            altitude: 88,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 45,
+            speed: 7,
+            timestamp: Date()
+        )
         engine.processExternalLocation(latestPhysicalLocation)
         assertEqual(
             manager.sentGPSPositions.count,
@@ -11671,6 +11680,63 @@ struct NavigationProtocolTests {
             readUInt16LE(packet, offset: 14),
             DeviceGPSPacketBuilder.invalidSpeedCmps,
             "restored idle GPS should omit ride speed"
+        )
+        assertEqual(readInt16LE(packet, offset: 16), 0, "restored idle GPS should omit altitude")
+        assertEqual(readUInt32LE(packet, offset: 18), 0, "restored idle GPS should omit distance")
+        assertEqual(readUInt32LE(packet, offset: 22), 0, "restored idle GPS should omit elapsed time")
+        assertEqual(
+            readUInt32LE(packet, offset: 26),
+            DeviceGPSPacketBuilder.invalidRouteRemainingMeters,
+            "restored idle GPS should omit route remaining distance"
+        )
+    }
+
+    static func testNavigationEngineKeepsPhysicalGPSAfterSimulationStepCompletion() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        let physicalLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.3, longitude: -122.3),
+            altitude: 91,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 50,
+            speed: 8,
+            timestamp: Date()
+        )
+        engine.processExternalLocation(physicalLocation)
+        manager.sentGPSPositions.removeAll()
+
+        let routeCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.001, longitude: -122.0)
+        ]
+        let route = TestRoute(
+            steps: [
+                TestRouteStep(instructions: "Continue", coordinates: routeCoordinates),
+                TestRouteStep(instructions: "", coordinates: [])
+            ],
+            coordinates: routeCoordinates
+        )
+        engine.startNavigation(with: route, isTestMode: true)
+        engine.updateSimulationForTesting(timeInterval: 10)
+
+        assertEqual(
+            manager.sentGPSPositions.count,
+            1,
+            "step-based simulation completion should leave one restored physical GPS packet"
+        )
+        guard let packet = manager.sentGPSPositions.first else { return }
+        assertEqual(readInt32LE(packet, offset: 0), 37_300_000, "completion should retain physical latitude")
+        assertEqual(readInt32LE(packet, offset: 4), -122_300_000, "completion should retain physical longitude")
+        assertEqual(
+            readUInt16LE(packet, offset: 14),
+            DeviceGPSPacketBuilder.invalidSpeedCmps,
+            "completion restore should remain idle telemetry"
         )
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -11697,8 +11697,17 @@ struct NavigationProtocolTests {
                 isOfflineMapSelectionActive: true,
                 isDestinationSelectionActive: false
             ),
-            nil,
+            .none,
             "offline map selection should remain free to pan"
+        )
+        assertEqual(
+            MapTrackingPolicy.desiredMode(
+                isNavigating: true,
+                isOfflineMapSelectionActive: true,
+                isDestinationSelectionActive: false
+            ),
+            .none,
+            "offline map selection should override navigation heading-follow"
         )
         assertEqual(
             MapTrackingPolicy.desiredMode(
@@ -11706,7 +11715,7 @@ struct NavigationProtocolTests {
                 isOfflineMapSelectionActive: false,
                 isDestinationSelectionActive: true
             ),
-            nil,
+            .none,
             "a selected long-press destination should remain visible while GPS updates"
         )
     }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -518,6 +518,7 @@ struct NavigationProtocolTests {
         testDestinationPickerProtocol()
         testRouteInitialLocationUsesResolvedSource()
         testRouteTransportTypes()
+        testMapTrackingPolicy()
         testDeviceGPSPacketBuilder()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
@@ -11645,8 +11646,21 @@ struct NavigationProtocolTests {
         )
         engine.processExternalLocation(idleLocation)
 
-        assertEqual(manager.sentGPSPositions.count, 1, "idle GPS sync should still send position/time")
-        let packet = manager.sentGPSPositions[0]
+        let updatedIdleLocation = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.0001, longitude: -122.0001),
+            altitude: 43,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: 95,
+            speed: 6,
+            timestamp: Date()
+        )
+        engine.processExternalLocation(updatedIdleLocation)
+
+        assertEqual(manager.sentGPSPositions.count, 2, "every idle map location should update the device position")
+        let packet = manager.sentGPSPositions[1]
+        assertEqual(readInt32LE(packet, offset: 0), 37_000_100, "idle GPS update should use the latest latitude")
+        assertEqual(readInt32LE(packet, offset: 4), -122_000_100, "idle GPS update should use the latest longitude")
         assertEqual(readUInt16LE(packet, offset: 14),
                     DeviceGPSPacketBuilder.invalidSpeedCmps,
                     "idle GPS sync should omit speed telemetry")
@@ -11656,6 +11670,24 @@ struct NavigationProtocolTests {
         assertEqual(readUInt32LE(packet, offset: 26),
                     DeviceGPSPacketBuilder.invalidRouteRemainingMeters,
                     "idle GPS sync should omit route remaining telemetry")
+    }
+
+    static func testMapTrackingPolicy() {
+        assertEqual(
+            MapTrackingPolicy.desiredMode(isNavigating: false, isOfflineMapSelectionActive: false),
+            .follow,
+            "dot mode should follow the current location"
+        )
+        assertEqual(
+            MapTrackingPolicy.desiredMode(isNavigating: true, isOfflineMapSelectionActive: false),
+            .followWithHeading,
+            "navigation should follow the current location and heading"
+        )
+        assertEqual(
+            MapTrackingPolicy.desiredMode(isNavigating: false, isOfflineMapSelectionActive: true),
+            nil,
+            "offline map selection should remain free to pan"
+        )
     }
 
     static func testNavigationEngineIgnoresLiveLocationFarFromRouteStart() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -570,6 +570,7 @@ struct NavigationProtocolTests {
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
+        testNavigationEngineRestoresPhysicalGPSAfterSimulation()
         testNavigationEngineOmitsRideTelemetryWhenIdle()
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testNavigationEngineReplacesRouteWithoutResettingTelemetry()
@@ -11625,6 +11626,52 @@ struct NavigationProtocolTests {
         RunLoop.main.run(until: Date().addingTimeInterval(0.1))
 
         assertEqual(manager.sentRouteGeometry, [Data()], "idle readiness should clear route geometry")
+    }
+
+    static func testNavigationEngineRestoresPhysicalGPSAfterSimulation() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+
+        let initialPhysicalLocation = CLLocation(latitude: 37.1, longitude: -122.1)
+        engine.processExternalLocation(initialPhysicalLocation)
+        manager.sentGPSPositions.removeAll()
+
+        let route = TestRoute(
+            instructions: "Continue",
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 1.30, longitude: 103.80),
+                CLLocationCoordinate2D(latitude: 1.31, longitude: 103.81)
+            ]
+        )
+        engine.startNavigation(with: route, isTestMode: true)
+
+        let latestPhysicalLocation = CLLocation(latitude: 37.2, longitude: -122.2)
+        engine.processExternalLocation(latestPhysicalLocation)
+        assertEqual(
+            manager.sentGPSPositions.count,
+            0,
+            "physical GPS should be cached without overriding active simulation"
+        )
+
+        engine.stopNavigation()
+
+        assertEqual(
+            manager.sentGPSPositions.count,
+            1,
+            "stopping simulation should immediately restore the latest physical GPS"
+        )
+        guard let packet = manager.sentGPSPositions.first else { return }
+        assertEqual(readInt32LE(packet, offset: 0), 37_200_000, "restored GPS should use physical latitude")
+        assertEqual(readInt32LE(packet, offset: 4), -122_200_000, "restored GPS should use physical longitude")
+        assertEqual(
+            readUInt16LE(packet, offset: 14),
+            DeviceGPSPacketBuilder.invalidSpeedCmps,
+            "restored idle GPS should omit ride speed"
+        )
     }
 
     static func testNavigationEngineOmitsRideTelemetryWhenIdle() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -11707,7 +11707,7 @@ struct NavigationProtocolTests {
                 isDestinationSelectionActive: true
             ),
             nil,
-            "a pending long-press destination should remain visible while GPS updates"
+            "a selected long-press destination should remain visible while GPS updates"
         )
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -11674,19 +11674,40 @@ struct NavigationProtocolTests {
 
     static func testMapTrackingPolicy() {
         assertEqual(
-            MapTrackingPolicy.desiredMode(isNavigating: false, isOfflineMapSelectionActive: false),
+            MapTrackingPolicy.desiredMode(
+                isNavigating: false,
+                isOfflineMapSelectionActive: false,
+                isDestinationSelectionActive: false
+            ),
             .follow,
             "dot mode should follow the current location"
         )
         assertEqual(
-            MapTrackingPolicy.desiredMode(isNavigating: true, isOfflineMapSelectionActive: false),
+            MapTrackingPolicy.desiredMode(
+                isNavigating: true,
+                isOfflineMapSelectionActive: false,
+                isDestinationSelectionActive: false
+            ),
             .followWithHeading,
             "navigation should follow the current location and heading"
         )
         assertEqual(
-            MapTrackingPolicy.desiredMode(isNavigating: false, isOfflineMapSelectionActive: true),
+            MapTrackingPolicy.desiredMode(
+                isNavigating: false,
+                isOfflineMapSelectionActive: true,
+                isDestinationSelectionActive: false
+            ),
             nil,
             "offline map selection should remain free to pan"
+        )
+        assertEqual(
+            MapTrackingPolicy.desiredMode(
+                isNavigating: false,
+                isOfflineMapSelectionActive: false,
+                isDestinationSelectionActive: true
+            ),
+            nil,
+            "a pending long-press destination should remain visible while GPS updates"
         )
     }
 

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -28,6 +28,7 @@ xcrun swiftc \
   ios-app/BikeComputer/BikeComputer/Models/OfflineMapServiceConfig.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/DeviceCapabilityRetry.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
@@ -53,6 +54,7 @@ xcrun swiftc \
   -o "${CATALYST_OUT}" \
   ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
   ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
 


### PR DESCRIPTION
## Summary

- keep the iOS map centered on the live user location in non-navigation dot mode
- stream every accepted idle location update to the connected bike computer instead of throttling updates to once every ten minutes
- preserve navigation heading-follow behavior and allow free panning while selecting an offline map area or acting on a dropped destination pin

## Root cause

The iOS map only switched from heading-follow to ordinary follow when navigation ended; if tracking had already fallen back to `.none`, dot mode never re-enabled following. Separately, the idle BLE GPS path intentionally sent at most one position every ten minutes, leaving the device map stale outside navigation.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`

## Impact

Idle updates continue to omit ride-only speed, altitude, distance, elapsed-time, and route-remaining telemetry. No BLE protocol or firmware changes are required.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
