### PR TITLE
Omit unused Sharp from screenshot CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,9 +18,18 @@ jobs:
         with:
           bun-version: "1.3.11"
       - name: Install dependencies without lifecycle scripts
-        run: bun install --ignore-scripts --frozen-lockfile
+        run: bun install --ignore-scripts --frozen-lockfile --omit=optional
+      - name: Verify unused Sharp image optimizer is omitted
+        run: >-
+          test ! -e node_modules/sharp &&
+          ! find node_modules/@img -maxdepth 1 -name 'sharp*' -print -quit
+          2>/dev/null | grep -q .
       - name: Audit dependencies
-        run: bun audit
+        # Bun 1.3.11 audits optional entries in bun.lock even when they were
+        # omitted above. Ignore only Sharp's absent-package advisories.
+        run: >-
+          bun audit
+          --ignore GHSA-f88m-g3jw-g9cj
       - name: Unit tests
         run: bun test
       - name: Build generator
@@ -29,20 +38,20 @@ jobs:
           NEXT_TELEMETRY_DISABLED: "1"
       - name: Validate committed exports
         run: >-
-          bun x tsx scripts/validate-exports.ts
+          bun run scripts/validate-exports.ts
           --dir exports/app-store-screenshots/screenshots
           --allow 1242x2688
           --output /tmp/app-store-screenshots-validation.txt
           --json /tmp/app-store-screenshots-validation.json
       - name: Validate Apple Watch screenshot
         run: >-
-          bun x tsx scripts/validate-exports.ts
+          bun run scripts/validate-exports.ts
           --dir public/screenshots/watch
           --allow 416x496
           --output /tmp/apple-watch-screenshot-validation.txt
           --json /tmp/apple-watch-screenshot-validation.json
       - name: Verify committed release package provenance and ZIP
-        run: bun run verify:release
+        run: bun run scripts/release-package.ts
 
   esp32:
     name: ESP32 (${{ matrix.target }})

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -295,7 +295,7 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
             "tsx scripts/release-package.ts",
         )
         workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
-        self.assertIn("bun run verify:release", workflow)
+        self.assertIn("bun run scripts/release-package.ts", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- omit optional dependencies from the App Store screenshot CI install, keeping Next.js's unused Sharp optimizer out of `node_modules`
- explicitly verify that neither `sharp` nor its native `@img/sharp*` packages were installed
- run the TypeScript validators directly with Bun so they do not depend on omitted optional esbuild binaries
- keep auditing every installed dependency while excluding the Sharp advisory that Bun 1.3.11 still reads from the frozen lockfile
- update the iOS release-assets contract test to require the direct Bun provenance command used by CI

## Why

The screenshot generator uses ordinary `<img>` elements and does not use Next.js image optimization. Sharp is therefore unnecessary, but its newly disclosed libvips vulnerabilities were failing the repository CI audit.

## Validation

- Sharp and `@img/sharp*` absent after the frozen install
- `bun audit --ignore GHSA-f88m-g3jw-g9cj`
- `bun test` (4 tests)
- `bun run build`
- committed iPhone and Apple Watch export validation
- release screenshot provenance and ZIP integrity verification
