### PR TITLE
Run App Store screenshot tooling manually

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,53 +6,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  app-store-screenshots:
-    name: App Store Screenshots
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ios-app/AppStoreScreenshots
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: "1.3.11"
-      - name: Install dependencies without lifecycle scripts
-        run: bun install --ignore-scripts --frozen-lockfile --omit=optional
-      - name: Verify unused Sharp image optimizer is omitted
-        run: >-
-          test ! -e node_modules/sharp &&
-          ! find node_modules/@img -maxdepth 1 -name 'sharp*' -print -quit
-          2>/dev/null | grep -q .
-      - name: Audit dependencies
-        # Bun 1.3.11 audits optional entries in bun.lock even when they were
-        # omitted above. Ignore only Sharp's absent-package advisories.
-        run: >-
-          bun audit
-          --ignore GHSA-f88m-g3jw-g9cj
-      - name: Unit tests
-        run: bun test
-      - name: Build generator
-        run: bun run build
-        env:
-          NEXT_TELEMETRY_DISABLED: "1"
-      - name: Validate committed exports
-        run: >-
-          bun run scripts/validate-exports.ts
-          --dir exports/app-store-screenshots/screenshots
-          --allow 1242x2688
-          --output /tmp/app-store-screenshots-validation.txt
-          --json /tmp/app-store-screenshots-validation.json
-      - name: Validate Apple Watch screenshot
-        run: >-
-          bun run scripts/validate-exports.ts
-          --dir public/screenshots/watch
-          --allow 416x496
-          --output /tmp/apple-watch-screenshot-validation.txt
-          --json /tmp/apple-watch-screenshot-validation.json
-      - name: Verify committed release package provenance and ZIP
-        run: bun run scripts/release-package.ts
-
   esp32:
     name: ESP32 (${{ matrix.target }})
     runs-on: ubuntu-latest

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -284,7 +284,7 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
             ).read_text(),
         )
 
-    def test_screenshot_release_package_is_source_bound_in_ci(self):
+    def test_screenshot_release_package_is_available_for_manual_verification(self):
         screenshot_root = REPO_ROOT / "ios-app" / "AppStoreScreenshots"
         provenance = json.loads(
             (
@@ -311,7 +311,7 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
             "tsx scripts/release-package.ts",
         )
         workflow = (REPO_ROOT / ".github" / "workflows" / "ci.yml").read_text()
-        self.assertIn("bun run scripts/release-package.ts", workflow)
+        self.assertNotIn("app-store-screenshots:", workflow)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the App Store screenshot generator and export validation job from GitHub CI
- keep the local screenshot export, validation, and release-package commands available for manual use
- update the release-assets regression test to enforce that screenshot CI stays disabled

## Verification
- /usr/bin/python3 -m unittest scripts.tests.test_workout_release_assets -v (from ios-app)
- parsed .github/workflows/ci.yml with Ruby YAML
- git diff --check origin/main