### PR TITLE
Add a Start Ride Apple Watch complication

### DIFF
--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		57A006012F00000100000001 /* WorkoutWatchAvailabilityMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A006002F00000100000001 /* WorkoutWatchAvailabilityMonitor.swift */; };
 		57A006032F00000100000001 /* WatchHeartRateZoneSettingsReceiver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A006022F00000100000001 /* WatchHeartRateZoneSettingsReceiver.swift */; };
 		57A005012F00000100000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A005002F00000100000001 /* Assets.xcassets */; };
+		57A0070C2F00000100000001 /* BikeComputerWatchComplications.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 57A007012F00000100000001 /* BikeComputerWatchComplications.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		57A0070D2F00000100000001 /* WatchWorkoutLaunchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -30,6 +32,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 57A000072F00000100000001;
 			remoteInfo = BikeComputerWatch;
+		};
+		57A0070E2F00000100000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E6EF8F2EED853C00AE5F9B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57A007072F00000100000001;
+			remoteInfo = BikeComputerWatchComplications;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -43,6 +52,17 @@
 				57A0000C2F00000100000001 /* BikeComputerWatch.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57A0070B2F00000100000001 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				57A0070C2F00000100000001 /* BikeComputerWatchComplications.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -63,6 +83,8 @@
 		57A006002F00000100000001 /* WorkoutWatchAvailabilityMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WorkoutWatchAvailabilityMonitor.swift (Tests)"; path = BikeComputer/Managers/WorkoutWatchAvailabilityMonitor.swift; sourceTree = "<group>"; };
 		57A006022F00000100000001 /* WatchHeartRateZoneSettingsReceiver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WatchHeartRateZoneSettingsReceiver.swift (Tests)"; path = BikeComputerWatch/Managers/WatchHeartRateZoneSettingsReceiver.swift; sourceTree = "<group>"; };
 		57A005002F00000100000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = BikeComputer/Assets.xcassets; sourceTree = "<group>"; };
+		57A007012F00000100000001 /* BikeComputerWatchComplications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BikeComputerWatchComplications.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WatchWorkoutLaunchRequest.swift (Complication)"; path = WorkoutShared/WatchWorkoutLaunchRequest.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -80,6 +102,13 @@
 				Info.plist,
 			);
 			target = 57A000072F00000100000001 /* BikeComputerWatch */;
+		};
+		57A007032F00000100000001 /* Exceptions for "BikeComputerWatchComplications" folder in "BikeComputerWatchComplications" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 57A007072F00000100000001 /* BikeComputerWatchComplications */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -103,6 +132,14 @@
 		57A0000F2F00000100000001 /* WorkoutShared */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = WorkoutShared;
+			sourceTree = "<group>";
+		};
+		57A007022F00000100000001 /* BikeComputerWatchComplications */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				57A007032F00000100000001 /* Exceptions for "BikeComputerWatchComplications" folder in "BikeComputerWatchComplications" target */,
+			);
+			path = BikeComputerWatchComplications;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -136,6 +173,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A007052F00000100000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -144,7 +188,9 @@
 			children = (
 				83E6EF992EED853C00AE5F9B /* BikeComputer */,
 				57A000022F00000100000001 /* BikeComputerWatch */,
+				57A007022F00000100000001 /* BikeComputerWatchComplications */,
 				57A0000F2F00000100000001 /* WorkoutShared */,
+				57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */,
 				57A001002F00000100000001 /* WorkoutContractTests.swift */,
 				57A002002F00000100000001 /* WatchWorkoutRecoveryStore.swift */,
 				57A003002F00000100000001 /* WatchWorkoutManager.swift */,
@@ -165,6 +211,7 @@
 			children = (
 				83E6EF972EED853C00AE5F9B /* BikeComputer.app */,
 				57A000012F00000100000001 /* BikeComputerWatch.app */,
+				57A007012F00000100000001 /* BikeComputerWatchComplications.appex */,
 				57A001012F00000100000001 /* WorkoutContractiOSTests.xctest */,
 				57A001022F00000100000001 /* WorkoutContractWatchTests.xctest */,
 			);
@@ -207,10 +254,12 @@
 				57A000042F00000100000001 /* Sources */,
 				57A000052F00000100000001 /* Frameworks */,
 				57A000062F00000100000001 /* Resources */,
+				57A0070B2F00000100000001 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				57A0070F2F00000100000001 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				57A000022F00000100000001 /* BikeComputerWatch */,
@@ -222,6 +271,28 @@
 			productName = BikeComputerWatch;
 			productReference = 57A000012F00000100000001 /* BikeComputerWatch.app */;
 			productType = "com.apple.product-type.application";
+		};
+		57A007072F00000100000001 /* BikeComputerWatchComplications */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57A0070A2F00000100000001 /* Build configuration list for PBXNativeTarget "BikeComputerWatchComplications" */;
+			buildPhases = (
+				57A007042F00000100000001 /* Sources */,
+				57A007052F00000100000001 /* Frameworks */,
+				57A007062F00000100000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				57A007022F00000100000001 /* BikeComputerWatchComplications */,
+			);
+			name = BikeComputerWatchComplications;
+			packageProductDependencies = (
+			);
+			productName = BikeComputerWatchComplications;
+			productReference = 57A007012F00000100000001 /* BikeComputerWatchComplications.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		57A0010B2F00000100000001 /* WorkoutContractiOSTests */ = {
 			isa = PBXNativeTarget;
@@ -283,6 +354,9 @@
 					57A000072F00000100000001 = {
 						CreatedOnToolsVersion = 26.6;
 					};
+					57A007072F00000100000001 = {
+						CreatedOnToolsVersion = 26.1.1;
+					};
 					57A0010B2F00000100000001 = {
 						CreatedOnToolsVersion = 26.6;
 					};
@@ -307,6 +381,7 @@
 			targets = (
 				83E6EF962EED853C00AE5F9B /* BikeComputer */,
 				57A000072F00000100000001 /* BikeComputerWatch */,
+				57A007072F00000100000001 /* BikeComputerWatchComplications */,
 				57A0010B2F00000100000001 /* WorkoutContractiOSTests */,
 				57A0010C2F00000100000001 /* WorkoutContractWatchTests */,
 			);
@@ -337,6 +412,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		57A0010A2F00000100000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		57A007062F00000100000001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -386,6 +468,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A007042F00000100000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				57A0070D2F00000100000001 /* WatchWorkoutLaunchRequest.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -393,6 +483,11 @@
 			isa = PBXTargetDependency;
 			target = 57A000072F00000100000001 /* BikeComputerWatch */;
 			targetProxy = 57A0000D2F00000100000001 /* PBXContainerItemProxy */;
+		};
+		57A0070F2F00000100000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57A007072F00000100000001 /* BikeComputerWatchComplications */;
+			targetProxy = 57A0070E2F00000100000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -689,6 +784,69 @@
 			};
 			name = Release;
 		};
+		57A007082F00000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = 4H5PK8686H;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Start Ride";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp.complications;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Debug;
+		};
+		57A007092F00000100000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = 4H5PK8686H;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = "Start Ride";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp.complications;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "watchos watchsimulator";
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				VALIDATE_PRODUCT = YES;
+				WATCHOS_DEPLOYMENT_TARGET = 10.0;
+			};
+			name = Release;
+		};
 		57A0010D2F00000100000001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -791,6 +949,15 @@
 			buildConfigurations = (
 				57A000082F00000100000001 /* Debug */,
 				57A000092F00000100000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57A0070A2F00000100000001 /* Build configuration list for PBXNativeTarget "BikeComputerWatchComplications" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57A007082F00000100000001 /* Debug */,
+				57A007092F00000100000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios-app/BikeComputer/BikeComputerWatch/BikeComputerWatchApp.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/BikeComputerWatchApp.swift
@@ -7,6 +7,9 @@ struct BikeComputerWatchApp: App {
     var body: some Scene {
         WindowGroup {
             WatchWorkoutRootView(manager: appDelegate.workoutManager)
+                .onOpenURL { url in
+                    appDelegate.workoutManager.handleLaunchURL(url)
+                }
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Info.plist
+++ b/ios-app/BikeComputer/BikeComputerWatch/Info.plist
@@ -2,6 +2,17 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLName</key>
+			<string>LetItRide.BikeComputer.watchkitapp</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>bikecomputer</string>
+			</array>
+		</dict>
+	</array>
 	<key>WKApplication</key>
 	<true/>
 	<key>WKCompanionAppBundleIdentifier</key>

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -911,20 +911,42 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             return
         }
         guard complicationStartTask == nil,
-              !isRecovering,
-              !isRecoveryLoopRunning else {
+              canAdmitPendingComplicationStart else {
             return
         }
-        hasPendingComplicationStartRequest = false
         complicationStartTask = Task { [weak self] in
             guard let self else { return }
+            let admissionRecoveryGeneration = recoverySignalQueue.generation
+            defer {
+                if !isWorkoutActive,
+                   recoverySignalQueue.generation != admissionRecoveryGeneration {
+                    hasPendingComplicationStartRequest = true
+                }
+                complicationStartTask = nil
+                drainPendingComplicationStartIfPossible()
+            }
+            if isWorkoutActive {
+                hasPendingComplicationStartRequest = false
+                return
+            }
+            guard canAdmitPendingComplicationStart else { return }
+            hasPendingComplicationStartRequest = false
             if let injectedComplicationStartOperation {
                 await injectedComplicationStartOperation()
             } else {
                 await startOutdoorCyclingWorkout()
             }
-            complicationStartTask = nil
         }
+    }
+
+    private var canAdmitPendingComplicationStart: Bool {
+        !isRecovering
+            && !isRecoveryLoopRunning
+            && [.ready, .needsAuthorization].contains(setupState)
+            && session == nil
+            && !isAwaitingDetachedSessionCleanup
+            && !hasPendingWorkoutRecovery
+            && [.missing, .valid].contains(recoveryStore.loadState)
     }
 
     private func refreshAuthorizationState() async {
@@ -958,6 +980,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     }
 
     private func authorizeHealthKit() async {
+        defer { drainPendingComplicationStartIfPossible() }
         guard !isWorkoutActive else { return }
         guard HKHealthStore.isHealthDataAvailable() else {
             setupState = .unavailable
@@ -1964,6 +1987,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             isRecovering = false
         }
         drainPendingWorkoutConfigurationIfPossible()
+        drainPendingComplicationStartIfPossible()
     }
 
     private func attachRecoveredRouteBuilder(

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -336,6 +336,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         WatchRecoveredDiscardFinalizationAdapter?
     private let injectedWorkoutConfigurationHandler:
         (@MainActor (HKWorkoutConfiguration) -> Void)?
+    private let injectedComplicationStartOperation:
+        (@MainActor () async -> Void)?
     private let injectedRemotePauseOperation:
         (@MainActor (HKWorkoutSession) -> Void)?
     private let injectedRemoteResumeOperation:
@@ -358,6 +360,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var finalizationTask: Task<Void, Never>?
     private var mirrorRetryTask: Task<Void, Never>?
     private var mirrorShutdownWatchdogTask: Task<Void, Never>?
+    private var complicationStartTask: Task<Void, Never>?
     private var authoritativeFinalizationEndDate: Date?
     private var isBuilderReadyForFinalization = false
     private var isIdentityMetadataRetryPending = false
@@ -391,6 +394,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var isStartFailureMirrorDeliveryPending = false
     private var shutdownMirrorFailureRetryCount = 0
     private var pendingWorkoutConfiguration: HKWorkoutConfiguration?
+    private var hasPendingComplicationStartRequest = false
     private var pendingTerminalErrorPersistence: (
         code: WorkoutSafeErrorCodeV1,
         endDate: Date
@@ -434,6 +438,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             finalizationClaimObserver: nil,
             recoveredDiscardFinalizationAdapter: nil,
             workoutConfigurationHandler: nil,
+            complicationStartOperation: nil,
             remotePauseOperation: nil,
             remoteResumeOperation: nil,
             mirrorStartOperation: nil,
@@ -483,6 +488,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             WatchRecoveredDiscardFinalizationAdapter? = nil,
         workoutConfigurationHandler:
             (@MainActor (HKWorkoutConfiguration) -> Void)? = nil,
+        complicationStartOperation:
+            (@MainActor () async -> Void)? = nil,
         remotePauseOperation:
             (@MainActor (HKWorkoutSession) -> Void)? = nil,
         remoteResumeOperation:
@@ -516,6 +523,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         self.injectedRecoveredDiscardFinalizationAdapter =
             recoveredDiscardFinalizationAdapter
         self.injectedWorkoutConfigurationHandler = workoutConfigurationHandler
+        self.injectedComplicationStartOperation = complicationStartOperation
         self.injectedRemotePauseOperation = remotePauseOperation
         self.injectedRemoteResumeOperation = remoteResumeOperation
         self.injectedMirrorStartOperation = mirrorStartOperation
@@ -558,6 +566,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         finalizationTask?.cancel()
         mirrorRetryTask?.cancel()
         mirrorShutdownWatchdogTask?.cancel()
+        complicationStartTask?.cancel()
     }
 
     var state: WorkoutSessionStateV1 { lifecycle.state }
@@ -630,6 +639,15 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             hasAttachedSession: session != nil
         ) else { return }
         startRecoveryLoopIfNeeded()
+    }
+
+    func handleLaunchURL(_ url: URL) {
+        guard WatchWorkoutLaunchRequest(url: url) == .startOutdoorCycling,
+              complicationStartTask == nil else {
+            return
+        }
+        hasPendingComplicationStartRequest = true
+        drainPendingComplicationStartIfPossible()
     }
 
     func startOutdoorCycling() {
@@ -799,6 +817,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             startRecoveryLoopIfNeeded()
         }
         drainPendingWorkoutConfigurationIfPossible()
+        drainPendingComplicationStartIfPossible()
     }
 
     private func initialize() async {
@@ -806,6 +825,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         defer {
             isRecoveryLoopRunning = false
             drainPendingWorkoutConfigurationIfPossible()
+            drainPendingComplicationStartIfPossible()
         }
         guard HKHealthStore.isHealthDataAvailable() else {
             setupState = .unavailable
@@ -881,6 +901,29 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             await self?.startOutdoorCyclingWorkout(
                 configuration: configuration
             )
+        }
+    }
+
+    private func drainPendingComplicationStartIfPossible() {
+        guard hasPendingComplicationStartRequest else { return }
+        if isWorkoutActive {
+            hasPendingComplicationStartRequest = false
+            return
+        }
+        guard complicationStartTask == nil,
+              !isRecovering,
+              !isRecoveryLoopRunning else {
+            return
+        }
+        hasPendingComplicationStartRequest = false
+        complicationStartTask = Task { [weak self] in
+            guard let self else { return }
+            if let injectedComplicationStartOperation {
+                await injectedComplicationStartOperation()
+            } else {
+                await startOutdoorCyclingWorkout()
+            }
+            complicationStartTask = nil
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import WidgetKit
+
+private struct StartRideEntry: TimelineEntry {
+    let date: Date
+}
+
+private struct StartRideProvider: TimelineProvider {
+    func placeholder(in context: Context) -> StartRideEntry {
+        StartRideEntry(date: Date())
+    }
+
+    func getSnapshot(
+        in context: Context,
+        completion: @escaping (StartRideEntry) -> Void
+    ) {
+        completion(StartRideEntry(date: Date()))
+    }
+
+    func getTimeline(
+        in context: Context,
+        completion: @escaping (Timeline<StartRideEntry>) -> Void
+    ) {
+        completion(
+            Timeline(
+                entries: [StartRideEntry(date: Date())],
+                policy: .never
+            )
+        )
+    }
+}
+
+private struct StartRideComplicationView: View {
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        Group {
+            switch family {
+            case .accessoryCircular:
+                ZStack {
+                    AccessoryWidgetBackground()
+                    Image(systemName: "bicycle")
+                        .font(.title2)
+                        .widgetAccentable()
+                }
+            case .accessoryRectangular:
+                HStack(spacing: 8) {
+                    Image(systemName: "bicycle")
+                        .font(.title2)
+                        .widgetAccentable()
+                    VStack(alignment: .leading, spacing: 1) {
+                        Text("BikeComputer")
+                            .font(.headline)
+                        Text("Start Ride")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            case .accessoryInline:
+                Label("Start Ride", systemImage: "bicycle")
+            case .accessoryCorner:
+                Image(systemName: "bicycle")
+                    .widgetAccentable()
+                    .widgetLabel {
+                        Text("Start Ride")
+                    }
+            default:
+                Image(systemName: "bicycle")
+            }
+        }
+        .containerBackground(for: .widget) {
+            Color.clear
+        }
+        .widgetURL(WatchWorkoutLaunchRequest.startOutdoorCyclingURL)
+        .accessibilityLabel("Start a BikeComputer ride")
+    }
+}
+
+private struct StartRideComplication: Widget {
+    let kind = "StartRideComplication"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: StartRideProvider()) { _ in
+            StartRideComplicationView()
+        }
+        .configurationDisplayName("Start Ride")
+        .description("Start an outdoor cycling workout in BikeComputer.")
+        .supportedFamilies([
+            .accessoryCircular,
+            .accessoryRectangular,
+            .accessoryInline,
+            .accessoryCorner,
+        ])
+    }
+}
+
+@main
+struct BikeComputerWatchComplications: WidgetBundle {
+    var body: some Widget {
+        StartRideComplication()
+    }
+}

--- a/ios-app/BikeComputer/BikeComputerWatchComplications/Info.plist
+++ b/ios-app/BikeComputer/BikeComputerWatchComplications/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -212,9 +212,14 @@ final class WatchWorkoutManagerTests: XCTestCase {
             recoveryStore: WatchWorkoutRecoveryStore(
                 persistence: ToggleRecoveryPersistence()
             ),
+            requestAuthorization: {},
+            refreshAuthorization: {},
+            authorizationRefreshState: .ready,
             complicationStartOperation: { await start.run() },
             initializeOnLaunch: false
         )
+        manager.requestAuthorization()
+        try await waitUntil { manager.setupState == .ready }
 
         manager.handleLaunchURL(
             URL(string: "bikecomputer://workout/summary")!
@@ -232,6 +237,179 @@ final class WatchWorkoutManagerTests: XCTestCase {
         start.complete()
         await Task.yield()
         XCTAssertEqual(start.callCount, 1)
+    }
+
+    func testComplicationStartWaitsForSuccessfulRecoveryRetry() async throws {
+        let recovery = RecoveryProbe()
+        var startCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            recoverActiveWorkoutSession: { await recovery.run() },
+            refreshAuthorization: {},
+            authorizationRefreshState: .ready,
+            complicationStartOperation: { startCount += 1 },
+            initializeOnLaunch: true
+        )
+        try await waitUntil { recovery.callCount == 1 }
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        recovery.completeWithError()
+        try await waitUntil {
+            manager.setupState == .failed && !manager.isRecovering
+        }
+        await Task.yield()
+        XCTAssertEqual(startCount, 0)
+
+        manager.retrySetup()
+        try await waitUntil { recovery.callCount == 2 }
+        recovery.completeWithoutSession()
+        try await waitUntil { startCount == 1 }
+    }
+
+    func testComplicationStartRequestsRequiredHealthAuthorization() async throws {
+        let recovery = RecoveryProbe()
+        var authorizationRequestCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            recoverActiveWorkoutSession: { await recovery.run() },
+            requestAuthorization: { authorizationRequestCount += 1 },
+            refreshAuthorization: {},
+            authorizationRefreshState: .needsAuthorization,
+            initializeOnLaunch: true
+        )
+        try await waitUntil { recovery.callCount == 1 }
+        recovery.completeWithoutSession()
+        try await waitUntil {
+            manager.setupState == .needsAuthorization
+                && !manager.isRecovering
+        }
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+
+        try await waitUntil { authorizationRequestCount == 1 }
+        XCTAssertEqual(manager.setupState, .needsAuthorization)
+    }
+
+    func testComplicationStartRequeuesIfRecoveryBeginsBeforeTaskRuns() async throws {
+        let recovery = RecoveryProbe()
+        var startCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            recoverActiveWorkoutSession: { await recovery.run() },
+            refreshAuthorization: {},
+            authorizationRefreshState: .ready,
+            complicationStartOperation: { startCount += 1 },
+            initializeOnLaunch: true
+        )
+        try await waitUntil { recovery.callCount == 1 }
+        recovery.completeWithoutSession()
+        try await waitUntil {
+            manager.setupState == .ready && !manager.isRecovering
+        }
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        manager.handleActiveWorkoutRecovery()
+        try await waitUntil { recovery.callCount == 2 }
+        await Task.yield()
+        XCTAssertEqual(startCount, 0)
+
+        recovery.completeWithoutSession()
+        try await waitUntil { startCount == 1 }
+    }
+
+    func testComplicationStartRequeuesIfRecoveryBeginsDuringAuthorization() async throws {
+        let recovery = RecoveryProbe()
+        let authorization = AsyncThrowingVoidProbe()
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            recoverActiveWorkoutSession: { await recovery.run() },
+            requestAuthorization: { try await authorization.run() },
+            refreshAuthorization: {},
+            authorizationRefreshState: .needsAuthorization,
+            initializeOnLaunch: true
+        )
+        try await waitUntil { recovery.callCount == 1 }
+        recovery.completeWithoutSession()
+        try await waitUntil {
+            manager.setupState == .needsAuthorization
+                && !manager.isRecovering
+        }
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        try await waitUntil { authorization.callCount == 1 }
+        manager.handleActiveWorkoutRecovery()
+        try await waitUntil { recovery.callCount == 2 }
+
+        authorization.complete()
+        recovery.completeWithoutSession()
+        try await waitUntil { authorization.callCount == 2 }
+        authorization.complete()
+    }
+
+    func testComplicationStartStaysBlockedForUnsafeRecoveryStores() async throws {
+        let corruptPersistence = ToggleRecoveryPersistence()
+        corruptPersistence.data = Data([0x00, 0x01, 0x02])
+        var corruptStartCount = 0
+        let corruptManager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: corruptPersistence
+            ),
+            complicationStartOperation: { corruptStartCount += 1 },
+            initializeOnLaunch: true
+        )
+        try await waitUntil { corruptManager.setupState == .failed }
+        corruptManager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        await Task.yield()
+        XCTAssertEqual(corruptStartCount, 0)
+        XCTAssertTrue(corruptManager.hasCorruptRecoveryState)
+
+        let unavailablePersistence = ToggleRecoveryPersistence()
+        unavailablePersistence.failsLoad = true
+        var unavailableStartCount = 0
+        let unavailableManager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: unavailablePersistence
+            ),
+            complicationStartOperation: { unavailableStartCount += 1 },
+            initializeOnLaunch: true
+        )
+        try await waitUntil { unavailableManager.setupState == .failed }
+        unavailableManager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        await Task.yield()
+        XCTAssertEqual(unavailableStartCount, 0)
+        XCTAssertTrue(unavailableManager.hasUnavailableRecoveryState)
     }
 
     func testProductionMirrorStartRetryAndBackpressure() async throws {
@@ -6200,6 +6378,51 @@ final class WatchWorkoutManagerTests: XCTestCase {
 
         XCTAssertEqual(deliveredConfigurations.count, 1)
         XCTAssertTrue(deliveredConfigurations[0] === queuedConfiguration)
+        XCTAssertFalse(manager.hasAttachedSessionForTesting)
+    }
+
+    func testQueuedComplicationStartDrainsAfterRecoveredTombstoneCleanup() async throws {
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let terminalIdentity = try archiveSavedIdentity(in: recoveryStore)
+        let healthStore = HKHealthStore()
+        let sessionConfiguration = HKWorkoutConfiguration()
+        sessionConfiguration.activityType = .cycling
+        sessionConfiguration.locationType = .outdoor
+        let recoveredSession = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: sessionConfiguration
+        )
+        let recoveredBuilder = recoveredSession.associatedWorkoutBuilder()
+        var startCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            recoveredSaveRuntimeAdapter: WatchRecoveredSaveRuntimeAdapter(
+                session: recoveredSession,
+                builder: recoveredBuilder,
+                sessionState: { .running }
+            ),
+            complicationStartOperation: { startCount += 1 },
+            initializeOnLaunch: false
+        )
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        await Task.yield()
+        XCTAssertEqual(startCount, 0)
+
+        manager.completeTerminalTombstoneSessionCleanup(
+            recoveredSession,
+            builder: recoveredBuilder,
+            sessionID: terminalIdentity.sessionID,
+            disposition: .save
+        )
+
+        try await waitUntil { startCount == 1 }
         XCTAssertFalse(manager.hasAttachedSessionForTesting)
     }
 

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -176,6 +176,64 @@ final class WatchWorkoutManagerTests: XCTestCase {
         XCTAssertFalse(manager.isRecovering)
     }
 
+    func testComplicationStartWaitsForColdLaunchRecovery() async throws {
+        let recovery = RecoveryProbe()
+        var startCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            recoverActiveWorkoutSession: { await recovery.run() },
+            refreshAuthorization: {},
+            authorizationRefreshState: .ready,
+            complicationStartOperation: { startCount += 1 },
+            initializeOnLaunch: true
+        )
+        try await waitUntil { recovery.callCount == 1 }
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        await Task.yield()
+        XCTAssertEqual(startCount, 0)
+
+        recovery.completeWithoutSession()
+        try await waitUntil { startCount == 1 }
+        XCTAssertFalse(manager.isRecovering)
+    }
+
+    func testComplicationStartIgnoresUnknownAndDuplicateURLs() async throws {
+        let start = AsyncVoidProbe()
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            complicationStartOperation: { await start.run() },
+            initializeOnLaunch: false
+        )
+
+        manager.handleLaunchURL(
+            URL(string: "bikecomputer://workout/summary")!
+        )
+        await Task.yield()
+        XCTAssertEqual(start.callCount, 0)
+
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        manager.handleLaunchURL(
+            WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+        )
+        try await waitUntil { start.callCount == 1 }
+        start.complete()
+        await Task.yield()
+        XCTAssertEqual(start.callCount, 1)
+    }
+
     func testProductionMirrorStartRetryAndBackpressure() async throws {
         let probe = WatchMirrorTransportProbe()
         let runtime = try makeMirrorRuntime(probe: probe)

--- a/ios-app/BikeComputer/WorkoutShared/WatchWorkoutLaunchRequest.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WatchWorkoutLaunchRequest.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+nonisolated enum WatchWorkoutLaunchRequest: Equatable, Sendable {
+    case startOutdoorCycling
+
+    static let startOutdoorCyclingURL: URL = {
+        guard let url = URL(string: "bikecomputer://workout/start") else {
+            preconditionFailure("The bundled workout launch URL must be valid")
+        }
+        return url
+    }()
+
+    init?(url: URL) {
+        guard url.scheme?.lowercased() == "bikecomputer",
+              url.host?.lowercased() == "workout",
+              url.path == "/start" else {
+            return nil
+        }
+        self = .startOutdoorCycling
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -128,6 +128,7 @@ private struct WorkoutContractTestSuite {
         testWorkoutUICompositionRetainsPhaseThreeExitCriteria()
         testMainRideControlsComposition()
         testWorkoutFormattingKeepsUnavailableValuesDistinctFromZero()
+        testWatchWorkoutLaunchRequest()
     }
 
     private mutating func expect(
@@ -5263,6 +5264,27 @@ private struct WorkoutContractTestSuite {
         _ source: WorkoutMetricSourceV1? = nil
     ) -> WorkoutMetricV1 {
         WorkoutMetricV1(value: value, unit: unit, capturedAt: date, source: source)
+    }
+
+    private mutating func testWatchWorkoutLaunchRequest() {
+        expect(
+            WatchWorkoutLaunchRequest(
+                url: WatchWorkoutLaunchRequest.startOutdoorCyclingURL
+            ) == .startOutdoorCycling,
+            "the complication URL must resolve to a start-workout request"
+        )
+        expect(
+            WatchWorkoutLaunchRequest(
+                url: URL(string: "bikecomputer://workout/summary")!
+            ) == nil,
+            "unknown BikeComputer paths must not start a workout"
+        )
+        expect(
+            WatchWorkoutLaunchRequest(
+                url: URL(string: "https://workout/start")!
+            ) == nil,
+            "foreign URL schemes must not start a workout"
+        )
     }
 
     private func makeEnvelope(

--- a/ios-app/scripts/run-workout-contract-tests.sh
+++ b/ios-app/scripts/run-workout-contract-tests.sh
@@ -21,6 +21,7 @@ xcrun swiftc \
   ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutWatchAvailability.swift \
+  ios-app/BikeComputer/WorkoutShared/WatchWorkoutLaunchRequest.swift \
   ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift \
   ios-app/BikeComputerTests/WorkoutContractTests.swift
 

--- a/ios-app/scripts/tests/test_verify_release_container.py
+++ b/ios-app/scripts/tests/test_verify_release_container.py
@@ -15,9 +15,16 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
     def make_fixture(self, root: Path) -> Path:
         app = root / "BikeComputer.app"
         watch = app / "Watch" / "BikeComputerWatch.app"
+        complication = watch / "PlugIns" / "BikeComputerWatchComplications.appex"
         watch.mkdir(parents=True)
+        complication.mkdir(parents=True)
 
-        for path in [app / "BikeComputer", watch / "BikeComputerWatch", watch / "Assets.car"]:
+        for path in [
+            app / "BikeComputer",
+            watch / "BikeComputerWatch",
+            watch / "Assets.car",
+            complication / "BikeComputerWatchComplications",
+        ]:
             path.write_bytes(b"fixture")
 
         shutil.copyfile(
@@ -34,9 +41,25 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             plistlib.dump(
                 {
                     "CFBundleIdentifier": "LetItRide.BikeComputer.watchkitapp",
+                    "CFBundleURLTypes": [
+                        {"CFBundleURLSchemes": ["another-scheme"]},
+                        {"CFBundleURLSchemes": ["bikecomputer"]},
+                    ],
                     "WKBackgroundModes": ["workout-processing"],
                     "CFBundleIcons": {
                         "CFBundlePrimaryIcon": {"CFBundleIconName": "AppIcon"}
+                    },
+                },
+                handle,
+            )
+        with (complication / "Info.plist").open("wb") as handle:
+            plistlib.dump(
+                {
+                    "CFBundleIdentifier": (
+                        "LetItRide.BikeComputer.watchkitapp.complications"
+                    ),
+                    "NSExtension": {
+                        "NSExtensionPointIdentifier": "com.apple.widgetkit-extension"
                     },
                 },
                 handle,
@@ -64,6 +87,34 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             with watch_info.open("rb") as handle:
                 payload = plistlib.load(handle)
             del payload["CFBundleIcons"]
+            with watch_info.open("wb") as handle:
+                plistlib.dump(payload, handle)
+
+            result = self.run_verifier(app)
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_watch_bundle_without_complication_extension(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            app = self.make_fixture(Path(temporary))
+            complication = (
+                app
+                / "Watch"
+                / "BikeComputerWatch.app"
+                / "PlugIns"
+                / "BikeComputerWatchComplications.appex"
+            )
+            shutil.rmtree(complication)
+
+            result = self.run_verifier(app)
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_watch_bundle_without_complication_url_scheme(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            app = self.make_fixture(Path(temporary))
+            watch_info = app / "Watch" / "BikeComputerWatch.app" / "Info.plist"
+            with watch_info.open("rb") as handle:
+                payload = plistlib.load(handle)
+            del payload["CFBundleURLTypes"]
             with watch_info.open("wb") as handle:
                 plistlib.dump(payload, handle)
 

--- a/ios-app/scripts/verify-release-container.sh
+++ b/ios-app/scripts/verify-release-container.sh
@@ -8,6 +8,7 @@ fi
 
 APP_PATH="${1%/}"
 WATCH_PATH="${APP_PATH}/Watch/BikeComputerWatch.app"
+COMPLICATION_PATH="${WATCH_PATH}/PlugIns/BikeComputerWatchComplications.appex"
 SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 require_file() {
@@ -17,6 +18,45 @@ require_file() {
   fi
 }
 
+require_plist_value() {
+  local plist_path="$1"
+  local key_path="$2"
+  local expected="$3"
+  local actual
+  if ! actual="$(/usr/libexec/PlistBuddy -c "Print ${key_path}" "${plist_path}")"; then
+    echo "missing release-container plist value: ${plist_path} ${key_path}" >&2
+    exit 1
+  fi
+  if [[ "${actual}" != "${expected}" ]]; then
+    echo "invalid release-container plist value: ${plist_path} ${key_path}=${actual}" >&2
+    exit 1
+  fi
+}
+
+require_url_scheme() {
+  local plist_path="$1"
+  local expected="$2"
+  local url_type_index=0
+  local scheme_index
+  local actual
+  while /usr/libexec/PlistBuddy \
+    -c "Print :CFBundleURLTypes:${url_type_index}" \
+    "${plist_path}" >/dev/null 2>&1; do
+    scheme_index=0
+    while actual="$(/usr/libexec/PlistBuddy \
+      -c "Print :CFBundleURLTypes:${url_type_index}:CFBundleURLSchemes:${scheme_index}" \
+      "${plist_path}" 2>/dev/null)"; do
+      if [[ "${actual}" == "${expected}" ]]; then
+        return
+      fi
+      ((scheme_index += 1))
+    done
+    ((url_type_index += 1))
+  done
+  echo "missing release-container URL scheme: ${plist_path} ${expected}" >&2
+  exit 1
+}
+
 require_file "${APP_PATH}/Info.plist"
 require_file "${APP_PATH}/BikeComputer"
 require_file "${APP_PATH}/PrivacyInfo.xcprivacy"
@@ -24,20 +64,38 @@ require_file "${WATCH_PATH}/Info.plist"
 require_file "${WATCH_PATH}/BikeComputerWatch"
 require_file "${WATCH_PATH}/PrivacyInfo.xcprivacy"
 require_file "${WATCH_PATH}/Assets.car"
+require_file "${COMPLICATION_PATH}/Info.plist"
+require_file "${COMPLICATION_PATH}/BikeComputerWatchComplications"
 
 cmp "${SOURCE_ROOT}/BikeComputer/BikeComputer/PrivacyInfo.xcprivacy" \
   "${APP_PATH}/PrivacyInfo.xcprivacy"
 cmp "${SOURCE_ROOT}/BikeComputer/BikeComputerWatch/PrivacyInfo.xcprivacy" \
   "${WATCH_PATH}/PrivacyInfo.xcprivacy"
 
-[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${APP_PATH}/Info.plist")" \
-  == "LetItRide.BikeComputer" ]]
-[[ "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleIdentifier' "${WATCH_PATH}/Info.plist")" \
-  == "LetItRide.BikeComputer.watchkitapp" ]]
+require_plist_value \
+  "${APP_PATH}/Info.plist" \
+  ":CFBundleIdentifier" \
+  "LetItRide.BikeComputer"
+require_plist_value \
+  "${WATCH_PATH}/Info.plist" \
+  ":CFBundleIdentifier" \
+  "LetItRide.BikeComputer.watchkitapp"
+require_plist_value \
+  "${COMPLICATION_PATH}/Info.plist" \
+  ":CFBundleIdentifier" \
+  "LetItRide.BikeComputer.watchkitapp.complications"
+require_plist_value \
+  "${COMPLICATION_PATH}/Info.plist" \
+  ":NSExtension:NSExtensionPointIdentifier" \
+  "com.apple.widgetkit-extension"
+require_url_scheme "${WATCH_PATH}/Info.plist" "bikecomputer"
 WATCH_BACKGROUND_MODES="$(
   /usr/libexec/PlistBuddy -c 'Print :WKBackgroundModes' "${WATCH_PATH}/Info.plist"
 )"
-[[ "${WATCH_BACKGROUND_MODES}" == *"workout-processing"* ]]
+if [[ "${WATCH_BACKGROUND_MODES}" != *"workout-processing"* ]]; then
+  echo "invalid Watch background modes: ${WATCH_BACKGROUND_MODES}" >&2
+  exit 1
+fi
 WATCH_PRIMARY_ICON="$(
   /usr/libexec/PlistBuddy \
     -c 'Print :CFBundleIcons:CFBundlePrimaryIcon:CFBundleIconName' \
@@ -48,4 +106,4 @@ if [[ "${WATCH_PRIMARY_ICON}" != "AppIcon" ]]; then
   exit 1
 fi
 
-echo "Release iPhone container and embedded Watch app verified"
+echo "Release iPhone container, Watch app, and complication extension verified"


### PR DESCRIPTION
## Summary

- add a watchOS WidgetKit extension with circular, rectangular, inline, and corner Start Ride complications
- deep-link complication taps into the existing BikeComputer outdoor-cycling workout flow
- defer taps until recovery and safe workout admission complete, including recovery races during HealthKit authorization
- embed and validate the complication extension inside the existing Watch app

## Why

The BikeComputer Watch app was installable and launchable, but it had no complication provider, so it could not be selected on the Modular watch face. This adds the missing complication surface and makes a tap start a ride immediately after the Watch app becomes active.

Health authorization, active-workout recovery, durable recovery state, and existing lifecycle failure handling remain authoritative. If setup is incomplete or recovery state is unsafe, the app keeps the tap pending or shows the existing setup/error state instead of bypassing those gates.

## Validation

- `cd ios-app && ./scripts/run-navigation-tests.sh`
- watchOS simulator suite: 101 tests passed
- portable workout contract tests passed
- iOS workout platform tests passed
- release-container verifier tests: 11 passed
- generic iOS Release build with signing disabled and embedded-binary validation passed
- verified the built bundle contains `BikeComputerWatch.app/PlugIns/BikeComputerWatchComplications.appex`, the WidgetKit extension point, and the `bikecomputer` Watch URL scheme
- deep review loop: no remaining P0-P2 findings

Physical watch-face selection, tap delivery, and real HealthKit startup still need a signed install on a paired Watch.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
