### PR TITLE
Add Settings screen to Apple Watch app

### DIFF
--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchSettingsView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct WatchSettingsView: View {
+    var body: some View {
+        Form {
+            Section("About") {
+                LabeledContent("Version", value: versionDescription)
+            }
+        }
+        .navigationTitle("Settings")
+    }
+
+    private var versionDescription: String {
+        let version = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String
+        let build = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String
+
+        return switch (version, build) {
+        case let (.some(version), .some(build)):
+            "\(version) (\(build))"
+        case let (.some(version), .none):
+            version
+        case let (.none, .some(build)):
+            build
+        case (.none, .none):
+            "Unknown"
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        WatchSettingsView()
+    }
+}

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
@@ -23,7 +23,9 @@ struct WatchWorkoutRootView: View {
             } else if manager.state.isActive {
                 LiveWorkoutView(manager: manager)
             } else {
-                WorkoutStartView(manager: manager)
+                NavigationStack {
+                    WorkoutStartView(manager: manager)
+                }
             }
         }
     }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
@@ -35,8 +35,13 @@ struct WorkoutStartView: View {
                     .buttonStyle(.borderless)
                 }
 
-                Link("Privacy Policy", destination: AppPrivacyPolicy.url)
-                    .font(.caption2)
+                NavigationLink {
+                    WatchSettingsView()
+                } label: {
+                    Image(systemName: "gearshape")
+                        .accessibilityLabel("Settings")
+                }
+                .buttonStyle(.borderless)
             }
             .padding(.horizontal, 8)
         }

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -108,12 +108,6 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
         ios_settings = (
             IOS_PROJECT / "BikeComputer" / "Views" / "SettingsView.swift"
         ).read_text()
-        watch_start = (
-            IOS_PROJECT
-            / "BikeComputerWatch"
-            / "Views"
-            / "WorkoutStartView.swift"
-        ).read_text()
         public_policy = (REPO_ROOT / "PRIVACY_POLICY.md").read_text()
         normalized_policy = " ".join(public_policy.split())
         disclosures = (
@@ -122,13 +116,41 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
 
         self.assertIn(PRIVACY_POLICY_URL, shared_policy)
         self.assertIn("AppPrivacyPolicy.url", ios_settings)
-        self.assertIn("AppPrivacyPolicy.url", watch_start)
         self.assertIn("same or equivalent privacy protection", normalized_policy)
         self.assertIn("30 days after a map job becomes ready", normalized_policy)
         self.assertIn("renaming or downloading a map does not extend", normalized_policy)
         self.assertIn("scheduled maintenance process", normalized_policy)
         self.assertIn("until you request its deletion", normalized_policy)
         self.assertIn(PRIVACY_POLICY_URL, disclosures)
+
+    def test_watch_settings_exposes_the_installed_app_version(self):
+        watch_root = (
+            IOS_PROJECT
+            / "BikeComputerWatch"
+            / "Views"
+            / "WatchWorkoutRootView.swift"
+        ).read_text()
+        watch_start = (
+            IOS_PROJECT
+            / "BikeComputerWatch"
+            / "Views"
+            / "WorkoutStartView.swift"
+        ).read_text()
+        watch_settings = (
+            IOS_PROJECT
+            / "BikeComputerWatch"
+            / "Views"
+            / "WatchSettingsView.swift"
+        ).read_text()
+
+        self.assertIn("NavigationStack", watch_root)
+        self.assertIn("WatchSettingsView()", watch_start)
+        self.assertIn('Image(systemName: "gearshape")', watch_start)
+        self.assertIn('accessibilityLabel("Settings")', watch_start)
+        self.assertNotIn("AppPrivacyPolicy.url", watch_start)
+        self.assertIn('LabeledContent("Version"', watch_settings)
+        self.assertIn('"CFBundleShortVersionString"', watch_settings)
+        self.assertIn('"CFBundleVersion"', watch_settings)
 
     def test_permission_copy_and_entitlements_match_workout_ownership(self):
         ios_info = load_plist(IOS_PROJECT / "BikeComputer" / "Info.plist")


### PR DESCRIPTION
## Summary
- replace the Watch start-screen privacy link with a settings gear
- add native push navigation to a Watch Settings screen
- show the installed app version and build number from the Watch bundle

## Verification
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputerWatch -destination "generic/platform=watchOS" -derivedDataPath /private/tmp/open-bike-watch-settings-build CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild test -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme WorkoutContractWatchTests -destination "platform=watchOS Simulator,id=F381E5F7-A766-4477-BCB7-3E2D5513ED8C" -derivedDataPath /private/tmp/open-bike-watch-settings-tests` (101 tests)
- built Watch bundle reports version `1.1` and build `7`