### PR TITLE
Fix Watch discard confirmation

### DIFF
--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -150,7 +150,7 @@ struct LiveWorkoutView: View {
             .padding(.horizontal, 6)
         }
         .confirmationDialog(
-            "Finish this ride?",
+            "Finish Ride?",
             isPresented: finishOptionsPresented
         ) {
             if case .options(let sessionID) = finishPrompt {
@@ -167,34 +167,33 @@ struct LiveWorkoutView: View {
                 }
             }
         } message: {
-            Text("Saving creates one workout in Health. Discarding saves nothing.")
+            Text("Saving creates a workout in your Fitness app.")
         }
         .alert(
             WorkoutDiscardDisclosureV1.title,
-            isPresented: discardConfirmationPresented
-        ) {
-            if case .discardConfirmation(let sessionID) = finishPrompt {
-                Button(WorkoutDiscardDisclosureV1.cancelTitle, role: .cancel) {
-                    WorkoutDiscardDisclosureV1.perform(
-                        .cancel,
-                        expectedSessionID: sessionID,
-                        currentSessionID: manager.activeSessionID,
-                        discard: manager.discard
-                    )
-                }
-                Button(
-                    WorkoutDiscardDisclosureV1.confirmTitle,
-                    role: .destructive
-                ) {
-                    WorkoutDiscardDisclosureV1.perform(
-                        .confirmDiscard,
-                        expectedSessionID: sessionID,
-                        currentSessionID: manager.activeSessionID,
-                        discard: manager.discard
-                    )
-                }
+            isPresented: discardConfirmationPresented,
+            presenting: discardConfirmationSessionID
+        ) { sessionID in
+            Button(WorkoutDiscardDisclosureV1.cancelTitle, role: .cancel) {
+                WorkoutDiscardDisclosureV1.perform(
+                    .cancel,
+                    expectedSessionID: sessionID,
+                    currentSessionID: manager.activeSessionID,
+                    discard: manager.discard
+                )
             }
-        } message: {
+            Button(
+                WorkoutDiscardDisclosureV1.confirmTitle,
+                role: .destructive
+            ) {
+                WorkoutDiscardDisclosureV1.perform(
+                    .confirmDiscard,
+                    expectedSessionID: sessionID,
+                    currentSessionID: manager.activeSessionID,
+                    discard: manager.discard
+                )
+            }
+        } message: { _ in
             Text(WorkoutDiscardDisclosureV1.message)
         }
         .onChange(of: manager.activeSessionID) {
@@ -223,6 +222,13 @@ struct LiveWorkoutView: View {
                 }
             }
         )
+    }
+
+    private var discardConfirmationSessionID: UUID? {
+        guard case .discardConfirmation(let sessionID) = finishPrompt else {
+            return nil
+        }
+        return sessionID
     }
 
     private func requestDiscardConfirmation(for sessionID: UUID) {

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
@@ -129,8 +129,8 @@ nonisolated enum WorkoutDiscardDisclosureV1 {
         case confirmDiscard
     }
 
-    static let title = "Discard Workout?"
-    static let message = "This can’t be undone. This ride will not be saved to Health."
+    static let title = "Discard Ride?"
+    static let message = "Discarding can't be undone."
     static let cancelTitle = "Keep Riding"
     static let confirmTitle = "Discard Workout"
 

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -4709,9 +4709,10 @@ private struct WorkoutContractTestSuite {
             "the final destructive confirmation must discard exactly once"
         )
         expect(
-            WorkoutDiscardDisclosureV1.message.contains("can’t be undone")
-                && WorkoutDiscardDisclosureV1.message.contains("not be saved to Health"),
-            "the final discard warning must disclose irreversibility and the Health outcome"
+            WorkoutDiscardDisclosureV1.title == "Discard Ride?"
+                && WorkoutDiscardDisclosureV1.message
+                    == "Discarding can't be undone.",
+            "the final discard warning must use the concise rider-facing copy"
         )
         expect(
             WorkoutDiscardDisclosureV1.cancelTitle == "Keep Riding"
@@ -4946,6 +4947,24 @@ private struct WorkoutContractTestSuite {
                 "\(surface) finish prompts must be scoped to and invalidated with their session"
             )
         }
+
+        let compactWatchSource = watchSource.filter { !$0.isWhitespace }
+        expect(
+            compactWatchSource.contains(
+                "isPresented:discardConfirmationPresented,presenting:discardConfirmationSessionID"
+            )
+                && compactWatchSource.contains(
+                    "){sessionIDinButton(WorkoutDiscardDisclosureV1.cancelTitle"
+                ),
+            "Watch discard confirmation must capture its session before alert dismissal"
+        )
+        expect(
+            watchSource.contains("\"Finish Ride?\"")
+                && watchSource.contains(
+                    "\"Saving creates a workout in your Fitness app.\""
+                ),
+            "Watch finish confirmation must use the concise rider-facing copy"
+        )
     }
 
     private mutating func testWorkoutUICompositionRetainsPhaseThreeExitCriteria() {


### PR DESCRIPTION
## Summary

- Capture the Watch discard alert session as presentation data so dismissing the alert cannot clear the destructive action context.
- Shorten the Watch finish and shared discard confirmation copy.
- Extend workout contract coverage for the Watch alert lifetime and the new copy.

## Root cause

The Watch alert built its destructive action from mutable prompt state. watchOS can dismiss the alert and clear that state before dispatching the button action, so the final Discard tap could return to the live workout without requesting discard.

## Validation

- `ios-app/scripts/run-workout-contract-tests.sh`
- `ios-app/scripts/run-workout-platform-tests.sh watchos`
- `ios-app/scripts/run-workout-platform-tests.sh ios`
- Full `BikeComputer` generic iOS build with `CODE_SIGNING_ALLOWED=NO`

## Contributor License Agreement

Choose the statement that applies:

- [ ] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [ ] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
