### PR TITLE
Keep live workouts active in background

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -15,7 +15,10 @@ struct BikeComputerApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ContentView(workoutMirrorManager: appDelegate.workoutMirrorManager)
+            ContentView(
+                workoutMirrorManager: appDelegate.workoutMirrorManager,
+                coordinator: appDelegate.coordinator
+            )
         }
     }
 }
@@ -25,18 +28,37 @@ struct BikeComputerApp: App {
 @MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
     let workoutMirrorManager = WorkoutMirrorManager()
+    let locationManager = CurrentLocationManager()
+    lazy var coordinator = BikeComputerCoordinator(
+        destinationStore: SavedDestinationStore(),
+        workoutMetricsStore: workoutMirrorManager.store,
+        locationManager: locationManager
+    )
+
+    override init() {
+        super.init()
+        locationManager.bindWorkoutMetricsStore(
+            workoutMirrorManager.store
+        )
+    }
     
     func application(_ application: UIApplication, 
                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         
         // Configure for background location updates
         print("BikeComputer app launched")
+        _ = coordinator
         workoutMirrorManager.installMirroringHandler()
         
         return true
     }
+
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        coordinator.applicationDidBecomeActive()
+    }
     
     func applicationDidEnterBackground(_ application: UIApplication) {
+        coordinator.setViewingMap(false)
         print("App entered background - navigation continues")
     }
     

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -43,20 +43,22 @@ struct ContentView: View {
     @MainActor
     init(
         workoutMirrorManager: WorkoutMirrorManager,
+        coordinator: BikeComputerCoordinator? = nil,
         watchAvailability: WorkoutWatchAvailabilityMonitor? = nil
     ) {
         let watchAvailability = watchAvailability
             ?? WorkoutWatchAvailabilityMonitor()
+        let coordinator = coordinator ?? BikeComputerCoordinator(
+            destinationStore: SavedDestinationStore(),
+            workoutMetricsStore: workoutMirrorManager.store
+        )
         self.workoutMirrorManager = workoutMirrorManager
         _watchAvailability = StateObject(wrappedValue: watchAvailability)
         _workoutStore = ObservedObject(
             wrappedValue: workoutMirrorManager.store
         )
         _coordinator = StateObject(
-            wrappedValue: BikeComputerCoordinator(
-                destinationStore: SavedDestinationStore(),
-                workoutMetricsStore: workoutMirrorManager.store
-            )
+            wrappedValue: coordinator
         )
     }
     
@@ -191,12 +193,14 @@ struct ContentView: View {
             migrateExistingInstallOnboardingIfNeeded()
             isOfflineMapOnboardingStatePrepared = true
             watchAvailability.activate()
+            coordinator.setViewingMap(scenePhase == .active)
             updateIdleTimer()
             coordinator.applicationDidBecomeActive()
             workoutMirrorManager.refreshFreshness()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: scenePhase) { newValue in
+            coordinator.setViewingMap(newValue == .active)
             updateIdleTimer(for: newValue)
             guard newValue == .active else { return }
             coordinator.applicationDidBecomeActive()
@@ -206,10 +210,11 @@ struct ContentView: View {
         .onChange(of: coordinator.isNavigating) { _ in
             updateIdleTimer()
         }
-        .onChange(of: workoutStore.presentation.isWorkoutActive) { _ in
+        .onChange(of: workoutStore.shouldMaintainWorkoutServices) { _ in
             updateIdleTimer()
         }
         .onDisappear {
+            coordinator.setViewingMap(false)
             UIApplication.shared.isIdleTimerDisabled = false
         }
         .onChange(of: coordinator.bleManager.isConnected) { _ in
@@ -255,12 +260,13 @@ struct ContentView: View {
     }
 
     private func updateIdleTimer(for phase: ScenePhase? = nil) {
-        UIApplication.shared.isIdleTimerDisabled =
-            RideActivityPolicy.shouldKeepScreenAwake(
-                isNavigating: coordinator.isNavigating,
-                isWorkoutActive: workoutStore.presentation.isWorkoutActive,
-                isApplicationActive: (phase ?? scenePhase) == .active
-            )
+        RideIdleTimerController.update(
+            isNavigating: coordinator.isNavigating,
+            isWorkoutActive: workoutStore.shouldMaintainWorkoutServices,
+            isApplicationActive: (phase ?? scenePhase) == .active
+        ) {
+            UIApplication.shared.isIdleTimerDisabled = $0
+        }
     }
 
     private func schedulePendingMapInstallResume() {

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -206,6 +206,9 @@ struct ContentView: View {
         .onChange(of: coordinator.isNavigating) { _ in
             updateIdleTimer()
         }
+        .onChange(of: workoutStore.presentation.isWorkoutActive) { _ in
+            updateIdleTimer()
+        }
         .onDisappear {
             UIApplication.shared.isIdleTimerDisabled = false
         }
@@ -253,7 +256,11 @@ struct ContentView: View {
 
     private func updateIdleTimer(for phase: ScenePhase? = nil) {
         UIApplication.shared.isIdleTimerDisabled =
-            coordinator.isNavigating && (phase ?? scenePhase) == .active
+            RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: coordinator.isNavigating,
+                isWorkoutActive: workoutStore.presentation.isWorkoutActive,
+                isApplicationActive: (phase ?? scenePhase) == .active
+            )
     }
 
     private func schedulePendingMapInstallResume() {

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -66,7 +66,7 @@ class BikeComputerCoordinator: ObservableObject {
     let destinationStore: SavedDestinationStore
     let workoutMetricsStore: WorkoutMetricsStore
     private let navEngine = NavigationEngine()
-    private let locationManager = CurrentLocationManager()
+    private let locationManager: CurrentLocationManager
     private let directionsFactory: NavigationDirectionsFactory
     private let startServices: Bool
     private let now: () -> Date
@@ -144,6 +144,7 @@ class BikeComputerCoordinator: ObservableObject {
     init(
         destinationStore: SavedDestinationStore,
         workoutMetricsStore: WorkoutMetricsStore? = nil,
+        locationManager: CurrentLocationManager? = nil,
         directionsFactory: @escaping NavigationDirectionsFactory = {
             MapKitNavigationDirectionsTask(request: $0)
         },
@@ -153,6 +154,7 @@ class BikeComputerCoordinator: ObservableObject {
         self.destinationStore = destinationStore
         self.workoutMetricsStore = workoutMetricsStore
             ?? WorkoutMetricsStore(now: now)
+        self.locationManager = locationManager ?? CurrentLocationManager()
         self.directionsFactory = directionsFactory
         self.startServices = startServices
         self.now = now
@@ -200,13 +202,7 @@ class BikeComputerCoordinator: ObservableObject {
         navEngine.$isSimulationMode
             .assign(to: &$isSimulationMode)
 
-        workoutMetricsStore.$presentation
-            .map { $0.isWorkoutActive }
-            .removeDuplicates()
-            .sink { [weak self] isWorkoutActive in
-                self?.locationManager.setWorkoutActive(isWorkoutActive)
-            }
-            .store(in: &cancellables)
+        locationManager.bindWorkoutMetricsStore(workoutMetricsStore)
 
         navEngine.$simulatedPosition
             .assign(to: &$simulatedPosition)
@@ -374,9 +370,6 @@ class BikeComputerCoordinator: ObservableObject {
 
         // Start BLE operations
         bleManager.startScanning()
-
-        // Enable location tracking for map view
-        locationManager.setViewingMap(true)
     }
 
     private func processNavigationLocation(_ location: CLLocation) {
@@ -524,6 +517,7 @@ class BikeComputerCoordinator: ObservableObject {
     }
 
     func applicationDidBecomeActive() {
+        locationManager.applicationDidBecomeActive()
         locationManager.prepareDeviceDestinationRequestsIfNeeded()
         bleManager.resumeAutoReconnectIfNeeded()
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -200,6 +200,14 @@ class BikeComputerCoordinator: ObservableObject {
         navEngine.$isSimulationMode
             .assign(to: &$isSimulationMode)
 
+        workoutMetricsStore.$presentation
+            .map { $0.isWorkoutActive }
+            .removeDuplicates()
+            .sink { [weak self] isWorkoutActive in
+                self?.locationManager.setWorkoutActive(isWorkoutActive)
+            }
+            .store(in: &cancellables)
+
         navEngine.$simulatedPosition
             .assign(to: &$simulatedPosition)
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -12,6 +12,38 @@ import Combine
 import UIKit
 #endif
 
+nonisolated enum RideActivityPolicy {
+    static func shouldTrackLocation(
+        isNavigating: Bool,
+        isViewingMap: Bool,
+        isWorkoutActive: Bool,
+        isRefreshingDeviceDestinationLocation: Bool
+    ) -> Bool {
+        isNavigating ||
+            isViewingMap ||
+            isWorkoutActive ||
+            isRefreshingDeviceDestinationLocation
+    }
+
+    static func shouldTrackLocationInBackground(
+        isNavigating: Bool,
+        isWorkoutActive: Bool,
+        isRefreshingDeviceDestinationLocation: Bool
+    ) -> Bool {
+        isNavigating ||
+            isWorkoutActive ||
+            isRefreshingDeviceDestinationLocation
+    }
+
+    static func shouldKeepScreenAwake(
+        isNavigating: Bool,
+        isWorkoutActive: Bool,
+        isApplicationActive: Bool
+    ) -> Bool {
+        isApplicationActive && (isNavigating || isWorkoutActive)
+    }
+}
+
 class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var currentLocation: CLLocation?
     @Published var currentAddress: String = "Current Location"
@@ -24,6 +56,7 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     // MARK: - Optimization #3: Intelligent Location Update Management
     private var isNavigating = false
     private var isViewingMap = false
+    private var isWorkoutActive = false
     private var isLocationUpdating = false
     private var isDeviceDestinationRequestsEnabled = false
     private var isRefreshingDeviceDestinationLocation = false
@@ -103,13 +136,28 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         isViewingMap = viewing
         updateLocationTracking()
     }
+
+    func setWorkoutActive(_ active: Bool) {
+        guard isWorkoutActive != active else { return }
+        isWorkoutActive = active
+        updateLocationTracking()
+    }
     
     public func updateLocationTracking(restart: Bool = false) {
-        let shouldTrack = isNavigating || 
-                         isViewingMap || 
-                         isRefreshingDeviceDestinationLocation
-        let shouldTrackInBackground = isNavigating ||
-                                      isRefreshingDeviceDestinationLocation
+        let shouldTrack = RideActivityPolicy.shouldTrackLocation(
+            isNavigating: isNavigating,
+            isViewingMap: isViewingMap,
+            isWorkoutActive: isWorkoutActive,
+            isRefreshingDeviceDestinationLocation:
+                isRefreshingDeviceDestinationLocation
+        )
+        let shouldTrackInBackground =
+            RideActivityPolicy.shouldTrackLocationInBackground(
+                isNavigating: isNavigating,
+                isWorkoutActive: isWorkoutActive,
+                isRefreshingDeviceDestinationLocation:
+                    isRefreshingDeviceDestinationLocation
+            )
 
         if shouldTrackInBackground &&
             Self.isAuthorizedWhenInUse(locationManager.authorizationStatus) &&
@@ -117,9 +165,9 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
             locationManager.requestAlwaysAuthorization()
         }
 
+#if !os(macOS)
         locationManager.allowsBackgroundLocationUpdates = shouldTrackInBackground
         locationManager.pausesLocationUpdatesAutomatically = !shouldTrackInBackground
-#if !os(macOS)
         locationManager.showsBackgroundLocationIndicator = shouldTrackInBackground
 #endif
         
@@ -127,7 +175,7 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
             if isLocationUpdating {
                 locationManager.stopUpdatingLocation()
             }
-            print("🌍 Starting location updates (navigating: \(isNavigating), map: \(isViewingMap), device destination request: \(isRefreshingDeviceDestinationLocation))")
+            print("🌍 Starting location updates (navigating: \(isNavigating), map: \(isViewingMap), workout: \(isWorkoutActive), device destination request: \(isRefreshingDeviceDestinationLocation))")
             locationManager.startUpdatingLocation()
             isLocationUpdating = true
         } else if (!shouldTrack || !isLocationAuthorized) && isLocationUpdating {

--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -44,14 +44,119 @@ nonisolated enum RideActivityPolicy {
     }
 }
 
+nonisolated enum RideIdleTimerController {
+    static func update(
+        isNavigating: Bool,
+        isWorkoutActive: Bool,
+        isApplicationActive: Bool,
+        setIdleTimerDisabled: (Bool) -> Void
+    ) {
+        setIdleTimerDisabled(
+            RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: isNavigating,
+                isWorkoutActive: isWorkoutActive,
+                isApplicationActive: isApplicationActive
+            )
+        )
+    }
+}
+
+enum LocationAuthorizationLevel {
+    case denied
+    case whenInUse
+    case always
+}
+
+protocol LocationManagerClient: AnyObject {
+    var authorizationStatus: CLAuthorizationStatus { get }
+    var authorizationLevel: LocationAuthorizationLevel { get }
+
+    func setDelegate(_ delegate: CLLocationManagerDelegate?)
+    func configureForCycling()
+    func setBackgroundTrackingEnabled(_ enabled: Bool)
+    func requestLocation()
+    func requestWhenInUseAuthorization()
+    func requestAlwaysAuthorization()
+    func startUpdatingLocation()
+    func stopUpdatingLocation()
+}
+
+final class CoreLocationManagerClient: LocationManagerClient {
+    private let manager = CLLocationManager()
+
+    var authorizationStatus: CLAuthorizationStatus {
+        manager.authorizationStatus
+    }
+
+    var authorizationLevel: LocationAuthorizationLevel {
+        switch manager.authorizationStatus {
+        case .authorizedAlways:
+            return .always
+#if !os(macOS)
+        case .authorizedWhenInUse:
+            return .whenInUse
+#endif
+        case .notDetermined, .restricted, .denied:
+            return .denied
+        @unknown default:
+            return .denied
+        }
+    }
+
+    func setDelegate(_ delegate: CLLocationManagerDelegate?) {
+        manager.delegate = delegate
+    }
+
+    func configureForCycling() {
+        manager.desiredAccuracy = kCLLocationAccuracyBest
+        manager.distanceFilter = 5
+        manager.activityType = .fitness
+#if !os(macOS)
+        manager.allowsBackgroundLocationUpdates = false
+        manager.pausesLocationUpdatesAutomatically = true
+        manager.showsBackgroundLocationIndicator = false
+#endif
+    }
+
+    func setBackgroundTrackingEnabled(_ enabled: Bool) {
+#if !os(macOS)
+        manager.allowsBackgroundLocationUpdates = enabled
+        manager.pausesLocationUpdatesAutomatically = !enabled
+        manager.showsBackgroundLocationIndicator = enabled
+#endif
+    }
+
+    func requestLocation() {
+        manager.requestLocation()
+    }
+
+    func requestWhenInUseAuthorization() {
+        manager.requestWhenInUseAuthorization()
+    }
+
+    func requestAlwaysAuthorization() {
+        manager.requestAlwaysAuthorization()
+    }
+
+    func startUpdatingLocation() {
+        manager.startUpdatingLocation()
+    }
+
+    func stopUpdatingLocation() {
+        manager.stopUpdatingLocation()
+    }
+}
+
 class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDelegate {
     @Published var currentLocation: CLLocation?
     @Published var currentAddress: String = "Current Location"
     @Published var authorizationStatus: CLAuthorizationStatus
     
-    private let locationManager = CLLocationManager()
+    private let locationManager: LocationManagerClient
+    private let applicationIsActive: () -> Bool
     private var lastGeocodedLocation: CLLocation?
     private var lastGeocodeTime: Date?
+    private var workoutActivityCancellable: AnyCancellable?
     
     // MARK: - Optimization #3: Intelligent Location Update Management
     private var isNavigating = false
@@ -61,19 +166,19 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     private var isDeviceDestinationRequestsEnabled = false
     private var isRefreshingDeviceDestinationLocation = false
     private var hasRequestedAlwaysAuthorizationForDeviceDestinations = false
+    private var hasRequestedAlwaysAuthorizationForRideActivity = false
     
-    override init() {
+    init(
+        locationManager: LocationManagerClient = CoreLocationManagerClient(),
+        applicationIsActive: @escaping () -> Bool =
+            CurrentLocationManager.defaultApplicationIsActive
+    ) {
+        self.locationManager = locationManager
+        self.applicationIsActive = applicationIsActive
         authorizationStatus = locationManager.authorizationStatus
         super.init()
-        locationManager.delegate = self
-        locationManager.desiredAccuracy = kCLLocationAccuracyBest
-        locationManager.distanceFilter = 5 // Update every 5 meters for better tracking
-        locationManager.activityType = .fitness
-        locationManager.allowsBackgroundLocationUpdates = false
-        locationManager.pausesLocationUpdatesAutomatically = true
-#if !os(macOS)
-        locationManager.showsBackgroundLocationIndicator = false
-#endif
+        locationManager.setDelegate(self)
+        locationManager.configureForCycling()
         // First-run onboarding owns the permission prompt so the user can read
         // the rationale or skip location before iOS asks for access.
     }
@@ -90,8 +195,8 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
 
     func prepareDeviceDestinationRequestsIfNeeded() {
         guard isDeviceDestinationRequestsEnabled,
-              Self.isAuthorizedWhenInUse(authorizationStatus),
-              Self.applicationIsActive,
+              locationManager.authorizationLevel == .whenInUse,
+              applicationIsActive(),
               !hasRequestedAlwaysAuthorizationForDeviceDestinations else {
             return
         }
@@ -102,7 +207,8 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     @discardableResult
     func beginDeviceDestinationLocationRefresh(restart: Bool) -> Bool {
         guard isLocationAuthorized,
-              authorizationStatus == .authorizedAlways || Self.applicationIsActive else {
+              locationManager.authorizationLevel == .always
+                || applicationIsActive() else {
             return false
         }
         isRefreshingDeviceDestinationLocation = true
@@ -121,8 +227,8 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
     }
 
     var isLocationAuthorized: Bool {
-        authorizationStatus == .authorizedAlways ||
-            Self.isAuthorizedWhenInUse(authorizationStatus)
+        locationManager.authorizationLevel == .always ||
+            locationManager.authorizationLevel == .whenInUse
     }
     
     // MARK: - Smart Location Update Control (Optimization #3)
@@ -142,11 +248,25 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         isWorkoutActive = active
         updateLocationTracking()
     }
+
+    @MainActor
+    func bindWorkoutMetricsStore(_ store: WorkoutMetricsStore) {
+        workoutActivityCancellable = store.$shouldMaintainWorkoutServices
+            .removeDuplicates()
+            .sink { [weak self] isWorkoutActive in
+                self?.setWorkoutActive(isWorkoutActive)
+            }
+    }
+
+    func applicationDidBecomeActive() {
+        updateLocationTracking()
+    }
     
     public func updateLocationTracking(restart: Bool = false) {
+        let isApplicationActive = applicationIsActive()
         let shouldTrack = RideActivityPolicy.shouldTrackLocation(
             isNavigating: isNavigating,
-            isViewingMap: isViewingMap,
+            isViewingMap: isViewingMap && isApplicationActive,
             isWorkoutActive: isWorkoutActive,
             isRefreshingDeviceDestinationLocation:
                 isRefreshingDeviceDestinationLocation
@@ -160,18 +280,23 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
             )
 
         if shouldTrackInBackground &&
-            Self.isAuthorizedWhenInUse(locationManager.authorizationStatus) &&
-            Self.applicationIsActive {
+            locationManager.authorizationLevel == .whenInUse &&
+            isApplicationActive &&
+            !hasRequestedAlwaysAuthorizationForRideActivity {
+            hasRequestedAlwaysAuthorizationForRideActivity = true
             locationManager.requestAlwaysAuthorization()
         }
 
-#if !os(macOS)
-        locationManager.allowsBackgroundLocationUpdates = shouldTrackInBackground
-        locationManager.pausesLocationUpdatesAutomatically = !shouldTrackInBackground
-        locationManager.showsBackgroundLocationIndicator = shouldTrackInBackground
-#endif
+        locationManager.setBackgroundTrackingEnabled(shouldTrackInBackground)
+
+        let canStartUpdates =
+            locationManager.authorizationLevel == .always
+                || isApplicationActive
         
-        if shouldTrack && isLocationAuthorized && (!isLocationUpdating || restart) {
+        if shouldTrack &&
+            isLocationAuthorized &&
+            canStartUpdates &&
+            (!isLocationUpdating || restart) {
             if isLocationUpdating {
                 locationManager.stopUpdatingLocation()
             }
@@ -269,19 +394,12 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
         updateLocationTracking()
     }
 
-    private static var applicationIsActive: Bool {
+    private static func defaultApplicationIsActive() -> Bool {
 #if canImport(UIKit) && !HOST_TESTING
-        UIApplication.shared.applicationState == .active
+        return UIApplication.shared.applicationState == .active
 #else
-        true
+        return true
 #endif
     }
 
-    private static func isAuthorizedWhenInUse(_ status: CLAuthorizationStatus) -> Bool {
-#if os(macOS)
-        false
-#else
-        status == .authorizedWhenInUse
-#endif
-    }
 }

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
@@ -1,11 +1,40 @@
 import Combine
 import Foundation
 
+nonisolated struct WorkoutServiceActivityTracker: Sendable {
+    static let reconnectionGracePeriod: TimeInterval = 5 * 60
+    private(set) var unverifiedSince: Date?
+
+    mutating func shouldMaintainServices(
+        for presentation: WorkoutMirrorPresentationV1,
+        at date: Date
+    ) -> Bool {
+        guard presentation.isWorkoutActive else {
+            unverifiedSince = nil
+            return false
+        }
+        switch presentation.connectionState {
+        case .awaitingFirstSnapshot, .connected:
+            unverifiedSince = nil
+            return true
+        case .stale, .disconnected:
+            let graceStartedAt = unverifiedSince ?? date
+            unverifiedSince = graceStartedAt
+            return date.timeIntervalSince(graceStartedAt)
+                <= Self.reconnectionGracePeriod
+        case .unsupported, .idle, .launchingWatch, .ended, .failed:
+            unverifiedSince = nil
+            return false
+        }
+    }
+}
+
 /// Main-actor publication boundary for all Watch-owned workout state shown on
 /// iPhone. The store never writes HealthKit data or persists raw health metrics.
 @MainActor
 final class WorkoutMetricsStore: ObservableObject {
     @Published private(set) var presentation: WorkoutMirrorPresentationV1
+    @Published private(set) var shouldMaintainWorkoutServices: Bool
 
     private var reducer: WorkoutMirrorStateReducer
     private var iPhoneTelemetry: WorkoutIPhoneTelemetryV1 = .empty
@@ -15,6 +44,7 @@ final class WorkoutMetricsStore: ObservableObject {
     private var completedNavigationDistanceMeters: Double = 0
     private var wasNavigationDistanceAdvancing = false
     private let now: () -> Date
+    private var workoutServiceActivityTracker: WorkoutServiceActivityTracker
 
     var currentEnvelope: WorkoutEnvelopeV1? {
         reducer.latestEnvelope
@@ -34,11 +64,20 @@ final class WorkoutMetricsStore: ObservableObject {
     ) {
         self.reducer = reducer
         self.now = now
-        presentation = WorkoutIPhoneTelemetryMerge.presentation(
+        let referenceDate = now()
+        let presentation = WorkoutIPhoneTelemetryMerge.presentation(
             reducer.presentation,
             phone: .empty,
-            at: now()
+            at: referenceDate
         )
+        var workoutServiceActivityTracker = WorkoutServiceActivityTracker()
+        self.presentation = presentation
+        shouldMaintainWorkoutServices =
+            workoutServiceActivityTracker.shouldMaintainServices(
+                for: presentation,
+                at: referenceDate
+            )
+        self.workoutServiceActivityTracker = workoutServiceActivityTracker
     }
 
     @discardableResult
@@ -210,11 +249,12 @@ final class WorkoutMetricsStore: ObservableObject {
     }
 
     private func publish() {
+        let referenceDate = now()
         let base = reducer.presentation
         let merged = WorkoutIPhoneTelemetryMerge.presentation(
             base,
             phone: normalizedIPhoneTelemetry(for: base),
-            at: now()
+            at: referenceDate
         )
         let next: WorkoutMirrorPresentationV1
         if base.sessionState == .ended,
@@ -242,6 +282,16 @@ final class WorkoutMetricsStore: ObservableObject {
             )
         } else {
             next = merged
+        }
+        let nextShouldMaintainWorkoutServices =
+            workoutServiceActivityTracker.shouldMaintainServices(
+                for: next,
+                at: referenceDate
+            )
+        if nextShouldMaintainWorkoutServices
+            != shouldMaintainWorkoutServices {
+            shouldMaintainWorkoutServices =
+                nextShouldMaintainWorkoutServices
         }
         guard next != presentation else { return }
         presentation = next

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -493,6 +493,55 @@ final class TestRoute: MKRoute {
     }
 }
 
+final class TestLocationManagerClient: LocationManagerClient {
+    var authorizationStatus: CLAuthorizationStatus
+    var authorizationLevel: LocationAuthorizationLevel
+    private(set) weak var delegate: CLLocationManagerDelegate?
+    private(set) var backgroundTrackingEnabledHistory: [Bool] = []
+    private(set) var requestLocationCallCount = 0
+    private(set) var requestWhenInUseAuthorizationCallCount = 0
+    private(set) var requestAlwaysAuthorizationCallCount = 0
+    private(set) var startUpdatingLocationCallCount = 0
+    private(set) var stopUpdatingLocationCallCount = 0
+
+    init(authorizationLevel: LocationAuthorizationLevel) {
+        self.authorizationLevel = authorizationLevel
+        authorizationStatus = authorizationLevel == .always
+            ? .authorizedAlways
+            : .notDetermined
+    }
+
+    func setDelegate(_ delegate: CLLocationManagerDelegate?) {
+        self.delegate = delegate
+    }
+
+    func configureForCycling() {}
+
+    func setBackgroundTrackingEnabled(_ enabled: Bool) {
+        backgroundTrackingEnabledHistory.append(enabled)
+    }
+
+    func requestLocation() {
+        requestLocationCallCount += 1
+    }
+
+    func requestWhenInUseAuthorization() {
+        requestWhenInUseAuthorizationCallCount += 1
+    }
+
+    func requestAlwaysAuthorization() {
+        requestAlwaysAuthorizationCallCount += 1
+    }
+
+    func startUpdatingLocation() {
+        startUpdatingLocationCallCount += 1
+    }
+
+    func stopUpdatingLocation() {
+        stopUpdatingLocationCallCount += 1
+    }
+}
+
 @main
 struct NavigationProtocolTests {
     @MainActor
@@ -504,6 +553,7 @@ struct NavigationProtocolTests {
         testReplacementStepSelectionUsesUnambiguousGeometry()
         testCoordinatorReroutesAndAppliesLatestRoute()
         testWorkoutAndNavigationLifecyclesStayIndependent()
+        testRideActivityRuntimeIntegration()
         testCoordinatorRejectsStaleRerouteLocations()
         testCoordinatorDetectsDeviationFromCurrentStep()
         testCoordinatorEnforcesRerouteCooldown()
@@ -2694,6 +2744,202 @@ struct NavigationProtocolTests {
             coordinator.isNavigating,
             "ending the workout must not stop navigation"
         )
+    }
+
+    @MainActor
+    static func testRideActivityRuntimeIntegration() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_300_100)
+        var currentDate = now
+        var isApplicationActive = false
+        let locationClient = TestLocationManagerClient(
+            authorizationLevel: .whenInUse
+        )
+        let locationManager = CurrentLocationManager(
+            locationManager: locationClient,
+            applicationIsActive: { isApplicationActive }
+        )
+        let store = WorkoutMetricsStore(now: { currentDate })
+        store.attachMirroredSession(at: now)
+        _ = store.ingestBatch(
+            [
+                WorkoutEnvelopeV1(
+                    kind: .snapshot,
+                    sessionID: UUID(),
+                    sessionToken: 4,
+                    sequence: 1,
+                    capturedAt: now,
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: now
+                    )
+                ),
+            ],
+            receivedAt: now
+        )
+
+        locationManager.bindWorkoutMetricsStore(store)
+
+        assertEqual(
+            locationClient.startUpdatingLocationCallCount,
+            0,
+            "a background-launched workout must defer a When-In-Use location start"
+        )
+        assertEqual(
+            locationClient.requestAlwaysAuthorizationCallCount,
+            0,
+            "Always authorization can only be requested after the app becomes active"
+        )
+        assert(
+            locationClient.backgroundTrackingEnabledHistory.last == true,
+            "a connected workout should configure background location delivery"
+        )
+
+        isApplicationActive = true
+        locationManager.applicationDidBecomeActive()
+
+        assertEqual(
+            locationClient.requestAlwaysAuthorizationCallCount,
+            1,
+            "foregrounding a background-launched workout should request Always authorization"
+        )
+        assertEqual(
+            locationClient.startUpdatingLocationCallCount,
+            1,
+            "foregrounding should retry the deferred workout location start"
+        )
+
+        store.disconnect(error: .watchUnavailable)
+        assertEqual(
+            locationClient.stopUpdatingLocationCallCount,
+            0,
+            "a disconnected live workout should keep location active during the reconnection grace period"
+        )
+        assert(
+            locationClient.backgroundTrackingEnabledHistory.last == true,
+            "the reconnection grace period should preserve background workout tracking"
+        )
+
+        currentDate = now.addingTimeInterval(
+            WorkoutServiceActivityTracker.reconnectionGracePeriod + 0.001
+        )
+        store.refreshFreshness(at: currentDate)
+        assertEqual(
+            locationClient.stopUpdatingLocationCallCount,
+            1,
+            "an unverified workout should release location after the bounded grace period"
+        )
+        assert(
+            locationClient.backgroundTrackingEnabledHistory.last == false,
+            "expired workout reconnection grace should release background tracking"
+        )
+
+        locationManager.setNavigating(true)
+        assertEqual(
+            locationClient.startUpdatingLocationCallCount,
+            2,
+            "navigation should remain able to start location after workout grace expires"
+        )
+        locationManager.setNavigating(false)
+        assertEqual(
+            locationClient.stopUpdatingLocationCallCount,
+            2,
+            "ending navigation should release its independent location claim"
+        )
+
+        let alwaysClient = TestLocationManagerClient(
+            authorizationLevel: .always
+        )
+        let backgroundLocationManager = CurrentLocationManager(
+            locationManager: alwaysClient,
+            applicationIsActive: { false }
+        )
+        backgroundLocationManager.bindWorkoutMetricsStore(storeForActiveWorkout(
+            at: now.addingTimeInterval(1)
+        ))
+        assertEqual(
+            alwaysClient.startUpdatingLocationCallCount,
+            1,
+            "Always-authorized workout tracking may start during a background launch"
+        )
+
+        let headlessClient = TestLocationManagerClient(
+            authorizationLevel: .always
+        )
+        var isHeadlessSceneActive = false
+        let headlessLocationManager = CurrentLocationManager(
+            locationManager: headlessClient,
+            applicationIsActive: { isHeadlessSceneActive }
+        )
+        headlessLocationManager.setViewingMap(true)
+        assertEqual(
+            headlessClient.startUpdatingLocationCallCount,
+            0,
+            "a headless background launch must not treat the map as visible"
+        )
+        isHeadlessSceneActive = true
+        headlessLocationManager.applicationDidBecomeActive()
+        assertEqual(
+            headlessClient.startUpdatingLocationCallCount,
+            1,
+            "an active visible map should start foreground location"
+        )
+        isHeadlessSceneActive = false
+        headlessLocationManager.setViewingMap(false)
+        assertEqual(
+            headlessClient.stopUpdatingLocationCallCount,
+            1,
+            "backgrounding the visible map should release its location claim"
+        )
+
+        var idleTimerValues: [Bool] = []
+        RideIdleTimerController.update(
+            isNavigating: false,
+            isWorkoutActive: true,
+            isApplicationActive: true,
+            setIdleTimerDisabled: { idleTimerValues.append($0) }
+        )
+        RideIdleTimerController.update(
+            isNavigating: false,
+            isWorkoutActive: true,
+            isApplicationActive: false,
+            setIdleTimerDisabled: { idleTimerValues.append($0) }
+        )
+        RideIdleTimerController.update(
+            isNavigating: true,
+            isWorkoutActive: false,
+            isApplicationActive: true,
+            setIdleTimerDisabled: { idleTimerValues.append($0) }
+        )
+        assertEqual(
+            idleTimerValues,
+            [true, false, true],
+            "the idle-timer adapter should apply workout, background, and navigation policy"
+        )
+    }
+
+    @MainActor
+    private static func storeForActiveWorkout(
+        at date: Date
+    ) -> WorkoutMetricsStore {
+        let store = WorkoutMetricsStore(now: { date })
+        store.attachMirroredSession(at: date)
+        _ = store.ingestBatch(
+            [
+                WorkoutEnvelopeV1(
+                    kind: .snapshot,
+                    sessionID: UUID(),
+                    sessionToken: 5,
+                    sequence: 1,
+                    capturedAt: date,
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: date
+                    )
+                ),
+            ],
+            receivedAt: date
+        )
+        return store
     }
 
     @MainActor
@@ -11834,7 +12080,97 @@ struct NavigationProtocolTests {
         )
     }
 
+    @MainActor
     static func testRideActivityPolicy() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let store = storeForActiveWorkout(at: now)
+        var tracker = WorkoutServiceActivityTracker()
+        assert(
+            tracker.shouldMaintainServices(
+                for: store.presentation,
+                at: now
+            ),
+            "a connected live workout should power companion services"
+        )
+        store.disconnect(error: .watchUnavailable)
+        assert(
+            tracker.shouldMaintainServices(
+                for: store.presentation,
+                at: now
+            ),
+            "a disconnected active workout should start a bounded service grace period"
+        )
+        assert(
+            tracker.shouldMaintainServices(
+                for: store.presentation,
+                at: now.addingTimeInterval(
+                    WorkoutServiceActivityTracker.reconnectionGracePeriod
+                )
+            ),
+            "a disconnected active workout should retain services through the grace boundary"
+        )
+        assert(
+            !tracker.shouldMaintainServices(
+                for: store.presentation,
+                at: now.addingTimeInterval(
+                    WorkoutServiceActivityTracker.reconnectionGracePeriod
+                        + 0.001
+                )
+            ),
+            "an unverified active state should not power services indefinitely"
+        )
+
+        let staleStore = storeForActiveWorkout(at: now)
+        var staleTracker = WorkoutServiceActivityTracker()
+        _ = staleTracker.shouldMaintainServices(
+            for: staleStore.presentation,
+            at: now
+        )
+        let becameStaleAt = now.addingTimeInterval(
+            WorkoutMirrorStateReducer.defaultStaleAfter + 0.001
+        )
+        staleStore.refreshFreshness(at: becameStaleAt)
+        assertEqual(
+            staleStore.presentation.connectionState,
+            .stale,
+            "the service policy test should exercise a genuinely stale mirror"
+        )
+        assert(
+            staleTracker.shouldMaintainServices(
+                for: staleStore.presentation,
+                at: becameStaleAt
+            ),
+            "a stale live workout should retain services during reconnection grace"
+        )
+        assert(
+            !staleTracker.shouldMaintainServices(
+                for: staleStore.presentation,
+                at: becameStaleAt.addingTimeInterval(
+                    WorkoutServiceActivityTracker.reconnectionGracePeriod
+                        + 0.001
+                )
+            ),
+            "stale workout grace should also be bounded"
+        )
+
+        let reconnectedStore = storeForActiveWorkout(
+            at: becameStaleAt.addingTimeInterval(30)
+        )
+        assert(
+            staleTracker.shouldMaintainServices(
+                for: reconnectedStore.presentation,
+                at: becameStaleAt.addingTimeInterval(30)
+            ),
+            "a verified reconnect should reactivate services and clear expired grace"
+        )
+        reconnectedStore.disconnect(error: .watchUnavailable)
+        assert(
+            staleTracker.shouldMaintainServices(
+                for: reconnectedStore.presentation,
+                at: becameStaleAt.addingTimeInterval(30)
+            ),
+            "a later disconnect should receive a fresh bounded grace period"
+        )
         assert(
             RideActivityPolicy.shouldTrackLocation(
                 isNavigating: false,

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -519,6 +519,7 @@ struct NavigationProtocolTests {
         testRouteInitialLocationUsesResolvedSource()
         testRouteTransportTypes()
         testMapTrackingPolicy()
+        testRideActivityPolicy()
         testDeviceGPSPacketBuilder()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
@@ -11830,6 +11831,66 @@ struct NavigationProtocolTests {
             ),
             .none,
             "a selected long-press destination should remain visible while GPS updates"
+        )
+    }
+
+    static func testRideActivityPolicy() {
+        assert(
+            RideActivityPolicy.shouldTrackLocation(
+                isNavigating: false,
+                isViewingMap: false,
+                isWorkoutActive: true,
+                isRefreshingDeviceDestinationLocation: false
+            ),
+            "a live workout should keep location tracking active"
+        )
+        assert(
+            RideActivityPolicy.shouldTrackLocationInBackground(
+                isNavigating: false,
+                isWorkoutActive: true,
+                isRefreshingDeviceDestinationLocation: false
+            ),
+            "a live workout should enable background location tracking without navigation"
+        )
+        assert(
+            !RideActivityPolicy.shouldTrackLocationInBackground(
+                isNavigating: false,
+                isWorkoutActive: false,
+                isRefreshingDeviceDestinationLocation: false
+            ),
+            "an idle map view should not enable background location tracking"
+        )
+        assert(
+            RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: false,
+                isWorkoutActive: true,
+                isApplicationActive: true
+            ),
+            "a foreground live workout should keep the iPhone screen awake"
+        )
+        assert(
+            RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: true,
+                isWorkoutActive: false,
+                isApplicationActive: true
+            ),
+            "foreground navigation should continue keeping the screen awake"
+        )
+        assert(
+            !RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: false,
+                isWorkoutActive: true,
+                isApplicationActive: false
+            ),
+            "the app should restore normal idle behavior while backgrounded"
+        )
+        assert(
+            !RideActivityPolicy.shouldKeepScreenAwake(
+                isNavigating: false,
+                isWorkoutActive: false,
+                isApplicationActive: true
+            ),
+            "an idle foreground app should allow Auto-Lock"
         )
     }
 


### PR DESCRIPTION
## Summary

### What changed

- Treat a verified mirrored Watch workout as an active ride for iPhone location tracking, independently of navigation.
- Keep the complete BLE/GPS/workout relay runtime alive from app launch so a Watch workout can wake the iPhone in the background without waiting for a SwiftUI scene.
- Defer a background-started When-In-Use location request and retry the Always upgrade plus location start when the app becomes active.
- Keep the iPhone screen awake while navigation or a maintained workout is active in the foreground.
- Preserve workout-driven GPS and screen-awake behavior through a five-minute stale/disconnected reconnection grace period; restore ordinary behavior after terminal state or grace expiry.
- Tie map-only location tracking to an active visible scene so headless launches and post-workout cleanup do not retain a map location claim.
- Add injectable Core Location and idle-timer boundaries with lifecycle, permission, navigation-overlap, grace-expiry, reconnect, and headless-map regression coverage.

### Why

Workout mirroring, BLE relay, iPhone location, and Auto-Lock previously had different owners and lifecycles. A workout started on Apple Watch without navigation could therefore show metrics in the iOS app while the bike computer stopped receiving fresh GPS after the iPhone backgrounded. A cold HealthKit launch could also create the workout state without creating the view-owned BLE/GPS relay.

### Impact

A verified live Watch workout now keeps the iPhone GPS relay active without requiring a route and keeps the foreground workout display awake. Brief Watch transport interruptions retain those services for five minutes to allow reconnection; if the workout remains unverified beyond that bound, workout-driven GPS and screen-awake behavior stop to avoid indefinite battery and privacy impact. Background GPS still requires Always Location permission, and force-quitting the app remains outside iOS background-execution guarantees.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
  - NavigationProtocolTests passed
  - DestinationCalloutLayoutTests passed
  - SavedMapPreviewCatalystTests passed
  - Opt-in live MapKit snapshot smoke test skipped by design
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' -derivedDataPath /tmp/open-bike-pr126-derived CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- `./ios-app/scripts/run-workout-contract-tests.sh` still reports the same three pre-existing Watch discard source-contract failures present on `main`; this PR does not touch those inputs.

Physical iPhone/Watch/ESP32 background validation remains to be completed when the devices are available.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
