### PR TITLE
Add workout segments on Watch and iPhone

### DIFF
--- a/docs/watchos-workout-companion-implementation-plan.md
+++ b/docs/watchos-workout-companion-implementation-plan.md
@@ -287,6 +287,9 @@ to a fresh sender generation without reusing the Watch's retained replay
 watermark. Watch retires prior sender UUIDs for the workout; delayed controls
 from a retired process cannot resume.
 
+Version 1.4 adds user-marked workout segments. Segment controls retain the same
+sender and sequence identity so the Watch can make them replay-safe.
+
 WorkoutSnapshotV1 contains:
 
 - session state: idle, starting, running, paused, ending, ended, or failed;
@@ -301,6 +304,8 @@ WorkoutSnapshotV1 contains:
 - current heart-rate zone, zone count, and optional zone durations;
 - latest location coordinate, timestamp, horizontal/vertical accuracy, course,
   speed, and altitude;
+- the most recently completed segment's one-based index, boundary dates, active
+  duration, and optional distance;
 - a compact availability/source mask;
 - an optional user-safe error code, never raw sensitive data; an explicit
   opposite Save/Discard outcome is presented as a terminal-choice conflict,
@@ -313,12 +318,15 @@ WorkoutControlV1 contains:
 
 - pause;
 - resume;
+- mark a segment;
 - request end and save;
 - request discard;
 - request current full snapshot.
 
 The Watch acknowledges state-changing controls with the resulting state and
-sequence. It does not require acknowledgements for every metric snapshot.
+sequence. A rejected segment carries the safe `segmentMarkFailed` error without
+failing or ending the workout. It does not require acknowledgements for every
+metric snapshot.
 
 Decoder rules:
 
@@ -395,6 +403,25 @@ HKWorkoutSessionDelegate.
 - Elapsed time and distance do not advance while paused.
 - Route points received during a pause are ignored.
 - ESP32 displays a PAUSED state without converting unavailable speed to zero.
+
+### Segments
+
+- Marking a segment is available while the workout is running on both Watch and
+  iPhone.
+- The Watch writes an `HKWorkoutEvent` of type `segment` to the live builder and
+  remains the only HealthKit writer.
+- Segment duration uses builder elapsed time so pauses are excluded. Distance is
+  the delta between cumulative Watch workout distances when both boundaries have
+  usable values.
+- A successful boundary is mirrored before either UI shows success feedback.
+- BikeComputer metadata on each event stores the segment index and cumulative
+  values needed to reconstruct the next boundary after workout recovery.
+- A remote segment control stores its sender and sequence in the event metadata
+  so a replay cannot create a duplicate segment.
+- If at least one segment was marked, saving adds the final segment from the last
+  boundary to the authoritative workout end date.
+- Segment writes use a bounded timeout. A failure leaves the workout running and
+  never blocks save or discard.
 
 ### End and save
 
@@ -510,7 +537,7 @@ Create one long-lived manager, available on iOS 17 and later.
 - Install workoutSessionMirroringStartHandler during AppDelegate launch.
 - Decode remote envelopes on the HealthKit delegate queue and hand validated
   snapshots to a MainActor store.
-- Expose start, pause, resume, end, and discard requests.
+- Expose start, pause, resume, mark-segment, end, and discard requests.
 - Track launch timeout, remote disconnect, stale data, and cross-app session
   displacement as explicit states.
 - Treat native terminal state as sticky: freshness ticks or delayed active
@@ -898,6 +925,8 @@ Exit criteria:
 - Batched snapshots publish only the latest valid state.
 - Metric precedence and no double-counting.
 - Elapsed-time behavior across pause/resume.
+- Sequential segment duration/distance accounting, replay safety, recovery, and
+  bounded HealthKit write failure.
 - Sensor/GPS speed source selection.
 - Missing permissions and missing sensor values.
 - Staleness transitions.
@@ -933,8 +962,9 @@ Use a real paired Watch and iPhone; simulator-only validation is insufficient.
 5. Disable Bluetooth between Watch and iPhone, then reconnect.
 6. Lock/background iPhone while navigating and measure update latency.
 7. Background iPhone without navigation and verify honest stale behavior.
-8. Pause/resume from Watch and iPhone.
-9. End from Watch and from iPhone.
+8. Pause/resume and mark multiple segments from Watch and iPhone.
+9. End from Watch and from iPhone, then verify the segment boundaries in
+   Fitness.
 10. With Apple Workout active, start directly from Watch and iPhone in separate
     runs; verify any start failure or displacement is reported honestly.
 11. Deny HealthKit, then deny Watch location separately.

--- a/docs/watchos-workout-companion-implementation-plan.md
+++ b/docs/watchos-workout-companion-implementation-plan.md
@@ -325,8 +325,9 @@ WorkoutControlV1 contains:
 
 The Watch acknowledges state-changing controls with the resulting state and
 sequence. A rejected segment carries the safe `segmentMarkFailed` error without
-failing or ending the workout. It does not require acknowledgements for every
-metric snapshot.
+failing or ending the workout. A timed-out, non-cancellable HealthKit write is
+reported as `segmentMarkUnconfirmed` until its callback supplies a definitive
+result. It does not require acknowledgements for every metric snapshot.
 
 Decoder rules:
 
@@ -407,21 +408,37 @@ HKWorkoutSessionDelegate.
 ### Segments
 
 - Marking a segment is available while the workout is running on both Watch and
-  iPhone.
+  iPhone. The iPhone action requires a Watch snapshot using schema 1.4 or later,
+  so staggered app updates do not send an undecodable control to an older Watch.
 - The Watch writes an `HKWorkoutEvent` of type `segment` to the live builder and
   remains the only HealthKit writer.
 - Segment duration uses builder elapsed time so pauses are excluded. Distance is
   the delta between cumulative Watch workout distances when both boundaries have
-  usable values.
+  usable values from the same source; a source change omits that segment's
+  distance and establishes a new baseline.
 - A successful boundary is mirrored before either UI shows success feedback.
 - BikeComputer metadata on each event stores the segment index and cumulative
   values needed to reconstruct the next boundary after workout recovery.
 - A remote segment control stores its sender and sequence in the event metadata
   so a replay cannot create a duplicate segment.
+- Before starting that HealthKit write, Watch durably journals the exact remote
+  control and original boundary candidate in the same transaction as its replay
+  checkpoint. Recovery can therefore resume the original boundary if the app
+  exits after accepting the command but before HealthKit records the event.
+- If its definitive acknowledgement is lost, iPhone retains and replays that
+  exact sender/sequence after the confirmation timeout and on reconnect. A
+  segment-count change alone never attributes a Watch-local boundary to the
+  iPhone command.
 - If at least one segment was marked, saving adds the final segment from the last
   boundary to the authoritative workout end date.
-- Segment writes use a bounded timeout. A failure leaves the workout running and
-  never blocks save or discard.
+- Segment writes use a bounded confirmation window. Because HealthKit writes
+  cannot be cancelled after submission, a timeout keeps the boundary pending,
+  prevents duplicate retries, and reconciles the late callback. Pause and finish
+  intent remain available while confirmation is pending. Save waits for one
+  additional bounded window so it can close the final segment correctly. If the
+  callback still does not arrive, the stopped ride remains retryable and the
+  rider can explicitly save anyway with a warning that the pending segment is
+  not guaranteed. Discard never waits for segment confirmation.
 
 ### End and save
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -25,6 +25,8 @@ struct ContentView: View {
     @State private var showingSettings = false
     @State private var showingBikeComputerSetup = false
     @State private var showingWorkoutDashboard = false
+    @State private var workoutSegmentToast: WorkoutCompletedSegmentV1?
+    @State private var observedWorkoutSegmentIndex: UInt32?
     @State private var isSearchPanelExpanded = false
     @State private var dismissedOfflineMapOnboarding = false
     @State private var confirmedDeviceMapMissing = false
@@ -139,6 +141,18 @@ struct ContentView: View {
                     .transition(.scale(scale: 0.96).combined(with: .opacity))
                     .zIndex(20)
                 }
+
+                if let workoutSegmentToast,
+                   !showingWorkoutDashboard {
+                    VStack {
+                        workoutSegmentToastView(workoutSegmentToast)
+                            .padding(.horizontal, 14)
+                            .padding(.top, 8)
+                        Spacer()
+                    }
+                    .transition(.move(edge: .top).combined(with: .opacity))
+                    .zIndex(30)
+                }
             }
             .alert("Navigation Error", isPresented: $coordinator.alert.isShowing) {
                 Button("OK", role: .cancel) { }
@@ -198,6 +212,7 @@ struct ContentView: View {
             updateIdleTimer()
             coordinator.applicationDidBecomeActive()
             workoutMirrorManager.refreshFreshness()
+            observedWorkoutSegmentIndex = currentWorkoutSegment?.index
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
         }
         .onChange(of: scenePhase) { newValue in
@@ -213,6 +228,26 @@ struct ContentView: View {
         }
         .onChange(of: workoutStore.shouldMaintainWorkoutServices) { _ in
             updateIdleTimer()
+        }
+        .onChange(of: currentWorkoutSegment?.index) { index in
+            guard let index,
+                  index != observedWorkoutSegmentIndex else {
+                observedWorkoutSegmentIndex = index
+                return
+            }
+            observedWorkoutSegmentIndex = index
+            guard scenePhase == .active,
+                  !showingWorkoutDashboard,
+                  workoutStore.presentation.isWorkoutActive,
+                  let segment = currentWorkoutSegment else {
+                workoutSegmentToast = nil
+                return
+            }
+            UINotificationFeedbackGenerator()
+                .notificationOccurred(.success)
+            withAnimation {
+                workoutSegmentToast = segment
+            }
         }
         .onDisappear {
             coordinator.setViewingMap(false)
@@ -258,6 +293,51 @@ struct ContentView: View {
             }
             hasCompletedFirstRunMapOnboarding = true
         }
+        .task(id: workoutSegmentToast?.index) {
+            guard let index = workoutSegmentToast?.index else { return }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard workoutSegmentToast?.index == index else { return }
+            withAnimation {
+                workoutSegmentToast = nil
+            }
+        }
+    }
+
+    private var currentWorkoutSegment: WorkoutCompletedSegmentV1? {
+        (workoutStore.presentation.finalSnapshot
+            ?? workoutStore.presentation.snapshot).lastCompletedSegment
+    }
+
+    private func workoutSegmentToastView(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "flag.checkered")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Segment \(segment.index)")
+                    .font(.subheadline.weight(.semibold))
+                Text(workoutSegmentSummary(segment))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 3)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func workoutSegmentSummary(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> String {
+        let duration = WorkoutValueFormatter.duration(segment.duration)
+        guard let distance = segment.distanceMeters else {
+            return duration
+        }
+        return "\(duration)  •  \(WorkoutValueFormatter.distance(distance)) \(WorkoutValueFormatter.distanceUnit(distance))"
     }
 
     private func updateIdleTimer(for phase: ScenePhase? = nil) {

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -183,6 +183,7 @@ struct ContentView: View {
                     onStart: workoutMirrorManager.startOutdoorCyclingOnWatch,
                     onPause: workoutMirrorManager.pause,
                     onResume: workoutMirrorManager.resume,
+                    onMarkSegment: workoutMirrorManager.markSegment,
                     onEndAndSave: workoutMirrorManager.endAndSave,
                     onDiscard: workoutMirrorManager.discard,
                     onDone: workoutMirrorManager.resetTerminalPresentation

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
@@ -54,6 +54,22 @@ final class WorkoutMetricsStore: ObservableObject {
         reducer.pendingControlSequence
     }
 
+    var supportsSegmentMarking: Bool {
+        guard let version = reducer.latestEnvelope?.schemaVersion else {
+            return false
+        }
+        return version.major == WorkoutSchemaVersion.current.major
+            && version.minor >= 4
+    }
+
+    var isSegmentConfirmationPending: Bool {
+        reducer.isSegmentConfirmationPending
+    }
+
+    var currentUnconfirmedSegmentControlSequence: UInt64? {
+        reducer.currentUnconfirmedSegmentControlSequence
+    }
+
     var canResetTerminalPresentation: Bool {
         reducer.canResetTerminalPresentation
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
@@ -266,6 +266,11 @@ final class WorkoutMirrorManager: NSObject {
         scheduleControlConfirmationTimeout(for: .resume)
     }
 
+    func markSegment() {
+        guard store.presentation.sessionState == .running else { return }
+        enqueueStateChangingControl(.markSegment)
+    }
+
     func endAndSave() {
         enqueueStateChangingControl(.endAndSave)
     }

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
@@ -106,6 +106,8 @@ final class WorkoutMirrorManager: NSObject {
     private var controlSequencer = WorkoutControlEnvelopeSequencer()
     private var remoteQueue: [RemoteMessage] = []
     private var remoteSendInFlight: RemoteSendAttempt?
+    private var segmentStatusReplayMessage: RemoteMessage?
+    private var segmentReplayAfterSendAttemptID: UUID?
 
     init(
         healthStore: HKHealthStore = HKHealthStore(),
@@ -247,8 +249,13 @@ final class WorkoutMirrorManager: NSObject {
     func pause() {
         guard #available(iOS 17.0, *),
               let session = mirroredTransport,
-              store.presentation.sessionState == .running,
-              store.markPendingControl(.pause) else {
+              store.presentation.sessionState == .running else {
+            return
+        }
+        releasePendingSegmentForLifecycleControl(
+            prioritizeRemoteQueue: false
+        )
+        guard store.markPendingControl(.pause) else {
             return
         }
         session.pause()
@@ -258,8 +265,13 @@ final class WorkoutMirrorManager: NSObject {
     func resume() {
         guard #available(iOS 17.0, *),
               let session = mirroredTransport,
-              store.presentation.sessionState == .paused,
-              store.markPendingControl(.resume) else {
+              store.presentation.sessionState == .paused else {
+            return
+        }
+        releasePendingSegmentForLifecycleControl(
+            prioritizeRemoteQueue: false
+        )
+        guard store.markPendingControl(.resume) else {
             return
         }
         session.resume()
@@ -267,15 +279,25 @@ final class WorkoutMirrorManager: NSObject {
     }
 
     func markSegment() {
-        guard store.presentation.sessionState == .running else { return }
+        guard store.presentation.sessionState == .running,
+              store.supportsSegmentMarking,
+              !store.isSegmentConfirmationPending else {
+            return
+        }
         enqueueStateChangingControl(.markSegment)
     }
 
     func endAndSave() {
+        releasePendingSegmentForLifecycleControl(
+            prioritizeRemoteQueue: true
+        )
         enqueueStateChangingControl(.endAndSave)
     }
 
     func discard() {
+        releasePendingSegmentForLifecycleControl(
+            prioritizeRemoteQueue: true
+        )
         enqueueStateChangingControl(.discard)
     }
 
@@ -403,7 +425,9 @@ final class WorkoutMirrorManager: NSObject {
                 $0.control == control
                     && $0.envelope.sequence == sequence
             }
-            if control == .endAndSave || control == .discard {
+            if control == .endAndSave
+                || control == .discard
+                || control == .markSegment {
                 // HealthKit does not provide cancellation for a remote send.
                 // Once the correlated control has exhausted its bounded
                 // confirmation window, invalidate whichever attempt owns the
@@ -416,13 +440,16 @@ final class WorkoutMirrorManager: NSObject {
                 sequence: sequence,
                 error: control == .endAndSave || control == .discard
                     ? .terminalChoiceUnconfirmed
-                    : .watchUnavailable
+                    : control == .markSegment
+                        ? .segmentMarkUnconfirmed
+                        : .watchUnavailable
             )
             pendingControlTimeoutControl = nil
             pendingControlTimeoutSequence = nil
             pendingControlTimeoutTask = nil
             pendingControlTimeoutAttemptID = nil
             synchronizeFinalSnapshotTimeoutWithPresentation()
+            enqueueUnconfirmedSegmentReplayIfNeeded()
             drainRemoteQueue()
         }
     }
@@ -433,6 +460,81 @@ final class WorkoutMirrorManager: NSObject {
         pendingControlTimeoutAttemptID = nil
         pendingControlTimeoutControl = nil
         pendingControlTimeoutSequence = nil
+    }
+
+    private func releasePendingSegmentForLifecycleControl(
+        prioritizeRemoteQueue: Bool
+    ) {
+        guard store.presentation.pendingControl == .markSegment,
+              let sequence = store.currentPendingControlSequence else {
+            if prioritizeRemoteQueue {
+                abandonSegmentStatusReplay()
+            }
+            return
+        }
+        let markWasSubmitted =
+            remoteSendInFlight?.message.control == .markSegment
+                && remoteSendInFlight?.message.envelope.sequence == sequence
+                || pendingControlTimeoutControl == .markSegment
+                    && pendingControlTimeoutSequence == sequence
+        let submittedMarkAttemptID = remoteSendInFlight.flatMap { attempt in
+            attempt.message.control == .markSegment
+                && attempt.message.envelope.sequence == sequence
+                ? attempt.id
+                : nil
+        }
+        remoteQueue.removeAll {
+            $0.control == .markSegment
+                && $0.envelope.sequence == sequence
+        }
+        if prioritizeRemoteQueue {
+            remoteQueue.removeAll {
+                $0.control == .requestCurrentSnapshot
+            }
+            if markWasSubmitted
+                || remoteSendInFlight?.message.control
+                    == .requestCurrentSnapshot {
+                remoteSendInFlight = nil
+            }
+            // A terminal choice supersedes status recovery for this boundary.
+            // Never resurrect the mark after End or Discard has been sent.
+            abandonSegmentStatusReplay()
+        } else {
+            // Pause/resume may overtake a submitted mark. If its transport
+            // callback is still outstanding, replay exactly once when that
+            // particular callback releases the queue.
+            segmentReplayAfterSendAttemptID = submittedMarkAttemptID
+        }
+        cancelControlConfirmationTimeout()
+        store.failPendingControl(
+            .markSegment,
+            sequence: sequence,
+            error: markWasSubmitted
+                ? .segmentMarkUnconfirmed
+                : .segmentMarkFailed
+        )
+        if !prioritizeRemoteQueue {
+            enqueueUnconfirmedSegmentReplayIfNeeded()
+            drainRemoteQueue()
+        }
+    }
+
+    private func abandonSegmentStatusReplay() {
+        guard let message = segmentStatusReplayMessage else {
+            segmentReplayAfterSendAttemptID = nil
+            return
+        }
+        let sequence = message.envelope.sequence
+        remoteQueue.removeAll {
+            $0.control == .markSegment
+                && $0.envelope.sequence == sequence
+        }
+        if remoteSendInFlight?.message.control == .markSegment,
+           remoteSendInFlight?.message.envelope.sequence == sequence {
+            remoteSendInFlight = nil
+        }
+        segmentStatusReplayMessage = nil
+        segmentReplayAfterSendAttemptID = nil
     }
 
     private func synchronizeControlTimeoutWithPresentation() {
@@ -540,7 +642,10 @@ final class WorkoutMirrorManager: NSObject {
 
         // HealthKit can provide a fresh HKWorkoutSession instance after a
         // reconnect. Preserve ordered state, replace the object reference, and
-        // request one full snapshot instead of replaying old metric history.
+        // replay an outcome-unknown segment before requesting one full
+        // snapshot. The exact original sender/sequence is the only safe way
+        // to distinguish it from a Watch-local segment boundary.
+        enqueueUnconfirmedSegmentReplayIfNeeded()
         if store.currentEnvelope?.snapshot?.state.isActive == true {
             enqueueSnapshotRequestIfPossible()
         }
@@ -559,16 +664,20 @@ final class WorkoutMirrorManager: NSObject {
             control,
             sequence: envelope.sequence
         ) else { return }
+        // A best-effort snapshot request must never hold a rider control
+        // behind a callback that HealthKit may delay indefinitely.
+        remoteQueue.removeAll {
+            $0.control == .requestCurrentSnapshot
+        }
+        if remoteSendInFlight?.message.control == .requestCurrentSnapshot {
+            remoteSendInFlight = nil
+        }
         remoteQueue.append(
             RemoteMessage(
                 envelope: envelope,
                 control: control,
                 reportsFailure: true
             )
-        )
-        scheduleControlConfirmationTimeout(
-            for: control,
-            sequence: envelope.sequence
         )
         drainRemoteQueue()
     }
@@ -592,6 +701,43 @@ final class WorkoutMirrorManager: NSObject {
         )
     }
 
+    private func enqueueUnconfirmedSegmentReplayIfNeeded() {
+        guard let message = segmentStatusReplayMessage,
+              message.control == .markSegment,
+              store.currentUnconfirmedSegmentControlSequence
+                == message.envelope.sequence,
+              remoteSendInFlight?.message.envelope.sequence
+                != message.envelope.sequence,
+              !remoteQueue.contains(where: {
+                  $0.control == .markSegment
+                      && $0.envelope.sequence == message.envelope.sequence
+              }) else {
+            return
+        }
+        remoteQueue.insert(message, at: 0)
+    }
+
+    private func synchronizeSegmentStatusReplayWithPresentation() {
+        guard let message = segmentStatusReplayMessage else { return }
+        let sequence = message.envelope.sequence
+        let isStillPending =
+            store.presentation.pendingControl == .markSegment
+                && store.currentPendingControlSequence == sequence
+        let isStillUnconfirmed =
+            store.currentUnconfirmedSegmentControlSequence == sequence
+        guard !isStillPending, !isStillUnconfirmed else { return }
+        remoteQueue.removeAll {
+            $0.control == .markSegment
+                && $0.envelope.sequence == sequence
+        }
+        if remoteSendInFlight?.message.control == .markSegment,
+           remoteSendInFlight?.message.envelope.sequence == sequence {
+            remoteSendInFlight = nil
+        }
+        segmentReplayAfterSendAttemptID = nil
+        segmentStatusReplayMessage = nil
+    }
+
     private func makeControlEnvelope(
         _ control: WorkoutControlV1
     ) -> WorkoutEnvelopeV1? {
@@ -613,6 +759,8 @@ final class WorkoutMirrorManager: NSObject {
         cancelFirstSnapshotTimeout()
         remoteQueue.removeAll()
         remoteSendInFlight = nil
+        segmentStatusReplayMessage = nil
+        segmentReplayAfterSendAttemptID = nil
         controlSequencer.reset()
         cancelControlConfirmationTimeout()
         cancelFinalSnapshotTimeout()
@@ -707,12 +855,31 @@ final class WorkoutMirrorManager: NSObject {
             message: message
         )
         remoteSendInFlight = attempt
+        if message.control == .markSegment {
+            segmentStatusReplayMessage = message
+        }
+        if message.reportsFailure,
+           store.presentation.pendingControl == message.control,
+           store.currentPendingControlSequence == message.envelope.sequence {
+            // A queued control has not reached HealthKit yet, so its
+            // confirmation window must begin only when it is actually
+            // submitted to the mirrored session.
+            scheduleControlConfirmationTimeout(
+                for: message.control,
+                sequence: message.envelope.sequence
+            )
+        }
         let callbackReference = WorkoutWeakReference(self)
         session.send(data: data) { success, error in
             Task { @MainActor in
                 guard let manager = callbackReference.value,
                       manager.remoteSendInFlight?.id == attempt.id else {
                     return
+                }
+                let shouldEnqueueDeferredSegmentReplay =
+                    manager.segmentReplayAfterSendAttemptID == attempt.id
+                if shouldEnqueueDeferredSegmentReplay {
+                    manager.segmentReplayAfterSendAttemptID = nil
                 }
                 manager.remoteSendInFlight = nil
                 if !success, message.reportsFailure {
@@ -723,6 +890,9 @@ final class WorkoutMirrorManager: NSObject {
                     )
                 }
                 manager.synchronizeControlTimeoutWithPresentation()
+                if shouldEnqueueDeferredSegmentReplay {
+                    manager.enqueueUnconfirmedSegmentReplayIfNeeded()
+                }
                 manager.drainRemoteQueue()
             }
         }
@@ -767,6 +937,7 @@ final class WorkoutMirrorManager: NSObject {
         guard isCurrentTransport(transport) else { return }
         let drainSessionID = pendingTerminalFailureSessionID
         let result = store.ingestBatch(envelopes, receivedAt: receivedAt)
+        synchronizeSegmentStatusReplayWithPresentation()
         if let sessionID = result.latestSnapshotEnvelope?.sessionID {
             currentTransportSessionID = sessionID
             currentTransportStartDate = result.latestSnapshotEnvelope?

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -363,27 +363,57 @@ struct RideMetricsPanel: View {
             TimelineView(.periodic(from: Date(), by: 1)) { context in
                 workoutStatus(
                     delayedWorkoutStatus(at: context.date),
-                    color: .orange
+                    color: .orange,
+                    detail: workoutRecoveryDetail
                 )
             }
         } else if presentation.connectionState == .disconnected {
             TimelineView(.periodic(from: Date(), by: 1)) { context in
                 workoutStatus(
                     disconnectedWorkoutStatus(at: context.date),
-                    color: .red
+                    color: .red,
+                    detail: workoutRecoveryDetail
                 )
             }
-        } else if presentation.errorCode != nil {
-            workoutStatus("Workout needs attention", color: .orange)
+        } else if let errorCode = presentation.errorCode {
+            workoutStatus(
+                WorkoutErrorCopyV1.title(errorCode),
+                color: .orange,
+                detail: WorkoutErrorCopyV1.detail(
+                    errorCode,
+                    context: WorkoutErrorCopyV1.context(for: presentation)
+                )
+            )
         }
     }
 
-    private func workoutStatus(_ title: String, color: Color) -> some View {
+    private var workoutRecoveryDetail: String? {
+        let presentation = workoutStore.presentation
+        guard let errorCode = presentation.errorCode else { return nil }
+        return WorkoutErrorCopyV1.detail(
+            errorCode,
+            context: WorkoutErrorCopyV1.context(for: presentation)
+        )
+    }
+
+    private func workoutStatus(
+        _ title: String,
+        color: Color,
+        detail: String? = nil
+    ) -> some View {
         HStack(spacing: 7) {
             Image(systemName: "applewatch.radiowaves.left.and.right")
-            Text(title)
-                .lineLimit(1)
-                .minimumScaleFactor(0.75)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                if let detail {
+                    Text(detail)
+                        .font(.caption2)
+                        .lineLimit(2)
+                        .minimumScaleFactor(0.75)
+                }
+            }
             Spacer(minLength: 0)
         }
         .font(.caption.weight(.semibold))
@@ -483,7 +513,8 @@ struct RideMetricsPanel: View {
     private var canControlWorkout: Bool {
         let presentation = workoutStore.presentation
         return presentation.sessionID != nil
-            && presentation.pendingControl == nil
+            && (presentation.pendingControl == nil
+                || presentation.pendingControl == .markSegment)
             && presentation.connectionState != .disconnected
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 private enum WorkoutStartAvailabilityAlert: String, Identifiable {
     case unsupported
@@ -402,11 +403,14 @@ struct WorkoutDashboardView: View {
     let onStart: () -> Void
     let onPause: () -> Void
     let onResume: () -> Void
+    let onMarkSegment: () -> Void
     let onEndAndSave: () -> Void
     let onDiscard: () -> Void
     let onDone: () -> Bool
 
     @Environment(\.dismiss) private var dismiss
+    @State private var segmentToast: WorkoutCompletedSegmentV1?
+    @State private var observedSegmentIndex: UInt32?
 
     var body: some View {
         NavigationView {
@@ -433,6 +437,45 @@ struct WorkoutDashboardView: View {
                 }
             }
         }
+        .overlay(alignment: .top) {
+            if let segmentToast {
+                segmentToastView(segmentToast)
+                    .padding(.horizontal)
+                    .padding(.top, 8)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .onAppear {
+            observedSegmentIndex = currentCompletedSegment?.index
+        }
+        .onChange(of: currentCompletedSegment?.index) { index in
+            guard let index,
+                  index != observedSegmentIndex,
+                  store.presentation.isWorkoutActive,
+                  let segment = currentCompletedSegment else {
+                observedSegmentIndex = index
+                return
+            }
+            observedSegmentIndex = index
+            UINotificationFeedbackGenerator()
+                .notificationOccurred(.success)
+            withAnimation {
+                segmentToast = segment
+            }
+        }
+        .task(id: segmentToast?.index) {
+            guard let index = segmentToast?.index else { return }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard segmentToast?.index == index else { return }
+            withAnimation {
+                segmentToast = nil
+            }
+        }
+    }
+
+    private var currentCompletedSegment: WorkoutCompletedSegmentV1? {
+        (store.presentation.finalSnapshot ?? store.presentation.snapshot)
+            .lastCompletedSegment
     }
 
     @ViewBuilder
@@ -508,6 +551,16 @@ struct WorkoutDashboardView: View {
                     .font(.system(size: 42, weight: .semibold, design: .rounded))
                     .monospacedDigit()
                     .accessibilityLabel("Elapsed time")
+
+                if let segment = snapshot.lastCompletedSegment,
+                   store.presentation.isWorkoutActive {
+                    Label(
+                        "Segment \(segment.index + 1) in progress",
+                        systemImage: "flag.checkered"
+                    )
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                }
 
                 LazyVGrid(columns: columns, spacing: 12) {
                     metric(
@@ -662,15 +715,25 @@ struct WorkoutDashboardView: View {
                 .multilineTextAlignment(.center)
         } else if presentation.isWorkoutActive {
             HStack(spacing: 12) {
+                Button(action: onMarkSegment) {
+                    Label("Segment", systemImage: "flag.checkered")
+                }
+                .tint(.blue)
+                .disabled(
+                    presentation.sessionState != .running
+                        || presentation.pendingControl != nil
+                )
+                .accessibilityLabel("Mark workout segment")
+
                 if presentation.sessionState == .paused {
                     Button(action: onResume) {
-                        Label("Resume Workout", systemImage: "play.fill")
+                        Label("Resume", systemImage: "play.fill")
                     }
                     .tint(.green)
                     .disabled(presentation.pendingControl != nil)
                 } else {
                     Button(action: onPause) {
-                        Label("Pause Workout", systemImage: "pause.fill")
+                        Label("Pause", systemImage: "pause.fill")
                     }
                     .tint(.orange)
                     .disabled(
@@ -684,7 +747,7 @@ struct WorkoutDashboardView: View {
                     onEndAndSave: onEndAndSave,
                     onDiscard: onDiscard
                 ) {
-                    Label("End Workout", systemImage: "stop.fill")
+                    Label("End", systemImage: "stop.fill")
                 }
                 .disabled(
                     presentation.sessionState == .ending
@@ -693,6 +756,38 @@ struct WorkoutDashboardView: View {
             }
             .buttonStyle(.borderedProminent)
         }
+    }
+
+    private func segmentToastView(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: "flag.checkered")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.blue)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Segment \(segment.index)")
+                    .font(.subheadline.weight(.semibold))
+                Text(segmentSummary(segment))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding(12)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 14))
+        .shadow(color: .black.opacity(0.15), radius: 8, y: 3)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func segmentSummary(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> String {
+        let duration = WorkoutValueFormatter.duration(segment.duration)
+        guard let distance = segment.distanceMeters else {
+            return duration
+        }
+        return "\(duration)  •  \(WorkoutValueFormatter.distance(distance)) \(WorkoutValueFormatter.distanceUnit(distance))"
     }
 
     private func metric(

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -409,6 +409,7 @@ struct WorkoutDashboardView: View {
     let onDone: () -> Bool
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
     @State private var segmentToast: WorkoutCompletedSegmentV1?
     @State private var observedSegmentIndex: UInt32?
 
@@ -449,14 +450,13 @@ struct WorkoutDashboardView: View {
             observedSegmentIndex = currentCompletedSegment?.index
         }
         .onChange(of: currentCompletedSegment?.index) { index in
-            guard let index,
-                  index != observedSegmentIndex,
-                  store.presentation.isWorkoutActive,
-                  let segment = currentCompletedSegment else {
-                observedSegmentIndex = index
-                return
-            }
+            let previousIndex = observedSegmentIndex
             observedSegmentIndex = index
+            guard scenePhase == .active,
+                  let index,
+                  index != previousIndex,
+                  store.presentation.isWorkoutActive,
+                  let segment = currentCompletedSegment else { return }
             UINotificationFeedbackGenerator()
                 .notificationOccurred(.success)
             withAnimation {
@@ -714,6 +714,12 @@ struct WorkoutDashboardView: View {
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
         } else if presentation.isWorkoutActive {
+            if !store.supportsSegmentMarking {
+                Text("Update BikeComputer on Apple Watch to mark segments from iPhone.")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
             HStack(spacing: 12) {
                 Button(action: onMarkSegment) {
                     Label("Segment", systemImage: "flag.checkered")
@@ -722,6 +728,8 @@ struct WorkoutDashboardView: View {
                 .disabled(
                     presentation.sessionState != .running
                         || presentation.pendingControl != nil
+                        || !store.supportsSegmentMarking
+                        || store.isSegmentConfirmationPending
                 )
                 .accessibilityLabel("Mark workout segment")
 
@@ -730,7 +738,10 @@ struct WorkoutDashboardView: View {
                         Label("Resume", systemImage: "play.fill")
                     }
                     .tint(.green)
-                    .disabled(presentation.pendingControl != nil)
+                    .disabled(
+                        presentation.pendingControl != nil
+                            && presentation.pendingControl != .markSegment
+                    )
                 } else {
                     Button(action: onPause) {
                         Label("Pause", systemImage: "pause.fill")
@@ -738,7 +749,9 @@ struct WorkoutDashboardView: View {
                     .tint(.orange)
                     .disabled(
                         presentation.sessionState != .running
-                            || presentation.pendingControl != nil
+                            || (presentation.pendingControl != nil
+                                && presentation.pendingControl
+                                    != .markSegment)
                     )
                 }
 
@@ -751,7 +764,8 @@ struct WorkoutDashboardView: View {
                 }
                 .disabled(
                     presentation.sessionState == .ending
-                        || presentation.pendingControl != nil
+                        || (presentation.pendingControl != nil
+                            && presentation.pendingControl != .markSegment)
                 )
             }
             .buttonStyle(.borderedProminent)

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -21,6 +21,11 @@ enum WatchWorkoutFinishRequestError: Equatable {
     case identityMetadataFailed
 }
 
+enum WatchWorkoutSegmentError: Equatable {
+    case unavailable
+    case healthKitWriteFailed
+}
+
 struct WatchWorkoutSummary: Equatable {
     enum Outcome: Equatable {
         case saved
@@ -285,8 +290,40 @@ typealias WatchMirrorSendOperation = @MainActor (
     @escaping @Sendable (Bool, Error?) -> Void
 ) -> Void
 
+typealias WatchSegmentEventOperation = @MainActor (
+    HKWorkoutEvent
+) async throws -> Void
+
 @MainActor
 final class WatchWorkoutManager: NSObject, ObservableObject {
+    private enum SegmentMetadataKey {
+        static let origin = "com.openbikecomputer.workout.segment.origin"
+        static let index = "com.openbikecomputer.workout.segment.index"
+        static let activeDuration =
+            "com.openbikecomputer.workout.segment.activeDuration"
+        static let distanceMeters =
+            "com.openbikecomputer.workout.segment.distanceMeters"
+        static let cumulativeElapsed =
+            "com.openbikecomputer.workout.segment.cumulativeElapsed"
+        static let cumulativeDistance =
+            "com.openbikecomputer.workout.segment.cumulativeDistance"
+        static let controlSenderID =
+            "com.openbikecomputer.workout.segment.controlSenderID"
+        static let controlSequence =
+            "com.openbikecomputer.workout.segment.controlSequence"
+        static let originValue = "BikeComputer"
+    }
+
+    private enum SegmentEventWriteOutcome: Equatable, Sendable {
+        case success
+        case failure
+    }
+
+    private struct RemoteSegmentControlContext {
+        let envelope: WorkoutEnvelopeV1
+        let acceptedGate: WorkoutRemoteControlSequenceGate
+    }
+
     private enum ConfirmedTerminalCompletion {
         case saved(summary: WatchWorkoutSummary, at: Date)
         case discarded(summary: WatchWorkoutSummary, at: Date)
@@ -302,6 +339,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     @Published private(set) var isTerminalArchivePending = false
     @Published private(set) var isTerminalPublicationPending = false
     @Published private(set) var maximumHeartRateBPM: Int
+    @Published private(set) var isMarkingSegment = false
+    @Published private(set) var segmentError: WatchWorkoutSegmentError?
 
     private let healthStore: HKHealthStore
     private let routeRecorder: WatchRouteRecorder
@@ -342,6 +381,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         (@MainActor (HKWorkoutSession) -> Void)?
     private let injectedRemoteResumeOperation:
         (@MainActor (HKWorkoutSession) -> Void)?
+    private let injectedSegmentEventOperation: WatchSegmentEventOperation?
+    private let segmentNow: @MainActor () -> Date
+    private let segmentWriteTimeout: TimeInterval
     private let injectedMirrorStartOperation: WatchMirrorStartOperation?
     private let injectedMirrorSendOperation: WatchMirrorSendOperation?
     private let injectedMirrorShutdownEndSession: (
@@ -361,6 +403,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var mirrorRetryTask: Task<Void, Never>?
     private var mirrorShutdownWatchdogTask: Task<Void, Never>?
     private var complicationStartTask: Task<Void, Never>?
+    private var segmentOperationTask: Task<Void, Never>?
+    private var segmentOperationAttemptID: UUID?
     private var authoritativeFinalizationEndDate: Date?
     private var isBuilderReadyForFinalization = false
     private var isIdentityMetadataRetryPending = false
@@ -390,6 +434,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         control: WorkoutControlV1,
         sequence: UInt64
     )?
+    private var remoteSegmentControlContext: RemoteSegmentControlContext?
+    private var deferredRemoteWorkoutEnvelopes: [WorkoutEnvelopeV1] = []
     private var isTerminalMirrorDeliveryPending = false
     private var isStartFailureMirrorDeliveryPending = false
     private var shutdownMirrorFailureRetryCount = 0
@@ -412,6 +458,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var cyclingPower: WorkoutMetricV1?
     private var cyclingCadence: WorkoutMetricV1?
     private var terminalRouteDistance: WorkoutMetricCandidate?
+    private var segmentAccumulator = WorkoutSegmentAccumulator()
 
     override convenience init() {
 #if DEBUG
@@ -441,6 +488,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             complicationStartOperation: nil,
             remotePauseOperation: nil,
             remoteResumeOperation: nil,
+            segmentEventOperation: nil,
+            segmentWriteTimeout: 10,
             mirrorStartOperation: nil,
             mirrorSendOperation: nil,
             mirrorShutdownEndSession: nil,
@@ -494,6 +543,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             (@MainActor (HKWorkoutSession) -> Void)? = nil,
         remoteResumeOperation:
             (@MainActor (HKWorkoutSession) -> Void)? = nil,
+        segmentEventOperation: WatchSegmentEventOperation? = nil,
+        segmentNow: @MainActor @escaping () -> Date = Date.init,
+        segmentWriteTimeout: TimeInterval = 10,
         mirrorStartOperation: WatchMirrorStartOperation? = nil,
         mirrorSendOperation: WatchMirrorSendOperation? = nil,
         mirrorShutdownEndSession:
@@ -526,6 +578,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         self.injectedComplicationStartOperation = complicationStartOperation
         self.injectedRemotePauseOperation = remotePauseOperation
         self.injectedRemoteResumeOperation = remoteResumeOperation
+        self.injectedSegmentEventOperation = segmentEventOperation
+        self.segmentNow = segmentNow
+        self.segmentWriteTimeout = segmentWriteTimeout.isFinite
+            ? min(max(0.01, segmentWriteTimeout), 60)
+            : 10
         self.injectedMirrorStartOperation = mirrorStartOperation
         self.injectedMirrorSendOperation = mirrorSendOperation
         self.injectedMirrorShutdownEndSession = mirrorShutdownEndSession
@@ -537,6 +594,13 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         if let recoveredSaveRuntimeAdapter {
             session = recoveredSaveRuntimeAdapter.session
             builder = recoveredSaveRuntimeAdapter.builder
+            if let workoutStart = recoveryStore.recoveredIdentity?.startDate
+                ?? recoveredSaveRuntimeAdapter.builder.startDate {
+                restoreSegmentAccumulator(
+                    from: recoveredSaveRuntimeAdapter.builder,
+                    workoutStart: workoutStart
+                )
+            }
             isBuilderReadyForFinalization = true
         }
         isFinishFailureRollbackPending = initialFinishFailureRollbackPending
@@ -567,6 +631,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         mirrorRetryTask?.cancel()
         mirrorShutdownWatchdogTask?.cancel()
         complicationStartTask?.cancel()
+        segmentOperationTask?.cancel()
     }
 
     var state: WorkoutSessionStateV1 { lifecycle.state }
@@ -688,6 +753,15 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     func resume() {
         guard lifecycle.state == .paused else { return }
         session?.resume()
+    }
+
+    func markSegment() {
+        guard lifecycle.state == .running else {
+            segmentError = .unavailable
+            return
+        }
+        guard !isMarkingSegment else { return }
+        beginSegmentMark(remoteContext: nil)
     }
 
     func endAndSave() {
@@ -1044,6 +1118,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         isTerminalPublicationPending = false
         preparedRouteForFinalization = nil
         let startDate = Date()
+        segmentAccumulator.reset(workoutStart: startDate)
+        segmentError = nil
+        isMarkingSegment = false
+        remoteSegmentControlContext = nil
+        deferredRemoteWorkoutEnvelopes.removeAll()
 
         let configuration: HKWorkoutConfiguration
         if let suppliedConfiguration {
@@ -1077,6 +1156,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
 
             self.session = session
             self.builder = builder
+            restoreSegmentAccumulator(
+                from: builder,
+                workoutStart: startDate
+            )
             let routeBuilder = builder.seriesBuilder(
                 for: HKSeriesType.workoutRoute()
             ) as? HKWorkoutRouteBuilder
@@ -1491,6 +1574,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         let recoveredFinishRequest = recoveredIdentity.finishRequest
         session = recoveredSession
         builder = recoveredBuilder
+        restoreSegmentAccumulator(
+            from: recoveredBuilder,
+            workoutStart: recoveredIdentity.startDate
+        )
         isBuilderReadyForFinalization = true
         isIdentityMetadataRetryPending = false
         isTerminalPublicationPending = false
@@ -2334,6 +2421,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         disposition: WorkoutFinishDisposition,
         endDate: Date
     ) async {
+        await waitForSegmentOperationBeforeFinalization()
         if disposition == .discard {
             let metadata = injectedRecoveredDiscardFinalizationAdapter?
                 .metadata()
@@ -2417,6 +2505,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 },
                 endCollection: { [weak self] in
                     guard let self else { throw WorkoutFinalizationError.managerReleased }
+                    await closeFinalSegmentIfNeeded(
+                        in: builder,
+                        at: endDate
+                    )
                     try await endCollection(builder, at: endDate)
                     updateAllMetrics(from: builder, capturedAt: endDate)
                 },
@@ -2737,6 +2829,14 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         periodicSnapshotTask = nil
         coalescedSnapshotTask?.cancel()
         coalescedSnapshotTask = nil
+        segmentOperationTask?.cancel()
+        segmentOperationTask = nil
+        segmentOperationAttemptID = nil
+        isMarkingSegment = false
+        segmentError = nil
+        remoteSegmentControlContext = nil
+        deferredRemoteWorkoutEnvelopes.removeAll()
+        segmentAccumulator = WorkoutSegmentAccumulator()
         handleAttachedSessionRelease()
     }
 
@@ -2764,7 +2864,397 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         periodicSnapshotTask = nil
         coalescedSnapshotTask?.cancel()
         coalescedSnapshotTask = nil
+        segmentOperationTask?.cancel()
+        segmentOperationTask = nil
+        segmentOperationAttemptID = nil
+        isMarkingSegment = false
+        segmentError = nil
+        remoteSegmentControlContext = nil
+        deferredRemoteWorkoutEnvelopes.removeAll()
+        segmentAccumulator = WorkoutSegmentAccumulator()
         handleAttachedSessionRelease()
+    }
+
+    private func beginSegmentMark(
+        remoteContext: RemoteSegmentControlContext?
+    ) {
+        guard lifecycle.state == .running,
+              !isMarkingSegment,
+              builder != nil || injectedSegmentEventOperation != nil else {
+            segmentError = .unavailable
+            if let remoteContext {
+                commitRemoteSegmentControl(remoteContext)
+                publishAcknowledgement(
+                    for: .markSegment,
+                    acknowledgedSequence: remoteContext.envelope.sequence,
+                    errorCode: .segmentMarkFailed
+                )
+            }
+            return
+        }
+
+        let endedAt = segmentNow()
+        let currentSnapshot = makeSnapshot(capturedAt: endedAt)
+        guard let cumulativeElapsedTime =
+                currentSnapshot.elapsedTime?.value,
+              let candidate = segmentAccumulator.candidate(
+                  endedAt: endedAt,
+                  cumulativeElapsedTime: cumulativeElapsedTime,
+                  cumulativeDistanceMeters:
+                    currentSnapshot.cyclingDistance?.value
+              ) else {
+            segmentError = .unavailable
+            if let remoteContext {
+                commitRemoteSegmentControl(remoteContext)
+                publishAcknowledgement(
+                    for: .markSegment,
+                    acknowledgedSequence: remoteContext.envelope.sequence,
+                    errorCode: .segmentMarkFailed
+                )
+            }
+            return
+        }
+
+        let event = makeSegmentEvent(
+            candidate,
+            remoteEnvelope: remoteContext?.envelope
+        )
+        isMarkingSegment = true
+        segmentError = nil
+        remoteSegmentControlContext = remoteContext
+        let attemptID = UUID()
+        segmentOperationAttemptID = attemptID
+        let targetBuilder = builder
+        segmentOperationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                try await addSegmentEvent(event, to: targetBuilder)
+                completeSegmentMark(
+                    attemptID: attemptID,
+                    candidate: candidate,
+                    error: nil
+                )
+            } catch {
+                completeSegmentMark(
+                    attemptID: attemptID,
+                    candidate: nil,
+                    error: .healthKitWriteFailed
+                )
+            }
+        }
+    }
+
+    private func completeSegmentMark(
+        attemptID: UUID,
+        candidate: WorkoutSegmentCandidate?,
+        error: WatchWorkoutSegmentError?
+    ) {
+        guard attemptID == segmentOperationAttemptID else { return }
+        let remoteContext = remoteSegmentControlContext
+        if let candidate, segmentAccumulator.commit(candidate) {
+            segmentError = nil
+            publishSnapshotImmediately()
+        } else {
+            segmentError = error ?? .healthKitWriteFailed
+        }
+        if let remoteContext {
+            commitRemoteSegmentControl(remoteContext)
+            publishAcknowledgement(
+                for: .markSegment,
+                acknowledgedSequence: remoteContext.envelope.sequence,
+                errorCode: candidate == nil ? .segmentMarkFailed : nil
+            )
+        }
+        remoteSegmentControlContext = nil
+        isMarkingSegment = false
+        segmentOperationAttemptID = nil
+        segmentOperationTask?.cancel()
+        segmentOperationTask = nil
+        drainDeferredRemoteWorkoutEnvelopes()
+    }
+
+    private func waitForSegmentOperationBeforeFinalization() async {
+        while isMarkingSegment {
+            do {
+                try await Task.sleep(nanoseconds: 10_000_000)
+            } catch {
+                return
+            }
+        }
+    }
+
+    private func commitRemoteSegmentControl(
+        _ context: RemoteSegmentControlContext
+    ) {
+        do {
+            _ = try recoveryStore.persistRemoteControlCheckpoint(
+                context.acceptedGate.checkpoint,
+                finishing: nil,
+                requestedAt: nil,
+                explicitRiderChoice: true,
+                terminalErrorCode: nil,
+                terminalAcknowledgement: nil
+            )
+            if let persistedIdentity = recoveryStore.recoveredIdentity {
+                identity = persistedIdentity
+            }
+        } catch {
+            // The HealthKit event metadata still provides exact replay
+            // detection if the process exits before this checkpoint is saved.
+        }
+        remoteControlGate = context.acceptedGate
+    }
+
+    private func drainDeferredRemoteWorkoutEnvelopes() {
+        guard !isMarkingSegment,
+              !deferredRemoteWorkoutEnvelopes.isEmpty,
+              let session else {
+            return
+        }
+        let deferred = deferredRemoteWorkoutEnvelopes
+        deferredRemoteWorkoutEnvelopes.removeAll()
+        handleRemoteWorkoutEnvelopes(deferred, from: session)
+    }
+
+    private func makeSegmentEvent(
+        _ candidate: WorkoutSegmentCandidate,
+        remoteEnvelope: WorkoutEnvelopeV1?
+    ) -> HKWorkoutEvent {
+        var metadata: [String: Any] = [
+            SegmentMetadataKey.origin: SegmentMetadataKey.originValue,
+            SegmentMetadataKey.index:
+                NSNumber(value: candidate.completedSegment.index),
+            SegmentMetadataKey.activeDuration:
+                NSNumber(value: candidate.completedSegment.duration),
+            SegmentMetadataKey.cumulativeElapsed:
+                NSNumber(value: candidate.cumulativeElapsedTime),
+        ]
+        if let distance = candidate.completedSegment.distanceMeters {
+            metadata[SegmentMetadataKey.distanceMeters] = NSNumber(
+                value: distance
+            )
+        }
+        if let cumulativeDistance = candidate.cumulativeDistanceMeters {
+            metadata[SegmentMetadataKey.cumulativeDistance] = NSNumber(
+                value: cumulativeDistance
+            )
+        }
+        if let senderID = remoteEnvelope?.controlSenderID {
+            metadata[SegmentMetadataKey.controlSenderID] = senderID.uuidString
+        }
+        if let sequence = remoteEnvelope?.sequence {
+            metadata[SegmentMetadataKey.controlSequence] = NSNumber(
+                value: sequence
+            )
+        }
+        return HKWorkoutEvent(
+            type: .segment,
+            dateInterval: DateInterval(
+                start: candidate.completedSegment.startedAt,
+                end: candidate.completedSegment.endedAt
+            ),
+            metadata: metadata
+        )
+    }
+
+    private func addSegmentEvent(
+        _ event: HKWorkoutEvent,
+        to builder: HKLiveWorkoutBuilder?
+    ) async throws {
+        let operation = Task { @MainActor [weak self] in
+            guard let self else {
+                return SegmentEventWriteOutcome.failure
+            }
+            do {
+                try await performSegmentEventWrite(event, to: builder)
+                return SegmentEventWriteOutcome.success
+            } catch {
+                return SegmentEventWriteOutcome.failure
+            }
+        }
+        let timeout = segmentWriteTimeout
+        let outcomes = AsyncStream<SegmentEventWriteOutcome> {
+            continuation in
+            Task {
+                continuation.yield(await operation.value)
+                continuation.finish()
+            }
+            Task {
+                do {
+                    try await Task.sleep(
+                        nanoseconds: UInt64(timeout * 1_000_000_000)
+                    )
+                } catch {
+                    return
+                }
+                continuation.yield(.failure)
+                continuation.finish()
+            }
+        }
+        var iterator = outcomes.makeAsyncIterator()
+        guard let outcome = await iterator.next() else {
+            operation.cancel()
+            throw WorkoutSegmentWriteError.writeFailed
+        }
+        operation.cancel()
+        guard outcome == .success else {
+            throw WorkoutSegmentWriteError.writeFailed
+        }
+    }
+
+    private func performSegmentEventWrite(
+        _ event: HKWorkoutEvent,
+        to builder: HKLiveWorkoutBuilder?
+    ) async throws {
+        if let injectedSegmentEventOperation {
+            try await injectedSegmentEventOperation(event)
+            return
+        }
+        guard let builder else {
+            throw WorkoutSegmentWriteError.builderUnavailable
+        }
+        try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<Void, Error>) in
+            builder.addWorkoutEvents([event]) { success, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if success {
+                    continuation.resume(returning: ())
+                } else {
+                    continuation.resume(
+                        throwing: WorkoutSegmentWriteError.writeFailed
+                    )
+                }
+            }
+        }
+    }
+
+    private func closeFinalSegmentIfNeeded(
+        in builder: HKLiveWorkoutBuilder?,
+        at endDate: Date
+    ) async {
+        guard segmentAccumulator.hasCompletedSegments else { return }
+        let currentSnapshot = makeSnapshot(capturedAt: endDate)
+        guard let cumulativeElapsedTime =
+                currentSnapshot.elapsedTime?.value,
+              let candidate = segmentAccumulator.candidate(
+                  endedAt: endDate,
+                  cumulativeElapsedTime: cumulativeElapsedTime,
+                  cumulativeDistanceMeters:
+                    currentSnapshot.cyclingDistance?.value
+              ),
+              candidate.completedSegment.duration > 0 else {
+            return
+        }
+        do {
+            try await addSegmentEvent(
+                makeSegmentEvent(candidate, remoteEnvelope: nil),
+                to: builder
+            )
+            _ = segmentAccumulator.commit(candidate)
+        } catch {
+            // Never hold a completed ride hostage to a best-effort final
+            // segment boundary. Previously committed segments remain valid.
+            segmentError = .healthKitWriteFailed
+        }
+    }
+
+    private func restoreSegmentAccumulator(
+        from builder: HKLiveWorkoutBuilder,
+        workoutStart: Date
+    ) {
+        let restored = builder.workoutEvents.compactMap {
+            completedSegment(from: $0, workoutStart: workoutStart)
+        }.max { lhs, rhs in
+            lhs.segment.index < rhs.segment.index
+        }
+        segmentAccumulator.restore(
+            workoutStart: workoutStart,
+            lastCompletedSegment: restored?.segment,
+            cumulativeElapsedTime: restored?.cumulativeElapsedTime,
+            cumulativeDistanceMeters: restored?.cumulativeDistanceMeters
+        )
+    }
+
+    private func completedSegment(
+        from event: HKWorkoutEvent,
+        workoutStart: Date
+    ) -> (
+        segment: WorkoutCompletedSegmentV1,
+        cumulativeElapsedTime: TimeInterval,
+        cumulativeDistanceMeters: Double?
+    )? {
+        guard event.type == .segment,
+              let metadata = event.metadata,
+              metadata[SegmentMetadataKey.origin] as? String
+                == SegmentMetadataKey.originValue,
+              let index = (
+                  metadata[SegmentMetadataKey.index] as? NSNumber
+              )?.uint32Value,
+              index > 0,
+              index < UInt32.max,
+              let duration = (
+                  metadata[SegmentMetadataKey.activeDuration] as? NSNumber
+              )?.doubleValue,
+              duration.isFinite,
+              duration >= 0,
+              event.dateInterval.start >= workoutStart,
+              duration <= event.dateInterval.duration + 1,
+              let cumulativeElapsed = (
+                  metadata[SegmentMetadataKey.cumulativeElapsed] as? NSNumber
+              )?.doubleValue,
+              cumulativeElapsed.isFinite,
+              cumulativeElapsed >= duration else {
+            return nil
+        }
+        let distance = (
+            metadata[SegmentMetadataKey.distanceMeters] as? NSNumber
+        )?.doubleValue
+        let cumulativeDistance = (
+            metadata[SegmentMetadataKey.cumulativeDistance] as? NSNumber
+        )?.doubleValue
+        let distanceIsWithinCumulative: Bool
+        if let distance, let cumulativeDistance {
+            distanceIsWithinCumulative = distance <= cumulativeDistance
+        } else {
+            distanceIsWithinCumulative = true
+        }
+        guard distance.map({ $0.isFinite && $0 >= 0 }) ?? true,
+              cumulativeDistance.map({
+                  $0.isFinite && $0 >= 0
+              }) ?? true,
+              distanceIsWithinCumulative else {
+            return nil
+        }
+        return (
+            WorkoutCompletedSegmentV1(
+                index: index,
+                startedAt: event.dateInterval.start,
+                endedAt: event.dateInterval.end,
+                duration: duration,
+                distanceMeters: distance
+            ),
+            cumulativeElapsed,
+            cumulativeDistance
+        )
+    }
+
+    private func containsSegmentEvent(
+        matching envelope: WorkoutEnvelopeV1
+    ) -> Bool {
+        guard let senderID = envelope.controlSenderID else { return false }
+        return builder?.workoutEvents.contains { event in
+            guard event.type == .segment,
+                  let metadata = event.metadata,
+                  metadata[SegmentMetadataKey.controlSenderID] as? String
+                    == senderID.uuidString,
+                  let sequence = (
+                      metadata[SegmentMetadataKey.controlSequence] as? NSNumber
+                  )?.uint64Value else {
+                return false
+            }
+            return sequence == envelope.sequence
+        } ?? false
     }
 
     private func updateMetrics(
@@ -3220,6 +3710,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             state: state,
             startDate: identity.startDate
         )
+        segmentAccumulator.reset(workoutStart: identity.startDate)
     }
 
     func startMirroringForTesting() {
@@ -3241,6 +3732,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             unit: .beatsPerMinute,
             capturedAt: capturedAt
         )
+    }
+
+    func closeFinalSegmentForTesting(at endDate: Date) async {
+        await closeFinalSegmentIfNeeded(in: builder, at: endDate)
     }
 
     func markMirrorShutdownDeliveryPendingForTesting(startFailure: Bool) {
@@ -3301,11 +3796,15 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
               let identity else {
             return
         }
+        if isMarkingSegment {
+            deferredRemoteWorkoutEnvelopes.append(contentsOf: envelopes)
+            return
+        }
         let expectedGeneration = identity.transportGenerationID
             ?? identity.sessionID
         let receivedAt = Date()
 
-        for envelope in envelopes {
+        for (offset, envelope) in envelopes.enumerated() {
             guard envelope.sessionID == identity.sessionID,
                   envelope.sessionToken == identity.sessionToken,
                   envelope.transportGenerationID == expectedGeneration,
@@ -3320,7 +3819,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                     requestedTerminalDisposition = .save
                 case .discard:
                     requestedTerminalDisposition = .discard
-                case .requestCurrentSnapshot, .pause, .resume:
+                case .requestCurrentSnapshot, .pause, .resume, .markSegment:
                     requestedTerminalDisposition = nil
                 }
             } else {
@@ -3345,9 +3844,43 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                     envelope,
                     receivedAt: receivedAt
                 ) else {
+                    if control == .markSegment {
+                        let wasWritten = containsSegmentEvent(
+                            matching: envelope
+                        )
+                        publishAcknowledgement(
+                            for: .markSegment,
+                            acknowledgedSequence: envelope.sequence,
+                            errorCode: wasWritten
+                                ? nil
+                                : .segmentMarkFailed
+                        )
+                    }
                     _ = publishDurableTerminalAcknowledgement(
                         matching: envelope
                     )
+                    continue
+                }
+                if control == .markSegment {
+                    let context = RemoteSegmentControlContext(
+                        envelope: envelope,
+                        acceptedGate: candidateGate
+                    )
+                    if containsSegmentEvent(matching: envelope) {
+                        commitRemoteSegmentControl(context)
+                        publishAcknowledgement(
+                            for: .markSegment,
+                            acknowledgedSequence: envelope.sequence
+                        )
+                        continue
+                    }
+                    beginSegmentMark(remoteContext: context)
+                    if isMarkingSegment {
+                        deferredRemoteWorkoutEnvelopes.append(
+                            contentsOf: envelopes.dropFirst(offset + 1)
+                        )
+                        return
+                    }
                     continue
                 }
                 let terminalAcknowledgement:
@@ -3393,7 +3926,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                         workoutSession.resume()
                     }
                 case .requestCurrentSnapshot, .pause, .resume,
-                     .endAndSave, .discard:
+                     .markSegment, .endAndSave, .discard:
                     break
                 }
                 persistedTerminalDisposition = try recoveryStore
@@ -3443,6 +3976,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                         acknowledgedSequence: envelope.sequence
                     )
                 }
+            case .markSegment:
+                break
             case .endAndSave:
                 if persistedTerminalDisposition == .save {
                     _ = publishDurableTerminalAcknowledgement(
@@ -3481,7 +4016,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             .save
         case .discard:
             .discard
-        case .requestCurrentSnapshot, .pause, .resume:
+        case .requestCurrentSnapshot, .pause, .resume, .markSegment:
             nil
         }
     }
@@ -3544,7 +4079,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
 
     private func publishAcknowledgement(
         for control: WorkoutControlV1,
-        acknowledgedSequence: UInt64
+        acknowledgedSequence: UInt64,
+        errorCode: WorkoutSafeErrorCodeV1? = nil
     ) {
         guard let identity,
               let sequence = recoveryStore.nextSequence() else {
@@ -3562,7 +4098,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             acknowledgement: WorkoutAcknowledgementV1(
                 control: control,
                 resultingState: lifecycle.state,
-                acknowledgedSequence: acknowledgedSequence
+                acknowledgedSequence: acknowledgedSequence,
+                errorCode: errorCode
             )
         )
         guard (try? WorkoutContractCodec.validate(envelope)) != nil else {
@@ -3579,6 +4116,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             isConfirmed = lifecycle.state == .paused
         case .resume:
             isConfirmed = lifecycle.state == .running
+        case .markSegment:
+            isConfirmed = true
         case .endAndSave, .discard:
             isConfirmed = lifecycle.state == .ending
                 || lifecycle.state == .ended
@@ -3817,6 +4356,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 : WorkoutHeartRateZoneProfile.zoneCount,
             heartRateZoneDurations: nil,
             location: location,
+            lastCompletedSegment: segmentAccumulator.lastCompletedSegment,
             availability: availability,
             errorCode: lastErrorCode,
             terminalOutcome: terminalOutcome
@@ -4445,4 +4985,9 @@ private enum WorkoutFinalizationError: Error {
     case endCollectionFailed
     case finishWorkoutFailed
     case managerReleased
+}
+
+private enum WorkoutSegmentWriteError: Error {
+    case builderUnavailable
+    case writeFailed
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -19,11 +19,13 @@ enum WatchWorkoutFinishRequestError: Equatable {
     case saveFailed
     case reconciliationFailed
     case identityMetadataFailed
+    case segmentConfirmationPending
 }
 
 enum WatchWorkoutSegmentError: Equatable {
     case unavailable
     case healthKitWriteFailed
+    case confirmationPending
 }
 
 struct WatchWorkoutSummary: Equatable {
@@ -307,6 +309,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             "com.openbikecomputer.workout.segment.cumulativeElapsed"
         static let cumulativeDistance =
             "com.openbikecomputer.workout.segment.cumulativeDistance"
+        static let cumulativeDistanceSource =
+            "com.openbikecomputer.workout.segment.cumulativeDistanceSource"
+        static let eventID =
+            "com.openbikecomputer.workout.segment.eventID"
         static let controlSenderID =
             "com.openbikecomputer.workout.segment.controlSenderID"
         static let controlSequence =
@@ -321,7 +327,6 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
 
     private struct RemoteSegmentControlContext {
         let envelope: WorkoutEnvelopeV1
-        let acceptedGate: WorkoutRemoteControlSequenceGate
     }
 
     private enum ConfirmedTerminalCompletion {
@@ -382,6 +387,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private let injectedRemoteResumeOperation:
         (@MainActor (HKWorkoutSession) -> Void)?
     private let injectedSegmentEventOperation: WatchSegmentEventOperation?
+    private let injectedEndCollectionOperation:
+        (@MainActor (HKLiveWorkoutBuilder, Date) async throws -> Void)?
+    private let injectedFinishWorkoutOperation:
+        (@MainActor (HKLiveWorkoutBuilder) async throws -> Void)?
     private let segmentNow: @MainActor () -> Date
     private let segmentWriteTimeout: TimeInterval
     private let injectedMirrorStartOperation: WatchMirrorStartOperation?
@@ -404,7 +413,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var mirrorShutdownWatchdogTask: Task<Void, Never>?
     private var complicationStartTask: Task<Void, Never>?
     private var segmentOperationTask: Task<Void, Never>?
+    private var segmentOperationTimeoutTask: Task<Void, Never>?
     private var segmentOperationAttemptID: UUID?
+    private var finalSegmentOperationTask: Task<Void, Never>?
+    private var finalSegmentOperationAttemptID: UUID?
+    private var hasAttemptedFinalSegmentClosure = false
+    private var allowsSavingWithUnconfirmedSegment = false
     private var authoritativeFinalizationEndDate: Date?
     private var isBuilderReadyForFinalization = false
     private var isIdentityMetadataRetryPending = false
@@ -435,7 +449,6 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         sequence: UInt64
     )?
     private var remoteSegmentControlContext: RemoteSegmentControlContext?
-    private var deferredRemoteWorkoutEnvelopes: [WorkoutEnvelopeV1] = []
     private var isTerminalMirrorDeliveryPending = false
     private var isStartFailureMirrorDeliveryPending = false
     private var shutdownMirrorFailureRetryCount = 0
@@ -544,6 +557,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         remoteResumeOperation:
             (@MainActor (HKWorkoutSession) -> Void)? = nil,
         segmentEventOperation: WatchSegmentEventOperation? = nil,
+        endCollectionOperation:
+            (@MainActor (HKLiveWorkoutBuilder, Date) async throws -> Void)?
+                = nil,
+        finishWorkoutOperation:
+            (@MainActor (HKLiveWorkoutBuilder) async throws -> Void)? = nil,
         segmentNow: @MainActor @escaping () -> Date = Date.init,
         segmentWriteTimeout: TimeInterval = 10,
         mirrorStartOperation: WatchMirrorStartOperation? = nil,
@@ -579,6 +597,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         self.injectedRemotePauseOperation = remotePauseOperation
         self.injectedRemoteResumeOperation = remoteResumeOperation
         self.injectedSegmentEventOperation = segmentEventOperation
+        self.injectedEndCollectionOperation = endCollectionOperation
+        self.injectedFinishWorkoutOperation = finishWorkoutOperation
         self.segmentNow = segmentNow
         self.segmentWriteTimeout = segmentWriteTimeout.isFinite
             ? min(max(0.01, segmentWriteTimeout), 60)
@@ -632,6 +652,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         mirrorShutdownWatchdogTask?.cancel()
         complicationStartTask?.cancel()
         segmentOperationTask?.cancel()
+        segmentOperationTimeoutTask?.cancel()
+        finalSegmentOperationTask?.cancel()
     }
 
     var state: WorkoutSessionStateV1 { lifecycle.state }
@@ -773,9 +795,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     }
 
     func retryFinalization() {
+        let isRetryingSegmentFinalization =
+            finishRequestError == .segmentConfirmationPending
         guard finishRequestError == .reconciliationFailed
                 || finishRequestError == .saveFailed
                 || finishRequestError == .identityMetadataFailed
+                || isRetryingSegmentFinalization
                 || finishRequestError == .terminalErrorPersistenceFailed,
               lifecycle.state == .ending,
               finalizationTask == nil else {
@@ -799,6 +824,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             terminalCauseRetryEndDate = retryEndDate
         }
         finishRequestError = nil
+        if isRetryingSegmentFinalization,
+           lastErrorCode == .segmentFinalizationPending {
+            lastErrorCode = nil
+        }
         Task { [weak self] in
             guard let self else { return }
             if isIdentityMetadataRetryPending {
@@ -831,6 +860,15 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 await resumeRecoveredStoppedSaveFinalization()
             }
         }
+    }
+
+    func saveWithoutUnconfirmedSegment() {
+        guard finishRequestError == .segmentConfirmationPending,
+              lifecycle.state == .ending else {
+            return
+        }
+        allowsSavingWithUnconfirmedSegment = true
+        retryFinalization()
     }
 
     func dismissSummary() {
@@ -1122,7 +1160,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         segmentError = nil
         isMarkingSegment = false
         remoteSegmentControlContext = nil
-        deferredRemoteWorkoutEnvelopes.removeAll()
+        hasAttemptedFinalSegmentClosure = false
+        allowsSavingWithUnconfirmedSegment = false
 
         let configuration: HKWorkoutConfiguration
         if let suppliedConfiguration {
@@ -1611,6 +1650,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         }
 
         updateAllMetrics(from: recoveredBuilder, capturedAt: Date())
+        resumePersistedRemoteSegmentIntentIfNeeded()
         setupState = .ready
         startMirroringIfNeeded(for: recoveredSession)
         publishSnapshotImmediately()
@@ -2421,7 +2461,19 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         disposition: WorkoutFinishDisposition,
         endDate: Date
     ) async {
-        await waitForSegmentOperationBeforeFinalization()
+        if disposition == .save,
+           !allowsSavingWithUnconfirmedSegment {
+            let segmentResolved =
+                await waitForSegmentOperationBeforeFinalization()
+            guard segmentResolved else {
+                lifecycle.releaseFinalizationClaimForRetry()
+                finishRequestError = .segmentConfirmationPending
+                segmentError = .confirmationPending
+                lastErrorCode = .segmentFinalizationPending
+                publishSnapshotImmediately()
+                return
+            }
+        }
         if disposition == .discard {
             let metadata = injectedRecoveredDiscardFinalizationAdapter?
                 .metadata()
@@ -2505,10 +2557,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 },
                 endCollection: { [weak self] in
                     guard let self else { throw WorkoutFinalizationError.managerReleased }
-                    await closeFinalSegmentIfNeeded(
+                    guard await closeFinalSegmentIfNeeded(
                         in: builder,
                         at: endDate
-                    )
+                    ) else {
+                        throw WorkoutSegmentWriteError.finalizationPending
+                    }
                     try await endCollection(builder, at: endDate)
                     updateAllMetrics(from: builder, capturedAt: endDate)
                 },
@@ -2578,6 +2632,16 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     }
 
     func handleFinalizationFailure(_ error: Error) {
+        if case WorkoutSegmentWriteError.finalizationPending = error {
+            lifecycle.releaseFinalizationClaimForRetry()
+            finishRequestError = .segmentConfirmationPending
+            if segmentError == nil {
+                segmentError = .confirmationPending
+            }
+            lastErrorCode = .segmentFinalizationPending
+            publishSnapshotImmediately()
+            return
+        }
         if case WorkoutFinalizationPersistenceError
             .finishFailureRollbackPending = error {
             isFinishFailureRollbackPending = true
@@ -2831,11 +2895,17 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         coalescedSnapshotTask = nil
         segmentOperationTask?.cancel()
         segmentOperationTask = nil
+        segmentOperationTimeoutTask?.cancel()
+        segmentOperationTimeoutTask = nil
         segmentOperationAttemptID = nil
+        finalSegmentOperationTask?.cancel()
+        finalSegmentOperationTask = nil
+        finalSegmentOperationAttemptID = nil
+        hasAttemptedFinalSegmentClosure = false
+        allowsSavingWithUnconfirmedSegment = false
         isMarkingSegment = false
         segmentError = nil
         remoteSegmentControlContext = nil
-        deferredRemoteWorkoutEnvelopes.removeAll()
         segmentAccumulator = WorkoutSegmentAccumulator()
         handleAttachedSessionRelease()
     }
@@ -2866,24 +2936,61 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         coalescedSnapshotTask = nil
         segmentOperationTask?.cancel()
         segmentOperationTask = nil
+        segmentOperationTimeoutTask?.cancel()
+        segmentOperationTimeoutTask = nil
         segmentOperationAttemptID = nil
+        finalSegmentOperationTask?.cancel()
+        finalSegmentOperationTask = nil
+        finalSegmentOperationAttemptID = nil
+        hasAttemptedFinalSegmentClosure = false
+        allowsSavingWithUnconfirmedSegment = false
         isMarkingSegment = false
         segmentError = nil
         remoteSegmentControlContext = nil
-        deferredRemoteWorkoutEnvelopes.removeAll()
         segmentAccumulator = WorkoutSegmentAccumulator()
         handleAttachedSessionRelease()
     }
 
     private func beginSegmentMark(
-        remoteContext: RemoteSegmentControlContext?
+        remoteContext: RemoteSegmentControlContext?,
+        recoveredCandidate: WorkoutSegmentCandidate? = nil
     ) {
-        guard lifecycle.state == .running,
-              !isMarkingSegment,
+        let canWriteRecoveredBoundary = recoveredCandidate != nil
+            && [.running, .paused, .ending].contains(lifecycle.state)
+        guard lifecycle.state == .running || canWriteRecoveredBoundary,
+              segmentOperationAttemptID == nil,
               builder != nil || injectedSegmentEventOperation != nil else {
+            let errorCode: WorkoutSafeErrorCodeV1
+            if segmentOperationAttemptID != nil {
+                if remoteContext == nil {
+                    segmentError = .confirmationPending
+                }
+                errorCode = remoteContext == nil
+                    ? .segmentMarkUnconfirmed
+                    : .segmentMarkFailed
+            } else {
+                segmentError = .unavailable
+                errorCode = .segmentMarkFailed
+            }
+            if let remoteContext {
+                publishAcknowledgement(
+                    for: .markSegment,
+                    acknowledgedSequence: remoteContext.envelope.sequence,
+                    errorCode: errorCode
+                )
+            }
+            return
+        }
+
+        let candidate: WorkoutSegmentCandidate?
+        if let recoveredCandidate {
+            candidate = recoveredCandidate
+        } else {
+            candidate = makeCurrentSegmentCandidate()
+        }
+        guard let candidate else {
             segmentError = .unavailable
             if let remoteContext {
-                commitRemoteSegmentControl(remoteContext)
                 publishAcknowledgement(
                     for: .markSegment,
                     acknowledgedSequence: remoteContext.envelope.sequence,
@@ -2892,24 +2999,19 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             }
             return
         }
-
-        let endedAt = segmentNow()
-        let currentSnapshot = makeSnapshot(capturedAt: endedAt)
-        guard let cumulativeElapsedTime =
-                currentSnapshot.elapsedTime?.value,
-              let candidate = segmentAccumulator.candidate(
-                  endedAt: endedAt,
-                  cumulativeElapsedTime: cumulativeElapsedTime,
-                  cumulativeDistanceMeters:
-                    currentSnapshot.cyclingDistance?.value
-              ) else {
-            segmentError = .unavailable
+        var validationAccumulator = segmentAccumulator
+        guard validationAccumulator.commit(candidate) else {
+            segmentError = .healthKitWriteFailed
             if let remoteContext {
-                commitRemoteSegmentControl(remoteContext)
+                let didClear = clearPersistedRemoteSegmentIntent(
+                    matching: remoteContext.envelope
+                )
                 publishAcknowledgement(
                     for: .markSegment,
                     acknowledgedSequence: remoteContext.envelope.sequence,
-                    errorCode: .segmentMarkFailed
+                    errorCode: didClear
+                        ? .segmentMarkFailed
+                        : .segmentMarkUnconfirmed
                 )
             }
             return
@@ -2925,95 +3027,230 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         let attemptID = UUID()
         segmentOperationAttemptID = attemptID
         let targetBuilder = builder
+        let injectedOperation = injectedSegmentEventOperation
         segmentOperationTask = Task { @MainActor [weak self] in
-            guard let self else { return }
+            let outcome = await Self.segmentEventWriteOutcome(
+                event,
+                to: targetBuilder,
+                injectedOperation: injectedOperation
+            )
+            self?.completeSegmentMark(
+                attemptID: attemptID,
+                candidate: candidate,
+                outcome: outcome
+            )
+        }
+        let timeout = segmentWriteTimeout
+        segmentOperationTimeoutTask = Task { @MainActor [weak self] in
             do {
-                try await addSegmentEvent(event, to: targetBuilder)
-                completeSegmentMark(
-                    attemptID: attemptID,
-                    candidate: candidate,
-                    error: nil
+                try await Task.sleep(
+                    nanoseconds: UInt64(timeout * 1_000_000_000)
                 )
             } catch {
-                completeSegmentMark(
-                    attemptID: attemptID,
-                    candidate: nil,
-                    error: .healthKitWriteFailed
-                )
+                return
             }
+            self?.timeOutSegmentMark(attemptID: attemptID)
+        }
+    }
+
+    private func makeCurrentSegmentCandidate() -> WorkoutSegmentCandidate? {
+        let endedAt = segmentNow()
+        let currentSnapshot = makeSnapshot(capturedAt: endedAt)
+        guard let cumulativeElapsedTime =
+                currentSnapshot.elapsedTime?.value else {
+            return nil
+        }
+        return segmentAccumulator.candidate(
+            endedAt: endedAt,
+            cumulativeElapsedTime: cumulativeElapsedTime,
+            cumulativeDistanceMeters:
+                currentSnapshot.cyclingDistance?.value,
+            cumulativeDistanceSource:
+                currentSnapshot.cyclingDistance?.source
+        )
+    }
+
+    private func timeOutSegmentMark(attemptID: UUID) {
+        guard attemptID == segmentOperationAttemptID else { return }
+        isMarkingSegment = false
+        segmentError = .confirmationPending
+        if let remoteContext = remoteSegmentControlContext {
+            publishAcknowledgement(
+                for: .markSegment,
+                acknowledgedSequence: remoteContext.envelope.sequence,
+                errorCode: .segmentMarkUnconfirmed
+            )
         }
     }
 
     private func completeSegmentMark(
         attemptID: UUID,
-        candidate: WorkoutSegmentCandidate?,
-        error: WatchWorkoutSegmentError?
+        candidate: WorkoutSegmentCandidate,
+        outcome: SegmentEventWriteOutcome
     ) {
         guard attemptID == segmentOperationAttemptID else { return }
         let remoteContext = remoteSegmentControlContext
-        if let candidate, segmentAccumulator.commit(candidate) {
+        let didCommit = outcome == .success
+            && segmentAccumulator.commit(candidate)
+        if didCommit {
             segmentError = nil
             publishSnapshotImmediately()
         } else {
-            segmentError = error ?? .healthKitWriteFailed
+            segmentError = .healthKitWriteFailed
         }
         if let remoteContext {
-            commitRemoteSegmentControl(remoteContext)
+            let didClear = clearPersistedRemoteSegmentIntent(
+                matching: remoteContext.envelope
+            )
             publishAcknowledgement(
                 for: .markSegment,
                 acknowledgedSequence: remoteContext.envelope.sequence,
-                errorCode: candidate == nil ? .segmentMarkFailed : nil
+                errorCode: didCommit
+                    ? nil
+                    : didClear
+                        ? .segmentMarkFailed
+                        : .segmentMarkUnconfirmed
             )
         }
         remoteSegmentControlContext = nil
         isMarkingSegment = false
         segmentOperationAttemptID = nil
-        segmentOperationTask?.cancel()
+        segmentOperationTimeoutTask?.cancel()
+        segmentOperationTimeoutTask = nil
         segmentOperationTask = nil
-        drainDeferredRemoteWorkoutEnvelopes()
     }
 
-    private func waitForSegmentOperationBeforeFinalization() async {
-        while isMarkingSegment {
+    private func waitForSegmentOperationBeforeFinalization() async -> Bool {
+        guard let attemptID = segmentOperationAttemptID,
+              segmentOperationTask != nil else {
+            return true
+        }
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(
+            by: .nanoseconds(
+                Int64(segmentWriteTimeout * 1_000_000_000)
+            )
+        )
+        while segmentOperationAttemptID == attemptID,
+              clock.now < deadline {
             do {
-                try await Task.sleep(nanoseconds: 10_000_000)
+                try await Task.sleep(nanoseconds: 25_000_000)
             } catch {
-                return
+                return false
             }
         }
+        return segmentOperationAttemptID != attemptID
     }
 
     private func commitRemoteSegmentControl(
-        _ context: RemoteSegmentControlContext
-    ) {
+        _ envelope: WorkoutEnvelopeV1,
+        candidate: WorkoutSegmentCandidate
+    ) -> Bool {
+        var candidateGate = remoteControlGate
+        guard (try? candidateGate.ingest(envelope)) == true else {
+            return false
+        }
+        let intent = WatchWorkoutRecoveryStore.RemoteSegmentIntent(
+            controlSenderID: envelope.controlSenderID,
+            acknowledgedSequence: envelope.sequence,
+            capturedAt: envelope.capturedAt,
+            completedSegment: candidate.completedSegment,
+            cumulativeElapsedTime: candidate.cumulativeElapsedTime,
+            cumulativeDistanceMeters: candidate.cumulativeDistanceMeters,
+            cumulativeDistanceSource: candidate.cumulativeDistanceSource
+        )
         do {
-            _ = try recoveryStore.persistRemoteControlCheckpoint(
-                context.acceptedGate.checkpoint,
-                finishing: nil,
-                requestedAt: nil,
-                explicitRiderChoice: true,
-                terminalErrorCode: nil,
-                terminalAcknowledgement: nil
+            try recoveryStore.persistRemoteSegmentControl(
+                checkpoint: candidateGate.checkpoint,
+                intent: intent
             )
             if let persistedIdentity = recoveryStore.recoveredIdentity {
                 identity = persistedIdentity
             }
         } catch {
-            // The HealthKit event metadata still provides exact replay
-            // detection if the process exits before this checkpoint is saved.
+            // Do not start HealthKit work until the replay checkpoint and
+            // original boundary are durable as one transaction.
+            return false
         }
-        remoteControlGate = context.acceptedGate
+        remoteControlGate = candidateGate
+        return true
     }
 
-    private func drainDeferredRemoteWorkoutEnvelopes() {
-        guard !isMarkingSegment,
-              !deferredRemoteWorkoutEnvelopes.isEmpty,
-              let session else {
+    private func commitRemoteSegmentRejection(
+        _ envelope: WorkoutEnvelopeV1
+    ) -> Bool {
+        var candidateGate = remoteControlGate
+        guard (try? candidateGate.ingest(envelope)) == true else {
+            return false
+        }
+        do {
+            _ = try recoveryStore.persistRemoteControlCheckpoint(
+                candidateGate.checkpoint
+            )
+            if let persistedIdentity = recoveryStore.recoveredIdentity {
+                identity = persistedIdentity
+            }
+        } catch {
+            return false
+        }
+        remoteControlGate = candidateGate
+        return true
+    }
+
+    @discardableResult
+    private func clearPersistedRemoteSegmentIntent(
+        matching envelope: WorkoutEnvelopeV1
+    ) -> Bool {
+        do {
+            try recoveryStore.clearRemoteSegmentIntent(matching: envelope)
+            if let persistedIdentity = recoveryStore.recoveredIdentity {
+                identity = persistedIdentity
+            }
+            return true
+        } catch {
+            // Event metadata remains the authoritative completion evidence.
+            // A later exact replay will reconcile it and retry this cleanup.
+            return false
+        }
+    }
+
+    private static func segmentCandidate(
+        from intent: WatchWorkoutRecoveryStore.RemoteSegmentIntent
+    ) -> WorkoutSegmentCandidate {
+        WorkoutSegmentCandidate(
+            completedSegment: intent.completedSegment,
+            cumulativeElapsedTime: intent.cumulativeElapsedTime,
+            cumulativeDistanceMeters: intent.cumulativeDistanceMeters,
+            cumulativeDistanceSource: intent.cumulativeDistanceSource
+        )
+    }
+
+    private func resumePersistedRemoteSegmentIntentIfNeeded() {
+        guard segmentOperationAttemptID == nil,
+              let identity,
+              let intent = recoveryStore.recoveredIdentity?
+                .remoteSegmentIntent else {
             return
         }
-        let deferred = deferredRemoteWorkoutEnvelopes
-        deferredRemoteWorkoutEnvelopes.removeAll()
-        handleRemoteWorkoutEnvelopes(deferred, from: session)
+        let envelope = WorkoutEnvelopeV1(
+            kind: .control,
+            sessionID: identity.sessionID,
+            sessionToken: identity.sessionToken,
+            transportGenerationID:
+                identity.transportGenerationID ?? identity.sessionID,
+            sequence: intent.acknowledgedSequence,
+            capturedAt: intent.capturedAt,
+            controlSenderID: intent.controlSenderID,
+            control: .markSegment
+        )
+        if containsSegmentEvent(matching: envelope) {
+            clearPersistedRemoteSegmentIntent(matching: envelope)
+            return
+        }
+        beginSegmentMark(
+            remoteContext: RemoteSegmentControlContext(envelope: envelope),
+            recoveredCandidate: Self.segmentCandidate(from: intent)
+        )
     }
 
     private func makeSegmentEvent(
@@ -3028,6 +3265,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 NSNumber(value: candidate.completedSegment.duration),
             SegmentMetadataKey.cumulativeElapsed:
                 NSNumber(value: candidate.cumulativeElapsedTime),
+            SegmentMetadataKey.eventID: UUID().uuidString,
         ]
         if let distance = candidate.completedSegment.distanceMeters {
             metadata[SegmentMetadataKey.distanceMeters] = NSNumber(
@@ -3038,6 +3276,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             metadata[SegmentMetadataKey.cumulativeDistance] = NSNumber(
                 value: cumulativeDistance
             )
+        }
+        if let cumulativeDistanceSource =
+                candidate.cumulativeDistanceSource {
+            metadata[SegmentMetadataKey.cumulativeDistanceSource] =
+                cumulativeDistanceSource.rawValue
         }
         if let senderID = remoteEnvelope?.controlSenderID {
             metadata[SegmentMetadataKey.controlSenderID] = senderID.uuidString
@@ -3057,57 +3300,30 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         )
     }
 
-    private func addSegmentEvent(
+    private static func segmentEventWriteOutcome(
         _ event: HKWorkoutEvent,
-        to builder: HKLiveWorkoutBuilder?
-    ) async throws {
-        let operation = Task { @MainActor [weak self] in
-            guard let self else {
-                return SegmentEventWriteOutcome.failure
-            }
-            do {
-                try await performSegmentEventWrite(event, to: builder)
-                return SegmentEventWriteOutcome.success
-            } catch {
-                return SegmentEventWriteOutcome.failure
-            }
-        }
-        let timeout = segmentWriteTimeout
-        let outcomes = AsyncStream<SegmentEventWriteOutcome> {
-            continuation in
-            Task {
-                continuation.yield(await operation.value)
-                continuation.finish()
-            }
-            Task {
-                do {
-                    try await Task.sleep(
-                        nanoseconds: UInt64(timeout * 1_000_000_000)
-                    )
-                } catch {
-                    return
-                }
-                continuation.yield(.failure)
-                continuation.finish()
-            }
-        }
-        var iterator = outcomes.makeAsyncIterator()
-        guard let outcome = await iterator.next() else {
-            operation.cancel()
-            throw WorkoutSegmentWriteError.writeFailed
-        }
-        operation.cancel()
-        guard outcome == .success else {
-            throw WorkoutSegmentWriteError.writeFailed
+        to builder: HKLiveWorkoutBuilder?,
+        injectedOperation: WatchSegmentEventOperation?
+    ) async -> SegmentEventWriteOutcome {
+        do {
+            try await performSegmentEventWrite(
+                event,
+                to: builder,
+                injectedOperation: injectedOperation
+            )
+            return .success
+        } catch {
+            return .failure
         }
     }
 
-    private func performSegmentEventWrite(
+    private static func performSegmentEventWrite(
         _ event: HKWorkoutEvent,
-        to builder: HKLiveWorkoutBuilder?
+        to builder: HKLiveWorkoutBuilder?,
+        injectedOperation: WatchSegmentEventOperation?
     ) async throws {
-        if let injectedSegmentEventOperation {
-            try await injectedSegmentEventOperation(event)
+        if let injectedOperation {
+            try await injectedOperation(event)
             return
         }
         guard let builder else {
@@ -3132,8 +3348,20 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private func closeFinalSegmentIfNeeded(
         in builder: HKLiveWorkoutBuilder?,
         at endDate: Date
-    ) async {
-        guard segmentAccumulator.hasCompletedSegments else { return }
+    ) async -> Bool {
+        if allowsSavingWithUnconfirmedSegment {
+            return true
+        }
+        guard segmentAccumulator.hasCompletedSegments,
+              segmentOperationAttemptID == nil else {
+            return segmentOperationAttemptID == nil
+        }
+        if let attemptID = finalSegmentOperationAttemptID {
+            return await waitForFinalSegmentOperation(attemptID)
+        }
+        guard !hasAttemptedFinalSegmentClosure else {
+            return true
+        }
         let currentSnapshot = makeSnapshot(capturedAt: endDate)
         guard let cumulativeElapsedTime =
                 currentSnapshot.elapsedTime?.value,
@@ -3141,22 +3369,70 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                   endedAt: endDate,
                   cumulativeElapsedTime: cumulativeElapsedTime,
                   cumulativeDistanceMeters:
-                    currentSnapshot.cyclingDistance?.value
+                    currentSnapshot.cyclingDistance?.value,
+                  cumulativeDistanceSource:
+                    currentSnapshot.cyclingDistance?.source
               ),
               candidate.completedSegment.duration > 0 else {
-            return
+            return true
         }
-        do {
-            try await addSegmentEvent(
-                makeSegmentEvent(candidate, remoteEnvelope: nil),
-                to: builder
+        hasAttemptedFinalSegmentClosure = true
+        let attemptID = UUID()
+        finalSegmentOperationAttemptID = attemptID
+        let event = makeSegmentEvent(candidate, remoteEnvelope: nil)
+        let injectedOperation = injectedSegmentEventOperation
+        finalSegmentOperationTask = Task { @MainActor [weak self] in
+            let outcome = await Self.segmentEventWriteOutcome(
+                event,
+                to: builder,
+                injectedOperation: injectedOperation
             )
-            _ = segmentAccumulator.commit(candidate)
-        } catch {
-            // Never hold a completed ride hostage to a best-effort final
-            // segment boundary. Previously committed segments remain valid.
+            self?.completeFinalSegmentWrite(
+                attemptID: attemptID,
+                candidate: candidate,
+                outcome: outcome
+            )
+        }
+        return await waitForFinalSegmentOperation(attemptID)
+    }
+
+    private func waitForFinalSegmentOperation(_ attemptID: UUID) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(
+            by: .nanoseconds(
+                Int64(segmentWriteTimeout * 1_000_000_000)
+            )
+        )
+        while finalSegmentOperationAttemptID == attemptID,
+              clock.now < deadline {
+            do {
+                try await Task.sleep(nanoseconds: 25_000_000)
+            } catch {
+                return false
+            }
+        }
+        if finalSegmentOperationAttemptID == attemptID {
+            segmentError = .confirmationPending
+            return false
+        }
+        return hasAttemptedFinalSegmentClosure
+    }
+
+    private func completeFinalSegmentWrite(
+        attemptID: UUID,
+        candidate: WorkoutSegmentCandidate,
+        outcome: SegmentEventWriteOutcome
+    ) {
+        guard attemptID == finalSegmentOperationAttemptID else { return }
+        if outcome == .success, segmentAccumulator.commit(candidate) {
+            segmentError = nil
+            publishSnapshotImmediately()
+        } else {
+            hasAttemptedFinalSegmentClosure = false
             segmentError = .healthKitWriteFailed
         }
+        finalSegmentOperationAttemptID = nil
+        finalSegmentOperationTask = nil
     }
 
     private func restoreSegmentAccumulator(
@@ -3172,7 +3448,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             workoutStart: workoutStart,
             lastCompletedSegment: restored?.segment,
             cumulativeElapsedTime: restored?.cumulativeElapsedTime,
-            cumulativeDistanceMeters: restored?.cumulativeDistanceMeters
+            cumulativeDistanceMeters: restored?.cumulativeDistanceMeters,
+            cumulativeDistanceSource: restored?.cumulativeDistanceSource
         )
     }
 
@@ -3182,7 +3459,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     ) -> (
         segment: WorkoutCompletedSegmentV1,
         cumulativeElapsedTime: TimeInterval,
-        cumulativeDistanceMeters: Double?
+        cumulativeDistanceMeters: Double?,
+        cumulativeDistanceSource: WorkoutMetricSourceV1?
     )? {
         guard event.type == .segment,
               let metadata = event.metadata,
@@ -3213,6 +3491,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         let cumulativeDistance = (
             metadata[SegmentMetadataKey.cumulativeDistance] as? NSNumber
         )?.doubleValue
+        let cumulativeDistanceSource = (
+            metadata[SegmentMetadataKey.cumulativeDistanceSource] as? String
+        ).flatMap(WorkoutMetricSourceV1.init(rawValue:))
         let distanceIsWithinCumulative: Bool
         if let distance, let cumulativeDistance {
             distanceIsWithinCumulative = distance <= cumulativeDistance
@@ -3235,7 +3516,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 distanceMeters: distance
             ),
             cumulativeElapsed,
-            cumulativeDistance
+            cumulativeDistance,
+            cumulativeDistanceSource
         )
     }
 
@@ -3255,6 +3537,18 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             }
             return sequence == envelope.sequence
         } ?? false
+    }
+
+    private func isPendingSegmentControl(
+        _ envelope: WorkoutEnvelopeV1
+    ) -> Bool {
+        guard let pending = remoteSegmentControlContext?.envelope else {
+            return false
+        }
+        return pending.sessionID == envelope.sessionID
+            && pending.sessionToken == envelope.sessionToken
+            && pending.controlSenderID == envelope.controlSenderID
+            && pending.sequence == envelope.sequence
     }
 
     private func updateMetrics(
@@ -3711,6 +4005,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             startDate: identity.startDate
         )
         segmentAccumulator.reset(workoutStart: identity.startDate)
+        resumePersistedRemoteSegmentIntentIfNeeded()
     }
 
     func startMirroringForTesting() {
@@ -3734,8 +4029,23 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         )
     }
 
-    func closeFinalSegmentForTesting(at endDate: Date) async {
+    func closeFinalSegmentForTesting(at endDate: Date) async -> Bool {
         await closeFinalSegmentIfNeeded(in: builder, at: endDate)
+    }
+
+    func waitForSegmentOperationBeforeFinalizationForTesting() async -> Bool {
+        await waitForSegmentOperationBeforeFinalization()
+    }
+
+    func finalizeForTesting(
+        disposition: WorkoutFinishDisposition,
+        endDate: Date
+    ) async {
+        await finalize(disposition: disposition, endDate: endDate)
+    }
+
+    var allowsSavingWithUnconfirmedSegmentForTesting: Bool {
+        allowsSavingWithUnconfirmedSegment
     }
 
     func markMirrorShutdownDeliveryPendingForTesting(startFailure: Bool) {
@@ -3796,15 +4106,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
               let identity else {
             return
         }
-        if isMarkingSegment {
-            deferredRemoteWorkoutEnvelopes.append(contentsOf: envelopes)
-            return
-        }
         let expectedGeneration = identity.transportGenerationID
             ?? identity.sessionID
         let receivedAt = Date()
 
-        for (offset, envelope) in envelopes.enumerated() {
+        for envelope in envelopes {
             guard envelope.sessionID == identity.sessionID,
                   envelope.sessionToken == identity.sessionToken,
                   envelope.transportGenerationID == expectedGeneration,
@@ -3848,13 +4154,37 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                         let wasWritten = containsSegmentEvent(
                             matching: envelope
                         )
-                        publishAcknowledgement(
-                            for: .markSegment,
-                            acknowledgedSequence: envelope.sequence,
-                            errorCode: wasWritten
-                                ? nil
-                                : .segmentMarkFailed
-                        )
+                        if wasWritten {
+                            clearPersistedRemoteSegmentIntent(
+                                matching: envelope
+                            )
+                            publishAcknowledgement(
+                                for: .markSegment,
+                                acknowledgedSequence: envelope.sequence
+                            )
+                        } else if isPendingSegmentControl(envelope) {
+                            publishAcknowledgement(
+                                for: .markSegment,
+                                acknowledgedSequence: envelope.sequence,
+                                errorCode: .segmentMarkUnconfirmed
+                            )
+                        } else if let intent = recoveryStore
+                            .recoveredIdentity?.remoteSegmentIntent,
+                                  intent.matches(envelope) {
+                            beginSegmentMark(
+                                remoteContext: RemoteSegmentControlContext(
+                                    envelope: envelope
+                                ),
+                                recoveredCandidate:
+                                    Self.segmentCandidate(from: intent)
+                            )
+                        } else {
+                            publishAcknowledgement(
+                                for: .markSegment,
+                                acknowledgedSequence: envelope.sequence,
+                                errorCode: .segmentMarkFailed
+                            )
+                        }
                     }
                     _ = publishDurableTerminalAcknowledgement(
                         matching: envelope
@@ -3863,24 +4193,58 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 }
                 if control == .markSegment {
                     let context = RemoteSegmentControlContext(
-                        envelope: envelope,
-                        acceptedGate: candidateGate
+                        envelope: envelope
                     )
                     if containsSegmentEvent(matching: envelope) {
-                        commitRemoteSegmentControl(context)
                         publishAcknowledgement(
                             for: .markSegment,
                             acknowledgedSequence: envelope.sequence
                         )
                         continue
                     }
-                    beginSegmentMark(remoteContext: context)
-                    if isMarkingSegment {
-                        deferredRemoteWorkoutEnvelopes.append(
-                            contentsOf: envelopes.dropFirst(offset + 1)
+                    guard lifecycle.state == .running,
+                          segmentOperationAttemptID == nil,
+                          builder != nil
+                            || injectedSegmentEventOperation != nil else {
+                        let didPersistRejection =
+                            commitRemoteSegmentRejection(envelope)
+                        publishAcknowledgement(
+                            for: .markSegment,
+                            acknowledgedSequence: envelope.sequence,
+                            errorCode: didPersistRejection
+                                ? .segmentMarkFailed
+                                : .segmentMarkUnconfirmed
                         )
-                        return
+                        continue
                     }
+                    guard let candidate = makeCurrentSegmentCandidate() else {
+                        let didPersistRejection =
+                            commitRemoteSegmentRejection(envelope)
+                        publishAcknowledgement(
+                            for: .markSegment,
+                            acknowledgedSequence: envelope.sequence,
+                            errorCode: didPersistRejection
+                                ? .segmentMarkFailed
+                                : .segmentMarkUnconfirmed
+                        )
+                        continue
+                    }
+                    guard commitRemoteSegmentControl(
+                        envelope,
+                        candidate: candidate
+                    ) else {
+                        segmentError = .healthKitWriteFailed
+                        publishAcknowledgement(
+                            for: .markSegment,
+                            acknowledgedSequence: envelope.sequence,
+                            errorCode: .segmentMarkUnconfirmed
+                        )
+                        continue
+                    }
+                    beginSegmentMark(
+                        remoteContext: context,
+                        recoveredCandidate: candidate
+                    )
                     continue
                 }
                 let terminalAcknowledgement:
@@ -4628,6 +4992,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         _ builder: HKLiveWorkoutBuilder,
         at endDate: Date
     ) async throws {
+        if let injectedEndCollectionOperation {
+            try await injectedEndCollectionOperation(builder, endDate)
+            return
+        }
         try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Void, Error>) in
             builder.endCollection(withEnd: endDate) { success, error in
@@ -4645,6 +5013,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private func finishWorkout(
         _ builder: HKLiveWorkoutBuilder
     ) async throws {
+        if let injectedFinishWorkoutOperation {
+            try await injectedFinishWorkoutOperation(builder)
+            return
+        }
         try await withCheckedThrowingContinuation { continuation in
             builder.finishWorkout { workout, error in
                 switch WorkoutFinishCallbackPolicy.outcome(
@@ -4990,4 +5362,5 @@ private enum WorkoutFinalizationError: Error {
 private enum WorkoutSegmentWriteError: Error {
     case builderUnavailable
     case writeFailed
+    case finalizationPending
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
@@ -179,6 +179,10 @@ nonisolated final class WatchWorkoutRecoveryStore {
         var sequenceHighWatermark: UInt64
         var remoteControlCheckpoint:
             WorkoutRemoteControlSequenceGate.Checkpoint? = nil
+        /// A remotely requested segment boundary is journaled with the replay
+        /// checkpoint before its HealthKit event write begins. This closes the
+        /// crash window where the checkpoint was durable but the event was not.
+        var remoteSegmentIntent: RemoteSegmentIntent? = nil
         var remoteTerminalAcknowledgement:
             RemoteTerminalAcknowledgement? = nil
         var finishRequest: FinishRequest?
@@ -190,6 +194,44 @@ nonisolated final class WatchWorkoutRecoveryStore {
         /// metadata-less recovered builder. It may later bind once to the
         /// builder's genuine validated UUID, but can never become saveable.
         var corruptResetSyntheticCleanupIdentity: Bool?
+    }
+
+    struct RemoteSegmentIntent: Codable, Equatable {
+        let controlSenderID: UUID?
+        let acknowledgedSequence: UInt64
+        let capturedAt: Date
+        let completedSegment: WorkoutCompletedSegmentV1
+        let cumulativeElapsedTime: TimeInterval
+        let cumulativeDistanceMeters: Double?
+        let cumulativeDistanceSource: WorkoutMetricSourceV1?
+
+        var isValid: Bool {
+            acknowledgedSequence > 0
+                && capturedAt.timeIntervalSinceReferenceDate.isFinite
+                && completedSegment.index > 0
+                && completedSegment.startedAt
+                    .timeIntervalSinceReferenceDate.isFinite
+                && completedSegment.endedAt
+                    .timeIntervalSinceReferenceDate.isFinite
+                && completedSegment.endedAt >= completedSegment.startedAt
+                && completedSegment.duration.isFinite
+                && completedSegment.duration >= 0
+                && completedSegment.distanceMeters.map {
+                    $0.isFinite && $0 >= 0
+                } ?? true
+                && cumulativeElapsedTime.isFinite
+                && cumulativeElapsedTime >= completedSegment.duration
+                && cumulativeDistanceMeters.map {
+                    $0.isFinite && $0 >= 0
+                } ?? true
+        }
+
+        func matches(_ envelope: WorkoutEnvelopeV1) -> Bool {
+            envelope.control == .markSegment
+                && envelope.controlSenderID == controlSenderID
+                && envelope.sequence == acknowledgedSequence
+                && envelope.capturedAt == capturedAt
+        }
     }
 
     struct RemoteTerminalAcknowledgement: Codable, Equatable {
@@ -607,6 +649,44 @@ nonisolated final class WatchWorkoutRecoveryStore {
         try persist(identity)
         self.identity = identity
         return effectiveDisposition
+    }
+
+    func persistRemoteSegmentControl(
+        checkpoint: WorkoutRemoteControlSequenceGate.Checkpoint,
+        intent: RemoteSegmentIntent
+    ) throws {
+        guard checkpoint.isValid,
+              intent.isValid,
+              intent.controlSenderID.map({ senderID in
+                  checkpoint.seenSenderIDs.contains(senderID)
+                      && (checkpoint.currentSenderID != senderID
+                          || checkpoint.highestSequence
+                              >= intent.acknowledgedSequence)
+              }) ?? (
+                  checkpoint.legacyHighestSequence
+                      >= intent.acknowledgedSequence
+              ),
+              var identity else {
+            throw RecoveryStoreError.missingOrInvalidIdentity
+        }
+        identity.remoteControlCheckpoint = checkpoint
+        identity.remoteSegmentIntent = intent
+        try persist(identity)
+        self.identity = identity
+    }
+
+    func clearRemoteSegmentIntent(
+        matching envelope: WorkoutEnvelopeV1
+    ) throws {
+        guard var identity else {
+            throw RecoveryStoreError.missingOrInvalidIdentity
+        }
+        guard identity.remoteSegmentIntent?.matches(envelope) == true else {
+            return
+        }
+        identity.remoteSegmentIntent = nil
+        try persist(identity)
+        self.identity = identity
     }
 
     @discardableResult
@@ -1093,9 +1173,28 @@ nonisolated final class WatchWorkoutRecoveryStore {
               identity.transportGenerationID != zeroUUID,
               identity.startDate.timeIntervalSinceReferenceDate.isFinite,
               identity.remoteControlCheckpoint?.isValid ?? true,
+              identity.remoteSegmentIntent?.isValid ?? true,
               identity.finishRequest?.requestedAt.timeIntervalSinceReferenceDate.isFinite
                 ?? true else {
             return nil
+        }
+        if let intent = identity.remoteSegmentIntent {
+            guard let checkpoint = identity.remoteControlCheckpoint else {
+                return nil
+            }
+            if let senderID = intent.controlSenderID {
+                guard checkpoint.seenSenderIDs.contains(senderID),
+                      checkpoint.currentSenderID != senderID
+                        || checkpoint.highestSequence
+                            >= intent.acknowledgedSequence else {
+                    return nil
+                }
+            } else {
+                guard checkpoint.legacyHighestSequence
+                        >= intent.acknowledgedSequence else {
+                    return nil
+                }
+            }
         }
         if let acknowledgement = identity.remoteTerminalAcknowledgement {
             guard let checkpoint = identity.remoteControlCheckpoint,

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
@@ -208,7 +208,7 @@ nonisolated final class WatchWorkoutRecoveryStore {
                 .save
             case .discard:
                 .discard
-            case .requestCurrentSnapshot, .pause, .resume:
+            case .requestCurrentSnapshot, .pause, .resume, .markSegment:
                 nil
             }
         }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WatchKit
 
 private enum WorkoutFinishPrompt {
     case options(sessionID: UUID)
@@ -14,6 +15,8 @@ private enum WorkoutFinishPrompt {
 struct LiveWorkoutView: View {
     @ObservedObject var manager: WatchWorkoutManager
     @State private var finishPrompt: WorkoutFinishPrompt?
+    @State private var segmentToast: WorkoutCompletedSegmentV1?
+    @State private var observedSegmentIndex: UInt32?
 
     var body: some View {
         Group {
@@ -25,6 +28,43 @@ struct LiveWorkoutView: View {
         }
         .onChange(of: manager.activeSessionID) {
             finishPrompt = nil
+            observedSegmentIndex = manager.snapshot
+                .lastCompletedSegment?.index
+            segmentToast = nil
+        }
+        .onAppear {
+            observedSegmentIndex = manager.snapshot
+                .lastCompletedSegment?.index
+        }
+        .onChange(of: manager.snapshot.lastCompletedSegment?.index) {
+            let index = manager.snapshot.lastCompletedSegment?.index
+            guard let index,
+                  index != observedSegmentIndex,
+                  manager.state.isActive,
+                  let segment = manager.snapshot.lastCompletedSegment else {
+                observedSegmentIndex = index
+                return
+            }
+            observedSegmentIndex = index
+            WKInterfaceDevice.current().play(.success)
+            withAnimation {
+                segmentToast = segment
+            }
+        }
+        .overlay(alignment: .top) {
+            if let segmentToast {
+                segmentToastView(segmentToast)
+                    .padding(.horizontal, 4)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .task(id: segmentToast?.index) {
+            guard let index = segmentToast?.index else { return }
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard segmentToast?.index == index else { return }
+            withAnimation {
+                segmentToast = nil
+            }
         }
     }
 
@@ -55,6 +95,16 @@ struct LiveWorkoutView: View {
                     }
                 }
 
+                if let segmentError = manager.segmentError {
+                    Label(
+                        segmentErrorMessage(segmentError),
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.orange)
+                    .multilineTextAlignment(.center)
+                }
+
                 if manager.snapshot.errorCode == .anotherWorkoutActive {
                     Label(
                         WorkoutCrossAppTakeoverCopyV1.live(
@@ -71,6 +121,15 @@ struct LiveWorkoutView: View {
                     .font(.system(.title2, design: .rounded, weight: .semibold))
                     .monospacedDigit()
                     .accessibilityLabel("Elapsed time")
+
+                if let segment = manager.snapshot.lastCompletedSegment {
+                    Label(
+                        "Segment \(segment.index + 1)",
+                        systemImage: "flag.checkered"
+                    )
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                }
 
                 LazyVGrid(columns: columns, spacing: 8) {
                     metric(
@@ -133,6 +192,22 @@ struct LiveWorkoutView: View {
 
                 HStack(spacing: 8) {
                     Button {
+                        manager.markSegment()
+                    } label: {
+                        if manager.isMarkingSegment {
+                            ProgressView()
+                        } else {
+                            Image(systemName: "flag.checkered")
+                        }
+                    }
+                    .tint(.blue)
+                    .disabled(
+                        manager.state != .running
+                            || manager.isMarkingSegment
+                    )
+                    .accessibilityLabel("Mark workout segment")
+
+                    Button {
                         if manager.state == .paused {
                             manager.resume()
                         } else {
@@ -142,7 +217,10 @@ struct LiveWorkoutView: View {
                         Image(systemName: manager.state == .paused ? "play.fill" : "pause.fill")
                     }
                     .tint(manager.state == .paused ? .green : .orange)
-                    .disabled(![.running, .paused].contains(manager.state))
+                    .disabled(
+                        ![.running, .paused].contains(manager.state)
+                            || manager.isMarkingSegment
+                    )
                     .accessibilityLabel(manager.state == .paused ? "Resume ride" : "Pause ride")
 
                     Button(role: .destructive) {
@@ -152,7 +230,10 @@ struct LiveWorkoutView: View {
                     } label: {
                         Image(systemName: "stop.fill")
                     }
-                    .disabled(manager.state == .ending)
+                    .disabled(
+                        manager.state == .ending
+                            || manager.isMarkingSegment
+                    )
                     .accessibilityLabel("End ride")
                 }
             }
@@ -268,6 +349,35 @@ struct LiveWorkoutView: View {
         .accessibilityLabel("\(title), \(value) \(unit)")
     }
 
+    private func segmentToastView(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> some View {
+        VStack(spacing: 2) {
+            Label(
+                "Segment \(segment.index)",
+                systemImage: "flag.checkered"
+            )
+            .font(.caption.weight(.semibold))
+            Text(segmentSummary(segment))
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 10))
+        .accessibilityElement(children: .combine)
+    }
+
+    private func segmentSummary(
+        _ segment: WorkoutCompletedSegmentV1
+    ) -> String {
+        let duration = WorkoutValueFormatter.duration(segment.duration)
+        guard let distance = segment.distanceMeters else {
+            return duration
+        }
+        return "\(duration) · \(WorkoutValueFormatter.distance(distance)) \(WorkoutValueFormatter.distanceUnit(distance))"
+    }
+
     private var columns: [GridItem] {
         [GridItem(.flexible()), GridItem(.flexible())]
     }
@@ -314,6 +424,17 @@ struct LiveWorkoutView: View {
             "Couldn’t verify whether this ride was saved. Retry safely."
         case .identityMetadataFailed:
             "Couldn’t finish the ride safely yet. Retry recovery."
+        }
+    }
+
+    private func segmentErrorMessage(
+        _ error: WatchWorkoutSegmentError
+    ) -> String {
+        switch error {
+        case .unavailable:
+            "Resume the ride before marking a segment."
+        case .healthKitWriteFailed:
+            "Couldn’t mark that segment. The ride is still running."
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -86,9 +86,16 @@ struct LiveWorkoutView: View {
                         if finishError == .reconciliationFailed
                             || finishError == .saveFailed
                             || finishError == .identityMetadataFailed
+                            || finishError == .segmentConfirmationPending
                             || finishError == .terminalErrorPersistenceFailed {
                             Button(manager.isDiscarding ? "Retry Recovery" : "Retry Save") {
                                 manager.retryFinalization()
+                            }
+                            .font(.caption2)
+                        }
+                        if finishError == .segmentConfirmationPending {
+                            Button("Save Anyway") {
+                                manager.saveWithoutUnconfirmedSegment()
                             }
                             .font(.caption2)
                         }
@@ -204,6 +211,7 @@ struct LiveWorkoutView: View {
                     .disabled(
                         manager.state != .running
                             || manager.isMarkingSegment
+                            || manager.segmentError == .confirmationPending
                     )
                     .accessibilityLabel("Mark workout segment")
 
@@ -219,7 +227,6 @@ struct LiveWorkoutView: View {
                     .tint(manager.state == .paused ? .green : .orange)
                     .disabled(
                         ![.running, .paused].contains(manager.state)
-                            || manager.isMarkingSegment
                     )
                     .accessibilityLabel(manager.state == .paused ? "Resume ride" : "Pause ride")
 
@@ -232,7 +239,6 @@ struct LiveWorkoutView: View {
                     }
                     .disabled(
                         manager.state == .ending
-                            || manager.isMarkingSegment
                     )
                     .accessibilityLabel("End ride")
                 }
@@ -424,6 +430,8 @@ struct LiveWorkoutView: View {
             "Couldn’t verify whether this ride was saved. Retry safely."
         case .identityMetadataFailed:
             "Couldn’t finish the ride safely yet. Retry recovery."
+        case .segmentConfirmationPending:
+            "A segment is still pending. Retry, or save now without guaranteeing it."
         }
     }
 
@@ -435,6 +443,8 @@ struct LiveWorkoutView: View {
             "Resume the ride before marking a segment."
         case .healthKitWriteFailed:
             "Couldn’t mark that segment. The ride is still running."
+        case .confirmationPending:
+            "Still confirming that segment. You can pause or end the ride."
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
@@ -142,6 +142,10 @@ struct WorkoutStartView: View {
             "The requested finish choice could not be confirmed."
         case .segmentMarkFailed:
             "A segment could not be marked. The workout itself is unchanged."
+        case .segmentMarkUnconfirmed:
+            "A segment is still being confirmed. Check the live workout."
+        case .segmentFinalizationPending:
+            "Open the live workout to finish saving a pending segment."
         case .sessionFailed, .unknown, nil:
             "The workout couldn’t be started or recovered."
         }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
@@ -140,6 +140,8 @@ struct WorkoutStartView: View {
             "The other finish choice was already committed."
         case .terminalChoiceUnconfirmed:
             "The requested finish choice could not be confirmed."
+        case .segmentMarkFailed:
+            "A segment could not be marked. The workout itself is unchanged."
         case .sessionFailed, .unknown, nil:
             "The workout couldn’t be started or recovered."
         }

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -15,8 +15,179 @@ private final class FakeWatchHeartRateZoneConnectivitySession:
     }
 }
 
+private enum SegmentEventProbeError: Error {
+    case requested
+}
+
 @MainActor
 final class WatchWorkoutManagerTests: XCTestCase {
+    func testLocalSegmentsRecordSequentialHealthKitEventsAndCloseAtFinish()
+        async throws {
+        let startDate = Date().addingTimeInterval(-60)
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        var elapsedTime: TimeInterval = 50
+        var segmentDate = startDate.addingTimeInterval(60)
+        var events: [HKWorkoutEvent] = []
+        var shouldFail = false
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            builderElapsedTime: { _ in elapsedTime },
+            segmentEventOperation: { event in
+                if shouldFail { throw SegmentEventProbeError.requested }
+                events.append(event)
+            },
+            segmentNow: { segmentDate },
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+
+        manager.markSegment()
+        try await waitUntil { events.count == 1 && !manager.isMarkingSegment }
+        let first = try XCTUnwrap(events.first)
+        XCTAssertEqual(first.type, .segment)
+        XCTAssertEqual(first.dateInterval.start, startDate)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.index, 1)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.duration, 50)
+
+        elapsedTime = 80
+        segmentDate = startDate.addingTimeInterval(100)
+        manager.markSegment()
+        try await waitUntil { events.count == 2 && !manager.isMarkingSegment }
+        XCTAssertEqual(events[1].dateInterval.start, first.dateInterval.end)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.index, 2)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.duration, 30)
+
+        shouldFail = true
+        elapsedTime = 90
+        segmentDate = startDate.addingTimeInterval(110)
+        manager.markSegment()
+        try await waitUntil {
+            !manager.isMarkingSegment
+                && manager.segmentError == .healthKitWriteFailed
+        }
+        XCTAssertEqual(events.count, 2)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.index, 2)
+
+        shouldFail = false
+        elapsedTime = 110
+        let finalEnd = events[1].dateInterval.end.addingTimeInterval(30)
+        await manager.closeFinalSegmentForTesting(at: finalEnd)
+        XCTAssertEqual(events.count, 3)
+        XCTAssertEqual(events[2].dateInterval.start, events[1].dateInterval.end)
+        XCTAssertEqual(events[2].dateInterval.end, finalEnd)
+    }
+
+    func testRemoteSegmentControlIsReplaySafe() async throws {
+        let startDate = Date().addingTimeInterval(-30)
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        var events: [HKWorkoutEvent] = []
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            builderElapsedTime: { _ in 25 },
+            segmentEventOperation: { events.append($0) },
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+        let control = WorkoutEnvelopeV1(
+            kind: .control,
+            sessionID: identity.sessionID,
+            sessionToken: identity.sessionToken,
+            transportGenerationID:
+                identity.transportGenerationID ?? identity.sessionID,
+            sequence: 40,
+            capturedAt: Date(),
+            controlSenderID: UUID(),
+            control: .markSegment
+        )
+
+        manager.handleRemoteWorkoutEnvelopes([control], from: session)
+        try await waitUntil { events.count == 1 && !manager.isMarkingSegment }
+        manager.handleRemoteWorkoutEnvelopes([control], from: session)
+        await Task.yield()
+
+        XCTAssertEqual(events.count, 1)
+        XCTAssertEqual(manager.snapshot.lastCompletedSegment?.index, 1)
+    }
+
+    func testSegmentWriteTimeoutUnblocksControlsAndIgnoresLateCompletion()
+        async throws {
+        let startDate = Date().addingTimeInterval(-30)
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let probe = AsyncThrowingVoidProbe()
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            builderElapsedTime: { _ in 25 },
+            segmentEventOperation: { _ in try await probe.run() },
+            segmentWriteTimeout: 0.05,
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+
+        manager.markSegment()
+        try await waitUntil { probe.callCount == 1 }
+        try await waitUntil {
+            !manager.isMarkingSegment
+                && manager.segmentError == .healthKitWriteFailed
+        }
+        XCTAssertNil(manager.snapshot.lastCompletedSegment)
+
+        probe.complete()
+        await Task.yield()
+        XCTAssertNil(manager.snapshot.lastCompletedSegment)
+        XCTAssertEqual(manager.segmentError, .healthKitWriteFailed)
+    }
+
     func testProductionSnapshotPublishesConfiguredHeartRateZone() async throws {
         let defaultsSuiteName = "WatchWorkoutManagerHeartRateZoneTests"
         let defaults = try XCTUnwrap(

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -88,7 +88,9 @@ final class WatchWorkoutManagerTests: XCTestCase {
         shouldFail = false
         elapsedTime = 110
         let finalEnd = events[1].dateInterval.end.addingTimeInterval(30)
-        await manager.closeFinalSegmentForTesting(at: finalEnd)
+        let didCloseFinalSegment =
+            await manager.closeFinalSegmentForTesting(at: finalEnd)
+        XCTAssertTrue(didCloseFinalSegment)
         XCTAssertEqual(events.count, 3)
         XCTAssertEqual(events[2].dateInterval.start, events[1].dateInterval.end)
         XCTAssertEqual(events[2].dateInterval.end, finalEnd)
@@ -108,6 +110,7 @@ final class WatchWorkoutManagerTests: XCTestCase {
             healthStore: healthStore,
             configuration: configuration
         )
+        let mirrorProbe = WatchMirrorTransportProbe()
         var events: [HKWorkoutEvent] = []
         let manager = WatchWorkoutManager(
             healthStore: healthStore,
@@ -115,6 +118,10 @@ final class WatchWorkoutManagerTests: XCTestCase {
             recoveryStore: recoveryStore,
             builderElapsedTime: { _ in 25 },
             segmentEventOperation: { events.append($0) },
+            mirrorStartOperation: mirrorProbe.start,
+            mirrorSendOperation: mirrorProbe.send,
+            mirrorShutdownEndSession: mirrorProbe.endSession,
+            mirrorRetryDelay: 0.01,
             initializeOnLaunch: false
         )
         manager.configureMirrorRuntimeForTesting(
@@ -122,6 +129,13 @@ final class WatchWorkoutManagerTests: XCTestCase {
             identity: identity,
             state: .running
         )
+        manager.startMirroringForTesting()
+        mirrorProbe.completeNextStart(succeeded: true)
+        await Task.yield()
+        XCTAssertTrue(manager.publishMirrorSnapshotForTesting())
+        try await waitUntil { !mirrorProbe.sentData.isEmpty }
+        mirrorProbe.completeNextSend(succeeded: true)
+        await Task.yield()
         let control = WorkoutEnvelopeV1(
             kind: .control,
             sessionID: identity.sessionID,
@@ -141,9 +155,201 @@ final class WatchWorkoutManagerTests: XCTestCase {
 
         XCTAssertEqual(events.count, 1)
         XCTAssertEqual(manager.snapshot.lastCompletedSegment?.index, 1)
+        XCTAssertNil(recoveryStore.recoveredIdentity?.remoteSegmentIntent)
     }
 
-    func testSegmentWriteTimeoutUnblocksControlsAndIgnoresLateCompletion()
+    func testRemoteSegmentIntentSurvivesCrashBeforeHealthKitEvent()
+        async throws {
+        let startDate = Date(timeIntervalSinceReferenceDate: 800_400_100)
+        let boundaryDate = startDate.addingTimeInterval(25)
+        let persistence = ToggleRecoveryPersistence()
+        let firstStore = WatchWorkoutRecoveryStore(persistence: persistence)
+        let identity = try firstStore.begin(startDate: startDate)
+        let control = WorkoutEnvelopeV1(
+            kind: .control,
+            sessionID: identity.sessionID,
+            sessionToken: identity.sessionToken,
+            transportGenerationID:
+                identity.transportGenerationID ?? identity.sessionID,
+            sequence: 40,
+            capturedAt: boundaryDate,
+            controlSenderID: UUID(),
+            control: .markSegment
+        )
+        var gate = WorkoutRemoteControlSequenceGate()
+        XCTAssertTrue(try gate.ingest(control))
+        let completedSegment = WorkoutCompletedSegmentV1(
+            index: 1,
+            startedAt: startDate,
+            endedAt: boundaryDate,
+            duration: 25,
+            distanceMeters: 125
+        )
+        try firstStore.persistRemoteSegmentControl(
+            checkpoint: gate.checkpoint,
+            intent: WatchWorkoutRecoveryStore.RemoteSegmentIntent(
+                controlSenderID: control.controlSenderID,
+                acknowledgedSequence: control.sequence,
+                capturedAt: control.capturedAt,
+                completedSegment: completedSegment,
+                cumulativeElapsedTime: 25,
+                cumulativeDistanceMeters: 125,
+                cumulativeDistanceSource: .healthKit
+            )
+        )
+
+        // Simulate process death after the checkpoint+intent transaction but
+        // before HealthKit receives the event.
+        let recoveredStore = WatchWorkoutRecoveryStore(
+            persistence: persistence
+        )
+        let recoveredIdentity = try XCTUnwrap(
+            recoveredStore.recoveredIdentity
+        )
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        var events: [HKWorkoutEvent] = []
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveredStore,
+            segmentEventOperation: { events.append($0) },
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: recoveredIdentity,
+            state: .running
+        )
+
+        // Recovery must resume the accepted boundary without waiting for the
+        // iPhone to reconnect or replay the command.
+        try await waitUntil {
+            events.count == 1 && !manager.isMarkingSegment
+        }
+
+        XCTAssertEqual(events[0].dateInterval.start, startDate)
+        XCTAssertEqual(events[0].dateInterval.end, boundaryDate)
+        XCTAssertEqual(
+            manager.snapshot.lastCompletedSegment,
+            completedSegment
+        )
+        XCTAssertNil(recoveredStore.recoveredIdentity?.remoteSegmentIntent)
+    }
+
+    func testRemoteSegmentDoesNotWriteUntilIntentIsDurable() async throws {
+        let startDate = Date().addingTimeInterval(-30)
+        let persistence = ToggleRecoveryPersistence()
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: persistence
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let mirrorProbe = WatchMirrorTransportProbe()
+        var events: [HKWorkoutEvent] = []
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            builderElapsedTime: { _ in 25 },
+            segmentEventOperation: { events.append($0) },
+            mirrorStartOperation: mirrorProbe.start,
+            mirrorSendOperation: mirrorProbe.send,
+            mirrorShutdownEndSession: mirrorProbe.endSession,
+            mirrorRetryDelay: 0.01,
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+        manager.startMirroringForTesting()
+        mirrorProbe.completeNextStart(succeeded: true)
+        await Task.yield()
+        XCTAssertTrue(manager.publishMirrorSnapshotForTesting())
+        try await waitUntil { !mirrorProbe.sentData.isEmpty }
+        mirrorProbe.completeNextSend(succeeded: true)
+        await Task.yield()
+        let control = WorkoutEnvelopeV1(
+            kind: .control,
+            sessionID: identity.sessionID,
+            sessionToken: identity.sessionToken,
+            transportGenerationID:
+                identity.transportGenerationID ?? identity.sessionID,
+            sequence: 41,
+            capturedAt: Date(),
+            controlSenderID: UUID(),
+            control: .markSegment
+        )
+
+        persistence.failsSave = true
+        manager.handleRemoteWorkoutEnvelopes([control], from: session)
+        await Task.yield()
+        XCTAssertTrue(events.isEmpty)
+        XCTAssertNil(
+            recoveryStore.recoveredIdentity?.remoteControlCheckpoint
+        )
+        XCTAssertNil(recoveryStore.recoveredIdentity?.remoteSegmentIntent)
+        try await waitUntil {
+            mirrorProbe.sentData.compactMap {
+                try? WorkoutContractCodec.decode($0)
+            }.contains {
+                $0.acknowledgement?.control == .markSegment
+                    && $0.acknowledgement?.acknowledgedSequence
+                        == control.sequence
+                    && $0.acknowledgement?.errorCode
+                        == .segmentMarkUnconfirmed
+            }
+        }
+        mirrorProbe.completeNextSend(succeeded: true)
+
+        persistence.failsSave = false
+        manager.handleRemoteWorkoutEnvelopes([control], from: session)
+        try await waitUntil {
+            events.count == 1 && !manager.isMarkingSegment
+        }
+        XCTAssertEqual(events.count, 1)
+        XCTAssertNil(recoveryStore.recoveredIdentity?.remoteSegmentIntent)
+        for _ in 0..<4 {
+            let hasSuccess = mirrorProbe.sentData.compactMap {
+                try? WorkoutContractCodec.decode($0)
+            }.contains {
+                $0.acknowledgement?.control == .markSegment
+                    && $0.acknowledgement?.acknowledgedSequence
+                        == control.sequence
+                    && $0.acknowledgement?.errorCode == nil
+            }
+            if hasSuccess { break }
+            mirrorProbe.completeNextSend(succeeded: true)
+            await Task.yield()
+        }
+        XCTAssertTrue(
+            mirrorProbe.sentData.compactMap {
+                try? WorkoutContractCodec.decode($0)
+            }.contains {
+                $0.acknowledgement?.control == .markSegment
+                    && $0.acknowledgement?.acknowledgedSequence
+                        == control.sequence
+                    && $0.acknowledgement?.errorCode == nil
+            }
+        )
+    }
+
+    func testSegmentWriteTimeoutKeepsBoundaryPendingAndReconcilesLateSuccess()
         async throws {
         let startDate = Date().addingTimeInterval(-30)
         let recoveryStore = WatchWorkoutRecoveryStore(
@@ -159,12 +365,16 @@ final class WatchWorkoutManagerTests: XCTestCase {
             configuration: configuration
         )
         let probe = AsyncThrowingVoidProbe()
+        var events: [HKWorkoutEvent] = []
         let manager = WatchWorkoutManager(
             healthStore: healthStore,
             routeRecorder: WatchRouteRecorder(),
             recoveryStore: recoveryStore,
             builderElapsedTime: { _ in 25 },
-            segmentEventOperation: { _ in try await probe.run() },
+            segmentEventOperation: { event in
+                try await probe.run()
+                events.append(event)
+            },
             segmentWriteTimeout: 0.05,
             initializeOnLaunch: false
         )
@@ -178,14 +388,300 @@ final class WatchWorkoutManagerTests: XCTestCase {
         try await waitUntil { probe.callCount == 1 }
         try await waitUntil {
             !manager.isMarkingSegment
-                && manager.segmentError == .healthKitWriteFailed
+                && manager.segmentError == .confirmationPending
         }
         XCTAssertNil(manager.snapshot.lastCompletedSegment)
 
+        manager.markSegment()
+        XCTAssertEqual(probe.callCount, 1)
+        XCTAssertEqual(manager.segmentError, .confirmationPending)
+        let didResolveBeforeFinalizationTimeout =
+            await manager
+                .waitForSegmentOperationBeforeFinalizationForTesting()
+        XCTAssertFalse(didResolveBeforeFinalizationTimeout)
+
         probe.complete()
+        try await waitUntil {
+            events.count == 1
+                && manager.snapshot.lastCompletedSegment?.index == 1
+        }
+        XCTAssertNil(manager.segmentError)
+    }
+
+    func testFinalSegmentTimeoutBlocksCollectionUntilLateWriteResolves()
+        async throws {
+        let startDate = Date().addingTimeInterval(-60)
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let tailProbe = AsyncThrowingVoidProbe()
+        var events: [HKWorkoutEvent] = []
+        var shouldDelay = false
+        let firstBoundary = startDate.addingTimeInterval(25)
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            builderElapsedTime: { _ in shouldDelay ? 50 : 25 },
+            segmentEventOperation: { event in
+                if shouldDelay {
+                    try await tailProbe.run()
+                }
+                events.append(event)
+            },
+            segmentNow: { firstBoundary },
+            segmentWriteTimeout: 0.05,
+            initializeOnLaunch: false
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+
+        manager.markSegment()
+        try await waitUntil {
+            events.count == 1
+                && manager.snapshot.lastCompletedSegment?.index == 1
+        }
+
+        shouldDelay = true
+        let finalEnd = startDate.addingTimeInterval(50)
+        let didResolveBeforeTimeout =
+            await manager.closeFinalSegmentForTesting(at: finalEnd)
+        XCTAssertFalse(didResolveBeforeTimeout)
+        XCTAssertEqual(tailProbe.callCount, 1)
+        XCTAssertEqual(manager.segmentError, .confirmationPending)
+        XCTAssertEqual(events.count, 1)
+
+        tailProbe.complete()
+        try await waitUntil {
+            events.count == 2
+                && manager.snapshot.lastCompletedSegment?.index == 2
+        }
+        XCTAssertNil(manager.segmentError)
+        let didResolveAfterLateCompletion =
+            await manager.closeFinalSegmentForTesting(at: finalEnd)
+        XCTAssertTrue(didResolveAfterLateCompletion)
+        XCTAssertEqual(events.count, 2)
+    }
+
+    func testFinishRequiresExplicitEscapeWhileSegmentIsUnconfirmedAndDiscardDoesNotWait()
+        async throws {
+        let startDate = Date().addingTimeInterval(-30)
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let identity = try recoveryStore.begin(startDate: startDate)
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let saveBuilder = session.associatedWorkoutBuilder()
+        let saveProbe = AsyncThrowingVoidProbe()
+        var endCollectionCount = 0
+        var finishWorkoutCount = 0
+        let saveManager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            recoveredSaveRuntimeAdapter: WatchRecoveredSaveRuntimeAdapter(
+                session: session,
+                builder: saveBuilder,
+                sessionState: { .stopped }
+            ),
+            recoveredSaveResolver: { _, _ in
+                RecoveredSaveResolution(
+                    action: .finalize(.full),
+                    workout: nil
+                )
+            },
+            builderElapsedTime: { _ in 25 },
+            segmentEventOperation: { _ in
+                try await saveProbe.run()
+            },
+            endCollectionOperation: { _, _ in
+                endCollectionCount += 1
+            },
+            finishWorkoutOperation: { _ in
+                finishWorkoutCount += 1
+            },
+            segmentWriteTimeout: 0.05,
+            initializeOnLaunch: false
+        )
+        saveManager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+        saveManager.markSegment()
+        try await waitUntil { saveProbe.callCount == 1 }
+        saveManager.endAndSave()
+        await saveManager.finalizeForTesting(
+            disposition: .save,
+            endDate: startDate.addingTimeInterval(30)
+        )
+
+        XCTAssertEqual(
+            saveManager.finishRequestError,
+            .segmentConfirmationPending
+        )
+        XCTAssertEqual(
+            saveManager.snapshot.errorCode,
+            .segmentFinalizationPending
+        )
+        XCTAssertFalse(
+            saveManager.allowsSavingWithUnconfirmedSegmentForTesting
+        )
+
+        saveManager.saveWithoutUnconfirmedSegment()
+        XCTAssertTrue(
+            saveManager.allowsSavingWithUnconfirmedSegmentForTesting
+        )
+        try await waitUntil {
+            endCollectionCount == 1
+                && finishWorkoutCount == 1
+                && saveManager.summary?.outcome == .saved
+        }
+        XCTAssertEqual(endCollectionCount, 1)
+        XCTAssertEqual(finishWorkoutCount, 1)
+        XCTAssertNil(recoveryStore.recoveredIdentity)
+        saveProbe.complete()
+
+        let discardProbe = AsyncThrowingVoidProbe()
+        var discardWorkoutCount = 0
+        var discardRouteCount = 0
+        var endSessionCount = 0
+        let discardStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let discardIdentity = try discardStore.begin(startDate: startDate)
+        let discardSession = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let discardManager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: discardStore,
+            builderElapsedTime: { _ in 25 },
+            recoveredDiscardFinalizationAdapter:
+                WatchRecoveredDiscardFinalizationAdapter(
+                    discardWorkout: { discardWorkoutCount += 1 },
+                    discardRoute: { discardRouteCount += 1 },
+                    endSession: { endSessionCount += 1 }
+                ),
+            segmentEventOperation: { _ in
+                try await discardProbe.run()
+            },
+            segmentWriteTimeout: 0.05,
+            initializeOnLaunch: false
+        )
+        discardManager.configureMirrorRuntimeForTesting(
+            session: discardSession,
+            identity: discardIdentity,
+            state: .running
+        )
+        discardManager.markSegment()
+        try await waitUntil { discardProbe.callCount == 1 }
+        discardManager.discard()
+        await discardManager.finalizeForTesting(
+            disposition: .discard,
+            endDate: startDate.addingTimeInterval(30)
+        )
+
+        XCTAssertEqual(discardWorkoutCount, 1)
+        XCTAssertEqual(discardRouteCount, 1)
+        XCTAssertEqual(endSessionCount, 1)
+        XCTAssertNotEqual(
+            discardManager.finishRequestError,
+            .segmentConfirmationPending
+        )
+        discardProbe.complete()
+    }
+
+    func testRemoteSegmentDuringLocalWriteFailsWithoutOrphaningConfirmation()
+        async throws {
+        let mirrorProbe = WatchMirrorTransportProbe()
+        let segmentProbe = AsyncThrowingVoidProbe()
+        let runtime = try makeMirrorRuntime(
+            probe: mirrorProbe,
+            builderElapsedTime: { _ in 25 },
+            segmentEventOperation: { _ in
+                try await segmentProbe.run()
+            }
+        )
+        runtime.manager.configureMirrorRuntimeForTesting(
+            session: runtime.session,
+            identity: runtime.identity,
+            state: .running
+        )
+        runtime.manager.startMirroringForTesting()
+        XCTAssertEqual(mirrorProbe.startCallCount, 1)
+        mirrorProbe.completeNextStart(succeeded: true)
         await Task.yield()
-        XCTAssertNil(manager.snapshot.lastCompletedSegment)
-        XCTAssertEqual(manager.segmentError, .healthKitWriteFailed)
+        XCTAssertTrue(runtime.manager.publishMirrorSnapshotForTesting())
+        try await waitUntil { !mirrorProbe.sentData.isEmpty }
+        mirrorProbe.completeNextSend(succeeded: true)
+        await Task.yield()
+
+        runtime.manager.markSegment()
+        try await waitUntil { segmentProbe.callCount == 1 }
+        let remoteControl = WorkoutEnvelopeV1(
+            kind: .control,
+            sessionID: runtime.identity.sessionID,
+            sessionToken: runtime.identity.sessionToken,
+            transportGenerationID:
+                runtime.identity.transportGenerationID
+                    ?? runtime.identity.sessionID,
+            sequence: 1,
+            capturedAt: runtime.identity.startDate.addingTimeInterval(1),
+            controlSenderID: UUID(),
+            control: .markSegment
+        )
+        runtime.manager.handleRemoteWorkoutEnvelopes(
+            [remoteControl],
+            from: runtime.session
+        )
+        try await waitUntil {
+            mirrorProbe.sentData.compactMap {
+                try? WorkoutContractCodec.decode($0)
+            }.contains {
+                $0.acknowledgement?.control == .markSegment
+                    && $0.acknowledgement?.acknowledgedSequence
+                        == remoteControl.sequence
+                    && $0.acknowledgement?.errorCode
+                        == .segmentMarkFailed
+                }
+        }
+        XCTAssertNil(
+            runtime.store.recoveredIdentity?.remoteSegmentIntent
+        )
+
+        segmentProbe.complete()
+        try await waitUntil {
+            runtime.manager.snapshot.lastCompletedSegment?.index == 1
+        }
+        runtime.manager.handleRemoteWorkoutEnvelopes(
+            [remoteControl],
+            from: runtime.session
+        )
+        await Task.yield()
+        XCTAssertEqual(segmentProbe.callCount, 1)
+        XCTAssertNil(runtime.manager.segmentError)
     }
 
     func testProductionSnapshotPublishesConfiguredHeartRateZone() async throws {
@@ -7152,7 +7648,10 @@ final class WatchWorkoutManagerTests: XCTestCase {
         probe: WatchMirrorTransportProbe,
         shutdownTimeout: TimeInterval = 10,
         workoutConfigurationHandler:
-            (@MainActor (HKWorkoutConfiguration) -> Void)? = nil
+            (@MainActor (HKWorkoutConfiguration) -> Void)? = nil,
+        builderElapsedTime:
+            (@MainActor (HKLiveWorkoutBuilder?) -> TimeInterval)? = nil,
+        segmentEventOperation: WatchSegmentEventOperation? = nil
     ) throws -> (
         manager: WatchWorkoutManager,
         session: HKWorkoutSession,
@@ -7177,7 +7676,9 @@ final class WatchWorkoutManagerTests: XCTestCase {
             healthStore: healthStore,
             routeRecorder: WatchRouteRecorder(),
             recoveryStore: store,
+            builderElapsedTime: builderElapsedTime,
             workoutConfigurationHandler: workoutConfigurationHandler,
+            segmentEventOperation: segmentEventOperation,
             mirrorStartOperation: probe.start,
             mirrorSendOperation: probe.send,
             mirrorShutdownEndSession: probe.endSession,
@@ -7190,13 +7691,19 @@ final class WatchWorkoutManagerTests: XCTestCase {
 
     private func waitUntil(
         timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line,
         condition: @MainActor () -> Bool
     ) async throws {
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: timeout)
         while !condition() {
             guard clock.now < deadline else {
-                XCTFail("Timed out waiting for asynchronous Watch state")
+                XCTFail(
+                    "Timed out waiting for asynchronous Watch state",
+                    file: file,
+                    line: line
+                )
                 return
             }
             try await Task.sleep(for: .milliseconds(10))

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 nonisolated struct WorkoutSchemaVersion: Codable, Equatable, Sendable {
-    static let current = Self(major: 1, minor: 3)
+    static let current = Self(major: 1, minor: 4)
 
     let major: UInt16
     let minor: UInt16
@@ -109,6 +109,7 @@ nonisolated enum WorkoutSafeErrorCodeV1: String, Codable, Sendable {
     case finalSummaryUnavailable
     case terminalChoiceConflict
     case terminalChoiceUnconfirmed
+    case segmentMarkFailed
     case sessionFailed
     case unknown
 
@@ -150,6 +151,14 @@ nonisolated enum WorkoutDiscardDisclosureV1 {
     }
 }
 
+nonisolated struct WorkoutCompletedSegmentV1: Codable, Equatable, Sendable {
+    let index: UInt32
+    let startedAt: Date
+    let endedAt: Date
+    let duration: TimeInterval
+    let distanceMeters: Double?
+}
+
 nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
     let state: WorkoutSessionStateV1
     let startDate: Date?
@@ -165,6 +174,7 @@ nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
     let heartRateZoneCount: UInt8?
     let heartRateZoneDurations: WorkoutZoneDurationsV1?
     let location: WorkoutLocationV1?
+    let lastCompletedSegment: WorkoutCompletedSegmentV1?
     let availability: WorkoutAvailabilityMaskV1
     let errorCode: WorkoutSafeErrorCodeV1?
     let terminalOutcome: WorkoutTerminalOutcomeV1?
@@ -184,6 +194,7 @@ nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
         heartRateZoneCount: UInt8? = nil,
         heartRateZoneDurations: WorkoutZoneDurationsV1? = nil,
         location: WorkoutLocationV1? = nil,
+        lastCompletedSegment: WorkoutCompletedSegmentV1? = nil,
         availability: WorkoutAvailabilityMaskV1 = [],
         errorCode: WorkoutSafeErrorCodeV1? = nil,
         terminalOutcome: WorkoutTerminalOutcomeV1? = nil
@@ -202,6 +213,7 @@ nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
         self.heartRateZoneCount = heartRateZoneCount
         self.heartRateZoneDurations = heartRateZoneDurations
         self.location = location
+        self.lastCompletedSegment = lastCompletedSegment
         self.availability = availability
         self.errorCode = errorCode
         self.terminalOutcome = terminalOutcome
@@ -211,6 +223,7 @@ nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
 nonisolated enum WorkoutControlV1: String, Codable, Sendable {
     case pause
     case resume
+    case markSegment
     case endAndSave
     case discard
     case requestCurrentSnapshot
@@ -220,6 +233,19 @@ nonisolated struct WorkoutAcknowledgementV1: Codable, Equatable, Sendable {
     let control: WorkoutControlV1
     let resultingState: WorkoutSessionStateV1
     let acknowledgedSequence: UInt64
+    let errorCode: WorkoutSafeErrorCodeV1?
+
+    init(
+        control: WorkoutControlV1,
+        resultingState: WorkoutSessionStateV1,
+        acknowledgedSequence: UInt64,
+        errorCode: WorkoutSafeErrorCodeV1? = nil
+    ) {
+        self.control = control
+        self.resultingState = resultingState
+        self.acknowledgedSequence = acknowledgedSequence
+        self.errorCode = errorCode
+    }
 }
 
 nonisolated struct WorkoutErrorV1: Codable, Equatable, Sendable {
@@ -369,9 +395,15 @@ nonisolated enum WorkoutContractCodec {
             guard envelope.snapshot == nil,
                   envelope.controlSenderID == nil,
                   envelope.control == nil,
-                  envelope.acknowledgement != nil,
+                  let acknowledgement = envelope.acknowledgement,
                   envelope.error == nil else {
                 throw WorkoutContractError.invalidEnvelopePayload
+            }
+            if let errorCode = acknowledgement.errorCode {
+                guard acknowledgement.control == .markSegment,
+                      errorCode == .segmentMarkFailed else {
+                    throw WorkoutContractError.invalidEnvelopePayload
+                }
             }
         case .error:
             guard envelope.snapshot == nil,
@@ -504,6 +536,25 @@ nonisolated enum WorkoutContractCodec {
             }
             if (location.altitude == nil) != (location.verticalAccuracy == nil) {
                 throw WorkoutContractError.invalidLocation
+            }
+        }
+        if let segment = snapshot.lastCompletedSegment {
+            guard segment.index > 0,
+                  segment.index < UInt32.max,
+                  segment.startedAt.timeIntervalSinceReferenceDate.isFinite,
+                  segment.endedAt.timeIntervalSinceReferenceDate.isFinite,
+                  segment.startedAt <= segment.endedAt,
+                  snapshot.startDate.map({ segment.startedAt >= $0 }) ?? false,
+                  segment.endedAt <= envelopeCapturedAt,
+                  segment.duration.isFinite,
+                  segment.duration >= 0,
+                  segment.duration
+                    <= segment.endedAt.timeIntervalSince(segment.startedAt)
+                        + 1,
+                  segment.distanceMeters.map({
+                      $0.isFinite && $0 >= 0
+                  }) ?? true else {
+                throw WorkoutContractError.invalidMetric
             }
         }
 

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
@@ -110,6 +110,8 @@ nonisolated enum WorkoutSafeErrorCodeV1: String, Codable, Sendable {
     case terminalChoiceConflict
     case terminalChoiceUnconfirmed
     case segmentMarkFailed
+    case segmentMarkUnconfirmed
+    case segmentFinalizationPending
     case sessionFailed
     case unknown
 
@@ -401,7 +403,8 @@ nonisolated enum WorkoutContractCodec {
             }
             if let errorCode = acknowledgement.errorCode {
                 guard acknowledgement.control == .markSegment,
-                      errorCode == .segmentMarkFailed else {
+                      errorCode == .segmentMarkFailed
+                        || errorCode == .segmentMarkUnconfirmed else {
                     throw WorkoutContractError.invalidEnvelopePayload
                 }
             }

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
@@ -216,6 +216,8 @@ nonisolated enum WorkoutErrorCopyV1 {
             return "Finish choice not applied"
         case .terminalChoiceUnconfirmed:
             return "Finish choice unconfirmed"
+        case .segmentMarkFailed:
+            return "Segment wasn’t marked"
         case .sessionFailed, .unknown, nil:
             return "Workout needs attention"
         }
@@ -245,6 +247,8 @@ nonisolated enum WorkoutErrorCopyV1 {
             return "Apple Watch had already committed the other finish choice. The saved or discarded result shown above is authoritative."
         case .terminalChoiceUnconfirmed:
             return "BikeComputer could not confirm whether your Save or Discard choice was applied. Check BikeComputer on Apple Watch; if the ride ended, verify the result in Health."
+        case .segmentMarkFailed:
+            return "Apple Watch couldn’t add that segment to the workout. The ride is still running, so you can try again."
         case .sessionFailed, .unknown, nil:
             return "Check BikeComputer on Apple Watch. No workout is saved or ended by iPhone alone."
         }
@@ -466,6 +470,7 @@ nonisolated enum WorkoutIPhoneTelemetryMerge {
             heartRateZoneCount: watch.heartRateZoneCount,
             heartRateZoneDurations: watch.heartRateZoneDurations,
             location: location,
+            lastCompletedSegment: watch.lastCompletedSegment,
             availability: availability,
             errorCode: watch.errorCode,
             terminalOutcome: watch.terminalOutcome
@@ -822,9 +827,14 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
                acknowledgementConfirmsPendingControl(
                    acknowledgement,
                    envelope: envelope
-               ) {
+            ) {
                 pendingControl = nil
                 pendingControlSequence = nil
+                if let acknowledgementError = acknowledgement.errorCode {
+                    commandErrorCode = acknowledgementError
+                } else if timedOutTerminalControl == nil {
+                    commandErrorCode = nil
+                }
             } else if let acknowledgement = envelope.acknowledgement,
                       acknowledgementResolvesTimedOutTerminalControl(
                           acknowledgement,
@@ -1117,14 +1127,26 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         }
         switch acknowledgement.control {
         case .pause:
-            return acknowledgement.resultingState == .paused
+            return acknowledgement.errorCode == nil
+                && acknowledgement.resultingState == .paused
         case .resume:
-            return acknowledgement.resultingState == .running
+            return acknowledgement.errorCode == nil
+                && acknowledgement.resultingState == .running
+        case .markSegment:
+            return [
+                WorkoutSessionStateV1.running,
+                .paused,
+                .ending,
+                .ended,
+            ].contains(acknowledgement.resultingState)
+                && (acknowledgement.errorCode == nil
+                    || acknowledgement.errorCode == .segmentMarkFailed)
         case .endAndSave, .discard:
-            return acknowledgement.resultingState == .ending
-                || acknowledgement.resultingState == .ended
+            return acknowledgement.errorCode == nil
+                && (acknowledgement.resultingState == .ending
+                    || acknowledgement.resultingState == .ended)
         case .requestCurrentSnapshot:
-            return true
+            return acknowledgement.errorCode == nil
         }
     }
 

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
@@ -218,6 +218,10 @@ nonisolated enum WorkoutErrorCopyV1 {
             return "Finish choice unconfirmed"
         case .segmentMarkFailed:
             return "Segment wasn’t marked"
+        case .segmentMarkUnconfirmed:
+            return "Segment confirmation pending"
+        case .segmentFinalizationPending:
+            return "Segment is delaying save"
         case .sessionFailed, .unknown, nil:
             return "Workout needs attention"
         }
@@ -249,6 +253,10 @@ nonisolated enum WorkoutErrorCopyV1 {
             return "BikeComputer could not confirm whether your Save or Discard choice was applied. Check BikeComputer on Apple Watch; if the ride ended, verify the result in Health."
         case .segmentMarkFailed:
             return "Apple Watch couldn’t add that segment to the workout. The ride is still running, so you can try again."
+        case .segmentMarkUnconfirmed:
+            return "Apple Watch is still confirming that segment. You can pause or end the ride, but wait before marking another segment."
+        case .segmentFinalizationPending:
+            return "Open BikeComputer on Apple Watch to retry the pending segment or save the ride anyway."
         case .sessionFailed, .unknown, nil:
             return "Check BikeComputer on Apple Watch. No workout is saved or ended by iPhone alone."
         }
@@ -598,6 +606,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
     private(set) var commandErrorCode: WorkoutSafeErrorCodeV1?
     private(set) var pendingControl: WorkoutControlV1?
     private(set) var pendingControlSequence: UInt64?
+    private var unconfirmedSegmentControlSequence: UInt64?
     private var timedOutTerminalControl: WorkoutControlV1?
     private var timedOutTerminalControlSequence: UInt64?
     private(set) var finalSnapshot: WorkoutSnapshotV1?
@@ -638,6 +647,14 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
             || commandErrorCode == .finalSummaryUnavailable
     }
 
+    var isSegmentConfirmationPending: Bool {
+        unconfirmedSegmentControlSequence != nil
+    }
+
+    var currentUnconfirmedSegmentControlSequence: UInt64? {
+        unconfirmedSegmentControlSequence
+    }
+
     mutating func markUnsupported() {
         connectionState = .unsupported
         hasMirroredSession = false
@@ -647,6 +664,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         commandErrorCode = nil
         pendingControl = nil
         pendingControlSequence = nil
+        unconfirmedSegmentControlSequence = nil
         clearTimedOutTerminalControl()
     }
 
@@ -672,6 +690,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         commandErrorCode = nil
         pendingControl = nil
         pendingControlSequence = nil
+        unconfirmedSegmentControlSequence = nil
         clearTimedOutTerminalControl()
         confirmedSessionState = .starting
         sessionStateConfirmedAt = date
@@ -733,13 +752,15 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
             finalSnapshot = nil
             pendingControl = nil
             pendingControlSequence = nil
+            unconfirmedSegmentControlSequence = nil
             clearTimedOutTerminalControl()
         }
         hasMirroredSession = true
         activeLaunchID = nil
         launchDeadline = nil
         errorCode = nil
-        if timedOutTerminalControl == nil {
+        if timedOutTerminalControl == nil,
+           unconfirmedSegmentControlSequence == nil {
             commandErrorCode = nil
         }
         connectionState = .awaitingFirstSnapshot
@@ -832,9 +853,29 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
                 pendingControlSequence = nil
                 if let acknowledgementError = acknowledgement.errorCode {
                     commandErrorCode = acknowledgementError
-                } else if timedOutTerminalControl == nil {
-                    commandErrorCode = nil
+                    if acknowledgement.control == .markSegment,
+                       acknowledgementError == .segmentMarkUnconfirmed {
+                        unconfirmedSegmentControlSequence =
+                            acknowledgement.acknowledgedSequence
+                    } else if acknowledgement.control == .markSegment {
+                        unconfirmedSegmentControlSequence = nil
+                    }
+                } else {
+                    if timedOutTerminalControl == nil,
+                       unconfirmedSegmentControlSequence == nil {
+                        commandErrorCode = nil
+                    }
+                    if acknowledgement.control == .markSegment {
+                        unconfirmedSegmentControlSequence = nil
+                    }
                 }
+            } else if let acknowledgement = envelope.acknowledgement,
+                      acknowledgementResolvesUnconfirmedSegmentControl(
+                          acknowledgement,
+                          envelope: envelope
+                      ) {
+                unconfirmedSegmentControlSequence = nil
+                commandErrorCode = acknowledgement.errorCode
             } else if let acknowledgement = envelope.acknowledgement,
                       acknowledgementResolvesTimedOutTerminalControl(
                           acknowledgement,
@@ -863,6 +904,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
             commandErrorCode = nil
             pendingControl = nil
             pendingControlSequence = nil
+            unconfirmedSegmentControlSequence = nil
             clearTimedOutTerminalControl()
             finalSnapshot = nil
         }
@@ -933,7 +975,8 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         sessionStateConfirmedAt = date
         clearConfirmedControlIfNeeded(for: state, terminalOutcome: nil)
         if (state == .running || state == .paused),
-           timedOutTerminalControl == nil {
+           timedOutTerminalControl == nil,
+           unconfirmedSegmentControlSequence == nil {
             commandErrorCode = nil
         }
 
@@ -977,7 +1020,11 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         _ control: WorkoutControlV1,
         sequence: UInt64? = nil
     ) -> Bool {
-        guard pendingControl == nil else { return false }
+        guard pendingControl == nil,
+              control != .markSegment
+                || unconfirmedSegmentControlSequence == nil else {
+            return false
+        }
         pendingControl = control
         pendingControlSequence = sequence
         if control == .endAndSave || control == .discard {
@@ -1003,6 +1050,10 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         }
         pendingControl = nil
         pendingControlSequence = nil
+        if control == .markSegment,
+           error == .segmentMarkUnconfirmed {
+            unconfirmedSegmentControlSequence = sequence
+        }
         let preservesTimedOutTerminalChoice = timedOutTerminalControl != nil
             && control != .endAndSave
             && control != .discard
@@ -1041,6 +1092,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         launchDeadline = nil
         pendingControl = nil
         pendingControlSequence = nil
+        unconfirmedSegmentControlSequence = nil
         clearTimedOutTerminalControl()
         connectionState = .failed
         errorCode = error
@@ -1056,6 +1108,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         launchDeadline = nil
         pendingControl = nil
         pendingControlSequence = nil
+        unconfirmedSegmentControlSequence = nil
         clearTimedOutTerminalControl()
         connectionState = .connected
         errorCode = error
@@ -1103,6 +1156,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         commandErrorCode = nil
         pendingControl = nil
         pendingControlSequence = nil
+        unconfirmedSegmentControlSequence = nil
         clearTimedOutTerminalControl()
         finalSnapshot = nil
         activeLaunchID = nil
@@ -1140,7 +1194,8 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
                 .ended,
             ].contains(acknowledgement.resultingState)
                 && (acknowledgement.errorCode == nil
-                    || acknowledgement.errorCode == .segmentMarkFailed)
+                    || acknowledgement.errorCode == .segmentMarkFailed
+                    || acknowledgement.errorCode == .segmentMarkUnconfirmed)
         case .endAndSave, .discard:
             return acknowledgement.errorCode == nil
                 && (acknowledgement.resultingState == .ending
@@ -1148,6 +1203,24 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
         case .requestCurrentSnapshot:
             return acknowledgement.errorCode == nil
         }
+    }
+
+    private func acknowledgementResolvesUnconfirmedSegmentControl(
+        _ acknowledgement: WorkoutAcknowledgementV1,
+        envelope: WorkoutEnvelopeV1
+    ) -> Bool {
+        guard let current = latestEnvelope,
+              envelope.sessionID == current.sessionID,
+              envelope.sessionToken == current.sessionToken,
+              envelope.transportGenerationID
+                == current.transportGenerationID,
+              acknowledgement.control == .markSegment,
+              acknowledgement.acknowledgedSequence
+                == unconfirmedSegmentControlSequence else {
+            return false
+        }
+        return acknowledgement.errorCode == nil
+            || acknowledgement.errorCode == .segmentMarkFailed
     }
 
     private func acknowledgementResolvesTimedOutTerminalControl(
@@ -1183,7 +1256,9 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
             pendingControl = nil
             pendingControlSequence = nil
             if timedOutTerminalControl == nil {
-                commandErrorCode = nil
+                if unconfirmedSegmentControlSequence == nil {
+                    commandErrorCode = nil
+                }
             }
         case (.endAndSave?, .ended, .discarded?),
              (.discard?, .ended, .saved?):

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
@@ -296,6 +296,7 @@ nonisolated struct WorkoutSegmentCandidate: Equatable, Sendable {
     let completedSegment: WorkoutCompletedSegmentV1
     let cumulativeElapsedTime: TimeInterval
     let cumulativeDistanceMeters: Double?
+    let cumulativeDistanceSource: WorkoutMetricSourceV1?
 }
 
 /// Tracks sequential user-marked workout segments using active workout time
@@ -308,6 +309,7 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
     private(set) var segmentStartedAt: Date?
     private(set) var elapsedTimeAtStart: TimeInterval = 0
     private(set) var distanceAtStartMeters: Double?
+    private(set) var distanceSourceAtStart: WorkoutMetricSourceV1?
     private(set) var lastCompletedSegment: WorkoutCompletedSegmentV1?
 
     var hasCompletedSegments: Bool {
@@ -324,6 +326,7 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
         segmentStartedAt = workoutStart
         elapsedTimeAtStart = 0
         distanceAtStartMeters = 0
+        distanceSourceAtStart = nil
         lastCompletedSegment = nil
     }
 
@@ -331,7 +334,8 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
         workoutStart: Date,
         lastCompletedSegment: WorkoutCompletedSegmentV1?,
         cumulativeElapsedTime: TimeInterval?,
-        cumulativeDistanceMeters: Double?
+        cumulativeDistanceMeters: Double?,
+        cumulativeDistanceSource: WorkoutMetricSourceV1? = nil
     ) {
         reset(workoutStart: workoutStart)
         guard let lastCompletedSegment,
@@ -349,12 +353,14 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
         segmentStartedAt = lastCompletedSegment.endedAt
         elapsedTimeAtStart = cumulativeElapsedTime
         distanceAtStartMeters = cumulativeDistanceMeters
+        distanceSourceAtStart = cumulativeDistanceSource
     }
 
     func candidate(
         endedAt: Date,
         cumulativeElapsedTime: TimeInterval,
-        cumulativeDistanceMeters: Double?
+        cumulativeDistanceMeters: Double?,
+        cumulativeDistanceSource: WorkoutMetricSourceV1? = nil
     ) -> WorkoutSegmentCandidate? {
         guard let workoutStart,
               let segmentStartedAt,
@@ -373,7 +379,9 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
         let distanceMeters: Double?
         if let cumulativeDistanceMeters,
            let distanceAtStartMeters,
-           cumulativeDistanceMeters >= distanceAtStartMeters {
+           cumulativeDistanceMeters >= distanceAtStartMeters,
+           nextIndex == 1
+            || cumulativeDistanceSource == distanceSourceAtStart {
             distanceMeters = cumulativeDistanceMeters - distanceAtStartMeters
         } else {
             distanceMeters = nil
@@ -387,7 +395,8 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
                 distanceMeters: distanceMeters
             ),
             cumulativeElapsedTime: cumulativeElapsedTime,
-            cumulativeDistanceMeters: cumulativeDistanceMeters
+            cumulativeDistanceMeters: cumulativeDistanceMeters,
+            cumulativeDistanceSource: cumulativeDistanceSource
         )
     }
 
@@ -402,6 +411,7 @@ nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
         segmentStartedAt = candidate.completedSegment.endedAt
         elapsedTimeAtStart = candidate.cumulativeElapsedTime
         distanceAtStartMeters = candidate.cumulativeDistanceMeters
+        distanceSourceAtStart = candidate.cumulativeDistanceSource
         return true
     }
 }

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
@@ -292,6 +292,120 @@ nonisolated enum WorkoutRouteSegmentFilter {
     }
 }
 
+nonisolated struct WorkoutSegmentCandidate: Equatable, Sendable {
+    let completedSegment: WorkoutCompletedSegmentV1
+    let cumulativeElapsedTime: TimeInterval
+    let cumulativeDistanceMeters: Double?
+}
+
+/// Tracks sequential user-marked workout segments using active workout time
+/// and cumulative distance. The Watch persists each committed boundary in the
+/// HealthKit event metadata, allowing this state to be reconstructed after
+/// workout recovery without maintaining a second source of truth.
+nonisolated struct WorkoutSegmentAccumulator: Equatable, Sendable {
+    private(set) var workoutStart: Date?
+    private(set) var nextIndex: UInt32 = 1
+    private(set) var segmentStartedAt: Date?
+    private(set) var elapsedTimeAtStart: TimeInterval = 0
+    private(set) var distanceAtStartMeters: Double?
+    private(set) var lastCompletedSegment: WorkoutCompletedSegmentV1?
+
+    var hasCompletedSegments: Bool {
+        lastCompletedSegment != nil
+    }
+
+    mutating func reset(workoutStart: Date) {
+        guard workoutStart.timeIntervalSinceReferenceDate.isFinite else {
+            self = Self()
+            return
+        }
+        self.workoutStart = workoutStart
+        nextIndex = 1
+        segmentStartedAt = workoutStart
+        elapsedTimeAtStart = 0
+        distanceAtStartMeters = 0
+        lastCompletedSegment = nil
+    }
+
+    mutating func restore(
+        workoutStart: Date,
+        lastCompletedSegment: WorkoutCompletedSegmentV1?,
+        cumulativeElapsedTime: TimeInterval?,
+        cumulativeDistanceMeters: Double?
+    ) {
+        reset(workoutStart: workoutStart)
+        guard let lastCompletedSegment,
+              lastCompletedSegment.index < UInt32.max,
+              let cumulativeElapsedTime,
+              cumulativeElapsedTime.isFinite,
+              cumulativeElapsedTime >= lastCompletedSegment.duration,
+              cumulativeDistanceMeters.map({
+                  $0.isFinite && $0 >= 0
+              }) ?? true else {
+            return
+        }
+        self.lastCompletedSegment = lastCompletedSegment
+        nextIndex = lastCompletedSegment.index + 1
+        segmentStartedAt = lastCompletedSegment.endedAt
+        elapsedTimeAtStart = cumulativeElapsedTime
+        distanceAtStartMeters = cumulativeDistanceMeters
+    }
+
+    func candidate(
+        endedAt: Date,
+        cumulativeElapsedTime: TimeInterval,
+        cumulativeDistanceMeters: Double?
+    ) -> WorkoutSegmentCandidate? {
+        guard let workoutStart,
+              let segmentStartedAt,
+              nextIndex < UInt32.max,
+              endedAt.timeIntervalSinceReferenceDate.isFinite,
+              endedAt >= workoutStart,
+              endedAt >= segmentStartedAt,
+              cumulativeElapsedTime.isFinite,
+              cumulativeElapsedTime >= elapsedTimeAtStart,
+              cumulativeDistanceMeters.map({
+                  $0.isFinite && $0 >= 0
+              }) ?? true else {
+            return nil
+        }
+        let duration = cumulativeElapsedTime - elapsedTimeAtStart
+        let distanceMeters: Double?
+        if let cumulativeDistanceMeters,
+           let distanceAtStartMeters,
+           cumulativeDistanceMeters >= distanceAtStartMeters {
+            distanceMeters = cumulativeDistanceMeters - distanceAtStartMeters
+        } else {
+            distanceMeters = nil
+        }
+        return WorkoutSegmentCandidate(
+            completedSegment: WorkoutCompletedSegmentV1(
+                index: nextIndex,
+                startedAt: segmentStartedAt,
+                endedAt: endedAt,
+                duration: duration,
+                distanceMeters: distanceMeters
+            ),
+            cumulativeElapsedTime: cumulativeElapsedTime,
+            cumulativeDistanceMeters: cumulativeDistanceMeters
+        )
+    }
+
+    mutating func commit(_ candidate: WorkoutSegmentCandidate) -> Bool {
+        guard candidate.completedSegment.index == nextIndex,
+              candidate.completedSegment.startedAt == segmentStartedAt,
+              nextIndex < UInt32.max else {
+            return false
+        }
+        lastCompletedSegment = candidate.completedSegment
+        nextIndex += 1
+        segmentStartedAt = candidate.completedSegment.endedAt
+        elapsedTimeAtStart = candidate.cumulativeElapsedTime
+        distanceAtStartMeters = candidate.cumulativeDistanceMeters
+        return true
+    }
+}
+
 nonisolated enum WorkoutRouteQueuePolicy {
     /// Bounds retained-but-not-yet-written location data if HealthKit stalls.
     /// A route is abandoned on overflow instead of silently saving a partial

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5287,9 +5287,9 @@ private struct WorkoutContractTestSuite {
             return
         }
 
-        for (surface, source, sessionSource, discardClosure) in [
-            ("iPhone", iPhoneSource, "store.presentation.sessionID", "onDiscard"),
-            ("Watch", watchSource, "manager.activeSessionID", "manager.discard"),
+        for (surface, source, sessionSource) in [
+            ("iPhone", iPhoneSource, "store.presentation.sessionID"),
+            ("Watch", watchSource, "manager.activeSessionID"),
         ] {
             let compactSource = source.filter { !$0.isWhitespace }
             expect(
@@ -5297,21 +5297,6 @@ private struct WorkoutContractTestSuite {
                     "Button(\"DiscardWorkout\",role:.destructive){requestDiscardConfirmation(for:sessionID)}"
                 ),
                 "\(surface) finish options must request, not execute, discard"
-            )
-            expect(
-                compactSource.contains(
-                    "WorkoutDiscardDisclosureV1.perform(.cancel,expectedSessionID:sessionID,currentSessionID:\(sessionSource),discard:\(discardClosure))"
-                )
-                    && compactSource.contains(
-                        "WorkoutDiscardDisclosureV1.perform(.confirmDiscard,expectedSessionID:sessionID,currentSessionID:\(sessionSource),discard:\(discardClosure))"
-                    ),
-                "\(surface) final warning must map Keep Riding and Discard to shared policy choices"
-            )
-            expect(
-                compactSource.contains(
-                    "isPresented:discardConfirmationPresented"
-                ),
-                "\(surface) must present the dedicated final discard warning"
             )
             expect(
                 compactSource.contains(
@@ -5325,15 +5310,32 @@ private struct WorkoutContractTestSuite {
             )
         }
 
+        let compactIPhoneSource = iPhoneSource.filter { !$0.isWhitespace }
+        expect(
+            compactIPhoneSource.contains(
+                "WorkoutDiscardDisclosureV1.perform(.cancel,expectedSessionID:sessionID,currentSessionID:store.presentation.sessionID,discard:onDiscard)"
+            )
+                && compactIPhoneSource.contains(
+                    "WorkoutDiscardDisclosureV1.perform(.confirmDiscard,expectedSessionID:sessionID,currentSessionID:store.presentation.sessionID,discard:onDiscard)"
+                )
+                && compactIPhoneSource.contains(
+                    "isPresented:discardConfirmationPresented"
+                ),
+            "iPhone final warning must preserve shared disclosure policy and session capture"
+        )
+
         let compactWatchSource = watchSource.filter { !$0.isWhitespace }
         expect(
             compactWatchSource.contains(
-                "isPresented:discardConfirmationPresented,presenting:discardConfirmationSessionID"
+                "ifcase.discardConfirmation(letsessionID)=finishPrompt{discardConfirmationView(sessionID:sessionID)}"
             )
                 && compactWatchSource.contains(
-                    "){sessionIDinButton(WorkoutDiscardDisclosureV1.cancelTitle"
+                    "Button(WorkoutDiscardDisclosureV1.confirmTitle,role:.destructive){finishPrompt=nilguardmanager.activeSessionID==sessionIDelse{return}manager.discard()}"
+                )
+                && compactWatchSource.contains(
+                    "Button(WorkoutDiscardDisclosureV1.cancelTitle,role:.cancel){finishPrompt=nil}"
                 ),
-            "Watch discard confirmation must capture its session before alert dismissal"
+            "Watch dedicated discard screen must preserve disclosure choices and capture its session before dismissal"
         )
         expect(
             watchSource.contains("\"Finish Ride?\"")

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -220,7 +220,8 @@ private struct WorkoutContractTestSuite {
         let first = accumulator.candidate(
             endedAt: firstEnd,
             cumulativeElapsedTime: 55,
-            cumulativeDistanceMeters: 1_000
+            cumulativeDistanceMeters: 1_000,
+            cumulativeDistanceSource: .watchRoute
         )
         expect(first?.completedSegment.index == 1, "first segment should be numbered one")
         expect(first?.completedSegment.duration == 55, "segment duration should use active workout time")
@@ -233,7 +234,8 @@ private struct WorkoutContractTestSuite {
         let second = accumulator.candidate(
             endedAt: secondEnd,
             cumulativeElapsedTime: 90,
-            cumulativeDistanceMeters: 1_650
+            cumulativeDistanceMeters: 1_650,
+            cumulativeDistanceSource: .watchRoute
         )
         expect(second?.completedSegment.index == 2, "segments should increment monotonically")
         expect(second?.completedSegment.duration == 35, "pause time must not enter the next segment duration")
@@ -270,15 +272,28 @@ private struct WorkoutContractTestSuite {
             workoutStart: start,
             lastCompletedSegment: accumulator.lastCompletedSegment,
             cumulativeElapsedTime: 90,
-            cumulativeDistanceMeters: 1_650
+            cumulativeDistanceMeters: 1_650,
+            cumulativeDistanceSource: .watchRoute
         )
         expect(
             restored.candidate(
                 endedAt: secondEnd.addingTimeInterval(30),
                 cumulativeElapsedTime: 120,
-                cumulativeDistanceMeters: 2_100
+                cumulativeDistanceMeters: 2_100,
+                cumulativeDistanceSource: .watchRoute
             )?.completedSegment.index == 3,
             "recovered segment state should continue with the next index"
+        )
+
+        let sourceChange = restored.candidate(
+            endedAt: secondEnd.addingTimeInterval(30),
+            cumulativeElapsedTime: 120,
+            cumulativeDistanceMeters: 2_000,
+            cumulativeDistanceSource: .healthKit
+        )
+        expect(
+            sourceChange?.completedSegment.distanceMeters == nil,
+            "a segment must not subtract cumulative totals from different distance sources"
         )
 
         let invalidSegment = makeEnvelope(
@@ -3832,6 +3847,207 @@ private struct WorkoutContractTestSuite {
                     == .segmentMarkFailed,
             "a correlated segment failure should clear pending state without failing the workout"
         )
+
+        var unconfirmedSegmentReducer = WorkoutMirrorStateReducer()
+        unconfirmedSegmentReducer.attachMirroredSession(at: now)
+        _ = unconfirmedSegmentReducer.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sessionToken: 9,
+                    transportGenerationID: generation,
+                    sequence: 1,
+                    capturedAt: now,
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: now
+                    )
+                ),
+            ],
+            receivedAt: now
+        )
+        expect(
+            unconfirmedSegmentReducer.markPendingControl(
+                .markSegment,
+                sequence: 78
+            ),
+            "a segment request should become pending before its outcome is unknown"
+        )
+        let segmentUnconfirmed = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 2,
+            capturedAt: now.addingTimeInterval(1),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 78,
+                errorCode: .segmentMarkUnconfirmed
+            )
+        )
+        _ = unconfirmedSegmentReducer.ingestBatch(
+            [segmentUnconfirmed],
+            receivedAt: now.addingTimeInterval(1)
+        )
+        unconfirmedSegmentReducer.attachMirroredSession(
+            at: now.addingTimeInterval(2)
+        )
+        expect(
+            unconfirmedSegmentReducer.isSegmentConfirmationPending
+                && unconfirmedSegmentReducer.presentation.errorCode
+                    == .segmentMarkUnconfirmed
+                && !unconfirmedSegmentReducer.markPendingControl(
+                    .markSegment,
+                    sequence: 79
+                ),
+            "reconnection must preserve an outcome-unknown segment and block another boundary"
+        )
+        let recoveredSegmentSnapshot = WorkoutEnvelopeV1(
+            kind: .snapshot,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 3,
+            capturedAt: now.addingTimeInterval(3),
+            snapshot: WorkoutSnapshotV1(
+                state: .running,
+                startDate: now,
+                lastCompletedSegment: WorkoutCompletedSegmentV1(
+                    index: 1,
+                    startedAt: now,
+                    endedAt: now.addingTimeInterval(3),
+                    duration: 3,
+                    distanceMeters: nil
+                )
+            )
+        )
+        _ = unconfirmedSegmentReducer.ingestBatch(
+            [recoveredSegmentSnapshot],
+            receivedAt: now.addingTimeInterval(3)
+        )
+        expect(
+            unconfirmedSegmentReducer.isSegmentConfirmationPending,
+            "segment count alone must not attribute a Watch-local boundary to an iPhone command"
+        )
+        let recoveredSegmentAcknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 4,
+            capturedAt: now.addingTimeInterval(4),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 78
+            )
+        )
+        _ = unconfirmedSegmentReducer.ingestBatch(
+            [recoveredSegmentAcknowledgement],
+            receivedAt: now.addingTimeInterval(4)
+        )
+        expect(
+            !unconfirmedSegmentReducer.isSegmentConfirmationPending
+                && unconfirmedSegmentReducer.presentation.errorCode == nil,
+            "the Watch replay acknowledgement must resolve the exact original segment command"
+        )
+
+        var snapshotFirstReducer = WorkoutMirrorStateReducer()
+        snapshotFirstReducer.attachMirroredSession(at: now)
+        _ = snapshotFirstReducer.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sessionToken: 9,
+                    transportGenerationID: generation,
+                    sequence: 1,
+                    capturedAt: now,
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: now
+                    )
+                ),
+            ],
+            receivedAt: now
+        )
+        expect(
+            snapshotFirstReducer.markPendingControl(
+                .markSegment,
+                sequence: 80
+            ),
+            "the command-time segment baseline must be captured before delivery"
+        )
+        _ = snapshotFirstReducer.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sessionToken: 9,
+                    transportGenerationID: generation,
+                    sequence: 2,
+                    capturedAt: now.addingTimeInterval(1),
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: now,
+                        lastCompletedSegment: WorkoutCompletedSegmentV1(
+                            index: 1,
+                            startedAt: now,
+                            endedAt: now.addingTimeInterval(1),
+                            duration: 1,
+                            distanceMeters: nil
+                        )
+                    )
+                ),
+            ],
+            receivedAt: now.addingTimeInterval(1)
+        )
+        let delayedUnconfirmedAcknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 3,
+            capturedAt: now.addingTimeInterval(2),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 80,
+                errorCode: .segmentMarkUnconfirmed
+            )
+        )
+        _ = snapshotFirstReducer.ingestBatch(
+            [delayedUnconfirmedAcknowledgement],
+            receivedAt: now.addingTimeInterval(2)
+        )
+        expect(
+            snapshotFirstReducer.isSegmentConfirmationPending
+                && snapshotFirstReducer.presentation.errorCode
+                    == .segmentMarkUnconfirmed,
+            "a delayed unrelated snapshot must not clear the correlated command before Watch acknowledgement"
+        )
+        let snapshotFirstDefinitiveAcknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 4,
+            capturedAt: now.addingTimeInterval(3),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 80
+            )
+        )
+        _ = snapshotFirstReducer.ingestBatch(
+            [snapshotFirstDefinitiveAcknowledgement],
+            receivedAt: now.addingTimeInterval(3)
+        )
+        expect(
+            !snapshotFirstReducer.isSegmentConfirmationPending
+                && snapshotFirstReducer.presentation.errorCode == nil,
+            "a definitive replay acknowledgement must resolve a snapshot-first segment command"
+        )
     }
 
     private mutating func testMirrorReducerReplacesTerminalSessionCleanly() {
@@ -5145,6 +5361,12 @@ private struct WorkoutContractTestSuite {
             .appendingPathComponent(
                 "BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift"
             )
+        let navigationDetailsViewURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                "BikeComputer/BikeComputer/Views/NavigationDetailsView.swift"
+            )
         let summaryWatchViewURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -5158,6 +5380,10 @@ private struct WorkoutContractTestSuite {
               ),
               let liveWatchViewSource = try? String(
                 contentsOf: liveWatchViewURL,
+                encoding: .utf8
+              ),
+              let navigationDetailsViewSource = try? String(
+                contentsOf: navigationDetailsViewURL,
                 encoding: .utf8
               ),
               let summaryWatchViewSource = try? String(
@@ -5216,6 +5442,12 @@ private struct WorkoutContractTestSuite {
         )
 
         let compactSource = source.filter { !$0.isWhitespace }
+        let compactContentViewSource =
+            contentViewSource.filter { !$0.isWhitespace }
+        let compactLiveWatchViewSource =
+            liveWatchViewSource.filter { !$0.isWhitespace }
+        let compactNavigationDetailsViewSource =
+            navigationDetailsViewSource.filter { !$0.isWhitespace }
         for metricBinding in [
             "metric(\"HeartRate\",WorkoutValueFormatter.heartRate(snapshot.currentHeartRate?.value),\"BPM\"",
             "metric(\"HeartZone\",zoneValue(snapshot),\"\"",
@@ -5258,6 +5490,42 @@ private struct WorkoutContractTestSuite {
                     "WorkoutFinishButton(store:store,onEndAndSave:onEndAndSave,onDiscard:onDiscard){Label(\"End\""
                 ),
             "dashboard labels must remain bound to the matching control closures"
+        )
+        expect(
+            compactSource.contains(
+                "presentation.pendingControl!=nil&&presentation.pendingControl!=.markSegment"
+            )
+                && compactNavigationDetailsViewSource.contains(
+                    "presentation.pendingControl==nil||presentation.pendingControl==.markSegment"
+                ),
+            "iPhone lifecycle controls must remain reachable while a segment is pending"
+        )
+        expect(
+            compactContentViewSource.contains("scenePhase==.active")
+                && compactContentViewSource.contains(
+                    "!showingWorkoutDashboard"
+                )
+                && compactSource.contains("scenePhase==.active"),
+            "segment feedback must be foreground-only and avoid dashboard duplicates"
+        )
+        expect(
+            compactNavigationDetailsViewSource.contains(
+                "WorkoutErrorCopyV1.detail(errorCode,context:WorkoutErrorCopyV1.context(for:presentation))"
+            )
+                && compactNavigationDetailsViewSource.contains(
+                    "delayedWorkoutStatus(at:context.date),color:.orange,detail:workoutRecoveryDetail"
+                )
+                && compactNavigationDetailsViewSource.contains(
+                    "disconnectedWorkoutStatus(at:context.date),color:.red,detail:workoutRecoveryDetail"
+                ),
+            "the active iPhone ride panel must show actionable Watch recovery copy"
+        )
+        expect(
+            compactLiveWatchViewSource.contains("Button(\"SaveAnyway\")")
+                && compactLiveWatchViewSource.contains(
+                    "manager.saveWithoutUnconfirmedSegment()"
+                ),
+            "a permanently unconfirmed segment must leave a rider-visible save escape"
         )
         expect(
             compactSource.contains(

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -56,6 +56,7 @@ private struct WorkoutContractTestSuite {
 
     mutating func run() async {
         testSnapshotRoundTrip()
+        testSegmentRoundTripValidationAndAccumulation()
         testTerminalOutcomeRoundTripAndValidation()
         testAllMessageKindsRoundTrip()
         testCompatibleMinorVersionIgnoresUnknownFields()
@@ -208,6 +209,119 @@ private struct WorkoutContractTestSuite {
             expect(try roundTripWorkoutEnvelope(envelope) == envelope, "snapshot should round-trip")
         } catch {
             expect(false, "snapshot round-trip threw \(error)")
+        }
+    }
+
+    private mutating func testSegmentRoundTripValidationAndAccumulation() {
+        let start = Date(timeIntervalSinceReferenceDate: 800_000_010)
+        let firstEnd = start.addingTimeInterval(60)
+        var accumulator = WorkoutSegmentAccumulator()
+        accumulator.reset(workoutStart: start)
+        let first = accumulator.candidate(
+            endedAt: firstEnd,
+            cumulativeElapsedTime: 55,
+            cumulativeDistanceMeters: 1_000
+        )
+        expect(first?.completedSegment.index == 1, "first segment should be numbered one")
+        expect(first?.completedSegment.duration == 55, "segment duration should use active workout time")
+        expect(first?.completedSegment.distanceMeters == 1_000, "first segment should begin at zero distance")
+        if let first {
+            expect(accumulator.commit(first), "first segment candidate should commit")
+        }
+
+        let secondEnd = firstEnd.addingTimeInterval(40)
+        let second = accumulator.candidate(
+            endedAt: secondEnd,
+            cumulativeElapsedTime: 90,
+            cumulativeDistanceMeters: 1_650
+        )
+        expect(second?.completedSegment.index == 2, "segments should increment monotonically")
+        expect(second?.completedSegment.duration == 35, "pause time must not enter the next segment duration")
+        expect(second?.completedSegment.distanceMeters == 650, "segment distance should use cumulative-distance boundaries")
+        if let second {
+            expect(accumulator.commit(second), "second segment candidate should commit")
+        }
+
+        let snapshot = WorkoutSnapshotV1(
+            state: .running,
+            startDate: start,
+            elapsedTime: metric(90, .seconds, secondEnd),
+            lastCompletedSegment: accumulator.lastCompletedSegment,
+            availability: [.elapsedTime]
+        )
+        let envelope = makeEnvelope(
+            sequence: 1,
+            capturedAt: secondEnd,
+            snapshot: snapshot
+        )
+        do {
+            let decoded = try roundTripWorkoutEnvelope(envelope)
+            expect(
+                decoded.snapshot?.lastCompletedSegment
+                    == accumulator.lastCompletedSegment,
+                "the latest segment summary should round-trip with live metrics"
+            )
+        } catch {
+            expect(false, "segment snapshot round-trip threw \(error)")
+        }
+
+        var restored = WorkoutSegmentAccumulator()
+        restored.restore(
+            workoutStart: start,
+            lastCompletedSegment: accumulator.lastCompletedSegment,
+            cumulativeElapsedTime: 90,
+            cumulativeDistanceMeters: 1_650
+        )
+        expect(
+            restored.candidate(
+                endedAt: secondEnd.addingTimeInterval(30),
+                cumulativeElapsedTime: 120,
+                cumulativeDistanceMeters: 2_100
+            )?.completedSegment.index == 3,
+            "recovered segment state should continue with the next index"
+        )
+
+        let invalidSegment = makeEnvelope(
+            sequence: 2,
+            capturedAt: secondEnd,
+            snapshot: WorkoutSnapshotV1(
+                state: .running,
+                startDate: start,
+                lastCompletedSegment: WorkoutCompletedSegmentV1(
+                    index: 0,
+                    startedAt: start,
+                    endedAt: secondEnd,
+                    duration: 90,
+                    distanceMeters: 1_650
+                )
+            )
+        )
+        expectThrows(.invalidMetric, "zero segment index") {
+            try WorkoutContractCodec.validate(invalidSegment)
+        }
+
+        let failedAcknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: envelope.sessionID,
+            sessionToken: envelope.sessionToken,
+            transportGenerationID: envelope.transportGenerationID,
+            sequence: 3,
+            capturedAt: secondEnd,
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 2,
+                errorCode: .segmentMarkFailed
+            )
+        )
+        do {
+            expect(
+                try roundTripWorkoutEnvelope(failedAcknowledgement)
+                    == failedAcknowledgement,
+                "a correlated segment failure acknowledgement should round-trip"
+            )
+        } catch {
+            expect(false, "segment failure acknowledgement threw \(error)")
         }
     }
 
@@ -3671,6 +3785,53 @@ private struct WorkoutContractTestSuite {
             matchingOutcomeReducer.presentation.pendingControl == nil,
             "a matching explicit terminal outcome may confirm the pending choice"
         )
+
+        var segmentReducer = WorkoutMirrorStateReducer()
+        segmentReducer.attachMirroredSession(at: now)
+        _ = segmentReducer.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sessionToken: 9,
+                    transportGenerationID: generation,
+                    sequence: 1,
+                    capturedAt: now,
+                    snapshot: WorkoutSnapshotV1(
+                        state: .running,
+                        startDate: now
+                    )
+                ),
+            ],
+            receivedAt: now
+        )
+        expect(
+            segmentReducer.markPendingControl(.markSegment, sequence: 77),
+            "an iPhone segment request should become pending"
+        )
+        let segmentFailure = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: sessionID,
+            sessionToken: 9,
+            transportGenerationID: generation,
+            sequence: 2,
+            capturedAt: now.addingTimeInterval(1),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: 77,
+                errorCode: .segmentMarkFailed
+            )
+        )
+        _ = segmentReducer.ingestBatch(
+            [segmentFailure],
+            receivedAt: now.addingTimeInterval(1)
+        )
+        expect(
+            segmentReducer.presentation.pendingControl == nil
+                && segmentReducer.presentation.errorCode
+                    == .segmentMarkFailed,
+            "a correlated segment failure should clear pending state without failing the workout"
+        )
     }
 
     private mutating func testMirrorReducerReplacesTerminalSessionCleanly() {
@@ -5029,6 +5190,7 @@ private struct WorkoutContractTestSuite {
             "dashboard must render live capture age"
         )
         for controlRoute in [
+            "Button(action: onMarkSegment)",
             "Button(action: onResume)",
             "Button(action: onPause)",
             "Button(\"End and Save\") {",
@@ -5072,10 +5234,16 @@ private struct WorkoutContractTestSuite {
         }
         expect(
             compactSource.contains(
-                "ifpresentation.sessionState==.paused{Button(action:onResume){Label(\"ResumeWorkout\""
+                "Button(action:onMarkSegment){Label(\"Segment\",systemImage:\"flag.checkered\")}"
             )
                 && compactSource.contains(
-                    "else{Button(action:onPause){Label(\"PauseWorkout\""
+                    "ifpresentation.sessionState==.paused{Button(action:onResume){Label(\"Resume\""
+                )
+                && compactSource.contains(
+                    "else{Button(action:onPause){Label(\"Pause\""
+                )
+                && compactSource.contains(
+                    ".accessibilityLabel(\"Markworkoutsegment\")"
                 )
                 && compactSource.contains(
                     "Button(\"EndandSave\"){finishPrompt=nilguardstore.presentation.sessionID==sessionIDelse{return}onEndAndSave()}"
@@ -5087,7 +5255,7 @@ private struct WorkoutContractTestSuite {
                     "WorkoutDiscardDisclosureV1.perform(.confirmDiscard,expectedSessionID:sessionID,currentSessionID:store.presentation.sessionID,discard:onDiscard)"
                 )
                 && compactSource.contains(
-                    "WorkoutFinishButton(store:store,onEndAndSave:onEndAndSave,onDiscard:onDiscard){Label(\"EndWorkout\""
+                    "WorkoutFinishButton(store:store,onEndAndSave:onEndAndSave,onDiscard:onDiscard){Label(\"End\""
                 ),
             "dashboard labels must remain bound to the matching control closures"
         )
@@ -5104,7 +5272,7 @@ private struct WorkoutContractTestSuite {
                 "WorkoutCompactCard(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onOpen:{showingWorkoutDashboard=true})"
             )
                 && compactContentView.contains(
-                    ".sheet(isPresented:$showingWorkoutDashboard){WorkoutDashboardView(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onPause:workoutMirrorManager.pause,onResume:workoutMirrorManager.resume,onEndAndSave:workoutMirrorManager.endAndSave,onDiscard:workoutMirrorManager.discard,onDone:workoutMirrorManager.resetTerminalPresentation)}"
+                    ".sheet(isPresented:$showingWorkoutDashboard){WorkoutDashboardView(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onPause:workoutMirrorManager.pause,onResume:workoutMirrorManager.resume,onMarkSegment:workoutMirrorManager.markSegment,onEndAndSave:workoutMirrorManager.endAndSave,onDiscard:workoutMirrorManager.discard,onDone:workoutMirrorManager.resetTerminalPresentation)}"
                 ),
             "ContentView must present the dashboard from its exact state and inject each production manager action"
         )
@@ -5115,6 +5283,16 @@ private struct WorkoutContractTestSuite {
         let compactSummaryWatchView = summaryWatchViewSource.filter {
             !$0.isWhitespace
         }
+        expect(
+            compactLiveWatchView.contains("manager.markSegment()")
+                && compactLiveWatchView.contains(
+                    ".accessibilityLabel(\"Markworkoutsegment\")"
+                )
+                && compactLiveWatchView.contains(
+                    "manager.snapshot.lastCompletedSegment"
+                ),
+            "Watch live workout must expose segment marking and its latest completed segment"
+        )
         expect(
             compactLiveWatchView.contains(
                 "WorkoutCrossAppTakeoverCopyV1.live(disposition:manager.isDiscarding?.discard:.save)"

--- a/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
@@ -1995,6 +1995,314 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
         )
     }
 
+    func testProductionSegmentControlRequiresWatchSchema14() throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_375)
+        let manager = WorkoutMirrorManager(now: { now })
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let current = makeSnapshotEnvelope(sequence: 47, capturedAt: now)
+        let oldWatchSnapshot = WorkoutEnvelopeV1(
+            schemaVersion: WorkoutSchemaVersion(major: 1, minor: 3),
+            kind: .snapshot,
+            sessionID: current.sessionID,
+            sessionToken: current.sessionToken,
+            transportGenerationID: current.transportGenerationID,
+            sequence: current.sequence,
+            capturedAt: current.capturedAt,
+            snapshot: current.snapshot
+        )
+        manager.applyRemoteEnvelopes(
+            [oldWatchSnapshot],
+            receivedAt: now,
+            from: transport
+        )
+
+        XCTAssertFalse(manager.store.supportsSegmentMarking)
+        manager.markSegment()
+        XCTAssertTrue(transport.sentData.isEmpty)
+        XCTAssertNil(manager.store.presentation.pendingControl)
+    }
+
+    func testProductionSegmentTimeoutAcceptsCorrelatedLateSuccess()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_380)
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            controlConfirmationTimeout: 0.02
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(sequence: 48, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: transport
+        )
+        manager.markSegment()
+        let control = try WorkoutContractCodec.decode(
+            XCTUnwrap(transport.sentData.first)
+        )
+
+        try await Task.sleep(for: .milliseconds(50))
+        XCTAssertNil(manager.store.presentation.pendingControl)
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .segmentMarkUnconfirmed
+        )
+        XCTAssertEqual(transport.sentData.count, 2)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[1]),
+            control
+        )
+
+        // Completing both the invalidated original callback and the replay
+        // callback without an acknowledgement must not create a send loop.
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        XCTAssertEqual(transport.sentData.count, 2)
+
+        manager.markSegment()
+        XCTAssertEqual(transport.sentData.count, 2)
+
+        let acknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: snapshot.sessionID,
+            sessionToken: snapshot.sessionToken,
+            transportGenerationID: snapshot.transportGenerationID,
+            sequence: 49,
+            capturedAt: now.addingTimeInterval(1),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: control.sequence
+            )
+        )
+        manager.applyRemoteEnvelopes(
+            [acknowledgement],
+            receivedAt: now.addingTimeInterval(1),
+            from: transport
+        )
+        XCTAssertNil(manager.store.presentation.errorCode)
+    }
+
+    func testProductionSegmentReplayRecoversLostFailureAcknowledgement()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_382)
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            controlConfirmationTimeout: 0.02
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(sequence: 48, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: transport
+        )
+        manager.markSegment()
+        let control = try WorkoutContractCodec.decode(
+            XCTUnwrap(transport.sentData.first)
+        )
+
+        try await waitUntil { transport.sentData.count == 2 }
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[1]),
+            control
+        )
+        let replayFailure = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: snapshot.sessionID,
+            sessionToken: snapshot.sessionToken,
+            transportGenerationID: snapshot.transportGenerationID,
+            sequence: 49,
+            capturedAt: now.addingTimeInterval(1),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: control.sequence,
+                errorCode: .segmentMarkFailed
+            )
+        )
+        manager.applyRemoteEnvelopes(
+            [replayFailure],
+            receivedAt: now.addingTimeInterval(1),
+            from: transport
+        )
+
+        XCTAssertFalse(manager.store.isSegmentConfirmationPending)
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .segmentMarkFailed
+        )
+        manager.markSegment()
+        XCTAssertEqual(transport.sentData.count, 3)
+    }
+
+    func testProductionFinishSupersedesUnconfirmedSegmentReplay()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_383)
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            controlConfirmationTimeout: 0.02
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        manager.applyRemoteEnvelopes(
+            [makeSnapshotEnvelope(sequence: 48, capturedAt: now)],
+            receivedAt: now,
+            from: transport
+        )
+        manager.markSegment()
+        try await waitUntil { transport.sentData.count == 2 }
+
+        manager.endAndSave()
+
+        XCTAssertEqual(transport.sentData.count, 3)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[2]).control,
+            .endAndSave
+        )
+        XCTAssertEqual(
+            manager.store.presentation.pendingControl,
+            .endAndSave
+        )
+
+        // Stale callbacks for the abandoned original and replay must not send
+        // another mark after the terminal choice.
+        transport.completeNext(succeeded: true)
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        XCTAssertEqual(transport.sentData.count, 3)
+
+        manager.applyRemoteDisconnect(error: nil, from: transport)
+        let replacement = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(replacement)
+        XCTAssertEqual(replacement.sentData.count, 1)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(replacement.sentData[0]).control,
+            .endAndSave
+        )
+    }
+
+    func testProductionSegmentPreemptsSnapshotAndStartsSubmittedTimeout()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_385)
+        let waiter = ControlledWorkoutTimeoutWaiter()
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            controlConfirmationWait: { timeout in
+                try await waiter.wait(timeout)
+            }
+        )
+        let original = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(original)
+        let snapshot = makeSnapshotEnvelope(sequence: 49, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: original
+        )
+
+        let replacement = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(replacement)
+        XCTAssertEqual(replacement.sentData.count, 1)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(replacement.sentData[0]).control,
+            .requestCurrentSnapshot
+        )
+
+        manager.markSegment()
+        try await waitUntil {
+            replacement.sentData.count == 2
+                && waiter.waitCallCount == 1
+        }
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(replacement.sentData[1]).control,
+            .markSegment
+        )
+        XCTAssertEqual(
+            manager.store.presentation.pendingControl,
+            .markSegment
+        )
+    }
+
+    func testProductionFinishCanSupersedePendingSegmentControl() async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_390)
+        let manager = WorkoutMirrorManager(now: { now })
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(sequence: 50, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: transport
+        )
+        manager.markSegment()
+        XCTAssertEqual(
+            manager.store.presentation.pendingControl,
+            .markSegment
+        )
+
+        manager.endAndSave()
+
+        XCTAssertEqual(transport.sentData.count, 2)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[1]).control,
+            .endAndSave
+        )
+        XCTAssertEqual(
+            manager.store.presentation.pendingControl,
+            .endAndSave
+        )
+
+        // Neither the invalidated mark callback nor the terminal callback may
+        // resurrect the superseded segment after the terminal choice.
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        XCTAssertEqual(transport.sentData.count, 2)
+    }
+
+    func testProductionPauseReplaysSegmentAfterOutstandingSendCallback()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_395)
+        let manager = WorkoutMirrorManager(now: { now })
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(sequence: 50, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: transport
+        )
+        manager.markSegment()
+        let originalControl = try WorkoutContractCodec.decode(
+            XCTUnwrap(transport.sentData.first)
+        )
+
+        manager.pause()
+
+        XCTAssertEqual(transport.pauseCallCount, 1)
+        XCTAssertEqual(transport.sentData.count, 1)
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[0]).control,
+            .markSegment
+        )
+        XCTAssertEqual(manager.store.presentation.pendingControl, .pause)
+        XCTAssertTrue(manager.store.isSegmentConfirmationPending)
+
+        transport.completeNext(succeeded: true)
+        try await waitUntil { transport.sentData.count == 2 }
+        XCTAssertEqual(
+            try WorkoutContractCodec.decode(transport.sentData[1]),
+            originalControl
+        )
+    }
+
     func testProductionReconnectResendsControlBeforeSnapshotRequest() async throws {
         let now = Date(timeIntervalSinceReferenceDate: 800_400_400)
         let manager = WorkoutMirrorManager(now: { now })

--- a/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
@@ -1939,6 +1939,62 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
         XCTAssertNil(manager.store.presentation.pendingControl)
     }
 
+    func testProductionSegmentControlReportsWatchWriteFailureWithoutEndingRide()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_350)
+        let manager = WorkoutMirrorManager(now: { now })
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(sequence: 45, capturedAt: now)
+        manager.applyRemoteEnvelopes(
+            [snapshot],
+            receivedAt: now,
+            from: transport
+        )
+
+        manager.markSegment()
+
+        XCTAssertEqual(transport.sentData.count, 1)
+        let control = try WorkoutContractCodec.decode(transport.sentData[0])
+        XCTAssertEqual(control.control, .markSegment)
+        XCTAssertEqual(
+            manager.store.presentation.pendingControl,
+            .markSegment
+        )
+
+        transport.completeNext(succeeded: true)
+        await Task.yield()
+        let acknowledgement = WorkoutEnvelopeV1(
+            kind: .acknowledgement,
+            sessionID: snapshot.sessionID,
+            sessionToken: snapshot.sessionToken,
+            transportGenerationID: snapshot.transportGenerationID,
+            sequence: 46,
+            capturedAt: now.addingTimeInterval(1),
+            acknowledgement: WorkoutAcknowledgementV1(
+                control: .markSegment,
+                resultingState: .running,
+                acknowledgedSequence: control.sequence,
+                errorCode: .segmentMarkFailed
+            )
+        )
+        manager.applyRemoteEnvelopes(
+            [acknowledgement],
+            receivedAt: now.addingTimeInterval(1),
+            from: transport
+        )
+
+        XCTAssertNil(manager.store.presentation.pendingControl)
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .segmentMarkFailed
+        )
+        XCTAssertEqual(
+            manager.store.presentation.sessionState,
+            .running
+        )
+    }
+
     func testProductionReconnectResendsControlBeforeSnapshotRequest() async throws {
         let now = Date(timeIntervalSinceReferenceDate: 800_400_400)
         let manager = WorkoutMirrorManager(now: { now })


### PR DESCRIPTION
## What changed

- add live **Segment** actions to the Apple Watch and iPhone workout controls
- record each confirmed boundary on Watch as a HealthKit segment event
- calculate duration from active builder time and distance from compatible
  cumulative workout-distance boundaries
- mirror the latest completed segment and actionable confirmation/recovery
  feedback to both apps
- make iPhone segment commands exact-envelope replay safe across timeouts,
  lifecycle controls, reconnects, and lost acknowledgements
- durably journal an accepted remote boundary before its HealthKit write, then
  resume that exact boundary after Watch process recovery
- serialize segment writes with finalization, close the final segment on save,
  and provide explicit Retry and Save Anyway recovery
- document the schema 1.4 segment and recovery contract

## Why

BikeComputer's Watch-owned workout flow did not expose the segment capability
available in Apple's Workout app. The mirrored iPhone controls also needed a
durable, crash-safe way to request a boundary without creating duplicates or
losing an accepted mark.

## User impact

During a running workout, riders can mark segments from either BikeComputer app.
The Watch remains the sole HealthKit writer. Both apps show the completed segment
number, duration, and distance when available. Pause, resume, end, and discard
remain available while a segment outcome is uncertain, and save has an explicit
escape if HealthKit never confirms the pending boundary.

## Validation

- iOS and Watch simulator app builds
- all 44 `WorkoutMirrorManagerProductionTests`
- all 107 `WatchWorkoutManagerTests`
- focused timeout, exact replay, lost-acknowledgement, crash-recovery,
  finalization, Save Anyway, Discard, and UI recovery-copy tests
- portable navigation suites
- `git diff --check`
- 11-iteration deep review loop with no remaining code P0/P1/P2 findings

Known baseline: the aggregate workout contract runner still reports the same
three pre-existing Watch discard-confirmation source-shape assertions. The
current `main` implementation already violates those stale expectations; the
feature-specific iOS and Watch suites pass.

Paired physical Watch/iPhone testing and Apple Fitness segment-boundary
verification were **not run** and remain a post-merge validation item.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
