### PR TITLE
Add interactive iPhone workout Live Activity

### DIFF
--- a/docs/iphone-workout-live-activity-implementation-plan.md
+++ b/docs/iphone-workout-live-activity-implementation-plan.md
@@ -369,6 +369,24 @@ Clear the suppression when the session reaches a terminal state.
 - Saved workout: publish a final summary, then end with dismissal after
   approximately 15 minutes.
 - Discarded workout: end immediately.
+- Missing final Watch snapshot: after the manager's bounded final-snapshot
+  wait expires, publish honest unavailable-final content and end with the same
+  system-owned delayed dismissal. That timeout is the Live Activity correction
+  cutoff: ActivityKit end content is immutable, so a later Watch envelope may
+  still correct the iPhone app's workout presentation but does not revise the
+  already-ended Lock Screen card. Keep background execution asserted from the
+  manager wait through completion of the controller's ActivityKit end call.
+  On relaunch, the recovery grace boundary is the equivalent cutoff for a
+  persisted Finishing card; retain its session tombstone after finalization so
+  a late recovery cannot create a conflicting second card. Bound both waits
+  by the process's remaining background time with a finalization safety margin,
+  leaving time for the normal path to await ActivityKit finalization. Perform
+  expiration bookkeeping synchronously and immediately queue best-effort
+  cleanup, but do not claim that ActivityKit's asynchronous `end` call can
+  complete inside UIKit's expiration callback. If the system suspends before
+  that queued work completes, reconcile it on the next app execution. Re-evaluate
+  recovered truth before every ActivityKit end in a multi-record reconciliation
+  batch.
 - User dismissal: stop managing the activity but do not send a workout command.
 - Activity authorization disabled: stop ActivityKit work silently.
 - System eight-hour expiration: allow it; the Watch workout continues.
@@ -510,7 +528,7 @@ The native Watch workout UI remains the primary Watch control surface.
 | ActivityKit update throws | Keep workout untouched and retry only from a later verified store update |
 | App crashes or is terminated | Reconcile the system Activity with the recovered mirrored session |
 | Workout exceeds Live Activity lifetime | Live Activity may disappear; Watch workout and save remain correct |
-| Workout ends while iPhone is disconnected | End or finalize the activity when the terminal Watch snapshot is later received |
+| Workout ends while iPhone is disconnected | Finalize from the terminal Watch snapshot when it arrives within the bounded wait; otherwise end with honest unavailable-final content and a system-owned delayed dismissal |
 
 ## Implementation phases
 

--- a/docs/iphone-workout-live-activity-implementation-plan.md
+++ b/docs/iphone-workout-live-activity-implementation-plan.md
@@ -1,0 +1,754 @@
+# iPhone Interactive Workout Live Activity Implementation Plan
+
+## Outcome
+
+Add a BikeComputer Live Activity that presents the active Watch-owned cycling
+workout on the iPhone Lock Screen and in the Dynamic Island. The largest Lock
+Screen and expanded presentations use the available 160-point height for:
+
+- elapsed active workout time;
+- current speed;
+- cycling distance;
+- current heart rate when available;
+- the most recently completed user-marked segment;
+- a Segment button; and
+- a Pause or Resume button.
+
+The Live Activity is a display and control surface only. The Apple Watch remains
+the sole owner of `HKWorkoutSession`, `HKLiveWorkoutBuilder`, segment events,
+route recording, and the saved `HKWorkout`.
+
+## Branch and dependency baseline
+
+This plan is stacked on `feature/workout-segments`, the head branch of PR #128.
+At preparation time:
+
+- `main` was `95bffc59776967bd33e7271169620933df5aa6e5`;
+- `feature/workout-segments` was
+  `c3722bd72cb1e0390b91dce050f3933155619130`;
+- GitHub reported the segment branch one commit ahead of `main` and zero
+  commits behind; and
+- `main` was the merge base, so no merge or pull from `main` was necessary.
+
+Keep Live Activity implementation stacked on the segment branch until PR #128
+merges. After PR #128 lands, rebase the implementation branch onto the new
+`main` or recreate it from `main` and cherry-pick only the Live Activity
+commits. Do not merge `main` into PR #128 solely for this work.
+
+PR #128 is treated as implemented and authoritative. In particular, reuse:
+
+- `WorkoutControlV1.markSegment`;
+- `WorkoutCompletedSegmentV1`;
+- `WorkoutSnapshotV1.lastCompletedSegment`;
+- `WorkoutMirrorManager.markSegment()`;
+- the existing replay-safe command sequencing and acknowledgement path;
+- the Watch `HKWorkoutEvent` of type `segment`; and
+- the existing pending-control and `segmentMarkFailed` behavior.
+
+Do not create another segment counter, segment persistence model, or
+iPhone-owned segment writer.
+
+## Product contract
+
+- The Watch continues to own and save exactly one workout.
+- The iPhone `WorkoutMetricsStore` remains the canonical publication boundary
+  for Watch-owned workout state on iPhone.
+- A verified active workout can create one Live Activity for its session.
+- The Lock Screen presentation uses the maximum useful content budget: up to
+  408 by 160 points on larger current iPhones and 371 by 160 points on smaller
+  current iPhones.
+- Dynamic Island compact and minimal presentations remain glanceable; a long
+  press exposes the expanded presentation and its controls.
+- Segment is enabled only while the verified workout state is running and no
+  other control is pending.
+- Pause is enabled only while running. Resume replaces Pause while paused.
+- Button taps never mutate Live Activity state directly. They invoke the
+  existing iPhone workout-control path, and the UI changes only from the
+  resulting mirrored state or acknowledgement.
+- A successful segment acknowledgement exposes
+  `lastCompletedSegment`; rejected or timed-out segment requests remain
+  nonterminal and show honest failure state.
+- Dismissing, disabling, expiring, or failing the Live Activity never pauses,
+  ends, discards, duplicates, or otherwise changes the Watch workout.
+- End and Discard remain in the app and Watch UI. They are intentionally absent
+  from the Live Activity because they are destructive, require more
+  confirmation space, and are not part of the requested quick-control surface.
+- No workout metric, route, or location is uploaded to a backend.
+
+## Platform constraints
+
+### Availability
+
+The iPhone app keeps its iOS 15 deployment target for existing navigation
+features. The Live Activity extension uses iOS 17 as its minimum because:
+
+- the existing mirrored workout feature requires iOS 17;
+- interactive Live Activity buttons require iOS 17; and
+- the feature has no meaningful fallback without the mirrored Watch workout.
+
+Wrap ActivityKit and App Intents integration in iOS 17 availability checks.
+On iOS 15 and 16, the existing app and Watch behavior continues without a Live
+Activity.
+
+### Start restrictions
+
+ActivityKit normally permits a local app to request a Live Activity only while
+the app is in the foreground. Updating and ending an existing activity is
+allowed while the app runs in the background.
+
+Required behavior:
+
+1. If a ride starts from the iPhone app, request the Live Activity after the
+   first verified active Watch snapshot arrives.
+2. If a ride starts on Watch while the iPhone app is already foreground,
+   request it after the mirrored session and first verified snapshot arrive.
+3. If a ride starts on Watch while the iPhone app is not foreground and no Live
+   Activity exists, do not claim that one was created. Request it when the app
+   next enters the foreground and the same workout is still verified active.
+4. Continue updating an already-created Live Activity while the iPhone is
+   backgrounded and receives mirrored workout updates.
+
+Automatically starting an iPhone Live Activity for a Watch-started ride while
+the iPhone app is fully backgrounded would require a system-invoked
+`LiveActivityIntent` start path or ActivityKit push-to-start infrastructure.
+Neither is required for the first version. Do not introduce a backend merely to
+remove this limitation.
+
+### Lock Screen authentication
+
+The controls use `LiveActivityIntent` so the system runs their implementations
+in the BikeComputer app process without presenting the app UI. iOS still
+requires the person to authenticate and unlock before a button or toggle on a
+locked device performs its action. Treat Face ID as part of the interaction;
+do not promise a no-authentication cycling control.
+
+Viewing the Live Activity does not require opening the app. Validate the exact
+authentication experience on physical iPhones with and without Always-On
+display.
+
+### Lifetime
+
+Live Activities are system-managed and intended for activities of up to about
+eight hours. A longer Watch workout must continue and save correctly even if
+the system ends or removes its Live Activity. Do not make workout ownership,
+background execution, or finalization depend on ActivityKit.
+
+## Decisions locked into this plan
+
+1. Watch is the only HealthKit writer and workout owner.
+2. `WorkoutMetricsStore.presentation` is the only source used to derive Live
+   Activity content on iPhone.
+3. The widget extension never reads HealthKit or talks directly to Watch.
+4. Live Activity intents route into the existing `WorkoutMirrorManager`.
+5. Segment success remains acknowledgement-driven and replay-safe.
+6. Pause and Resume continue to use the mirrored native
+   `HKWorkoutSession` controls already implemented by
+   `WorkoutMirrorManager`.
+7. The ActivityKit state is a narrow, display-safe projection, not a copy of
+   `WorkoutSnapshotV1`.
+8. No location, route, destination, navigation instruction, session token,
+   control sender identity, or raw HealthKit object enters ActivityKit content.
+9. No App Group is needed. ActivityKit distributes content to the extension,
+   while `LiveActivityIntent` runs in the app process.
+10. No APNs entitlement or `NSSupportsLiveActivitiesFrequentUpdates` setting is
+    added because the first version uses local mirrored-session updates.
+11. The feature shows only Segment and Pause/Resume as interactive controls.
+12. User dismissal is respected for the remainder of that workout session.
+
+## Target and project setup
+
+Add an iOS Widget Extension named `BikeComputerLiveActivity` to
+`ios-app/BikeComputer/BikeComputer.xcodeproj`.
+
+The extension:
+
+- has deployment target iOS 17.0;
+- uses bundle identifier
+  `LetItRide.BikeComputer.WorkoutLiveActivity`;
+- is embedded in the `BikeComputer` application target;
+- imports WidgetKit, ActivityKit, AppIntents, and SwiftUI;
+- contains an `ActivityConfiguration`, not a Home Screen widget timeline;
+- has no HealthKit, location, Bluetooth, networking, or App Group entitlement;
+  and
+- is built automatically by the main iOS scheme.
+
+Add `NSSupportsLiveActivities` with value `true` to the iPhone app Info.plist.
+Do not add `NSSupportsLiveActivitiesFrequentUpdates` without a measured need
+and an APNs update design.
+
+Suggested source layout:
+
+```text
+ios-app/BikeComputer/
+  BikeComputer/
+    Managers/
+      WorkoutLiveActivityController.swift
+    SystemActions/
+      WorkoutLiveActivityCommandRouter.swift
+  BikeComputerLiveActivity/
+    BikeComputerLiveActivityBundle.swift
+    WorkoutLiveActivityWidget.swift
+    WorkoutLiveActivityViews.swift
+    Info.plist
+  WorkoutLiveActivityShared/
+    WorkoutLiveActivityAttributes.swift
+    WorkoutLiveActivityIntents.swift
+    WorkoutLiveActivityFormatting.swift
+  BikeComputerTests/
+    WorkoutLiveActivityStateMapperTests.swift
+    WorkoutLiveActivityControllerTests.swift
+    WorkoutLiveActivityIntentTests.swift
+```
+
+Give `WorkoutLiveActivityShared` files target membership in both the iPhone app
+and Live Activity extension. Keep business logic out of the extension. Ensure
+the `LiveActivityIntent` declarations are compiled into the app target so the
+system can execute them in the app process.
+
+## ActivityKit contract
+
+Define `WorkoutLiveActivityAttributes: ActivityAttributes`.
+
+Static attributes:
+
+- `sessionID: UUID`;
+- `workoutStartDate: Date`; and
+- an activity kind fixed to outdoor cycling if a future-proof discriminator is
+  useful.
+
+Dynamic content state:
+
+- `phase`: running, paused, stale, disconnected, ending, or final;
+- `capturedAt: Date`;
+- `elapsedActiveSeconds: TimeInterval`;
+- `currentSpeedKilometersPerHour: Double?`;
+- `cyclingDistanceMeters: Double?`;
+- `currentHeartRateBPM: Double?`;
+- `lastCompletedSegmentIndex: UInt32?`;
+- `lastCompletedSegmentDuration: TimeInterval?`;
+- `lastCompletedSegmentDistanceMeters: Double?`;
+- `pendingAction`: none, segment, pause, or resume;
+- `finalOutcome`: saved, discarded, or none; and
+- a narrow display error such as segment rejected or controls unavailable.
+
+Keep the encoded attributes and content comfortably below ActivityKit's 4 KB
+payload limit.
+
+Do not place these existing values into the ActivityKit contract:
+
+- route coordinates or altitude;
+- navigation source or destination;
+- HealthKit samples or objects;
+- full heart-rate-zone histories;
+- control sequences, tokens, sender IDs, or acknowledgements;
+- raw diagnostic errors; or
+- the full `WorkoutSnapshotV1`.
+
+## State mapping
+
+Implement a pure `WorkoutLiveActivityStateMapper` so mapping can be unit tested
+without ActivityKit.
+
+Map `WorkoutMetricsStore.presentation` as follows:
+
+| Workout presentation | Live Activity behavior |
+| --- | --- |
+| Launching Watch or awaiting first snapshot | Do not start yet |
+| Verified connected and running | Running content; Segment and Pause enabled when no command is pending |
+| Verified connected and paused | Freeze active elapsed time; Resume enabled |
+| Stale but workout remains active | Freeze instantaneous metrics and elapsed time; show Delayed; disable controls |
+| Disconnected but workout remains active | Show Watch disconnected / ride continues on Watch; disable controls |
+| Ending | Show Finishing; disable controls |
+| Saved final snapshot | Show final time and distance, end with a 15-minute dismissal window |
+| Discarded final snapshot | End and dismiss immediately |
+| Failed with active Watch workout | Preserve the activity as unavailable/stale; never imply the workout ended |
+| Failed or idle with no active session | End any matching activity after reconciliation |
+
+The mapper must reject nonfinite or negative metrics and preserve optionality:
+missing heart rate is an em dash, not zero.
+
+### Elapsed-time rendering
+
+Do not call `Activity.update` every second merely to animate elapsed time.
+
+When running:
+
+- derive a timer anchor as `capturedAt - elapsedActiveSeconds`; and
+- render it with SwiftUI's timer-style text so the system advances the visible
+  timer.
+
+When paused, stale, disconnected, ending, or final:
+
+- render the fixed formatted `elapsedActiveSeconds`; and
+- do not let wall-clock time masquerade as active workout time.
+
+Every new verified Watch snapshot recalibrates the timer anchor from
+`HKLiveWorkoutBuilder.elapsedTime`, which already excludes pauses.
+
+### Segment rendering
+
+The current segment is `lastCompletedSegment.index + 1` after at least one
+completed segment, otherwise segment 1.
+
+After a Segment tap:
+
+1. immediately publish pending Segment state from the existing
+   `WorkoutMetricsStore`;
+2. disable both control buttons while that command is pending;
+3. wait for the existing Watch acknowledgement and mirrored snapshot;
+4. show the new completed segment only when
+   `lastCompletedSegment.index` advances; and
+5. show a small nonterminal rejection state when the existing safe error is
+   `segmentMarkFailed`.
+
+The top status row can persist the last completed segment summary, for example
+`SEG 3 · 08:42 · 4.2 KM`. Do not depend on a short-lived animation task for the
+only confirmation because the app process may be suspended.
+
+## Live Activity lifecycle controller
+
+Add a main-actor `WorkoutLiveActivityController` owned by `AppDelegate`.
+Construct it with:
+
+- `workoutMirrorManager.store`;
+- an ActivityKit client hidden behind a protocol for tests;
+- an authorization provider;
+- the application foreground/background state; and
+- a lightweight UserDefaults suppression store containing session IDs only.
+
+The controller subscribes to `WorkoutMetricsStore.$presentation`.
+
+### Start
+
+Start only when all are true:
+
+- iOS 17 or later;
+- `ActivityAuthorizationInfo().areActivitiesEnabled`;
+- the app is foreground;
+- the presentation contains a verified `sessionID`;
+- the snapshot has a valid start date;
+- the workout is running or paused; and
+- the same session was not dismissed or suppressed by the user.
+
+Use one Activity per workout session. Never create parallel activities for
+individual segments.
+
+### Update
+
+- State transitions, pending-control changes, segment acknowledgements, stale
+  transitions, and terminal state update immediately.
+- Coalesce ordinary metric-only changes to at most one latest-wins update per
+  second.
+- Skip byte-equivalent content.
+- Set `staleDate` consistently with the existing workout freshness policy.
+- If content becomes stale, do not continue presenting speed or heart rate as
+  current.
+- Recover cleanly from ActivityKit update errors without changing workout
+  state.
+
+### Reconcile and recover
+
+At app launch:
+
+1. install the existing mirrored-workout handler first;
+2. enumerate existing `Activity<WorkoutLiveActivityAttributes>.activities`;
+3. retain at most one Activity for the verified active session;
+4. end duplicates and definitively orphaned activities;
+5. if the store is initially idle during a cold background launch, allow a
+   bounded reconciliation grace period for HealthKit to deliver the mirrored
+   session before ending an existing activity; and
+6. update the retained activity from the latest verified presentation.
+
+Observe each activity's state updates. If the person dismisses it, persist only
+that session ID as suppressed until the workout ends. This prevents an app
+foreground transition from recreating something the person explicitly removed.
+Clear the suppression when the session reaches a terminal state.
+
+### End
+
+- Saved workout: publish a final summary, then end with dismissal after
+  approximately 15 minutes.
+- Discarded workout: end immediately.
+- User dismissal: stop managing the activity but do not send a workout command.
+- Activity authorization disabled: stop ActivityKit work silently.
+- System eight-hour expiration: allow it; the Watch workout continues.
+
+## App Intent control routing
+
+Define three narrow intents:
+
+- `BikeComputerMarkSegmentIntent`;
+- `BikeComputerPauseWorkoutIntent`; and
+- `BikeComputerResumeWorkoutIntent`.
+
+Each conforms to `LiveActivityIntent` and carries the `sessionID` embedded in
+the Live Activity. The intent declarations are available to the extension for
+`Button(intent:)`, but execution routes through the app process.
+
+Register one app-process dependency or command router during `AppDelegate`
+launch. The router owns no workout state; it holds access to the existing
+`WorkoutMirrorManager` and validates against its store.
+
+Every intent must:
+
+1. ensure the manager and mirroring handler are installed;
+2. verify the intent session ID matches the current verified session;
+3. reject stale, disconnected, terminal, or conflicting pending-control state;
+4. validate the expected running or paused state;
+5. invoke `WorkoutMirrorManager.markSegment()`, `.pause()`, or `.resume()`;
+6. return without fabricating success; and
+7. let the store/controller publish pending and confirmed state.
+
+For a cold app process launched by an intent, permit a short bounded wait for
+the mirrored session handler to deliver the current session. If it does not
+arrive, fail safely and leave the Watch workout untouched.
+
+Do not create a second `WorkoutMirrorManager` for intents. The `AppDelegate`
+instance remains the only iPhone workout-control owner.
+
+## Lock Screen presentation
+
+Use the full useful 160-point height without inserting empty space. Maintain
+Apple's standard 14-point outer margin and at least 44-point control targets.
+
+Recommended layout:
+
+```text
+┌──────────────────────────────────────────┐
+│ ● RIDING / SEG 3               01:24:37 │
+│                                          │
+│  27.4 km/h        42.6 km        142 bpm │
+│  CURRENT          DISTANCE        HEART  │
+│                                          │
+│ [  + SEGMENT  ]              [ Ⅱ PAUSE ] │
+└──────────────────────────────────────────┘
+```
+
+Paused presentation:
+
+- replace Riding with Paused;
+- freeze the timer;
+- render instantaneous speed as unavailable unless the verified paused
+  snapshot explicitly provides an appropriate value; and
+- replace Pause with Resume.
+
+Stale/disconnected presentation:
+
+- use a clear Delayed or Watch disconnected label;
+- freeze the timer at the last verified active duration;
+- de-emphasize or remove instantaneous speed and heart rate;
+- retain cumulative distance with a Last updated treatment; and
+- disable both controls.
+
+Use `activityBackgroundTint` sparingly, verify Dark Mode and Always-On reduced
+luminance, and set `activitySystemActionForegroundColor` so the system dismiss
+control stays legible.
+
+## Dynamic Island and other system presentations
+
+### Compact
+
+- Leading: BikeComputer cycling glyph plus running/paused indicator.
+- Trailing: elapsed active time, or current speed when the timer cannot fit
+  legibly.
+
+No buttons appear in compact or minimal presentations.
+
+### Minimal
+
+- Show a cycling glyph with a compact running/paused status treatment.
+- Do not attempt to squeeze segment, heart rate, or distance into the minimal
+  region.
+
+### Expanded
+
+- Use the same metric priority as the Lock Screen.
+- Put Segment and Pause/Resume in the bottom region with full tap targets.
+- Keep expanded height at or below the 160-point system limit.
+
+### StandBy, CarPlay, Watch, and Mac
+
+ActivityKit can reuse these presentations on additional system surfaces.
+Confirm that:
+
+- StandBy's scaled Lock Screen view remains legible in Night Mode;
+- CarPlay does not expose unsafe or clipped controls;
+- the paired Watch Smart Stack presentation does not confuse the native
+  BikeComputer Watch workout UI; and
+- missing features on a given surface degrade to display-only content.
+
+The native Watch workout UI remains the primary Watch control surface.
+
+## Accessibility and privacy
+
+- Provide combined VoiceOver labels for status, timer, each metric, segment
+  summary, and control.
+- Preserve Dynamic Type legibility without exceeding the 160-point height.
+- Never rely only on color to distinguish running, paused, stale, and failed.
+- Use monospaced digits for changing numeric values.
+- Respect Reduce Motion and reduced luminance.
+- Do not put route coordinates, destination names, street instructions, or raw
+  errors on the Lock Screen.
+- Treat heart rate as optional and omit it when unavailable rather than showing
+  zero.
+- Document in release notes that active workout metrics may be visible on the
+  Lock Screen and Always-On display.
+
+## Failure behavior
+
+| Failure | Required behavior |
+| --- | --- |
+| Live Activities disabled | Workout continues; app omits the activity without repeated prompts |
+| Live Activity dismissed | Respect dismissal for that session; workout continues |
+| Watch link becomes stale | Freeze active values, show delayed state, disable controls |
+| Watch disconnects | State that the ride continues on Watch; disable controls |
+| Segment write rejected | Show nonterminal segment failure; do not advance segment index |
+| Segment acknowledgement delayed | Keep pending state; do not optimistically show success |
+| Pause/Resume confirmation delayed | Keep prior confirmed phase and pending state |
+| Intent launches a cold app process | Wait briefly for the mirrored session, then fail safely |
+| Intent session ID is old | Reject without affecting the current workout |
+| ActivityKit update throws | Keep workout untouched and retry only from a later verified store update |
+| App crashes or is terminated | Reconcile the system Activity with the recovered mirrored session |
+| Workout exceeds Live Activity lifetime | Live Activity may disappear; Watch workout and save remain correct |
+| Workout ends while iPhone is disconnected | End or finalize the activity when the terminal Watch snapshot is later received |
+
+## Implementation phases
+
+### Phase 1: target and shared contract
+
+1. Add the iOS 17 Widget Extension and embed it in the iPhone target.
+2. Enable `NSSupportsLiveActivities`.
+3. Add shared ActivityAttributes, content state, action enum, and pure
+   formatting.
+4. Add running, paused, stale, disconnected, segment, and final previews.
+
+Gate:
+
+- iOS app still builds for the iOS 15 deployment target;
+- extension builds for iOS 17;
+- Watch targets and existing workout tests still build; and
+- encoded ActivityKit content is below 4 KB.
+
+### Phase 2: state mapper and lifecycle controller
+
+1. Implement the pure presentation-to-content mapper.
+2. Implement start, update, coalescing, stale-date, end, and suppression logic.
+3. Install the controller after the mirrored-session handler in `AppDelegate`.
+4. Implement launch reconciliation and duplicate cleanup.
+
+Gate:
+
+- one verified workout creates at most one Activity;
+- metric-only updates are coalesced;
+- pause and stale states freeze active time honestly;
+- user dismissal is respected; and
+- no ActivityKit failure changes workout state.
+
+### Phase 3: interactive controls
+
+1. Add the three `LiveActivityIntent` types.
+2. Register a single app-process command dependency.
+3. Route Segment, Pause, and Resume into the existing
+   `WorkoutMirrorManager`.
+4. Validate session identity, state, connection, and pending controls.
+5. Surface pending and acknowledged state through the controller.
+
+Gate:
+
+- Segment advances only after PR #128's mirrored acknowledgement;
+- Pause/Resume changes only after confirmed mirrored session state;
+- stale or old-session actions are rejected;
+- cold-process invocation fails safely when mirroring cannot recover; and
+- button interaction never opens a duplicate workout or app-owned
+  `HKWorkoutSession`.
+
+### Phase 4: system-surface UI
+
+1. Implement the maximum-height Lock Screen design.
+2. Implement compact, minimal, and expanded Dynamic Island layouts.
+3. Add stale, disconnected, missing-heart-rate, pending-control, segment-failed,
+   saved, and discarded variants.
+4. Verify accessibility, Dark Mode, Always-On, and StandBy.
+
+Gate:
+
+- the Lock Screen and expanded views never exceed 160 points;
+- controls retain at least 44-point tap targets;
+- content is not clipped at 371- and 408-point widths;
+- no health metric is presented as zero when unavailable; and
+- compact/minimal views remain readable with two simultaneous Live Activities.
+
+### Phase 5: verification and rollout
+
+1. Run automated mapper, controller, intent, and existing workout tests.
+2. Build iPhone, extension, Watch app, complication, and workout test targets.
+3. Complete the physical iPhone/Watch matrix.
+4. Update user-facing documentation and release notes.
+5. Merge only after PR #128 is merged and the implementation is rebased onto
+   current `main`.
+
+## Automated test strategy
+
+### State mapper
+
+- connected running snapshot maps all available primary metrics;
+- missing or invalid heart rate remains unavailable;
+- paused state freezes elapsed time;
+- stale and disconnected state freeze instantaneous data and disable controls;
+- pending Segment, Pause, and Resume map correctly;
+- advancing `lastCompletedSegment.index` updates the summary;
+- `segmentMarkFailed` never advances the segment;
+- saved and discarded terminal outcomes map differently; and
+- mismatched or missing session identity cannot start an Activity.
+
+### Lifecycle controller
+
+Use an ActivityKit client protocol with a fake implementation.
+
+- foreground verified start requests one activity;
+- duplicate equivalent states do not update;
+- metric bursts coalesce latest-wins;
+- state and segment transitions bypass metric coalescing;
+- background state updates an existing Activity but does not request a new one;
+- launch reconciliation retains the matching Activity and ends duplicates;
+- reconciliation grace avoids ending an activity before mirroring recovers;
+- user dismissal suppresses recreation for that session;
+- saved outcome ends after the configured final-summary window;
+- discarded outcome ends immediately; and
+- ActivityKit errors do not call a workout command.
+
+### Intents and routing
+
+- Segment routes to `WorkoutMirrorManager.markSegment()` only while running;
+- Pause routes only while running;
+- Resume routes only while paused;
+- old session IDs are rejected;
+- stale, disconnected, terminal, and pending-control states are rejected;
+- cold launch waits only for the bounded recovery interval;
+- missing manager dependency fails safely; and
+- the intent does not report confirmed success before the Watch response.
+
+### Existing regression suites
+
+Retain and run PR #128 coverage for:
+
+- segment duration and distance accounting;
+- HealthKit segment event metadata;
+- remote command replay safety;
+- duplicate control acknowledgement;
+- recovery from existing segment events;
+- segment write timeout/failure;
+- sequential segments across pause and resume; and
+- final segment closure at workout end.
+
+## Physical-device validation matrix
+
+Use a real paired Apple Watch and iPhone; simulator-only validation is
+insufficient.
+
+1. Start from iPhone foreground, receive the first Watch snapshot, lock iPhone,
+   and verify the Live Activity.
+2. Start from Watch while iPhone is foreground and verify the same result.
+3. Start from Watch while iPhone is backgrounded and verify the documented
+   deferred-start behavior when iPhone next foregrounds.
+4. Mark several segments from the Lock Screen and verify each appears only
+   after Watch acknowledgement and in the final HealthKit workout.
+5. Pause and Resume from the Lock Screen and verify Watch, iPhone app, Live
+   Activity, elapsed time, and route recording agree.
+6. Authenticate button taps with Face ID from a genuinely locked device.
+7. Test Dynamic Island compact, minimal with a competing Live Activity, and
+   expanded presentations.
+8. Test an iPhone without Dynamic Island.
+9. Lock an Always-On iPhone and verify reduced-luminance contrast.
+10. Test StandBy and Night Mode.
+11. Disconnect Watch during a ride; verify stale/disconnected content and
+    disabled controls while the Watch workout continues.
+12. Reconnect Watch; verify a coherent latest snapshot restores the activity.
+13. Kill and relaunch the iPhone app; verify Activity reconciliation and intent
+    routing recover without a duplicate workout.
+14. Dismiss the Live Activity manually; verify it stays dismissed and the
+    workout continues.
+15. Disable Live Activities for BikeComputer; verify the workout is unaffected.
+16. End and Save from Watch and from iPhone in separate rides; verify the final
+    summary and delayed dismissal.
+17. Discard a test ride; verify immediate Live Activity dismissal and no saved
+    workout.
+18. Run with heart rate unavailable and confirm no false zero.
+19. Run with a segment write failure injection and confirm nonterminal failure.
+20. Simulate an eight-hour ActivityKit expiration and confirm Watch workout
+    ownership and saving remain independent.
+
+## Acceptance criteria
+
+- A verified active BikeComputer workout can present a Live Activity on iPhone.
+- The Lock Screen layout uses the maximum useful 160-point content budget and
+  fits both 371- and 408-point widths.
+- Elapsed active time, current speed, cycling distance, and optional heart rate
+  are legible at a glance.
+- Segment and Pause/Resume are available on the Lock Screen and expanded
+  Dynamic Island presentation.
+- Segment uses PR #128's existing replay-safe Watch command and
+  acknowledgement; no duplicate segment system exists.
+- Pause/Resume uses the existing mirrored `HKWorkoutSession`.
+- Pending, stale, disconnected, failed, paused, and final states are honest.
+- A button for an old or mismatched workout session cannot affect the current
+  workout.
+- Live Activity dismissal, failure, disablement, or expiration cannot alter the
+  Watch workout.
+- Watch remains the only HealthKit writer and exactly one workout is saved.
+- No raw health metrics, route coordinates, or navigation destinations are
+  persisted in an App Group or sent to a backend.
+- The app keeps its iOS 15 navigation compatibility; Live Activity features
+  activate on iOS 17 or later.
+- App, Live Activity extension, Watch app, Watch complication, and workout test
+  targets build successfully.
+- The complete physical-device matrix passes before release.
+
+## Expected implementation touch points
+
+Project and configuration:
+
+- `ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj`
+- `ios-app/BikeComputer/BikeComputer/Info.plist`
+- new `ios-app/BikeComputer/BikeComputerLiveActivity/` target
+- new `ios-app/BikeComputer/WorkoutLiveActivityShared/` shared files
+
+iPhone app:
+
+- `ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift`
+- new
+  `ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift`
+- new
+  `ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift`
+- `ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift` only
+  if a narrow async/control-routing adapter is required
+- `ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift` only
+  if a narrow observation helper is required
+
+Tests:
+
+- new focused Live Activity mapper/controller/intent tests under
+  `ios-app/BikeComputer/BikeComputerTests/`
+- existing `WorkoutContractTests.swift`
+- existing `WorkoutMirrorManagerTests.swift`
+- existing Watch workout manager tests
+
+Documentation:
+
+- `README.md` or iOS documentation for availability and Watch-start behavior
+- release notes for Lock Screen metric visibility and authentication
+
+## Apple references
+
+- Live Activities Human Interface Guidelines:
+  https://developer.apple.com/design/human-interface-guidelines/live-activities
+- Displaying live data with Live Activities:
+  https://developer.apple.com/documentation/activitykit/displaying-live-data-with-live-activities
+- Adding interactivity to widgets and Live Activities:
+  https://developer.apple.com/documentation/widgetkit/adding-interactivity-to-widgets-and-live-activities
+- `LiveActivityIntent`:
+  https://developer.apple.com/documentation/appintents/liveactivityintent
+- Building a workout app for iPhone and iPad:
+  https://developer.apple.com/documentation/healthkit/building-a-workout-app-for-iphone-and-ipad
+- Building a multidevice workout app:
+  https://developer.apple.com/documentation/healthkit/building-a-multidevice-workout-app

--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -14,6 +14,8 @@ Watch, iPhone, and compatible Bike Computer hardware.
   sensor data.
 - Pause, resume, save, or discard from either Apple device.
 - Recover an active Watch workout after an interruption.
+- Follow an active workout from the iPhone Lock Screen and Dynamic Island,
+  including Segment and Pause/Resume controls.
 - Keep navigation and workout controls independent.
 - Show current Watch metrics on the ESP32 Ride Stats pages with compatible
   firmware.
@@ -35,7 +37,8 @@ To test:
    location access.
 3. Select **Start Ride**.
 4. Open BikeComputer on iPhone to view the same live workout and use mirrored
-   pause, resume, save, or discard controls.
+   pause, resume, save, discard, or segment controls. Lock the iPhone to review
+   the Live Activity and authenticate a Segment or Pause/Resume action.
 5. End that workout, then select **Start workout** on iPhone. With the Watch
    paired and the companion installed, this starts the Watch-owned workout
    directly without a second confirmation.
@@ -48,6 +51,13 @@ cannot detect another app's workout, so any resulting displacement is reported
 honestly instead of being retried. Saving creates one Health workout from Watch;
 discarding creates none. A route requires Watch location permission
 and actual outdoor movement.
+
+The Live Activity is created after a verified Watch snapshot while the iPhone
+app is foreground. If a ride starts from Watch while iPhone is backgrounded,
+foreground BikeComputer once to create it. Active workout metrics may remain
+visible on the Lock Screen and Always-On display. Dismissing or disabling the
+Live Activity has no effect on the Watch-owned workout, and no Live Activity
+content is sent to a backend.
 
 No account or external cycling sensor is required. Optional Bluetooth bike
 computer hardware is not required to review the Watch/iPhone workflow.

--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -23,6 +23,14 @@
 		57A005012F00000100000001 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 57A005002F00000100000001 /* Assets.xcassets */; };
 		57A0070C2F00000100000001 /* BikeComputerWatchComplications.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 57A007012F00000100000001 /* BikeComputerWatchComplications.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		57A0070D2F00000100000001 /* WatchWorkoutLaunchRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */; };
+		57A0080C2F00000100000001 /* BikeComputerLiveActivity.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 57A008012F00000100000001 /* BikeComputerLiveActivity.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		57A009102F00000100000001 /* WorkoutLiveActivityStateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009002F00000100000001 /* WorkoutLiveActivityStateMapper.swift */; };
+		57A009112F00000100000001 /* WorkoutLiveActivityController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009012F00000100000001 /* WorkoutLiveActivityController.swift */; };
+		57A009122F00000100000001 /* WorkoutLiveActivityCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009022F00000100000001 /* WorkoutLiveActivityCommandRouter.swift */; };
+		57A009132F00000100000001 /* WorkoutLiveActivityTestFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009032F00000100000001 /* WorkoutLiveActivityTestFixtures.swift */; };
+		57A009142F00000100000001 /* WorkoutLiveActivityStateMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009042F00000100000001 /* WorkoutLiveActivityStateMapperTests.swift */; };
+		57A009152F00000100000001 /* WorkoutLiveActivityIntentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009052F00000100000001 /* WorkoutLiveActivityIntentTests.swift */; };
+		57A009162F00000100000001 /* WorkoutLiveActivityControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57A009062F00000100000001 /* WorkoutLiveActivityControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +47,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 57A007072F00000100000001;
 			remoteInfo = BikeComputerWatchComplications;
+		};
+		57A0080D2F00000100000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 83E6EF8F2EED853C00AE5F9B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 57A008072F00000100000001;
+			remoteInfo = BikeComputerLiveActivity;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -65,6 +80,17 @@
 			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A0080B2F00000100000001 /* Embed App Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				57A0080C2F00000100000001 /* BikeComputerLiveActivity.appex in Embed App Extensions */,
+			);
+			name = "Embed App Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
@@ -85,6 +111,14 @@
 		57A005002F00000100000001 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = BikeComputer/Assets.xcassets; sourceTree = "<group>"; };
 		57A007012F00000100000001 /* BikeComputerWatchComplications.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BikeComputerWatchComplications.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WatchWorkoutLaunchRequest.swift (Complication)"; path = WorkoutShared/WatchWorkoutLaunchRequest.swift; sourceTree = "<group>"; };
+		57A008012F00000100000001 /* BikeComputerLiveActivity.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = BikeComputerLiveActivity.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		57A009002F00000100000001 /* WorkoutLiveActivityStateMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WorkoutLiveActivityStateMapper.swift (Tests)"; path = BikeComputer/Managers/WorkoutLiveActivityStateMapper.swift; sourceTree = "<group>"; };
+		57A009012F00000100000001 /* WorkoutLiveActivityController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WorkoutLiveActivityController.swift (Tests)"; path = BikeComputer/Managers/WorkoutLiveActivityController.swift; sourceTree = "<group>"; };
+		57A009022F00000100000001 /* WorkoutLiveActivityCommandRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "WorkoutLiveActivityCommandRouter.swift (Tests)"; path = BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift; sourceTree = "<group>"; };
+		57A009032F00000100000001 /* WorkoutLiveActivityTestFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../BikeComputerTests/WorkoutLiveActivityTestFixtures.swift; sourceTree = "<group>"; };
+		57A009042F00000100000001 /* WorkoutLiveActivityStateMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift; sourceTree = "<group>"; };
+		57A009052F00000100000001 /* WorkoutLiveActivityIntentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../BikeComputerTests/WorkoutLiveActivityIntentTests.swift; sourceTree = "<group>"; };
+		57A009062F00000100000001 /* WorkoutLiveActivityControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ../BikeComputerTests/WorkoutLiveActivityControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
@@ -109,6 +143,13 @@
 				Info.plist,
 			);
 			target = 57A007072F00000100000001 /* BikeComputerWatchComplications */;
+		};
+		57A008032F00000100000001 /* Exceptions for "BikeComputerLiveActivity" folder in "BikeComputerLiveActivity" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 57A008072F00000100000001 /* BikeComputerLiveActivity */;
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
@@ -140,6 +181,19 @@
 				57A007032F00000100000001 /* Exceptions for "BikeComputerWatchComplications" folder in "BikeComputerWatchComplications" target */,
 			);
 			path = BikeComputerWatchComplications;
+			sourceTree = "<group>";
+		};
+		57A008022F00000100000001 /* BikeComputerLiveActivity */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				57A008032F00000100000001 /* Exceptions for "BikeComputerLiveActivity" folder in "BikeComputerLiveActivity" target */,
+			);
+			path = BikeComputerLiveActivity;
+			sourceTree = "<group>";
+		};
+		57A008122F00000100000001 /* WorkoutLiveActivityShared */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = WorkoutLiveActivityShared;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -180,6 +234,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A008052F00000100000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -189,7 +250,16 @@
 				83E6EF992EED853C00AE5F9B /* BikeComputer */,
 				57A000022F00000100000001 /* BikeComputerWatch */,
 				57A007022F00000100000001 /* BikeComputerWatchComplications */,
+				57A008022F00000100000001 /* BikeComputerLiveActivity */,
 				57A0000F2F00000100000001 /* WorkoutShared */,
+				57A008122F00000100000001 /* WorkoutLiveActivityShared */,
+				57A009002F00000100000001 /* WorkoutLiveActivityStateMapper.swift */,
+				57A009012F00000100000001 /* WorkoutLiveActivityController.swift */,
+				57A009022F00000100000001 /* WorkoutLiveActivityCommandRouter.swift */,
+				57A009032F00000100000001 /* WorkoutLiveActivityTestFixtures.swift */,
+				57A009042F00000100000001 /* WorkoutLiveActivityStateMapperTests.swift */,
+				57A009052F00000100000001 /* WorkoutLiveActivityIntentTests.swift */,
+				57A009062F00000100000001 /* WorkoutLiveActivityControllerTests.swift */,
 				57A007122F00000100000001 /* WatchWorkoutLaunchRequest.swift */,
 				57A001002F00000100000001 /* WorkoutContractTests.swift */,
 				57A002002F00000100000001 /* WatchWorkoutRecoveryStore.swift */,
@@ -212,6 +282,7 @@
 				83E6EF972EED853C00AE5F9B /* BikeComputer.app */,
 				57A000012F00000100000001 /* BikeComputerWatch.app */,
 				57A007012F00000100000001 /* BikeComputerWatchComplications.appex */,
+				57A008012F00000100000001 /* BikeComputerLiveActivity.appex */,
 				57A001012F00000100000001 /* WorkoutContractiOSTests.xctest */,
 				57A001022F00000100000001 /* WorkoutContractWatchTests.xctest */,
 			);
@@ -229,16 +300,19 @@
 				83E6EF942EED853C00AE5F9B /* Frameworks */,
 				83E6EF952EED853C00AE5F9B /* Resources */,
 				57A0000B2F00000100000001 /* Embed Watch Content */,
+				57A0080B2F00000100000001 /* Embed App Extensions */,
 				4D53545245414D4944454E54 /* Generate Map Stream Build Identity */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 				57A0000E2F00000100000001 /* PBXTargetDependency */,
+				57A0080E2F00000100000001 /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				83E6EF992EED853C00AE5F9B /* BikeComputer */,
 				57A0000F2F00000100000001 /* WorkoutShared */,
+				57A008122F00000100000001 /* WorkoutLiveActivityShared */,
 			);
 			name = BikeComputer;
 			packageProductDependencies = (
@@ -294,6 +368,29 @@
 			productReference = 57A007012F00000100000001 /* BikeComputerWatchComplications.appex */;
 			productType = "com.apple.product-type.app-extension";
 		};
+		57A008072F00000100000001 /* BikeComputerLiveActivity */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 57A0080A2F00000100000001 /* Build configuration list for PBXNativeTarget "BikeComputerLiveActivity" */;
+			buildPhases = (
+				57A008042F00000100000001 /* Sources */,
+				57A008052F00000100000001 /* Frameworks */,
+				57A008062F00000100000001 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				57A008022F00000100000001 /* BikeComputerLiveActivity */,
+				57A008122F00000100000001 /* WorkoutLiveActivityShared */,
+			);
+			name = BikeComputerLiveActivity;
+			packageProductDependencies = (
+			);
+			productName = BikeComputerLiveActivity;
+			productReference = 57A008012F00000100000001 /* BikeComputerLiveActivity.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		57A0010B2F00000100000001 /* WorkoutContractiOSTests */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 57A001112F00000100000001 /* Build configuration list for PBXNativeTarget "WorkoutContractiOSTests" */;
@@ -308,6 +405,7 @@
 			);
 			fileSystemSynchronizedGroups = (
 				57A0000F2F00000100000001 /* WorkoutShared */,
+				57A008122F00000100000001 /* WorkoutLiveActivityShared */,
 			);
 			name = WorkoutContractiOSTests;
 			packageProductDependencies = (
@@ -357,6 +455,9 @@
 					57A007072F00000100000001 = {
 						CreatedOnToolsVersion = 26.1.1;
 					};
+					57A008072F00000100000001 = {
+						CreatedOnToolsVersion = 26.6;
+					};
 					57A0010B2F00000100000001 = {
 						CreatedOnToolsVersion = 26.6;
 					};
@@ -382,6 +483,7 @@
 				83E6EF962EED853C00AE5F9B /* BikeComputer */,
 				57A000072F00000100000001 /* BikeComputerWatch */,
 				57A007072F00000100000001 /* BikeComputerWatchComplications */,
+				57A008072F00000100000001 /* BikeComputerLiveActivity */,
 				57A0010B2F00000100000001 /* WorkoutContractiOSTests */,
 				57A0010C2F00000100000001 /* WorkoutContractWatchTests */,
 			);
@@ -425,6 +527,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A008062F00000100000001 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
@@ -452,6 +561,13 @@
 				57A004042F00000100000001 /* WorkoutMetricsStore.swift in Sources */,
 				57A004052F00000100000001 /* WorkoutMirrorManagerTests.swift in Sources */,
 				57A006012F00000100000001 /* WorkoutWatchAvailabilityMonitor.swift in Sources */,
+				57A009102F00000100000001 /* WorkoutLiveActivityStateMapper.swift in Sources */,
+				57A009112F00000100000001 /* WorkoutLiveActivityController.swift in Sources */,
+				57A009122F00000100000001 /* WorkoutLiveActivityCommandRouter.swift in Sources */,
+				57A009132F00000100000001 /* WorkoutLiveActivityTestFixtures.swift in Sources */,
+				57A009142F00000100000001 /* WorkoutLiveActivityStateMapperTests.swift in Sources */,
+				57A009152F00000100000001 /* WorkoutLiveActivityIntentTests.swift in Sources */,
+				57A009162F00000100000001 /* WorkoutLiveActivityControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -476,6 +592,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		57A008042F00000100000001 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -488,6 +611,11 @@
 			isa = PBXTargetDependency;
 			target = 57A007072F00000100000001 /* BikeComputerWatchComplications */;
 			targetProxy = 57A0070E2F00000100000001 /* PBXContainerItemProxy */;
+		};
+		57A0080E2F00000100000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 57A008072F00000100000001 /* BikeComputerLiveActivity */;
+			targetProxy = 57A0080D2F00000100000001 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -847,6 +975,75 @@
 			};
 			name = Release;
 		};
+		57A008082F00000100000001 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = 4H5PK8686H;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		57A008092F00000100000001 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 7;
+				DEVELOPMENT_TEAM = 4H5PK8686H;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.1;
+				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutLiveActivity;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
+				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
+				SWIFT_APPROACHABLE_CONCURRENCY = YES;
+				SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 1;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		57A0010D2F00000100000001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -958,6 +1155,15 @@
 			buildConfigurations = (
 				57A007082F00000100000001 /* Debug */,
 				57A007092F00000100000001 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		57A0080A2F00000100000001 /* Build configuration list for PBXNativeTarget "BikeComputerLiveActivity" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				57A008082F00000100000001 /* Debug */,
+				57A008092F00000100000001 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -5,6 +5,7 @@
 //  Main iOS App Entry Point
 //
 
+import AppIntents
 import SwiftUI
 
 @main
@@ -29,6 +30,9 @@ struct BikeComputerApp: App {
 class AppDelegate: NSObject, UIApplicationDelegate {
     let workoutMirrorManager = WorkoutMirrorManager()
     let locationManager = CurrentLocationManager()
+    private var workoutLiveActivityController: AnyObject?
+    private var workoutLiveActivityCommandRouter: AnyObject?
+    private var workoutLiveActivityIntentDispatcher: AnyObject?
     lazy var coordinator = BikeComputerCoordinator(
         destinationStore: SavedDestinationStore(),
         workoutMetricsStore: workoutMirrorManager.store,
@@ -49,16 +53,52 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         print("BikeComputer app launched")
         _ = coordinator
         workoutMirrorManager.installMirroringHandler()
+        if #available(iOS 17.0, *) {
+            let commandRouter = WorkoutLiveActivityCommandRouter(
+                manager: workoutMirrorManager
+            )
+            let dispatcher = WorkoutLiveActivityIntentDispatcher {
+                [weak commandRouter] action, sessionID in
+                guard let commandRouter else { return false }
+                return await commandRouter.perform(
+                    action,
+                    sessionID: sessionID
+                )
+            }
+            AppDependencyManager.shared.add(dependency: dispatcher)
+
+            let controller = WorkoutLiveActivityController(
+                store: workoutMirrorManager.store
+            )
+            controller.start(
+                isApplicationForeground: application.applicationState == .active
+            )
+            workoutLiveActivityCommandRouter = commandRouter
+            workoutLiveActivityIntentDispatcher = dispatcher
+            workoutLiveActivityController = controller
+        }
         
         return true
     }
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         coordinator.applicationDidBecomeActive()
+        if #available(iOS 17.0, *),
+           let controller =
+               workoutLiveActivityController
+                as? WorkoutLiveActivityController {
+            controller.setApplicationForeground(true)
+        }
     }
     
     func applicationDidEnterBackground(_ application: UIApplication) {
         coordinator.setViewingMap(false)
+        if #available(iOS 17.0, *),
+           let controller =
+               workoutLiveActivityController
+                as? WorkoutLiveActivityController {
+            controller.setApplicationForeground(false)
+        }
         print("App entered background - navigation continues")
     }
     

--- a/ios-app/BikeComputer/BikeComputer/Info.plist
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 
 	<key>UIBackgroundModes</key>
 	<array>

--- a/ios-app/BikeComputer/BikeComputer/Info.plist.template
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist.template
@@ -4,6 +4,8 @@
 <dict>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 
 	<!-- 
 	Info.plist Configuration Template for BikeComputer

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
@@ -1,6 +1,7 @@
 import ActivityKit
 import Combine
 import Foundation
+import UIKit
 
 @available(iOS 17.0, *)
 enum WorkoutLiveActivitySystemState: Equatable, Sendable {
@@ -64,6 +65,8 @@ protocol WorkoutLiveActivitySuppressionStoring: AnyObject {
 @MainActor
 protocol WorkoutLiveActivityPresentationProviding: AnyObject {
     var presentation: WorkoutMirrorPresentationV1 { get }
+    var supportsSegmentMarking: Bool { get }
+    var isSegmentConfirmationPending: Bool { get }
     var presentationPublisher:
         AnyPublisher<WorkoutMirrorPresentationV1, Never> { get }
 }
@@ -243,13 +246,17 @@ final class SystemWorkoutLiveActivityClient: WorkoutLiveActivityClient {
 final class WorkoutLiveActivityController {
     nonisolated static let metricUpdateInterval: TimeInterval = 1
     nonisolated static let finalSummaryDismissalInterval: TimeInterval = 15 * 60
-    nonisolated static let reconciliationGracePeriod: TimeInterval = 3
+    nonisolated static let reconciliationGracePeriod: TimeInterval =
+        WorkoutMirrorStateReducer.defaultStartTimeout
 
     private let presentationSource:
         any WorkoutLiveActivityPresentationProviding
     private let client: WorkoutLiveActivityClient
     private let authorization: WorkoutLiveActivityAuthorizationProviding
     private let suppressionStore: WorkoutLiveActivitySuppressionStoring
+    private let finalizationBackgroundLease:
+        any WorkoutBackgroundExecutionLeasing
+    private let backgroundTimeRemaining: () -> TimeInterval
     private let now: () -> Date
     private let wait:
         @MainActor @Sendable (TimeInterval) async throws -> Void
@@ -261,14 +268,18 @@ final class WorkoutLiveActivityController {
         WorkoutLiveActivityAttributes.ContentState?
     private var lastPublishedAt: Date?
     private var latestPresentation: WorkoutMirrorPresentationV1
+    private var pendingPresentation: WorkoutMirrorPresentationV1?
+    private var presentationProcessingTask: Task<Void, Never>?
     private var pendingMetricContent:
         WorkoutLiveActivityAttributes.ContentState?
+    private var isMetricUpdateDue = false
     private var metricUpdateTask: Task<Void, Never>?
     private var activityStateTask: Task<Void, Never>?
     private var reconciliationTask: Task<Void, Never>?
     private var reconciliationGraceTask: Task<Void, Never>?
     private var hasReconciled = false
     private var isWithinReconciliationGrace = false
+    private var isReconciliationGraceExpiryPending = false
     private var isApplicationForeground = false
     private var systemEndedSessionIDs: Set<UUID> = []
 
@@ -277,6 +288,9 @@ final class WorkoutLiveActivityController {
         client: WorkoutLiveActivityClient? = nil,
         authorization: WorkoutLiveActivityAuthorizationProviding? = nil,
         suppressionStore: WorkoutLiveActivitySuppressionStoring? = nil,
+        finalizationBackgroundLease:
+            (any WorkoutBackgroundExecutionLeasing)? = nil,
+        backgroundTimeRemaining: (() -> TimeInterval)? = nil,
         now: @escaping () -> Date = Date.init,
         wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
     ) {
@@ -286,6 +300,11 @@ final class WorkoutLiveActivityController {
             ?? SystemWorkoutLiveActivityAuthorizationProvider()
         self.suppressionStore = suppressionStore
             ?? WorkoutLiveActivitySuppressionStore()
+        self.finalizationBackgroundLease =
+            finalizationBackgroundLease
+            ?? SystemWorkoutBackgroundExecutionLease()
+        self.backgroundTimeRemaining = backgroundTimeRemaining
+            ?? Self.defaultBackgroundTimeRemaining
         self.now = now
         self.wait = wait ?? { interval in
             try await Task.sleep(
@@ -301,6 +320,9 @@ final class WorkoutLiveActivityController {
         client: WorkoutLiveActivityClient,
         authorization: WorkoutLiveActivityAuthorizationProviding,
         suppressionStore: WorkoutLiveActivitySuppressionStoring,
+        finalizationBackgroundLease:
+            (any WorkoutBackgroundExecutionLeasing)? = nil,
+        backgroundTimeRemaining: (() -> TimeInterval)? = nil,
         now: @escaping () -> Date = Date.init,
         wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
     ) {
@@ -308,6 +330,11 @@ final class WorkoutLiveActivityController {
         self.client = client
         self.authorization = authorization
         self.suppressionStore = suppressionStore
+        self.finalizationBackgroundLease =
+            finalizationBackgroundLease
+            ?? SystemWorkoutBackgroundExecutionLease()
+        self.backgroundTimeRemaining = backgroundTimeRemaining
+            ?? Self.defaultBackgroundTimeRemaining
         self.now = now
         self.wait = wait ?? { interval in
             try await Task.sleep(
@@ -317,7 +344,16 @@ final class WorkoutLiveActivityController {
         latestPresentation = presentationSource.presentation
     }
 
+    private static func defaultBackgroundTimeRemaining() -> TimeInterval {
+#if WORKOUT_CONTRACT_XCTEST
+        .greatestFiniteMagnitude
+#else
+        UIApplication.shared.backgroundTimeRemaining
+#endif
+    }
+
     deinit {
+        presentationProcessingTask?.cancel()
         metricUpdateTask?.cancel()
         activityStateTask?.cancel()
         reconciliationTask?.cancel()
@@ -336,10 +372,16 @@ final class WorkoutLiveActivityController {
             [weak self] presentation in
             guard let self else { return }
             latestPresentation = presentation
+            // Initial reconciliation may already have retained the matching
+            // Activity and be suspended while ending a duplicate. Preserve
+            // the manager-to-controller finalization lease handoff even
+            // though presentation processing must remain serialized behind
+            // reconciliation.
+            retainFinalizationBackgroundExecutionIfNeeded(
+                for: presentation
+            )
             guard hasReconciled else { return }
-            Task { @MainActor [weak self] in
-                await self?.handle(presentation)
-            }
+            enqueue(presentation)
         }
         reconciliationTask = Task { @MainActor [weak self] in
             await self?.reconcileExistingActivities()
@@ -349,10 +391,7 @@ final class WorkoutLiveActivityController {
     func setApplicationForeground(_ isForeground: Bool) {
         isApplicationForeground = isForeground
         guard isForeground, hasReconciled else { return }
-        Task { @MainActor [weak self] in
-            guard let self else { return }
-            await handle(latestPresentation)
-        }
+        enqueue(latestPresentation)
     }
 
     private func reconcileExistingActivities() async {
@@ -372,7 +411,11 @@ final class WorkoutLiveActivityController {
         }
         let mapped = WorkoutLiveActivityStateMapper.map(
             latestPresentation,
-            at: now()
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
         )
 
         if let mapped {
@@ -383,6 +426,18 @@ final class WorkoutLiveActivityController {
                 retain(retained)
             }
             for record in records where record.id != managedActivityID {
+                let currentSessionID = WorkoutLiveActivityStateMapper.map(
+                    latestPresentation,
+                    at: now(),
+                    supportsSegmentMarking:
+                        presentationSource.supportsSegmentMarking,
+                    isSegmentConfirmationPending:
+                        presentationSource.isSegmentConfirmationPending
+                )?.attributes.sessionID
+                guard currentSessionID == mapped.attributes.sessionID else {
+                    await reconcileExistingActivities()
+                    return
+                }
                 await client.end(
                     id: record.id,
                     contentState: nil,
@@ -394,13 +449,32 @@ final class WorkoutLiveActivityController {
         }
 
         hasReconciled = true
-        await handle(latestPresentation)
+        enqueue(latestPresentation)
+        if !isWithinReconciliationGrace {
+            releaseReconciliationLeaseIfNoTerminalFinalization()
+        }
     }
 
     private func beginReconciliationGrace() {
         isWithinReconciliationGrace = true
+        isReconciliationGraceExpiryPending = false
         reconciliationGraceTask?.cancel()
-        let grace = Self.reconciliationGracePeriod
+        finalizationBackgroundLease.begin { [weak self] in
+            guard let self, isWithinReconciliationGrace else { return }
+            reconciliationGraceTask?.cancel()
+            reconciliationGraceTask = nil
+            isReconciliationGraceExpiryPending = true
+            enqueue(latestPresentation)
+        }
+        let grace = WorkoutBackgroundExecutionBudget.boundedDelay(
+            requested: Self.reconciliationGracePeriod,
+            backgroundTimeRemaining: backgroundTimeRemaining()
+        )
+        if grace == 0 {
+            isReconciliationGraceExpiryPending = true
+            enqueue(latestPresentation)
+            return
+        }
         let wait = wait
         reconciliationGraceTask = Task { @MainActor [weak self] in
             do {
@@ -409,26 +483,180 @@ final class WorkoutLiveActivityController {
                 return
             }
             guard let self, !Task.isCancelled else { return }
-            isWithinReconciliationGrace = false
+            isReconciliationGraceExpiryPending = true
+            enqueue(latestPresentation)
+        }
+    }
+
+    private func enqueue(
+        _ presentation: WorkoutMirrorPresentationV1
+    ) {
+        retainFinalizationBackgroundExecutionIfNeeded(
+            for: presentation
+        )
+        pendingPresentation = presentation
+        guard presentationProcessingTask == nil else { return }
+        presentationProcessingTask = Task { @MainActor [weak self] in
+            await self?.processPendingPresentations()
+        }
+    }
+
+    private func processPendingPresentations() async {
+        while !Task.isCancelled,
+              let presentation = pendingPresentation {
+            pendingPresentation = nil
+            if isReconciliationGraceExpiryPending {
+                isReconciliationGraceExpiryPending = false
+                await expireReconciliationGrace()
+            } else {
+                await handle(presentation)
+            }
+        }
+        presentationProcessingTask = nil
+    }
+
+    private func expireReconciliationGrace() async {
+        guard isWithinReconciliationGrace else { return }
+        isWithinReconciliationGrace = false
+        reconciliationGraceTask = nil
+
+        if WorkoutLiveActivityStateMapper.map(
+            latestPresentation,
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
+        ) != nil {
+            await reconcileExistingActivities()
+            releaseReconciliationLeaseIfNoTerminalFinalization()
+            return
+        }
+
+        // Give a terminal or active recovery already queued on the main actor
+        // one final chance to win before ActivityKit end content becomes
+        // immutable. Recovery after the call below starts is past this
+        // relaunch correction cutoff.
+        await Task.yield()
+        if WorkoutLiveActivityStateMapper.map(
+            latestPresentation,
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
+        ) != nil {
+            await reconcileExistingActivities()
+            releaseReconciliationLeaseIfNoTerminalFinalization()
+            return
+        }
+
+        let records = client.records().filter {
+            $0.systemState == .active || $0.systemState == .stale
+        }
+        for record in records {
             if WorkoutLiveActivityStateMapper.map(
                 latestPresentation,
-                at: now()
+                at: now(),
+                supportsSegmentMarking:
+                    presentationSource.supportsSegmentMarking,
+                isSegmentConfirmationPending:
+                    presentationSource.isSegmentConfirmationPending
             ) != nil {
                 await reconcileExistingActivities()
+                releaseReconciliationLeaseIfNoTerminalFinalization()
                 return
             }
-            let records = client.records().filter {
-                $0.systemState == .active || $0.systemState == .stale
+            let recoveredFinalContent =
+                record.contentState.phase == .ending
+                ? unavailableFinalContent(from: record.contentState)
+                : nil
+            if recoveredFinalContent != nil {
+                finalizationBackgroundLease.begin {}
             }
-            for record in records {
-                await client.end(
-                    id: record.id,
-                    contentState: nil,
-                    dismissal: .immediate
-                )
+            await client.end(
+                id: record.id,
+                contentState: recoveredFinalContent,
+                dismissal: recoveredFinalContent == nil
+                    ? .immediate
+                    : .after(
+                        now().addingTimeInterval(
+                            Self.finalSummaryDismissalInterval
+                        )
+                    )
+            )
+            if recoveredFinalContent == nil {
+                // A generic orphan is removed immediately, so a late verified
+                // active session may create its one replacement.
+                suppressionStore.remove(record.attributes.sessionID)
+            } else {
+                // Finalization is the relaunch correction cutoff. Keep the
+                // tombstone so a later recovery cannot create a second card
+                // beside immutable unavailable-final content.
+                suppressionStore.insert(record.attributes.sessionID)
             }
-            await handle(latestPresentation)
         }
+        finalizationBackgroundLease.end()
+        enqueue(latestPresentation)
+    }
+
+    private func retainFinalizationBackgroundExecutionIfNeeded(
+        for presentation: WorkoutMirrorPresentationV1
+    ) {
+        guard managedActivityID != nil,
+              let managedSessionID,
+              let mapped = WorkoutLiveActivityStateMapper.map(
+                  presentation,
+                  at: now(),
+                  supportsSegmentMarking:
+                      presentationSource.supportsSegmentMarking,
+                  isSegmentConfirmationPending:
+                      presentationSource.isSegmentConfirmationPending
+              ),
+              mapped.isTerminal,
+              mapped.attributes.sessionID == managedSessionID else {
+            return
+        }
+        // Combine delivery is synchronous. Acquiring here bridges the manager
+        // wait lease to the separately queued ActivityKit end operation.
+        finalizationBackgroundLease.begin {}
+    }
+
+    private func releaseReconciliationLeaseIfNoTerminalFinalization() {
+        let current = WorkoutLiveActivityStateMapper.map(
+            latestPresentation,
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
+        )
+        if managedActivityID == nil || current?.isTerminal != true {
+            finalizationBackgroundLease.end()
+        }
+    }
+
+    private func unavailableFinalContent(
+        from content: WorkoutLiveActivityAttributes.ContentState
+    ) -> WorkoutLiveActivityAttributes.ContentState {
+        WorkoutLiveActivityAttributes.ContentState(
+            phase: .final,
+            capturedAt: content.capturedAt,
+            elapsedActiveSeconds: content.elapsedActiveSeconds,
+            currentSpeedKilometersPerHour: nil,
+            cyclingDistanceMeters: content.cyclingDistanceMeters,
+            currentHeartRateBPM: nil,
+            lastCompletedSegmentIndex:
+                content.lastCompletedSegmentIndex,
+            lastCompletedSegmentDuration:
+                content.lastCompletedSegmentDuration,
+            lastCompletedSegmentDistanceMeters:
+                content.lastCompletedSegmentDistanceMeters,
+            isSegmentControlAvailable: false,
+            pendingAction: .none,
+            finalOutcome: .none,
+            displayError: .finalSummaryUnavailable
+        )
     }
 
     private func handle(
@@ -440,18 +668,27 @@ final class WorkoutLiveActivityController {
         }
         guard let mapped = WorkoutLiveActivityStateMapper.map(
             presentation,
-            at: now()
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
         ) else {
             guard !isWithinReconciliationGrace else { return }
+            if shouldRetainManagedActivity(while: presentation) {
+                return
+            }
             await endManagedActivity(dismissal: .immediate)
             return
         }
 
         if isWithinReconciliationGrace {
             isWithinReconciliationGrace = false
+            isReconciliationGraceExpiryPending = false
             reconciliationGraceTask?.cancel()
             reconciliationGraceTask = nil
             await reconcileExistingActivities()
+            releaseReconciliationLeaseIfNoTerminalFinalization()
             return
         }
 
@@ -461,19 +698,22 @@ final class WorkoutLiveActivityController {
         }
 
         if mapped.isTerminal {
-            suppressionStore.remove(mapped.attributes.sessionID)
             systemEndedSessionIDs.remove(mapped.attributes.sessionID)
             guard managedSessionID == mapped.attributes.sessionID else {
                 return
             }
-            let dismissal: WorkoutLiveActivityDismissal =
-                mapped.contentState.finalOutcome == .saved
-                ? .after(
+            suppressionStore.remove(mapped.attributes.sessionID)
+            let dismissal: WorkoutLiveActivityDismissal
+            switch mapped.contentState.finalOutcome {
+            case .saved, .none:
+                dismissal = .after(
                     now().addingTimeInterval(
                         Self.finalSummaryDismissalInterval
                     )
                 )
-                : .immediate
+            case .discarded:
+                dismissal = .immediate
+            }
             await endManagedActivity(
                 finalContent: mapped.contentState,
                 dismissal: dismissal
@@ -502,6 +742,21 @@ final class WorkoutLiveActivityController {
         )
     }
 
+    private func shouldRetainManagedActivity(
+        while presentation: WorkoutMirrorPresentationV1
+    ) -> Bool {
+        guard let managedSessionID,
+              presentation.sessionID == managedSessionID else {
+            return false
+        }
+        switch presentation.connectionState {
+        case .launchingWatch, .awaitingFirstSnapshot:
+            return true
+        default:
+            return false
+        }
+    }
+
     private func requestActivity(
         _ mapped: WorkoutLiveActivityMappedPresentation
     ) {
@@ -525,7 +780,10 @@ final class WorkoutLiveActivityController {
         _ content: WorkoutLiveActivityAttributes.ContentState,
         to activityID: String
     ) async {
-        guard content != lastPublishedContent else { return }
+        guard content != lastPublishedContent else {
+            cancelPendingMetricUpdate()
+            return
+        }
         let elapsedSinceLastUpdate = lastPublishedAt.map {
             max(0, now().timeIntervalSince($0))
         } ?? Self.metricUpdateInterval
@@ -535,6 +793,7 @@ final class WorkoutLiveActivityController {
         )
 
         guard requiresImmediateUpdate
+            || isMetricUpdateDue
             || elapsedSinceLastUpdate >= Self.metricUpdateInterval else {
             pendingMetricContent = content
             scheduleMetricUpdate(
@@ -557,13 +816,13 @@ final class WorkoutLiveActivityController {
             }
             guard let self, !Task.isCancelled else { return }
             metricUpdateTask = nil
-            guard let content = pendingMetricContent,
-                  let activityID = managedActivityID else {
+            guard pendingMetricContent != nil,
+                  managedActivityID != nil else {
                 pendingMetricContent = nil
                 return
             }
-            pendingMetricContent = nil
-            await update(content, activityID: activityID)
+            isMetricUpdateDue = true
+            enqueue(latestPresentation)
         }
     }
 
@@ -577,6 +836,10 @@ final class WorkoutLiveActivityController {
                 contentState: content,
                 staleDate: staleDate(for: content)
             )
+            guard !Task.isCancelled,
+                  managedActivityID == activityID else {
+                return
+            }
             lastPublishedContent = content
             lastPublishedAt = now()
         } catch {
@@ -598,6 +861,7 @@ final class WorkoutLiveActivityController {
             contentState: finalContent,
             dismissal: dismissal
         )
+        finalizationBackgroundLease.end()
         managedActivityID = nil
         managedSessionID = nil
         lastPublishedContent = nil
@@ -607,6 +871,10 @@ final class WorkoutLiveActivityController {
     private func retain(_ record: WorkoutLiveActivityRecord) {
         managedActivityID = record.id
         managedSessionID = record.attributes.sessionID
+        // Persist that this session has already owned a Live Activity. If the
+        // process is absent when the user dismisses it or the system expires
+        // it, a later launch must not create a replacement for the same ride.
+        suppressionStore.insert(record.attributes.sessionID)
         lastPublishedContent = record.contentState
         observeSystemState(
             activityID: record.id,
@@ -645,6 +913,7 @@ final class WorkoutLiveActivityController {
 
     private func abandonManagedActivity() {
         cancelPendingMetricUpdate()
+        finalizationBackgroundLease.end()
         managedActivityID = nil
         managedSessionID = nil
         lastPublishedContent = nil
@@ -657,6 +926,7 @@ final class WorkoutLiveActivityController {
         metricUpdateTask?.cancel()
         metricUpdateTask = nil
         pendingMetricContent = nil
+        isMetricUpdateDue = false
     }
 
     private func staleDate(

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
@@ -1,0 +1,689 @@
+import ActivityKit
+import Combine
+import Foundation
+
+@available(iOS 17.0, *)
+enum WorkoutLiveActivitySystemState: Equatable, Sendable {
+    case active
+    case stale
+    case ended
+    case dismissed
+}
+
+@available(iOS 17.0, *)
+enum WorkoutLiveActivityDismissal: Equatable, Sendable {
+    case immediate
+    case after(Date)
+}
+
+@available(iOS 17.0, *)
+struct WorkoutLiveActivityRecord: Equatable, Sendable {
+    let id: String
+    let attributes: WorkoutLiveActivityAttributes
+    let contentState: WorkoutLiveActivityAttributes.ContentState
+    let systemState: WorkoutLiveActivitySystemState
+}
+
+@available(iOS 17.0, *)
+@MainActor
+protocol WorkoutLiveActivityClient {
+    func records() -> [WorkoutLiveActivityRecord]
+    func request(
+        attributes: WorkoutLiveActivityAttributes,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) throws -> WorkoutLiveActivityRecord
+    func update(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) async throws
+    func end(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState?,
+        dismissal: WorkoutLiveActivityDismissal
+    ) async
+    func stateUpdates(
+        for id: String
+    ) -> AsyncStream<WorkoutLiveActivitySystemState>
+}
+
+@available(iOS 17.0, *)
+protocol WorkoutLiveActivityAuthorizationProviding {
+    var areActivitiesEnabled: Bool { get }
+}
+
+@available(iOS 17.0, *)
+protocol WorkoutLiveActivitySuppressionStoring: AnyObject {
+    func contains(_ sessionID: UUID) -> Bool
+    func insert(_ sessionID: UUID)
+    func remove(_ sessionID: UUID)
+}
+
+@available(iOS 17.0, *)
+@MainActor
+protocol WorkoutLiveActivityPresentationProviding: AnyObject {
+    var presentation: WorkoutMirrorPresentationV1 { get }
+    var presentationPublisher:
+        AnyPublisher<WorkoutMirrorPresentationV1, Never> { get }
+}
+
+@available(iOS 17.0, *)
+extension WorkoutMetricsStore: WorkoutLiveActivityPresentationProviding {
+    var presentationPublisher:
+        AnyPublisher<WorkoutMirrorPresentationV1, Never> {
+        $presentation.eraseToAnyPublisher()
+    }
+}
+
+@available(iOS 17.0, *)
+struct SystemWorkoutLiveActivityAuthorizationProvider:
+    WorkoutLiveActivityAuthorizationProviding {
+    var areActivitiesEnabled: Bool {
+        ActivityAuthorizationInfo().areActivitiesEnabled
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class WorkoutLiveActivitySuppressionStore:
+    WorkoutLiveActivitySuppressionStoring {
+    private static let defaultsKey =
+        "WorkoutLiveActivitySuppressedSessionIDs"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    func contains(_ sessionID: UUID) -> Bool {
+        identifiers.contains(sessionID.uuidString)
+    }
+
+    func insert(_ sessionID: UUID) {
+        var identifiers = identifiers
+        identifiers.insert(sessionID.uuidString)
+        defaults.set(Array(identifiers).sorted(), forKey: Self.defaultsKey)
+    }
+
+    func remove(_ sessionID: UUID) {
+        var identifiers = identifiers
+        identifiers.remove(sessionID.uuidString)
+        defaults.set(Array(identifiers).sorted(), forKey: Self.defaultsKey)
+    }
+
+    private var identifiers: Set<String> {
+        Set(defaults.stringArray(forKey: Self.defaultsKey) ?? [])
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class SystemWorkoutLiveActivityClient: WorkoutLiveActivityClient {
+    private enum ClientError: Error {
+        case missingActivity
+    }
+
+    func records() -> [WorkoutLiveActivityRecord] {
+        Activity<WorkoutLiveActivityAttributes>.activities.map(record)
+    }
+
+    func request(
+        attributes: WorkoutLiveActivityAttributes,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) throws -> WorkoutLiveActivityRecord {
+        let activity = try Activity<WorkoutLiveActivityAttributes>.request(
+            attributes: attributes,
+            content: ActivityContent(
+                state: contentState,
+                staleDate: staleDate
+            ),
+            pushType: nil
+        )
+        return record(activity)
+    }
+
+    func update(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) async throws {
+        guard let activity = activity(id: id) else {
+            throw ClientError.missingActivity
+        }
+        await activity.update(
+            ActivityContent(
+                state: contentState,
+                staleDate: staleDate
+            )
+        )
+    }
+
+    func end(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState?,
+        dismissal: WorkoutLiveActivityDismissal
+    ) async {
+        guard let activity = activity(id: id) else { return }
+        let content = contentState.map {
+            ActivityContent(state: $0, staleDate: nil)
+        }
+        let policy: ActivityUIDismissalPolicy
+        switch dismissal {
+        case .immediate:
+            policy = .immediate
+        case .after(let date):
+            policy = .after(date)
+        }
+        await activity.end(content, dismissalPolicy: policy)
+    }
+
+    func stateUpdates(
+        for id: String
+    ) -> AsyncStream<WorkoutLiveActivitySystemState> {
+        guard let activity = activity(id: id) else {
+            return AsyncStream { continuation in
+                continuation.finish()
+            }
+        }
+        return AsyncStream { continuation in
+            let task = Task {
+                for await state in activity.activityStateUpdates {
+                    continuation.yield(Self.systemState(state))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    private func activity(
+        id: String
+    ) -> Activity<WorkoutLiveActivityAttributes>? {
+        Activity<WorkoutLiveActivityAttributes>.activities.first {
+            $0.id == id
+        }
+    }
+
+    private func record(
+        _ activity: Activity<WorkoutLiveActivityAttributes>
+    ) -> WorkoutLiveActivityRecord {
+        WorkoutLiveActivityRecord(
+            id: activity.id,
+            attributes: activity.attributes,
+            contentState: activity.content.state,
+            systemState: Self.systemState(activity.activityState)
+        )
+    }
+
+    private static func systemState(
+        _ state: ActivityState
+    ) -> WorkoutLiveActivitySystemState {
+        switch state {
+        case .active:
+            return .active
+        case .stale:
+            return .stale
+        case .dismissed:
+            return .dismissed
+        case .ended:
+            return .ended
+        default:
+            // Covers newer nonterminal states such as the iOS 26 pending
+            // request state without raising the app's deployment target.
+            return .active
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class WorkoutLiveActivityController {
+    nonisolated static let metricUpdateInterval: TimeInterval = 1
+    nonisolated static let finalSummaryDismissalInterval: TimeInterval = 15 * 60
+    nonisolated static let reconciliationGracePeriod: TimeInterval = 3
+
+    private let presentationSource:
+        any WorkoutLiveActivityPresentationProviding
+    private let client: WorkoutLiveActivityClient
+    private let authorization: WorkoutLiveActivityAuthorizationProviding
+    private let suppressionStore: WorkoutLiveActivitySuppressionStoring
+    private let now: () -> Date
+    private let wait:
+        @MainActor @Sendable (TimeInterval) async throws -> Void
+
+    private var presentationCancellable: AnyCancellable?
+    private var managedActivityID: String?
+    private var managedSessionID: UUID?
+    private var lastPublishedContent:
+        WorkoutLiveActivityAttributes.ContentState?
+    private var lastPublishedAt: Date?
+    private var latestPresentation: WorkoutMirrorPresentationV1
+    private var pendingMetricContent:
+        WorkoutLiveActivityAttributes.ContentState?
+    private var metricUpdateTask: Task<Void, Never>?
+    private var activityStateTask: Task<Void, Never>?
+    private var reconciliationTask: Task<Void, Never>?
+    private var reconciliationGraceTask: Task<Void, Never>?
+    private var hasReconciled = false
+    private var isWithinReconciliationGrace = false
+    private var isApplicationForeground = false
+    private var systemEndedSessionIDs: Set<UUID> = []
+
+    init(
+        store: WorkoutMetricsStore,
+        client: WorkoutLiveActivityClient? = nil,
+        authorization: WorkoutLiveActivityAuthorizationProviding? = nil,
+        suppressionStore: WorkoutLiveActivitySuppressionStoring? = nil,
+        now: @escaping () -> Date = Date.init,
+        wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
+    ) {
+        presentationSource = store
+        self.client = client ?? SystemWorkoutLiveActivityClient()
+        self.authorization = authorization
+            ?? SystemWorkoutLiveActivityAuthorizationProvider()
+        self.suppressionStore = suppressionStore
+            ?? WorkoutLiveActivitySuppressionStore()
+        self.now = now
+        self.wait = wait ?? { interval in
+            try await Task.sleep(
+                nanoseconds: UInt64(interval * 1_000_000_000)
+            )
+        }
+        latestPresentation = store.presentation
+    }
+
+    init(
+        presentationSource:
+            any WorkoutLiveActivityPresentationProviding,
+        client: WorkoutLiveActivityClient,
+        authorization: WorkoutLiveActivityAuthorizationProviding,
+        suppressionStore: WorkoutLiveActivitySuppressionStoring,
+        now: @escaping () -> Date = Date.init,
+        wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
+    ) {
+        self.presentationSource = presentationSource
+        self.client = client
+        self.authorization = authorization
+        self.suppressionStore = suppressionStore
+        self.now = now
+        self.wait = wait ?? { interval in
+            try await Task.sleep(
+                nanoseconds: UInt64(interval * 1_000_000_000)
+            )
+        }
+        latestPresentation = presentationSource.presentation
+    }
+
+    deinit {
+        metricUpdateTask?.cancel()
+        activityStateTask?.cancel()
+        reconciliationTask?.cancel()
+        reconciliationGraceTask?.cancel()
+    }
+
+    func start(isApplicationForeground: Bool) {
+        guard presentationCancellable == nil else {
+            setApplicationForeground(isApplicationForeground)
+            return
+        }
+        self.isApplicationForeground = isApplicationForeground
+        latestPresentation = presentationSource.presentation
+        let publisher = presentationSource.presentationPublisher
+        presentationCancellable = publisher.sink {
+            [weak self] presentation in
+            guard let self else { return }
+            latestPresentation = presentation
+            guard hasReconciled else { return }
+            Task { @MainActor [weak self] in
+                await self?.handle(presentation)
+            }
+        }
+        reconciliationTask = Task { @MainActor [weak self] in
+            await self?.reconcileExistingActivities()
+        }
+    }
+
+    func setApplicationForeground(_ isForeground: Bool) {
+        isApplicationForeground = isForeground
+        guard isForeground, hasReconciled else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            await handle(latestPresentation)
+        }
+    }
+
+    private func reconcileExistingActivities() async {
+        let allRecords = client.records()
+        for record in allRecords {
+            switch record.systemState {
+            case .dismissed:
+                suppressionStore.insert(record.attributes.sessionID)
+            case .ended:
+                systemEndedSessionIDs.insert(record.attributes.sessionID)
+            case .active, .stale:
+                break
+            }
+        }
+        let records = allRecords.filter {
+            $0.systemState == .active || $0.systemState == .stale
+        }
+        let mapped = WorkoutLiveActivityStateMapper.map(
+            latestPresentation,
+            at: now()
+        )
+
+        if let mapped {
+            let matching = records.filter {
+                $0.attributes.sessionID == mapped.attributes.sessionID
+            }
+            if let retained = matching.first {
+                retain(retained)
+            }
+            for record in records where record.id != managedActivityID {
+                await client.end(
+                    id: record.id,
+                    contentState: nil,
+                    dismissal: .immediate
+                )
+            }
+        } else if !records.isEmpty {
+            beginReconciliationGrace()
+        }
+
+        hasReconciled = true
+        await handle(latestPresentation)
+    }
+
+    private func beginReconciliationGrace() {
+        isWithinReconciliationGrace = true
+        reconciliationGraceTask?.cancel()
+        let grace = Self.reconciliationGracePeriod
+        let wait = wait
+        reconciliationGraceTask = Task { @MainActor [weak self] in
+            do {
+                try await wait(grace)
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled else { return }
+            isWithinReconciliationGrace = false
+            if WorkoutLiveActivityStateMapper.map(
+                latestPresentation,
+                at: now()
+            ) != nil {
+                await reconcileExistingActivities()
+                return
+            }
+            let records = client.records().filter {
+                $0.systemState == .active || $0.systemState == .stale
+            }
+            for record in records {
+                await client.end(
+                    id: record.id,
+                    contentState: nil,
+                    dismissal: .immediate
+                )
+            }
+            await handle(latestPresentation)
+        }
+    }
+
+    private func handle(
+        _ presentation: WorkoutMirrorPresentationV1
+    ) async {
+        guard authorization.areActivitiesEnabled else {
+            cancelPendingMetricUpdate()
+            return
+        }
+        guard let mapped = WorkoutLiveActivityStateMapper.map(
+            presentation,
+            at: now()
+        ) else {
+            guard !isWithinReconciliationGrace else { return }
+            await endManagedActivity(dismissal: .immediate)
+            return
+        }
+
+        if isWithinReconciliationGrace {
+            isWithinReconciliationGrace = false
+            reconciliationGraceTask?.cancel()
+            reconciliationGraceTask = nil
+            await reconcileExistingActivities()
+            return
+        }
+
+        if managedSessionID != nil,
+           managedSessionID != mapped.attributes.sessionID {
+            await endManagedActivity(dismissal: .immediate)
+        }
+
+        if mapped.isTerminal {
+            suppressionStore.remove(mapped.attributes.sessionID)
+            systemEndedSessionIDs.remove(mapped.attributes.sessionID)
+            guard managedSessionID == mapped.attributes.sessionID else {
+                return
+            }
+            let dismissal: WorkoutLiveActivityDismissal =
+                mapped.contentState.finalOutcome == .saved
+                ? .after(
+                    now().addingTimeInterval(
+                        Self.finalSummaryDismissalInterval
+                    )
+                )
+                : .immediate
+            await endManagedActivity(
+                finalContent: mapped.contentState,
+                dismissal: dismissal
+            )
+            return
+        }
+
+        guard let managedActivityID else {
+            guard mapped.isStartEligible,
+                  isApplicationForeground,
+                  !suppressionStore.contains(
+                      mapped.attributes.sessionID
+                  ),
+                  !systemEndedSessionIDs.contains(
+                      mapped.attributes.sessionID
+                  ) else {
+                return
+            }
+            requestActivity(mapped)
+            return
+        }
+
+        await publish(
+            mapped.contentState,
+            to: managedActivityID
+        )
+    }
+
+    private func requestActivity(
+        _ mapped: WorkoutLiveActivityMappedPresentation
+    ) {
+        do {
+            let content = mapped.contentState
+            let record = try client.request(
+                attributes: mapped.attributes,
+                contentState: content,
+                staleDate: staleDate(for: content)
+            )
+            retain(record)
+            lastPublishedContent = content
+            lastPublishedAt = now()
+        } catch {
+            // ActivityKit failure is display-only. A later verified store
+            // update or foreground transition may safely try again.
+        }
+    }
+
+    private func publish(
+        _ content: WorkoutLiveActivityAttributes.ContentState,
+        to activityID: String
+    ) async {
+        guard content != lastPublishedContent else { return }
+        let elapsedSinceLastUpdate = lastPublishedAt.map {
+            max(0, now().timeIntervalSince($0))
+        } ?? Self.metricUpdateInterval
+        let requiresImmediateUpdate = isCriticalChange(
+            from: lastPublishedContent,
+            to: content
+        )
+
+        guard requiresImmediateUpdate
+            || elapsedSinceLastUpdate >= Self.metricUpdateInterval else {
+            pendingMetricContent = content
+            scheduleMetricUpdate(
+                after: Self.metricUpdateInterval - elapsedSinceLastUpdate
+            )
+            return
+        }
+        cancelPendingMetricUpdate()
+        await update(content, activityID: activityID)
+    }
+
+    private func scheduleMetricUpdate(after delay: TimeInterval) {
+        guard metricUpdateTask == nil else { return }
+        let wait = wait
+        metricUpdateTask = Task { @MainActor [weak self] in
+            do {
+                try await wait(max(0, delay))
+            } catch {
+                return
+            }
+            guard let self, !Task.isCancelled else { return }
+            metricUpdateTask = nil
+            guard let content = pendingMetricContent,
+                  let activityID = managedActivityID else {
+                pendingMetricContent = nil
+                return
+            }
+            pendingMetricContent = nil
+            await update(content, activityID: activityID)
+        }
+    }
+
+    private func update(
+        _ content: WorkoutLiveActivityAttributes.ContentState,
+        activityID: String
+    ) async {
+        do {
+            try await client.update(
+                id: activityID,
+                contentState: content,
+                staleDate: staleDate(for: content)
+            )
+            lastPublishedContent = content
+            lastPublishedAt = now()
+        } catch {
+            // Keep the previous publication marker so a later verified store
+            // update retries. Workout state is never changed here.
+        }
+    }
+
+    private func endManagedActivity(
+        finalContent: WorkoutLiveActivityAttributes.ContentState? = nil,
+        dismissal: WorkoutLiveActivityDismissal
+    ) async {
+        cancelPendingMetricUpdate()
+        activityStateTask?.cancel()
+        activityStateTask = nil
+        guard let activityID = managedActivityID else { return }
+        await client.end(
+            id: activityID,
+            contentState: finalContent,
+            dismissal: dismissal
+        )
+        managedActivityID = nil
+        managedSessionID = nil
+        lastPublishedContent = nil
+        lastPublishedAt = nil
+    }
+
+    private func retain(_ record: WorkoutLiveActivityRecord) {
+        managedActivityID = record.id
+        managedSessionID = record.attributes.sessionID
+        lastPublishedContent = record.contentState
+        observeSystemState(
+            activityID: record.id,
+            sessionID: record.attributes.sessionID
+        )
+    }
+
+    private func observeSystemState(
+        activityID: String,
+        sessionID: UUID
+    ) {
+        activityStateTask?.cancel()
+        let updates = client.stateUpdates(for: activityID)
+        activityStateTask = Task { @MainActor [weak self] in
+            for await state in updates {
+                guard let self,
+                      managedActivityID == activityID,
+                      managedSessionID == sessionID else {
+                    return
+                }
+                switch state {
+                case .dismissed:
+                    suppressionStore.insert(sessionID)
+                    abandonManagedActivity()
+                    return
+                case .ended:
+                    systemEndedSessionIDs.insert(sessionID)
+                    abandonManagedActivity()
+                    return
+                case .active, .stale:
+                    break
+                }
+            }
+        }
+    }
+
+    private func abandonManagedActivity() {
+        cancelPendingMetricUpdate()
+        managedActivityID = nil
+        managedSessionID = nil
+        lastPublishedContent = nil
+        lastPublishedAt = nil
+        activityStateTask?.cancel()
+        activityStateTask = nil
+    }
+
+    private func cancelPendingMetricUpdate() {
+        metricUpdateTask?.cancel()
+        metricUpdateTask = nil
+        pendingMetricContent = nil
+    }
+
+    private func staleDate(
+        for content: WorkoutLiveActivityAttributes.ContentState
+    ) -> Date? {
+        guard content.phase == .running || content.phase == .paused else {
+            return nil
+        }
+        return content.capturedAt.addingTimeInterval(
+            WorkoutMirrorStateReducer.defaultStaleAfter
+        )
+    }
+
+    private func isCriticalChange(
+        from previous: WorkoutLiveActivityAttributes.ContentState?,
+        to next: WorkoutLiveActivityAttributes.ContentState
+    ) -> Bool {
+        guard let previous else { return true }
+        return previous.phase != next.phase
+            || previous.pendingAction != next.pendingAction
+            || previous.finalOutcome != next.finalOutcome
+            || previous.displayError != next.displayError
+            || previous.lastCompletedSegmentIndex
+                != next.lastCompletedSegmentIndex
+            || previous.lastCompletedSegmentDuration
+                != next.lastCompletedSegmentDuration
+            || previous.lastCompletedSegmentDistanceMeters
+                != next.lastCompletedSegmentDistanceMeters
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityStateMapper.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityStateMapper.swift
@@ -15,7 +15,9 @@ nonisolated struct WorkoutLiveActivityMappedPresentation: Equatable, Sendable {
 nonisolated enum WorkoutLiveActivityStateMapper {
     static func map(
         _ presentation: WorkoutMirrorPresentationV1,
-        at referenceDate: Date
+        at referenceDate: Date,
+        supportsSegmentMarking: Bool = true,
+        isSegmentConfirmationPending: Bool = false
     ) -> WorkoutLiveActivityMappedPresentation? {
         let snapshot = presentation.finalSnapshot ?? presentation.snapshot
         guard let sessionID = presentation.sessionID,
@@ -53,14 +55,19 @@ nonisolated enum WorkoutLiveActivityStateMapper {
                 snapshot.elapsedTime,
                 unit: .seconds,
                 allowZero: true
-            ) ?? 0,
+            ),
             currentSpeedKilometersPerHour: hidesInstantaneousMetrics
                 ? nil
                 : metric(
                     snapshot.currentSpeed,
                     unit: .metersPerSecond,
                     allowZero: true
-                ).map { $0 * 3.6 },
+                ).flatMap {
+                    let kilometersPerHour = $0 * 3.6
+                    return kilometersPerHour.isFinite
+                        ? kilometersPerHour
+                        : nil
+                },
             cyclingDistanceMeters: metric(
                 snapshot.cyclingDistance,
                 unit: .meters,
@@ -76,6 +83,8 @@ nonisolated enum WorkoutLiveActivityStateMapper {
             lastCompletedSegmentIndex: segment?.index,
             lastCompletedSegmentDuration: segment?.duration,
             lastCompletedSegmentDistanceMeters: segment?.distanceMeters,
+            isSegmentControlAvailable: supportsSegmentMarking
+                && !isSegmentConfirmationPending,
             pendingAction: pendingAction,
             finalOutcome: finalOutcome,
             displayError: displayError(
@@ -103,10 +112,14 @@ nonisolated enum WorkoutLiveActivityStateMapper {
         for presentation: WorkoutMirrorPresentationV1,
         snapshot: WorkoutSnapshotV1
     ) -> WorkoutLiveActivityPhase? {
+        let errorCode = presentation.errorCode ?? snapshot.errorCode
         if snapshot.terminalOutcome != nil
-            || presentation.connectionState == .ended
-            || presentation.sessionState == .ended {
+            || errorCode == .finalSummaryUnavailable {
             return .final
+        }
+        if presentation.connectionState == .ended
+            || presentation.sessionState == .ended {
+            return .ending
         }
 
         switch presentation.connectionState {
@@ -146,7 +159,11 @@ nonisolated enum WorkoutLiveActivityStateMapper {
             return .pause
         case .resume:
             return .resume
-        case .endAndSave, .discard, .requestCurrentSnapshot, nil:
+        case .endAndSave:
+            return .endAndSave
+        case .discard:
+            return .discard
+        case .requestCurrentSnapshot, nil:
             return .none
         }
     }
@@ -173,6 +190,12 @@ nonisolated enum WorkoutLiveActivityStateMapper {
             return .segmentRejected
         case .segmentMarkUnconfirmed:
             return .segmentUnconfirmed
+        case .terminalChoiceUnconfirmed:
+            return phase == .final
+                ? .finalSummaryUnavailable
+                : .controlsUnavailable
+        case .finalSummaryUnavailable:
+            return .finalSummaryUnavailable
         default:
             if phase == .stale || phase == .disconnected {
                 return .controlsUnavailable

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityStateMapper.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityStateMapper.swift
@@ -1,0 +1,230 @@
+import Foundation
+
+@available(iOS 17.0, *)
+nonisolated struct WorkoutLiveActivityMappedPresentation: Equatable, Sendable {
+    let attributes: WorkoutLiveActivityAttributes
+    let contentState: WorkoutLiveActivityAttributes.ContentState
+    let isStartEligible: Bool
+
+    var isTerminal: Bool {
+        contentState.phase == .final
+    }
+}
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityStateMapper {
+    static func map(
+        _ presentation: WorkoutMirrorPresentationV1,
+        at referenceDate: Date
+    ) -> WorkoutLiveActivityMappedPresentation? {
+        let snapshot = presentation.finalSnapshot ?? presentation.snapshot
+        guard let sessionID = presentation.sessionID,
+              let startDate = snapshot.startDate
+                ?? presentation.snapshot.startDate,
+              startDate <= referenceDate,
+              let capturedAt = validCaptureDate(
+                  presentation.capturedAt
+                    ?? snapshot.elapsedTime?.capturedAt
+                    ?? snapshot.cyclingDistance?.capturedAt,
+                  notBefore: startDate,
+                  at: referenceDate
+              ),
+              let phase = phase(
+                  for: presentation,
+                  snapshot: snapshot
+              ) else {
+            return nil
+        }
+
+        let hidesInstantaneousMetrics = [
+            .stale,
+            .disconnected,
+            .ending,
+            .final,
+        ].contains(phase)
+        let segment = validSegment(snapshot.lastCompletedSegment)
+        let pendingAction = pendingAction(presentation.pendingControl)
+        let finalOutcome = finalOutcome(snapshot.terminalOutcome)
+
+        let state = WorkoutLiveActivityAttributes.ContentState(
+            phase: phase,
+            capturedAt: capturedAt,
+            elapsedActiveSeconds: metric(
+                snapshot.elapsedTime,
+                unit: .seconds,
+                allowZero: true
+            ) ?? 0,
+            currentSpeedKilometersPerHour: hidesInstantaneousMetrics
+                ? nil
+                : metric(
+                    snapshot.currentSpeed,
+                    unit: .metersPerSecond,
+                    allowZero: true
+                ).map { $0 * 3.6 },
+            cyclingDistanceMeters: metric(
+                snapshot.cyclingDistance,
+                unit: .meters,
+                allowZero: true
+            ),
+            currentHeartRateBPM: hidesInstantaneousMetrics
+                ? nil
+                : metric(
+                    snapshot.currentHeartRate,
+                    unit: .beatsPerMinute,
+                    allowZero: false
+                ),
+            lastCompletedSegmentIndex: segment?.index,
+            lastCompletedSegmentDuration: segment?.duration,
+            lastCompletedSegmentDistanceMeters: segment?.distanceMeters,
+            pendingAction: pendingAction,
+            finalOutcome: finalOutcome,
+            displayError: displayError(
+                phase: phase,
+                errorCode: presentation.errorCode
+                    ?? snapshot.errorCode
+            )
+        )
+        let isStartEligible = presentation.connectionState == .connected
+            && (phase == .running || phase == .paused)
+            && presentation.pendingControl != .endAndSave
+            && presentation.pendingControl != .discard
+
+        return WorkoutLiveActivityMappedPresentation(
+            attributes: WorkoutLiveActivityAttributes(
+                sessionID: sessionID,
+                workoutStartDate: startDate
+            ),
+            contentState: state,
+            isStartEligible: isStartEligible
+        )
+    }
+
+    private static func phase(
+        for presentation: WorkoutMirrorPresentationV1,
+        snapshot: WorkoutSnapshotV1
+    ) -> WorkoutLiveActivityPhase? {
+        if snapshot.terminalOutcome != nil
+            || presentation.connectionState == .ended
+            || presentation.sessionState == .ended {
+            return .final
+        }
+
+        switch presentation.connectionState {
+        case .stale:
+            return presentation.isWorkoutActive ? .stale : nil
+        case .disconnected:
+            return presentation.isWorkoutActive ? .disconnected : nil
+        case .failed:
+            return presentation.isWorkoutActive ? .stale : nil
+        case .connected:
+            switch presentation.sessionState {
+            case .running:
+                return .running
+            case .paused:
+                return .paused
+            case .ending:
+                return .ending
+            case .ended:
+                return .final
+            case .idle, .starting, .failed:
+                return nil
+            }
+        case .unsupported, .idle, .launchingWatch, .awaitingFirstSnapshot:
+            return nil
+        case .ended:
+            return .final
+        }
+    }
+
+    private static func pendingAction(
+        _ control: WorkoutControlV1?
+    ) -> WorkoutLiveActivityPendingAction {
+        switch control {
+        case .markSegment:
+            return .segment
+        case .pause:
+            return .pause
+        case .resume:
+            return .resume
+        case .endAndSave, .discard, .requestCurrentSnapshot, nil:
+            return .none
+        }
+    }
+
+    private static func finalOutcome(
+        _ outcome: WorkoutTerminalOutcomeV1?
+    ) -> WorkoutLiveActivityFinalOutcome {
+        switch outcome {
+        case .saved:
+            return .saved
+        case .discarded:
+            return .discarded
+        case nil:
+            return .none
+        }
+    }
+
+    private static func displayError(
+        phase: WorkoutLiveActivityPhase,
+        errorCode: WorkoutSafeErrorCodeV1?
+    ) -> WorkoutLiveActivityDisplayError {
+        switch errorCode {
+        case .segmentMarkFailed:
+            return .segmentRejected
+        case .segmentMarkUnconfirmed:
+            return .segmentUnconfirmed
+        default:
+            if phase == .stale || phase == .disconnected {
+                return .controlsUnavailable
+            }
+            return .none
+        }
+    }
+
+    private static func metric(
+        _ metric: WorkoutMetricV1?,
+        unit: WorkoutMetricUnitV1,
+        allowZero: Bool
+    ) -> Double? {
+        guard let metric,
+              metric.unit == unit,
+              metric.value.isFinite,
+              allowZero ? metric.value >= 0 : metric.value > 0 else {
+            return nil
+        }
+        return metric.value
+    }
+
+    private static func validSegment(
+        _ segment: WorkoutCompletedSegmentV1?
+    ) -> WorkoutCompletedSegmentV1? {
+        guard let segment,
+              segment.index > 0,
+              segment.startedAt <= segment.endedAt,
+              segment.duration.isFinite,
+              segment.duration >= 0,
+              segment.distanceMeters == nil
+                || (
+                    segment.distanceMeters?.isFinite == true
+                        && (segment.distanceMeters ?? -1) >= 0
+                ) else {
+            return nil
+        }
+        return segment
+    }
+
+    private static func validCaptureDate(
+        _ date: Date?,
+        notBefore startDate: Date,
+        at referenceDate: Date
+    ) -> Date? {
+        guard let date,
+              date >= startDate,
+              date <= referenceDate.addingTimeInterval(
+                  WorkoutMirrorStateReducer.maximumFutureCaptureSkew
+              ) else {
+            return nil
+        }
+        return date
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMirrorManager.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HealthKit
+import UIKit
 
 @available(iOS 17.0, *)
 @MainActor
@@ -48,6 +49,63 @@ private final class HealthKitMirroredSessionTransport:
     }
 }
 
+@MainActor
+protocol WorkoutBackgroundExecutionLeasing: AnyObject {
+    func begin(
+        expirationHandler: @escaping @MainActor @Sendable () -> Void
+    )
+    func end()
+}
+
+nonisolated enum WorkoutBackgroundExecutionBudget {
+    static let finalizationSafetyMargin: TimeInterval = 5
+
+    static func boundedDelay(
+        requested: TimeInterval,
+        backgroundTimeRemaining: TimeInterval
+    ) -> TimeInterval {
+        guard backgroundTimeRemaining.isFinite else {
+            return requested
+        }
+        return min(
+            requested,
+            max(
+                0,
+                backgroundTimeRemaining - finalizationSafetyMargin
+            )
+        )
+    }
+}
+
+@MainActor
+final class SystemWorkoutBackgroundExecutionLease:
+    WorkoutBackgroundExecutionLeasing {
+    private var identifier = UIBackgroundTaskIdentifier.invalid
+
+    func begin(
+        expirationHandler: @escaping @MainActor @Sendable () -> Void
+    ) {
+        guard identifier == .invalid else { return }
+        identifier = UIApplication.shared.beginBackgroundTask(
+            withName: "Finalize mirrored workout"
+        ) {
+            // UIKit's expiration callback is synchronous on the main thread.
+            // Do not defer expiration bookkeeping to a Task after the
+            // callback returns.
+            MainActor.assumeIsolated { [self] in
+                expirationHandler()
+                self.end()
+            }
+        }
+    }
+
+    func end() {
+        guard identifier != .invalid else { return }
+        UIApplication.shared.endBackgroundTask(identifier)
+        identifier = .invalid
+    }
+}
+
 /// Long-lived iPhone bridge for a Watch-owned primary workout session.
 ///
 /// The manager intentionally has no workout builder and never asks HealthKit
@@ -73,6 +131,9 @@ final class WorkoutMirrorManager: NSObject {
         @MainActor @Sendable (TimeInterval) async throws -> Void
     private let finalSnapshotWait:
         @MainActor @Sendable (TimeInterval) async throws -> Void
+    private let finalSnapshotBackgroundLease:
+        any WorkoutBackgroundExecutionLeasing
+    private let backgroundTimeRemaining: () -> TimeInterval
     private let terminalFailureDrainWait:
         @MainActor @Sendable (TimeInterval) async throws -> Void
     private let launchWatchApp: (
@@ -127,6 +188,9 @@ final class WorkoutMirrorManager: NSObject {
         finalSnapshotWait: (@MainActor @Sendable (
             TimeInterval
         ) async throws -> Void)? = nil,
+        finalSnapshotBackgroundLease:
+            (any WorkoutBackgroundExecutionLeasing)? = nil,
+        backgroundTimeRemaining: (() -> TimeInterval)? = nil,
         terminalFailureDrainWait: (@MainActor @Sendable (
             TimeInterval
         ) async throws -> Void)? = nil,
@@ -162,6 +226,11 @@ final class WorkoutMirrorManager: NSObject {
                 nanoseconds: UInt64(timeout * 1_000_000_000)
             )
         }
+        self.finalSnapshotBackgroundLease =
+            finalSnapshotBackgroundLease
+            ?? SystemWorkoutBackgroundExecutionLease()
+        self.backgroundTimeRemaining = backgroundTimeRemaining
+            ?? Self.defaultBackgroundTimeRemaining
         self.terminalFailureDrainWait = terminalFailureDrainWait
             ?? { timeout in
                 try await Task.sleep(
@@ -175,6 +244,14 @@ final class WorkoutMirrorManager: NSObject {
             )
         }
         super.init()
+    }
+
+    private static func defaultBackgroundTimeRemaining() -> TimeInterval {
+#if WORKOUT_CONTRACT_XCTEST
+        .greatestFiniteMagnitude
+#else
+        UIApplication.shared.backgroundTimeRemaining
+#endif
     }
 
     deinit {
@@ -545,17 +622,34 @@ final class WorkoutMirrorManager: NSObject {
     private func synchronizeFinalSnapshotTimeoutWithPresentation() {
         let presentation = store.presentation
         guard presentation.connectionState == .ended,
-              presentation.finalSnapshot == nil,
+              presentation.finalSnapshot?.terminalOutcome == nil,
               presentation.pendingControl == nil,
               !store.canResetTerminalPresentation else {
             cancelFinalSnapshotTimeout()
             return
         }
         guard finalSnapshotTimeoutTask == nil else { return }
-        let timeout = finalSnapshotTimeout
         let attemptID = UUID()
         let wait = finalSnapshotWait
         finalSnapshotTimeoutAttemptID = attemptID
+        finalSnapshotBackgroundLease.begin { [weak self] in
+            guard let self,
+                  finalSnapshotTimeoutAttemptID == attemptID else {
+                return
+            }
+            _ = store.timeOutFinalSnapshot()
+            cancelFinalSnapshotTimeout()
+        }
+        guard finalSnapshotTimeoutAttemptID == attemptID else { return }
+        let timeout = WorkoutBackgroundExecutionBudget.boundedDelay(
+            requested: finalSnapshotTimeout,
+            backgroundTimeRemaining: backgroundTimeRemaining()
+        )
+        if timeout == 0 {
+            _ = store.timeOutFinalSnapshot()
+            cancelFinalSnapshotTimeout()
+            return
+        }
         finalSnapshotTimeoutTask = Task { @MainActor [weak self] in
             do {
                 try await wait(timeout)
@@ -568,8 +662,7 @@ final class WorkoutMirrorManager: NSObject {
                 return
             }
             _ = store.timeOutFinalSnapshot()
-            finalSnapshotTimeoutTask = nil
-            finalSnapshotTimeoutAttemptID = nil
+            cancelFinalSnapshotTimeout()
         }
     }
 
@@ -577,6 +670,7 @@ final class WorkoutMirrorManager: NSObject {
         finalSnapshotTimeoutTask?.cancel()
         finalSnapshotTimeoutTask = nil
         finalSnapshotTimeoutAttemptID = nil
+        finalSnapshotBackgroundLease.end()
     }
 
     @available(iOS 17.0, *)

--- a/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
+++ b/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
@@ -23,7 +23,6 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
     private let pauseAction: @MainActor () -> Void
     private let resumeAction: @MainActor () -> Void
     private let recoveryTimeout: TimeInterval
-    private let now: () -> Date
     private let wait:
         @MainActor @Sendable (TimeInterval) async throws -> Void
 
@@ -39,7 +38,6 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
     init(
         store: any WorkoutLiveActivityControlStateProviding,
         recoveryTimeout: TimeInterval = defaultRecoveryTimeout,
-        now: @escaping () -> Date = Date.init,
         wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil,
         markSegment: @escaping @MainActor () -> Void,
         pause: @escaping @MainActor () -> Void,
@@ -49,7 +47,6 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
         self.recoveryTimeout = recoveryTimeout.isFinite
             ? min(max(0, recoveryTimeout), 5)
             : Self.defaultRecoveryTimeout
-        self.now = now
         self.wait = wait ?? { interval in
             try await Task.sleep(
                 nanoseconds: UInt64(interval * 1_000_000_000)
@@ -70,7 +67,8 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
         let presentation = controlState.presentation
         guard presentation.sessionID == sessionID,
               presentation.connectionState == .connected,
-              presentation.pendingControl == nil else {
+              presentation.pendingControl == nil,
+              presentation.errorCode != .terminalChoiceUnconfirmed else {
             return false
         }
 
@@ -104,13 +102,15 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
             return false
         }
 
-        let deadline = now().addingTimeInterval(recoveryTimeout)
-        while recoveryTimeout > 0, now() < deadline {
+        var remaining = recoveryTimeout
+        while remaining > 0 {
+            let interval = min(Self.recoveryPollInterval, remaining)
             do {
-                try await wait(Self.recoveryPollInterval)
+                try await wait(interval)
             } catch {
                 return false
             }
+            remaining -= interval
             if controlState.presentation.sessionID == sessionID {
                 return true
             }

--- a/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
+++ b/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+@available(iOS 17.0, *)
+@MainActor
+protocol WorkoutLiveActivityControlStateProviding: AnyObject {
+    var presentation: WorkoutMirrorPresentationV1 { get }
+    var supportsSegmentMarking: Bool { get }
+    var isSegmentConfirmationPending: Bool { get }
+}
+
+@available(iOS 17.0, *)
+extension WorkoutMetricsStore: WorkoutLiveActivityControlStateProviding {}
+
+@available(iOS 17.0, *)
+@MainActor
+final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
+    nonisolated static let defaultRecoveryTimeout: TimeInterval = 2
+    nonisolated static let recoveryPollInterval: TimeInterval = 0.1
+
+    private let controlState:
+        any WorkoutLiveActivityControlStateProviding
+    private let markSegmentAction: @MainActor () -> Void
+    private let pauseAction: @MainActor () -> Void
+    private let resumeAction: @MainActor () -> Void
+    private let recoveryTimeout: TimeInterval
+    private let now: () -> Date
+    private let wait:
+        @MainActor @Sendable (TimeInterval) async throws -> Void
+
+    convenience init(manager: WorkoutMirrorManager) {
+        self.init(
+            store: manager.store,
+            markSegment: { manager.markSegment() },
+            pause: { manager.pause() },
+            resume: { manager.resume() }
+        )
+    }
+
+    init(
+        store: any WorkoutLiveActivityControlStateProviding,
+        recoveryTimeout: TimeInterval = defaultRecoveryTimeout,
+        now: @escaping () -> Date = Date.init,
+        wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil,
+        markSegment: @escaping @MainActor () -> Void,
+        pause: @escaping @MainActor () -> Void,
+        resume: @escaping @MainActor () -> Void
+    ) {
+        controlState = store
+        self.recoveryTimeout = recoveryTimeout.isFinite
+            ? min(max(0, recoveryTimeout), 5)
+            : Self.defaultRecoveryTimeout
+        self.now = now
+        self.wait = wait ?? { interval in
+            try await Task.sleep(
+                nanoseconds: UInt64(interval * 1_000_000_000)
+            )
+        }
+        markSegmentAction = markSegment
+        pauseAction = pause
+        resumeAction = resume
+    }
+
+    func perform(
+        _ action: WorkoutLiveActivityAction,
+        sessionID: UUID
+    ) async -> Bool {
+        guard await recoverSessionIfNeeded(sessionID: sessionID) else {
+            return false
+        }
+        let presentation = controlState.presentation
+        guard presentation.sessionID == sessionID,
+              presentation.connectionState == .connected,
+              presentation.pendingControl == nil else {
+            return false
+        }
+
+        switch action {
+        case .segment:
+            guard presentation.sessionState == .running,
+                  controlState.supportsSegmentMarking,
+                  !controlState.isSegmentConfirmationPending else {
+                return false
+            }
+            markSegmentAction()
+            return controlState.presentation.pendingControl == .markSegment
+        case .pause:
+            guard presentation.sessionState == .running else { return false }
+            pauseAction()
+            return controlState.presentation.pendingControl == .pause
+        case .resume:
+            guard presentation.sessionState == .paused else { return false }
+            resumeAction()
+            return controlState.presentation.pendingControl == .resume
+        }
+    }
+
+    private func recoverSessionIfNeeded(sessionID: UUID) async -> Bool {
+        if controlState.presentation.sessionID == sessionID {
+            return true
+        }
+        // A different verified session must never be displaced by an old
+        // Lock Screen action.
+        if controlState.presentation.sessionID != nil {
+            return false
+        }
+
+        let deadline = now().addingTimeInterval(recoveryTimeout)
+        while recoveryTimeout > 0, now() < deadline {
+            do {
+                try await wait(Self.recoveryPollInterval)
+            } catch {
+                return false
+            }
+            if controlState.presentation.sessionID == sessionID {
+                return true
+            }
+            if controlState.presentation.sessionID != nil {
+                return false
+            }
+        }
+        return false
+    }
+}

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/BikeComputerLiveActivityBundle.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/BikeComputerLiveActivityBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct BikeComputerLiveActivityBundle: WidgetBundle {
+    var body: some Widget {
+        WorkoutLiveActivityWidget()
+    }
+}

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/Info.plist
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/Info.plist
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
@@ -9,22 +9,26 @@ typealias WorkoutLiveActivityContext =
 struct WorkoutLiveActivityLockScreenView: View {
     let context: WorkoutLiveActivityContext
 
+    private var state: WorkoutLiveActivityAttributes.ContentState {
+        context.state.displayState(isSystemStale: context.isStale)
+    }
+
     var body: some View {
         VStack(spacing: 12) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                WorkoutLiveActivityStatusView(state: context.state)
+                WorkoutLiveActivityStatusView(state: state)
                 Spacer(minLength: 4)
                 WorkoutLiveActivityElapsedView(
-                    state: context.state,
+                    state: state,
                     font: .title2.bold().monospacedDigit()
                 )
             }
 
-            WorkoutLiveActivityMetricStrip(state: context.state)
+            WorkoutLiveActivityMetricStrip(state: state)
 
             WorkoutLiveActivityControls(
                 sessionID: context.attributes.sessionID,
-                state: context.state
+                state: state
             )
         }
         .padding(14)
@@ -69,21 +73,27 @@ struct WorkoutLiveActivityElapsedView: View {
 
     var body: some View {
         Group {
-            if state.phase == .running {
-                Text(state.timerAnchor, style: .timer)
-            } else {
+            if state.phase == .running,
+               let timerAnchor = state.timerAnchor {
+                Text(timerAnchor, style: .timer)
+            } else if let elapsedActiveSeconds =
+                state.elapsedActiveSeconds {
                 Text(
                     WorkoutLiveActivityFormatting.duration(
-                        state.elapsedActiveSeconds
+                        elapsedActiveSeconds
                     )
                 )
+            } else {
+                Text("—")
             }
         }
         .font(font)
         .lineLimit(1)
         .minimumScaleFactor(0.7)
         .accessibilityLabel(
-            "Active time \(WorkoutLiveActivityFormatting.duration(state.elapsedActiveSeconds))"
+            state.elapsedActiveSeconds.map {
+                "Active time \(WorkoutLiveActivityFormatting.duration($0))"
+            } ?? "Active time unavailable"
         )
     }
 }
@@ -216,8 +226,10 @@ private struct WorkoutLiveActivityButtonStyle: ButtonStyle {
 }
 
 extension WorkoutLiveActivityAttributes.ContentState {
-    var timerAnchor: Date {
-        capturedAt.addingTimeInterval(-elapsedActiveSeconds)
+    var timerAnchor: Date? {
+        elapsedActiveSeconds.map {
+            capturedAt.addingTimeInterval(-$0)
+        }
     }
 
     var statusColor: Color {
@@ -265,6 +277,8 @@ extension WorkoutLiveActivityAttributes.ContentState {
             return "Segment confirmation pending"
         case .controlsUnavailable:
             return "Ride continues on Apple Watch"
+        case .finalSummaryUnavailable:
+            return "Final summary unavailable"
         case .none:
             break
         }

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
@@ -1,0 +1,301 @@
+import ActivityKit
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+typealias WorkoutLiveActivityContext =
+    ActivityViewContext<WorkoutLiveActivityAttributes>
+
+struct WorkoutLiveActivityLockScreenView: View {
+    let context: WorkoutLiveActivityContext
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                WorkoutLiveActivityStatusView(state: context.state)
+                Spacer(minLength: 4)
+                WorkoutLiveActivityElapsedView(
+                    state: context.state,
+                    font: .title2.bold().monospacedDigit()
+                )
+            }
+
+            WorkoutLiveActivityMetricStrip(state: context.state)
+
+            WorkoutLiveActivityControls(
+                sessionID: context.attributes.sessionID,
+                state: context.state
+            )
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, maxHeight: 160)
+        .foregroundStyle(.white)
+    }
+}
+
+struct WorkoutLiveActivityStatusView: View {
+    let state: WorkoutLiveActivityAttributes.ContentState
+    var compact = false
+
+    var body: some View {
+        HStack(spacing: compact ? 4 : 6) {
+            Circle()
+                .fill(state.statusColor)
+                .frame(width: compact ? 6 : 8, height: compact ? 6 : 8)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(state.statusTitle.uppercased())
+                    .font(
+                        compact
+                            ? .caption2.bold()
+                            : .caption.bold()
+                    )
+                    .lineLimit(1)
+                if !compact, let detail = state.statusDetail {
+                    Text(detail)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(state.statusAccessibilityLabel)
+    }
+}
+
+struct WorkoutLiveActivityElapsedView: View {
+    let state: WorkoutLiveActivityAttributes.ContentState
+    let font: Font
+
+    var body: some View {
+        Group {
+            if state.phase == .running {
+                Text(state.timerAnchor, style: .timer)
+            } else {
+                Text(
+                    WorkoutLiveActivityFormatting.duration(
+                        state.elapsedActiveSeconds
+                    )
+                )
+            }
+        }
+        .font(font)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .accessibilityLabel(
+            "Active time \(WorkoutLiveActivityFormatting.duration(state.elapsedActiveSeconds))"
+        )
+    }
+}
+
+struct WorkoutLiveActivityMetricStrip: View {
+    let state: WorkoutLiveActivityAttributes.ContentState
+    var compact = false
+
+    var body: some View {
+        HStack(spacing: compact ? 8 : 14) {
+            WorkoutLiveActivityMetric(
+                value: WorkoutLiveActivityFormatting.speed(
+                    state.currentSpeedKilometersPerHour
+                ),
+                unit: "KM/H",
+                label: "Current speed",
+                compact: compact
+            )
+            WorkoutLiveActivityMetric(
+                value: WorkoutLiveActivityFormatting.distance(
+                    state.cyclingDistanceMeters
+                ),
+                unit: WorkoutLiveActivityFormatting.distanceUnit(
+                    state.cyclingDistanceMeters
+                ),
+                label: state.phase == .stale
+                    || state.phase == .disconnected
+                    ? "Last distance"
+                    : "Distance",
+                compact: compact
+            )
+            WorkoutLiveActivityMetric(
+                value: WorkoutLiveActivityFormatting.heartRate(
+                    state.currentHeartRateBPM
+                ),
+                unit: "BPM",
+                label: "Heart rate",
+                compact: compact
+            )
+        }
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private struct WorkoutLiveActivityMetric: View {
+    let value: String
+    let unit: String
+    let label: String
+    let compact: Bool
+
+    var body: some View {
+        VStack(spacing: 1) {
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(value)
+                    .font(
+                        compact
+                            ? .caption.bold().monospacedDigit()
+                            : .title3.bold().monospacedDigit()
+                    )
+                    .minimumScaleFactor(0.65)
+                Text(unit)
+                    .font(.system(size: compact ? 7 : 9, weight: .semibold))
+                    .foregroundStyle(.secondary)
+            }
+            if !compact {
+                Text(label.uppercased())
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label), \(value) \(unit)")
+    }
+}
+
+struct WorkoutLiveActivityControls: View {
+    let sessionID: UUID
+    let state: WorkoutLiveActivityAttributes.ContentState
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Button(
+                intent: BikeComputerMarkSegmentIntent(sessionID: sessionID)
+            ) {
+                Label("Segment", systemImage: "flag.checkered")
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .disabled(!state.canMarkSegment)
+
+            if state.phase == .paused {
+                Button(
+                    intent: BikeComputerResumeWorkoutIntent(
+                        sessionID: sessionID
+                    )
+                ) {
+                    Label("Resume", systemImage: "play.fill")
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .disabled(!state.canResume)
+            } else {
+                Button(
+                    intent: BikeComputerPauseWorkoutIntent(
+                        sessionID: sessionID
+                    )
+                ) {
+                    Label("Pause", systemImage: "pause.fill")
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .disabled(!state.canPause)
+            }
+        }
+        .font(.caption.bold())
+        .labelStyle(.titleAndIcon)
+        .buttonStyle(WorkoutLiveActivityButtonStyle())
+        .opacity(state.controlsAreVisuallyAvailable ? 1 : 0.55)
+    }
+}
+
+private struct WorkoutLiveActivityButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .foregroundStyle(.white)
+            .background(
+                Color.white.opacity(configuration.isPressed ? 0.24 : 0.14),
+                in: RoundedRectangle(cornerRadius: 12)
+            )
+    }
+}
+
+extension WorkoutLiveActivityAttributes.ContentState {
+    var timerAnchor: Date {
+        capturedAt.addingTimeInterval(-elapsedActiveSeconds)
+    }
+
+    var statusColor: Color {
+        switch phase {
+        case .running:
+            return .green
+        case .paused:
+            return .yellow
+        case .stale, .disconnected:
+            return .orange
+        case .ending, .final:
+            return .blue
+        }
+    }
+
+    var statusTitle: String {
+        switch phase {
+        case .running:
+            return "Riding"
+        case .paused:
+            return "Paused"
+        case .stale:
+            return "Delayed"
+        case .disconnected:
+            return "Watch disconnected"
+        case .ending:
+            return "Finishing"
+        case .final:
+            switch finalOutcome {
+            case .saved:
+                return "Ride saved"
+            case .discarded:
+                return "Ride discarded"
+            case .none:
+                return "Ride finished"
+            }
+        }
+    }
+
+    var statusDetail: String? {
+        switch displayError {
+        case .segmentRejected:
+            return "Segment wasn’t marked"
+        case .segmentUnconfirmed:
+            return "Segment confirmation pending"
+        case .controlsUnavailable:
+            return "Ride continues on Apple Watch"
+        case .none:
+            break
+        }
+        if let segment = WorkoutLiveActivityFormatting.segmentSummary(
+            index: lastCompletedSegmentIndex,
+            duration: lastCompletedSegmentDuration,
+            distanceMeters: lastCompletedSegmentDistanceMeters
+        ) {
+            return segment
+        }
+        return "Segment \(currentSegmentIndex)"
+    }
+
+    var statusAccessibilityLabel: String {
+        [statusTitle, statusDetail].compactMap { $0 }.joined(separator: ", ")
+    }
+
+    var minimalSymbolName: String {
+        switch phase {
+        case .paused:
+            return "pause.circle.fill"
+        case .stale, .disconnected:
+            return "applewatch.slash"
+        case .ending, .final:
+            return "checkmark.circle.fill"
+        case .running:
+            return "figure.outdoor.cycle"
+        }
+    }
+
+    var controlsAreVisuallyAvailable: Bool {
+        canMarkSegment || canPause || canResume
+    }
+}

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityWidget.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityWidget.swift
@@ -11,29 +11,32 @@ struct WorkoutLiveActivityWidget: Widget {
                 .activityBackgroundTint(Color.black.opacity(0.92))
                 .activitySystemActionForegroundColor(.white)
         } dynamicIsland: { context in
-            DynamicIsland {
+            let state = context.state.displayState(
+                isSystemStale: context.isStale
+            )
+            return DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
                     WorkoutLiveActivityStatusView(
-                        state: context.state,
+                        state: state,
                         compact: true
                     )
                 }
                 DynamicIslandExpandedRegion(.trailing) {
                     WorkoutLiveActivityElapsedView(
-                        state: context.state,
+                        state: state,
                         font: .title3.monospacedDigit()
                     )
                 }
                 DynamicIslandExpandedRegion(.center) {
                     WorkoutLiveActivityMetricStrip(
-                        state: context.state,
+                        state: state,
                         compact: true
                     )
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     WorkoutLiveActivityControls(
                         sessionID: context.attributes.sessionID,
-                        state: context.state
+                        state: state
                     )
                     .padding(.top, 4)
                 }
@@ -41,19 +44,19 @@ struct WorkoutLiveActivityWidget: Widget {
                 HStack(spacing: 3) {
                     Image(systemName: "figure.outdoor.cycle")
                     Circle()
-                        .fill(context.state.statusColor)
+                        .fill(state.statusColor)
                         .frame(width: 6, height: 6)
                 }
-                .accessibilityLabel(context.state.statusTitle)
+                .accessibilityLabel(state.statusTitle)
             } compactTrailing: {
                 WorkoutLiveActivityElapsedView(
-                    state: context.state,
+                    state: state,
                     font: .caption.monospacedDigit()
                 )
             } minimal: {
-                Image(systemName: context.state.minimalSymbolName)
-                    .foregroundStyle(context.state.statusColor)
-                    .accessibilityLabel(context.state.statusTitle)
+                Image(systemName: state.minimalSymbolName)
+                    .foregroundStyle(state.statusColor)
+                    .accessibilityLabel(state.statusTitle)
             }
             .keylineTint(.green)
         }

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityWidget.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityWidget.swift
@@ -1,0 +1,61 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+struct WorkoutLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(
+            for: WorkoutLiveActivityAttributes.self
+        ) { context in
+            WorkoutLiveActivityLockScreenView(context: context)
+                .activityBackgroundTint(Color.black.opacity(0.92))
+                .activitySystemActionForegroundColor(.white)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    WorkoutLiveActivityStatusView(
+                        state: context.state,
+                        compact: true
+                    )
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    WorkoutLiveActivityElapsedView(
+                        state: context.state,
+                        font: .title3.monospacedDigit()
+                    )
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    WorkoutLiveActivityMetricStrip(
+                        state: context.state,
+                        compact: true
+                    )
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    WorkoutLiveActivityControls(
+                        sessionID: context.attributes.sessionID,
+                        state: context.state
+                    )
+                    .padding(.top, 4)
+                }
+            } compactLeading: {
+                HStack(spacing: 3) {
+                    Image(systemName: "figure.outdoor.cycle")
+                    Circle()
+                        .fill(context.state.statusColor)
+                        .frame(width: 6, height: 6)
+                }
+                .accessibilityLabel(context.state.statusTitle)
+            } compactTrailing: {
+                WorkoutLiveActivityElapsedView(
+                    state: context.state,
+                    font: .caption.monospacedDigit()
+                )
+            } minimal: {
+                Image(systemName: context.state.minimalSymbolName)
+                    .foregroundStyle(context.state.statusColor)
+                    .accessibilityLabel(context.state.statusTitle)
+            }
+            .keylineTint(.green)
+        }
+    }
+}

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
@@ -18,6 +18,8 @@ nonisolated enum WorkoutLiveActivityPendingAction:
     case segment
     case pause
     case resume
+    case endAndSave
+    case discard
 }
 
 @available(iOS 17.0, *)
@@ -35,6 +37,7 @@ nonisolated enum WorkoutLiveActivityDisplayError:
     case segmentRejected
     case segmentUnconfirmed
     case controlsUnavailable
+    case finalSummaryUnavailable
 }
 
 @available(iOS 17.0, *)
@@ -50,13 +53,14 @@ nonisolated struct WorkoutLiveActivityAttributes:
     struct ContentState: Codable, Hashable, Sendable {
         let phase: WorkoutLiveActivityPhase
         let capturedAt: Date
-        let elapsedActiveSeconds: TimeInterval
+        let elapsedActiveSeconds: TimeInterval?
         let currentSpeedKilometersPerHour: Double?
         let cyclingDistanceMeters: Double?
         let currentHeartRateBPM: Double?
         let lastCompletedSegmentIndex: UInt32?
         let lastCompletedSegmentDuration: TimeInterval?
         let lastCompletedSegmentDistanceMeters: Double?
+        let isSegmentControlAvailable: Bool
         let pendingAction: WorkoutLiveActivityPendingAction
         let finalOutcome: WorkoutLiveActivityFinalOutcome
         let displayError: WorkoutLiveActivityDisplayError
@@ -69,11 +73,15 @@ nonisolated struct WorkoutLiveActivityAttributes:
         }
 
         var controlsEnabled: Bool {
-            phase == .running && pendingAction == .none
+            phase == .running
+                && pendingAction == .none
+                && displayError != .controlsUnavailable
         }
 
         var canMarkSegment: Bool {
             controlsEnabled
+                && isSegmentControlAvailable
+                && displayError != .segmentUnconfirmed
         }
 
         var canPause: Bool {
@@ -81,11 +89,37 @@ nonisolated struct WorkoutLiveActivityAttributes:
         }
 
         var canResume: Bool {
-            phase == .paused && pendingAction == .none
+            phase == .paused
+                && pendingAction == .none
+                && displayError != .controlsUnavailable
         }
 
         var isTerminal: Bool {
             phase == .final
+        }
+
+        func displayState(isSystemStale: Bool) -> Self {
+            guard isSystemStale,
+                  phase == .running || phase == .paused else {
+                return self
+            }
+            return Self(
+                phase: .stale,
+                capturedAt: capturedAt,
+                elapsedActiveSeconds: elapsedActiveSeconds,
+                currentSpeedKilometersPerHour: nil,
+                cyclingDistanceMeters: cyclingDistanceMeters,
+                currentHeartRateBPM: nil,
+                lastCompletedSegmentIndex: lastCompletedSegmentIndex,
+                lastCompletedSegmentDuration:
+                    lastCompletedSegmentDuration,
+                lastCompletedSegmentDistanceMeters:
+                    lastCompletedSegmentDistanceMeters,
+                isSegmentControlAvailable: isSegmentControlAvailable,
+                pendingAction: pendingAction,
+                finalOutcome: finalOutcome,
+                displayError: .controlsUnavailable
+            )
         }
     }
 

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
@@ -1,0 +1,109 @@
+import ActivityKit
+import Foundation
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityPhase: String, Codable, Hashable, Sendable {
+    case running
+    case paused
+    case stale
+    case disconnected
+    case ending
+    case final
+}
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityPendingAction:
+    String, Codable, Hashable, Sendable {
+    case none
+    case segment
+    case pause
+    case resume
+}
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityFinalOutcome:
+    String, Codable, Hashable, Sendable {
+    case none
+    case saved
+    case discarded
+}
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityDisplayError:
+    String, Codable, Hashable, Sendable {
+    case none
+    case segmentRejected
+    case segmentUnconfirmed
+    case controlsUnavailable
+}
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityAction: String, Codable, Hashable, Sendable {
+    case segment
+    case pause
+    case resume
+}
+
+@available(iOS 17.0, *)
+nonisolated struct WorkoutLiveActivityAttributes:
+    ActivityAttributes, Hashable, Sendable {
+    struct ContentState: Codable, Hashable, Sendable {
+        let phase: WorkoutLiveActivityPhase
+        let capturedAt: Date
+        let elapsedActiveSeconds: TimeInterval
+        let currentSpeedKilometersPerHour: Double?
+        let cyclingDistanceMeters: Double?
+        let currentHeartRateBPM: Double?
+        let lastCompletedSegmentIndex: UInt32?
+        let lastCompletedSegmentDuration: TimeInterval?
+        let lastCompletedSegmentDistanceMeters: Double?
+        let pendingAction: WorkoutLiveActivityPendingAction
+        let finalOutcome: WorkoutLiveActivityFinalOutcome
+        let displayError: WorkoutLiveActivityDisplayError
+
+        var currentSegmentIndex: UInt32 {
+            guard let lastCompletedSegmentIndex else { return 1 }
+            return lastCompletedSegmentIndex == .max
+                ? .max
+                : lastCompletedSegmentIndex + 1
+        }
+
+        var controlsEnabled: Bool {
+            phase == .running && pendingAction == .none
+        }
+
+        var canMarkSegment: Bool {
+            controlsEnabled
+        }
+
+        var canPause: Bool {
+            controlsEnabled
+        }
+
+        var canResume: Bool {
+            phase == .paused && pendingAction == .none
+        }
+
+        var isTerminal: Bool {
+            phase == .final
+        }
+    }
+
+    enum ActivityKind: String, Codable, Hashable, Sendable {
+        case outdoorCycling
+    }
+
+    let sessionID: UUID
+    let workoutStartDate: Date
+    let activityKind: ActivityKind
+
+    init(
+        sessionID: UUID,
+        workoutStartDate: Date,
+        activityKind: ActivityKind = .outdoorCycling
+    ) {
+        self.sessionID = sessionID
+        self.workoutStartDate = workoutStartDate
+        self.activityKind = activityKind
+    }
+}

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityFormatting.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityFormatting.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+@available(iOS 17.0, *)
+nonisolated enum WorkoutLiveActivityFormatting {
+    static func duration(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "—" }
+        let total = Int(min(seconds.rounded(.down), Double(Int32.max)))
+        let hours = total / 3_600
+        let minutes = (total % 3_600) / 60
+        let remainingSeconds = total % 60
+        if hours > 0 {
+            return String(
+                format: "%d:%02d:%02d",
+                hours,
+                minutes,
+                remainingSeconds
+            )
+        }
+        return String(format: "%02d:%02d", minutes, remainingSeconds)
+    }
+
+    static func speed(_ kilometersPerHour: Double?) -> String {
+        guard let kilometersPerHour,
+              kilometersPerHour.isFinite,
+              kilometersPerHour >= 0 else {
+            return "—"
+        }
+        return String(format: "%.1f", kilometersPerHour)
+    }
+
+    static func distance(_ meters: Double?) -> String {
+        guard let meters, meters.isFinite, meters >= 0 else { return "—" }
+        if meters >= 1_000 {
+            return String(format: "%.1f", meters / 1_000)
+        }
+        return String(format: "%.0f", meters)
+    }
+
+    static func distanceUnit(_ meters: Double?) -> String {
+        guard let meters, meters.isFinite, meters >= 1_000 else { return "M" }
+        return "KM"
+    }
+
+    static func heartRate(_ beatsPerMinute: Double?) -> String {
+        guard let beatsPerMinute,
+              beatsPerMinute.isFinite,
+              beatsPerMinute > 0 else {
+            return "—"
+        }
+        return String(format: "%.0f", beatsPerMinute)
+    }
+
+    static func segmentSummary(
+        index: UInt32?,
+        duration: TimeInterval?,
+        distanceMeters: Double?
+    ) -> String? {
+        guard let index else { return nil }
+        var parts = ["SEG \(index)"]
+        if let duration, duration.isFinite, duration >= 0 {
+            parts.append(Self.duration(duration))
+        }
+        if let distanceMeters,
+           distanceMeters.isFinite,
+           distanceMeters >= 0 {
+            parts.append(
+                "\(distance(distanceMeters)) \(distanceUnit(distanceMeters))"
+            )
+        }
+        return parts.joined(separator: " · ")
+    }
+}

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
@@ -28,14 +28,33 @@ final class WorkoutLiveActivityIntentDispatcher: @unchecked Sendable {
 }
 
 @available(iOS 17.0, *)
-private enum WorkoutLiveActivityIntentExecution {
+enum WorkoutLiveActivityIntentError: LocalizedError {
+    case invalidSession
+    case commandRejected
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidSession:
+            return "This workout control is no longer valid."
+        case .commandRejected:
+            return "The workout control could not be sent to Apple Watch."
+        }
+    }
+}
+
+@available(iOS 17.0, *)
+enum WorkoutLiveActivityIntentExecution {
     static func perform(
         _ action: WorkoutLiveActivityAction,
         sessionID: String,
         dispatcher: WorkoutLiveActivityIntentDispatcher
-    ) async {
-        guard let sessionID = UUID(uuidString: sessionID) else { return }
-        _ = await dispatcher.perform(action, sessionID: sessionID)
+    ) async throws {
+        guard let sessionID = UUID(uuidString: sessionID) else {
+            throw WorkoutLiveActivityIntentError.invalidSession
+        }
+        guard await dispatcher.perform(action, sessionID: sessionID) else {
+            throw WorkoutLiveActivityIntentError.commandRejected
+        }
     }
 }
 
@@ -46,6 +65,8 @@ struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
         "Marks a segment in the active BikeComputer workout on Apple Watch."
     )
     static let openAppWhenRun = false
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresAuthentication
 
     @Parameter(title: "Workout Session")
     var sessionID: String
@@ -60,7 +81,7 @@ struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        await WorkoutLiveActivityIntentExecution.perform(
+        try await WorkoutLiveActivityIntentExecution.perform(
             .segment,
             sessionID: sessionID,
             dispatcher: dispatcher
@@ -76,6 +97,8 @@ struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
         "Pauses the active BikeComputer workout on Apple Watch."
     )
     static let openAppWhenRun = false
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresAuthentication
 
     @Parameter(title: "Workout Session")
     var sessionID: String
@@ -90,7 +113,7 @@ struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        await WorkoutLiveActivityIntentExecution.perform(
+        try await WorkoutLiveActivityIntentExecution.perform(
             .pause,
             sessionID: sessionID,
             dispatcher: dispatcher
@@ -106,6 +129,8 @@ struct BikeComputerResumeWorkoutIntent: LiveActivityIntent {
         "Resumes the paused BikeComputer workout on Apple Watch."
     )
     static let openAppWhenRun = false
+    static let authenticationPolicy: IntentAuthenticationPolicy =
+        .requiresAuthentication
 
     @Parameter(title: "Workout Session")
     var sessionID: String
@@ -120,7 +145,7 @@ struct BikeComputerResumeWorkoutIntent: LiveActivityIntent {
     }
 
     func perform() async throws -> some IntentResult {
-        await WorkoutLiveActivityIntentExecution.perform(
+        try await WorkoutLiveActivityIntentExecution.perform(
             .resume,
             sessionID: sessionID,
             dispatcher: dispatcher

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
@@ -1,0 +1,130 @@
+import AppIntents
+import Foundation
+
+@available(iOS 17.0, *)
+final class WorkoutLiveActivityIntentDispatcher: @unchecked Sendable {
+    static let unavailable = WorkoutLiveActivityIntentDispatcher {
+        _, _ in false
+    }
+
+    private let handler:
+        @MainActor @Sendable (WorkoutLiveActivityAction, UUID) async -> Bool
+
+    init(
+        handler: @escaping @MainActor @Sendable (
+            WorkoutLiveActivityAction,
+            UUID
+        ) async -> Bool
+    ) {
+        self.handler = handler
+    }
+
+    func perform(
+        _ action: WorkoutLiveActivityAction,
+        sessionID: UUID
+    ) async -> Bool {
+        await handler(action, sessionID)
+    }
+}
+
+@available(iOS 17.0, *)
+private enum WorkoutLiveActivityIntentExecution {
+    static func perform(
+        _ action: WorkoutLiveActivityAction,
+        sessionID: String,
+        dispatcher: WorkoutLiveActivityIntentDispatcher
+    ) async {
+        guard let sessionID = UUID(uuidString: sessionID) else { return }
+        _ = await dispatcher.perform(action, sessionID: sessionID)
+    }
+}
+
+@available(iOS 17.0, *)
+struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Mark Workout Segment"
+    static let description = IntentDescription(
+        "Marks a segment in the active BikeComputer workout on Apple Watch."
+    )
+    static let openAppWhenRun = false
+
+    @Parameter(title: "Workout Session")
+    var sessionID: String
+
+    @AppDependency(default: .unavailable)
+    private var dispatcher: WorkoutLiveActivityIntentDispatcher
+
+    init() {}
+
+    init(sessionID: UUID) {
+        self.sessionID = sessionID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        await WorkoutLiveActivityIntentExecution.perform(
+            .segment,
+            sessionID: sessionID,
+            dispatcher: dispatcher
+        )
+        return .result()
+    }
+}
+
+@available(iOS 17.0, *)
+struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Pause Workout"
+    static let description = IntentDescription(
+        "Pauses the active BikeComputer workout on Apple Watch."
+    )
+    static let openAppWhenRun = false
+
+    @Parameter(title: "Workout Session")
+    var sessionID: String
+
+    @AppDependency(default: .unavailable)
+    private var dispatcher: WorkoutLiveActivityIntentDispatcher
+
+    init() {}
+
+    init(sessionID: UUID) {
+        self.sessionID = sessionID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        await WorkoutLiveActivityIntentExecution.perform(
+            .pause,
+            sessionID: sessionID,
+            dispatcher: dispatcher
+        )
+        return .result()
+    }
+}
+
+@available(iOS 17.0, *)
+struct BikeComputerResumeWorkoutIntent: LiveActivityIntent {
+    static let title: LocalizedStringResource = "Resume Workout"
+    static let description = IntentDescription(
+        "Resumes the paused BikeComputer workout on Apple Watch."
+    )
+    static let openAppWhenRun = false
+
+    @Parameter(title: "Workout Session")
+    var sessionID: String
+
+    @AppDependency(default: .unavailable)
+    private var dispatcher: WorkoutLiveActivityIntentDispatcher
+
+    init() {}
+
+    init(sessionID: UUID) {
+        self.sessionID = sessionID.uuidString
+    }
+
+    func perform() async throws -> some IntentResult {
+        await WorkoutLiveActivityIntentExecution.perform(
+            .resume,
+            sessionID: sessionID,
+            dispatcher: dispatcher
+        )
+        return .result()
+    }
+}

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
@@ -625,25 +625,35 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
             capturedAt: latestEnvelope?.capturedAt,
             receivedAt: lastReceivedAt,
             confirmedSessionState: confirmedSessionState,
-            errorCode: errorCode == .anotherWorkoutActive
-                || latestEnvelope?.snapshot?.errorCode
-                    == .anotherWorkoutActive
-                ? .anotherWorkoutActive
-                : latestEnvelope?.snapshot?.errorCode
-                    ?? commandErrorCode
-                    ?? errorCode,
+            errorCode: presentationErrorCode,
             pendingControl: pendingControl,
             finalSnapshot: finalSnapshot,
             navigation: .empty
         )
     }
 
+    private var presentationErrorCode: WorkoutSafeErrorCodeV1? {
+        if commandErrorCode == .finalSummaryUnavailable {
+            return .finalSummaryUnavailable
+        }
+        if errorCode == .anotherWorkoutActive
+            || latestEnvelope?.snapshot?.errorCode
+                == .anotherWorkoutActive {
+            return .anotherWorkoutActive
+        }
+        if commandErrorCode == .terminalChoiceUnconfirmed {
+            return commandErrorCode
+        }
+        return latestEnvelope?.snapshot?.errorCode
+            ?? commandErrorCode
+            ?? errorCode
+    }
+
     var canResetTerminalPresentation: Bool {
         guard !presentation.isWorkoutActive,
               pendingControl == nil else { return false }
         guard connectionState == .ended else { return true }
-        return finalSnapshot != nil
-            || commandErrorCode == .terminalChoiceUnconfirmed
+        return finalSnapshot?.terminalOutcome != nil
             || commandErrorCode == .finalSummaryUnavailable
     }
 
@@ -1137,7 +1147,7 @@ nonisolated struct WorkoutMirrorStateReducer: Sendable {
     @discardableResult
     mutating func timeOutFinalSnapshot() -> Bool {
         guard connectionState == .ended,
-              finalSnapshot == nil,
+              finalSnapshot?.terminalOutcome == nil,
               pendingControl == nil else { return false }
         commandErrorCode = .finalSummaryUnavailable
         return true

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -7,10 +7,18 @@ private final class FakeWorkoutLiveActivityClient:
     var recordsValue: [WorkoutLiveActivityRecord] = []
     var requestError: Error?
     var updateError: Error?
+    private var shouldSuspendNextUpdate = false
+    private var suspendedUpdate:
+        CheckedContinuation<Void, Never>?
+    private var shouldSuspendNextEnd = false
+    private var suspendedEnd:
+        CheckedContinuation<Void, Never>?
     private(set) var requestAttempts = 0
     private(set) var requests:
         [(WorkoutLiveActivityRecord, Date?)] = []
     private(set) var updates:
+        [(String, WorkoutLiveActivityAttributes.ContentState, Date?)] = []
+    private(set) var updateAttempts:
         [(String, WorkoutLiveActivityAttributes.ContentState, Date?)] = []
     private(set) var endings:
         [(
@@ -18,6 +26,7 @@ private final class FakeWorkoutLiveActivityClient:
             WorkoutLiveActivityAttributes.ContentState?,
             WorkoutLiveActivityDismissal
         )] = []
+    private(set) var endAttempts: [String] = []
     private var continuations:
         [String: AsyncStream<WorkoutLiveActivitySystemState>.Continuation] = [:]
 
@@ -50,10 +59,26 @@ private final class FakeWorkoutLiveActivityClient:
         contentState: WorkoutLiveActivityAttributes.ContentState,
         staleDate: Date?
     ) async throws {
+        updateAttempts.append((id, contentState, staleDate))
+        if shouldSuspendNextUpdate {
+            shouldSuspendNextUpdate = false
+            await withCheckedContinuation { continuation in
+                suspendedUpdate = continuation
+            }
+        }
         if let updateError {
             throw updateError
         }
         updates.append((id, contentState, staleDate))
+    }
+
+    func suspendNextUpdate() {
+        shouldSuspendNextUpdate = true
+    }
+
+    func resumeSuspendedUpdate() {
+        suspendedUpdate?.resume()
+        suspendedUpdate = nil
     }
 
     func end(
@@ -61,7 +86,32 @@ private final class FakeWorkoutLiveActivityClient:
         contentState: WorkoutLiveActivityAttributes.ContentState?,
         dismissal: WorkoutLiveActivityDismissal
     ) async {
+        endAttempts.append(id)
+        if shouldSuspendNextEnd {
+            shouldSuspendNextEnd = false
+            await withCheckedContinuation { continuation in
+                suspendedEnd = continuation
+            }
+        }
         endings.append((id, contentState, dismissal))
+        if let index = recordsValue.firstIndex(where: { $0.id == id }) {
+            let record = recordsValue[index]
+            recordsValue[index] = WorkoutLiveActivityRecord(
+                id: record.id,
+                attributes: record.attributes,
+                contentState: contentState ?? record.contentState,
+                systemState: .ended
+            )
+        }
+    }
+
+    func suspendNextEnd() {
+        shouldSuspendNextEnd = true
+    }
+
+    func resumeSuspendedEnd() {
+        suspendedEnd?.resume()
+        suspendedEnd = nil
     }
 
     func stateUpdates(
@@ -125,6 +175,40 @@ private final class WorkoutLiveActivityWaitScheduler {
     func resumeNext() {
         guard !continuations.isEmpty else { return }
         continuations.removeFirst().resume()
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+private final class FakeWorkoutBackgroundExecutionLease:
+    WorkoutBackgroundExecutionLeasing {
+    private(set) var isActive = false
+    private(set) var beginCount = 0
+    private(set) var endCount = 0
+    private var expirationHandler:
+        (@MainActor @Sendable () -> Void)?
+
+    func begin(
+        expirationHandler: @escaping @MainActor @Sendable () -> Void
+    ) {
+        guard !isActive else { return }
+        isActive = true
+        beginCount += 1
+        self.expirationHandler = expirationHandler
+    }
+
+    func end() {
+        guard isActive else { return }
+        isActive = false
+        endCount += 1
+        expirationHandler = nil
+    }
+
+    func expireSynchronously() {
+        guard isActive else { return }
+        let expirationHandler = expirationHandler
+        expirationHandler?()
+        end()
     }
 }
 
@@ -194,6 +278,56 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(client.updates.first?.1.phase, .paused)
     }
 
+    func testActiveTransportReplacementRetainsExistingActivity() async {
+        let sessionID = UUID()
+        let running = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(running)
+        let client = FakeWorkoutLiveActivityClient()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            WorkoutMirrorPresentationV1(
+                connectionState: .awaitingFirstSnapshot,
+                snapshot: running.snapshot,
+                sessionID: running.sessionID,
+                capturedAt: running.capturedAt,
+                receivedAt: running.receivedAt,
+                confirmedSessionState: running.confirmedSessionState,
+                errorCode: nil,
+                pendingControl: nil,
+                finalSnapshot: nil,
+                navigation: running.navigation
+            )
+        )
+        await settle()
+
+        XCTAssertTrue(client.endings.isEmpty)
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .paused,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(client.updates.last?.1.phase, .paused)
+        XCTAssertTrue(suppression.contains(sessionID))
+    }
+
     func testEquivalentPresentationDoesNotUpdate() async {
         let presentation = makeLiveActivityPresentation(
             capturedAt: capturedAt
@@ -254,6 +388,59 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         )
     }
 
+    func testMetricRevertCancelsPendingDueState() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                speedMetersPerSecond: 9
+            )
+        )
+        await settle()
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                speedMetersPerSecond: 8
+            )
+        )
+        await settle()
+        scheduler.resumeNext()
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                speedMetersPerSecond: 10
+            )
+        )
+        await settle()
+
+        XCTAssertTrue(client.updates.isEmpty)
+        XCTAssertEqual(scheduler.requestedIntervals.count, 2)
+        scheduler.resumeNext()
+        await settle()
+        XCTAssertEqual(
+            client.updates.last?.1.currentSpeedKilometersPerHour,
+            36
+        )
+    }
+
     func testStateTransitionBypassesMetricCoalescing() async {
         let sessionID = UUID()
         let source = source(sessionID: sessionID)
@@ -281,6 +468,85 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(client.updates.count, 1)
         XCTAssertEqual(client.updates.first?.1.phase, .paused)
         XCTAssertTrue(scheduler.requestedIntervals.isEmpty)
+    }
+
+    func testStateTransitionsPublishInOrderWhenEarlierUpdateSuspends()
+        async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+        client.suspendNextUpdate()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .paused,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+        XCTAssertEqual(client.updateAttempts.map(\.1.phase), [.paused])
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .running,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+        XCTAssertEqual(client.updateAttempts.map(\.1.phase), [.paused])
+
+        client.resumeSuspendedUpdate()
+        await settle()
+
+        XCTAssertEqual(
+            client.updateAttempts.map(\.1.phase),
+            [.paused, .running]
+        )
+        XCTAssertEqual(client.updates.map(\.1.phase), [.paused, .running])
+    }
+
+    func testSessionRolloverCannotBeClearedBySuspendedPriorEnd() async {
+        let firstSessionID = UUID()
+        let secondSessionID = UUID()
+        let source = source(sessionID: firstSessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+        client.suspendNextEnd()
+
+        let secondPresentation = makeLiveActivityPresentation(
+            sessionID: secondSessionID,
+            capturedAt: capturedAt
+        )
+        source.send(secondPresentation)
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["activity-1"])
+        XCTAssertEqual(client.requests.count, 1)
+
+        source.send(secondPresentation)
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["activity-1"])
+
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["activity-1"])
+        XCTAssertEqual(
+            client.requests.map(\.0.attributes.sessionID),
+            [firstSessionID, secondSessionID]
+        )
+        XCTAssertTrue(suppression.contains(secondSessionID))
     }
 
     func testSegmentAcknowledgementBypassesMetricCoalescing() async {
@@ -364,6 +630,152 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(Set(client.endings.map(\.0)), ["duplicate", "orphan"])
     }
 
+    func testInitialReconciliationRechecksSessionBetweenAwaitedEnds()
+        async throws {
+        let firstSessionID = UUID()
+        let recoveredSessionID = UUID()
+        let first = makeLiveActivityPresentation(
+            sessionID: firstSessionID,
+            capturedAt: capturedAt
+        )
+        let recovered = makeLiveActivityPresentation(
+            sessionID: recoveredSessionID,
+            capturedAt: capturedAt
+        )
+        let unrelated = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(capturedAt: capturedAt),
+                at: capturedAt
+            )
+        )
+        let recoveredMapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                recovered,
+                at: capturedAt
+            )
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(first)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("unrelated", mapped: unrelated),
+            record("recovered", mapped: recoveredMapped),
+        ]
+        client.suspendNextEnd()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: false)
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["unrelated"])
+
+        source.send(recovered)
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["unrelated"])
+        XCTAssertFalse(client.endAttempts.contains("recovered"))
+        XCTAssertTrue(client.requests.isEmpty)
+    }
+
+    func testInitialReconciliationRetainsTerminalLeaseDuringDuplicateEnd()
+        async throws {
+        let sessionID = UUID()
+        let active = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let terminal = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt,
+            terminalOutcome: .saved
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(active)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("matching", mapped: mapped),
+            record("duplicate", mapped: mapped),
+        ]
+        client.suspendNextEnd()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["duplicate"])
+
+        source.send(terminal)
+        XCTAssertTrue(
+            lease.isActive,
+            "terminal publication must acquire the controller lease synchronously"
+        )
+
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), [
+            "duplicate",
+            "matching",
+        ])
+        XCTAssertEqual(client.endings.last?.1?.finalOutcome, .saved)
+        XCTAssertFalse(lease.isActive)
+        XCTAssertEqual(lease.beginCount, 1)
+        XCTAssertEqual(lease.endCount, 1)
+    }
+
+    func testInitialReconciliationReleasesRetractedTerminalLease()
+        async throws {
+        let sessionID = UUID()
+        let active = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let terminal = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt,
+            terminalOutcome: .saved
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(active)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("matching", mapped: mapped),
+            record("duplicate", mapped: mapped),
+        ]
+        client.suspendNextEnd()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+
+        source.send(terminal)
+        XCTAssertTrue(lease.isActive)
+        source.send(active)
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["duplicate"])
+        XCTAssertFalse(lease.isActive)
+        XCTAssertEqual(lease.beginCount, 1)
+        XCTAssertEqual(lease.endCount, 1)
+    }
+
     func testReconciliationGraceRetainsColdLaunchActivityUntilRecovery()
         async throws {
         let sessionID = UUID()
@@ -390,9 +802,11 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
             record("existing", mapped: mapped),
         ]
         let scheduler = WorkoutLiveActivityWaitScheduler()
+        let lease = FakeWorkoutBackgroundExecutionLease()
         let controller = makeController(
             source: source,
             client: client,
+            finalizationBackgroundLease: lease,
             wait: { interval in
                 try await scheduler.wait(interval)
             }
@@ -404,9 +818,11 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(scheduler.requestedIntervals, [
             WorkoutLiveActivityController.reconciliationGracePeriod,
         ])
+        XCTAssertTrue(lease.isActive)
 
         source.send(active)
         await settle()
+        XCTAssertFalse(lease.isActive)
         scheduler.resumeNext()
         await settle()
 
@@ -442,6 +858,358 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(client.endings.count, 1)
         XCTAssertEqual(client.endings.first?.0, "orphan")
         XCTAssertEqual(client.endings.first?.2, .immediate)
+    }
+
+    func testReconciliationGraceUsesBackgroundBudgetAndLease()
+        async throws {
+        let active = makeLiveActivityPresentation(capturedAt: capturedAt)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("orphan", mapped: mapped)]
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease,
+            backgroundTimeRemaining: { 8 },
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+
+        XCTAssertTrue(lease.isActive)
+        XCTAssertEqual(scheduler.requestedIntervals, [3])
+
+        scheduler.resumeNext()
+        await settle()
+
+        XCTAssertFalse(lease.isActive)
+        XCTAssertEqual(client.endings.map(\.0), ["orphan"])
+    }
+
+    func testReconciliationExpirationSchedulesCleanupForNextExecutionTurn()
+        async throws {
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(capturedAt: capturedAt),
+                at: capturedAt
+            )
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("orphan", mapped: mapped)]
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+        XCTAssertTrue(lease.isActive)
+
+        lease.expireSynchronously()
+        XCTAssertFalse(lease.isActive)
+        XCTAssertTrue(client.endAttempts.isEmpty)
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["orphan"])
+    }
+
+    func testReconciliationGraceFinalizesRecoveredEndingActivity()
+        async throws {
+        let sessionID = UUID()
+        let ending = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(ending, at: capturedAt)
+        )
+        XCTAssertEqual(mapped.contentState.phase, .ending)
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("ending", mapped: mapped)]
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression,
+            finalizationBackgroundLease: lease,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+        XCTAssertTrue(lease.isActive)
+
+        scheduler.resumeNext()
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.1?.phase, .final)
+        XCTAssertEqual(
+            client.endings.first?.1?.displayError,
+            .finalSummaryUnavailable
+        )
+        XCTAssertEqual(
+            client.endings.first?.2,
+            .after(
+                capturedAt.addingTimeInterval(
+                    WorkoutLiveActivityController
+                        .finalSummaryDismissalInterval
+                )
+            )
+        )
+        XCTAssertTrue(suppression.contains(sessionID))
+        XCTAssertFalse(lease.isActive)
+    }
+
+    func testRecoveredEndingCutoffPreventsSecondSameSessionActivity()
+        async throws {
+        let sessionID = UUID()
+        let ending = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(ending, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("ending", mapped: mapped)]
+        client.suspendNextEnd()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        scheduler.resumeNext()
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["ending"])
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+        XCTAssertTrue(client.requests.isEmpty)
+
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertTrue(client.requests.isEmpty)
+        XCTAssertTrue(suppression.contains(sessionID))
+    }
+
+    func testTerminalRecoveryQueuedBeforeRelaunchCutoffWins()
+        async throws {
+        let sessionID = UUID()
+        let ending = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(ending, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("ending", mapped: mapped)]
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        scheduler.resumeNext()
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                terminalOutcome: .saved
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.1?.finalOutcome, .saved)
+        XCTAssertEqual(
+            client.endings.first?.2,
+            .after(
+                capturedAt.addingTimeInterval(
+                    WorkoutLiveActivityController
+                        .finalSummaryDismissalInterval
+                )
+            )
+        )
+    }
+
+    func testGraceCleanupRechecksTruthBetweenAwaitedEnds()
+        async throws {
+        let recoveredSessionID = UUID()
+        let unrelatedMapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(capturedAt: capturedAt),
+                at: capturedAt
+            )
+        )
+        let ending = makeLiveActivityPresentation(
+            sessionID: recoveredSessionID,
+            state: .ended,
+            connection: .ended,
+            capturedAt: capturedAt
+        )
+        let endingMapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                ending,
+                at: capturedAt
+            )
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("unrelated", mapped: unrelatedMapped),
+            record("recovered", mapped: endingMapped),
+        ]
+        client.suspendNextEnd()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        scheduler.resumeNext()
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["unrelated"])
+        XCTAssertTrue(
+            lease.isActive,
+            "the grace lease must span the entire reconciliation batch"
+        )
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: recoveredSessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                terminalOutcome: .saved
+            )
+        )
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), [
+            "unrelated",
+            "recovered",
+        ])
+        XCTAssertNil(client.endings.first?.1)
+        XCTAssertEqual(
+            client.endings.last?.1?.finalOutcome,
+            .saved
+        )
+        XCTAssertFalse(lease.isActive)
+    }
+
+    func testReconciliationGraceSerializesRecoveryWithOrphanCleanup()
+        async throws {
+        let sessionID = UUID()
+        let active = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("existing", mapped: mapped)]
+        client.suspendNextEnd()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        suppression.insert(sessionID)
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        scheduler.resumeNext()
+        await settle()
+        XCTAssertEqual(client.endAttempts, ["existing"])
+
+        source.send(active)
+        await settle()
+        XCTAssertTrue(
+            client.requests.isEmpty,
+            "recovery must not create while the old Activity is still ending"
+        )
+
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["existing"])
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(
+            client.requests.first?.0.attributes.sessionID,
+            sessionID
+        )
+        XCTAssertTrue(suppression.contains(sessionID))
     }
 
     func testDismissalSuppressesRecreationForSameSession() async throws {
@@ -484,6 +1252,183 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
 
         XCTAssertEqual(client.requests.count, 1)
         XCTAssertTrue(client.endings.isEmpty)
+    }
+
+    func testCreatedSessionDoesNotRecreateAfterProcessDeath() async {
+        let sessionID = UUID()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let firstClient = FakeWorkoutLiveActivityClient()
+        let firstController = makeController(
+            source: source(sessionID: sessionID),
+            client: firstClient,
+            suppression: suppression
+        )
+        firstController.start(isApplicationForeground: true)
+        await settle()
+
+        XCTAssertEqual(firstClient.requests.count, 1)
+        XCTAssertTrue(suppression.contains(sessionID))
+
+        let relaunchedClient = FakeWorkoutLiveActivityClient()
+        let relaunchedController = makeController(
+            source: source(sessionID: sessionID),
+            client: relaunchedClient,
+            suppression: suppression
+        )
+        relaunchedController.start(isApplicationForeground: true)
+        await settle()
+
+        XCTAssertTrue(relaunchedClient.requests.isEmpty)
+    }
+
+    func testNativeEndWaitsForAuthoritativeSavedFinalSnapshot() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.updates.last?.1.phase, .ending)
+        XCTAssertTrue(client.endings.isEmpty)
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                terminalOutcome: .saved
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.1?.finalOutcome, .saved)
+        XCTAssertEqual(
+            client.endings.first?.2,
+            .after(
+                capturedAt.addingTimeInterval(
+                    WorkoutLiveActivityController
+                        .finalSummaryDismissalInterval
+                )
+            )
+        )
+    }
+
+    func testMissingFinalSnapshotEndsWithHonestUnavailableSummary()
+        async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                errorCode: .finalSummaryUnavailable
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.1?.phase, .final)
+        XCTAssertEqual(
+            client.endings.first?.1?.displayError,
+            .finalSummaryUnavailable
+        )
+        XCTAssertEqual(
+            client.endings.first?.2,
+            .after(
+                capturedAt.addingTimeInterval(
+                    WorkoutLiveActivityController
+                        .finalSummaryDismissalInterval
+                )
+            )
+        )
+    }
+
+    func testFinalizationBackgroundLeaseSpansActivityEndCompletion()
+        async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let controller = makeController(
+            source: source,
+            client: client,
+            finalizationBackgroundLease: lease
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+        client.suspendNextEnd()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                errorCode: .finalSummaryUnavailable
+            )
+        )
+        XCTAssertTrue(
+            lease.isActive,
+            "publisher delivery must acquire the controller lease synchronously"
+        )
+        await settle()
+
+        XCTAssertEqual(client.endAttempts, ["activity-1"])
+        XCTAssertTrue(lease.isActive)
+
+        client.resumeSuspendedEnd()
+        await settle()
+
+        XCTAssertFalse(lease.isActive)
+        XCTAssertEqual(lease.beginCount, 1)
+        XCTAssertEqual(lease.endCount, 1)
+    }
+
+    func testUnconfirmedTerminalChoiceWaitsForFinalCutoff() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                connection: .ended,
+                capturedAt: capturedAt,
+                errorCode: .terminalChoiceUnconfirmed
+            )
+        )
+        await settle()
+
+        XCTAssertTrue(client.endings.isEmpty)
+        XCTAssertEqual(client.updates.last?.1.phase, .ending)
+        XCTAssertEqual(
+            client.updates.last?.1.displayError,
+            .controlsUnavailable
+        )
     }
 
     func testSavedFinalSummaryEndsAfterFifteenMinutes() async {
@@ -591,6 +1536,9 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
             WorkoutLiveActivityAuthorizationProviding? = nil,
         suppression:
             WorkoutLiveActivitySuppressionStoring? = nil,
+        finalizationBackgroundLease:
+            (any WorkoutBackgroundExecutionLeasing)? = nil,
+        backgroundTimeRemaining: (() -> TimeInterval)? = nil,
         wait:
             (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
     ) -> WorkoutLiveActivityController {
@@ -602,6 +1550,11 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
                 ?? EnabledWorkoutLiveActivityAuthorization(),
             suppressionStore: suppression
                 ?? MemoryWorkoutLiveActivitySuppressionStore(),
+            finalizationBackgroundLease:
+                finalizationBackgroundLease,
+            backgroundTimeRemaining:
+                backgroundTimeRemaining
+                ?? { .greatestFiniteMagnitude },
             now: { referenceDate },
             wait: wait
         )

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -1,0 +1,627 @@
+import XCTest
+
+@available(iOS 17.0, *)
+@MainActor
+private final class FakeWorkoutLiveActivityClient:
+    WorkoutLiveActivityClient {
+    var recordsValue: [WorkoutLiveActivityRecord] = []
+    var requestError: Error?
+    var updateError: Error?
+    private(set) var requestAttempts = 0
+    private(set) var requests:
+        [(WorkoutLiveActivityRecord, Date?)] = []
+    private(set) var updates:
+        [(String, WorkoutLiveActivityAttributes.ContentState, Date?)] = []
+    private(set) var endings:
+        [(
+            String,
+            WorkoutLiveActivityAttributes.ContentState?,
+            WorkoutLiveActivityDismissal
+        )] = []
+    private var continuations:
+        [String: AsyncStream<WorkoutLiveActivitySystemState>.Continuation] = [:]
+
+    func records() -> [WorkoutLiveActivityRecord] {
+        recordsValue
+    }
+
+    func request(
+        attributes: WorkoutLiveActivityAttributes,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) throws -> WorkoutLiveActivityRecord {
+        requestAttempts += 1
+        if let requestError {
+            throw requestError
+        }
+        let record = WorkoutLiveActivityRecord(
+            id: "activity-\(requests.count + 1)",
+            attributes: attributes,
+            contentState: contentState,
+            systemState: .active
+        )
+        requests.append((record, staleDate))
+        recordsValue.append(record)
+        return record
+    }
+
+    func update(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState,
+        staleDate: Date?
+    ) async throws {
+        if let updateError {
+            throw updateError
+        }
+        updates.append((id, contentState, staleDate))
+    }
+
+    func end(
+        id: String,
+        contentState: WorkoutLiveActivityAttributes.ContentState?,
+        dismissal: WorkoutLiveActivityDismissal
+    ) async {
+        endings.append((id, contentState, dismissal))
+    }
+
+    func stateUpdates(
+        for id: String
+    ) -> AsyncStream<WorkoutLiveActivitySystemState> {
+        AsyncStream { continuation in
+            continuations[id] = continuation
+        }
+    }
+
+    func yield(
+        _ state: WorkoutLiveActivitySystemState,
+        for id: String
+    ) {
+        continuations[id]?.yield(state)
+    }
+}
+
+@available(iOS 17.0, *)
+private struct EnabledWorkoutLiveActivityAuthorization:
+    WorkoutLiveActivityAuthorizationProviding {
+    let areActivitiesEnabled: Bool
+
+    init(_ enabled: Bool = true) {
+        areActivitiesEnabled = enabled
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+private final class MemoryWorkoutLiveActivitySuppressionStore:
+    WorkoutLiveActivitySuppressionStoring {
+    private(set) var identifiers: Set<UUID> = []
+
+    func contains(_ sessionID: UUID) -> Bool {
+        identifiers.contains(sessionID)
+    }
+
+    func insert(_ sessionID: UUID) {
+        identifiers.insert(sessionID)
+    }
+
+    func remove(_ sessionID: UUID) {
+        identifiers.remove(sessionID)
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+private final class WorkoutLiveActivityWaitScheduler {
+    private(set) var requestedIntervals: [TimeInterval] = []
+    private var continuations: [CheckedContinuation<Void, Error>] = []
+
+    func wait(_ interval: TimeInterval) async throws {
+        requestedIntervals.append(interval)
+        try await withCheckedThrowingContinuation { continuation in
+            continuations.append(continuation)
+        }
+    }
+
+    func resumeNext() {
+        guard !continuations.isEmpty else { return }
+        continuations.removeFirst().resume()
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class WorkoutLiveActivityControllerTests: XCTestCase {
+    private let capturedAt =
+        Date(timeIntervalSinceReferenceDate: 800_500_000)
+
+    func testForegroundVerifiedWorkoutRequestsOnlyOneActivity() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+
+        controller.start(isApplicationForeground: true)
+        await settle()
+        controller.setApplicationForeground(true)
+        await settle()
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertEqual(
+            client.requests.first?.0.attributes.sessionID,
+            sessionID
+        )
+        XCTAssertEqual(
+            client.requests.first?.1,
+            capturedAt.addingTimeInterval(
+                WorkoutMirrorStateReducer.defaultStaleAfter
+            )
+        )
+    }
+
+    func testBackgroundWorkoutDefersStartUntilForeground() async {
+        let source = source()
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+
+        controller.start(isApplicationForeground: false)
+        await settle()
+        XCTAssertTrue(client.requests.isEmpty)
+
+        controller.setApplicationForeground(true)
+        await settle()
+        XCTAssertEqual(client.requests.count, 1)
+    }
+
+    func testBackgroundStateStillUpdatesExistingActivity() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        controller.setApplicationForeground(false)
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .paused,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.updates.count, 1)
+        XCTAssertEqual(client.updates.first?.1.phase, .paused)
+    }
+
+    func testEquivalentPresentationDoesNotUpdate() async {
+        let presentation = makeLiveActivityPresentation(
+            capturedAt: capturedAt
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(presentation)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(presentation)
+        await settle()
+
+        XCTAssertTrue(client.updates.isEmpty)
+    }
+
+    func testMetricBurstCoalescesLatestWins() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                speedMetersPerSecond: 9
+            )
+        )
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                speedMetersPerSecond: 10
+            )
+        )
+        await settle()
+
+        XCTAssertTrue(client.updates.isEmpty)
+        XCTAssertEqual(scheduler.requestedIntervals.count, 1)
+        scheduler.resumeNext()
+        await settle()
+
+        XCTAssertEqual(client.updates.count, 1)
+        XCTAssertEqual(
+            client.updates.first?.1.currentSpeedKilometersPerHour,
+            36
+        )
+    }
+
+    func testStateTransitionBypassesMetricCoalescing() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .paused,
+                capturedAt: capturedAt
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.updates.count, 1)
+        XCTAssertEqual(client.updates.first?.1.phase, .paused)
+        XCTAssertTrue(scheduler.requestedIntervals.isEmpty)
+    }
+
+    func testSegmentAcknowledgementBypassesMetricCoalescing() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+        let segment = WorkoutCompletedSegmentV1(
+            index: 1,
+            startedAt: capturedAt.addingTimeInterval(-60),
+            endedAt: capturedAt,
+            duration: 60,
+            distanceMeters: 500
+        )
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                segment: segment
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.updates.count, 1)
+        XCTAssertEqual(
+            client.updates.first?.1.lastCompletedSegmentIndex,
+            1
+        )
+        XCTAssertTrue(scheduler.requestedIntervals.isEmpty)
+    }
+
+    func testReconciliationRetainsMatchAndEndsDuplicatesAndOrphan()
+        async throws {
+        let sessionID = UUID()
+        let otherSessionID = UUID()
+        let presentation = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let content = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                presentation,
+                at: capturedAt
+            )
+        )
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("matching", mapped: content),
+            record("duplicate", mapped: content),
+            record(
+                "orphan",
+                mapped: try XCTUnwrap(
+                    WorkoutLiveActivityStateMapper.map(
+                        makeLiveActivityPresentation(
+                            sessionID: otherSessionID,
+                            capturedAt: capturedAt
+                        ),
+                        at: capturedAt
+                    )
+                )
+            ),
+        ]
+        let source =
+            TestWorkoutLiveActivityPresentationSource(presentation)
+        let controller = makeController(source: source, client: client)
+
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        XCTAssertTrue(client.requests.isEmpty)
+        XCTAssertEqual(Set(client.endings.map(\.0)), ["duplicate", "orphan"])
+    }
+
+    func testReconciliationGraceRetainsColdLaunchActivityUntilRecovery()
+        async throws {
+        let sessionID = UUID()
+        let active = makeLiveActivityPresentation(
+            sessionID: sessionID,
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let otherMapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt
+                ),
+                at: capturedAt
+            )
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [
+            record("other", mapped: otherMapped),
+            record("existing", mapped: mapped),
+        ]
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+
+        XCTAssertTrue(client.endings.isEmpty)
+        XCTAssertEqual(scheduler.requestedIntervals, [
+            WorkoutLiveActivityController.reconciliationGracePeriod,
+        ])
+
+        source.send(active)
+        await settle()
+        scheduler.resumeNext()
+        await settle()
+
+        XCTAssertEqual(client.endings.map(\.0), ["other"])
+        XCTAssertTrue(client.requests.isEmpty)
+    }
+
+    func testReconciliationGraceEndsOrphanAfterTimeout() async throws {
+        let active = makeLiveActivityPresentation(
+            capturedAt: capturedAt
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(active, at: capturedAt)
+        )
+        let source =
+            TestWorkoutLiveActivityPresentationSource(.idle)
+        let client = FakeWorkoutLiveActivityClient()
+        client.recordsValue = [record("orphan", mapped: mapped)]
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let controller = makeController(
+            source: source,
+            client: client,
+            wait: { interval in
+                try await scheduler.wait(interval)
+            }
+        )
+        controller.start(isApplicationForeground: false)
+        await settle()
+
+        scheduler.resumeNext()
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.0, "orphan")
+        XCTAssertEqual(client.endings.first?.2, .immediate)
+    }
+
+    func testDismissalSuppressesRecreationForSameSession() async throws {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let suppression = MemoryWorkoutLiveActivitySuppressionStore()
+        let controller = makeController(
+            source: source,
+            client: client,
+            suppression: suppression
+        )
+        controller.start(isApplicationForeground: true)
+        await settle()
+        let activityID = try XCTUnwrap(client.requests.first?.0.id)
+
+        client.yield(.dismissed, for: activityID)
+        await settle()
+        controller.setApplicationForeground(true)
+        await settle()
+
+        XCTAssertTrue(suppression.contains(sessionID))
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertTrue(client.endings.isEmpty)
+    }
+
+    func testSystemExpirationDoesNotRecreateSameSession() async throws {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+        let activityID = try XCTUnwrap(client.requests.first?.0.id)
+
+        client.yield(.ended, for: activityID)
+        await settle()
+        controller.setApplicationForeground(true)
+        await settle()
+
+        XCTAssertEqual(client.requests.count, 1)
+        XCTAssertTrue(client.endings.isEmpty)
+    }
+
+    func testSavedFinalSummaryEndsAfterFifteenMinutes() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                capturedAt: capturedAt,
+                terminalOutcome: .saved
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.1?.finalOutcome, .saved)
+        XCTAssertEqual(
+            client.endings.first?.2,
+            .after(
+                capturedAt.addingTimeInterval(
+                    WorkoutLiveActivityController
+                        .finalSummaryDismissalInterval
+                )
+            )
+        )
+    }
+
+    func testDiscardedFinalSummaryEndsImmediately() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                state: .ended,
+                capturedAt: capturedAt,
+                terminalOutcome: .discarded
+            )
+        )
+        await settle()
+
+        XCTAssertEqual(client.endings.count, 1)
+        XCTAssertEqual(client.endings.first?.2, .immediate)
+    }
+
+    func testActivityKitRequestFailureIsContainedAndRetryable() async {
+        enum TestError: Error { case unavailable }
+        let source = source()
+        let client = FakeWorkoutLiveActivityClient()
+        client.requestError = TestError.unavailable
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        XCTAssertEqual(client.requestAttempts, 1)
+        XCTAssertTrue(client.requests.isEmpty)
+
+        client.requestError = nil
+        controller.setApplicationForeground(true)
+        await settle()
+        XCTAssertEqual(client.requestAttempts, 2)
+        XCTAssertEqual(client.requests.count, 1)
+    }
+
+    func testDisabledAuthorizationDoesNotRequestActivity() async {
+        let source = source()
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(
+            source: source,
+            client: client,
+            authorization: EnabledWorkoutLiveActivityAuthorization(false)
+        )
+
+        controller.start(isApplicationForeground: true)
+        await settle()
+
+        XCTAssertEqual(client.requestAttempts, 0)
+    }
+
+    private func source(
+        sessionID: UUID = UUID()
+    ) -> TestWorkoutLiveActivityPresentationSource {
+        TestWorkoutLiveActivityPresentationSource(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt
+            )
+        )
+    }
+
+    private func makeController(
+        source: TestWorkoutLiveActivityPresentationSource,
+        client: FakeWorkoutLiveActivityClient,
+        authorization:
+            WorkoutLiveActivityAuthorizationProviding? = nil,
+        suppression:
+            WorkoutLiveActivitySuppressionStoring? = nil,
+        wait:
+            (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil
+    ) -> WorkoutLiveActivityController {
+        let referenceDate = capturedAt
+        return WorkoutLiveActivityController(
+            presentationSource: source,
+            client: client,
+            authorization: authorization
+                ?? EnabledWorkoutLiveActivityAuthorization(),
+            suppressionStore: suppression
+                ?? MemoryWorkoutLiveActivitySuppressionStore(),
+            now: { referenceDate },
+            wait: wait
+        )
+    }
+
+    private func record(
+        _ id: String,
+        mapped: WorkoutLiveActivityMappedPresentation
+    ) -> WorkoutLiveActivityRecord {
+        WorkoutLiveActivityRecord(
+            id: id,
+            attributes: mapped.attributes,
+            contentState: mapped.contentState,
+            systemState: .active
+        )
+    }
+
+    private func settle() async {
+        for _ in 0..<8 {
+            await Task.yield()
+        }
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
@@ -1,3 +1,4 @@
+import AppIntents
 import XCTest
 
 @available(iOS 17.0, *)
@@ -8,25 +9,24 @@ private final class WorkoutLiveActivityCallCounter {
 
 @available(iOS 17.0, *)
 @MainActor
-private final class WorkoutLiveActivityTestClock {
-    var date: Date
-    private(set) var waits = 0
-
-    init(_ date: Date) {
-        self.date = date
-    }
-
-    func advance(by interval: TimeInterval) {
-        waits += 1
-        date.addTimeInterval(interval)
-    }
-}
-
-@available(iOS 17.0, *)
-@MainActor
 final class WorkoutLiveActivityIntentTests: XCTestCase {
     private let capturedAt =
         Date(timeIntervalSinceReferenceDate: 800_500_000)
+
+    func testControlsRequireAuthentication() {
+        XCTAssertEqual(
+            BikeComputerMarkSegmentIntent.authenticationPolicy,
+            .requiresAuthentication
+        )
+        XCTAssertEqual(
+            BikeComputerPauseWorkoutIntent.authenticationPolicy,
+            .requiresAuthentication
+        )
+        XCTAssertEqual(
+            BikeComputerResumeWorkoutIntent.authenticationPolicy,
+            .requiresAuthentication
+        )
+    }
 
     func testSegmentRoutesOnlyForMatchingConnectedRunningSession() async {
         let sessionID = UUID()
@@ -172,6 +172,25 @@ final class WorkoutLiveActivityIntentTests: XCTestCase {
         XCTAssertEqual(calls.value, 0)
     }
 
+    func testTimedOutTerminalChoiceRejectsConflictingControls() async {
+        let sessionID = UUID()
+        let calls = WorkoutLiveActivityCallCounter()
+        let state = TestWorkoutLiveActivityControlState(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                errorCode: .terminalChoiceUnconfirmed
+            )
+        )
+        let rejected = await router(
+            state: state,
+            calls: calls
+        ).perform(.pause, sessionID: sessionID)
+
+        XCTAssertFalse(rejected)
+        XCTAssertEqual(calls.value, 0)
+    }
+
     func testCommandDoesNotReportSuccessWithoutPendingPublication() async {
         let sessionID = UUID()
         let state = controlState(sessionID: sessionID)
@@ -200,7 +219,6 @@ final class WorkoutLiveActivityIntentTests: XCTestCase {
         let router = WorkoutLiveActivityCommandRouter(
             store: state,
             recoveryTimeout: 1,
-            now: { capturedAt },
             wait: { _ in
                 state.presentation = makeLiveActivityPresentation(
                     sessionID: sessionID,
@@ -234,17 +252,50 @@ final class WorkoutLiveActivityIntentTests: XCTestCase {
         XCTAssertFalse(accepted)
     }
 
+    func testIntentExecutionThrowsWhenCommandIsRejected() async {
+        do {
+            try await WorkoutLiveActivityIntentExecution.perform(
+                .pause,
+                sessionID: UUID().uuidString,
+                dispatcher: .unavailable
+            )
+            XCTFail("A rejected workout command must not report success")
+        } catch let error as WorkoutLiveActivityIntentError {
+            guard case .commandRejected = error else {
+                return XCTFail("Unexpected intent error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected intent error: \(error)")
+        }
+    }
+
+    func testIntentExecutionRejectsMalformedSessionIdentifier() async {
+        do {
+            try await WorkoutLiveActivityIntentExecution.perform(
+                .pause,
+                sessionID: "not-a-session",
+                dispatcher: .unavailable
+            )
+            XCTFail("An invalid session must not report success")
+        } catch let error as WorkoutLiveActivityIntentError {
+            guard case .invalidSession = error else {
+                return XCTFail("Unexpected intent error: \(error)")
+            }
+        } catch {
+            XCTFail("Unexpected intent error: \(error)")
+        }
+    }
+
     func testColdIntentStopsAfterBoundedRecoveryTimeout() async {
         let sessionID = UUID()
         let state =
             TestWorkoutLiveActivityControlState(.idle)
-        let clock = WorkoutLiveActivityTestClock(capturedAt)
         let calls = WorkoutLiveActivityCallCounter()
+        var waits: [TimeInterval] = []
         let router = WorkoutLiveActivityCommandRouter(
             store: state,
             recoveryTimeout: 0.25,
-            now: { clock.date },
-            wait: { interval in clock.advance(by: interval) },
+            wait: { interval in waits.append(interval) },
             markSegment: {},
             pause: { calls.value += 1 },
             resume: {}
@@ -257,7 +308,10 @@ final class WorkoutLiveActivityIntentTests: XCTestCase {
 
         XCTAssertFalse(accepted)
         XCTAssertEqual(calls.value, 0)
-        XCTAssertEqual(clock.waits, 3)
+        XCTAssertEqual(waits.count, 3)
+        XCTAssertEqual(waits[0], 0.1, accuracy: 0.000_001)
+        XCTAssertEqual(waits[1], 0.1, accuracy: 0.000_001)
+        XCTAssertEqual(waits[2], 0.05, accuracy: 0.000_001)
     }
 
     private func controlState(

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
@@ -1,0 +1,298 @@
+import XCTest
+
+@available(iOS 17.0, *)
+@MainActor
+private final class WorkoutLiveActivityCallCounter {
+    var value = 0
+}
+
+@available(iOS 17.0, *)
+@MainActor
+private final class WorkoutLiveActivityTestClock {
+    var date: Date
+    private(set) var waits = 0
+
+    init(_ date: Date) {
+        self.date = date
+    }
+
+    func advance(by interval: TimeInterval) {
+        waits += 1
+        date.addTimeInterval(interval)
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class WorkoutLiveActivityIntentTests: XCTestCase {
+    private let capturedAt =
+        Date(timeIntervalSinceReferenceDate: 800_500_000)
+
+    func testSegmentRoutesOnlyForMatchingConnectedRunningSession() async {
+        let sessionID = UUID()
+        let state = controlState(sessionID: sessionID)
+        let calls = WorkoutLiveActivityCallCounter()
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            markSegment: {
+                calls.value += 1
+                state.presentation = self.presentation(
+                    sessionID: sessionID,
+                    pending: .markSegment
+                )
+            },
+            pause: {},
+            resume: {}
+        )
+
+        let rejected = await router.perform(
+            .segment,
+            sessionID: UUID()
+        )
+        XCTAssertFalse(rejected)
+        XCTAssertEqual(calls.value, 0)
+
+        let accepted = await router.perform(
+            .segment,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(calls.value, 1)
+        XCTAssertEqual(state.presentation.pendingControl, .markSegment)
+    }
+
+    func testPauseAndResumeValidateConfirmedState() async {
+        let sessionID = UUID()
+        let running = controlState(sessionID: sessionID)
+        let pauseCalls = WorkoutLiveActivityCallCounter()
+        let pauseRouter = WorkoutLiveActivityCommandRouter(
+            store: running,
+            markSegment: {},
+            pause: {
+                pauseCalls.value += 1
+                running.presentation = self.presentation(
+                    sessionID: sessionID,
+                    pending: .pause
+                )
+            },
+            resume: {}
+        )
+        let acceptedPause = await pauseRouter.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(acceptedPause)
+        XCTAssertEqual(pauseCalls.value, 1)
+
+        let paused = controlState(
+            sessionID: sessionID,
+            state: .paused
+        )
+        let resumeCalls = WorkoutLiveActivityCallCounter()
+        let resumeRouter = WorkoutLiveActivityCommandRouter(
+            store: paused,
+            markSegment: {},
+            pause: {},
+            resume: {
+                resumeCalls.value += 1
+                paused.presentation = self.presentation(
+                    sessionID: sessionID,
+                    state: .paused,
+                    pending: .resume
+                )
+            }
+        )
+        let rejectedPause = await resumeRouter.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(rejectedPause)
+        let acceptedResume = await resumeRouter.perform(
+            .resume,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(acceptedResume)
+        XCTAssertEqual(resumeCalls.value, 1)
+    }
+
+    func testDisconnectedPendingAndUnsupportedSegmentAreRejected() async {
+        let sessionID = UUID()
+        let calls = WorkoutLiveActivityCallCounter()
+        let disconnected = TestWorkoutLiveActivityControlState(
+            presentation(
+                sessionID: sessionID,
+                connection: .disconnected
+            )
+        )
+        let disconnectedRouter = router(
+            state: disconnected,
+            calls: calls
+        )
+        let disconnectedResult = await disconnectedRouter.perform(
+            .segment,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(disconnectedResult)
+
+        let pending = TestWorkoutLiveActivityControlState(
+            presentation(
+                sessionID: sessionID,
+                pending: .pause
+            )
+        )
+        let pendingRouter = router(state: pending, calls: calls)
+        let pendingResult = await pendingRouter.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(pendingResult)
+
+        let unsupported = controlState(sessionID: sessionID)
+        unsupported.supportsSegmentMarking = false
+        let unsupportedRouter = router(
+            state: unsupported,
+            calls: calls
+        )
+        let unsupportedResult = await unsupportedRouter.perform(
+            .segment,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(unsupportedResult)
+
+        let terminal = controlState(
+            sessionID: sessionID,
+            state: .ending
+        )
+        let terminalRouter = router(state: terminal, calls: calls)
+        let terminalResult = await terminalRouter.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(terminalResult)
+        XCTAssertEqual(calls.value, 0)
+    }
+
+    func testCommandDoesNotReportSuccessWithoutPendingPublication() async {
+        let sessionID = UUID()
+        let state = controlState(sessionID: sessionID)
+        let calls = WorkoutLiveActivityCallCounter()
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            markSegment: {},
+            pause: { calls.value += 1 },
+            resume: {}
+        )
+
+        let accepted = await router.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(calls.value, 1)
+    }
+
+    func testColdIntentWaitsBrieflyForMatchingMirroredSession() async {
+        let sessionID = UUID()
+        let capturedAt = capturedAt
+        let state =
+            TestWorkoutLiveActivityControlState(.idle)
+        let pauseCalls = WorkoutLiveActivityCallCounter()
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            recoveryTimeout: 1,
+            now: { capturedAt },
+            wait: { _ in
+                state.presentation = makeLiveActivityPresentation(
+                    sessionID: sessionID,
+                    capturedAt: capturedAt
+                )
+            },
+            markSegment: {},
+            pause: {
+                pauseCalls.value += 1
+                state.presentation = makeLiveActivityPresentation(
+                    sessionID: sessionID,
+                    capturedAt: capturedAt,
+                    pendingControl: .pause
+                )
+            },
+            resume: {}
+        )
+
+        let accepted = await router.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(accepted)
+        XCTAssertEqual(pauseCalls.value, 1)
+    }
+
+    func testMissingAppProcessDependencyFailsSafely() async {
+        let accepted = await WorkoutLiveActivityIntentDispatcher.unavailable
+            .perform(.pause, sessionID: UUID())
+
+        XCTAssertFalse(accepted)
+    }
+
+    func testColdIntentStopsAfterBoundedRecoveryTimeout() async {
+        let sessionID = UUID()
+        let state =
+            TestWorkoutLiveActivityControlState(.idle)
+        let clock = WorkoutLiveActivityTestClock(capturedAt)
+        let calls = WorkoutLiveActivityCallCounter()
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            recoveryTimeout: 0.25,
+            now: { clock.date },
+            wait: { interval in clock.advance(by: interval) },
+            markSegment: {},
+            pause: { calls.value += 1 },
+            resume: {}
+        )
+
+        let accepted = await router.perform(
+            .pause,
+            sessionID: sessionID
+        )
+
+        XCTAssertFalse(accepted)
+        XCTAssertEqual(calls.value, 0)
+        XCTAssertEqual(clock.waits, 3)
+    }
+
+    private func controlState(
+        sessionID: UUID,
+        state: WorkoutSessionStateV1 = .running
+    ) -> TestWorkoutLiveActivityControlState {
+        TestWorkoutLiveActivityControlState(
+            presentation(sessionID: sessionID, state: state)
+        )
+    }
+
+    private func presentation(
+        sessionID: UUID,
+        state: WorkoutSessionStateV1 = .running,
+        connection: WorkoutMirrorConnectionStateV1 = .connected,
+        pending: WorkoutControlV1? = nil
+    ) -> WorkoutMirrorPresentationV1 {
+        makeLiveActivityPresentation(
+            sessionID: sessionID,
+            state: state,
+            connection: connection,
+            capturedAt: capturedAt,
+            pendingControl: pending
+        )
+    }
+
+    private func router(
+        state: TestWorkoutLiveActivityControlState,
+        calls: WorkoutLiveActivityCallCounter
+    ) -> WorkoutLiveActivityCommandRouter {
+        WorkoutLiveActivityCommandRouter(
+            store: state,
+            markSegment: { calls.value += 1 },
+            pause: { calls.value += 1 },
+            resume: { calls.value += 1 }
+        )
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
@@ -76,6 +76,38 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         XCTAssertFalse(mapped.isStartEligible)
     }
 
+    func testSystemStaleStateFreezesDisplayWithoutAppRefresh() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(capturedAt: capturedAt),
+                at: capturedAt
+            )
+        )
+
+        let stale = mapped.contentState.displayState(isSystemStale: true)
+
+        XCTAssertEqual(stale.phase, .stale)
+        XCTAssertEqual(
+            stale.elapsedActiveSeconds,
+            mapped.contentState.elapsedActiveSeconds
+        )
+        XCTAssertNil(stale.currentSpeedKilometersPerHour)
+        XCTAssertNil(stale.currentHeartRateBPM)
+        XCTAssertEqual(
+            stale.cyclingDistanceMeters,
+            mapped.contentState.cyclingDistanceMeters
+        )
+        XCTAssertEqual(stale.displayError, .controlsUnavailable)
+        XCTAssertFalse(stale.canMarkSegment)
+        XCTAssertFalse(stale.canPause)
+
+        XCTAssertEqual(
+            mapped.contentState.displayState(isSystemStale: false),
+            mapped.contentState
+        )
+    }
+
     func testPausedAndTerminalStatesRemainHonest() throws {
         let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
         let paused = try XCTUnwrap(
@@ -124,6 +156,25 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
             saved.contentState.finalOutcome,
             discarded.contentState.finalOutcome
         )
+
+        let unavailable = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .ended,
+                    connection: .ended,
+                    capturedAt: capturedAt,
+                    errorCode: .finalSummaryUnavailable
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(unavailable.contentState.phase, .final)
+        XCTAssertEqual(unavailable.contentState.finalOutcome, .none)
+        XCTAssertEqual(
+            unavailable.contentState.displayError,
+            .finalSummaryUnavailable
+        )
+        XCTAssertTrue(unavailable.isTerminal)
     }
 
     func testDisconnectedAndEndingVariantsDisableInstantControls() throws {
@@ -201,6 +252,86 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         XCTAssertEqual(rejected.contentState.lastCompletedSegmentIndex, 2)
     }
 
+    func testTerminalPendingAndUnconfirmedStatesDisableControls() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        for pendingControl in [
+            WorkoutControlV1.endAndSave,
+            WorkoutControlV1.discard,
+        ] {
+            let pending = try XCTUnwrap(
+                WorkoutLiveActivityStateMapper.map(
+                    makeLiveActivityPresentation(
+                        capturedAt: capturedAt,
+                        pendingControl: pendingControl
+                    ),
+                    at: capturedAt
+                )
+            )
+            XCTAssertFalse(pending.contentState.canMarkSegment)
+            XCTAssertFalse(pending.contentState.canPause)
+        }
+
+        let unconfirmed = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    errorCode: .terminalChoiceUnconfirmed
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(
+            unconfirmed.contentState.displayError,
+            .controlsUnavailable
+        )
+        XCTAssertFalse(unconfirmed.contentState.canMarkSegment)
+        XCTAssertFalse(unconfirmed.contentState.canPause)
+
+        let endedUnconfirmed = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .ended,
+                    connection: .ended,
+                    capturedAt: capturedAt,
+                    errorCode: .terminalChoiceUnconfirmed
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertFalse(endedUnconfirmed.isTerminal)
+        XCTAssertEqual(endedUnconfirmed.contentState.phase, .ending)
+        XCTAssertEqual(
+            endedUnconfirmed.contentState.displayError,
+            .controlsUnavailable
+        )
+    }
+
+    func testUnsupportedAndUnconfirmedSegmentDisableSegmentOnly() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let unsupported = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(capturedAt: capturedAt),
+                at: capturedAt,
+                supportsSegmentMarking: false
+            )
+        )
+        XCTAssertFalse(unsupported.contentState.canMarkSegment)
+        XCTAssertTrue(unsupported.contentState.canPause)
+
+        let unconfirmed = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    errorCode: .segmentMarkUnconfirmed
+                ),
+                at: capturedAt,
+                isSegmentConfirmationPending: true
+            )
+        )
+        XCTAssertFalse(unconfirmed.contentState.canMarkSegment)
+        XCTAssertTrue(unconfirmed.contentState.canPause)
+    }
+
     func testInvalidMetricsRemainUnavailableInsteadOfZero() throws {
         let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
         let mapped = try XCTUnwrap(
@@ -218,6 +349,39 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         XCTAssertNil(mapped.contentState.currentSpeedKilometersPerHour)
         XCTAssertNil(mapped.contentState.cyclingDistanceMeters)
         XCTAssertNil(mapped.contentState.currentHeartRateBPM)
+    }
+
+    func testSpeedConversionOverflowRemainsUnavailable() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    speedMetersPerSecond: .greatestFiniteMagnitude
+                ),
+                at: capturedAt
+            )
+        )
+
+        XCTAssertNil(mapped.contentState.currentSpeedKilometersPerHour)
+    }
+
+    func testMissingElapsedTimeRemainsUnavailableInsteadOfFalseZero()
+        throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let presentation = makeLiveActivityPresentation(
+            capturedAt: capturedAt,
+            elapsed: nil
+        )
+
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                presentation,
+                at: capturedAt
+            )
+        )
+
+        XCTAssertNil(mapped.contentState.elapsedActiveSeconds)
     }
 
     func testUnverifiedAndMismatchedDataCannotStartActivity() {

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
@@ -1,0 +1,254 @@
+import XCTest
+
+@available(iOS 17.0, *)
+final class WorkoutLiveActivityStateMapperTests: XCTestCase {
+    func testRunningSnapshotMapsDisplaySafeMetricsAndControls() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let sessionID = UUID()
+        let segment = WorkoutCompletedSegmentV1(
+            index: 3,
+            startedAt: capturedAt.addingTimeInterval(-60),
+            endedAt: capturedAt,
+            duration: 60,
+            distanceMeters: 500
+        )
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    sessionID: sessionID,
+                    capturedAt: capturedAt,
+                    segment: segment
+                ),
+                at: capturedAt
+            )
+        )
+
+        XCTAssertEqual(mapped.attributes.sessionID, sessionID)
+        XCTAssertEqual(mapped.contentState.phase, .running)
+        XCTAssertEqual(
+            try XCTUnwrap(
+                mapped.contentState.currentSpeedKilometersPerHour
+            ),
+            28.8,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(mapped.contentState.cyclingDistanceMeters, 2_500)
+        XCTAssertEqual(mapped.contentState.currentHeartRateBPM, 140)
+        XCTAssertEqual(mapped.contentState.lastCompletedSegmentIndex, 3)
+        XCTAssertTrue(mapped.contentState.canMarkSegment)
+        XCTAssertTrue(mapped.isStartEligible)
+    }
+
+    func testInvalidHeartRateRemainsUnavailableAndPayloadIsSmall() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    heartRate: -.infinity
+                ),
+                at: capturedAt
+            )
+        )
+
+        XCTAssertNil(mapped.contentState.currentHeartRateBPM)
+        let payload = try JSONEncoder().encode(mapped.contentState)
+        XCTAssertLessThan(payload.count, 4_096)
+    }
+
+    func testStaleWorkoutFreezesInstantaneousMetricsAndControls() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    connection: .stale,
+                    capturedAt: capturedAt
+                ),
+                at: capturedAt.addingTimeInterval(12)
+            )
+        )
+
+        XCTAssertEqual(mapped.contentState.phase, .stale)
+        XCTAssertNil(mapped.contentState.currentSpeedKilometersPerHour)
+        XCTAssertNil(mapped.contentState.currentHeartRateBPM)
+        XCTAssertEqual(mapped.contentState.cyclingDistanceMeters, 2_500)
+        XCTAssertFalse(mapped.contentState.canMarkSegment)
+        XCTAssertFalse(mapped.isStartEligible)
+    }
+
+    func testPausedAndTerminalStatesRemainHonest() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let paused = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .paused,
+                    capturedAt: capturedAt,
+                    pendingControl: .resume
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(paused.contentState.phase, .paused)
+        XCTAssertEqual(paused.contentState.pendingAction, .resume)
+        XCTAssertFalse(paused.contentState.canResume)
+
+        let saved = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .ended,
+                    connection: .ended,
+                    capturedAt: capturedAt,
+                    terminalOutcome: .saved
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(saved.contentState.phase, .final)
+        XCTAssertEqual(saved.contentState.finalOutcome, .saved)
+        XCTAssertTrue(saved.isTerminal)
+        XCTAssertFalse(saved.isStartEligible)
+
+        let discarded = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .ended,
+                    connection: .ended,
+                    capturedAt: capturedAt,
+                    terminalOutcome: .discarded
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(discarded.contentState.finalOutcome, .discarded)
+        XCTAssertNotEqual(
+            saved.contentState.finalOutcome,
+            discarded.contentState.finalOutcome
+        )
+    }
+
+    func testDisconnectedAndEndingVariantsDisableInstantControls() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let disconnected = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    connection: .disconnected,
+                    capturedAt: capturedAt
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(disconnected.contentState.phase, .disconnected)
+        XCTAssertEqual(
+            disconnected.contentState.displayError,
+            .controlsUnavailable
+        )
+        XCTAssertNil(
+            disconnected.contentState.currentSpeedKilometersPerHour
+        )
+        XCTAssertFalse(disconnected.contentState.canMarkSegment)
+
+        let ending = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    state: .ending,
+                    capturedAt: capturedAt
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(ending.contentState.phase, .ending)
+        XCTAssertNil(ending.contentState.currentHeartRateBPM)
+        XCTAssertFalse(ending.contentState.canPause)
+    }
+
+    func testPendingSegmentAndSegmentFailureRemainUnconfirmed() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let segment = WorkoutCompletedSegmentV1(
+            index: 2,
+            startedAt: capturedAt.addingTimeInterval(-45),
+            endedAt: capturedAt,
+            duration: 45,
+            distanceMeters: 400
+        )
+        let pending = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    pendingControl: .markSegment,
+                    segment: segment
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(pending.contentState.pendingAction, .segment)
+        XCTAssertEqual(pending.contentState.lastCompletedSegmentIndex, 2)
+        XCTAssertFalse(pending.contentState.canMarkSegment)
+
+        let rejected = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    errorCode: .segmentMarkFailed,
+                    segment: segment
+                ),
+                at: capturedAt
+            )
+        )
+        XCTAssertEqual(
+            rejected.contentState.displayError,
+            .segmentRejected
+        )
+        XCTAssertEqual(rejected.contentState.lastCompletedSegmentIndex, 2)
+    }
+
+    func testInvalidMetricsRemainUnavailableInsteadOfZero() throws {
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let mapped = try XCTUnwrap(
+            WorkoutLiveActivityStateMapper.map(
+                makeLiveActivityPresentation(
+                    capturedAt: capturedAt,
+                    speedMetersPerSecond: .nan,
+                    distanceMeters: -1,
+                    heartRate: 0
+                ),
+                at: capturedAt
+            )
+        )
+
+        XCTAssertNil(mapped.contentState.currentSpeedKilometersPerHour)
+        XCTAssertNil(mapped.contentState.cyclingDistanceMeters)
+        XCTAssertNil(mapped.contentState.currentHeartRateBPM)
+    }
+
+    func testUnverifiedAndMismatchedDataCannotStartActivity() {
+        XCTAssertNil(
+            WorkoutLiveActivityStateMapper.map(
+                .idle,
+                at: Date(timeIntervalSinceReferenceDate: 800_500_000)
+            )
+        )
+
+        let capturedAt = Date(timeIntervalSinceReferenceDate: 800_500_000)
+        let verified = makeLiveActivityPresentation(
+            capturedAt: capturedAt
+        )
+        let missingIdentity = WorkoutMirrorPresentationV1(
+            connectionState: verified.connectionState,
+            snapshot: verified.snapshot,
+            sessionID: nil,
+            capturedAt: verified.capturedAt,
+            receivedAt: verified.receivedAt,
+            confirmedSessionState: verified.confirmedSessionState,
+            errorCode: verified.errorCode,
+            pendingControl: verified.pendingControl,
+            finalSnapshot: verified.finalSnapshot,
+            navigation: verified.navigation
+        )
+        XCTAssertNil(
+            WorkoutLiveActivityStateMapper.map(
+                missingIdentity,
+                at: capturedAt
+            )
+        )
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityTestFixtures.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityTestFixtures.swift
@@ -7,7 +7,7 @@ func makeLiveActivityPresentation(
     state: WorkoutSessionStateV1 = .running,
     connection: WorkoutMirrorConnectionStateV1 = .connected,
     capturedAt: Date = Date(timeIntervalSinceReferenceDate: 800_500_000),
-    elapsed: Double = 120,
+    elapsed: Double? = 120,
     speedMetersPerSecond: Double? = 8,
     distanceMeters: Double? = 2_500,
     heartRate: Double? = 140,
@@ -16,15 +16,17 @@ func makeLiveActivityPresentation(
     segment: WorkoutCompletedSegmentV1? = nil,
     terminalOutcome: WorkoutTerminalOutcomeV1? = nil
 ) -> WorkoutMirrorPresentationV1 {
-    let startDate = capturedAt.addingTimeInterval(-elapsed)
+    let startDate = capturedAt.addingTimeInterval(-(elapsed ?? 120))
     let snapshot = WorkoutSnapshotV1(
         state: state,
         startDate: startDate,
-        elapsedTime: WorkoutMetricV1(
-            value: elapsed,
-            unit: .seconds,
-            capturedAt: capturedAt
-        ),
+        elapsedTime: elapsed.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .seconds,
+                capturedAt: capturedAt
+            )
+        },
         currentHeartRate: heartRate.map {
             WorkoutMetricV1(
                 value: $0,
@@ -79,6 +81,8 @@ final class TestWorkoutLiveActivityPresentationSource:
         AnyPublisher<WorkoutMirrorPresentationV1, Never> {
         subject.eraseToAnyPublisher()
     }
+    var supportsSegmentMarking = true
+    var isSegmentConfirmationPending = false
 
     init(_ presentation: WorkoutMirrorPresentationV1) {
         subject = CurrentValueSubject(presentation)

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityTestFixtures.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityTestFixtures.swift
@@ -1,0 +1,103 @@
+import Combine
+import Foundation
+
+@available(iOS 17.0, *)
+func makeLiveActivityPresentation(
+    sessionID: UUID = UUID(),
+    state: WorkoutSessionStateV1 = .running,
+    connection: WorkoutMirrorConnectionStateV1 = .connected,
+    capturedAt: Date = Date(timeIntervalSinceReferenceDate: 800_500_000),
+    elapsed: Double = 120,
+    speedMetersPerSecond: Double? = 8,
+    distanceMeters: Double? = 2_500,
+    heartRate: Double? = 140,
+    pendingControl: WorkoutControlV1? = nil,
+    errorCode: WorkoutSafeErrorCodeV1? = nil,
+    segment: WorkoutCompletedSegmentV1? = nil,
+    terminalOutcome: WorkoutTerminalOutcomeV1? = nil
+) -> WorkoutMirrorPresentationV1 {
+    let startDate = capturedAt.addingTimeInterval(-elapsed)
+    let snapshot = WorkoutSnapshotV1(
+        state: state,
+        startDate: startDate,
+        elapsedTime: WorkoutMetricV1(
+            value: elapsed,
+            unit: .seconds,
+            capturedAt: capturedAt
+        ),
+        currentHeartRate: heartRate.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .beatsPerMinute,
+                capturedAt: capturedAt
+            )
+        },
+        cyclingDistance: distanceMeters.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .meters,
+                capturedAt: capturedAt
+            )
+        },
+        currentSpeed: speedMetersPerSecond.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .metersPerSecond,
+                capturedAt: capturedAt
+            )
+        },
+        lastCompletedSegment: segment,
+        terminalOutcome: terminalOutcome
+    )
+    return WorkoutMirrorPresentationV1(
+        connectionState: connection,
+        snapshot: snapshot,
+        sessionID: sessionID,
+        capturedAt: capturedAt,
+        receivedAt: capturedAt,
+        confirmedSessionState: state,
+        errorCode: errorCode,
+        pendingControl: pendingControl,
+        finalSnapshot: state == .ended ? snapshot : nil,
+        navigation: .empty
+    )
+}
+
+@available(iOS 17.0, *)
+@available(iOS 17.0, *)
+@MainActor
+final class TestWorkoutLiveActivityPresentationSource:
+    WorkoutLiveActivityPresentationProviding {
+    private let subject:
+        CurrentValueSubject<WorkoutMirrorPresentationV1, Never>
+
+    var presentation: WorkoutMirrorPresentationV1 {
+        subject.value
+    }
+
+    var presentationPublisher:
+        AnyPublisher<WorkoutMirrorPresentationV1, Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    init(_ presentation: WorkoutMirrorPresentationV1) {
+        subject = CurrentValueSubject(presentation)
+    }
+
+    func send(_ presentation: WorkoutMirrorPresentationV1) {
+        subject.send(presentation)
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+final class TestWorkoutLiveActivityControlState:
+    WorkoutLiveActivityControlStateProviding {
+    var presentation: WorkoutMirrorPresentationV1
+    var supportsSegmentMarking = true
+    var isSegmentConfirmationPending = false
+
+    init(_ presentation: WorkoutMirrorPresentationV1) {
+        self.presentation = presentation
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutMirrorManagerTests.swift
@@ -1797,7 +1797,13 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
         let transport = FakeMirroredSessionTransport()
         manager.acceptMirroredTransport(transport)
         manager.applyRemoteEnvelopes(
-            [makeSnapshotEnvelope(sequence: 1, capturedAt: now)],
+            [
+                makeSnapshotEnvelope(
+                    sequence: 1,
+                    capturedAt: now,
+                    errorCode: .anotherWorkoutActive
+                ),
+            ],
             receivedAt: now,
             from: transport
         )
@@ -1822,6 +1828,115 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
             manager.resetTerminalPresentation(),
             "the bounded timeout must permit dismissal only after publishing honest copy"
         )
+    }
+
+    func testOutcomeLessEndedSnapshotStillUsesFinalSnapshotTimeout()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_272)
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            finalSnapshotTimeout: 0.02
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        manager.applyRemoteEnvelopes(
+            [
+                makeSnapshotEnvelope(sequence: 1, capturedAt: now),
+                makeSnapshotEnvelope(
+                    sequence: 2,
+                    capturedAt: now.addingTimeInterval(1),
+                    state: .ended,
+                    startDate: now.addingTimeInterval(-30)
+                ),
+            ],
+            receivedAt: now.addingTimeInterval(1),
+            from: transport
+        )
+
+        XCTAssertNotNil(manager.store.presentation.finalSnapshot)
+        XCTAssertNil(
+            manager.store.presentation.finalSnapshot?.terminalOutcome
+        )
+        XCTAssertFalse(manager.store.canResetTerminalPresentation)
+
+        try await Task.sleep(for: .milliseconds(60))
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .finalSummaryUnavailable
+        )
+        XCTAssertTrue(manager.store.canResetTerminalPresentation)
+    }
+
+    func testFinalSnapshotExpirationPublishesSynchronouslyAndBalancesLease() {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_273)
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            finalSnapshotTimeout: 10,
+            finalSnapshotBackgroundLease: lease
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        manager.applyRemoteEnvelopes(
+            [makeSnapshotEnvelope(sequence: 1, capturedAt: now)],
+            receivedAt: now,
+            from: transport
+        )
+        manager.applyNativeSessionState(
+            .ended,
+            at: now.addingTimeInterval(1),
+            from: transport
+        )
+        XCTAssertTrue(lease.isActive)
+
+        lease.expireSynchronously()
+
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .finalSummaryUnavailable
+        )
+        XCTAssertTrue(manager.store.canResetTerminalPresentation)
+        XCTAssertFalse(lease.isActive)
+    }
+
+    func testFinalSnapshotWaitLeavesBackgroundFinalizationMargin()
+        async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_400_274)
+        let waiter = ControlledWorkoutTimeoutWaiter()
+        let lease = FakeWorkoutBackgroundExecutionLease()
+        let manager = WorkoutMirrorManager(
+            now: { now },
+            finalSnapshotTimeout: 10,
+            finalSnapshotWait: { timeout in
+                try await waiter.wait(timeout)
+            },
+            finalSnapshotBackgroundLease: lease,
+            backgroundTimeRemaining: {
+                XCTAssertTrue(
+                    lease.isActive,
+                    "background time is valid only after beginning the lease"
+                )
+                return 8
+            }
+        )
+        let transport = FakeMirroredSessionTransport()
+        manager.acceptMirroredTransport(transport)
+        manager.applyRemoteEnvelopes(
+            [makeSnapshotEnvelope(sequence: 1, capturedAt: now)],
+            receivedAt: now,
+            from: transport
+        )
+        manager.applyNativeSessionState(
+            .ended,
+            at: now.addingTimeInterval(1),
+            from: transport
+        )
+
+        try await waitUntil { waiter.waitCallCount == 1 }
+        XCTAssertEqual(waiter.timeouts, [3])
+
+        waiter.completeWait(at: 0)
+        await Task.yield()
     }
 
     func testFreshWatchSnapshotDoesNotResurrectStalePhoneLocation() async {
@@ -2647,7 +2762,8 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
         let now = Date(timeIntervalSinceReferenceDate: 800_400_800)
         let manager = WorkoutMirrorManager(
             now: { now },
-            controlConfirmationTimeout: 0.02
+            controlConfirmationTimeout: 0.02,
+            finalSnapshotTimeout: 0.1
         )
         let transport = FakeMirroredSessionTransport()
         manager.acceptMirroredTransport(transport)
@@ -2767,6 +2883,15 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
             "an unacknowledged opposite retry must fail honestly"
         )
         XCTAssertEqual(manager.store.presentation.connectionState, .ended)
+        XCTAssertFalse(
+            manager.resetTerminalPresentation(),
+            "terminal uncertainty must retain the final-snapshot correction window"
+        )
+        try await Task.sleep(for: .milliseconds(120))
+        XCTAssertEqual(
+            manager.store.presentation.errorCode,
+            .finalSummaryUnavailable
+        )
         XCTAssertTrue(manager.resetTerminalPresentation())
         XCTAssertEqual(manager.store.presentation.connectionState, .idle)
     }
@@ -2837,12 +2962,17 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
         let now = Date(timeIntervalSinceReferenceDate: 800_401_000)
         let manager = WorkoutMirrorManager(
             now: { now },
-            controlConfirmationTimeout: 0.02
+            controlConfirmationTimeout: 0.02,
+            finalSnapshotTimeout: 0.2
         )
         let transport = FakeMirroredSessionTransport()
         manager.acceptMirroredTransport(transport)
+        let snapshot = makeSnapshotEnvelope(
+            sequence: 90,
+            capturedAt: now
+        )
         manager.applyRemoteEnvelopes(
-            [makeSnapshotEnvelope(sequence: 90, capturedAt: now)],
+            [snapshot],
             receivedAt: now,
             from: transport
         )
@@ -2879,6 +3009,31 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
             manager.store.presentation.errorCode,
             .terminalChoiceUnconfirmed,
             "native end must reclassify an earlier terminal timeout"
+        )
+        XCTAssertFalse(
+            manager.store.canResetTerminalPresentation,
+            "terminal uncertainty must retain the final-snapshot correction window"
+        )
+
+        manager.applyRemoteEnvelopes(
+            terminalEnvelopes(
+                after: snapshot,
+                outcome: .saved,
+                capturedAt: now.addingTimeInterval(2)
+            ),
+            receivedAt: now.addingTimeInterval(3),
+            from: transport
+        )
+        XCTAssertEqual(
+            manager.store.presentation.finalSnapshot?.terminalOutcome,
+            .saved
+        )
+        XCTAssertNil(manager.store.presentation.errorCode)
+        XCTAssertTrue(manager.store.canResetTerminalPresentation)
+        try await Task.sleep(for: .milliseconds(250))
+        XCTAssertNil(
+            manager.store.presentation.errorCode,
+            "late timeout continuation must not replace authoritative final truth"
         )
     }
 
@@ -3405,11 +3560,12 @@ final class WorkoutMirrorManagerProductionTests: XCTestCase {
 private final class ControlledWorkoutTimeoutWaiter {
     private var continuations: [CheckedContinuation<Void, Error>?] = []
     private var returnedWaits: Set<Int> = []
+    private(set) var timeouts: [TimeInterval] = []
 
     var waitCallCount: Int { continuations.count }
 
     func wait(_ timeout: TimeInterval) async throws {
-        _ = timeout
+        timeouts.append(timeout)
         let index = continuations.count
         try await withCheckedThrowingContinuation { continuation in
             continuations.append(continuation)
@@ -3428,6 +3584,35 @@ private final class ControlledWorkoutTimeoutWaiter {
         }
         continuations[index] = nil
         continuation.resume()
+    }
+}
+
+@available(iOS 17.0, *)
+@MainActor
+private final class FakeWorkoutBackgroundExecutionLease:
+    WorkoutBackgroundExecutionLeasing {
+    private(set) var isActive = false
+    private var expirationHandler:
+        (@MainActor @Sendable () -> Void)?
+
+    func begin(
+        expirationHandler: @escaping @MainActor @Sendable () -> Void
+    ) {
+        guard !isActive else { return }
+        isActive = true
+        self.expirationHandler = expirationHandler
+    }
+
+    func end() {
+        isActive = false
+        expirationHandler = nil
+    }
+
+    func expireSynchronously() {
+        guard isActive else { return }
+        let expirationHandler = expirationHandler
+        expirationHandler?()
+        end()
     }
 }
 

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -50,6 +50,26 @@ If the iPhone or bike computer disconnects, the Watch workout continues. The
 iPhone and ESP32 show delayed, disconnected, or stale state instead of treating
 old data as current. Reconnection requests the newest coherent snapshot.
 
+## iPhone Live Activity
+
+On iOS 17 or later, a verified active Watch workout appears on the iPhone Lock
+Screen and Dynamic Island while Live Activities are enabled for BikeComputer.
+It shows active time, speed, distance, optional heart rate, and the most recent
+completed segment. Segment and Pause/Resume use the same replay-safe Watch
+control path as the in-app workout screen; End and Discard remain in the app
+and on Watch.
+
+ActivityKit permits BikeComputer to create the Live Activity only while the
+iPhone app is foreground. A workout started on Watch while iPhone is
+backgrounded therefore appears when BikeComputer next enters the foreground.
+An existing activity continues to receive mirrored updates in the background.
+Lock Screen controls require the normal iPhone authentication, and dismissing
+or disabling the activity never changes the Watch workout.
+
+Active workout metrics may be visible on the Lock Screen, Dynamic Island,
+Always-On display, and other system Live Activity surfaces. No Live Activity
+content is uploaded to a backend.
+
 ## Saving, discarding, and recovery
 
 - **End and Save** creates exactly one cycling workout in Health. A route is

--- a/ios-app/scripts/tests/test_verify_release_container.py
+++ b/ios-app/scripts/tests/test_verify_release_container.py
@@ -16,14 +16,17 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
         app = root / "BikeComputer.app"
         watch = app / "Watch" / "BikeComputerWatch.app"
         complication = watch / "PlugIns" / "BikeComputerWatchComplications.appex"
+        live_activity = app / "PlugIns" / "BikeComputerLiveActivity.appex"
         watch.mkdir(parents=True)
         complication.mkdir(parents=True)
+        live_activity.mkdir(parents=True)
 
         for path in [
             app / "BikeComputer",
             watch / "BikeComputerWatch",
             watch / "Assets.car",
             complication / "BikeComputerWatchComplications",
+            live_activity / "BikeComputerLiveActivity",
         ]:
             path.write_bytes(b"fixture")
 
@@ -36,7 +39,13 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             watch / "PrivacyInfo.xcprivacy",
         )
         with (app / "Info.plist").open("wb") as handle:
-            plistlib.dump({"CFBundleIdentifier": "LetItRide.BikeComputer"}, handle)
+            plistlib.dump(
+                {
+                    "CFBundleIdentifier": "LetItRide.BikeComputer",
+                    "NSSupportsLiveActivities": True,
+                },
+                handle,
+            )
         with (watch / "Info.plist").open("wb") as handle:
             plistlib.dump(
                 {
@@ -60,6 +69,20 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
                     ),
                     "NSExtension": {
                         "NSExtensionPointIdentifier": "com.apple.widgetkit-extension"
+                    },
+                },
+                handle,
+            )
+        with (live_activity / "Info.plist").open("wb") as handle:
+            plistlib.dump(
+                {
+                    "CFBundleIdentifier": (
+                        "LetItRide.BikeComputer.WorkoutLiveActivity"
+                    ),
+                    "NSExtension": {
+                        "NSExtensionPointIdentifier": (
+                            "com.apple.widgetkit-extension"
+                        )
                     },
                 },
                 handle,
@@ -117,6 +140,16 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             del payload["CFBundleURLTypes"]
             with watch_info.open("wb") as handle:
                 plistlib.dump(payload, handle)
+
+            result = self.run_verifier(app)
+            self.assertNotEqual(result.returncode, 0)
+
+    def test_rejects_container_without_live_activity_extension(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            app = self.make_fixture(Path(temporary))
+            shutil.rmtree(
+                app / "PlugIns" / "BikeComputerLiveActivity.appex"
+            )
 
             result = self.run_verifier(app)
             self.assertNotEqual(result.returncode, 0)

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -178,6 +178,32 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
         self.assertTrue(ios_entitlements["com.apple.developer.healthkit"])
         self.assertTrue(watch_entitlements["com.apple.developer.healthkit"])
 
+    def test_live_activity_is_enabled_without_push_or_frequent_updates(self):
+        ios_info = load_plist(IOS_PROJECT / "BikeComputer" / "Info.plist")
+        extension_info = load_plist(
+            IOS_PROJECT / "BikeComputerLiveActivity" / "Info.plist"
+        )
+        project = (
+            IOS_PROJECT / "BikeComputer.xcodeproj" / "project.pbxproj"
+        ).read_text()
+
+        self.assertTrue(ios_info["NSSupportsLiveActivities"])
+        self.assertNotIn("NSSupportsLiveActivitiesFrequentUpdates", ios_info)
+        self.assertEqual(
+            extension_info["NSExtension"]["NSExtensionPointIdentifier"],
+            "com.apple.widgetkit-extension",
+        )
+        self.assertIn(
+            "PRODUCT_BUNDLE_IDENTIFIER = "
+            "LetItRide.BikeComputer.WorkoutLiveActivity;",
+            project,
+        )
+        self.assertEqual(
+            project.count("IPHONEOS_DEPLOYMENT_TARGET = 17.0;"),
+            2,
+            "the Live Activity extension must be iOS 17 in Debug and Release",
+        )
+
     def test_privacy_manifests_distinguish_backend_collection_from_healthkit(self):
         ios_privacy = load_plist(
             IOS_PROJECT / "BikeComputer" / "PrivacyInfo.xcprivacy"

--- a/ios-app/scripts/verify-release-container.sh
+++ b/ios-app/scripts/verify-release-container.sh
@@ -9,6 +9,7 @@ fi
 APP_PATH="${1%/}"
 WATCH_PATH="${APP_PATH}/Watch/BikeComputerWatch.app"
 COMPLICATION_PATH="${WATCH_PATH}/PlugIns/BikeComputerWatchComplications.appex"
+LIVE_ACTIVITY_PATH="${APP_PATH}/PlugIns/BikeComputerLiveActivity.appex"
 SOURCE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 require_file() {
@@ -66,6 +67,8 @@ require_file "${WATCH_PATH}/PrivacyInfo.xcprivacy"
 require_file "${WATCH_PATH}/Assets.car"
 require_file "${COMPLICATION_PATH}/Info.plist"
 require_file "${COMPLICATION_PATH}/BikeComputerWatchComplications"
+require_file "${LIVE_ACTIVITY_PATH}/Info.plist"
+require_file "${LIVE_ACTIVITY_PATH}/BikeComputerLiveActivity"
 
 cmp "${SOURCE_ROOT}/BikeComputer/BikeComputer/PrivacyInfo.xcprivacy" \
   "${APP_PATH}/PrivacyInfo.xcprivacy"
@@ -88,6 +91,18 @@ require_plist_value \
   "${COMPLICATION_PATH}/Info.plist" \
   ":NSExtension:NSExtensionPointIdentifier" \
   "com.apple.widgetkit-extension"
+require_plist_value \
+  "${LIVE_ACTIVITY_PATH}/Info.plist" \
+  ":CFBundleIdentifier" \
+  "LetItRide.BikeComputer.WorkoutLiveActivity"
+require_plist_value \
+  "${LIVE_ACTIVITY_PATH}/Info.plist" \
+  ":NSExtension:NSExtensionPointIdentifier" \
+  "com.apple.widgetkit-extension"
+require_plist_value \
+  "${APP_PATH}/Info.plist" \
+  ":NSSupportsLiveActivities" \
+  "true"
 require_url_scheme "${WATCH_PATH}/Info.plist" "bikecomputer"
 WATCH_BACKGROUND_MODES="$(
   /usr/libexec/PlistBuddy -c 'Print :WKBackgroundModes' "${WATCH_PATH}/Info.plist"
@@ -106,4 +121,4 @@ if [[ "${WATCH_PRIMARY_ICON}" != "AppIcon" ]]; then
   exit 1
 fi
 
-echo "Release iPhone container, Watch app, and complication extension verified"
+echo "Release iPhone container, Watch app, complication, and Live Activity verified"


### PR DESCRIPTION
## Summary

- add an iOS 17 Live Activity extension embedded in the existing iOS 15 app
- show Watch-owned workout time, speed, distance, optional heart rate, and the latest acknowledged segment on the Lock Screen and Dynamic Island
- add Segment and Pause/Resume `LiveActivityIntent` controls that route through the existing `WorkoutMirrorManager`
- start only from a foreground, verified mirrored workout while continuing updates for an existing activity in the background
- reconcile activities across app launches, coalesce metric updates, freeze stale values honestly, respect dismissal/expiration, and publish saved/discarded terminal behavior
- keep ActivityKit content display-only: no route, location, destination, session token, networking, App Group, push entitlement, or second HealthKit owner
- document foreground-start behavior, Lock Screen visibility/authentication, and release validation

## User impact

During a live BikeComputer workout, iPhone users can follow the ride without opening the app and can quickly mark a segment or pause/resume from the expanded Live Activity. Apple Watch remains the sole workout and HealthKit owner. If a Watch-started ride begins while iPhone is backgrounded, foregrounding BikeComputer once creates the Live Activity; an existing activity continues receiving mirrored updates in the background.

End and Discard remain in the app and Watch UI. Dismissing, disabling, expiring, or failing the Live Activity cannot change the Watch workout.

## Validation

- `WorkoutContractiOSTests`: full iOS simulator suite passed, including mapper, lifecycle-controller, intent-routing, reconciliation, suppression, coalescing, terminal, background-lease, and existing workout regressions
- `WorkoutContractWatchTests`: full watchOS simulator suite passed on Apple Watch Series 11
- `./ios-app/scripts/run-workout-contract-tests.sh`
- `python3 -m unittest discover -s ios-app/scripts/tests`: 14 tests passed
- unsigned generic iOS Release build passed while preserving the app's iOS 15 deployment target and the extension's iOS 17 target
- release-container verification confirmed the iPhone app embeds the Watch app, Watch complication, and Live Activity extension with the expected bundle identifiers and Info.plist contracts
- ActivityKit content encoding remains below 4 KB
- plist validation and `git diff --check`

## Remaining physical validation

The paired-device matrix was not run because no physical iPhone/Watch pair is connected. Before release, validate locked-device Face ID interaction, Watch- and iPhone-started workouts, background deferred start, Dynamic Island compact/minimal/expanded states, non-Dynamic-Island Lock Screen presentation, Always-On reduced luminance, StandBy/Night Mode, disconnect/reconnect, relaunch reconciliation, manual dismissal, authorization disablement, saved/discarded endings, missing heart rate, and injected segment failure.

Physical paired-device validation remains required before release.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.