### PR TITLE
Add expandable navigation stats sheet

### DIFF
--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -18,8 +18,8 @@ Watch, iPhone, and compatible Bike Computer hardware.
 - Show current Watch metrics on the ESP32 Ride Stats pages with compatible
   firmware.
 
-The workout companion requires iOS 17 and watchOS 10 or later. Existing iPhone
-navigation remains compatible with iOS 15 and later.
+The workout companion requires iOS 17 and watchOS 10 or later. iPhone
+navigation requires iOS 16.4 or later.
 
 ## App Review notes
 

--- a/docs/watchos-workout-companion-implementation-plan.md
+++ b/docs/watchos-workout-companion-implementation-plan.md
@@ -97,7 +97,7 @@ This plan was prepared from origin/main at 74a1d32b.
 
 1. Watch owns the primary workout session and the saved HKWorkout.
 2. iPhone receives a mirrored session and versioned full-state snapshots.
-3. The app keeps supporting iOS 15 for navigation, but Watch workout features
+3. The app supports iOS 16.4 or later for navigation, but Watch workout features
    are available only on iOS 17 or later with watchOS 10 or later.
 4. Watch and iPhone share one Codable workout contract.
 5. ESP32 workout data uses a dedicated characteristic and two compact,
@@ -118,9 +118,9 @@ ios-app/BikeComputer/BikeComputer.xcodeproj.
 - Watch app bundle identifier: use LetItRide.BikeComputer.watchkitapp unless
   App Store Connect requires an already-reserved identifier.
 - Watch deployment target: watchOS 10.0.
-- Keep the iOS deployment target at 15.0.
+- Set the iOS deployment target to 16.4.
 - Wrap mirrored-workout integration in iOS 17 availability checks so the
-  existing navigation app still launches and builds on iOS 15 and 16.
+  existing navigation app still launches and builds on iOS 16.4.
 - The Watch target is a companion target, not a standalone Watch-only product.
 - Keep version and build numbers aligned across the containing iOS app and
   Watch app.
@@ -848,7 +848,7 @@ Presentation rules:
 
 Exit criteria:
 
-- iOS 15 target still builds without entering workout code.
+- iOS 16.4 target still builds without entering workout code.
 - Watch target builds and installs.
 - Shared-contract tests pass on both platforms.
 

--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -653,7 +653,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -696,7 +696,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -853,7 +853,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutContractTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -872,7 +872,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutContractTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -21,7 +21,7 @@ private enum ContentSheetDestination: String, Identifiable {
 private struct RideMetricsCompactDetent: CustomPresentationDetent {
     static func height(in context: Context) -> CGFloat? {
         let preferredHeight: CGFloat =
-            context.dynamicTypeSize.isAccessibilitySize ? 440 : 360
+            context.dynamicTypeSize.isAccessibilitySize ? 360 : 280
         return min(preferredHeight, context.maxDetentValue * 0.72)
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -21,7 +21,7 @@ private enum ContentSheetDestination: String, Identifiable {
 private struct RideMetricsCompactDetent: CustomPresentationDetent {
     static func height(in context: Context) -> CGFloat? {
         let preferredHeight: CGFloat =
-            context.dynamicTypeSize.isAccessibilitySize ? 320 : 236
+            context.dynamicTypeSize.isAccessibilitySize ? 440 : 360
         return min(preferredHeight, context.maxDetentValue * 0.72)
     }
 }
@@ -219,6 +219,9 @@ struct ContentView: View {
         .onChange(of: workoutStore.shouldMaintainWorkoutServices) { _ in
             updateIdleTimer()
         }
+        .onChange(of: workoutStore.presentation.isWorkoutActive) { _ in
+            synchronizeRideMetricsSheet()
+        }
         .onChange(of: currentWorkoutSegment?.index) { index in
             guard let index,
                   index != observedWorkoutSegmentIndex else {
@@ -355,8 +358,7 @@ struct ContentView: View {
         case .rideMetrics:
             rideMetricsPanel(
                 isCompactHeight: false,
-                isSheetExpanded: rideMetricsDetent == .large,
-                onToggleExpansion: toggleRideMetricsDetent
+                isSheetExpanded: rideMetricsDetent == .large
             )
             .presentationDetents(
                 [.rideMetricsCompact, .large],
@@ -374,7 +376,7 @@ struct ContentView: View {
     }
 
     private func synchronizeRideMetricsSheet() {
-        if coordinator.isNavigating {
+        if workoutStore.presentation.isWorkoutActive {
             guard presentedSheet == nil else { return }
             rideMetricsDetent = .rideMetricsCompact
             presentedSheet = .rideMetrics
@@ -384,21 +386,15 @@ struct ContentView: View {
     }
 
     private func restoreRideMetricsSheetIfNeeded() {
-        guard coordinator.isNavigating else { return }
+        guard workoutStore.presentation.isWorkoutActive else { return }
         Task { @MainActor in
             await Task.yield()
-            guard presentedSheet == nil, coordinator.isNavigating else {
+            guard presentedSheet == nil,
+                  workoutStore.presentation.isWorkoutActive else {
                 return
             }
             rideMetricsDetent = .rideMetricsCompact
             presentedSheet = .rideMetrics
-        }
-    }
-
-    private func toggleRideMetricsDetent() {
-        withAnimation {
-            rideMetricsDetent =
-                rideMetricsDetent == .large ? .rideMetricsCompact : .large
         }
     }
 
@@ -567,9 +563,8 @@ struct ContentView: View {
                     .padding(.horizontal, 18)
             }
 
-            if !coordinator.isNavigating,
-               workoutStore.presentation.isWorkoutActive,
-               !isSearchPanelExpanded {
+            if coordinator.isNavigating,
+               !workoutStore.presentation.isWorkoutActive {
                 rideControlPanel(isCompactHeight: isCompactHeight)
             }
 
@@ -593,8 +588,7 @@ struct ContentView: View {
 
     private func rideMetricsPanel(
         isCompactHeight: Bool,
-        isSheetExpanded: Bool? = nil,
-        onToggleExpansion: (() -> Void)? = nil
+        isSheetExpanded: Bool? = nil
     ) -> some View {
         RideMetricsPanel(
             workoutStore: workoutStore,
@@ -610,8 +604,7 @@ struct ContentView: View {
             onResumeWorkout: workoutMirrorManager.resume,
             onEndAndSaveWorkout: workoutMirrorManager.endAndSave,
             onDiscardWorkout: workoutMirrorManager.discard,
-            isSheetExpanded: isSheetExpanded,
-            onToggleExpansion: onToggleExpansion
+            isSheetExpanded: isSheetExpanded
         )
     }
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -9,6 +9,29 @@ import SwiftUI
 import MapKit
 import UIKit
 
+private enum ContentSheetDestination: String, Identifiable {
+    case settings
+    case bikeComputerSetup
+    case workoutDashboard
+    case rideMetrics
+
+    var id: String { rawValue }
+}
+
+private struct RideMetricsCompactDetent: CustomPresentationDetent {
+    static func height(in context: Context) -> CGFloat? {
+        let preferredHeight: CGFloat =
+            context.dynamicTypeSize.isAccessibilitySize ? 320 : 236
+        return min(preferredHeight, context.maxDetentValue * 0.72)
+    }
+}
+
+private extension PresentationDetent {
+    static var rideMetricsCompact: PresentationDetent {
+        .custom(RideMetricsCompactDetent.self)
+    }
+}
+
 struct ContentView: View {
     
     // MARK: - State
@@ -22,9 +45,8 @@ struct ContentView: View {
     
     @State private var sourceAddress = ""
     @State private var destinationAddress = ""
-    @State private var showingSettings = false
-    @State private var showingBikeComputerSetup = false
-    @State private var showingWorkoutDashboard = false
+    @State private var presentedSheet: ContentSheetDestination?
+    @State private var rideMetricsDetent = PresentationDetent.rideMetricsCompact
     @State private var workoutSegmentToast: WorkoutCompletedSegmentV1?
     @State private var observedWorkoutSegmentIndex: UInt32?
     @State private var isSearchPanelExpanded = false
@@ -94,7 +116,9 @@ struct ContentView: View {
                             store: workoutStore,
                             watchAvailability: watchAvailability,
                             onStart: workoutMirrorManager.startOutdoorCyclingOnWatch,
-                            onOpen: { showingWorkoutDashboard = true }
+                            onOpen: {
+                                presentedSheet = .workoutDashboard
+                            }
                         )
                         .padding(.horizontal, 14)
                         .padding(.top, 8)
@@ -130,7 +154,9 @@ struct ContentView: View {
                         isLocationAuthorized: coordinator.isLocationAuthorized,
                         onRequestLocation: advancePastLocationAndRequestAccess,
                         onSkipLocation: advancePastLocation,
-                        onConnectDevice: { showingBikeComputerSetup = true },
+                        onConnectDevice: {
+                            presentedSheet = .bikeComputerSetup
+                        },
                         onCheckDeviceMaps: {
                             _ = coordinator.bleManager.requestMapTransferStatus()
                             _ = coordinator.bleManager.requestDeviceTransferStatus()
@@ -143,7 +169,7 @@ struct ContentView: View {
                 }
 
                 if let workoutSegmentToast,
-                   !showingWorkoutDashboard {
+                   presentedSheet != .workoutDashboard {
                     VStack {
                         workoutSegmentToastView(workoutSegmentToast)
                             .padding(.horizontal, 14)
@@ -159,49 +185,11 @@ struct ContentView: View {
             } message: {
                 Text(coordinator.alert.message)
             }
-            .sheet(isPresented: $showingSettings) {
-                SettingsView(
-                    locationAuthorized: coordinator.isLocationAuthorized,
-                    currentLocation: coordinator.currentLocation,
-                    offlineMapManager: offlineMapManager,
-                    firmwareUpdateManager: coordinator.firmwareUpdateManager,
-                    watchAvailability: watchAvailability,
-                    onStartTestNavigation: { destination in
-                        coordinator.startNavigation(
-                            from: .currentLocation,
-                            to: .query(destination),
-                            transportType: RouteTransportTypes.cycling,
-                            isTestMode: true
-                        )
-                    }
-                )
-                    .environmentObject(coordinator.bleManager)
-            }
-            .sheet(isPresented: $showingBikeComputerSetup) {
-                NavigationView {
-                    BikeComputersSettingsView()
-                        .toolbar {
-                            ToolbarItem(placement: .cancellationAction) {
-                                Button("Close") {
-                                    showingBikeComputerSetup = false
-                                }
-                            }
-                        }
-                }
-                .environmentObject(coordinator.bleManager)
-            }
-            .sheet(isPresented: $showingWorkoutDashboard) {
-                WorkoutDashboardView(
-                    store: workoutStore,
-                    watchAvailability: watchAvailability,
-                    onStart: workoutMirrorManager.startOutdoorCyclingOnWatch,
-                    onPause: workoutMirrorManager.pause,
-                    onResume: workoutMirrorManager.resume,
-                    onMarkSegment: workoutMirrorManager.markSegment,
-                    onEndAndSave: workoutMirrorManager.endAndSave,
-                    onDiscard: workoutMirrorManager.discard,
-                    onDone: workoutMirrorManager.resetTerminalPresentation
-                )
+            .sheet(
+                item: $presentedSheet,
+                onDismiss: restoreRideMetricsSheetIfNeeded
+            ) { destination in
+                presentedSheetContent(for: destination)
             }
         }
         .onAppear {
@@ -214,6 +202,7 @@ struct ContentView: View {
             workoutMirrorManager.refreshFreshness()
             observedWorkoutSegmentIndex = currentWorkoutSegment?.index
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
+            synchronizeRideMetricsSheet()
         }
         .onChange(of: scenePhase) { newValue in
             coordinator.setViewingMap(newValue == .active)
@@ -225,6 +214,7 @@ struct ContentView: View {
         }
         .onChange(of: coordinator.isNavigating) { _ in
             updateIdleTimer()
+            synchronizeRideMetricsSheet()
         }
         .onChange(of: workoutStore.shouldMaintainWorkoutServices) { _ in
             updateIdleTimer()
@@ -237,7 +227,7 @@ struct ContentView: View {
             }
             observedWorkoutSegmentIndex = index
             guard scenePhase == .active,
-                  !showingWorkoutDashboard,
+                  presentedSheet != .workoutDashboard,
                   workoutStore.presentation.isWorkoutActive,
                   let segment = currentWorkoutSegment else {
                 workoutSegmentToast = nil
@@ -259,12 +249,16 @@ struct ContentView: View {
         .onChange(of: coordinator.bleManager.isNavigationReady) { _ in
             schedulePendingMapInstallResume()
             if coordinator.bleManager.isNavigationReady {
-                showingBikeComputerSetup = false
+                if presentedSheet == .bikeComputerSetup {
+                    presentedSheet = nil
+                }
             }
         }
         .onChange(of: offlineMapManager.isMapAreaSelectionActive) { isActive in
             if isActive {
-                showingSettings = false
+                if presentedSheet == .settings {
+                    presentedSheet = nil
+                }
                 offlineMapSelectionWidth = nil
                 offlineMapSelectionHeight = nil
                 offlineMapSelectionCenterY = nil
@@ -300,6 +294,111 @@ struct ContentView: View {
             withAnimation {
                 workoutSegmentToast = nil
             }
+        }
+    }
+
+    @ViewBuilder
+    private func presentedSheetContent(
+        for destination: ContentSheetDestination
+    ) -> some View {
+        switch destination {
+        case .settings:
+            SettingsView(
+                locationAuthorized: coordinator.isLocationAuthorized,
+                currentLocation: coordinator.currentLocation,
+                offlineMapManager: offlineMapManager,
+                firmwareUpdateManager: coordinator.firmwareUpdateManager,
+                watchAvailability: watchAvailability,
+                onStartTestNavigation: { destination in
+                    coordinator.startNavigation(
+                        from: .currentLocation,
+                        to: .query(destination),
+                        transportType: RouteTransportTypes.cycling,
+                        isTestMode: true
+                    )
+                }
+            )
+            .environmentObject(coordinator.bleManager)
+            .presentationDetents([.large])
+            .presentationBackgroundInteraction(.disabled)
+
+        case .bikeComputerSetup:
+            NavigationView {
+                BikeComputersSettingsView()
+                    .toolbar {
+                        ToolbarItem(placement: .cancellationAction) {
+                            Button("Close") {
+                                presentedSheet = nil
+                            }
+                        }
+                    }
+            }
+            .environmentObject(coordinator.bleManager)
+            .presentationDetents([.large])
+            .presentationBackgroundInteraction(.disabled)
+
+        case .workoutDashboard:
+            WorkoutDashboardView(
+                store: workoutStore,
+                watchAvailability: watchAvailability,
+                onStart: workoutMirrorManager.startOutdoorCyclingOnWatch,
+                onPause: workoutMirrorManager.pause,
+                onResume: workoutMirrorManager.resume,
+                onMarkSegment: workoutMirrorManager.markSegment,
+                onEndAndSave: workoutMirrorManager.endAndSave,
+                onDiscard: workoutMirrorManager.discard,
+                onDone: workoutMirrorManager.resetTerminalPresentation
+            )
+            .presentationDetents([.large])
+            .presentationBackgroundInteraction(.disabled)
+
+        case .rideMetrics:
+            rideMetricsPanel(
+                isCompactHeight: false,
+                isSheetExpanded: rideMetricsDetent == .large,
+                onToggleExpansion: toggleRideMetricsDetent
+            )
+            .presentationDetents(
+                [.rideMetricsCompact, .large],
+                selection: $rideMetricsDetent
+            )
+            .presentationDragIndicator(.visible)
+            .presentationBackground(.regularMaterial)
+            .presentationBackgroundInteraction(
+                .enabled(upThrough: .rideMetricsCompact)
+            )
+            .presentationContentInteraction(.resizes)
+            .presentationCornerRadius(32)
+            .interactiveDismissDisabled()
+        }
+    }
+
+    private func synchronizeRideMetricsSheet() {
+        if coordinator.isNavigating {
+            guard presentedSheet == nil else { return }
+            rideMetricsDetent = .rideMetricsCompact
+            presentedSheet = .rideMetrics
+        } else if presentedSheet == .rideMetrics {
+            presentedSheet = nil
+        }
+    }
+
+    private func restoreRideMetricsSheetIfNeeded() {
+        guard coordinator.isNavigating else { return }
+        Task { @MainActor in
+            await Task.yield()
+            guard presentedSheet == nil, coordinator.isNavigating else {
+                return
+            }
+            rideMetricsDetent = .rideMetricsCompact
+            presentedSheet = .rideMetrics
+        }
+    }
+
+    private func toggleRideMetricsDetent() {
+        withAnimation {
+            rideMetricsDetent =
+                rideMetricsDetent == .large ? .rideMetricsCompact : .large
         }
     }
 
@@ -441,7 +540,7 @@ struct ContentView: View {
                 onReconnect: { coordinator.reconnect() }
             )
 
-            Button(action: { showingSettings = true }) {
+            Button(action: { presentedSheet = .settings }) {
                 Image(systemName: "gearshape.fill")
                     .font(.title3)
                     .foregroundColor(.primary)
@@ -468,8 +567,9 @@ struct ContentView: View {
                     .padding(.horizontal, 18)
             }
 
-            if (coordinator.isNavigating || workoutStore.presentation.isWorkoutActive),
-               (coordinator.isNavigating || !isSearchPanelExpanded) {
+            if !coordinator.isNavigating,
+               workoutStore.presentation.isWorkoutActive,
+               !isSearchPanelExpanded {
                 rideControlPanel(isCompactHeight: isCompactHeight)
             }
 
@@ -491,7 +591,11 @@ struct ContentView: View {
         .animation(.easeInOut(duration: 0.2), value: coordinator.isNavigating)
     }
 
-    private func rideControlPanel(isCompactHeight: Bool) -> some View {
+    private func rideMetricsPanel(
+        isCompactHeight: Bool,
+        isSheetExpanded: Bool? = nil,
+        onToggleExpansion: (() -> Void)? = nil
+    ) -> some View {
         RideMetricsPanel(
             workoutStore: workoutStore,
             watchAvailability: watchAvailability,
@@ -505,9 +609,15 @@ struct ContentView: View {
             onPauseWorkout: workoutMirrorManager.pause,
             onResumeWorkout: workoutMirrorManager.resume,
             onEndAndSaveWorkout: workoutMirrorManager.endAndSave,
-            onDiscardWorkout: workoutMirrorManager.discard
+            onDiscardWorkout: workoutMirrorManager.discard,
+            isSheetExpanded: isSheetExpanded,
+            onToggleExpansion: onToggleExpansion
         )
-        .padding(.horizontal, 12)
+    }
+
+    private func rideControlPanel(isCompactHeight: Bool) -> some View {
+        rideMetricsPanel(isCompactHeight: isCompactHeight)
+            .padding(.horizontal, 12)
     }
 
     private func routeAndWorkoutStartRow(maxHeight: CGFloat) -> some View {
@@ -587,7 +697,7 @@ struct ContentView: View {
 
     private var offlineMapStatusChip: some View {
         Button {
-            showingSettings = true
+            presentedSheet = .settings
         } label: {
             HStack(spacing: 10) {
                 if offlineMapManager.isBusy {

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -681,11 +681,21 @@ struct ContentView: View {
     }
 
     private var shouldShowOfflineMapStatusChip: Bool {
-        offlineMapManager.isBusy ||
+        guard !isOnlyCheckingForServerMaps else {
+            return false
+        }
+        return offlineMapManager.isBusy ||
             offlineMapManager.hasPendingMapJob ||
             offlineMapManager.currentJob != nil ||
             offlineMapManager.downloadedPackURL != nil ||
             offlineMapManager.errorMessage != nil
+    }
+
+    private var isOnlyCheckingForServerMaps: Bool {
+        offlineMapManager.isServerRecoveryCheckPending
+            && offlineMapManager.currentJob == nil
+            && offlineMapManager.downloadedPackURL == nil
+            && offlineMapManager.errorMessage == nil
     }
 
     private var offlineMapStatusChip: some View {

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -373,17 +373,39 @@ struct RideMetricsPanel: View {
     }
 
     private var workoutMetrics: some View {
-        workoutMetricGrid(isExpanded: false)
+        workoutMetricGrid(
+            metrics: workoutMetricValues,
+            columnCount: 3,
+            isExpanded: false
+        )
     }
 
     private var expandedWorkoutMetrics: some View {
-        workoutMetricGrid(isExpanded: true)
+        let metrics = workoutMetricValues
+        return VStack(spacing: 32) {
+            if let speed = metrics.first(where: { $0.id == "speed" }) {
+                RideMetricColumn(
+                    value: speed.value,
+                    unit: speed.unit,
+                    label: speed.label,
+                    isExpanded: true,
+                    isHero: true
+                )
+                .frame(maxWidth: .infinity)
+            }
+
+            workoutMetricGrid(
+                metrics: metrics.filter { $0.id != "speed" },
+                columnCount: 2,
+                isExpanded: true
+            )
+        }
     }
 
-    private func workoutMetricGrid(isExpanded: Bool) -> some View {
+    private var workoutMetricValues: [RideMetric] {
         let snapshot = workoutStore.presentation.snapshot
         let suppressInstantaneous = suppressInstantaneousMetrics
-        let metrics = [
+        return [
             RideMetric(
                 value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
                 label: "elapsed"
@@ -452,12 +474,19 @@ struct RideMetricsPanel: View {
                 label: "energy"
             ),
         ]
+    }
+
+    private func workoutMetricGrid(
+        metrics: [RideMetric],
+        columnCount: Int,
+        isExpanded: Bool
+    ) -> some View {
         let columns = Array(
             repeating: GridItem(
                 .flexible(),
                 spacing: isExpanded ? 24 : 0
             ),
-            count: isExpanded ? 2 : 3
+            count: columnCount
         )
 
         return LazyVGrid(
@@ -725,7 +754,7 @@ private struct RideControlLabel: View {
             .font(.subheadline.weight(.semibold))
             .lineLimit(1)
             .minimumScaleFactor(0.62)
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, minHeight: 36)
     }
 }
 
@@ -748,6 +777,7 @@ private struct RideMetricColumn: View {
     let unit: String?
     let label: String
     let isExpanded: Bool
+    var isHero = false
 
     var body: some View {
         VStack(spacing: isExpanded ? 4 : 2) {
@@ -778,7 +808,7 @@ private struct RideMetricColumn: View {
 
     private var valueFont: Font {
         .system(
-            size: isExpanded ? 42 : 25,
+            size: isHero ? 64 : isExpanded ? 42 : 25,
             weight: .bold,
             design: .rounded
         )
@@ -786,7 +816,7 @@ private struct RideMetricColumn: View {
 
     private var unitFont: Font {
         .system(
-            size: isExpanded ? 24 : 16,
+            size: isHero ? 28 : isExpanded ? 24 : 16,
             weight: .semibold,
             design: .rounded
         )
@@ -794,7 +824,7 @@ private struct RideMetricColumn: View {
 
     private var labelFont: Font {
         .system(
-            size: isExpanded ? 20 : 15,
+            size: isHero ? 22 : isExpanded ? 20 : 15,
             weight: .semibold,
             design: .rounded
         )

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -276,7 +276,7 @@ struct RideMetricsPanel: View {
             controls
                 .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 14 : 20)
                 .padding(.top, 12)
-                .padding(.bottom, 14)
+                .padding(.bottom, 4)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("rideMetricsSheet")

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -300,14 +300,14 @@ struct RideMetricsPanel: View {
                 VStack(alignment: .leading, spacing: 14) {
                     sheetSectionTitle("Workout", systemImage: "figure.outdoor.cycle")
                     workoutStatusBanner
-                    workoutMetrics
+                    expandedWorkoutMetrics
                 }
             }
 
             if isNavigating {
                 VStack(alignment: .leading, spacing: 14) {
                     sheetSectionTitle("Navigation", systemImage: "location.fill")
-                    navigationMetrics
+                    expandedNavigationMetrics
                 }
             }
         }
@@ -319,7 +319,7 @@ struct RideMetricsPanel: View {
         systemImage: String
     ) -> some View {
         Label(title, systemImage: systemImage)
-            .font(.headline)
+            .font(.title3.weight(.semibold))
             .foregroundColor(.secondary)
             .accessibilityAddTraits(.isHeader)
     }
@@ -345,97 +345,131 @@ struct RideMetricsPanel: View {
         .padding(.horizontal, 12)
     }
 
+    private var expandedNavigationMetrics: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: 24),
+                GridItem(.flexible(), spacing: 24),
+            ],
+            spacing: 26
+        ) {
+            NavigationMetricColumn(
+                value: formattedArrival,
+                label: "arrival",
+                isExpanded: true
+            )
+            NavigationMetricColumn(
+                value: formattedTime,
+                label: timeUnit,
+                isExpanded: true
+            )
+            NavigationMetricColumn(
+                value: formattedDistance,
+                label: distanceUnit,
+                isExpanded: true
+            )
+        }
+        .padding(.horizontal, 8)
+    }
+
     private var workoutMetrics: some View {
+        workoutMetricGrid(isExpanded: false)
+    }
+
+    private var expandedWorkoutMetrics: some View {
+        workoutMetricGrid(isExpanded: true)
+    }
+
+    private func workoutMetricGrid(isExpanded: Bool) -> some View {
         let snapshot = workoutStore.presentation.snapshot
         let suppressInstantaneous = suppressInstantaneousMetrics
-        return VStack(spacing: 12) {
-            HStack(alignment: .center, spacing: 0) {
-                RideMetricColumn(
-                    value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
-                    label: "elapsed"
-                )
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.whole(
-                            suppressInstantaneous
-                                ? nil
-                                : snapshot.cyclingCadence?.value
-                        ),
-                        unit: "rpm"
-                    ),
-                    label: "cadence"
-                )
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.whole(
-                            suppressInstantaneous
-                                ? nil
-                                : snapshot.cyclingPower?.value
-                        ),
-                        unit: "W"
-                    ),
-                    label: "power"
-                )
-            }
+        let metrics = [
+            RideMetric(
+                value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
+                label: "elapsed"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.whole(
+                    suppressInstantaneous
+                        ? nil
+                        : snapshot.cyclingCadence?.value
+                ),
+                unit: "rpm",
+                label: "cadence"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.whole(
+                    suppressInstantaneous
+                        ? nil
+                        : snapshot.cyclingPower?.value
+                ),
+                unit: "W",
+                label: "power"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.speed(
+                    suppressInstantaneous
+                        ? nil
+                        : snapshot.currentSpeed?.value
+                ),
+                unit: "km/h",
+                label: "speed"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.distance(snapshot.cyclingDistance?.value),
+                unit: WorkoutValueFormatter.distanceUnit(
+                    snapshot.cyclingDistance?.value
+                ).lowercased(),
+                label: "distance"
+            ),
+            RideMetric(
+                value: altitudeValue(
+                    suppressInstantaneous
+                        ? nil
+                        : snapshot.location?.altitude
+                ),
+                unit: "m",
+                label: "altitude"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.heartRate(
+                    suppressInstantaneous
+                        ? nil
+                        : snapshot.currentHeartRate?.value
+                ),
+                unit: "bpm",
+                label: "heart rate"
+            ),
+            RideMetric(
+                value: suppressInstantaneous
+                    ? "--"
+                    : heartRateZone(snapshot),
+                label: "heart zone"
+            ),
+            RideMetric(
+                value: WorkoutValueFormatter.energy(snapshot.activeEnergy?.value),
+                unit: "kcal",
+                label: "energy"
+            ),
+        ]
+        let columns = Array(
+            repeating: GridItem(
+                .flexible(),
+                spacing: isExpanded ? 24 : 0
+            ),
+            count: isExpanded ? 2 : 3
+        )
 
-            HStack(alignment: .center, spacing: 0) {
+        return LazyVGrid(
+            columns: columns,
+            spacing: isExpanded ? 26 : 12
+        ) {
+            ForEach(metrics) { metric in
                 RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.speed(
-                            suppressInstantaneous
-                                ? nil
-                                : snapshot.currentSpeed?.value
-                        ),
-                        unit: "km/h"
-                    ),
-                    label: "speed"
-                )
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.distance(snapshot.cyclingDistance?.value),
-                        unit: WorkoutValueFormatter.distanceUnit(
-                            snapshot.cyclingDistance?.value
-                        ).lowercased()
-                    ),
-                    label: "distance"
-                )
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        altitudeValue(
-                            suppressInstantaneous
-                                ? nil
-                                : snapshot.location?.altitude
-                        ),
-                        unit: "m"
-                    ),
-                    label: "altitude"
-                )
-            }
-
-            HStack(alignment: .center, spacing: 0) {
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.heartRate(
-                            suppressInstantaneous
-                                ? nil
-                                : snapshot.currentHeartRate?.value
-                        ),
-                        unit: "bpm"
-                    ),
-                    label: "heart rate"
-                )
-                RideMetricColumn(
-                    value: suppressInstantaneous
-                        ? "--"
-                        : heartRateZone(snapshot),
-                    label: "heart zone"
-                )
-                RideMetricColumn(
-                    value: valueWithUnit(
-                        WorkoutValueFormatter.energy(snapshot.activeEnergy?.value),
-                        unit: "kcal"
-                    ),
-                    label: "energy"
+                    value: metric.value,
+                    unit: metric.unit,
+                    label: metric.label,
+                    isExpanded: isExpanded
                 )
             }
         }
@@ -675,10 +709,6 @@ struct RideMetricsPanel: View {
         guard let altitude, altitude.isFinite else { return "--" }
         return String(format: "%.0f", altitude)
     }
-
-    private func valueWithUnit(_ value: String, unit: String) -> String {
-        value == "--" ? value : "\(value) \(unit)"
-    }
 }
 
 private struct RideControlLabel: View {
@@ -699,21 +729,45 @@ private struct RideControlLabel: View {
     }
 }
 
-private struct RideMetricColumn: View {
+private struct RideMetric: Identifiable {
     let value: String
+    let unit: String?
     let label: String
 
+    init(value: String, unit: String? = nil, label: String) {
+        self.value = value
+        self.unit = unit
+        self.label = label
+    }
+
+    var id: String { label }
+}
+
+private struct RideMetricColumn: View {
+    let value: String
+    let unit: String?
+    let label: String
+    let isExpanded: Bool
+
     var body: some View {
-        VStack(spacing: 2) {
-            Text(value)
-                .font(.system(size: 25, weight: .bold, design: .rounded))
-                .foregroundColor(.primary)
-                .monospacedDigit()
+        VStack(spacing: isExpanded ? 4 : 2) {
+            HStack(alignment: .firstTextBaseline, spacing: isExpanded ? 6 : 4) {
+                Text(value)
+                    .font(valueFont)
+                    .foregroundColor(.primary)
+                    .monospacedDigit()
+
+                if let unit, value != "--" {
+                    Text(unit)
+                        .font(unitFont)
+                        .foregroundColor(.secondary)
+                }
+            }
                 .lineLimit(1)
                 .minimumScaleFactor(0.55)
 
             Text(label)
-                .font(.system(size: 15, weight: .semibold, design: .rounded))
+                .font(labelFont)
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
@@ -721,22 +775,59 @@ private struct RideMetricColumn: View {
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .combine)
     }
+
+    private var valueFont: Font {
+        .system(
+            size: isExpanded ? 42 : 25,
+            weight: .bold,
+            design: .rounded
+        )
+    }
+
+    private var unitFont: Font {
+        .system(
+            size: isExpanded ? 24 : 16,
+            weight: .semibold,
+            design: .rounded
+        )
+    }
+
+    private var labelFont: Font {
+        .system(
+            size: isExpanded ? 20 : 15,
+            weight: .semibold,
+            design: .rounded
+        )
+    }
 }
 
 private struct NavigationMetricColumn: View {
     let value: String
     let label: String
+    var isExpanded = false
 
     var body: some View {
-        VStack(spacing: 2) {
+        VStack(spacing: isExpanded ? 4 : 2) {
             Text(value)
-                .font(.system(size: 34, weight: .bold, design: .rounded))
+                .font(
+                    .system(
+                        size: isExpanded ? 42 : 34,
+                        weight: .bold,
+                        design: .rounded
+                    )
+                )
                 .foregroundColor(.primary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
 
             Text(label)
-                .font(.system(size: 18, weight: .semibold, design: .rounded))
+                .font(
+                    .system(
+                        size: isExpanded ? 20 : 18,
+                        weight: .semibold,
+                        design: .rounded
+                    )
+                )
                 .foregroundColor(.secondary)
                 .lineLimit(1)
         }

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -198,7 +198,6 @@ struct RideMetricsPanel: View {
     let onEndAndSaveWorkout: () -> Void
     let onDiscardWorkout: () -> Void
     let isSheetExpanded: Bool?
-    let onToggleExpansion: (() -> Void)?
 
     var body: some View {
         if let isSheetExpanded {
@@ -254,13 +253,11 @@ struct RideMetricsPanel: View {
 
     private func sheetBody(isExpanded: Bool) -> some View {
         VStack(spacing: 0) {
-            sheetHeader(isExpanded: isExpanded)
-
             if isExpanded {
                 ScrollView(.vertical, showsIndicators: true) {
                     expandedMetricContent
                         .padding(.horizontal, 20)
-                        .padding(.top, 10)
+                        .padding(.top, 28)
                         .padding(.bottom, 24)
                 }
                 .frame(maxHeight: .infinity)
@@ -268,7 +265,8 @@ struct RideMetricsPanel: View {
                 ScrollView(.vertical, showsIndicators: false) {
                     compactSheetMetricContent
                         .padding(.horizontal, 12)
-                        .padding(.vertical, 6)
+                        .padding(.top, 24)
+                        .padding(.bottom, 8)
                 }
                 .frame(maxHeight: .infinity)
             }
@@ -284,36 +282,11 @@ struct RideMetricsPanel: View {
         .accessibilityIdentifier("rideMetricsSheet")
     }
 
-    private func sheetHeader(isExpanded: Bool) -> some View {
-        Button {
-            onToggleExpansion?()
-        } label: {
-            HStack(spacing: 12) {
-                Text("Ride Stats")
-                    .font(.title3.weight(.semibold))
-                    .foregroundColor(.primary)
-
-                Spacer()
-
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
-                    .font(.subheadline.weight(.bold))
-                    .foregroundColor(.secondary)
-                    .frame(width: 36, height: 36)
-                    .background(Color(.secondarySystemBackground), in: Circle())
-            }
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .disabled(onToggleExpansion == nil)
-        .padding(.horizontal, 20)
-        .padding(.top, 6)
-        .accessibilityLabel(isExpanded ? "Collapse ride stats" : "Expand ride stats")
-    }
-
     @ViewBuilder
     private var compactSheetMetricContent: some View {
         if workoutStore.presentation.isWorkoutActive {
             workoutStatusBanner
+            workoutMetrics
         }
 
         if isNavigating {

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -197,8 +197,18 @@ struct RideMetricsPanel: View {
     let onResumeWorkout: () -> Void
     let onEndAndSaveWorkout: () -> Void
     let onDiscardWorkout: () -> Void
+    let isSheetExpanded: Bool?
+    let onToggleExpansion: (() -> Void)?
 
     var body: some View {
+        if let isSheetExpanded {
+            sheetBody(isExpanded: isSheetExpanded)
+        } else {
+            overlayBody
+        }
+    }
+
+    private var overlayBody: some View {
         Group {
             if isCompactHeight && dynamicTypeSize.isAccessibilitySize {
                 ScrollView(.vertical, showsIndicators: true) {
@@ -242,6 +252,105 @@ struct RideMetricsPanel: View {
         .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
     }
 
+    private func sheetBody(isExpanded: Bool) -> some View {
+        VStack(spacing: 0) {
+            sheetHeader(isExpanded: isExpanded)
+
+            if isExpanded {
+                ScrollView(.vertical, showsIndicators: true) {
+                    expandedMetricContent
+                        .padding(.horizontal, 20)
+                        .padding(.top, 10)
+                        .padding(.bottom, 24)
+                }
+                .frame(maxHeight: .infinity)
+            } else {
+                ScrollView(.vertical, showsIndicators: false) {
+                    compactSheetMetricContent
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 6)
+                }
+                .frame(maxHeight: .infinity)
+            }
+
+            Divider()
+
+            controls
+                .padding(.horizontal, dynamicTypeSize.isAccessibilitySize ? 14 : 20)
+                .padding(.top, 12)
+                .padding(.bottom, 14)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .accessibilityIdentifier("rideMetricsSheet")
+    }
+
+    private func sheetHeader(isExpanded: Bool) -> some View {
+        Button {
+            onToggleExpansion?()
+        } label: {
+            HStack(spacing: 12) {
+                Text("Ride Stats")
+                    .font(.title3.weight(.semibold))
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.up")
+                    .font(.subheadline.weight(.bold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 36, height: 36)
+                    .background(Color(.secondarySystemBackground), in: Circle())
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(onToggleExpansion == nil)
+        .padding(.horizontal, 20)
+        .padding(.top, 6)
+        .accessibilityLabel(isExpanded ? "Collapse ride stats" : "Expand ride stats")
+    }
+
+    @ViewBuilder
+    private var compactSheetMetricContent: some View {
+        if workoutStore.presentation.isWorkoutActive {
+            workoutStatusBanner
+        }
+
+        if isNavigating {
+            navigationMetrics
+        }
+    }
+
+    private var expandedMetricContent: some View {
+        VStack(alignment: .leading, spacing: 28) {
+            if workoutStore.presentation.isWorkoutActive {
+                VStack(alignment: .leading, spacing: 14) {
+                    sheetSectionTitle("Workout", systemImage: "figure.outdoor.cycle")
+                    workoutStatusBanner
+                    workoutMetrics
+                }
+            }
+
+            if isNavigating {
+                VStack(alignment: .leading, spacing: 14) {
+                    sheetSectionTitle("Navigation", systemImage: "location.fill")
+                    navigationMetrics
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func sheetSectionTitle(
+        _ title: String,
+        systemImage: String
+    ) -> some View {
+        Label(title, systemImage: systemImage)
+            .font(.headline)
+            .foregroundColor(.secondary)
+            .accessibilityAddTraits(.isHeader)
+    }
+
     @ViewBuilder
     private var metricContent: some View {
         if workoutStore.presentation.isWorkoutActive {
@@ -250,13 +359,17 @@ struct RideMetricsPanel: View {
         }
 
         if isNavigating {
-            HStack(alignment: .center, spacing: 0) {
-                NavigationMetricColumn(value: formattedArrival, label: "arrival")
-                NavigationMetricColumn(value: formattedTime, label: timeUnit)
-                NavigationMetricColumn(value: formattedDistance, label: distanceUnit)
-            }
-            .padding(.horizontal, 12)
+            navigationMetrics
         }
+    }
+
+    private var navigationMetrics: some View {
+        HStack(alignment: .center, spacing: 0) {
+            NavigationMetricColumn(value: formattedArrival, label: "arrival")
+            NavigationMetricColumn(value: formattedTime, label: timeUnit)
+            NavigationMetricColumn(value: formattedDistance, label: distanceUnit)
+        }
+        .padding(.horizontal, 12)
     }
 
     private var workoutMetrics: some View {
@@ -264,6 +377,10 @@ struct RideMetricsPanel: View {
         let suppressInstantaneous = suppressInstantaneousMetrics
         return VStack(spacing: 12) {
             HStack(alignment: .center, spacing: 0) {
+                RideMetricColumn(
+                    value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
+                    label: "elapsed"
+                )
                 RideMetricColumn(
                     value: valueWithUnit(
                         WorkoutValueFormatter.whole(

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -124,29 +124,22 @@ struct LiveWorkoutView: View {
                     .multilineTextAlignment(.center)
                 }
 
-                Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))
-                    .font(.system(.title2, design: .rounded, weight: .semibold))
-                    .monospacedDigit()
-                    .accessibilityLabel("Elapsed time")
-
-                if let segment = manager.snapshot.lastCompletedSegment {
-                    Label(
-                        "Segment \(segment.index + 1)",
-                        systemImage: "flag.checkered"
-                    )
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                }
-
                 LazyVGrid(columns: columns, spacing: 8) {
                     metric(
                         title: "Heart",
                         value: WorkoutValueFormatter.heartRate(
                             manager.snapshot.currentHeartRate?.value
                         ),
-                        unit: heartRateUnit,
+                        unit: "BPM",
                         icon: "heart.fill",
                         color: .red
+                    )
+                    metric(
+                        title: "HR Zone",
+                        value: heartRateZoneValue,
+                        unit: heartRateZoneUnit,
+                        icon: "heart.circle.fill",
+                        color: .pink
                     )
                     metric(
                         title: "Distance",
@@ -196,6 +189,20 @@ struct LiveWorkoutView: View {
                         color: .mint
                     )
                 }
+
+                if let segment = manager.snapshot.lastCompletedSegment {
+                    Label(
+                        "Segment \(segment.index + 1)",
+                        systemImage: "flag.checkered"
+                    )
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                }
+
+                Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))
+                    .font(.system(.title2, design: .rounded, weight: .semibold))
+                    .monospacedDigit()
+                    .accessibilityLabel("Elapsed time")
 
                 HStack(spacing: 8) {
                     Button {
@@ -315,16 +322,19 @@ struct LiveWorkoutView: View {
         }
     }
 
+    @ViewBuilder
     private var stateHeader: some View {
-        HStack(spacing: 5) {
-            Circle()
-                .fill(stateColor)
-                .frame(width: 7, height: 7)
-            Text(stateLabel)
-                .font(.caption.weight(.semibold))
+        if let stateLabel {
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(stateColor)
+                    .frame(width: 7, height: 7)
+                Text(stateLabel)
+                    .font(.caption.weight(.semibold))
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Workout \(stateLabel)")
         }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Workout \(stateLabel)")
     }
 
     private func metric(
@@ -388,18 +398,24 @@ struct LiveWorkoutView: View {
         [GridItem(.flexible()), GridItem(.flexible())]
     }
 
-    private var heartRateUnit: String {
-        guard let zone = manager.snapshot.currentHeartRateZone,
-              let count = manager.snapshot.heartRateZoneCount else {
-            return "BPM"
+    private var heartRateZoneValue: String {
+        guard let zone = manager.snapshot.currentHeartRateZone else {
+            return "--"
         }
-        return "BPM · Z\(zone)/\(count)"
+        return "Z\(zone)"
     }
 
-    private var stateLabel: String {
+    private var heartRateZoneUnit: String {
+        guard let count = manager.snapshot.heartRateZoneCount else {
+            return "ZONE"
+        }
+        return "OF \(count)"
+    }
+
+    private var stateLabel: String? {
         switch manager.state {
         case .starting: "STARTING"
-        case .running: "LIVE"
+        case .running: nil
         case .paused: "PAUSED"
         case .ending: manager.isDiscarding ? "DISCARDING" : "SAVING"
         case .idle, .ended, .failed: "WORKOUT"

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5663,24 +5663,33 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             compactNavigation.contains(
-                "count:isExpanded?2:3"
+                "workoutMetricGrid(metrics:workoutMetricValues,columnCount:3,isExpanded:false)"
             )
                 && compactNavigation.contains(
-                    "expandedWorkoutMetrics"
+                    "metrics.first(where:{$0.id==\"speed\"})"
+                )
+                && compactNavigation.contains(
+                    "isExpanded:true,isHero:true"
+                )
+                && compactNavigation.contains(
+                    "metrics:metrics.filter{$0.id!=\"speed\"},columnCount:2,isExpanded:true"
                 )
                 && compactNavigation.contains(
                     "expandedNavigationMetrics"
                 )
                 && compactNavigation.contains(
-                    "size:isExpanded?42:25"
+                    "size:isHero?64:isExpanded?42:25"
                 )
                 && compactNavigation.contains(
-                    "size:isExpanded?24:16"
+                    "size:isHero?28:isExpanded?24:16"
                 )
                 && compactNavigation.contains(
                     "Text(unit).font(unitFont).foregroundColor(.secondary)"
+                )
+                && compactNavigation.contains(
+                    ".frame(maxWidth:.infinity,minHeight:36)"
                 ),
-            "expanded ride stats must use a larger two-column grid while measurement units remain smaller and secondary"
+            "expanded ride stats must feature a larger centered speed above a two-column grid, keep measurement units secondary, and use taller controls"
         )
 
         for binding in [

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5641,6 +5641,9 @@ private struct WorkoutContractTestSuite {
                     ".presentationDetents([.rideMetricsCompact,.large],selection:$rideMetricsDetent)"
                 )
                 && compactContent.contains(
+                    "context.dynamicTypeSize.isAccessibilitySize?360:280"
+                )
+                && compactContent.contains(
                     ".presentationDragIndicator(.visible)"
                 )
                 && compactContent.contains(

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5505,7 +5505,7 @@ private struct WorkoutContractTestSuite {
         expect(
             compactContentViewSource.contains("scenePhase==.active")
                 && compactContentViewSource.contains(
-                    "!showingWorkoutDashboard"
+                    "presentedSheet!=.workoutDashboard"
                 )
                 && compactSource.contains("scenePhase==.active"),
             "segment feedback must be foreground-only and avoid dashboard duplicates"
@@ -5539,10 +5539,10 @@ private struct WorkoutContractTestSuite {
         let compactContentView = contentViewSource.filter { !$0.isWhitespace }
         expect(
             compactContentView.contains(
-                "WorkoutCompactCard(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onOpen:{showingWorkoutDashboard=true})"
+                "WorkoutCompactCard(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onOpen:{presentedSheet=.workoutDashboard})"
             )
                 && compactContentView.contains(
-                    ".sheet(isPresented:$showingWorkoutDashboard){WorkoutDashboardView(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onPause:workoutMirrorManager.pause,onResume:workoutMirrorManager.resume,onMarkSegment:workoutMirrorManager.markSegment,onEndAndSave:workoutMirrorManager.endAndSave,onDiscard:workoutMirrorManager.discard,onDone:workoutMirrorManager.resetTerminalPresentation)}"
+                    "case.workoutDashboard:WorkoutDashboardView(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onPause:workoutMirrorManager.pause,onResume:workoutMirrorManager.resume,onMarkSegment:workoutMirrorManager.markSegment,onEndAndSave:workoutMirrorManager.endAndSave,onDiscard:workoutMirrorManager.discard,onDone:workoutMirrorManager.resetTerminalPresentation)"
                 ),
             "ContentView must present the dashboard from its exact state and inject each production manager action"
         )
@@ -5623,12 +5623,30 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             compactContent.contains(
-                "if(coordinator.isNavigating||workoutStore.presentation.isWorkoutActive),(coordinator.isNavigating||!isSearchPanelExpanded){rideControlPanel"
+                "if!coordinator.isNavigating,workoutStore.presentation.isWorkoutActive,!isSearchPanelExpanded{rideControlPanel"
             )
                 && compactContent.contains(
                     "if!coordinator.isNavigating{"
+                )
+                && compactContent.contains(
+                    "ifcoordinator.isNavigating{guardpresentedSheet==nilelse{return}rideMetricsDetent=.rideMetricsCompactpresentedSheet=.rideMetrics}"
+                )
+                && compactContent.contains(
+                    ".sheet(item:$presentedSheet,onDismiss:restoreRideMetricsSheetIfNeeded){destinationinpresentedSheetContent(for:destination)}"
+                )
+                && compactContent.contains(
+                    ".presentationDetents([.rideMetricsCompact,.large],selection:$rideMetricsDetent)"
+                )
+                && compactContent.contains(
+                    ".presentationDragIndicator(.visible)"
+                )
+                && compactContent.contains(
+                    ".presentationBackgroundInteraction(.enabled(upThrough:.rideMetricsCompact))"
+                )
+                && compactContent.contains(
+                    ".interactiveDismissDisabled()"
                 ),
-            "workout metrics must show with or without navigation while destination search remains available without navigation"
+            "navigation must use a native expandable stats sheet while workout-only metrics and destination search remain available"
         )
 
         for binding in [

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5623,13 +5623,16 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             compactContent.contains(
-                "if!coordinator.isNavigating,workoutStore.presentation.isWorkoutActive,!isSearchPanelExpanded{rideControlPanel"
+                "ifcoordinator.isNavigating,!workoutStore.presentation.isWorkoutActive{rideControlPanel"
             )
                 && compactContent.contains(
                     "if!coordinator.isNavigating{"
                 )
                 && compactContent.contains(
-                    "ifcoordinator.isNavigating{guardpresentedSheet==nilelse{return}rideMetricsDetent=.rideMetricsCompactpresentedSheet=.rideMetrics}"
+                    ".onChange(of:workoutStore.presentation.isWorkoutActive){_insynchronizeRideMetricsSheet()}"
+                )
+                && compactContent.contains(
+                    "ifworkoutStore.presentation.isWorkoutActive{guardpresentedSheet==nilelse{return}rideMetricsDetent=.rideMetricsCompactpresentedSheet=.rideMetrics}"
                 )
                 && compactContent.contains(
                     ".sheet(item:$presentedSheet,onDismiss:restoreRideMetricsSheetIfNeeded){destinationinpresentedSheetContent(for:destination)}"
@@ -5645,8 +5648,15 @@ private struct WorkoutContractTestSuite {
                 )
                 && compactContent.contains(
                     ".interactiveDismissDisabled()"
-                ),
-            "navigation must use a native expandable stats sheet while workout-only metrics and destination search remain available"
+                )
+                && compactNavigation.contains(
+                    "compactSheetMetricContent:someView{ifworkoutStore.presentation.isWorkoutActive{workoutStatusBannerworkoutMetrics}ifisNavigating{navigationMetrics}}"
+                )
+                && !compactNavigation.contains("Text(\"RideStats\")")
+                && !compactNavigation.contains("chevron.up")
+                && !compactNavigation.contains("chevron.down")
+                && !compactNavigation.contains("onToggleExpansion"),
+            "active workouts must own the expandable native stats sheet while navigation-only keeps the compact overlay"
         )
 
         for binding in [

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5661,6 +5661,27 @@ private struct WorkoutContractTestSuite {
                 && !compactNavigation.contains("onToggleExpansion"),
             "active workouts must own the expandable native stats sheet while navigation-only keeps the compact overlay"
         )
+        expect(
+            compactNavigation.contains(
+                "count:isExpanded?2:3"
+            )
+                && compactNavigation.contains(
+                    "expandedWorkoutMetrics"
+                )
+                && compactNavigation.contains(
+                    "expandedNavigationMetrics"
+                )
+                && compactNavigation.contains(
+                    "size:isExpanded?42:25"
+                )
+                && compactNavigation.contains(
+                    "size:isExpanded?24:16"
+                )
+                && compactNavigation.contains(
+                    "Text(unit).font(unitFont).foregroundColor(.secondary)"
+                ),
+            "expanded ride stats must use a larger two-column grid while measurement units remain smaller and secondary"
+        )
 
         for binding in [
             "WorkoutValueFormatter.whole(suppressInstantaneous?nil:snapshot.cyclingCadence?.value)",

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5564,6 +5564,36 @@ private struct WorkoutContractTestSuite {
             "Watch live workout must expose segment marking and its latest completed segment"
         )
         expect(
+            compactLiveWatchView.contains("case.running:nil")
+                && !liveWatchViewSource.contains("\"LIVE\"")
+                && compactLiveWatchView.contains(
+                    "metric(title:\"HRZone\",value:heartRateZoneValue,unit:heartRateZoneUnit"
+                )
+                && compactLiveWatchView.contains(
+                    "Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))"
+                ),
+            "Watch live workout must omit LIVE, expose heart-rate zone, and retain the elapsed timer"
+        )
+        if let gridIndex = compactLiveWatchView.range(
+            of: "LazyVGrid(columns:columns,spacing:8)"
+        )?.lowerBound,
+           let timerIndex = compactLiveWatchView.range(
+            of: "Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))"
+           )?.lowerBound,
+           let controlsIndex = compactLiveWatchView.range(
+            of: "HStack(spacing:8){Button{manager.markSegment()"
+           )?.lowerBound {
+            expect(
+                gridIndex < timerIndex && timerIndex < controlsIndex,
+                "Watch elapsed timer must appear below the stat grid and above workout controls"
+            )
+        } else {
+            expect(
+                false,
+                "Watch live workout grid, timer, and controls must remain discoverable"
+            )
+        }
+        expect(
             compactLiveWatchView.contains(
                 "WorkoutCrossAppTakeoverCopyV1.live(disposition:manager.isDiscarding?.discard:.save)"
             )
@@ -5688,8 +5718,20 @@ private struct WorkoutContractTestSuite {
                 )
                 && compactNavigation.contains(
                     ".frame(maxWidth:.infinity,minHeight:36)"
+                )
+                && compactNavigation.contains(
+                    ".padding(.bottom,4)"
                 ),
-            "expanded ride stats must feature a larger centered speed above a two-column grid, keep measurement units secondary, and use taller controls"
+            "expanded ride stats must feature a larger centered speed above a two-column grid, keep measurement units secondary, use taller controls, and avoid excess space below them"
+        )
+        expect(
+            compactContent.contains(
+                "guard!isOnlyCheckingForServerMapselse{returnfalse}"
+            )
+                && compactContent.contains(
+                    "offlineMapManager.isServerRecoveryCheckPending&&offlineMapManager.currentJob==nil&&offlineMapManager.downloadedPackURL==nil&&offlineMapManager.errorMessage==nil"
+                ),
+            "the passive offline-map recovery scan must not flash a startup status chip"
         )
 
         for binding in [

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -4,7 +4,7 @@ Open `BikeComputer/BikeComputer.xcodeproj` in Xcode.
 
 ## Requirements
 
-- Existing navigation remains available from iOS 15.
+- Navigation requires iOS 16.4 or later.
 - The mirrored workout experience requires iOS 17 or later and a paired Apple
   Watch running watchOS 10 or later.
 - Real workout validation requires physical devices. HealthKit workout

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -46,7 +46,7 @@ IOS_SUPPORT="${MACOS_SDK}/System/iOSSupport"
 xcrun swiftc \
   -D HOST_TESTING \
   -parse-as-library \
-  -target "$(uname -m)-apple-ios15.0-macabi" \
+  -target "$(uname -m)-apple-ios16.4-macabi" \
   -sdk "${MACOS_SDK}" \
   -F "${IOS_SUPPORT}/System/Library/Frameworks" \
   -I "${IOS_SUPPORT}/usr/lib/swift" \
@@ -65,7 +65,7 @@ PREVIEW_CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-saved-map-preview-tests"
 xcrun swiftc \
   -D HOST_TESTING \
   -parse-as-library \
-  -target "$(uname -m)-apple-ios15.0-macabi" \
+  -target "$(uname -m)-apple-ios16.4-macabi" \
   -sdk "${MACOS_SDK}" \
   -F "${IOS_SUPPORT}/System/Library/Frameworks" \
   -I "${IOS_SUPPORT}/usr/lib/swift" \


### PR DESCRIPTION
## Summary

- replace the fixed navigation metrics overlay with a native SwiftUI sheet that moves between an adaptive compact detent and the full-height large detent
- keep the map interactive while the sheet is compact, prevent accidental dismissal during navigation, and restore the stats sheet after Settings or other app sheets close
- show the navigation summary in the compact state and reveal the complete available workout and navigation metrics when expanded
- raise the iPhone app and iOS test deployment targets to iOS 16.4, with matching test-script and compatibility documentation updates

## Why

Navigation stats were rendered as a fixed bottom card, so riders could not expand them for a full-screen view. SwiftUI's native sheet detents provide the Apple Maps-style drag interaction, system physics, accessibility behavior, and controlled background interaction without a custom gesture implementation.

## Validation

- `cd ios-app && ./scripts/run-navigation-tests.sh`
- `xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Live drag verification was not run because no iOS Simulator was booted.
