### PR TITLE
Add numbered segment controls

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -18,7 +18,9 @@ struct BikeComputerApp: App {
         WindowGroup {
             ContentView(
                 workoutMirrorManager: appDelegate.workoutMirrorManager,
-                coordinator: appDelegate.coordinator
+                coordinator: appDelegate.coordinator,
+                liveActivityDiagnostics:
+                    appDelegate.workoutLiveActivityDiagnostics
             )
         }
     }
@@ -30,6 +32,8 @@ struct BikeComputerApp: App {
 class AppDelegate: NSObject, UIApplicationDelegate {
     let workoutMirrorManager = WorkoutMirrorManager()
     let locationManager = CurrentLocationManager()
+    let workoutLiveActivityDiagnostics =
+        WorkoutLiveActivityDiagnosticStore()
     private var workoutLiveActivityController: AnyObject?
     private var workoutLiveActivityCommandRouter: AnyObject?
     private var workoutLiveActivityIntentDispatcher: AnyObject?
@@ -68,7 +72,8 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             AppDependencyManager.shared.add(dependency: dispatcher)
 
             let controller = WorkoutLiveActivityController(
-                store: workoutMirrorManager.store
+                store: workoutMirrorManager.store,
+                diagnostics: workoutLiveActivityDiagnostics
             )
             controller.start(
                 isApplicationForeground: application.applicationState == .active

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -600,6 +600,7 @@ struct ContentView: View {
             remainingDistance: coordinator.routeRemainingDistance,
             onStopNavigation: { coordinator.stopNavigation() },
             onStartWorkout: workoutMirrorManager.startOutdoorCyclingOnWatch,
+            onMarkSegment: workoutMirrorManager.markSegment,
             onPauseWorkout: workoutMirrorManager.pause,
             onResumeWorkout: workoutMirrorManager.resume,
             onEndAndSaveWorkout: workoutMirrorManager.endAndSave,

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -40,6 +40,8 @@ struct ContentView: View {
     @StateObject private var offlineMapManager = OfflineMapManager()
     @StateObject private var watchAvailability: WorkoutWatchAvailabilityMonitor
     @ObservedObject private var workoutStore: WorkoutMetricsStore
+    @ObservedObject private var liveActivityDiagnostics:
+        WorkoutLiveActivityDiagnosticStore
     private let workoutMirrorManager: WorkoutMirrorManager
     @Environment(\.scenePhase) private var scenePhase
     
@@ -68,10 +70,14 @@ struct ContentView: View {
     init(
         workoutMirrorManager: WorkoutMirrorManager,
         coordinator: BikeComputerCoordinator? = nil,
-        watchAvailability: WorkoutWatchAvailabilityMonitor? = nil
+        watchAvailability: WorkoutWatchAvailabilityMonitor? = nil,
+        liveActivityDiagnostics:
+            WorkoutLiveActivityDiagnosticStore? = nil
     ) {
         let watchAvailability = watchAvailability
             ?? WorkoutWatchAvailabilityMonitor()
+        let liveActivityDiagnostics = liveActivityDiagnostics
+            ?? WorkoutLiveActivityDiagnosticStore()
         let coordinator = coordinator ?? BikeComputerCoordinator(
             destinationStore: SavedDestinationStore(),
             workoutMetricsStore: workoutMirrorManager.store
@@ -80,6 +86,9 @@ struct ContentView: View {
         _watchAvailability = StateObject(wrappedValue: watchAvailability)
         _workoutStore = ObservedObject(
             wrappedValue: workoutMirrorManager.store
+        )
+        _liveActivityDiagnostics = ObservedObject(
+            wrappedValue: liveActivityDiagnostics
         )
         _coordinator = StateObject(
             wrappedValue: coordinator
@@ -101,6 +110,14 @@ struct ContentView: View {
 
                 VStack(spacing: 0) {
                     topOverlay
+
+                    if workoutStore.presentation.isWorkoutActive,
+                       let issue =
+                           liveActivityDiagnostics.issueMessage {
+                        liveActivityDiagnosticBanner(issue)
+                            .padding(.horizontal, 14)
+                            .padding(.top, 8)
+                    }
 
                     if coordinator.isNavigating {
                         navigationInstructionBanner(
@@ -298,6 +315,24 @@ struct ContentView: View {
                 workoutSegmentToast = nil
             }
         }
+    }
+
+    private func liveActivityDiagnosticBanner(
+        _ message: String
+    ) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle.fill")
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(.orange)
+            .multilineTextAlignment(.leading)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 12))
+            .overlay {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(Color.orange.opacity(0.35), lineWidth: 1)
+            }
+            .accessibilityIdentifier("liveActivityDiagnostic")
     }
 
     @ViewBuilder

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
@@ -1,7 +1,24 @@
 import ActivityKit
 import Combine
 import Foundation
+import OSLog
 import UIKit
+
+@MainActor
+protocol WorkoutLiveActivityDiagnosticReporting: AnyObject {
+    func setIssue(_ message: String?)
+}
+
+@MainActor
+final class WorkoutLiveActivityDiagnosticStore:
+    ObservableObject,
+    WorkoutLiveActivityDiagnosticReporting {
+    @Published private(set) var issueMessage: String?
+
+    func setIssue(_ message: String?) {
+        issueMessage = message
+    }
+}
 
 @available(iOS 17.0, *)
 enum WorkoutLiveActivitySystemState: Equatable, Sendable {
@@ -248,12 +265,17 @@ final class WorkoutLiveActivityController {
     nonisolated static let finalSummaryDismissalInterval: TimeInterval = 15 * 60
     nonisolated static let reconciliationGracePeriod: TimeInterval =
         WorkoutMirrorStateReducer.defaultStartTimeout
+    private static let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "BikeComputer",
+        category: "WorkoutLiveActivity"
+    )
 
     private let presentationSource:
         any WorkoutLiveActivityPresentationProviding
     private let client: WorkoutLiveActivityClient
     private let authorization: WorkoutLiveActivityAuthorizationProviding
     private let suppressionStore: WorkoutLiveActivitySuppressionStoring
+    private let diagnostics: any WorkoutLiveActivityDiagnosticReporting
     private let finalizationBackgroundLease:
         any WorkoutBackgroundExecutionLeasing
     private let backgroundTimeRemaining: () -> TimeInterval
@@ -282,12 +304,15 @@ final class WorkoutLiveActivityController {
     private var isReconciliationGraceExpiryPending = false
     private var isApplicationForeground = false
     private var systemEndedSessionIDs: Set<UUID> = []
+    private var lastDiagnosticIssue: String?
 
     init(
         store: WorkoutMetricsStore,
         client: WorkoutLiveActivityClient? = nil,
         authorization: WorkoutLiveActivityAuthorizationProviding? = nil,
         suppressionStore: WorkoutLiveActivitySuppressionStoring? = nil,
+        diagnostics:
+            (any WorkoutLiveActivityDiagnosticReporting)? = nil,
         finalizationBackgroundLease:
             (any WorkoutBackgroundExecutionLeasing)? = nil,
         backgroundTimeRemaining: (() -> TimeInterval)? = nil,
@@ -300,6 +325,8 @@ final class WorkoutLiveActivityController {
             ?? SystemWorkoutLiveActivityAuthorizationProvider()
         self.suppressionStore = suppressionStore
             ?? WorkoutLiveActivitySuppressionStore()
+        self.diagnostics = diagnostics
+            ?? WorkoutLiveActivityDiagnosticStore()
         self.finalizationBackgroundLease =
             finalizationBackgroundLease
             ?? SystemWorkoutBackgroundExecutionLease()
@@ -320,6 +347,8 @@ final class WorkoutLiveActivityController {
         client: WorkoutLiveActivityClient,
         authorization: WorkoutLiveActivityAuthorizationProviding,
         suppressionStore: WorkoutLiveActivitySuppressionStoring,
+        diagnostics:
+            (any WorkoutLiveActivityDiagnosticReporting)? = nil,
         finalizationBackgroundLease:
             (any WorkoutBackgroundExecutionLeasing)? = nil,
         backgroundTimeRemaining: (() -> TimeInterval)? = nil,
@@ -330,6 +359,8 @@ final class WorkoutLiveActivityController {
         self.client = client
         self.authorization = authorization
         self.suppressionStore = suppressionStore
+        self.diagnostics = diagnostics
+            ?? WorkoutLiveActivityDiagnosticStore()
         self.finalizationBackgroundLease =
             finalizationBackgroundLease
             ?? SystemWorkoutBackgroundExecutionLease()
@@ -365,6 +396,9 @@ final class WorkoutLiveActivityController {
             setApplicationForeground(isApplicationForeground)
             return
         }
+        Self.logger.notice(
+            "Starting Live Activity controller; foreground=\(isApplicationForeground)"
+        )
         self.isApplicationForeground = isApplicationForeground
         latestPresentation = presentationSource.presentation
         let publisher = presentationSource.presentationPublisher
@@ -389,6 +423,9 @@ final class WorkoutLiveActivityController {
     }
 
     func setApplicationForeground(_ isForeground: Bool) {
+        Self.logger.debug(
+            "Application foreground state changed to \(isForeground)"
+        )
         isApplicationForeground = isForeground
         guard isForeground, hasReconciled else { return }
         enqueue(latestPresentation)
@@ -664,6 +701,10 @@ final class WorkoutLiveActivityController {
     ) async {
         guard authorization.areActivitiesEnabled else {
             cancelPendingMetricUpdate()
+            reportIssue(
+                "Live Activity unavailable: iOS reports that Live Activities "
+                    + "are disabled for BikeComputer."
+            )
             return
         }
         guard let mapped = WorkoutLiveActivityStateMapper.map(
@@ -676,9 +717,13 @@ final class WorkoutLiveActivityController {
         ) else {
             guard !isWithinReconciliationGrace else { return }
             if shouldRetainManagedActivity(while: presentation) {
+                Self.logger.debug(
+                    "Keeping the existing Live Activity while waiting for a fresh workout snapshot"
+                )
                 return
             }
             await endManagedActivity(dismissal: .immediate)
+            clearIssue()
             return
         }
 
@@ -698,6 +743,7 @@ final class WorkoutLiveActivityController {
         }
 
         if mapped.isTerminal {
+            clearIssue()
             systemEndedSessionIDs.remove(mapped.attributes.sessionID)
             guard managedSessionID == mapped.attributes.sessionID else {
                 return
@@ -722,14 +768,34 @@ final class WorkoutLiveActivityController {
         }
 
         guard let managedActivityID else {
-            guard mapped.isStartEligible,
-                  isApplicationForeground,
-                  !suppressionStore.contains(
-                      mapped.attributes.sessionID
-                  ),
-                  !systemEndedSessionIDs.contains(
-                      mapped.attributes.sessionID
-                  ) else {
+            guard mapped.isStartEligible else {
+                Self.logger.debug(
+                    "Live Activity request is waiting for a verified running or paused workout"
+                )
+                return
+            }
+            guard isApplicationForeground else {
+                Self.logger.notice(
+                    "Live Activity request deferred because the app is not foreground"
+                )
+                return
+            }
+            guard !suppressionStore.contains(
+                mapped.attributes.sessionID
+            ) else {
+                reportIssue(
+                    "Live Activity hidden because it was dismissed for this "
+                        + "workout. Start a new workout to try again."
+                )
+                return
+            }
+            guard !systemEndedSessionIDs.contains(
+                mapped.attributes.sessionID
+            ) else {
+                reportIssue(
+                    "Live Activity unavailable because iOS already ended it "
+                        + "for this workout. Start a new workout to try again."
+                )
                 return
             }
             requestActivity(mapped)
@@ -760,6 +826,10 @@ final class WorkoutLiveActivityController {
     private func requestActivity(
         _ mapped: WorkoutLiveActivityMappedPresentation
     ) {
+        let sessionID = mapped.attributes.sessionID.uuidString
+        Self.logger.notice(
+            "Requesting Live Activity for session \(sessionID, privacy: .public)"
+        )
         do {
             let content = mapped.contentState
             let record = try client.request(
@@ -770,10 +840,31 @@ final class WorkoutLiveActivityController {
             retain(record)
             lastPublishedContent = content
             lastPublishedAt = now()
+            clearIssue()
+            Self.logger.notice(
+                "Live Activity created; id=\(record.id, privacy: .public)"
+            )
         } catch {
-            // ActivityKit failure is display-only. A later verified store
-            // update or foreground transition may safely try again.
+            let nsError = error as NSError
+            reportIssue(
+                "Live Activity failed: \(error.localizedDescription) "
+                    + "(\(nsError.domain) \(nsError.code))."
+            )
         }
+    }
+
+    private func reportIssue(_ message: String) {
+        guard message != lastDiagnosticIssue else { return }
+        lastDiagnosticIssue = message
+        diagnostics.setIssue(message)
+        Self.logger.error("\(message, privacy: .public)")
+    }
+
+    private func clearIssue() {
+        guard lastDiagnosticIssue != nil else { return }
+        lastDiagnosticIssue = nil
+        diagnostics.setIssue(nil)
+        Self.logger.notice("Cleared Live Activity diagnostic issue")
     }
 
     private func publish(

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -193,6 +193,7 @@ struct RideMetricsPanel: View {
     let remainingDistance: CLLocationDistance?
     let onStopNavigation: () -> Void
     let onStartWorkout: () -> Void
+    let onMarkSegment: () -> Void
     let onPauseWorkout: () -> Void
     let onResumeWorkout: () -> Void
     let onEndAndSaveWorkout: () -> Void
@@ -606,6 +607,19 @@ struct RideMetricsPanel: View {
     private var workoutControls: some View {
         let presentation = workoutStore.presentation
         if presentation.isWorkoutActive {
+            Button(action: onMarkSegment) {
+                RideSegmentControlLabel(
+                    number: presentation.snapshot.currentSegmentIndex
+                )
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.green)
+            .disabled(!canMarkSegment)
+            .accessibilityLabel("Mark workout segment")
+            .accessibilityValue(
+                "Current segment \(presentation.snapshot.currentSegmentIndex)"
+            )
+
             if presentation.sessionState == .paused {
                 Button(action: onResumeWorkout) {
                     RideControlLabel(
@@ -669,6 +683,16 @@ struct RideMetricsPanel: View {
             && (presentation.pendingControl == nil
                 || presentation.pendingControl == .markSegment)
             && presentation.connectionState != .disconnected
+    }
+
+    private var canMarkSegment: Bool {
+        let presentation = workoutStore.presentation
+        return presentation.sessionID != nil
+            && presentation.sessionState == .running
+            && presentation.pendingControl == nil
+            && presentation.connectionState != .disconnected
+            && workoutStore.supportsSegmentMarking
+            && !workoutStore.isSegmentConfirmationPending
     }
 
     private var suppressInstantaneousMetrics: Bool {
@@ -755,6 +779,21 @@ private struct RideControlLabel: View {
             .lineLimit(1)
             .minimumScaleFactor(0.62)
             .frame(maxWidth: .infinity, minHeight: 36)
+    }
+}
+
+private struct RideSegmentControlLabel: View {
+    let number: UInt32
+
+    var body: some View {
+        HStack(spacing: 6) {
+            WorkoutSegmentNumberBadge(number: number, diameter: 22)
+            Text("Segment")
+        }
+        .font(.subheadline.weight(.semibold))
+        .lineLimit(1)
+        .minimumScaleFactor(0.62)
+        .frame(maxWidth: .infinity, minHeight: 36)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -478,6 +478,11 @@ struct WorkoutDashboardView: View {
             .lastCompletedSegment
     }
 
+    private var currentSegmentNumber: UInt32 {
+        (store.presentation.finalSnapshot ?? store.presentation.snapshot)
+            .currentSegmentIndex
+    }
+
     @ViewBuilder
     private var connectionBanner: some View {
         TimelineView(.periodic(from: Date(), by: 1)) { context in
@@ -552,12 +557,15 @@ struct WorkoutDashboardView: View {
                     .monospacedDigit()
                     .accessibilityLabel("Elapsed time")
 
-                if let segment = snapshot.lastCompletedSegment,
+                if snapshot.lastCompletedSegment != nil,
                    store.presentation.isWorkoutActive {
-                    Label(
-                        "Segment \(segment.index + 1) in progress",
-                        systemImage: "flag.checkered"
-                    )
+                    HStack(spacing: 7) {
+                        WorkoutSegmentNumberBadge(
+                            number: snapshot.currentSegmentIndex,
+                            diameter: 22
+                        )
+                        Text("Segment \(snapshot.currentSegmentIndex) in progress")
+                    }
                     .font(.subheadline.weight(.semibold))
                     .foregroundStyle(.secondary)
                 }
@@ -722,9 +730,15 @@ struct WorkoutDashboardView: View {
             }
             HStack(spacing: 12) {
                 Button(action: onMarkSegment) {
-                    Label("Segment", systemImage: "flag.checkered")
+                    HStack(spacing: 6) {
+                        WorkoutSegmentNumberBadge(
+                            number: currentSegmentNumber,
+                            diameter: 22
+                        )
+                        Text("Segment")
+                    }
                 }
-                .tint(.blue)
+                .tint(.green)
                 .disabled(
                     presentation.sessionState != .running
                         || presentation.pendingControl != nil
@@ -732,6 +746,9 @@ struct WorkoutDashboardView: View {
                         || store.isSegmentConfirmationPending
                 )
                 .accessibilityLabel("Mark workout segment")
+                .accessibilityValue(
+                    "Current segment \(currentSegmentNumber)"
+                )
 
                 if presentation.sessionState == .paused {
                     Button(action: onResume) {
@@ -919,6 +936,33 @@ struct WorkoutDashboardView: View {
         case .unknown: return "Unknown source"
         case nil: return nil
         }
+    }
+}
+
+struct WorkoutSegmentNumberBadge: View {
+    let number: UInt32
+    let diameter: CGFloat
+    var lineWidth: CGFloat = 2
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(lineWidth: lineWidth)
+            Text("\(number)")
+                .font(
+                    .system(
+                        size: diameter * 0.56,
+                        weight: .bold,
+                        design: .rounded
+                    )
+                )
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+                .padding(diameter * 0.12)
+        }
+        .frame(width: diameter, height: diameter)
+        .accessibilityHidden(true)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
@@ -180,10 +180,19 @@ struct WorkoutLiveActivityControls: View {
             Button(
                 intent: BikeComputerMarkSegmentIntent(sessionID: sessionID)
             ) {
-                Label("Segment", systemImage: "flag.checkered")
+                HStack(spacing: 6) {
+                    WorkoutLiveActivitySegmentNumberBadge(
+                        number: state.currentSegmentIndex
+                    )
+                    Text("Segment")
+                }
                     .frame(maxWidth: .infinity, minHeight: 44)
             }
             .disabled(!state.canMarkSegment)
+            .accessibilityLabel("Mark workout segment")
+            .accessibilityValue(
+                "Current segment \(state.currentSegmentIndex)"
+            )
 
             if state.phase == .paused {
                 Button(
@@ -211,6 +220,25 @@ struct WorkoutLiveActivityControls: View {
         .labelStyle(.titleAndIcon)
         .buttonStyle(WorkoutLiveActivityButtonStyle())
         .opacity(state.controlsAreVisuallyAvailable ? 1 : 0.55)
+    }
+}
+
+private struct WorkoutLiveActivitySegmentNumberBadge: View {
+    let number: UInt32
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(lineWidth: 2)
+            Text("\(number)")
+                .font(.system(size: 13, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+                .padding(3)
+        }
+        .frame(width: 22, height: 22)
+        .accessibilityHidden(true)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -190,15 +190,6 @@ struct LiveWorkoutView: View {
                     )
                 }
 
-                if let segment = manager.snapshot.lastCompletedSegment {
-                    Label(
-                        "Segment \(segment.index + 1)",
-                        systemImage: "flag.checkered"
-                    )
-                    .font(.caption.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                }
-
                 Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))
                     .font(.system(.title2, design: .rounded, weight: .semibold))
                     .monospacedDigit()
@@ -211,16 +202,21 @@ struct LiveWorkoutView: View {
                         if manager.isMarkingSegment {
                             ProgressView()
                         } else {
-                            Image(systemName: "flag.checkered")
+                            WatchSegmentNumberBadge(
+                                number: manager.snapshot.currentSegmentIndex
+                            )
                         }
                     }
-                    .tint(.blue)
+                    .tint(.green)
                     .disabled(
                         manager.state != .running
                             || manager.isMarkingSegment
                             || manager.segmentError == .confirmationPending
                     )
                     .accessibilityLabel("Mark workout segment")
+                    .accessibilityValue(
+                        "Current segment \(manager.snapshot.currentSegmentIndex)"
+                    )
 
                     Button {
                         if manager.state == .paused {
@@ -462,5 +458,24 @@ struct LiveWorkoutView: View {
         case .confirmationPending:
             "Still confirming that segment. You can pause or end the ride."
         }
+    }
+}
+
+private struct WatchSegmentNumberBadge: View {
+    let number: UInt32
+
+    var body: some View {
+        ZStack {
+            Circle()
+                .strokeBorder(lineWidth: 2)
+            Text("\(number)")
+                .font(.system(size: 15, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+                .padding(3)
+        }
+        .frame(width: 25, height: 25)
+        .accessibilityHidden(true)
     }
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -188,6 +188,13 @@ struct LiveWorkoutView: View {
                         icon: "arrow.triangle.2.circlepath",
                         color: .mint
                     )
+                    metric(
+                        title: "Altitude",
+                        value: altitudeValue,
+                        unit: "M",
+                        icon: "mountain.2.fill",
+                        color: .indigo
+                    )
                 }
 
                 Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))
@@ -406,6 +413,14 @@ struct LiveWorkoutView: View {
             return "ZONE"
         }
         return "OF \(count)"
+    }
+
+    private var altitudeValue: String {
+        guard let altitude = manager.snapshot.location?.altitude,
+              altitude.isFinite else {
+            return "--"
+        }
+        return String(format: "%.0f", altitude)
     }
 
     private var stateLabel: String? {

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
@@ -220,6 +220,13 @@ nonisolated struct WorkoutSnapshotV1: Codable, Equatable, Sendable {
         self.errorCode = errorCode
         self.terminalOutcome = terminalOutcome
     }
+
+    var currentSegmentIndex: UInt32 {
+        guard let lastCompletedSegment else { return 1 }
+        return lastCompletedSegment.index == .max
+            ? .max
+            : lastCompletedSegment.index + 1
+    }
 }
 
 nonisolated enum WorkoutControlV1: String, Codable, Sendable {

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5581,9 +5581,12 @@ private struct WorkoutContractTestSuite {
                     "metric(title:\"HRZone\",value:heartRateZoneValue,unit:heartRateZoneUnit"
                 )
                 && compactLiveWatchView.contains(
+                    "metric(title:\"Altitude\",value:altitudeValue,unit:\"M\""
+                )
+                && compactLiveWatchView.contains(
                     "Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))"
                 ),
-            "Watch live workout must omit LIVE, expose heart-rate zone, and retain the elapsed timer"
+            "Watch live workout must omit LIVE, expose heart-rate zone and altitude, and retain the elapsed timer"
         )
         if let gridIndex = compactLiveWatchView.range(
             of: "LazyVGrid(columns:columns,spacing:8)"

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -243,6 +243,10 @@ private struct WorkoutContractTestSuite {
         if let second {
             expect(accumulator.commit(second), "second segment candidate should commit")
         }
+        expect(
+            WorkoutSnapshotV1(state: .running).currentSegmentIndex == 1,
+            "a workout should begin with segment one in progress"
+        )
 
         let snapshot = WorkoutSnapshotV1(
             state: .running,
@@ -250,6 +254,10 @@ private struct WorkoutContractTestSuite {
             elapsedTime: metric(90, .seconds, secondEnd),
             lastCompletedSegment: accumulator.lastCompletedSegment,
             availability: [.elapsedTime]
+        )
+        expect(
+            snapshot.currentSegmentIndex == 3,
+            "the current segment number should follow the latest completed segment"
         )
         let envelope = makeEnvelope(
             sequence: 1,
@@ -5468,7 +5476,7 @@ private struct WorkoutContractTestSuite {
         }
         expect(
             compactSource.contains(
-                "Button(action:onMarkSegment){Label(\"Segment\",systemImage:\"flag.checkered\")}"
+                "Button(action:onMarkSegment){HStack(spacing:6){WorkoutSegmentNumberBadge(number:currentSegmentNumber,diameter:22)Text(\"Segment\")}}"
             )
                 && compactSource.contains(
                     "ifpresentation.sessionState==.paused{Button(action:onResume){Label(\"Resume\""
@@ -5555,6 +5563,9 @@ private struct WorkoutContractTestSuite {
         }
         expect(
             compactLiveWatchView.contains("manager.markSegment()")
+                && compactLiveWatchView.contains(
+                    "WatchSegmentNumberBadge(number:manager.snapshot.currentSegmentIndex)"
+                )
                 && compactLiveWatchView.contains(
                     ".accessibilityLabel(\"Markworkoutsegment\")"
                 )
@@ -5777,10 +5788,12 @@ private struct WorkoutContractTestSuite {
             "the main ride panel must render the zone as Zone N"
         )
         for control in [
+            "\"Segment\"",
             "\"Pauseworkout\"",
             "\"Resumeworkout\"",
             "\"Endworkout\"",
             "onStopNavigation",
+            "onMarkSegment",
             "onPauseWorkout",
             "onResumeWorkout",
             "onEndAndSaveWorkout",
@@ -5791,6 +5804,18 @@ private struct WorkoutContractTestSuite {
                 "main ride panel must retain control route: \(control)"
             )
         }
+        expect(
+            compactNavigation.contains(
+                "Button(action:onMarkSegment){RideSegmentControlLabel(number:presentation.snapshot.currentSegmentIndex)}"
+            )
+                && compactNavigation.contains(
+                    "presentation.pendingControl==nil"
+                )
+                && compactContent.contains(
+                    "onMarkSegment:workoutMirrorManager.markSegment"
+                ),
+            "the ride sheet must expose the numbered segment action with safe production wiring"
+        )
         expect(
             compactNavigation.contains(
                 "case.launchingWatch,.awaitingFirstSnapshot,.stale,.disconnected:"

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -1488,34 +1488,52 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         enum TestError: Error { case unavailable }
         let source = source()
         let client = FakeWorkoutLiveActivityClient()
+        let diagnostics = WorkoutLiveActivityDiagnosticStore()
         client.requestError = TestError.unavailable
-        let controller = makeController(source: source, client: client)
+        let controller = makeController(
+            source: source,
+            client: client,
+            diagnostics: diagnostics
+        )
         controller.start(isApplicationForeground: true)
         await settle()
 
         XCTAssertEqual(client.requestAttempts, 1)
         XCTAssertTrue(client.requests.isEmpty)
+        XCTAssertTrue(
+            diagnostics.issueMessage?.contains(
+                "Live Activity failed:"
+            ) == true
+        )
 
         client.requestError = nil
         controller.setApplicationForeground(true)
         await settle()
         XCTAssertEqual(client.requestAttempts, 2)
         XCTAssertEqual(client.requests.count, 1)
+        XCTAssertNil(diagnostics.issueMessage)
     }
 
     func testDisabledAuthorizationDoesNotRequestActivity() async {
         let source = source()
         let client = FakeWorkoutLiveActivityClient()
+        let diagnostics = WorkoutLiveActivityDiagnosticStore()
         let controller = makeController(
             source: source,
             client: client,
-            authorization: EnabledWorkoutLiveActivityAuthorization(false)
+            authorization: EnabledWorkoutLiveActivityAuthorization(false),
+            diagnostics: diagnostics
         )
 
         controller.start(isApplicationForeground: true)
         await settle()
 
         XCTAssertEqual(client.requestAttempts, 0)
+        XCTAssertEqual(
+            diagnostics.issueMessage,
+            "Live Activity unavailable: iOS reports that Live Activities "
+                + "are disabled for BikeComputer."
+        )
     }
 
     private func source(
@@ -1536,6 +1554,8 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
             WorkoutLiveActivityAuthorizationProviding? = nil,
         suppression:
             WorkoutLiveActivitySuppressionStoring? = nil,
+        diagnostics:
+            (any WorkoutLiveActivityDiagnosticReporting)? = nil,
         finalizationBackgroundLease:
             (any WorkoutBackgroundExecutionLeasing)? = nil,
         backgroundTimeRemaining: (() -> TimeInterval)? = nil,
@@ -1550,6 +1570,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
                 ?? EnabledWorkoutLiveActivityAuthorization(),
             suppressionStore: suppression
                 ?? MemoryWorkoutLiveActivitySuppressionStore(),
+            diagnostics: diagnostics,
             finalizationBackgroundLease:
                 finalizationBackgroundLease,
             backgroundTimeRemaining:


### PR DESCRIPTION
## Summary
- add a numbered current-segment action to the expandable iPhone ride stats sheet
- replace actionable/current checkered-flag icons with Apple Workout-style numbered circles on iPhone, Live Activity, and Apple Watch
- advance the displayed number after each completed segment and retain flags only for completion feedback

## Validation
- `./scripts/run-workout-contract-tests.sh`
- `./scripts/run-navigation-tests.sh`
- signed Debug build for connected iPhone, including Watch and Live Activity targets
- installed and launched on connected iPhone