### PR TITLE
Add cycling sensor settings and workout tile gating

### DIFF
--- a/docs/cycling-sensor-settings-implementation-plan.md
+++ b/docs/cycling-sensor-settings-implementation-plan.md
@@ -1,0 +1,730 @@
+# Cycling Sensor Settings and Workout Tile Gating Plan
+
+## Outcome
+
+Add an explicit cycling-sensor registry to the BikeComputer iPhone app. A
+person can enroll a cadence sensor, power meter, or combined cadence-and-power
+sensor from Settings, give it a custom name, and later edit, disable, or forget
+it.
+
+The workout stats sheet shows cadence and power tiles only for capabilities
+that the person has enrolled and enabled:
+
+- no enrolled cadence sensor: no cadence tile;
+- no enrolled power sensor: no power tile;
+- enrolled cadence sensor: show cadence, using `--` when no fresh value exists;
+- enrolled power sensor: show power, using `--` when no fresh value exists; and
+- enrolled combined sensor: show both tiles.
+
+Fresh data can discover a sensor and prompt the person to enroll it, but it
+must never enroll a sensor or reveal a tile automatically.
+
+This plan is associated with
+[issue #85, Pair directly with BLE cycling sensors and accessories](https://github.com/seichris/open-bike-computer/issues/85).
+It delivers the Apple Watch/HealthKit-assisted sensor-management slice of that
+issue. It does not complete issue #85's separate direct-to-ESP32 BLE work.
+
+## Baseline
+
+This plan was prepared from `origin/main` at
+`d41112a3f91d51bf4cebec98bc522671e042792f`.
+
+### Already implemented
+
+The metric transport and most of the runtime measurement path already exist:
+
+1. `WatchWorkoutManager` owns an `HKWorkoutSession` and
+   `HKLiveWorkoutBuilder`.
+2. The Watch requests cycling power and cycling cadence from HealthKit.
+3. The live builder delegate handles `cyclingPower` and `cyclingCadence`,
+   converts them to watts and RPM, and expires stale sensor values after the
+   existing paired-sensor freshness window.
+4. `WorkoutSnapshotV1` carries optional `cyclingPower` and `cyclingCadence`
+   metrics from Watch to iPhone.
+5. `WorkoutMetricsStore` publishes those mirrored values on iPhone.
+6. `WorkoutDeviceRelay` can relay both metrics from iPhone to the paired bike
+   computer.
+7. `NavigationDetailsView` already renders cadence and power tiles.
+
+This explains why the tiles can display real values today when a compatible
+sensor is connected to Apple Watch and the BikeComputer Watch app owns an
+active cycling workout.
+
+### Not implemented
+
+The current code does not have:
+
+- an app-owned sensor registry;
+- a sensor discovery or enrollment flow;
+- an editable sensor name;
+- a persisted enabled/disabled choice;
+- a reliable physical sensor identifier in the workout mirror contract;
+- a detected-sensor notification;
+- a deep link from that notification to sensor settings; or
+- tile gating based on a person's enrolled sensors.
+
+Today, the cadence and power tiles are always present and use `--` when their
+optional workout metrics are absent.
+
+## Apple platform contract
+
+Apple Watch owns system pairing for compatible cycling accessories. The person
+pairs one in **Apple Watch Settings > Bluetooth > Health Devices**. Apple says a
+configured accessory automatically connects when a cycling workout begins and
+can supply cadence and power metrics:
+
+- [Go cycling with Apple Watch](https://support.apple.com/en-ca/guide/watch/apd4cbc876c7/watchos)
+
+BikeComputer's Watch app already receives live data through
+`HKLiveWorkoutBuilderDelegate`:
+
+- [HKLiveWorkoutBuilderDelegate](https://developer.apple.com/documentation/healthkit/hkliveworkoutbuilderdelegate)
+
+HealthKit samples can have source and device metadata, but the callback used by
+the current implementation supplies `HKStatistics`, not a physical peripheral
+or a public list of connected Health Devices:
+
+- [HKQuantitySample](https://developer.apple.com/documentation/healthkit/hkquantitysample)
+- [HKSourceRevision](https://developer.apple.com/documentation/healthkit/hksourcerevision)
+
+Therefore, **Connect a new Sensor** is an app enrollment flow, not a replacement
+for Apple's Bluetooth pairing UI. It listens for actual sensor observations
+from an active BikeComputer workout. It must not claim that BikeComputer is
+pairing the accessory to Apple Watch.
+
+When no BikeComputer workout is active, the sensor screen must explain:
+
+1. pair the sensor under Apple Watch Settings > Bluetooth > Health Devices;
+2. wake the sensor by pedaling or rotating the crank; and
+3. start or continue an outdoor cycling workout in BikeComputer.
+
+The existing iPhone app deployment target remains iOS 16.4, and the existing
+Watch target remains watchOS 10. The workout mirroring path continues to use its
+current iOS 17 availability boundary.
+
+## Product definitions
+
+Use the following terms consistently in code and UI:
+
+- **System-paired**: Apple Watch knows the accessory under Health Devices.
+  BikeComputer cannot infer this merely from app settings.
+- **Observed**: BikeComputer received live cadence or power data during the
+  current workout.
+- **Enrolled**: the person added a sensor profile to **My Sensors**.
+- **Enabled**: the enrolled profile is allowed to control stats-tile
+  visibility.
+- **Reporting**: fresh data matching the profile is currently arriving.
+
+In product copy, the requested word **Connect** means “enroll this sensor in
+BikeComputer.” Internally, use `enroll`/`enrolled` to avoid confusing app state
+with an active Bluetooth connection.
+
+Do not show a row as **Connected** merely because it is enrolled. Use runtime
+status such as **Data received now**, **Last seen recently**, or
+**Not currently reporting**.
+
+## Decisions locked into this plan
+
+1. Sensor enrollment is explicit and local to the iPhone app.
+2. Live metric freshness does not decide whether a tile exists.
+3. Fresh observations can propose enrollment but cannot enroll automatically.
+4. Cadence and power tile visibility is the union of capabilities on enabled
+   enrolled profiles.
+5. An enrolled tile remains visible and changes to `--` when data becomes
+   stale or the sensor disconnects.
+6. An unenrolled tile stays hidden even if an unaccepted live observation has a
+   fresh value.
+7. Sensor discovery listens only to current BikeComputer workout data. It does
+   not scan HealthKit history.
+8. The iPhone owns names and enrollment choices. The Watch owns workout
+   collection.
+9. The first version does not ask iPhone `CoreBluetooth` to pair with a sensor
+   already managed by Apple Watch.
+10. A combined cadence-and-power device is inferred automatically only when
+    both measurements can be tied to the same stable device identity.
+11. If HealthKit does not expose a safe stable identity, use an honest logical
+    sensor profile and require the person to confirm its capabilities.
+12. Sensor metadata and workout metrics remain local. No backend is added.
+
+## Phase 0: physical-device identity feasibility gate
+
+Complete this spike before choosing the persisted identity model.
+
+### Test matrix
+
+Run a BikeComputer-owned cycling workout on physical devices with:
+
+- one cadence-only sensor;
+- one power-only sensor;
+- one combined cadence-and-power sensor;
+- separate cadence and power sensors active simultaneously; and
+- two sensors of the same capability, if hardware is available.
+
+For each setup, inspect the live and newly stored HealthKit samples for:
+
+- `HKObject.device`;
+- `HKObject.sourceRevision`;
+- manufacturer, model, hardware, firmware, local identifier, and UDI fields;
+- whether the metadata is present during the workout or only after storage;
+- whether the identity is stable after disconnect/reconnect and across
+  workouts;
+- whether cadence and power from one combined device share the same identity;
+  and
+- whether separate devices remain distinguishable.
+
+Do not log raw identifiers in ordinary production diagnostics. The spike may
+use a local debug build with redacted or hashed output.
+
+### Gate A: stable physical identity is available
+
+If a public HealthKit path exposes a stable identity with acceptable latency:
+
+- derive an app-local opaque identifier;
+- store only the minimum fields needed to match observations;
+- use a non-sensitive manufacturer/model string as a suggested name when
+  available;
+- never persist or mirror a serial number or UDI;
+- associate observed capabilities with that identity; and
+- allow multiple sensors with the same capability in **My Sensors**.
+
+### Gate B: stable physical identity is not available
+
+If HealthKit supplies only values or an Apple Watch/app source:
+
+- do not invent a physical device identifier;
+- create a logical candidate such as **Cadence Sensor**, **Power Sensor**, or
+  **Cycling Sensor**;
+- ask the person to confirm **Cadence**, **Power**, or **Cadence + Power** when
+  enrolling;
+- describe status as measurement data received, not hardware connected;
+- do not merge simultaneous cadence and power into one physical sensor without
+  explicit confirmation; and
+- document that multiple same-capability accessories cannot be distinguished
+  through the HealthKit-assisted path.
+
+Gate B still supports every tile-visibility requirement. It limits only
+automatic device naming and physical-device differentiation.
+
+Record the result of the spike in the eventual implementation PR and add a
+focused code comment at the identity boundary. Do not leave production behavior
+dependent on debug-only assumptions.
+
+## Persisted model
+
+Add a versioned, Codable registry owned by a `@MainActor`
+`CyclingSensorStore`.
+
+Suggested types:
+
+```swift
+struct CyclingSensorCapabilities: OptionSet, Codable, Sendable {
+    let rawValue: UInt8
+
+    static let cadence = Self(rawValue: 1 << 0)
+    static let power = Self(rawValue: 1 << 1)
+}
+
+enum CyclingSensorIdentityKind: Codable, Sendable {
+    case healthKitDevice(opaqueID: String)
+    case logical
+}
+
+struct CyclingSensorProfile: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var name: String
+    var capabilities: CyclingSensorCapabilities
+    var isEnabled: Bool
+    let identityKind: CyclingSensorIdentityKind
+    let createdAt: Date
+    var lastObservedAt: Date?
+}
+```
+
+The exact representation can change after Phase 0, but the store must expose:
+
+- ordered `profiles`;
+- `enabledCapabilities`;
+- create/enroll;
+- rename;
+- enable/disable;
+- forget;
+- match an observation to an existing profile; and
+- versioned decoding with corruption fallback that does not crash app launch.
+
+Persist registry metadata in `UserDefaults` under a new versioned key. Do not
+put raw workout samples, live values, or HealthKit objects in that registry.
+
+No migration should auto-enroll cadence or power based on previously seen
+workout data. Existing users start with no enrolled sensors, so both tiles are
+hidden until they make an explicit choice.
+
+## Observation and discovery model
+
+Use a separate ephemeral `CyclingSensorDetectionCoordinator`.
+
+An observation contains:
+
+- optional opaque physical identity from Phase 0;
+- observed capabilities;
+- safe suggested display name, if available;
+- `firstObservedAt` and `lastObservedAt`;
+- current workout session ID; and
+- whether it has already been offered, dismissed, enrolled, or matched.
+
+The coordinator:
+
+1. accepts only current, validated mirrored workout snapshots;
+2. treats a non-stale cadence metric as a cadence observation;
+3. treats a non-stale power metric as a power observation;
+4. merges observations only when their identity is proven equal;
+5. matches them against the sensor registry;
+6. publishes nearby candidates to the Settings UI;
+7. publishes at most one actionable enrollment prompt; and
+8. deduplicates repeated snapshots and rapid reconnects.
+
+Keep observations for the current workout plus a short enrollment grace period
+so a person can tap the notification and still see the candidate. Clear
+unresolved candidates at a defined boundary, such as after the workout plus 30
+minutes. Persist only a small prompt-dismissal token if needed to prevent a
+notification loop after app relaunch.
+
+Do not observe SwiftUI view rendering or the formatted `--` strings. Feed the
+detection coordinator from the accepted snapshot boundary in
+`WorkoutMirrorManager` or immediately after `WorkoutMetricsStore.ingestBatch`.
+
+## Watch-to-iPhone contract
+
+### Capability-only path
+
+The existing optional `cyclingCadence` and `cyclingPower` metrics are sufficient
+to detect capabilities. If Phase 0 returns Gate B, no workout schema change is
+required for initial enrollment.
+
+### Identity-aware path
+
+If Phase 0 returns Gate A, extend `WorkoutSnapshotV1` with an optional, bounded
+array of `CyclingSensorObservationV1` values:
+
+```swift
+struct CyclingSensorObservationV1: Codable, Equatable, Sendable {
+    let opaqueDeviceID: String
+    let suggestedName: String?
+    let capabilities: CyclingSensorCapabilitiesV1
+    let observedAt: Date
+}
+```
+
+Requirements:
+
+- bump the minor workout schema version from 1.4 to 1.5;
+- keep the new field optional with an empty default for old payloads;
+- reject malformed, future-dated, oversized, or duplicate observations;
+- cap the array to a small number such as eight;
+- never include serial number, UDI, or unrestricted metadata;
+- preserve major-version compatibility; and
+- add mixed-version encode/decode tests.
+
+The Watch should emit identity observations only after correlating a fresh
+sample to a validated identity. A statistics update by itself is not proof of
+identity.
+
+## Settings information architecture
+
+Extend the existing **My Bike Computer** page so its form contains both the
+current Bike Computer list and a new **My Sensors** group. Do not add another
+navigation level between **My Bike Computer** and the sensor list.
+
+Refactor `BikeComputersSettingsView` only as much as necessary to compose its
+existing content with `CyclingSensorsSettingsSection`. Preserve its current
+Bike Computer discovery, pairing, editable detail, reconnect, and deregistration
+behavior.
+
+The new sensor group follows the established Bike Computer interaction pattern:
+
+### Default state
+
+- Section label: **My Sensors**
+- Empty state: **No Sensors**
+- Supporting text: **Add a sensor after BikeComputer receives cadence or power
+  data from your Apple Watch.**
+- Action: **Connect a new Sensor**
+
+Show the action even when profiles already exist so another sensor can be
+enrolled.
+
+### Looking state
+
+Tapping **Connect a new Sensor** starts an enrollment-listening session and
+shows:
+
+- `ProgressView`;
+- **Looking nearby…**; and
+- a short instruction footer explaining the Apple Watch Health Devices setup.
+
+If no workout is active, do not spin indefinitely with no explanation. Show
+the three setup steps from the platform contract and keep the listener ready
+for the next BikeComputer workout. Provide **Stop Looking**.
+
+When fresh observations arrive, list unmatched candidates under **Nearby**.
+Do not list already enrolled profiles as new candidates.
+
+### Enrollment sheet
+
+Tapping a candidate opens a sheet modeled after the existing Bike Computer
+pairing sheet:
+
+- proposed name;
+- editable name;
+- detected capability or capability confirmation;
+- explanation that Apple Watch manages the Bluetooth connection; and
+- primary action **Connect Sensor**.
+
+The action writes the profile to the registry. Only after that commit succeeds
+may the corresponding stats tile appear.
+
+### My Sensors rows and detail
+
+Each enrolled profile appears under **My Sensors**. A row contains:
+
+- sensor name;
+- capability summary: **Cadence**, **Power**, or **Cadence + Power**;
+- enabled/disabled state; and
+- reporting status when a matching live observation exists.
+
+Tapping a row opens `CyclingSensorDetailView`, following
+`BikeComputerDetailView`:
+
+- edit and save the custom name;
+- enable or disable the sensor;
+- show capabilities;
+- show **Data received now** or a last-seen description;
+- explain the Apple Watch Health Devices relationship; and
+- **Forget Sensor** behind confirmation.
+
+Disabling or forgetting the last enabled profile for a capability immediately
+hides that capability's tile. Renaming never changes matching identity.
+
+## Detected-sensor bottom notification
+
+Reuse the visual language of the current offline-map status chip, but extract a
+small reusable actionable status-chip view instead of copying the layout.
+
+Show the sensor chip when:
+
+- a BikeComputer workout is active;
+- a fresh cadence or power observation was accepted;
+- no enabled enrolled profile covers that observation;
+- the candidate was not dismissed for the current workout; and
+- an enrollment screen is not already visible.
+
+Copy:
+
+- title: **Cadence sensor detected**, **Power sensor detected**, or
+  **Cycling sensor detected**;
+- action/subtitle: **Connect sensor?**
+
+Tapping the chip opens **My Bike Computer**, focuses its **My Sensors** group,
+and preserves the candidate so it is immediately selectable. This needs a real
+settings route, not just `presentedSheet = .settings`.
+
+Add a typed settings destination, for example:
+
+```swift
+enum SettingsDestination: Hashable {
+    case bikeComputer(sensorCandidateID: UUID?)
+    case offlineMaps
+}
+```
+
+Use `NavigationStack`/`NavigationPath` or a dedicated sheet destination so
+opening the chip reliably lands on the combined **My Bike Computer** page with
+the sensor candidate visible. Do not depend on timing delays, hidden
+`NavigationLink` activation, or a nested sensor-management page.
+
+Provide a non-destructive dismissal. **Not Now** suppresses the same candidate
+for the current workout; it does not enroll, disable, or forget anything. A
+future workout can offer it again.
+
+If both an offline-map status and sensor prompt are eligible, show one
+actionable chip at a time. Sensor enrollment has priority while its observation
+is fresh; the offline-map chip returns after enrollment, dismissal, or expiry.
+The normal workout/navigation controls remain visible.
+
+## Workout stats tile rules
+
+Move tile selection out of an unconditional array literal into a testable
+policy:
+
+```swift
+struct WorkoutMetricTilePolicy {
+    let enabledSensorCapabilities: CyclingSensorCapabilities
+
+    var showsCadence: Bool { enabledSensorCapabilities.contains(.cadence) }
+    var showsPower: Bool { enabledSensorCapabilities.contains(.power) }
+}
+```
+
+Inject `CyclingSensorStore` into `RideMetricsPanel` or pass its
+`enabledCapabilities` explicitly.
+
+Build the metric list in this order:
+
+1. elapsed;
+2. cadence, only when enabled;
+3. power, only when enabled;
+4. speed;
+5. distance;
+6. altitude;
+7. heart rate;
+8. heart zone; and
+9. energy.
+
+The compact and expanded layouts use the same filtered metric list. Preserve
+the current compact/expanded sizing and formatting work:
+
+- compact state uses its existing grid policy;
+- expanded state keeps the speed hero and two stats per row;
+- numeric value styling remains unchanged;
+- units such as `km/h`, `m`, `bpm`, and `kcal` keep their secondary gray,
+  smaller styling; and
+- a registered but stale cadence/power value renders as `--`, not zero.
+
+Enrollment affects workout stats tiles, including workouts shown while
+navigation is active. Navigation-only stats remain unchanged and never gain
+cadence or power tiles.
+
+Do not filter completed workout history solely because a sensor is later
+forgotten. The registry controls the live ride sheet; historical summaries
+continue to display measurements that were actually recorded.
+
+## Dependency wiring
+
+Create:
+
+```text
+ios-app/BikeComputer/BikeComputer/
+  Models/
+    CyclingSensorProfile.swift
+  Managers/
+    CyclingSensorStore.swift
+    CyclingSensorDetectionCoordinator.swift
+  Views/
+    CyclingSensorsSettingsSection.swift
+    CyclingSensorDetailView.swift
+    CyclingSensorEnrollmentSheet.swift
+    ActionStatusChip.swift
+```
+
+Recommended ownership:
+
+- `AppDelegate` creates the long-lived `CyclingSensorStore` and detection
+  coordinator;
+- `WorkoutMirrorManager` forwards accepted live snapshots to the coordinator;
+- `ContentView` observes pending prompts and owns sheet/deep-link routing;
+- `SettingsView` receives the store/coordinator through environment injection;
+  and
+- ride-metrics views receive the registry's enabled capabilities.
+
+Do not add cycling sensors to `BLEManager.knownDevices`. That registry represents
+BikeComputer peripherals, ownership handshakes, and authenticated app-to-ESP32
+connections. Apple Watch cycling sensors have different ownership, transport,
+and status semantics.
+
+If Gate A requires Watch-side observation state, add the narrowest possible
+Watch component and shared contract type. Do not move iPhone-owned names or
+enable choices into `WatchWorkoutManager` unless a Watch UI or collection rule
+actually needs them.
+
+## Implementation sequence
+
+### 1. Prove identity behavior
+
+- run the Phase 0 physical-device matrix;
+- choose Gate A or Gate B;
+- capture redacted evidence in the implementation PR; and
+- lock the observation contract before building UI.
+
+### 2. Add the registry and pure policies
+
+- implement the profile/capability model;
+- add versioned persistence;
+- implement enrollment, rename, enable/disable, and forget;
+- implement observation matching and prompt deduplication; and
+- implement `WorkoutMetricTilePolicy`.
+
+### 3. Feed live observations
+
+- observe only accepted current workout snapshots;
+- classify fresh cadence and power;
+- add the optional identity-aware mirror field only for Gate A;
+- retain a candidate long enough for notification-to-settings navigation; and
+- keep workout collection and save behavior unchanged.
+
+### 4. Build My Sensors UI
+
+- compose the new **My Sensors** group into the existing **My Bike Computer**
+  page;
+- implement the empty, looking, nearby, enrollment, list, and detail states;
+- add no-active-workout instructions;
+- support editable names and confirmed forget; and
+- ensure leaving the screen stops only the enrollment listener, not the
+  workout.
+
+### 5. Add prompt and deep link
+
+- extract the shared action chip presentation;
+- add the sensor prompt;
+- add typed routing to the sensor screen;
+- implement priority against the offline-map chip; and
+- add per-workout dismissal behavior.
+
+### 6. Gate live workout tiles
+
+- filter cadence and power by enabled registry capabilities;
+- preserve `--` for enrolled-but-stale sensors;
+- apply the same policy during active workout plus navigation;
+- leave navigation-only metrics unchanged; and
+- leave recorded workout summaries data-driven.
+
+### 7. Validate and document
+
+- run unit and contract tests;
+- test the complete flow on a physical Watch and iPhone;
+- test the stats sheet collapsed and expanded;
+- update the iOS README with Apple Watch Health Devices setup;
+- document Gate A or Gate B limitations; and
+- keep issue #85 open for the direct ESP32 work.
+
+## Automated tests
+
+### Sensor registry
+
+- empty/corrupt/default persistence;
+- round-trip versioned persistence;
+- enroll cadence, power, and combined profiles;
+- rename preserves identity;
+- disabling affects capability union;
+- forgetting the last capable profile removes that capability;
+- two enabled profiles with overlapping capabilities;
+- no migration from historical workout metrics; and
+- future registry versions fail safely.
+
+### Detection coordinator
+
+- cadence-only and power-only observations;
+- proven combined identity;
+- unproven simultaneous cadence and power remain separate;
+- repeated snapshots do not create repeated candidates;
+- an enabled matched profile suppresses the prompt;
+- a disabled matched profile is offered without becoming enabled;
+- **Not Now** suppresses only the current workout;
+- a new workout can offer the candidate again;
+- stale, future, terminal, and replayed snapshots are rejected; and
+- candidate grace-period expiry.
+
+### Workout contract, when Gate A applies
+
+- 1.5 round trip with observations;
+- 1.4 payload decodes with no observations;
+- unknown minor fields remain compatible;
+- malformed identity, invalid dates, duplicates, and oversize arrays fail
+  validation;
+- no sensitive metadata is encoded; and
+- snapshot merge preserves validated observations.
+
+### Tile policy
+
+- no profiles hides both cadence and power;
+- cadence only shows cadence;
+- power only shows power;
+- combined shows both;
+- disabled profiles do not expose tiles;
+- fresh but unenrolled metrics do not expose tiles;
+- enrolled stale metrics expose `--`;
+- active workout plus navigation uses the same gating; and
+- navigation-only metrics are unchanged.
+
+### Settings and routing
+
+- **Connect a new Sensor** enters **Looking nearby…**;
+- no-active-workout guidance is visible;
+- candidate tap opens enrollment;
+- enrollment adds the profile exactly once;
+- row tap opens detail;
+- rename, enable/disable, and forget update the list;
+- notification tap lands on **My Bike Computer** with the **My Sensors**
+  candidate visible;
+- dismiss does not enroll; and
+- offline-map chip returns after the sensor prompt resolves.
+
+## Physical acceptance matrix
+
+Validate on a supported iPhone, Apple Watch, and real sensors:
+
+| Scenario | Expected result |
+| --- | --- |
+| No enrolled sensor, no workout data | Cadence and power tiles are absent. |
+| Unenrolled cadence data arrives | Cadence tile remains absent; cadence prompt appears. |
+| Enroll cadence candidate | Cadence tile appears; power remains absent. |
+| Cadence sensor stops reporting | Cadence tile remains and shows `--` after freshness expiry. |
+| Enroll power candidate | Power tile appears and shows watts while reporting. |
+| Enroll verified/confirmed combined sensor | Both tiles appear. |
+| Disable cadence-only profile | Cadence tile disappears unless another enabled profile supplies cadence. |
+| Forget power profile | Power tile disappears unless another enabled profile supplies power. |
+| Workout and navigation run together | Enrolled workout tiles follow the same rules in the expandable sheet. |
+| Navigation runs without workout | Existing three navigation stats remain unchanged. |
+| Watch disconnects from iPhone | Watch workout continues; tiles remain configured and values become unavailable as existing freshness rules require. |
+| iPhone reconnects mid-workout | Current observations resume without duplicate profiles or prompts. |
+| App relaunches | Enrolled names and enabled choices survive; prompt deduplication remains bounded. |
+| No active workout while looking | UI explains how to pair/wake/start; it does not claim a Bluetooth scan is finding devices. |
+
+## Acceptance criteria
+
+This slice is complete when:
+
+- the existing **My Bike Computer** page contains a **My Sensors** group;
+- **Connect a new Sensor** shows a spinner and **Looking nearby…**;
+- actual current workout cadence/power data creates an honest nearby candidate;
+- an enrolled sensor appears under **My Sensors**;
+- tapping it opens a detail screen with editable name, enable/disable, status,
+  and confirmed forget;
+- fresh unknown sensor data shows one deduplicated **Connect sensor?** bottom
+  notification;
+- tapping the notification opens **My Bike Computer** with the detected sensor
+  ready to enroll;
+- no cadence or power tile appears before explicit enrollment;
+- enabled sensor capabilities, not sample freshness, decide tile visibility;
+- enrolled-but-stale tiles remain visible with `--`;
+- compact and expanded workout layouts remain correct;
+- the flow works during a workout with and without navigation;
+- the Watch-owned workout, HealthKit save, iPhone mirror, and ESP32 metric relay
+  do not regress; and
+- physical-device validation documents whether Gate A or Gate B shipped.
+
+## Relationship to issue #85
+
+This plan advances issue #85 by adding:
+
+- user-visible cadence/power sensor enrollment;
+- local sensor profiles and names;
+- capability-aware training-screen visibility;
+- live observation and reconnect-tolerant app behavior; and
+- a path that can later represent direct sensors consistently.
+
+The following issue #85 work remains separate:
+
+- ESP32-owned BLE scanning and direct GATT connections;
+- bonding, reconnect, and multi-peripheral scheduling on ESP32;
+- Cycling Speed and Cadence Service and Cycling Power Service parsing in
+  firmware;
+- direct heart-rate, temperature, radar/light, or other accessory support;
+- on-device sensor configuration screens;
+- direct-sensor ride-file logging and post-ride analysis;
+- direct sensor-to-ESP32 behavior without Apple Watch/iPhone;
+- ANT+ support and its hardware limitations; and
+- alerts, laps, targets, and broader configurable training screens.
+
+Keep issue #85 open after this Apple Watch/HealthKit-assisted slice merges.
+Future direct ESP32 work should reuse the capability vocabulary and user-facing
+profile concepts, but it must keep transport-specific identities and connection
+state separate.

--- a/docs/cycling-sensor-settings-implementation-plan.md
+++ b/docs/cycling-sensor-settings-implementation-plan.md
@@ -150,6 +150,19 @@ status such as **Data received now**, **Last seen recently**, or
 
 Complete this spike before choosing the persisted identity model.
 
+### Implementation decision for PR #133
+
+PR #133 implements **Gate B**. The current
+`HKLiveWorkoutBuilderDelegate` path exposes fresh cadence and power statistics,
+but the branch has no physical-sensor evidence proving that those statistics
+can be correlated to a stable accessory identity. The implementation therefore
+uses explicit local logical profiles and does not claim to identify, rename, or
+control the Apple Watch Bluetooth accessory.
+
+Gate A remains a compatible future upgrade after the physical matrix below
+proves a stable public identity source. No schema 1.5 identity payload is added
+in the Gate B implementation.
+
 ### Test matrix
 
 Run a BikeComputer-owned cycling workout on physical devices with:

--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -18,6 +18,9 @@ struct BikeComputerApp: App {
         WindowGroup {
             ContentView(
                 workoutMirrorManager: appDelegate.workoutMirrorManager,
+                cyclingSensorStore: appDelegate.cyclingSensorStore,
+                cyclingSensorDetectionCoordinator:
+                    appDelegate.cyclingSensorDetectionCoordinator,
                 coordinator: appDelegate.coordinator,
                 liveActivityDiagnostics:
                     appDelegate.workoutLiveActivityDiagnostics,
@@ -33,7 +36,10 @@ struct BikeComputerApp: App {
 
 @MainActor
 class AppDelegate: NSObject, UIApplicationDelegate {
-    let workoutMirrorManager = WorkoutMirrorManager()
+    let workoutMirrorManager: WorkoutMirrorManager
+    let cyclingSensorStore: CyclingSensorStore
+    let cyclingSensorDetectionCoordinator:
+        CyclingSensorDetectionCoordinator
     let locationManager = CurrentLocationManager()
     let workoutLiveActivityDiagnostics =
         WorkoutLiveActivityDiagnosticStore()
@@ -47,7 +53,20 @@ class AppDelegate: NSObject, UIApplicationDelegate {
     )
 
     override init() {
+        let workoutMirrorManager = WorkoutMirrorManager()
+        let cyclingSensorStore = CyclingSensorStore()
+        let cyclingSensorDetectionCoordinator =
+            CyclingSensorDetectionCoordinator(
+                sensorStore: cyclingSensorStore
+            )
+        self.workoutMirrorManager = workoutMirrorManager
+        self.cyclingSensorStore = cyclingSensorStore
+        self.cyclingSensorDetectionCoordinator =
+            cyclingSensorDetectionCoordinator
         super.init()
+        cyclingSensorDetectionCoordinator.bind(
+            to: workoutMirrorManager.store
+        )
         locationManager.bindWorkoutMetricsStore(
             workoutMirrorManager.store
         )

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -12,6 +12,7 @@ import UIKit
 private enum ContentSheetDestination: String, Identifiable {
     case settings
     case bikeComputerSetup
+    case sensorSettings
     case workoutDashboard
     case rideMetrics
 
@@ -42,6 +43,10 @@ struct ContentView: View {
     @ObservedObject private var workoutStore: WorkoutMetricsStore
     @ObservedObject private var liveActivityDiagnostics:
         WorkoutLiveActivityDiagnosticStore
+    @ObservedObject private var cyclingSensorStore:
+        CyclingSensorStore
+    @ObservedObject private var cyclingSensorDetectionCoordinator:
+        CyclingSensorDetectionCoordinator
     private let workoutMirrorManager: WorkoutMirrorManager
     private let onApplicationActiveChange: (Bool) -> Void
     @Environment(\.scenePhase) private var scenePhase
@@ -49,6 +54,8 @@ struct ContentView: View {
     @State private var sourceAddress = ""
     @State private var destinationAddress = ""
     @State private var presentedSheet: ContentSheetDestination?
+    @State private var queuedSheetAfterDismiss:
+        ContentSheetDestination?
     @State private var rideMetricsDetent = PresentationDetent.rideMetricsCompact
     @State private var workoutSegmentToast: WorkoutCompletedSegmentV1?
     @State private var observedWorkoutSegmentIndex: UInt32?
@@ -70,6 +77,9 @@ struct ContentView: View {
     @MainActor
     init(
         workoutMirrorManager: WorkoutMirrorManager,
+        cyclingSensorStore: CyclingSensorStore? = nil,
+        cyclingSensorDetectionCoordinator:
+            CyclingSensorDetectionCoordinator? = nil,
         coordinator: BikeComputerCoordinator? = nil,
         watchAvailability: WorkoutWatchAvailabilityMonitor? = nil,
         liveActivityDiagnostics:
@@ -81,12 +91,28 @@ struct ContentView: View {
             ?? WorkoutWatchAvailabilityMonitor()
         let liveActivityDiagnostics = liveActivityDiagnostics
             ?? WorkoutLiveActivityDiagnosticStore()
+        let cyclingSensorStore =
+            cyclingSensorStore ?? CyclingSensorStore()
+        let cyclingSensorDetectionCoordinator =
+            cyclingSensorDetectionCoordinator
+            ?? CyclingSensorDetectionCoordinator(
+                sensorStore: cyclingSensorStore
+            )
         let coordinator = coordinator ?? BikeComputerCoordinator(
             destinationStore: SavedDestinationStore(),
             workoutMetricsStore: workoutMirrorManager.store
         )
         self.workoutMirrorManager = workoutMirrorManager
         self.onApplicationActiveChange = onApplicationActiveChange
+        cyclingSensorDetectionCoordinator.bind(
+            to: workoutMirrorManager.store
+        )
+        _cyclingSensorStore = ObservedObject(
+            wrappedValue: cyclingSensorStore
+        )
+        _cyclingSensorDetectionCoordinator = ObservedObject(
+            wrappedValue: cyclingSensorDetectionCoordinator
+        )
         _watchAvailability = StateObject(wrappedValue: watchAvailability)
         _workoutStore = ObservedObject(
             wrappedValue: workoutMirrorManager.store
@@ -208,7 +234,7 @@ struct ContentView: View {
             }
             .sheet(
                 item: $presentedSheet,
-                onDismiss: restoreRideMetricsSheetIfNeeded
+                onDismiss: handleSheetDismissal
             ) { destination in
                 presentedSheetContent(for: destination)
             }
@@ -353,6 +379,9 @@ struct ContentView: View {
                 offlineMapManager: offlineMapManager,
                 firmwareUpdateManager: coordinator.firmwareUpdateManager,
                 watchAvailability: watchAvailability,
+                cyclingSensorStore: cyclingSensorStore,
+                cyclingSensorDetectionCoordinator:
+                    cyclingSensorDetectionCoordinator,
                 onStartTestNavigation: { destination in
                     coordinator.startNavigation(
                         from: .currentLocation,
@@ -368,7 +397,11 @@ struct ContentView: View {
 
         case .bikeComputerSetup:
             NavigationView {
-                BikeComputersSettingsView()
+                BikeComputersSettingsView(
+                    sensorStore: cyclingSensorStore,
+                    sensorDetectionCoordinator:
+                        cyclingSensorDetectionCoordinator
+                )
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
                             Button("Close") {
@@ -376,6 +409,25 @@ struct ContentView: View {
                             }
                         }
                     }
+            }
+            .environmentObject(coordinator.bleManager)
+            .presentationDetents([.large])
+            .presentationBackgroundInteraction(.disabled)
+
+        case .sensorSettings:
+            NavigationView {
+                BikeComputersSettingsView(
+                    sensorStore: cyclingSensorStore,
+                    sensorDetectionCoordinator:
+                        cyclingSensorDetectionCoordinator
+                )
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") {
+                            presentedSheet = nil
+                        }
+                    }
+                }
             }
             .environmentObject(coordinator.bleManager)
             .presentationDetents([.large])
@@ -436,6 +488,29 @@ struct ContentView: View {
             }
             rideMetricsDetent = .rideMetricsCompact
             presentedSheet = .rideMetrics
+        }
+    }
+
+    private func handleSheetDismissal() {
+        if let queuedSheetAfterDismiss {
+            self.queuedSheetAfterDismiss = nil
+            Task { @MainActor in
+                await Task.yield()
+                guard presentedSheet == nil else { return }
+                presentedSheet = queuedSheetAfterDismiss
+            }
+            return
+        }
+        restoreRideMetricsSheetIfNeeded()
+    }
+
+    private func openSensorSettings() {
+        cyclingSensorDetectionCoordinator.prepareForPromptNavigation()
+        if presentedSheet == nil {
+            presentedSheet = .sensorSettings
+        } else if presentedSheet != .sensorSettings {
+            queuedSheetAfterDismiss = .sensorSettings
+            presentedSheet = nil
         }
     }
 
@@ -646,6 +721,13 @@ struct ContentView: View {
             onResumeWorkout: workoutMirrorManager.resume,
             onEndAndSaveWorkout: workoutMirrorManager.endAndSave,
             onDiscardWorkout: workoutMirrorManager.discard,
+            enabledSensorCapabilities:
+                cyclingSensorStore.enabledCapabilities,
+            sensorPrompt:
+                cyclingSensorDetectionCoordinator.activePrompt,
+            onOpenSensorSettings: openSensorSettings,
+            onDismissSensorPrompt:
+                cyclingSensorDetectionCoordinator.dismissPrompt,
             isSheetExpanded: isSheetExpanded
         )
     }
@@ -741,36 +823,22 @@ struct ContentView: View {
     }
 
     private var offlineMapStatusChip: some View {
-        Button {
-            presentedSheet = .settings
-        } label: {
-            HStack(spacing: 10) {
-                if offlineMapManager.isBusy {
-                    ProgressView(value: offlineMapManager.activityProgress)
-                        .frame(width: 22, height: 22)
-                } else {
-                    Image(systemName: offlineMapManager.downloadedPackURL == nil ? "map" : "checkmark.circle.fill")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundColor(offlineMapManager.downloadedPackURL == nil ? .accentColor : .green)
-                }
-
-                VStack(alignment: .leading, spacing: 2) {
-                    Text(offlineMapStatusTitle)
-                        .font(.subheadline.weight(.semibold))
-                    Text("Open Map Settings")
-                        .font(.caption)
-                        .foregroundColor(.secondary)
-                }
+        ActionStatusChip(
+            title: offlineMapStatusTitle,
+            subtitle: "Open Map Settings",
+            systemImage: offlineMapManager.downloadedPackURL == nil
+                ? "map"
+                : "checkmark.circle.fill",
+            tint: offlineMapManager.downloadedPackURL == nil
+                ? .accentColor
+                : .green,
+            progress: offlineMapManager.isBusy
+                ? offlineMapManager.activityProgress
+                : nil,
+            action: {
+                presentedSheet = .settings
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 9)
-            .background(.regularMaterial, in: Capsule())
-            .overlay(
-                Capsule()
-                    .stroke(Color.primary.opacity(0.08), lineWidth: 1)
-            )
-        }
-        .buttonStyle(.plain)
+        )
         .accessibilityLabel("Offline map download status")
     }
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -400,7 +400,8 @@ struct ContentView: View {
                 BikeComputersSettingsView(
                     sensorStore: cyclingSensorStore,
                     sensorDetectionCoordinator:
-                        cyclingSensorDetectionCoordinator
+                        cyclingSensorDetectionCoordinator,
+                    startsBikeComputerDiscoveryOnAppear: true
                 )
                     .toolbar {
                         ToolbarItem(placement: .cancellationAction) {
@@ -419,7 +420,8 @@ struct ContentView: View {
                 BikeComputersSettingsView(
                     sensorStore: cyclingSensorStore,
                     sensorDetectionCoordinator:
-                        cyclingSensorDetectionCoordinator
+                        cyclingSensorDetectionCoordinator,
+                    focusSensorsOnAppear: true
                 )
                 .toolbar {
                     ToolbarItem(placement: .cancellationAction) {
@@ -492,25 +494,38 @@ struct ContentView: View {
     }
 
     private func handleSheetDismissal() {
-        if let queuedSheetAfterDismiss {
+        switch SensorSettingsRoutingPolicy.dismissalDecision(
+            hasQueuedSheet: queuedSheetAfterDismiss != nil,
+            isWorkoutActive: workoutStore.presentation.isWorkoutActive
+        ) {
+        case .presentQueuedSheet:
+            guard let queuedSheetAfterDismiss else { return }
             self.queuedSheetAfterDismiss = nil
             Task { @MainActor in
                 await Task.yield()
                 guard presentedSheet == nil else { return }
                 presentedSheet = queuedSheetAfterDismiss
             }
-            return
+        case .restoreRideMetrics:
+            restoreRideMetricsSheetIfNeeded()
+        case .doNothing:
+            break
         }
-        restoreRideMetricsSheetIfNeeded()
     }
 
     private func openSensorSettings() {
         cyclingSensorDetectionCoordinator.prepareForPromptNavigation()
-        if presentedSheet == nil {
+        switch SensorSettingsRoutingPolicy.openDecision(
+            hasPresentedSheet: presentedSheet != nil,
+            isSensorSettingsPresented: presentedSheet == .sensorSettings
+        ) {
+        case .presentImmediately:
             presentedSheet = .sensorSettings
-        } else if presentedSheet != .sensorSettings {
+        case .dismissAndQueue:
             queuedSheetAfterDismiss = .sensorSettings
             presentedSheet = nil
+        case .unchanged:
+            break
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
@@ -1,10 +1,20 @@
 import Combine
 import Foundation
 
+private struct CyclingSensorPromptDismissalEnvelope: Codable {
+    static let currentVersion = 1
+
+    let version: Int
+    let sessionID: UUID
+    let capabilities: CyclingSensorCapabilities
+}
+
 @MainActor
 final class CyclingSensorDetectionCoordinator: ObservableObject {
-    static let candidateGracePeriod: TimeInterval = 30 * 60
-    static let reportingFreshness: TimeInterval = 10
+    nonisolated static let candidateGracePeriod: TimeInterval = 30 * 60
+    nonisolated static let reportingFreshness: TimeInterval = 10
+    nonisolated static let defaultDismissalStorageKey =
+        "cyclingSensors.promptDismissal.v1"
 
     @Published private(set) var candidates: [CyclingSensorCandidate] = []
     @Published private(set) var activePrompt: CyclingSensorPrompt?
@@ -16,24 +26,40 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
     private let sensorStore: CyclingSensorStore
     private let now: () -> Date
     private let idGenerator: () -> UUID
+    private let candidateGracePeriod: TimeInterval
+    private let dismissalDefaults: UserDefaults
+    private let dismissalStorageKey: String
     private var presentationCancellable: AnyCancellable?
     private var profileCancellable: AnyCancellable?
+    private var candidateExpiryTask: Task<Void, Never>?
     private var currentSessionID: UUID?
     private var dismissedCapabilities = CyclingSensorCapabilities()
 
     init(
         sensorStore: CyclingSensorStore,
         now: @escaping () -> Date = Date.init,
-        idGenerator: @escaping () -> UUID = UUID.init
+        idGenerator: @escaping () -> UUID = UUID.init,
+        candidateGracePeriod: TimeInterval =
+            CyclingSensorDetectionCoordinator.candidateGracePeriod,
+        dismissalDefaults: UserDefaults = .standard,
+        dismissalStorageKey: String =
+            CyclingSensorDetectionCoordinator.defaultDismissalStorageKey
     ) {
         self.sensorStore = sensorStore
         self.now = now
         self.idGenerator = idGenerator
+        self.candidateGracePeriod = candidateGracePeriod
+        self.dismissalDefaults = dismissalDefaults
+        self.dismissalStorageKey = dismissalStorageKey
 
         profileCancellable = sensorStore.$profiles.sink {
             [weak self] profiles in
             self?.reconcileCandidatesAndPrompt(profiles: profiles)
         }
+    }
+
+    deinit {
+        candidateExpiryTask?.cancel()
     }
 
     func bind(to workoutStore: WorkoutMetricsStore) {
@@ -59,8 +85,12 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
     }
 
     func dismissPrompt() {
-        guard let prompt = activePrompt else { return }
+        guard let prompt = activePrompt,
+              currentSessionID != nil else {
+            return
+        }
         dismissedCapabilities.formUnion(prompt.capabilities)
+        persistPromptDismissal()
         activePrompt = nil
     }
 
@@ -69,6 +99,7 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
             !$0.capabilities.intersection(capabilities).isEmpty
         }
         dismissedCapabilities.subtract(capabilities)
+        persistPromptDismissal()
         reconcileCandidatesAndPrompt()
     }
 
@@ -77,6 +108,7 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
             !$0.capabilities.intersection(capabilities).isEmpty
         }
         dismissedCapabilities.formUnion(capabilities)
+        persistPromptDismissal()
         reconcileCandidatesAndPrompt()
     }
 
@@ -121,7 +153,9 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
 
         if currentSessionID != sessionID {
             currentSessionID = sessionID
-            dismissedCapabilities = []
+            dismissedCapabilities = restoredDismissedCapabilities(
+                for: sessionID
+            )
             candidates.removeAll()
             lastObservedAtByCapability = [:]
         }
@@ -163,6 +197,7 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
                 )
             )
         }
+        scheduleCandidateExpiry()
     }
 
     private func isFresh(
@@ -181,8 +216,9 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
     private func pruneCandidates(at date: Date) {
         candidates.removeAll {
             date.timeIntervalSince($0.lastObservedAt)
-                > Self.candidateGracePeriod
+                >= candidateGracePeriod
         }
+        scheduleCandidateExpiry()
     }
 
     private func reconcileCandidatesAndPrompt(
@@ -202,6 +238,7 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         candidates.removeAll { candidate in
             !matchingProfiles(candidate.capabilities).isEmpty
         }
+        scheduleCandidateExpiry()
 
         guard hasActiveWorkout else {
             activePrompt = nil
@@ -209,6 +246,8 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         }
 
         var unresolved = CyclingSensorCapabilities()
+        var enrollmentCapabilities = CyclingSensorCapabilities()
+        var enableCapabilities = CyclingSensorCapabilities()
 
         for capability in CyclingSensorCapabilities.supported
             .individualCapabilities {
@@ -220,13 +259,100 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
             )
             if !isEnabled && hasCurrentObservation {
                 unresolved.insert(capability)
+                if matches.isEmpty {
+                    enrollmentCapabilities.insert(capability)
+                } else {
+                    enableCapabilities.insert(capability)
+                }
             }
         }
 
         unresolved.subtract(dismissedCapabilities)
-        activePrompt = unresolved.isEmpty
-            ? nil
-            : CyclingSensorPrompt(capabilities: unresolved)
+        guard !unresolved.isEmpty else {
+            activePrompt = nil
+            return
+        }
+        let needsEnrollment =
+            !enrollmentCapabilities.intersection(unresolved).isEmpty
+        let needsEnable =
+            !enableCapabilities.intersection(unresolved).isEmpty
+        let action: CyclingSensorPrompt.Action
+        if needsEnrollment && needsEnable {
+            action = .review
+        } else if needsEnable {
+            action = .enable
+        } else {
+            action = .connect
+        }
+        activePrompt = CyclingSensorPrompt(
+            capabilities: unresolved,
+            action: action
+        )
+    }
+
+    private func scheduleCandidateExpiry() {
+        candidateExpiryTask?.cancel()
+        candidateExpiryTask = nil
+        guard let nextExpiry = candidates.map({
+            $0.lastObservedAt.addingTimeInterval(candidateGracePeriod)
+        }).min() else {
+            return
+        }
+
+        let delay = max(0, nextExpiry.timeIntervalSince(now()))
+        let nanoseconds = UInt64(
+            min(delay, Double(UInt64.max) / 1_000_000_000)
+                * 1_000_000_000
+        )
+        candidateExpiryTask = Task { [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled, let self else { return }
+            self.candidateExpiryTask = nil
+            let date = self.now()
+            self.pruneCandidates(at: date)
+            self.reconcileCandidatesAndPrompt(at: date)
+        }
+    }
+
+    private func restoredDismissedCapabilities(
+        for sessionID: UUID
+    ) -> CyclingSensorCapabilities {
+        guard let data = dismissalDefaults.data(
+            forKey: dismissalStorageKey
+        ),
+        let envelope = try? JSONDecoder().decode(
+            CyclingSensorPromptDismissalEnvelope.self,
+            from: data
+        ),
+        envelope.version
+            == CyclingSensorPromptDismissalEnvelope.currentVersion,
+        envelope.sessionID == sessionID else {
+            dismissalDefaults.removeObject(forKey: dismissalStorageKey)
+            return []
+        }
+        return envelope.capabilities.intersection(.supported)
+    }
+
+    private func persistPromptDismissal() {
+        guard let currentSessionID,
+              !dismissedCapabilities.isEmpty else {
+            dismissalDefaults.removeObject(forKey: dismissalStorageKey)
+            return
+        }
+        let envelope = CyclingSensorPromptDismissalEnvelope(
+            version: CyclingSensorPromptDismissalEnvelope.currentVersion,
+            sessionID: currentSessionID,
+            capabilities:
+                dismissedCapabilities.intersection(.supported)
+        )
+        guard let data = try? JSONEncoder().encode(envelope) else {
+            return
+        }
+        dismissalDefaults.set(data, forKey: dismissalStorageKey)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
@@ -1,0 +1,244 @@
+import Combine
+import Foundation
+
+@MainActor
+final class CyclingSensorDetectionCoordinator: ObservableObject {
+    static let candidateGracePeriod: TimeInterval = 30 * 60
+    static let reportingFreshness: TimeInterval = 10
+
+    @Published private(set) var candidates: [CyclingSensorCandidate] = []
+    @Published private(set) var activePrompt: CyclingSensorPrompt?
+    @Published private(set) var isLooking = false
+    @Published private(set) var hasActiveWorkout = false
+    @Published private(set) var lastObservedAtByCapability:
+        [CyclingSensorCapabilities: Date] = [:]
+
+    private let sensorStore: CyclingSensorStore
+    private let now: () -> Date
+    private let idGenerator: () -> UUID
+    private var presentationCancellable: AnyCancellable?
+    private var profileCancellable: AnyCancellable?
+    private var currentSessionID: UUID?
+    private var dismissedCapabilities = CyclingSensorCapabilities()
+
+    init(
+        sensorStore: CyclingSensorStore,
+        now: @escaping () -> Date = Date.init,
+        idGenerator: @escaping () -> UUID = UUID.init
+    ) {
+        self.sensorStore = sensorStore
+        self.now = now
+        self.idGenerator = idGenerator
+
+        profileCancellable = sensorStore.$profiles.sink {
+            [weak self] profiles in
+            self?.reconcileCandidatesAndPrompt(profiles: profiles)
+        }
+    }
+
+    func bind(to workoutStore: WorkoutMetricsStore) {
+        guard presentationCancellable == nil else { return }
+        presentationCancellable = workoutStore.$presentation.sink {
+            [weak self] presentation in
+            self?.ingest(presentation, at: self?.now() ?? Date())
+        }
+        ingest(workoutStore.presentation, at: now())
+    }
+
+    func beginLooking() {
+        isLooking = true
+        pruneCandidates(at: now())
+    }
+
+    func stopLooking() {
+        isLooking = false
+    }
+
+    func prepareForPromptNavigation() {
+        beginLooking()
+    }
+
+    func dismissPrompt() {
+        guard let prompt = activePrompt else { return }
+        dismissedCapabilities.formUnion(prompt.capabilities)
+        activePrompt = nil
+    }
+
+    func didEnroll(capabilities: CyclingSensorCapabilities) {
+        candidates.removeAll {
+            !$0.capabilities.intersection(capabilities).isEmpty
+        }
+        dismissedCapabilities.subtract(capabilities)
+        reconcileCandidatesAndPrompt()
+    }
+
+    func didForget(capabilities: CyclingSensorCapabilities) {
+        candidates.removeAll {
+            !$0.capabilities.intersection(capabilities).isEmpty
+        }
+        dismissedCapabilities.formUnion(capabilities)
+        reconcileCandidatesAndPrompt()
+    }
+
+    func lastObservedAt(
+        for capabilities: CyclingSensorCapabilities
+    ) -> Date? {
+        capabilities
+            .intersection(.supported)
+            .individualCapabilities
+            .compactMap { lastObservedAtByCapability[$0] }
+            .max()
+    }
+
+    func isReporting(
+        capabilities: CyclingSensorCapabilities,
+        at date: Date = Date()
+    ) -> Bool {
+        guard let lastObservedAt = lastObservedAt(for: capabilities) else {
+            return false
+        }
+        let age = date.timeIntervalSince(lastObservedAt)
+        return age >= 0 && age <= Self.reportingFreshness
+    }
+
+    func ingest(
+        _ presentation: WorkoutMirrorPresentationV1,
+        at date: Date
+    ) {
+        hasActiveWorkout = presentation.isWorkoutActive
+
+        guard presentation.isWorkoutActive,
+              presentation.connectionState == .connected,
+              let sessionID = presentation.sessionID else {
+            if !presentation.isWorkoutActive {
+                currentSessionID = nil
+                dismissedCapabilities = []
+            }
+            pruneCandidates(at: date)
+            reconcileCandidatesAndPrompt(at: date)
+            return
+        }
+
+        if currentSessionID != sessionID {
+            currentSessionID = sessionID
+            dismissedCapabilities = []
+            candidates.removeAll()
+            lastObservedAtByCapability = [:]
+        }
+
+        let snapshot = presentation.snapshot
+        if isFresh(snapshot.cyclingCadence, at: date) {
+            observe(.cadence, at: date)
+        }
+        if isFresh(snapshot.cyclingPower, at: date) {
+            observe(.power, at: date)
+        }
+
+        pruneCandidates(at: date)
+        reconcileCandidatesAndPrompt(at: date)
+    }
+
+    private func observe(
+        _ capability: CyclingSensorCapabilities,
+        at date: Date
+    ) {
+        lastObservedAtByCapability[capability] = date
+        sensorStore.markObserved(capabilities: capability, at: date)
+
+        guard sensorStore.profiles(matching: capability).isEmpty else {
+            return
+        }
+
+        if let index = candidates.firstIndex(where: {
+            $0.capabilities == capability
+        }) {
+            candidates[index].lastObservedAt = date
+        } else {
+            candidates.append(
+                CyclingSensorCandidate(
+                    id: idGenerator(),
+                    capabilities: capability,
+                    firstObservedAt: date,
+                    lastObservedAt: date
+                )
+            )
+        }
+    }
+
+    private func isFresh(
+        _ metric: WorkoutMetricV1?,
+        at date: Date
+    ) -> Bool {
+        guard let metric else { return false }
+        return WorkoutMetricFreshness.isFresh(
+            capturedAt: metric.capturedAt,
+            now: date,
+            maximumAge:
+                WorkoutMetricFreshness.pairedCyclingSensorMaximumAge
+        )
+    }
+
+    private func pruneCandidates(at date: Date) {
+        candidates.removeAll {
+            date.timeIntervalSince($0.lastObservedAt)
+                > Self.candidateGracePeriod
+        }
+    }
+
+    private func reconcileCandidatesAndPrompt(
+        profiles profileOverride: [CyclingSensorProfile]? = nil,
+        at referenceDate: Date? = nil
+    ) {
+        let profiles = profileOverride ?? sensorStore.profiles
+        let referenceDate = referenceDate ?? now()
+        func matchingProfiles(
+            _ capabilities: CyclingSensorCapabilities
+        ) -> [CyclingSensorProfile] {
+            profiles.filter {
+                !$0.capabilities.intersection(capabilities).isEmpty
+            }
+        }
+
+        candidates.removeAll { candidate in
+            !matchingProfiles(candidate.capabilities).isEmpty
+        }
+
+        guard hasActiveWorkout else {
+            activePrompt = nil
+            return
+        }
+
+        var unresolved = CyclingSensorCapabilities()
+
+        for capability in CyclingSensorCapabilities.supported
+            .individualCapabilities {
+            let matches = matchingProfiles(capability)
+            let isEnabled = matches.contains(where: \.isEnabled)
+            let hasCurrentObservation = isReporting(
+                capabilities: capability,
+                at: referenceDate
+            )
+            if !isEnabled && hasCurrentObservation {
+                unresolved.insert(capability)
+            }
+        }
+
+        unresolved.subtract(dismissedCapabilities)
+        activePrompt = unresolved.isEmpty
+            ? nil
+            : CyclingSensorPrompt(capabilities: unresolved)
+    }
+}
+
+private extension CyclingSensorCapabilities {
+    var individualCapabilities: [CyclingSensorCapabilities] {
+        var result: [CyclingSensorCapabilities] = []
+        if contains(.cadence) {
+            result.append(.cadence)
+        }
+        if contains(.power) {
+            result.append(.power)
+        }
+        return result
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift
@@ -47,10 +47,12 @@ final class CyclingSensorStore: ObservableObject {
     @discardableResult
     func enroll(
         name: String,
-        capabilities: CyclingSensorCapabilities
+        capabilities: CyclingSensorCapabilities,
+        lastObservedAt: Date? = nil
     ) -> CyclingSensorProfile? {
         let normalizedCapabilities = capabilities.intersection(.supported)
         guard !normalizedCapabilities.isEmpty else { return nil }
+        let createdAt = now()
 
         let profile = CyclingSensorProfile(
             id: idGenerator(),
@@ -61,8 +63,8 @@ final class CyclingSensorStore: ObservableObject {
             capabilities: normalizedCapabilities,
             isEnabled: true,
             identityKind: .logical,
-            createdAt: now(),
-            lastObservedAt: now()
+            createdAt: createdAt,
+            lastObservedAt: lastObservedAt
         )
         profiles.append(profile)
         persist()

--- a/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift
@@ -1,0 +1,172 @@
+import Combine
+import Foundation
+
+private struct CyclingSensorRegistryEnvelope: Codable {
+    static let currentVersion = 1
+
+    let version: Int
+    let profiles: [CyclingSensorProfile]
+}
+
+@MainActor
+final class CyclingSensorStore: ObservableObject {
+    nonisolated static let defaultStorageKey = "cyclingSensors.registry.v1"
+
+    @Published private(set) var profiles: [CyclingSensorProfile]
+
+    private let defaults: UserDefaults
+    private let storageKey: String
+    private let now: () -> Date
+    private let idGenerator: () -> UUID
+
+    var enabledCapabilities: CyclingSensorCapabilities {
+        profiles.reduce(into: CyclingSensorCapabilities()) {
+            capabilities, profile in
+            guard profile.isEnabled else { return }
+            capabilities.formUnion(profile.capabilities)
+        }
+        .intersection(.supported)
+    }
+
+    init(
+        defaults: UserDefaults = .standard,
+        storageKey: String = CyclingSensorStore.defaultStorageKey,
+        now: @escaping () -> Date = Date.init,
+        idGenerator: @escaping () -> UUID = UUID.init
+    ) {
+        self.defaults = defaults
+        self.storageKey = storageKey
+        self.now = now
+        self.idGenerator = idGenerator
+        profiles = Self.loadProfiles(
+            defaults: defaults,
+            storageKey: storageKey
+        )
+    }
+
+    @discardableResult
+    func enroll(
+        name: String,
+        capabilities: CyclingSensorCapabilities
+    ) -> CyclingSensorProfile? {
+        let normalizedCapabilities = capabilities.intersection(.supported)
+        guard !normalizedCapabilities.isEmpty else { return nil }
+
+        let profile = CyclingSensorProfile(
+            id: idGenerator(),
+            name: normalizedName(
+                name,
+                fallback: normalizedCapabilities.suggestedSensorName
+            ),
+            capabilities: normalizedCapabilities,
+            isEnabled: true,
+            identityKind: .logical,
+            createdAt: now(),
+            lastObservedAt: now()
+        )
+        profiles.append(profile)
+        persist()
+        return profile
+    }
+
+    func rename(profileID: UUID, to name: String) {
+        guard let index = profiles.firstIndex(where: { $0.id == profileID })
+        else {
+            return
+        }
+        let normalized = normalizedName(name, fallback: profiles[index].name)
+        guard profiles[index].name != normalized else { return }
+        profiles[index].name = normalized
+        persist()
+    }
+
+    func setEnabled(_ enabled: Bool, profileID: UUID) {
+        guard let index = profiles.firstIndex(where: { $0.id == profileID }),
+              profiles[index].isEnabled != enabled else {
+            return
+        }
+        profiles[index].isEnabled = enabled
+        persist()
+    }
+
+    func forget(profileID: UUID) {
+        let previousCount = profiles.count
+        profiles.removeAll { $0.id == profileID }
+        guard profiles.count != previousCount else { return }
+        persist()
+    }
+
+    func profile(id: UUID) -> CyclingSensorProfile? {
+        profiles.first { $0.id == id }
+    }
+
+    func profiles(
+        matching capabilities: CyclingSensorCapabilities
+    ) -> [CyclingSensorProfile] {
+        profiles.filter {
+            !$0.capabilities.intersection(capabilities).isEmpty
+        }
+    }
+
+    func markObserved(
+        capabilities: CyclingSensorCapabilities,
+        at date: Date
+    ) {
+        var changed = false
+        for index in profiles.indices {
+            guard !profiles[index].capabilities
+                .intersection(capabilities)
+                .isEmpty else {
+                continue
+            }
+            if let previous = profiles[index].lastObservedAt,
+               date.timeIntervalSince(previous) < 30 {
+                continue
+            }
+            profiles[index].lastObservedAt = date
+            changed = true
+        }
+        if changed {
+            persist()
+        }
+    }
+
+    private func normalizedName(_ name: String, fallback: String) -> String {
+        let normalized = name
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.isEmpty {
+            return fallback
+        }
+        return String(normalized.prefix(60))
+    }
+
+    private func persist() {
+        let envelope = CyclingSensorRegistryEnvelope(
+            version: CyclingSensorRegistryEnvelope.currentVersion,
+            profiles: profiles
+        )
+        guard let data = try? JSONEncoder().encode(envelope) else { return }
+        defaults.set(data, forKey: storageKey)
+    }
+
+    private static func loadProfiles(
+        defaults: UserDefaults,
+        storageKey: String
+    ) -> [CyclingSensorProfile] {
+        guard let data = defaults.data(forKey: storageKey),
+              let envelope = try? JSONDecoder().decode(
+                  CyclingSensorRegistryEnvelope.self,
+                  from: data
+              ),
+              envelope.version
+                == CyclingSensorRegistryEnvelope.currentVersion else {
+            return []
+        }
+        return envelope.profiles.filter {
+            !$0.capabilities.intersection(.supported).isEmpty
+                && !$0.name
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .isEmpty
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
@@ -184,6 +184,46 @@ enum BikeComputersMenuPolicy {
     }
 }
 
+enum BikeComputerSettingsPresentationPolicy {
+    static func title(
+        knownDeviceCount: Int,
+        isExplicitBikeComputerSetup: Bool
+    ) -> String {
+        if isExplicitBikeComputerSetup {
+            return BikeComputersMenuPolicy.title(
+                knownDeviceCount: knownDeviceCount
+            )
+        }
+        return knownDeviceCount > 1
+            ? "My Bike Computers"
+            : "My Bike Computer"
+    }
+
+    static func shouldStartDiscovery(
+        knownDeviceCount: Int,
+        isExplicitBikeComputerSetup: Bool,
+        isSensorLooking: Bool,
+        hasSensorCandidates: Bool
+    ) -> Bool {
+        isExplicitBikeComputerSetup
+            && BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+                knownDeviceCount: knownDeviceCount
+            )
+            && !isSensorLooking
+            && !hasSensorCandidates
+    }
+
+    static func shouldShowConnectAction(
+        knownDeviceCount: Int,
+        isExplicitBikeComputerSetup: Bool
+    ) -> Bool {
+        !isExplicitBikeComputerSetup
+            || BikeComputersMenuPolicy.shouldShowConnectNewDeviceAction(
+                knownDeviceCount: knownDeviceCount
+            )
+    }
+}
+
 enum BLEPendingScanPolicy {
     static let timeout: TimeInterval = 8
 

--- a/ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift
@@ -64,7 +64,14 @@ struct CyclingSensorCandidate: Identifiable, Equatable, Sendable {
 }
 
 struct CyclingSensorPrompt: Equatable, Sendable {
+    enum Action: Equatable, Sendable {
+        case connect
+        case enable
+        case review
+    }
+
     let capabilities: CyclingSensorCapabilities
+    let action: Action
 
     var title: String {
         switch capabilities.intersection(.supported) {
@@ -74,6 +81,17 @@ struct CyclingSensorPrompt: Equatable, Sendable {
             return "Power sensor detected"
         default:
             return "Cycling sensor detected"
+        }
+    }
+
+    var actionTitle: String {
+        switch action {
+        case .connect:
+            return "Connect sensor?"
+        case .enable:
+            return "Enable sensor?"
+        case .review:
+            return "Review sensors"
         }
     }
 }
@@ -87,5 +105,39 @@ struct WorkoutMetricTilePolicy: Equatable, Sendable {
 
     var showsPower: Bool {
         enabledSensorCapabilities.contains(.power)
+    }
+}
+
+enum SensorSettingsRouteDecision: Equatable, Sendable {
+    case presentImmediately
+    case dismissAndQueue
+    case unchanged
+}
+
+enum SheetDismissalDecision: Equatable, Sendable {
+    case presentQueuedSheet
+    case restoreRideMetrics
+    case doNothing
+}
+
+struct SensorSettingsRoutingPolicy: Sendable {
+    static func openDecision(
+        hasPresentedSheet: Bool,
+        isSensorSettingsPresented: Bool
+    ) -> SensorSettingsRouteDecision {
+        if isSensorSettingsPresented {
+            return .unchanged
+        }
+        return hasPresentedSheet ? .dismissAndQueue : .presentImmediately
+    }
+
+    static func dismissalDecision(
+        hasQueuedSheet: Bool,
+        isWorkoutActive: Bool
+    ) -> SheetDismissalDecision {
+        if hasQueuedSheet {
+            return .presentQueuedSheet
+        }
+        return isWorkoutActive ? .restoreRideMetrics : .doNothing
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct CyclingSensorCapabilities: OptionSet, Codable, Hashable, Sendable {
+    let rawValue: UInt8
+
+    static let cadence = Self(rawValue: 1 << 0)
+    static let power = Self(rawValue: 1 << 1)
+    static let supported: Self = [.cadence, .power]
+
+    var displayName: String {
+        switch intersection(.supported) {
+        case [.cadence, .power]:
+            return "Cadence + Power"
+        case .cadence:
+            return "Cadence"
+        case .power:
+            return "Power"
+        default:
+            return "Cycling"
+        }
+    }
+
+    var suggestedSensorName: String {
+        switch intersection(.supported) {
+        case [.cadence, .power]:
+            return "Cadence + Power Sensor"
+        case .cadence:
+            return "Cadence Sensor"
+        case .power:
+            return "Power Sensor"
+        default:
+            return "Cycling Sensor"
+        }
+    }
+}
+
+enum CyclingSensorIdentityKind: Codable, Equatable, Sendable {
+    /// The first implementation intentionally uses a logical profile because
+    /// HKLiveWorkoutBuilder statistics do not expose a trustworthy physical
+    /// cycling-peripheral identity. A future physical-device implementation
+    /// can add a versioned case after validation with real sensors.
+    case logical
+}
+
+struct CyclingSensorProfile: Identifiable, Codable, Equatable, Sendable {
+    let id: UUID
+    var name: String
+    var capabilities: CyclingSensorCapabilities
+    var isEnabled: Bool
+    let identityKind: CyclingSensorIdentityKind
+    let createdAt: Date
+    var lastObservedAt: Date?
+}
+
+struct CyclingSensorCandidate: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let capabilities: CyclingSensorCapabilities
+    let firstObservedAt: Date
+    var lastObservedAt: Date
+
+    var suggestedName: String {
+        capabilities.suggestedSensorName
+    }
+}
+
+struct CyclingSensorPrompt: Equatable, Sendable {
+    let capabilities: CyclingSensorCapabilities
+
+    var title: String {
+        switch capabilities.intersection(.supported) {
+        case .cadence:
+            return "Cadence sensor detected"
+        case .power:
+            return "Power sensor detected"
+        default:
+            return "Cycling sensor detected"
+        }
+    }
+}
+
+struct WorkoutMetricTilePolicy: Equatable, Sendable {
+    let enabledSensorCapabilities: CyclingSensorCapabilities
+
+    var showsCadence: Bool {
+        enabledSensorCapabilities.contains(.cadence)
+    }
+
+    var showsPower: Bool {
+        enabledSensorCapabilities.contains(.power)
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/ActionStatusChip.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/ActionStatusChip.swift
@@ -43,7 +43,7 @@ struct ActionStatusChip: View {
                     Image(systemName: "xmark")
                         .font(.caption.weight(.bold))
                         .foregroundColor(.secondary)
-                        .frame(width: 30, height: 30)
+                        .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)

--- a/ios-app/BikeComputer/BikeComputer/Views/ActionStatusChip.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/ActionStatusChip.swift
@@ -1,0 +1,63 @@
+import SwiftUI
+
+struct ActionStatusChip: View {
+    let title: String
+    let subtitle: String
+    let systemImage: String
+    var tint: Color = .accentColor
+    var progress: Double?
+    var onDismiss: (() -> Void)?
+    let action: () -> Void
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Button(action: action) {
+                HStack(spacing: 10) {
+                    if let progress {
+                        ProgressView(value: progress)
+                            .frame(width: 22, height: 22)
+                    } else {
+                        Image(systemName: systemImage)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(tint)
+                            .frame(width: 22, height: 22)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(title)
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundColor(.primary)
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.caption.weight(.bold))
+                        .foregroundColor(.secondary)
+                        .frame(width: 30, height: 30)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Not now")
+            }
+        }
+        .padding(.leading, 14)
+        .padding(.trailing, onDismiss == nil ? 14 : 8)
+        .padding(.vertical, 9)
+        .background(.regularMaterial, in: Capsule())
+        .overlay(
+            Capsule()
+                .stroke(Color.primary.opacity(0.08), lineWidth: 1)
+        )
+        .accessibilityElement(children: .contain)
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -2,12 +2,30 @@ import SwiftUI
 
 struct BikeComputersSettingsView: View {
     @EnvironmentObject private var bleManager: BLEManager
+    @ObservedObject private var sensorStore: CyclingSensorStore
+    @ObservedObject private var sensorDetectionCoordinator:
+        CyclingSensorDetectionCoordinator
     @State private var selectedCandidate: DiscoveredBikeComputerDevice?
     @State private var presentedPairingCompletionGeneration: UInt64?
     @State private var ownsDiscoveryLifecycle = false
 
+    init(
+        sensorStore: CyclingSensorStore,
+        sensorDetectionCoordinator: CyclingSensorDetectionCoordinator
+    ) {
+        _sensorStore = ObservedObject(wrappedValue: sensorStore)
+        _sensorDetectionCoordinator = ObservedObject(
+            wrappedValue: sensorDetectionCoordinator
+        )
+    }
+
     private var menuTitle: String {
-        BikeComputersMenuPolicy.title(
+        if sensorDetectionCoordinator.isLooking
+            || !sensorStore.profiles.isEmpty
+            || !sensorDetectionCoordinator.candidates.isEmpty {
+            return "My Bike Computer"
+        }
+        return BikeComputersMenuPolicy.title(
             knownDeviceCount: bleManager.knownDevices.count
         )
     }
@@ -33,9 +51,18 @@ struct BikeComputersSettingsView: View {
                 }
             } header: {
                 if !bleManager.knownDevices.isEmpty {
-                    Text(menuTitle)
+                    Text(
+                        bleManager.knownDevices.count == 1
+                            ? "My Bike Computer"
+                            : "My Bike Computers"
+                    )
                 }
             }
+
+            CyclingSensorsSettingsSections(
+                sensorStore: sensorStore,
+                detectionCoordinator: sensorDetectionCoordinator
+            )
 
             if bleManager.isDiscoveringDevices ||
                 !bleManager.discoveredDevices.isEmpty {
@@ -109,9 +136,7 @@ struct BikeComputersSettingsView: View {
                 .environmentObject(bleManager)
         }
         .onAppear {
-            if BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
-                knownDeviceCount: bleManager.knownDevices.count
-            ) {
+            if shouldStartBikeComputerDiscovery {
                 beginDiscovery()
             } else if bleManager.isDiscoveringDevices {
                 bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
@@ -126,7 +151,7 @@ struct BikeComputersSettingsView: View {
         .onChange(of: bleManager.knownDevices.count) { count in
             if BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
                 knownDeviceCount: count
-            ) {
+            ), !sensorDetectionCoordinator.isLooking {
                 if !ownsDiscoveryLifecycle {
                     beginDiscovery()
                 }
@@ -135,12 +160,35 @@ struct BikeComputersSettingsView: View {
                 bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
             }
         }
+        .onChange(of: sensorDetectionCoordinator.isLooking) {
+            isLooking in
+            if isLooking {
+                ownsDiscoveryLifecycle = false
+                if bleManager.isDiscoveringDevices {
+                    bleManager.cancelDeviceDiscovery(
+                        resumeAutoReconnect: true
+                    )
+                }
+            } else if shouldStartBikeComputerDiscovery,
+                      !ownsDiscoveryLifecycle {
+                beginDiscovery()
+            }
+        }
         .onDisappear {
             if ownsDiscoveryLifecycle || bleManager.isDiscoveringDevices {
                 ownsDiscoveryLifecycle = false
                 bleManager.cancelDeviceDiscovery(resumeAutoReconnect: true)
             }
+            sensorDetectionCoordinator.stopLooking()
         }
+    }
+
+    private var shouldStartBikeComputerDiscovery: Bool {
+        BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
+            knownDeviceCount: bleManager.knownDevices.count
+        )
+            && !sensorDetectionCoordinator.isLooking
+            && sensorDetectionCoordinator.candidates.isEmpty
     }
 
     private func beginDiscovery() {

--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -8,61 +8,36 @@ struct BikeComputersSettingsView: View {
     @State private var selectedCandidate: DiscoveredBikeComputerDevice?
     @State private var presentedPairingCompletionGeneration: UInt64?
     @State private var ownsDiscoveryLifecycle = false
+    private let focusSensorsOnAppear: Bool
+    private let startsBikeComputerDiscoveryOnAppear: Bool
 
     init(
         sensorStore: CyclingSensorStore,
-        sensorDetectionCoordinator: CyclingSensorDetectionCoordinator
+        sensorDetectionCoordinator: CyclingSensorDetectionCoordinator,
+        focusSensorsOnAppear: Bool = false,
+        startsBikeComputerDiscoveryOnAppear: Bool = false
     ) {
         _sensorStore = ObservedObject(wrappedValue: sensorStore)
         _sensorDetectionCoordinator = ObservedObject(
             wrappedValue: sensorDetectionCoordinator
         )
+        self.focusSensorsOnAppear = focusSensorsOnAppear
+        self.startsBikeComputerDiscoveryOnAppear =
+            startsBikeComputerDiscoveryOnAppear
     }
 
     private var menuTitle: String {
-        if sensorDetectionCoordinator.isLooking
-            || !sensorStore.profiles.isEmpty
-            || !sensorDetectionCoordinator.candidates.isEmpty {
-            return "My Bike Computer"
-        }
-        return BikeComputersMenuPolicy.title(
-            knownDeviceCount: bleManager.knownDevices.count
+        BikeComputerSettingsPresentationPolicy.title(
+            knownDeviceCount: bleManager.knownDevices.count,
+            isExplicitBikeComputerSetup:
+                startsBikeComputerDiscoveryOnAppear
         )
     }
 
     var body: some View {
         Form {
-            Section {
-                if bleManager.knownDevices.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Label("No Bike Computers", systemImage: "bicycle")
-                        Text("Add a nearby device and choose a name for it.")
-                            .font(.footnote)
-                            .foregroundStyle(.secondary)
-                    }
-                } else {
-                    ForEach(bleManager.knownDevices) { device in
-                        NavigationLink {
-                            BikeComputerDetailView(deviceID: device.deviceID)
-                        } label: {
-                            KnownBikeComputerRow(device: device)
-                        }
-                    }
-                }
-            } header: {
-                if !bleManager.knownDevices.isEmpty {
-                    Text(
-                        bleManager.knownDevices.count == 1
-                            ? "My Bike Computer"
-                            : "My Bike Computers"
-                    )
-                }
-            }
-
-            CyclingSensorsSettingsSections(
-                sensorStore: sensorStore,
-                detectionCoordinator: sensorDetectionCoordinator
-            )
+            bikeComputerSection
+            sensorProfilesSection
 
             if bleManager.isDiscoveringDevices ||
                 !bleManager.discoveredDevices.isEmpty {
@@ -93,9 +68,8 @@ struct BikeComputersSettingsView: View {
                 }
             }
 
-            if BikeComputersMenuPolicy.shouldShowConnectNewDeviceAction(
-                knownDeviceCount: bleManager.knownDevices.count
-            ), !bleManager.isDiscoveringDevices {
+            if shouldShowConnectBikeComputerAction,
+               !bleManager.isDiscoveringDevices {
                 Section {
                     Button {
                         beginDiscovery()
@@ -108,6 +82,8 @@ struct BikeComputersSettingsView: View {
                     .disabled(bleManager.deviceOperationDeviceID != nil)
                 }
             }
+
+            sensorConnectionSection
 
             if let error = bleManager.pairingError {
                 Section {
@@ -149,9 +125,7 @@ struct BikeComputersSettingsView: View {
             }
         }
         .onChange(of: bleManager.knownDevices.count) { count in
-            if BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
-                knownDeviceCount: count
-            ), !sensorDetectionCoordinator.isLooking {
+            if shouldStartBikeComputerDiscovery {
                 if !ownsDiscoveryLifecycle {
                     beginDiscovery()
                 }
@@ -183,12 +157,68 @@ struct BikeComputersSettingsView: View {
         }
     }
 
-    private var shouldStartBikeComputerDiscovery: Bool {
-        BikeComputersMenuPolicy.shouldStartDiscoveryOnEntry(
-            knownDeviceCount: bleManager.knownDevices.count
+    @ViewBuilder
+    private var bikeComputerSection: some View {
+        Section {
+            if bleManager.knownDevices.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("No Bike Computers", systemImage: "bicycle")
+                    Text("Add a nearby device and choose a name for it.")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            } else {
+                ForEach(bleManager.knownDevices) { device in
+                    NavigationLink {
+                        BikeComputerDetailView(deviceID: device.deviceID)
+                    } label: {
+                        KnownBikeComputerRow(device: device)
+                    }
+                }
+            }
+        } header: {
+            if !bleManager.knownDevices.isEmpty {
+                Text(
+                    bleManager.knownDevices.count == 1
+                        ? "My Bike Computer"
+                        : "My Bike Computers"
+                )
+            }
+        }
+    }
+
+    private var sensorProfilesSection: some View {
+        CyclingSensorProfilesSection(
+            sensorStore: sensorStore,
+            detectionCoordinator: sensorDetectionCoordinator,
+            focusOnAppear: focusSensorsOnAppear
         )
-            && !sensorDetectionCoordinator.isLooking
-            && sensorDetectionCoordinator.candidates.isEmpty
+    }
+
+    private var sensorConnectionSection: some View {
+        CyclingSensorConnectionSection(
+            sensorStore: sensorStore,
+            detectionCoordinator: sensorDetectionCoordinator
+        )
+    }
+
+    private var shouldShowConnectBikeComputerAction: Bool {
+        BikeComputerSettingsPresentationPolicy.shouldShowConnectAction(
+            knownDeviceCount: bleManager.knownDevices.count,
+            isExplicitBikeComputerSetup:
+                startsBikeComputerDiscoveryOnAppear
+        )
+    }
+
+    private var shouldStartBikeComputerDiscovery: Bool {
+        BikeComputerSettingsPresentationPolicy.shouldStartDiscovery(
+            knownDeviceCount: bleManager.knownDevices.count,
+            isExplicitBikeComputerSetup:
+                startsBikeComputerDiscoveryOnAppear,
+            isSensorLooking: sensorDetectionCoordinator.isLooking,
+            hasSensorCandidates:
+                !sensorDetectionCoordinator.candidates.isEmpty
+        )
     }
 
     private func beginDiscovery() {

--- a/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
@@ -1,6 +1,56 @@
 import SwiftUI
 
-struct CyclingSensorsSettingsSections: View {
+struct CyclingSensorProfilesSection: View {
+    @ObservedObject var sensorStore: CyclingSensorStore
+    @ObservedObject var detectionCoordinator:
+        CyclingSensorDetectionCoordinator
+    @AccessibilityFocusState private var isSensorSectionFocused: Bool
+    var focusOnAppear = false
+
+    var body: some View {
+        Section {
+            if sensorStore.profiles.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    Label("No Sensors", systemImage: "gauge")
+                    Text(
+                        "Add a sensor after BikeComputer receives cadence or power data from your Apple Watch."
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+            } else {
+                ForEach(sensorStore.profiles) { profile in
+                    NavigationLink {
+                        CyclingSensorDetailView(
+                            profileID: profile.id,
+                            sensorStore: sensorStore,
+                            detectionCoordinator:
+                                detectionCoordinator
+                        )
+                    } label: {
+                        CyclingSensorProfileRow(
+                            profile: profile,
+                            detectionCoordinator:
+                                detectionCoordinator
+                        )
+                    }
+                }
+            }
+        } header: {
+            Text("My Sensors")
+                .accessibilityFocused($isSensorSectionFocused)
+                .onAppear {
+                    guard focusOnAppear else { return }
+                    Task { @MainActor in
+                        await Task.yield()
+                        isSensorSectionFocused = true
+                    }
+                }
+        }
+    }
+}
+
+struct CyclingSensorConnectionSection: View {
     @ObservedObject var sensorStore: CyclingSensorStore
     @ObservedObject var detectionCoordinator:
         CyclingSensorDetectionCoordinator
@@ -8,38 +58,6 @@ struct CyclingSensorsSettingsSections: View {
 
     var body: some View {
         Group {
-            Section {
-                if sensorStore.profiles.isEmpty {
-                    VStack(alignment: .leading, spacing: 6) {
-                        Label("No Sensors", systemImage: "gauge")
-                        Text(
-                            "Add a sensor after BikeComputer receives cadence or power data from your Apple Watch."
-                        )
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                    }
-                } else {
-                    ForEach(sensorStore.profiles) { profile in
-                        NavigationLink {
-                            CyclingSensorDetailView(
-                                profileID: profile.id,
-                                sensorStore: sensorStore,
-                                detectionCoordinator:
-                                    detectionCoordinator
-                            )
-                        } label: {
-                            CyclingSensorProfileRow(
-                                profile: profile,
-                                detectionCoordinator:
-                                    detectionCoordinator
-                            )
-                        }
-                    }
-                }
-            } header: {
-                Text("My Sensors")
-            }
-
             if detectionCoordinator.isLooking {
                 Section {
                     if detectionCoordinator.candidates.isEmpty {
@@ -82,7 +100,7 @@ struct CyclingSensorsSettingsSections: View {
                     }
                 } footer: {
                     Text(
-                        "Apple Watch manages the Bluetooth connection. BikeComputer adds a sensor after it receives workout data."
+                        "This connects sensors like cadence or power meters to your Apple Watch and shows their data on your Bike Computer."
                     )
                 }
             }
@@ -251,7 +269,13 @@ private struct CyclingSensorEnrollmentSheet: View {
                     Button("Connect Sensor") {
                         guard sensorStore.enroll(
                             name: sensorName,
-                            capabilities: capabilityChoice.capabilities
+                            capabilities: capabilityChoice.capabilities,
+                            lastObservedAt:
+                                capabilityChoice.capabilities.intersection(
+                                    candidate.capabilities
+                                ).isEmpty
+                                    ? nil
+                                    : candidate.lastObservedAt
                         ) != nil else {
                             return
                         }

--- a/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
@@ -1,0 +1,448 @@
+import SwiftUI
+
+struct CyclingSensorsSettingsSections: View {
+    @ObservedObject var sensorStore: CyclingSensorStore
+    @ObservedObject var detectionCoordinator:
+        CyclingSensorDetectionCoordinator
+    @State private var selectedCandidate: CyclingSensorCandidate?
+
+    var body: some View {
+        Group {
+            Section {
+                if sensorStore.profiles.isEmpty {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("No Sensors", systemImage: "gauge")
+                        Text(
+                            "Add a sensor after BikeComputer receives cadence or power data from your Apple Watch."
+                        )
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    }
+                } else {
+                    ForEach(sensorStore.profiles) { profile in
+                        NavigationLink {
+                            CyclingSensorDetailView(
+                                profileID: profile.id,
+                                sensorStore: sensorStore,
+                                detectionCoordinator:
+                                    detectionCoordinator
+                            )
+                        } label: {
+                            CyclingSensorProfileRow(
+                                profile: profile,
+                                detectionCoordinator:
+                                    detectionCoordinator
+                            )
+                        }
+                    }
+                }
+            } header: {
+                Text("My Sensors")
+            }
+
+            if detectionCoordinator.isLooking {
+                Section {
+                    if detectionCoordinator.candidates.isEmpty {
+                        HStack(spacing: 12) {
+                            ProgressView()
+                            Text("Looking nearby…")
+                                .foregroundStyle(.secondary)
+                        }
+                    } else {
+                        ForEach(detectionCoordinator.candidates) {
+                            candidate in
+                            Button {
+                                selectedCandidate = candidate
+                            } label: {
+                                CyclingSensorCandidateRow(
+                                    candidate: candidate
+                                )
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+
+                    Button("Stop Looking", role: .cancel) {
+                        detectionCoordinator.stopLooking()
+                    }
+                } header: {
+                    Text("Nearby")
+                } footer: {
+                    Text(discoveryFooter)
+                }
+            } else {
+                Section {
+                    Button {
+                        detectionCoordinator.beginLooking()
+                    } label: {
+                        Label(
+                            "Connect a new Sensor",
+                            systemImage: "plus.circle"
+                        )
+                    }
+                } footer: {
+                    Text(
+                        "Apple Watch manages the Bluetooth connection. BikeComputer adds a sensor after it receives workout data."
+                    )
+                }
+            }
+        }
+        .sheet(item: $selectedCandidate) { candidate in
+            CyclingSensorEnrollmentSheet(
+                candidate: candidate,
+                sensorStore: sensorStore,
+                detectionCoordinator: detectionCoordinator
+            )
+        }
+    }
+
+    private var discoveryFooter: String {
+        if detectionCoordinator.hasActiveWorkout {
+            return "Keep pedaling so Apple Watch continues receiving cadence or power data."
+        }
+        return "On Apple Watch, pair the sensor in Settings > Bluetooth > Health Devices. Wake the sensor, then start a BikeComputer cycling workout."
+    }
+}
+
+private struct CyclingSensorProfileRow: View {
+    let profile: CyclingSensorProfile
+    @ObservedObject var detectionCoordinator:
+        CyclingSensorDetectionCoordinator
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "gauge")
+                .font(.title3)
+                .foregroundStyle(profile.isEnabled ? Color.accentColor : .secondary)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(profile.name)
+                Text(profile.capabilities.displayName)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !profile.isEnabled {
+                Text("Disabled")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                TimelineView(.periodic(from: Date(), by: 2)) { context in
+                    Text(
+                        detectionCoordinator.isReporting(
+                            capabilities: profile.capabilities,
+                            at: context.date
+                        )
+                            ? "Reporting"
+                            : "Not reporting"
+                    )
+                    .font(.caption)
+                    .foregroundStyle(
+                        detectionCoordinator.isReporting(
+                            capabilities: profile.capabilities,
+                            at: context.date
+                        )
+                            ? Color.green
+                            : .secondary
+                    )
+                }
+            }
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private struct CyclingSensorCandidateRow: View {
+    let candidate: CyclingSensorCandidate
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: "dot.radiowaves.left.and.right")
+                .font(.title3)
+                .foregroundStyle(Color.accentColor)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(candidate.suggestedName)
+                Text("\(candidate.capabilities.displayName) data received")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+}
+
+private enum CyclingSensorCapabilityChoice: String, CaseIterable, Identifiable {
+    case cadence
+    case power
+    case combined
+
+    var id: String { rawValue }
+
+    var capabilities: CyclingSensorCapabilities {
+        switch self {
+        case .cadence:
+            return .cadence
+        case .power:
+            return .power
+        case .combined:
+            return [.cadence, .power]
+        }
+    }
+
+    var title: String {
+        capabilities.displayName
+    }
+
+    init(capabilities: CyclingSensorCapabilities) {
+        if capabilities.contains(.cadence)
+            && capabilities.contains(.power) {
+            self = .combined
+        } else if capabilities.contains(.power) {
+            self = .power
+        } else {
+            self = .cadence
+        }
+    }
+}
+
+private struct CyclingSensorEnrollmentSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let candidate: CyclingSensorCandidate
+    @ObservedObject var sensorStore: CyclingSensorStore
+    @ObservedObject var detectionCoordinator:
+        CyclingSensorDetectionCoordinator
+    @State private var sensorName: String
+    @State private var capabilityChoice: CyclingSensorCapabilityChoice
+
+    init(
+        candidate: CyclingSensorCandidate,
+        sensorStore: CyclingSensorStore,
+        detectionCoordinator: CyclingSensorDetectionCoordinator
+    ) {
+        self.candidate = candidate
+        self.sensorStore = sensorStore
+        self.detectionCoordinator = detectionCoordinator
+        _sensorName = State(initialValue: candidate.suggestedName)
+        _capabilityChoice = State(
+            initialValue: CyclingSensorCapabilityChoice(
+                capabilities: candidate.capabilities
+            )
+        )
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section("Sensor") {
+                    TextField("Name", text: $sensorName)
+                    Picker("Measures", selection: $capabilityChoice) {
+                        ForEach(CyclingSensorCapabilityChoice.allCases) {
+                            choice in
+                            Text(choice.title).tag(choice)
+                        }
+                    }
+                }
+
+                Section {
+                    Button("Connect Sensor") {
+                        guard sensorStore.enroll(
+                            name: sensorName,
+                            capabilities: capabilityChoice.capabilities
+                        ) != nil else {
+                            return
+                        }
+                        detectionCoordinator.didEnroll(
+                            capabilities: capabilityChoice.capabilities
+                        )
+                        dismiss()
+                    }
+                } footer: {
+                    Text(
+                        "Apple Watch keeps managing the Bluetooth connection. This choice controls which BikeComputer workout stats are shown."
+                    )
+                }
+
+                Section {
+                    Label(
+                        "BikeComputer detected \(candidate.capabilities.displayName.lowercased()) data during the current workout.",
+                        systemImage: "applewatch.radiowaves.left.and.right"
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            .navigationTitle("Add Sensor")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+            .onChange(of: capabilityChoice) { newChoice in
+                if sensorName == candidate.suggestedName {
+                    sensorName =
+                        newChoice.capabilities.suggestedSensorName
+                }
+            }
+        }
+    }
+}
+
+private struct CyclingSensorDetailView: View {
+    @Environment(\.dismiss) private var dismiss
+    let profileID: UUID
+    @ObservedObject var sensorStore: CyclingSensorStore
+    @ObservedObject var detectionCoordinator:
+        CyclingSensorDetectionCoordinator
+    @State private var editedName = ""
+    @State private var showingForgetConfirmation = false
+
+    private var profile: CyclingSensorProfile? {
+        sensorStore.profile(id: profileID)
+    }
+
+    var body: some View {
+        Form {
+            if let profile {
+                Section("Sensor") {
+                    TextField("Name", text: $editedName)
+                    CyclingSensorValueRow(
+                        title: "Measures",
+                        value: profile.capabilities.displayName
+                    )
+                    TimelineView(.periodic(from: Date(), by: 2)) {
+                        context in
+                        CyclingSensorValueRow(
+                            title: "Status",
+                            value: statusText(
+                                profile: profile,
+                                at: context.date
+                            )
+                        )
+                    }
+                    Toggle(
+                        "Enabled",
+                        isOn: Binding(
+                            get: { profile.isEnabled },
+                            set: {
+                                sensorStore.setEnabled(
+                                    $0,
+                                    profileID: profile.id
+                                )
+                            }
+                        )
+                    )
+                }
+
+                Section {
+                    Button("Save Name") {
+                        sensorStore.rename(
+                            profileID: profile.id,
+                            to: editedName
+                        )
+                    }
+                    .disabled(
+                        normalizedEditedName.isEmpty
+                            || normalizedEditedName == profile.name
+                    )
+                }
+
+                Section {
+                    Button("Forget Sensor", role: .destructive) {
+                        showingForgetConfirmation = true
+                    }
+                } footer: {
+                    Text(
+                        "Forgetting removes this BikeComputer profile. It does not unpair the sensor from Apple Watch."
+                    )
+                }
+                .confirmationDialog(
+                    "Forget \(profile.name)?",
+                    isPresented: $showingForgetConfirmation,
+                    titleVisibility: .visible
+                ) {
+                    Button("Forget", role: .destructive) {
+                        detectionCoordinator.didForget(
+                            capabilities: profile.capabilities
+                        )
+                        sensorStore.forget(profileID: profile.id)
+                    }
+                    Button("Cancel", role: .cancel) { }
+                } message: {
+                    Text(
+                        "Cadence and power tiles supplied only by this profile will be hidden."
+                    )
+                }
+
+                Section {
+                    Text(
+                        "Pair or remove the physical accessory in Apple Watch Settings > Bluetooth > Health Devices."
+                    )
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .navigationTitle(profile?.name ?? "Sensor")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            editedName = profile?.name ?? ""
+        }
+        .onChange(of: profile?.name) { newName in
+            if let newName {
+                editedName = newName
+            }
+        }
+        .onChange(of: profile) { newProfile in
+            if newProfile == nil {
+                dismiss()
+            }
+        }
+    }
+
+    private var normalizedEditedName: String {
+        editedName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func statusText(
+        profile: CyclingSensorProfile,
+        at date: Date
+    ) -> String {
+        if detectionCoordinator.isReporting(
+            capabilities: profile.capabilities,
+            at: date
+        ) {
+            return "Data received now"
+        }
+        guard let lastObservedAt =
+            detectionCoordinator.lastObservedAt(
+                for: profile.capabilities
+            ) ?? profile.lastObservedAt else {
+            return "Not currently reporting"
+        }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .short
+        return "Last seen \(formatter.localizedString(for: lastObservedAt, relativeTo: date))"
+    }
+}
+
+private struct CyclingSensorValueRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(title)
+            Spacer()
+            Text(value)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.trailing)
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -198,6 +198,10 @@ struct RideMetricsPanel: View {
     let onResumeWorkout: () -> Void
     let onEndAndSaveWorkout: () -> Void
     let onDiscardWorkout: () -> Void
+    let enabledSensorCapabilities: CyclingSensorCapabilities
+    let sensorPrompt: CyclingSensorPrompt?
+    let onOpenSensorSettings: () -> Void
+    let onDismissSensorPrompt: () -> Void
     let isSheetExpanded: Bool?
 
     var body: some View {
@@ -270,6 +274,19 @@ struct RideMetricsPanel: View {
                         .padding(.bottom, 8)
                 }
                 .frame(maxHeight: .infinity)
+            }
+
+            if let sensorPrompt {
+                ActionStatusChip(
+                    title: sensorPrompt.title,
+                    subtitle: "Connect sensor?",
+                    systemImage: "dot.radiowaves.left.and.right",
+                    onDismiss: onDismissSensorPrompt,
+                    action: onOpenSensorSettings
+                )
+                .padding(.horizontal, 20)
+                .padding(.vertical, 8)
+                .accessibilityIdentifier("cyclingSensorPrompt")
             }
 
             Divider()
@@ -406,29 +423,45 @@ struct RideMetricsPanel: View {
     private var workoutMetricValues: [RideMetric] {
         let snapshot = workoutStore.presentation.snapshot
         let suppressInstantaneous = suppressInstantaneousMetrics
-        return [
+        let tilePolicy = WorkoutMetricTilePolicy(
+            enabledSensorCapabilities: enabledSensorCapabilities
+        )
+        var metrics = [
             RideMetric(
                 value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
                 label: "elapsed"
             ),
-            RideMetric(
-                value: WorkoutValueFormatter.whole(
-                    suppressInstantaneous
-                        ? nil
-                        : snapshot.cyclingCadence?.value
-                ),
-                unit: "rpm",
-                label: "cadence"
-            ),
-            RideMetric(
-                value: WorkoutValueFormatter.whole(
-                    suppressInstantaneous
-                        ? nil
-                        : snapshot.cyclingPower?.value
-                ),
-                unit: "W",
-                label: "power"
-            ),
+        ]
+
+        if tilePolicy.showsCadence {
+            metrics.append(
+                RideMetric(
+                    value: WorkoutValueFormatter.whole(
+                        suppressInstantaneous
+                            ? nil
+                            : snapshot.cyclingCadence?.value
+                    ),
+                    unit: "rpm",
+                    label: "cadence"
+                )
+            )
+        }
+
+        if tilePolicy.showsPower {
+            metrics.append(
+                RideMetric(
+                    value: WorkoutValueFormatter.whole(
+                        suppressInstantaneous
+                            ? nil
+                            : snapshot.cyclingPower?.value
+                    ),
+                    unit: "W",
+                    label: "power"
+                )
+            )
+        }
+
+        metrics.append(contentsOf: [
             RideMetric(
                 value: WorkoutValueFormatter.speed(
                     suppressInstantaneous
@@ -474,7 +507,8 @@ struct RideMetricsPanel: View {
                 unit: "kcal",
                 label: "energy"
             ),
-        ]
+        ])
+        return metrics
     }
 
     private func workoutMetricGrid(

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -279,7 +279,7 @@ struct RideMetricsPanel: View {
             if let sensorPrompt {
                 ActionStatusChip(
                     title: sensorPrompt.title,
-                    subtitle: "Connect sensor?",
+                    subtitle: sensorPrompt.actionTitle,
                     systemImage: "dot.radiowaves.left.and.right",
                     onDismiss: onDismissSensorPrompt,
                     action: onOpenSensorSettings

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -18,6 +18,10 @@ struct SettingsView: View {
     @ObservedObject private var firmwareUpdateManager: FirmwareUpdateManager
     @ObservedObject private var watchAvailability:
         WorkoutWatchAvailabilityMonitor
+    @ObservedObject private var cyclingSensorStore:
+        CyclingSensorStore
+    @ObservedObject private var cyclingSensorDetectionCoordinator:
+        CyclingSensorDetectionCoordinator
     @FocusState private var focusedSavedMapFilename: String?
     let locationAuthorized: Bool
     let currentLocation: CLLocation?
@@ -29,13 +33,27 @@ struct SettingsView: View {
         offlineMapManager: OfflineMapManager,
         firmwareUpdateManager: FirmwareUpdateManager,
         watchAvailability: WorkoutWatchAvailabilityMonitor,
+        cyclingSensorStore: CyclingSensorStore? = nil,
+        cyclingSensorDetectionCoordinator:
+            CyclingSensorDetectionCoordinator? = nil,
         onStartTestNavigation: @escaping (String) -> Void
     ) {
+        let cyclingSensorStore =
+            cyclingSensorStore ?? CyclingSensorStore()
         self.locationAuthorized = locationAuthorized
         self.currentLocation = currentLocation
         self.offlineMapManager = offlineMapManager
         self.firmwareUpdateManager = firmwareUpdateManager
         self.watchAvailability = watchAvailability
+        _cyclingSensorStore = ObservedObject(
+            wrappedValue: cyclingSensorStore
+        )
+        _cyclingSensorDetectionCoordinator = ObservedObject(
+            wrappedValue: cyclingSensorDetectionCoordinator
+                ?? CyclingSensorDetectionCoordinator(
+                    sensorStore: cyclingSensorStore
+                )
+        )
         self.onStartTestNavigation = onStartTestNavigation
     }
     
@@ -73,7 +91,11 @@ struct SettingsView: View {
 
                 Section {
                     NavigationLink {
-                        BikeComputersSettingsView()
+                        BikeComputersSettingsView(
+                            sensorStore: cyclingSensorStore,
+                            sensorDetectionCoordinator:
+                                cyclingSensorDetectionCoordinator
+                        )
                     } label: {
                         Label(
                             BikeComputersMenuPolicy.title(
@@ -100,6 +122,9 @@ struct SettingsView: View {
                             offlineMapManager: offlineMapManager,
                             firmwareUpdateManager: firmwareUpdateManager,
                             watchAvailability: watchAvailability,
+                            cyclingSensorStore: cyclingSensorStore,
+                            cyclingSensorDetectionCoordinator:
+                                cyclingSensorDetectionCoordinator,
                             currentLocation: currentLocation,
                             onStartTestNavigation: { destination in
                                 onStartTestNavigation(destination)
@@ -1257,6 +1282,9 @@ private struct DeveloperSettingsView: View {
     @ObservedObject var offlineMapManager: OfflineMapManager
     @ObservedObject var firmwareUpdateManager: FirmwareUpdateManager
     @ObservedObject var watchAvailability: WorkoutWatchAvailabilityMonitor
+    @ObservedObject var cyclingSensorStore: CyclingSensorStore
+    @ObservedObject var cyclingSensorDetectionCoordinator:
+        CyclingSensorDetectionCoordinator
     let currentLocation: CLLocation?
     let onStartTestNavigation: (String) -> Void
 
@@ -1340,7 +1368,11 @@ private struct DeveloperSettingsView: View {
                 }
 
                 NavigationLink {
-                    BikeComputersSettingsView()
+                    BikeComputersSettingsView(
+                        sensorStore: cyclingSensorStore,
+                        sensorDetectionCoordinator:
+                            cyclingSensorDetectionCoordinator
+                    )
                 } label: {
                     Label("Manage Bike Computers", systemImage: "bicycle")
                 }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -98,8 +98,10 @@ struct SettingsView: View {
                         )
                     } label: {
                         Label(
-                            BikeComputersMenuPolicy.title(
-                                knownDeviceCount: bleManager.knownDevices.count
+                            BikeComputerSettingsPresentationPolicy.title(
+                                knownDeviceCount:
+                                    bleManager.knownDevices.count,
+                                isExplicitBikeComputerSetup: false
                             ),
                             systemImage: "bicycle"
                         )

--- a/ios-app/BikeComputerTests/CyclingSensorTests.swift
+++ b/ios-app/BikeComputerTests/CyclingSensorTests.swift
@@ -1,0 +1,549 @@
+import Foundation
+
+private func sensorAssert(
+    _ condition: @autoclosure () -> Bool,
+    _ message: String
+) {
+    guard condition() else {
+        fputs("FAIL: \(message)\n", stderr)
+        Foundation.exit(1)
+    }
+}
+
+private func sensorAssertEqual<T: Equatable>(
+    _ actual: T,
+    _ expected: T,
+    _ message: String
+) {
+    sensorAssert(
+        actual == expected,
+        "\(message): expected \(expected), got \(actual)"
+    )
+}
+
+@MainActor
+private struct CyclingSensorTestSuite {
+    mutating func run() async {
+        testTilePolicy()
+        testRegistryPersistenceAndMutations()
+        testCorruptRegistryFailsSafe()
+        testFutureRegistryVersionFailsSafe()
+        testCapabilityUnionAcrossProfiles()
+        testFreshCadenceCreatesCandidateAndPrompt()
+        testCombinedMeasurementsRemainSeparateCandidates()
+        await testDisabledProfilePromptsUntilEnabled()
+        testPromptDismissalResetsForNextWorkout()
+        testCandidateGracePeriodExpiry()
+        testInactiveStaleFutureAndDisconnectedDataDoNotPrompt()
+        print("Cycling sensor tests passed")
+    }
+
+    private func testTilePolicy() {
+        sensorAssert(
+            !WorkoutMetricTilePolicy(enabledSensorCapabilities: [])
+                .showsCadence,
+            "empty registry hides cadence"
+        )
+        sensorAssert(
+            !WorkoutMetricTilePolicy(enabledSensorCapabilities: [])
+                .showsPower,
+            "empty registry hides power"
+        )
+        let cadence = WorkoutMetricTilePolicy(
+            enabledSensorCapabilities: .cadence
+        )
+        sensorAssert(cadence.showsCadence, "cadence profile shows cadence")
+        sensorAssert(!cadence.showsPower, "cadence profile hides power")
+        let combined = WorkoutMetricTilePolicy(
+            enabledSensorCapabilities: [.cadence, .power]
+        )
+        sensorAssert(combined.showsCadence, "combined shows cadence")
+        sensorAssert(combined.showsPower, "combined shows power")
+    }
+
+    private func testRegistryPersistenceAndMutations() {
+        let (defaults, suiteName) = makeDefaults("registry")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let now = Date(timeIntervalSinceReferenceDate: 900_000_000)
+        let profileID = UUID(uuidString:
+            "10000000-0000-0000-0000-000000000001")!
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors",
+            now: { now },
+            idGenerator: { profileID }
+        )
+
+        sensorAssert(store.profiles.isEmpty, "registry starts empty")
+        let profile = store.enroll(
+            name: "  Crank Sensor  ",
+            capabilities: .cadence
+        )
+        sensorAssertEqual(profile?.id, profileID, "enrollment uses ID")
+        sensorAssertEqual(
+            profile?.identityKind,
+            .logical,
+            "Gate B enrollment uses logical identity"
+        )
+        sensorAssertEqual(
+            store.enabledCapabilities,
+            .cadence,
+            "enabled enrollment exposes cadence"
+        )
+        store.rename(profileID: profileID, to: "Morning Bike")
+        store.setEnabled(false, profileID: profileID)
+        sensorAssert(
+            store.enabledCapabilities.isEmpty,
+            "disabled profile removes capability"
+        )
+
+        let restored = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors",
+            now: { now }
+        )
+        sensorAssertEqual(
+            restored.profile(id: profileID)?.name,
+            "Morning Bike",
+            "name persists"
+        )
+        sensorAssertEqual(
+            restored.profile(id: profileID)?.identityKind,
+            .logical,
+            "rename preserves identity"
+        )
+        sensorAssertEqual(
+            restored.profile(id: profileID)?.isEnabled,
+            false,
+            "enabled state persists"
+        )
+        restored.forget(profileID: profileID)
+        sensorAssert(restored.profiles.isEmpty, "forget removes profile")
+    }
+
+    private func testCorruptRegistryFailsSafe() {
+        let (defaults, suiteName) = makeDefaults("corrupt")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(Data("not-json".utf8), forKey: "sensors")
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors"
+        )
+        sensorAssert(store.profiles.isEmpty, "corrupt registry loads empty")
+    }
+
+    private func testFutureRegistryVersionFailsSafe() {
+        let (defaults, suiteName) = makeDefaults("future-version")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(
+            Data(#"{"version":2,"profiles":[]}"#.utf8),
+            forKey: "sensors"
+        )
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors"
+        )
+        sensorAssert(
+            store.profiles.isEmpty,
+            "future registry version loads empty"
+        )
+    }
+
+    private func testCapabilityUnionAcrossProfiles() {
+        let (defaults, suiteName) = makeDefaults("capability-union")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors"
+        )
+        let cadence = store.enroll(
+            name: "Cadence",
+            capabilities: .cadence
+        )!
+        let combined = store.enroll(
+            name: "Combined",
+            capabilities: [.cadence, .power]
+        )!
+        sensorAssertEqual(
+            store.enabledCapabilities,
+            [.cadence, .power],
+            "overlapping profiles expose the capability union"
+        )
+
+        store.setEnabled(false, profileID: combined.id)
+        sensorAssertEqual(
+            store.enabledCapabilities,
+            .cadence,
+            "disabled combined profile leaves cadence profile active"
+        )
+        store.forget(profileID: cadence.id)
+        sensorAssert(
+            store.enabledCapabilities.isEmpty,
+            "forgetting last enabled profile removes its capability"
+        )
+    }
+
+    private func testFreshCadenceCreatesCandidateAndPrompt() {
+        let fixture = makeFixture("fresh-cadence")
+        let sessionID = UUID()
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: sessionID,
+                at: fixture.now,
+                cadence: 82
+            ),
+            at: fixture.now
+        )
+
+        sensorAssertEqual(
+            fixture.coordinator.candidates.map(\.capabilities),
+            [.cadence],
+            "fresh cadence creates cadence candidate"
+        )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.capabilities,
+            .cadence,
+            "fresh cadence creates prompt"
+        )
+        sensorAssert(
+            fixture.store.enabledCapabilities.isEmpty,
+            "observation does not auto-enroll"
+        )
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: sessionID,
+                at: fixture.now.addingTimeInterval(1),
+                cadence: 83
+            ),
+            at: fixture.now.addingTimeInterval(1)
+        )
+        sensorAssertEqual(
+            fixture.coordinator.candidates.count,
+            1,
+            "repeated snapshots do not duplicate candidates"
+        )
+
+        _ = fixture.store.enroll(
+            name: "Cadence Sensor",
+            capabilities: .cadence
+        )
+        fixture.coordinator.didEnroll(capabilities: .cadence)
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "explicit enrollment clears prompt"
+        )
+        sensorAssertEqual(
+            fixture.store.enabledCapabilities,
+            .cadence,
+            "explicit enrollment exposes tile capability"
+        )
+    }
+
+    private func testCombinedMeasurementsRemainSeparateCandidates() {
+        let fixture = makeFixture("combined")
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now,
+                cadence: 90,
+                power: 245
+            ),
+            at: fixture.now
+        )
+
+        sensorAssertEqual(
+            Set(fixture.coordinator.candidates.map(\.capabilities)),
+            Set([.cadence, .power]),
+            "unidentified cadence and power stay separate candidates"
+        )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.capabilities,
+            [.cadence, .power],
+            "prompt summarizes both capabilities"
+        )
+    }
+
+    private mutating func testDisabledProfilePromptsUntilEnabled() async {
+        let fixture = makeFixture("disabled")
+        let profile = fixture.store.enroll(
+            name: "Power Meter",
+            capabilities: .power
+        )!
+        fixture.store.setEnabled(false, profileID: profile.id)
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now,
+                power: 210
+            ),
+            at: fixture.now
+        )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.capabilities,
+            .power,
+            "disabled observed profile prompts"
+        )
+
+        fixture.store.setEnabled(true, profileID: profile.id)
+        await Task.yield()
+        await Task.yield()
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "enabling matching profile clears prompt"
+        )
+    }
+
+    private func testPromptDismissalResetsForNextWorkout() {
+        let fixture = makeFixture("dismiss")
+        let firstSession = UUID()
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: firstSession,
+                at: fixture.now,
+                cadence: 78
+            ),
+            at: fixture.now
+        )
+        fixture.coordinator.dismissPrompt()
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "dismiss hides current prompt"
+        )
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: firstSession,
+                at: fixture.now.addingTimeInterval(1),
+                cadence: 79
+            ),
+            at: fixture.now.addingTimeInterval(1)
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "dismiss remains scoped to current workout"
+        )
+
+        let nextTime = fixture.now.addingTimeInterval(2)
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: nextTime,
+                cadence: 80
+            ),
+            at: nextTime
+        )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.capabilities,
+            .cadence,
+            "next workout can prompt again"
+        )
+    }
+
+    private func testCandidateGracePeriodExpiry() {
+        let fixture = makeFixture("candidate-expiry")
+        let sessionID = UUID()
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: sessionID,
+                at: fixture.now,
+                cadence: 70
+            ),
+            at: fixture.now
+        )
+
+        let expiredAt = fixture.now.addingTimeInterval(
+            CyclingSensorDetectionCoordinator.candidateGracePeriod + 1
+        )
+        fixture.coordinator.ingest(
+            presentation(sessionID: sessionID, at: expiredAt),
+            at: expiredAt
+        )
+        sensorAssert(
+            fixture.coordinator.candidates.isEmpty,
+            "candidate expires after the enrollment grace period"
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "expired candidate no longer prompts"
+        )
+    }
+
+    private func testInactiveStaleFutureAndDisconnectedDataDoNotPrompt() {
+        let fixture = makeFixture("inactive-stale")
+        fixture.coordinator.ingest(.idle, at: fixture.now)
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "idle presentation does not prompt"
+        )
+
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now.addingTimeInterval(-10),
+                cadence: 70
+            ),
+            at: fixture.now
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "stale cadence does not prompt"
+        )
+
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now.addingTimeInterval(1),
+                cadence: 71
+            ),
+            at: fixture.now
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "future cadence does not prompt"
+        )
+
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now,
+                cadence: 72,
+                connectionState: .disconnected
+            ),
+            at: fixture.now
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "disconnected cadence does not prompt"
+        )
+
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: fixture.now,
+                cadence: 73,
+                sessionState: .ended
+            ),
+            at: fixture.now
+        )
+        sensorAssert(
+            fixture.coordinator.activePrompt == nil,
+            "terminal workout data does not prompt"
+        )
+    }
+
+    private func makeDefaults(
+        _ suffix: String
+    ) -> (UserDefaults, String) {
+        let suiteName = "CyclingSensorTests.\(suffix).\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return (defaults, suiteName)
+    }
+
+    private func makeFixture(_ suffix: String) -> SensorFixture {
+        let (defaults, suiteName) = makeDefaults(suffix)
+        let now = Date(timeIntervalSinceReferenceDate: 900_100_000)
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors",
+            now: { now }
+        )
+        let coordinator = CyclingSensorDetectionCoordinator(
+            sensorStore: store,
+            now: { now }
+        )
+        return SensorFixture(
+            defaults: defaults,
+            suiteName: suiteName,
+            now: now,
+            store: store,
+            coordinator: coordinator
+        )
+    }
+
+    private func presentation(
+        sessionID: UUID,
+        at date: Date,
+        cadence: Double? = nil,
+        power: Double? = nil,
+        connectionState: WorkoutMirrorConnectionStateV1 = .connected,
+        sessionState: WorkoutSessionStateV1 = .running
+    ) -> WorkoutMirrorPresentationV1 {
+        let cadenceMetric = cadence.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .revolutionsPerMinute,
+                capturedAt: date,
+                source: .healthKit
+            )
+        }
+        let powerMetric = power.map {
+            WorkoutMetricV1(
+                value: $0,
+                unit: .watts,
+                capturedAt: date,
+                source: .healthKit
+            )
+        }
+        var availability = WorkoutAvailabilityMaskV1()
+        if cadenceMetric != nil {
+            availability.insert(.cyclingCadence)
+        }
+        if powerMetric != nil {
+            availability.insert(.cyclingPower)
+        }
+        return WorkoutMirrorPresentationV1(
+            connectionState: connectionState,
+            snapshot: WorkoutSnapshotV1(
+                state: sessionState,
+                startDate: date.addingTimeInterval(-60),
+                cyclingPower: powerMetric,
+                cyclingCadence: cadenceMetric,
+                availability: availability
+            ),
+            sessionID: sessionID,
+            capturedAt: date,
+            receivedAt: date,
+            confirmedSessionState: sessionState,
+            errorCode: nil,
+            pendingControl: nil,
+            finalSnapshot: nil,
+            navigation: .empty
+        )
+    }
+}
+
+@MainActor
+private final class SensorFixture {
+    let defaults: UserDefaults
+    let suiteName: String
+    let now: Date
+    let store: CyclingSensorStore
+    let coordinator: CyclingSensorDetectionCoordinator
+
+    init(
+        defaults: UserDefaults,
+        suiteName: String,
+        now: Date,
+        store: CyclingSensorStore,
+        coordinator: CyclingSensorDetectionCoordinator
+    ) {
+        self.defaults = defaults
+        self.suiteName = suiteName
+        self.now = now
+        self.store = store
+        self.coordinator = coordinator
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+}
+
+@main
+private enum CyclingSensorTestRunner {
+    @MainActor
+    static func main() async {
+        var suite = CyclingSensorTestSuite()
+        await suite.run()
+    }
+}

--- a/ios-app/BikeComputerTests/CyclingSensorTests.swift
+++ b/ios-app/BikeComputerTests/CyclingSensorTests.swift
@@ -25,6 +25,7 @@ private func sensorAssertEqual<T: Equatable>(
 private struct CyclingSensorTestSuite {
     mutating func run() async {
         testTilePolicy()
+        testSensorSettingsRoutingPolicy()
         testRegistryPersistenceAndMutations()
         testCorruptRegistryFailsSafe()
         testFutureRegistryVersionFailsSafe()
@@ -33,7 +34,9 @@ private struct CyclingSensorTestSuite {
         testCombinedMeasurementsRemainSeparateCandidates()
         await testDisabledProfilePromptsUntilEnabled()
         testPromptDismissalResetsForNextWorkout()
+        testPromptDismissalSurvivesRelaunch()
         testCandidateGracePeriodExpiry()
+        await testCandidateExpiresWithoutAnotherPresentation()
         testInactiveStaleFutureAndDisconnectedDataDoNotPrompt()
         print("Cycling sensor tests passed")
     }
@@ -59,6 +62,57 @@ private struct CyclingSensorTestSuite {
         )
         sensorAssert(combined.showsCadence, "combined shows cadence")
         sensorAssert(combined.showsPower, "combined shows power")
+    }
+
+    private func testSensorSettingsRoutingPolicy() {
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.openDecision(
+                hasPresentedSheet: false,
+                isSensorSettingsPresented: false
+            ),
+            .presentImmediately,
+            "sensor settings presents immediately when no sheet is open"
+        )
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.openDecision(
+                hasPresentedSheet: true,
+                isSensorSettingsPresented: false
+            ),
+            .dismissAndQueue,
+            "sensor settings queues behind the ride metrics sheet"
+        )
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.openDecision(
+                hasPresentedSheet: true,
+                isSensorSettingsPresented: true
+            ),
+            .unchanged,
+            "an existing sensor settings sheet is not replaced"
+        )
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.dismissalDecision(
+                hasQueuedSheet: true,
+                isWorkoutActive: true
+            ),
+            .presentQueuedSheet,
+            "a queued sensor sheet wins over ride metrics restoration"
+        )
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.dismissalDecision(
+                hasQueuedSheet: false,
+                isWorkoutActive: true
+            ),
+            .restoreRideMetrics,
+            "ride metrics returns after sensor settings closes"
+        )
+        sensorAssertEqual(
+            SensorSettingsRoutingPolicy.dismissalDecision(
+                hasQueuedSheet: false,
+                isWorkoutActive: false
+            ),
+            .doNothing,
+            "no sheet is restored after the workout ends"
+        )
     }
 
     private func testRegistryPersistenceAndMutations() {
@@ -89,6 +143,10 @@ private struct CyclingSensorTestSuite {
             store.enabledCapabilities,
             .cadence,
             "enabled enrollment exposes cadence"
+        )
+        sensorAssert(
+            profile?.lastObservedAt == nil,
+            "manual enrollment does not invent a last-seen timestamp"
         )
         store.rename(profileID: profileID, to: "Morning Bike")
         store.setEnabled(false, profileID: profileID)
@@ -205,6 +263,11 @@ private struct CyclingSensorTestSuite {
             .cadence,
             "fresh cadence creates prompt"
         )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.action,
+            .connect,
+            "unknown cadence offers connection"
+        )
         sensorAssert(
             fixture.store.enabledCapabilities.isEmpty,
             "observation does not auto-enroll"
@@ -283,6 +346,15 @@ private struct CyclingSensorTestSuite {
             .power,
             "disabled observed profile prompts"
         )
+        sensorAssertEqual(
+            fixture.coordinator.activePrompt?.action,
+            .enable,
+            "disabled observed profile offers enable instead of duplicate enrollment"
+        )
+        sensorAssert(
+            fixture.coordinator.candidates.isEmpty,
+            "disabled profiles are not duplicated as nearby candidates"
+        )
 
         fixture.store.setEnabled(true, profileID: profile.id)
         await Task.yield()
@@ -338,6 +410,59 @@ private struct CyclingSensorTestSuite {
         )
     }
 
+    private func testPromptDismissalSurvivesRelaunch() {
+        let fixture = makeFixture("dismiss-relaunch")
+        let sessionID = UUID()
+        fixture.coordinator.ingest(
+            presentation(
+                sessionID: sessionID,
+                at: fixture.now,
+                cadence: 84
+            ),
+            at: fixture.now
+        )
+        fixture.coordinator.dismissPrompt()
+
+        let restoredStore = CyclingSensorStore(
+            defaults: fixture.defaults,
+            storageKey: "sensors",
+            now: { fixture.now }
+        )
+        let restoredCoordinator = CyclingSensorDetectionCoordinator(
+            sensorStore: restoredStore,
+            now: { fixture.now },
+            dismissalDefaults: fixture.defaults,
+            dismissalStorageKey: "prompt-dismissal"
+        )
+        restoredCoordinator.ingest(
+            presentation(
+                sessionID: sessionID,
+                at: fixture.now,
+                cadence: 85
+            ),
+            at: fixture.now
+        )
+        sensorAssert(
+            restoredCoordinator.activePrompt == nil,
+            "same-workout dismissal survives coordinator recreation"
+        )
+
+        let nextTime = fixture.now.addingTimeInterval(1)
+        restoredCoordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: nextTime,
+                cadence: 86
+            ),
+            at: nextTime
+        )
+        sensorAssertEqual(
+            restoredCoordinator.activePrompt?.action,
+            .connect,
+            "a new workout can offer the sensor again after relaunch"
+        )
+    }
+
     private func testCandidateGracePeriodExpiry() {
         let fixture = makeFixture("candidate-expiry")
         let sessionID = UUID()
@@ -364,6 +489,42 @@ private struct CyclingSensorTestSuite {
         sensorAssert(
             fixture.coordinator.activePrompt == nil,
             "expired candidate no longer prompts"
+        )
+    }
+
+    private mutating func testCandidateExpiresWithoutAnotherPresentation()
+        async {
+        let (defaults, suiteName) = makeDefaults("scheduled-expiry")
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = CyclingSensorStore(
+            defaults: defaults,
+            storageKey: "sensors"
+        )
+        let coordinator = CyclingSensorDetectionCoordinator(
+            sensorStore: store,
+            candidateGracePeriod: 0.03,
+            dismissalDefaults: defaults,
+            dismissalStorageKey: "prompt-dismissal"
+        )
+        let detectedAt = Date()
+        coordinator.ingest(
+            presentation(
+                sessionID: UUID(),
+                at: detectedAt,
+                cadence: 72
+            ),
+            at: detectedAt
+        )
+        sensorAssertEqual(
+            coordinator.candidates.count,
+            1,
+            "scheduled-expiry fixture starts with a candidate"
+        )
+
+        try? await Task.sleep(nanoseconds: 100_000_000)
+        sensorAssert(
+            coordinator.candidates.isEmpty,
+            "candidate expires on wall-clock time without another presentation"
         )
     }
 
@@ -449,7 +610,9 @@ private struct CyclingSensorTestSuite {
         )
         let coordinator = CyclingSensorDetectionCoordinator(
             sensorStore: store,
-            now: { now }
+            now: { now },
+            dismissalDefaults: defaults,
+            dismissalStorageKey: "prompt-dismissal"
         )
         return SensorFixture(
             defaults: defaults,

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -10122,6 +10122,48 @@ struct NavigationProtocolTests {
             isDiscoveringDevices: false,
             pairingCompletedDuringPresentation: false
         ), "discovery waits for Bluetooth to become available")
+        assertEqual(
+            BikeComputerSettingsPresentationPolicy.title(
+                knownDeviceCount: 0,
+                isExplicitBikeComputerSetup: false
+            ),
+            "My Bike Computer",
+            "combined settings keeps sensors discoverable without a bike computer"
+        )
+        assert(
+            !BikeComputerSettingsPresentationPolicy.shouldStartDiscovery(
+                knownDeviceCount: 0,
+                isExplicitBikeComputerSetup: false,
+                isSensorLooking: false,
+                hasSensorCandidates: false
+            ),
+            "combined settings does not start unrelated bike discovery"
+        )
+        assert(
+            BikeComputerSettingsPresentationPolicy.shouldShowConnectAction(
+                knownDeviceCount: 0,
+                isExplicitBikeComputerSetup: false
+            ),
+            "combined settings offers explicit bike setup"
+        )
+        assert(
+            BikeComputerSettingsPresentationPolicy.shouldStartDiscovery(
+                knownDeviceCount: 0,
+                isExplicitBikeComputerSetup: true,
+                isSensorLooking: false,
+                hasSensorCandidates: false
+            ),
+            "explicit bike-computer setup still starts discovery"
+        )
+        assert(
+            !BikeComputerSettingsPresentationPolicy.shouldStartDiscovery(
+                knownDeviceCount: 0,
+                isExplicitBikeComputerSetup: true,
+                isSensorLooking: true,
+                hasSensorCandidates: false
+            ),
+            "sensor enrollment takes priority over bike discovery"
+        )
         assert(BLEPendingScanPolicy.accepts(
             discoveredIdentifier: peripheralID,
             pendingIdentifier: peripheralID

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5708,7 +5708,13 @@ private struct WorkoutContractTestSuite {
                     "ifworkoutStore.presentation.isWorkoutActive{guardpresentedSheet==nilelse{return}rideMetricsDetent=.rideMetricsCompactpresentedSheet=.rideMetrics}"
                 )
                 && compactContent.contains(
-                    ".sheet(item:$presentedSheet,onDismiss:restoreRideMetricsSheetIfNeeded){destinationinpresentedSheetContent(for:destination)}"
+                    ".sheet(item:$presentedSheet,onDismiss:handleSheetDismissal){destinationinpresentedSheetContent(for:destination)}"
+                )
+                && compactContent.contains(
+                    "queuedSheetAfterDismiss=.sensorSettingspresentedSheet=nil"
+                )
+                && compactContent.contains(
+                    "ifletqueuedSheetAfterDismiss{self.queuedSheetAfterDismiss=nil"
                 )
                 && compactContent.contains(
                     ".presentationDetents([.rideMetricsCompact,.large],selection:$rideMetricsDetent)"
@@ -5733,6 +5739,24 @@ private struct WorkoutContractTestSuite {
                 && !compactNavigation.contains("chevron.down")
                 && !compactNavigation.contains("onToggleExpansion"),
             "active workouts must own the expandable native stats sheet while navigation-only keeps the compact overlay"
+        )
+        expect(
+            compactNavigation.contains(
+                "lettilePolicy=WorkoutMetricTilePolicy(enabledSensorCapabilities:enabledSensorCapabilities)"
+            )
+                && compactNavigation.contains(
+                    "iftilePolicy.showsCadence{metrics.append("
+                )
+                && compactNavigation.contains(
+                    "iftilePolicy.showsPower{metrics.append("
+                )
+                && compactNavigation.contains(
+                    "ifletsensorPrompt{ActionStatusChip("
+                )
+                && compactContent.contains(
+                    "case.sensorSettings:NavigationView{BikeComputersSettingsView("
+                ),
+            "sensor enrollment must gate cadence and power tiles and route detected sensors to My Bike Computer"
         )
         expect(
             compactNavigation.contains(

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5711,10 +5711,16 @@ private struct WorkoutContractTestSuite {
                     ".sheet(item:$presentedSheet,onDismiss:handleSheetDismissal){destinationinpresentedSheetContent(for:destination)}"
                 )
                 && compactContent.contains(
-                    "queuedSheetAfterDismiss=.sensorSettingspresentedSheet=nil"
+                    "SensorSettingsRoutingPolicy.openDecision("
                 )
                 && compactContent.contains(
-                    "ifletqueuedSheetAfterDismiss{self.queuedSheetAfterDismiss=nil"
+                    "case.dismissAndQueue:queuedSheetAfterDismiss=.sensorSettingspresentedSheet=nil"
+                )
+                && compactContent.contains(
+                    "SensorSettingsRoutingPolicy.dismissalDecision("
+                )
+                && compactContent.contains(
+                    "case.presentQueuedSheet:guardletqueuedSheetAfterDismisselse{return}self.queuedSheetAfterDismiss=nil"
                 )
                 && compactContent.contains(
                     ".presentationDetents([.rideMetricsCompact,.large],selection:$rideMetricsDetent)"

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -50,6 +50,30 @@ If the iPhone or bike computer disconnects, the Watch workout continues. The
 iPhone and ESP32 show delayed, disconnected, or stale state instead of treating
 old data as current. Reconnection requests the newest coherent snapshot.
 
+## Cadence and power sensors
+
+Pair compatible Bluetooth cycling sensors in **Apple Watch Settings >
+Bluetooth > Health Devices**. Wake the sensor and start a BikeComputer cycling
+workout so the Watch can collect cadence or power through HealthKit.
+
+When BikeComputer first receives one of these measurements, the active workout
+sheet offers **Connect sensor?**. Open **Settings > My Bike Computer**, or tap
+that prompt, then use **My Sensors > Connect a new Sensor**. The app listens for
+current workout data and lets you name a cadence sensor, power sensor, or
+combined cadence-and-power sensor.
+
+Only capabilities enabled under **My Sensors** appear as live workout tiles. An
+enabled tile stays visible and shows `--` when its measurement is stale or the
+sensor is not currently reporting. Forgetting or disabling the last profile
+for a capability hides its tile.
+
+Apple Watch continues to own the physical Bluetooth connection. The current
+public live-workout statistics identify whether cadence or power data arrived,
+but do not provide BikeComputer with a validated physical peripheral identity.
+Sensor profiles are therefore local logical profiles; BikeComputer does not
+claim to pair, rename, or disconnect the accessory at the system level, and it
+cannot distinguish multiple accessories that report the same capability.
+
 ## iPhone Live Activity
 
 On iOS 17 or later, a verified active Watch workout appears on the iPhone Lock

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -39,6 +39,24 @@ xcrun swiftc \
 
 "${OUT}"
 
+CYCLING_SENSOR_OUT="${TMPDIR:-/tmp}/open-bike-cycling-sensor-tests"
+
+xcrun swiftc \
+  -parse-as-library \
+  -default-isolation MainActor \
+  -o "${CYCLING_SENSOR_OUT}" \
+  ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift \
+  ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift \
+  ios-app/BikeComputerTests/CyclingSensorTests.swift
+
+"${CYCLING_SENSOR_OUT}"
+
 CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-destination-callout-tests"
 MACOS_SDK="$(xcrun --sdk macosx --show-sdk-path)"
 IOS_SUPPORT="${MACOS_SDK}/System/iOSSupport"


### PR DESCRIPTION
## Summary

Implements the Apple Watch/HealthKit-assisted cycling-sensor slice planned for [issue #85](https://github.com/seichris/open-bike-computer/issues/85).

- adds a persisted **My Sensors** registry with cadence, power, and combined logical profiles
- adds **Connect a new Sensor**, Looking nearby, enrollment, rename, enable/disable, reporting status, and confirmed forget flows
- detects fresh cadence/power observations from active mirrored Watch workouts and shows a deduplicated **Connect sensor?** action
- gates cadence and power workout tiles by enabled enrolled capabilities; registered-but-stale metrics remain visible as `--`
- preserves the compact workout grid, expanded speed hero/two-column layout, and navigation-only stats
- reuses the offline-map status-chip presentation and adds reliable routing from the workout sheet to **My Bike Computer**

## Architecture and scope

This ships the plans **Gate B**: HealthKit live workout statistics expose cadence/power values but no validated physical accessory identity in the current callback path. Profiles are explicit local logical profiles, and the user confirms whether a candidate measures cadence, power, or both.

Data path: **sensor -> Apple Watch -> iPhone -> ESP32 bike computer**.

This does **not** implement sensor -> ESP32 direct BLE pairing, scanning, GATT parsing, bonding, or reconnect behavior. Issue #85 remains open for that work.

## Validation

- generated build-identity tests
- Swift navigation, cycling-sensor, MapKit layout, and preview helper tests
- workout contract host tests
- workout contract tests on iOS Simulator
- workout contract and WatchWorkoutManager tests on watchOS Simulator
- Debug generic iOS build
- Release Watch build
- Release iPhone app build and app-container verification

Physical cadence/power sensor validation remains required with real sensor hardware; the implementation deliberately does not infer a physical identity without that evidence.