### PR TITLE
Fix Live Activity foreground tracking

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -20,7 +20,10 @@ struct BikeComputerApp: App {
                 workoutMirrorManager: appDelegate.workoutMirrorManager,
                 coordinator: appDelegate.coordinator,
                 liveActivityDiagnostics:
-                    appDelegate.workoutLiveActivityDiagnostics
+                    appDelegate.workoutLiveActivityDiagnostics,
+                onApplicationActiveChange: {
+                    appDelegate.setApplicationActive($0)
+                }
             )
         }
     }
@@ -88,23 +91,22 @@ class AppDelegate: NSObject, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         coordinator.applicationDidBecomeActive()
-        if #available(iOS 17.0, *),
-           let controller =
-               workoutLiveActivityController
-                as? WorkoutLiveActivityController {
-            controller.setApplicationForeground(true)
-        }
+        setApplicationActive(true)
     }
     
     func applicationDidEnterBackground(_ application: UIApplication) {
         coordinator.setViewingMap(false)
+        setApplicationActive(false)
+        print("App entered background - navigation continues")
+    }
+
+    func setApplicationActive(_ isActive: Bool) {
         if #available(iOS 17.0, *),
            let controller =
                workoutLiveActivityController
                 as? WorkoutLiveActivityController {
-            controller.setApplicationForeground(false)
+            controller.setApplicationForeground(isActive)
         }
-        print("App entered background - navigation continues")
     }
     
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -61,19 +61,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
         _ = coordinator
         workoutMirrorManager.installMirroringHandler()
         if #available(iOS 17.0, *) {
-            let commandRouter = WorkoutLiveActivityCommandRouter(
-                manager: workoutMirrorManager
-            )
-            let dispatcher = WorkoutLiveActivityIntentDispatcher {
-                [weak commandRouter] action, sessionID in
-                guard let commandRouter else { return false }
-                return await commandRouter.perform(
-                    action,
-                    sessionID: sessionID
-                )
-            }
-            AppDependencyManager.shared.add(dependency: dispatcher)
-
             let controller = WorkoutLiveActivityController(
                 store: workoutMirrorManager.store,
                 diagnostics: workoutLiveActivityDiagnostics
@@ -81,6 +68,32 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             controller.start(
                 isApplicationForeground: application.applicationState == .active
             )
+            let commandRouter = WorkoutLiveActivityCommandRouter(
+                manager: workoutMirrorManager
+            )
+            let dispatcher = WorkoutLiveActivityIntentDispatcher {
+                [weak commandRouter, weak controller] action, sessionID in
+                guard let commandRouter, let controller else { return false }
+                guard await commandRouter.perform(
+                    action,
+                    sessionID: sessionID
+                ) else {
+                    return false
+                }
+                _ = await controller.publishCurrentStateForIntent(
+                    sessionID: sessionID
+                )
+                await commandRouter.waitForResolution(
+                    of: action,
+                    sessionID: sessionID
+                )
+                _ = await controller.publishCurrentStateForIntent(
+                    sessionID: sessionID
+                )
+                return true
+            }
+            AppDependencyManager.shared.add(dependency: dispatcher)
+
             workoutLiveActivityCommandRouter = commandRouter
             workoutLiveActivityIntentDispatcher = dispatcher
             workoutLiveActivityController = controller

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -43,6 +43,7 @@ struct ContentView: View {
     @ObservedObject private var liveActivityDiagnostics:
         WorkoutLiveActivityDiagnosticStore
     private let workoutMirrorManager: WorkoutMirrorManager
+    private let onApplicationActiveChange: (Bool) -> Void
     @Environment(\.scenePhase) private var scenePhase
     
     @State private var sourceAddress = ""
@@ -72,7 +73,9 @@ struct ContentView: View {
         coordinator: BikeComputerCoordinator? = nil,
         watchAvailability: WorkoutWatchAvailabilityMonitor? = nil,
         liveActivityDiagnostics:
-            WorkoutLiveActivityDiagnosticStore? = nil
+            WorkoutLiveActivityDiagnosticStore? = nil,
+        onApplicationActiveChange:
+            @escaping (Bool) -> Void = { _ in }
     ) {
         let watchAvailability = watchAvailability
             ?? WorkoutWatchAvailabilityMonitor()
@@ -83,6 +86,7 @@ struct ContentView: View {
             workoutMetricsStore: workoutMirrorManager.store
         )
         self.workoutMirrorManager = workoutMirrorManager
+        self.onApplicationActiveChange = onApplicationActiveChange
         _watchAvailability = StateObject(wrappedValue: watchAvailability)
         _workoutStore = ObservedObject(
             wrappedValue: workoutMirrorManager.store
@@ -210,6 +214,7 @@ struct ContentView: View {
             }
         }
         .onAppear {
+            onApplicationActiveChange(scenePhase == .active)
             migrateExistingInstallOnboardingIfNeeded()
             isOfflineMapOnboardingStatePrepared = true
             watchAvailability.activate()
@@ -222,6 +227,7 @@ struct ContentView: View {
             synchronizeRideMetricsSheet()
         }
         .onChange(of: scenePhase) { newValue in
+            onApplicationActiveChange(newValue == .active)
             coordinator.setViewingMap(newValue == .active)
             updateIdleTimer(for: newValue)
             guard newValue == .active else { return }

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
@@ -431,6 +431,46 @@ final class WorkoutLiveActivityController {
         enqueue(latestPresentation)
     }
 
+    @discardableResult
+    func publishCurrentStateForIntent(sessionID: UUID) async -> Bool {
+        if let reconciliationTask {
+            await reconciliationTask.value
+        }
+        guard hasReconciled else { return false }
+
+        let presentation = presentationSource.presentation
+        latestPresentation = presentation
+        guard WorkoutLiveActivityStateMapper.map(
+            presentation,
+            at: now(),
+            supportsSegmentMarking:
+                presentationSource.supportsSegmentMarking,
+            isSegmentConfirmationPending:
+                presentationSource.isSegmentConfirmationPending
+        )?.attributes.sessionID == sessionID else {
+            return false
+        }
+
+        enqueue(presentation)
+        while let processingTask = presentationProcessingTask {
+            await processingTask.value
+        }
+
+        guard managedSessionID == sessionID,
+              let publishedContent = lastPublishedContent,
+              let currentContent = WorkoutLiveActivityStateMapper.map(
+                  presentationSource.presentation,
+                  at: now(),
+                  supportsSegmentMarking:
+                      presentationSource.supportsSegmentMarking,
+                  isSegmentConfirmationPending:
+                      presentationSource.isSegmentConfirmationPending
+              )?.contentState else {
+            return false
+        }
+        return publishedContent == currentContent
+    }
+
     private func reconcileExistingActivities() async {
         let allRecords = client.records()
         for record in allRecords {

--- a/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
+++ b/ios-app/BikeComputer/BikeComputer/SystemActions/WorkoutLiveActivityCommandRouter.swift
@@ -15,6 +15,7 @@ extension WorkoutMetricsStore: WorkoutLiveActivityControlStateProviding {}
 @MainActor
 final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
     nonisolated static let defaultRecoveryTimeout: TimeInterval = 2
+    nonisolated static let defaultActionResolutionTimeout: TimeInterval = 2
     nonisolated static let recoveryPollInterval: TimeInterval = 0.1
 
     private let controlState:
@@ -23,7 +24,10 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
     private let pauseAction: @MainActor () -> Void
     private let resumeAction: @MainActor () -> Void
     private let recoveryTimeout: TimeInterval
+    private let actionResolutionTimeout: TimeInterval
     private let wait:
+        @MainActor @Sendable (TimeInterval) async throws -> Void
+    private let actionResolutionWait:
         @MainActor @Sendable (TimeInterval) async throws -> Void
 
     convenience init(manager: WorkoutMirrorManager) {
@@ -38,7 +42,12 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
     init(
         store: any WorkoutLiveActivityControlStateProviding,
         recoveryTimeout: TimeInterval = defaultRecoveryTimeout,
+        actionResolutionTimeout: TimeInterval =
+            defaultActionResolutionTimeout,
         wait: (@MainActor @Sendable (TimeInterval) async throws -> Void)? = nil,
+        actionResolutionWait: (@MainActor @Sendable (
+            TimeInterval
+        ) async throws -> Void)? = nil,
         markSegment: @escaping @MainActor () -> Void,
         pause: @escaping @MainActor () -> Void,
         resume: @escaping @MainActor () -> Void
@@ -47,7 +56,15 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
         self.recoveryTimeout = recoveryTimeout.isFinite
             ? min(max(0, recoveryTimeout), 5)
             : Self.defaultRecoveryTimeout
+        self.actionResolutionTimeout = actionResolutionTimeout.isFinite
+            ? min(max(0, actionResolutionTimeout), 5)
+            : Self.defaultActionResolutionTimeout
         self.wait = wait ?? { interval in
+            try await Task.sleep(
+                nanoseconds: UInt64(interval * 1_000_000_000)
+            )
+        }
+        self.actionResolutionWait = actionResolutionWait ?? { interval in
             try await Task.sleep(
                 nanoseconds: UInt64(interval * 1_000_000_000)
             )
@@ -89,6 +106,34 @@ final class WorkoutLiveActivityCommandRouter: @unchecked Sendable {
             guard presentation.sessionState == .paused else { return false }
             resumeAction()
             return controlState.presentation.pendingControl == .resume
+        }
+    }
+
+    func waitForResolution(
+        of action: WorkoutLiveActivityAction,
+        sessionID: UUID
+    ) async {
+        let expectedControl: WorkoutControlV1
+        switch action {
+        case .segment:
+            expectedControl = .markSegment
+        case .pause:
+            expectedControl = .pause
+        case .resume:
+            expectedControl = .resume
+        }
+
+        var remaining = actionResolutionTimeout
+        while remaining > 0,
+              controlState.presentation.sessionID == sessionID,
+              controlState.presentation.pendingControl == expectedControl {
+            let interval = min(Self.recoveryPollInterval, remaining)
+            do {
+                try await actionResolutionWait(interval)
+            } catch {
+                return
+            }
+            remaining -= interval
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
@@ -181,15 +181,24 @@ struct WorkoutLiveActivityControls: View {
                 intent: BikeComputerMarkSegmentIntent(sessionID: sessionID)
             ) {
                 HStack(spacing: 6) {
-                    WorkoutLiveActivitySegmentNumberBadge(
-                        number: state.currentSegmentIndex
-                    )
-                    Text("Segment")
+                    if state.pendingAction == .segment {
+                        Image(systemName: "hourglass")
+                    } else {
+                        WorkoutLiveActivitySegmentNumberBadge(
+                            number: state.currentSegmentIndex
+                        )
+                    }
+                    Text(state.segmentControlTitle)
                 }
                     .frame(maxWidth: .infinity, minHeight: 44)
+                    .invalidatableContent()
             }
             .disabled(!state.canMarkSegment)
-            .accessibilityLabel("Mark workout segment")
+            .accessibilityLabel(
+                state.pendingAction == .segment
+                    ? "Marking workout segment"
+                    : "Mark workout segment"
+            )
             .accessibilityValue(
                 "Current segment \(state.currentSegmentIndex)"
             )
@@ -200,8 +209,12 @@ struct WorkoutLiveActivityControls: View {
                         sessionID: sessionID
                     )
                 ) {
-                    Label("Resume", systemImage: "play.fill")
+                    Label(
+                        state.pauseControlTitle,
+                        systemImage: state.pauseControlSystemImage
+                    )
                         .frame(maxWidth: .infinity, minHeight: 44)
+                        .invalidatableContent()
                 }
                 .disabled(!state.canResume)
             } else {
@@ -210,8 +223,12 @@ struct WorkoutLiveActivityControls: View {
                         sessionID: sessionID
                     )
                 ) {
-                    Label("Pause", systemImage: "pause.fill")
+                    Label(
+                        state.pauseControlTitle,
+                        systemImage: state.pauseControlSystemImage
+                    )
                         .frame(maxWidth: .infinity, minHeight: 44)
+                        .invalidatableContent()
                 }
                 .disabled(!state.canPause)
             }

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityAttributes.swift
@@ -94,6 +94,30 @@ nonisolated struct WorkoutLiveActivityAttributes:
                 && displayError != .controlsUnavailable
         }
 
+        var segmentControlTitle: String {
+            pendingAction == .segment ? "Marking…" : "Segment"
+        }
+
+        var pauseControlTitle: String {
+            switch pendingAction {
+            case .pause:
+                return "Pausing…"
+            case .resume:
+                return "Resuming…"
+            default:
+                return phase == .paused ? "Resume" : "Pause"
+            }
+        }
+
+        var pauseControlSystemImage: String {
+            switch pendingAction {
+            case .pause, .resume:
+                return "hourglass"
+            default:
+                return phase == .paused ? "play.fill" : "pause.fill"
+            }
+        }
+
         var isTerminal: Bool {
             phase == .final
         }

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5560,6 +5560,12 @@ private struct WorkoutContractTestSuite {
             compactAppSource.contains(
                 "onApplicationActiveChange:{appDelegate.setApplicationActive($0)}"
             )
+                && compactAppSource.contains(
+                    "publishCurrentStateForIntent(sessionID:sessionID)"
+                )
+                && compactAppSource.contains(
+                    "waitForResolution(of:action,sessionID:sessionID)"
+                )
                 && compactContentView.contains(
                     "onApplicationActiveChange(scenePhase==.active)"
                 )

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5365,6 +5365,12 @@ private struct WorkoutContractTestSuite {
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("BikeComputer/BikeComputer/ContentView.swift")
+        let appURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                "BikeComputer/BikeComputer/BikeComputerApp.swift"
+            )
         let liveWatchViewURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -5386,6 +5392,10 @@ private struct WorkoutContractTestSuite {
         guard let source = try? String(contentsOf: sourceURL, encoding: .utf8),
               let contentViewSource = try? String(
                 contentsOf: contentViewURL,
+                encoding: .utf8
+              ),
+              let appSource = try? String(
+                contentsOf: appURL,
                 encoding: .utf8
               ),
               let liveWatchViewSource = try? String(
@@ -5545,6 +5555,19 @@ private struct WorkoutContractTestSuite {
         )
 
         let compactContentView = contentViewSource.filter { !$0.isWhitespace }
+        let compactAppSource = appSource.filter { !$0.isWhitespace }
+        expect(
+            compactAppSource.contains(
+                "onApplicationActiveChange:{appDelegate.setApplicationActive($0)}"
+            )
+                && compactContentView.contains(
+                    "onApplicationActiveChange(scenePhase==.active)"
+                )
+                && compactContentView.contains(
+                    "onApplicationActiveChange(newValue==.active)"
+                ),
+            "SwiftUI scene phase must drive Live Activity foreground state"
+        )
         expect(
             compactContentView.contains(
                 "WorkoutCompactCard(store:workoutStore,watchAvailability:watchAvailability,onStart:workoutMirrorManager.startOutdoorCyclingOnWatch,onOpen:{presentedSheet=.workoutDashboard})"

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -470,6 +470,40 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertTrue(scheduler.requestedIntervals.isEmpty)
     }
 
+    func testIntentFlushAwaitsPendingActivityUpdate() async {
+        let sessionID = UUID()
+        let source = source(sessionID: sessionID)
+        let client = FakeWorkoutLiveActivityClient()
+        let controller = makeController(source: source, client: client)
+        controller.start(isApplicationForeground: true)
+        await settle()
+        client.suspendNextUpdate()
+
+        source.send(
+            makeLiveActivityPresentation(
+                sessionID: sessionID,
+                capturedAt: capturedAt,
+                pendingControl: .pause
+            )
+        )
+        let flushTask = Task {
+            await controller.publishCurrentStateForIntent(
+                sessionID: sessionID
+            )
+        }
+        await settle()
+
+        XCTAssertEqual(
+            client.updateAttempts.map(\.1.pendingAction),
+            [.pause]
+        )
+
+        client.resumeSuspendedUpdate()
+        let published = await flushTask.value
+        XCTAssertTrue(published)
+        XCTAssertEqual(client.updates.last?.1.pendingAction, .pause)
+    }
+
     func testStateTransitionsPublishInOrderWhenEarlierUpdateSuspends()
         async {
         let sessionID = UUID()

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityIntentTests.swift
@@ -245,6 +245,85 @@ final class WorkoutLiveActivityIntentTests: XCTestCase {
         XCTAssertEqual(pauseCalls.value, 1)
     }
 
+    func testActionResolutionWaitStopsAfterWatchConfirmation() async {
+        let sessionID = UUID()
+        let state = controlState(sessionID: sessionID)
+        var waits: [TimeInterval] = []
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            actionResolutionTimeout: 1,
+            actionResolutionWait: { interval in
+                waits.append(interval)
+                state.presentation = self.presentation(
+                    sessionID: sessionID,
+                    state: .paused
+                )
+            },
+            markSegment: {},
+            pause: {
+                state.presentation = self.presentation(
+                    sessionID: sessionID,
+                    pending: .pause
+                )
+            },
+            resume: {}
+        )
+
+        let accepted = await router.perform(
+            .pause,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(accepted)
+        await router.waitForResolution(
+            of: .pause,
+            sessionID: sessionID
+        )
+
+        XCTAssertEqual(waits, [0.1])
+        XCTAssertEqual(state.presentation.sessionState, .paused)
+        XCTAssertNil(state.presentation.pendingControl)
+    }
+
+    func testActionResolutionWaitHasBoundedTimeout() async {
+        let sessionID = UUID()
+        let state = controlState(sessionID: sessionID)
+        var waits: [TimeInterval] = []
+        let router = WorkoutLiveActivityCommandRouter(
+            store: state,
+            actionResolutionTimeout: 0.25,
+            actionResolutionWait: { interval in
+                waits.append(interval)
+            },
+            markSegment: {
+                state.presentation = self.presentation(
+                    sessionID: sessionID,
+                    pending: .markSegment
+                )
+            },
+            pause: {},
+            resume: {}
+        )
+
+        let accepted = await router.perform(
+            .segment,
+            sessionID: sessionID
+        )
+        XCTAssertTrue(accepted)
+        await router.waitForResolution(
+            of: .segment,
+            sessionID: sessionID
+        )
+
+        XCTAssertEqual(waits.count, 3)
+        XCTAssertEqual(waits[0], 0.1, accuracy: 0.000_001)
+        XCTAssertEqual(waits[1], 0.1, accuracy: 0.000_001)
+        XCTAssertEqual(waits[2], 0.05, accuracy: 0.000_001)
+        XCTAssertEqual(
+            state.presentation.pendingControl,
+            .markSegment
+        )
+    }
+
     func testMissingAppProcessDependencyFailsSafely() async {
         let accepted = await WorkoutLiveActivityIntentDispatcher.unavailable
             .perform(.pause, sessionID: UUID())

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityStateMapperTests.swift
@@ -36,6 +36,12 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         XCTAssertEqual(mapped.contentState.currentHeartRateBPM, 140)
         XCTAssertEqual(mapped.contentState.lastCompletedSegmentIndex, 3)
         XCTAssertTrue(mapped.contentState.canMarkSegment)
+        XCTAssertEqual(mapped.contentState.segmentControlTitle, "Segment")
+        XCTAssertEqual(mapped.contentState.pauseControlTitle, "Pause")
+        XCTAssertEqual(
+            mapped.contentState.pauseControlSystemImage,
+            "pause.fill"
+        )
         XCTAssertTrue(mapped.isStartEligible)
     }
 
@@ -122,6 +128,11 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         )
         XCTAssertEqual(paused.contentState.phase, .paused)
         XCTAssertEqual(paused.contentState.pendingAction, .resume)
+        XCTAssertEqual(paused.contentState.pauseControlTitle, "Resuming…")
+        XCTAssertEqual(
+            paused.contentState.pauseControlSystemImage,
+            "hourglass"
+        )
         XCTAssertFalse(paused.contentState.canResume)
 
         let saved = try XCTUnwrap(
@@ -233,6 +244,10 @@ final class WorkoutLiveActivityStateMapperTests: XCTestCase {
         )
         XCTAssertEqual(pending.contentState.pendingAction, .segment)
         XCTAssertEqual(pending.contentState.lastCompletedSegmentIndex, 2)
+        XCTAssertEqual(
+            pending.contentState.segmentControlTitle,
+            "Marking…"
+        )
         XCTAssertFalse(pending.contentState.canMarkSegment)
 
         let rejected = try XCTUnwrap(


### PR DESCRIPTION
## Summary
- drive Live Activity foreground state from SwiftUI `scenePhase`
- retain AppDelegate lifecycle callbacks as a fallback
- publish a visible pending control state before a Live Activity intent finishes
- keep the intent alive briefly for Watch acknowledgement, then publish the authoritative Pause/Resume or segment state
- show `Pausing…`, `Resuming…`, and `Marking…` while commands are pending
- cover lifecycle, ActivityKit publication, acknowledgement, timeout, and display-state behavior with regression tests

## Verification
- `./scripts/run-workout-contract-tests.sh`
- focused `WorkoutLiveActivityIntentTests`, `WorkoutLiveActivityStateMapperTests`, and `WorkoutLiveActivityControllerTests` on the iOS Simulator
- signed Debug build for the connected iPhone
- installed and launched BikeComputer 1.1 (7) on the connected iPhone

A fresh Watch workout is needed for the final Lock Screen interaction check because replacing the iPhone app can invalidate the mirrored HealthKit server for a workout that was already running.