### PR TITLE
Simplify adaptive Ride Stats display

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -420,12 +420,13 @@ continue to populate the legacy ride fields and cannot clear or overwrite Watch
 workout state.
 
 Ride Stats uses the Watch workout state whenever a non-idle core frame has been
-accepted, otherwise it displays the legacy GPS ride fields. The Live page shows
-speed, current heart rate and zone, distance, elapsed time, power, and cadence.
-The Summary page shows average heart rate, active energy, altitude, route
-remaining, and source/freshness. Unavailable workout values display as `--`.
-A long press toggles pages; the existing short-tap and hardware screen cycling
-remain unchanged.
+accepted, otherwise it displays the legacy GPS ride fields. Its single page
+shows speed, current heart rate and zone, distance, and elapsed time. The bottom
+row shows altitude and route remaining when neither power nor cadence is
+available. One available power or cadence metric replaces altitude; when both
+are available, power and cadence replace altitude and route remaining.
+Unavailable non-adaptive values display as `--`. Existing short-tap and hardware
+screen cycling remain unchanged.
 
 ## Map Settings (`2A73`)
 

--- a/docs/watchos-workout-companion-implementation-plan.md
+++ b/docs/watchos-workout-companion-implementation-plan.md
@@ -762,42 +762,34 @@ state when it is active/current and legacy GPS ride telemetry otherwise.
 
 ### Ride Stats presentation
 
-Keep the existing Ride Stats screen, but make it capable of showing every
-received workout metric using two pages:
-
-Page 1, Live:
+Keep Ride Stats as one glanceable page:
 
 - hero speed;
 - current heart rate and zone;
 - distance;
 - elapsed time;
-- power;
-- cadence.
+- two adaptive bottom-row metrics.
 
-Page 2, Summary/navigation:
-
-- average heart rate;
-- active energy;
-- altitude;
-- route remaining from the existing navigation state;
-- source/freshness indicator;
-- paused, ended, or failed status.
+The bottom row shows altitude and route remaining when neither optional sensor
+metric is available. One available power or cadence metric replaces altitude.
+When both are available, the row shows power and cadence. Average heart rate,
+active energy, and source/freshness are not shown on the device.
 
 Interaction:
 
 - short tap keeps the existing optional cycle-to-next-screen behavior;
-- long press while on Ride Stats toggles between the two workout pages;
 - a hardware screen-cycle action remains unchanged;
-- page selection is RAM-only and does not add a persisted setting in v1.
+- Ride Stats has no subpages or page-selection state.
 
 Presentation rules:
 
-- show -- for unavailable metrics;
 - never render absent power/cadence/heart rate as zero;
+- replace unavailable power/cadence fields with altitude and route remaining
+  according to the adaptive bottom-row rules;
 - show PAUSED without clearing the last valid numbers;
 - show stale/link-lost state after 10 seconds without current core data;
 - do not interpret a stale Watch speed as current;
-- show the final summary after ended until cleared;
+- retain final values after ended until cleared;
 - retain readable type sizes on both Waveshare 1.75 and 2.06 builds.
 
 ## Privacy and security
@@ -829,7 +821,7 @@ Presentation rules:
 | Mirroring reconnects | Replace session reference and request a full snapshot. |
 | ESP32 disconnects | App continues; resend latest core and extended frames after auth. |
 | iPhone becomes suspended | Show snapshot age after resume; never replay old metrics as live. |
-| Power/cadence sensor absent | Show --; remaining metrics continue. |
+| Power/cadence sensor absent | Show altitude and route remaining in their places; remaining metrics continue. |
 | Watch app crashes | Recover the active workout session and reattach delegates. |
 | Firmware lacks bit 7 | Keep current GPS ride telemetry; hide unsupported device-live status. |
 | Malformed BLE frame | Reject without altering the last valid state. |
@@ -911,7 +903,7 @@ Exit criteria:
 1. Implement RAM-only WorkoutTelemetryState.
 2. Parse authenticated native/fallback frames.
 3. Keep workout and GPS telemetry state independent.
-4. Add two-page Ride Stats presentation and staleness handling.
+4. Add single-page adaptive Ride Stats presentation and staleness handling.
 5. Add host/unit coverage for parser and formatter behavior.
 6. Build both Waveshare environments.
 

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -112,7 +112,6 @@ const ScreenMapRenderSettings &currentMapStyleSettings() {
 }
 
 static void tapCycleScreenEvent(lv_event_t *event);
-static void rideStatsInteractionEvent(lv_event_t *event);
 static void mapGuidanceOverlayTapEvent(lv_event_t *event);
 static void updateMapGuidanceOverlay();
 static void refreshMapGuidanceOverlayAsync(void *userData);
@@ -1388,29 +1387,6 @@ static void tapCycleScreenEvent(lv_event_t *event) {
   showNextMainScreen();
 }
 
-static void rideStatsInteractionEvent(lv_event_t *event) {
-  const lv_event_code_t code = lv_event_get_code(event);
-  ride_telemetry_layout::InteractionEvent interaction =
-      ride_telemetry_layout::InteractionEvent::Other;
-  if (code == LV_EVENT_PRESSED) {
-    interaction = ride_telemetry_layout::InteractionEvent::Pressed;
-  } else if (code == LV_EVENT_LONG_PRESSED) {
-    interaction = ride_telemetry_layout::InteractionEvent::LongPressed;
-  } else if (code == LV_EVENT_CLICKED) {
-    interaction = ride_telemetry_layout::InteractionEvent::Clicked;
-  }
-
-  const ride_telemetry_layout::InteractionAction action =
-      handleRideTelemetryInteraction(interaction);
-  if (action == ride_telemetry_layout::InteractionAction::TogglePage) {
-    log_i("UI: toggled Ride Stats page");
-    return;
-  }
-  if (action == ride_telemetry_layout::InteractionAction::CycleScreen) {
-    tapCycleScreenEvent(event);
-  }
-}
-
 static void mapGuidanceOverlayTapEvent(lv_event_t *event) {
   if (mapGuidancePickerExpanded && !hasCurrentNavigationData()) {
     return;
@@ -1467,7 +1443,7 @@ void createMainScr() {
   rideTelemetryScr(rideStatsTile);
   lv_obj_add_event_cb(rideStatsTile, updateRideTelemetryEvent,
                       LV_EVENT_VALUE_CHANGED, NULL);
-  lv_obj_add_event_cb(rideStatsTile, rideStatsInteractionEvent, LV_EVENT_ALL,
+  lv_obj_add_event_cb(rideStatsTile, tapCycleScreenEvent, LV_EVENT_CLICKED,
                       NULL);
   lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
 

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -21,12 +21,9 @@ struct Layout {
   int32_t screenHeight = 0;
   Rect page{};
   Rect status{};
-  Rect pageIndicator{};
   Rect hero{};
   Rect heroUnit{};
-  std::array<Rect, 6> liveMetrics{};
-  std::array<Rect, 4> summaryMetrics{};
-  Rect source{};
+  std::array<Rect, 6> metrics{};
 };
 
 constexpr Layout makeLayout(int32_t width, int32_t height) {
@@ -42,11 +39,10 @@ constexpr Layout makeLayout(int32_t width, int32_t height) {
   layout.screenWidth = width;
   layout.screenHeight = height;
   layout.page = {0, 0, width, height};
-  layout.status = {16, 8, width - 112, 24};
-  layout.pageIndicator = {width - 80, 8, 64, 24};
+  layout.status = {16, 8, width - 32, 24};
   layout.hero = {0, 30, width, 60};
   layout.heroUnit = {0, 92, width, 24};
-  layout.liveMetrics = {{
+  layout.metrics = {{
       {leftX, metricFirstY, columnWidth, metricCellHeight},
       {rightX, metricFirstY, columnWidth, metricCellHeight},
       {leftX, metricFirstY + metricRowSpacing, columnWidth,
@@ -58,16 +54,6 @@ constexpr Layout makeLayout(int32_t width, int32_t height) {
       {rightX, metricFirstY + 2 * metricRowSpacing, columnWidth,
        metricCellHeight},
   }};
-  layout.summaryMetrics = {{
-      {leftX, metricFirstY, columnWidth, metricCellHeight},
-      {rightX, metricFirstY, columnWidth, metricCellHeight},
-      {leftX, metricFirstY + metricRowSpacing, columnWidth,
-       metricCellHeight},
-      {rightX, metricFirstY + metricRowSpacing, columnWidth,
-       metricCellHeight},
-  }};
-  layout.source = {16, metricFirstY + 2 * metricRowSpacing + 8,
-                   width - 32, 64};
   return layout;
 }
 
@@ -79,79 +65,23 @@ constexpr bool fits(const Rect &rect, int32_t width, int32_t height) {
 constexpr bool isValid(const Layout &layout) {
   if (!fits(layout.page, layout.screenWidth, layout.screenHeight) ||
       !fits(layout.status, layout.screenWidth, layout.screenHeight) ||
-      !fits(layout.pageIndicator, layout.screenWidth,
-            layout.screenHeight) ||
       !fits(layout.hero, layout.screenWidth, layout.screenHeight) ||
-      !fits(layout.heroUnit, layout.screenWidth, layout.screenHeight) ||
-      !fits(layout.source, layout.screenWidth, layout.screenHeight) ||
-      layout.status.right() > layout.pageIndicator.x) {
+      !fits(layout.heroUnit, layout.screenWidth, layout.screenHeight)) {
     return false;
   }
-  for (const Rect &metric : layout.liveMetrics) {
-    if (!fits(metric, layout.screenWidth, layout.screenHeight)) {
-      return false;
-    }
-  }
-  for (const Rect &metric : layout.summaryMetrics) {
+  for (const Rect &metric : layout.metrics) {
     if (!fits(metric, layout.screenWidth, layout.screenHeight)) {
       return false;
     }
   }
   for (std::size_t row = 0; row < 3; ++row) {
-    const Rect &left = layout.liveMetrics[row * 2];
-    const Rect &right = layout.liveMetrics[row * 2 + 1];
+    const Rect &left = layout.metrics[row * 2];
+    const Rect &right = layout.metrics[row * 2 + 1];
     if (left.right() > right.x) {
       return false;
     }
   }
-  return layout.liveMetrics[3].bottom() <=
-             layout.liveMetrics[4].y &&
-         layout.summaryMetrics[3].bottom() <= layout.source.y;
-}
-
-enum class Page : uint8_t { Live = 0, Summary = 1 };
-enum class InteractionEvent : uint8_t {
-  Pressed,
-  LongPressed,
-  Clicked,
-  Other,
-};
-enum class InteractionAction : uint8_t {
-  None,
-  TogglePage,
-  CycleScreen,
-};
-
-struct InteractionState {
-  Page page = Page::Live;
-  bool longPressTriggered = false;
-};
-
-constexpr Page toggled(Page page) {
-  return page == Page::Live ? Page::Summary : Page::Live;
-}
-
-constexpr InteractionAction handleInteraction(
-    InteractionState &state, InteractionEvent event) {
-  switch (event) {
-  case InteractionEvent::Pressed:
-    state.longPressTriggered = false;
-    return InteractionAction::None;
-  case InteractionEvent::LongPressed:
-    state.longPressTriggered = true;
-    state.page = toggled(state.page);
-    return InteractionAction::TogglePage;
-  case InteractionEvent::Clicked:
-    return state.longPressTriggered ? InteractionAction::None
-                                    : InteractionAction::CycleScreen;
-  case InteractionEvent::Other:
-    return InteractionAction::None;
-  }
-  return InteractionAction::None;
-}
-
-constexpr uint8_t pageIndex(Page page) {
-  return static_cast<uint8_t>(page);
+  return layout.metrics[3].bottom() <= layout.metrics[4].y;
 }
 
 } // namespace ride_telemetry_layout

--- a/esp32/lib/gui/src/rideTelemetryPresenter.hpp
+++ b/esp32/lib/gui/src/rideTelemetryPresenter.hpp
@@ -40,6 +40,18 @@ struct ViewModel {
   workout_telemetry::OptionalMetric<uint32_t> routeRemainingMeters{};
 };
 
+enum class BottomMetric : uint8_t {
+  Altitude,
+  RouteRemaining,
+  Power,
+  Cadence,
+};
+
+struct BottomMetricSelection {
+  BottomMetric left = BottomMetric::Altitude;
+  BottomMetric right = BottomMetric::RouteRemaining;
+};
+
 inline ViewModel makeViewModel(
     const workout_telemetry::Snapshot &workout,
     const LegacyRideTelemetry &legacy) {
@@ -190,9 +202,60 @@ inline void formatCadence(const ViewModel &model, char *buffer,
   formatTenths(model.cyclingCadenceTenthsRpm.value, buffer, size);
 }
 
+inline BottomMetricSelection selectBottomMetrics(const ViewModel &model) {
+  const bool hasPower = model.cyclingPowerWatts.available;
+  const bool hasCadence = model.cyclingCadenceTenthsRpm.available;
+  if (hasPower && hasCadence) {
+    return {BottomMetric::Power, BottomMetric::Cadence};
+  }
+  if (hasPower) {
+    return {BottomMetric::Power, BottomMetric::RouteRemaining};
+  }
+  if (hasCadence) {
+    return {BottomMetric::Cadence, BottomMetric::RouteRemaining};
+  }
+  return {BottomMetric::Altitude, BottomMetric::RouteRemaining};
+}
+
+inline const char *bottomMetricTitle(BottomMetric metric) {
+  switch (metric) {
+  case BottomMetric::Altitude:
+    return "Altitude m";
+  case BottomMetric::RouteRemaining:
+    return "Route left";
+  case BottomMetric::Power:
+    return "Power W";
+  case BottomMetric::Cadence:
+    return "Cadence rpm";
+  }
+  return "--";
+}
+
+inline void formatBottomMetric(BottomMetric metric, const ViewModel &model,
+                               char *buffer, std::size_t size) {
+  switch (metric) {
+  case BottomMetric::Altitude:
+    formatInteger(model.altitudeMeters, buffer, size);
+    return;
+  case BottomMetric::RouteRemaining:
+    formatDistance(model.routeRemainingMeters, buffer, size);
+    return;
+  case BottomMetric::Power:
+    formatInteger(model.cyclingPowerWatts, buffer, size);
+    return;
+  case BottomMetric::Cadence:
+    formatCadence(model, buffer, size);
+    return;
+  }
+  unavailable(buffer, size);
+}
+
 inline const char *statusLabel(const ViewModel &model) {
   if (!model.usesWorkout) {
     return "LEGACY RIDE";
+  }
+  if (model.stale) {
+    return "LINK LOST";
   }
   switch (model.sessionState) {
   case SessionState::Starting:

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -1,6 +1,6 @@
 /**
  * @file rideTelemetryScr.cpp
- * @brief Two-page Watch workout and legacy GPS ride telemetry screen.
+ * @brief Adaptive Watch workout and legacy GPS ride telemetry screen.
  */
 
 #include "rideTelemetryScr.hpp"
@@ -19,24 +19,21 @@ namespace {
 
 constexpr lv_coord_t kMetricValueOffsetY = 26;
 
-lv_obj_t *livePage = nullptr;
-lv_obj_t *summaryPage = nullptr;
-lv_obj_t *liveStatus = nullptr;
-lv_obj_t *summaryStatus = nullptr;
+struct MetricLabels {
+  lv_obj_t *title = nullptr;
+  lv_obj_t *value = nullptr;
+};
+
+lv_obj_t *ridePage = nullptr;
+lv_obj_t *rideStatus = nullptr;
 lv_obj_t *rideSpeedValue = nullptr;
 lv_obj_t *rideHeartRateValue = nullptr;
 lv_obj_t *rideZoneValue = nullptr;
 lv_obj_t *rideDistanceValue = nullptr;
 lv_obj_t *rideElapsedValue = nullptr;
-lv_obj_t *ridePowerValue = nullptr;
-lv_obj_t *rideCadenceValue = nullptr;
-lv_obj_t *rideAverageHeartRateValue = nullptr;
-lv_obj_t *rideEnergyValue = nullptr;
-lv_obj_t *rideAltitudeValue = nullptr;
-lv_obj_t *rideRouteRemainingValue = nullptr;
-lv_obj_t *rideSourceValue = nullptr;
+MetricLabels rideBottomLeft{};
+MetricLabels rideBottomRight{};
 ride_telemetry_layout::Layout rideLayout{};
-ride_telemetry_layout::InteractionState interactionState{};
 
 void setLabelIfChanged(lv_obj_t *label, const char *text) {
   if (label == nullptr || text == nullptr) {
@@ -59,44 +56,36 @@ lv_obj_t *createPage(lv_obj_t *screen) {
   return page;
 }
 
-lv_obj_t *createHeader(lv_obj_t *page, const char *pageLabel) {
+lv_obj_t *createHeader(lv_obj_t *page) {
   lv_obj_t *status = lv_label_create(page);
   lv_obj_set_width(status, rideLayout.status.width);
   lv_obj_set_pos(status, rideLayout.status.x, rideLayout.status.y);
   lv_obj_set_style_text_font(status, &lv_font_montserrat_18, 0);
   lv_obj_set_style_text_color(status, lv_color_hex(0x66DD88), 0);
   lv_label_set_text_static(status, "LEGACY RIDE");
-
-  lv_obj_t *indicator = lv_label_create(page);
-  lv_obj_set_width(indicator, rideLayout.pageIndicator.width);
-  lv_obj_set_pos(indicator, rideLayout.pageIndicator.x,
-                 rideLayout.pageIndicator.y);
-  lv_obj_set_style_text_font(indicator, &lv_font_montserrat_18, 0);
-  lv_obj_set_style_text_color(indicator, lv_color_hex(0x888888), 0);
-  lv_obj_set_style_text_align(indicator, LV_TEXT_ALIGN_RIGHT, 0);
-  lv_label_set_text_static(indicator, pageLabel);
   return status;
 }
 
-lv_obj_t *createMetric(lv_obj_t *page, const char *title,
-                       const ride_telemetry_layout::Rect &rect) {
-  lv_obj_t *titleLabel = lv_label_create(page);
-  lv_obj_set_width(titleLabel, rect.width);
-  lv_obj_set_pos(titleLabel, rect.x, rect.y);
-  lv_obj_set_style_text_font(titleLabel, &lv_font_montserrat_18, 0);
-  lv_obj_set_style_text_color(titleLabel, lv_color_hex(0x999999), 0);
-  lv_obj_set_style_text_align(titleLabel, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_text_static(titleLabel, title);
+MetricLabels createMetric(lv_obj_t *page, const char *title,
+                          const ride_telemetry_layout::Rect &rect) {
+  MetricLabels labels{};
+  labels.title = lv_label_create(page);
+  lv_obj_set_width(labels.title, rect.width);
+  lv_obj_set_pos(labels.title, rect.x, rect.y);
+  lv_obj_set_style_text_font(labels.title, &lv_font_montserrat_18, 0);
+  lv_obj_set_style_text_color(labels.title, lv_color_hex(0x999999), 0);
+  lv_obj_set_style_text_align(labels.title, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_text(labels.title, title);
 
-  lv_obj_t *valueLabel = lv_label_create(page);
-  lv_obj_set_width(valueLabel, rect.width);
-  lv_obj_set_pos(valueLabel, rect.x, rect.y + kMetricValueOffsetY);
-  lv_obj_set_style_text_font(valueLabel, &lv_font_montserrat_38, 0);
-  lv_obj_set_style_text_color(valueLabel, lv_color_white(), 0);
-  lv_obj_set_style_text_align(valueLabel, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_long_mode(valueLabel, LV_LABEL_LONG_CLIP);
-  lv_label_set_text_static(valueLabel, "--");
-  return valueLabel;
+  labels.value = lv_label_create(page);
+  lv_obj_set_width(labels.value, rect.width);
+  lv_obj_set_pos(labels.value, rect.x, rect.y + kMetricValueOffsetY);
+  lv_obj_set_style_text_font(labels.value, &lv_font_montserrat_38, 0);
+  lv_obj_set_style_text_color(labels.value, lv_color_white(), 0);
+  lv_obj_set_style_text_align(labels.value, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_long_mode(labels.value, LV_LABEL_LONG_CLIP);
+  lv_label_set_text_static(labels.value, "--");
+  return labels;
 }
 
 ride_telemetry_presenter::ViewModel currentViewModel() {
@@ -132,17 +121,15 @@ void updateStatusLabel(lv_obj_t *label,
   lv_obj_set_style_text_color(label, color, 0);
 }
 
-void updatePageVisibility() {
-  if (livePage == nullptr || summaryPage == nullptr) {
-    return;
-  }
-  if (interactionState.page == ride_telemetry_layout::Page::Live) {
-    lv_obj_clear_flag(livePage, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(summaryPage, LV_OBJ_FLAG_HIDDEN);
-  } else {
-    lv_obj_add_flag(livePage, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(summaryPage, LV_OBJ_FLAG_HIDDEN);
-  }
+void updateBottomMetric(
+    MetricLabels labels, ride_telemetry_presenter::BottomMetric metric,
+    const ride_telemetry_presenter::ViewModel &model) {
+  setLabelIfChanged(labels.title,
+                    ride_telemetry_presenter::bottomMetricTitle(metric));
+  char value[24];
+  ride_telemetry_presenter::formatBottomMetric(metric, model, value,
+                                                sizeof(value));
+  setLabelIfChanged(labels.value, value);
 }
 
 } // namespace
@@ -153,10 +140,10 @@ void rideTelemetryScr(_lv_obj_t *screen) {
 
   rideLayout = ride_telemetry_layout::makeLayout(TFT_WIDTH, TFT_HEIGHT);
 
-  livePage = createPage(screen);
-  liveStatus = createHeader(livePage, "1 / 2");
+  ridePage = createPage(screen);
+  rideStatus = createHeader(ridePage);
 
-  rideSpeedValue = lv_label_create(livePage);
+  rideSpeedValue = lv_label_create(ridePage);
   lv_obj_set_width(rideSpeedValue, rideLayout.hero.width);
   lv_obj_set_pos(rideSpeedValue, rideLayout.hero.x, rideLayout.hero.y);
   lv_obj_set_style_text_font(rideSpeedValue, &ride_value_font_56, 0);
@@ -164,7 +151,7 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_obj_set_style_text_align(rideSpeedValue, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text_static(rideSpeedValue, "0.0");
 
-  lv_obj_t *speedUnit = lv_label_create(livePage);
+  lv_obj_t *speedUnit = lv_label_create(ridePage);
   lv_obj_set_width(speedUnit, rideLayout.heroUnit.width);
   lv_obj_set_pos(speedUnit, rideLayout.heroUnit.x, rideLayout.heroUnit.y);
   lv_obj_set_style_text_font(speedUnit, &lv_font_montserrat_18, 0);
@@ -173,56 +160,24 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_label_set_text_static(speedUnit, "km/h");
 
   rideHeartRateValue =
-      createMetric(livePage, "Heart bpm", rideLayout.liveMetrics[0]);
+      createMetric(ridePage, "Heart bpm", rideLayout.metrics[0]).value;
   rideZoneValue =
-      createMetric(livePage, "HR zone", rideLayout.liveMetrics[1]);
+      createMetric(ridePage, "HR zone", rideLayout.metrics[1]).value;
   rideDistanceValue =
-      createMetric(livePage, "Distance", rideLayout.liveMetrics[2]);
+      createMetric(ridePage, "Distance", rideLayout.metrics[2]).value;
   rideElapsedValue =
-      createMetric(livePage, "Elapsed", rideLayout.liveMetrics[3]);
-  ridePowerValue =
-      createMetric(livePage, "Power W", rideLayout.liveMetrics[4]);
-  rideCadenceValue =
-      createMetric(livePage, "Cadence rpm", rideLayout.liveMetrics[5]);
+      createMetric(ridePage, "Elapsed", rideLayout.metrics[3]).value;
+  rideBottomLeft =
+      createMetric(ridePage, "Altitude m", rideLayout.metrics[4]);
+  rideBottomRight =
+      createMetric(ridePage, "Route left", rideLayout.metrics[5]);
 
-  summaryPage = createPage(screen);
-  summaryStatus = createHeader(summaryPage, "2 / 2");
-  rideAverageHeartRateValue = createMetric(
-      summaryPage, "Avg heart bpm", rideLayout.summaryMetrics[0]);
-  rideEnergyValue = createMetric(summaryPage, "Energy kcal",
-                                 rideLayout.summaryMetrics[1]);
-  rideAltitudeValue = createMetric(summaryPage, "Altitude m",
-                                   rideLayout.summaryMetrics[2]);
-  rideRouteRemainingValue = createMetric(
-      summaryPage, "Route left", rideLayout.summaryMetrics[3]);
-
-  lv_obj_t *sourceTitle = lv_label_create(summaryPage);
-  lv_obj_set_width(sourceTitle, rideLayout.source.width);
-  lv_obj_set_pos(sourceTitle, rideLayout.source.x, rideLayout.source.y);
-  lv_obj_set_style_text_font(sourceTitle, &lv_font_montserrat_18, 0);
-  lv_obj_set_style_text_color(sourceTitle, lv_color_hex(0x999999), 0);
-  lv_obj_set_style_text_align(sourceTitle, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_text_static(sourceTitle, "Source / freshness");
-
-  rideSourceValue = lv_label_create(summaryPage);
-  lv_obj_set_width(rideSourceValue, rideLayout.source.width);
-  lv_obj_set_pos(rideSourceValue, rideLayout.source.x,
-                 rideLayout.source.y + 30);
-  lv_obj_set_style_text_font(rideSourceValue, &lv_font_montserrat_24, 0);
-  lv_obj_set_style_text_color(rideSourceValue, lv_color_white(), 0);
-  lv_obj_set_style_text_align(rideSourceValue, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_long_mode(rideSourceValue, LV_LABEL_LONG_CLIP);
-  lv_label_set_text_static(rideSourceValue, "PHONE GPS");
-
-  interactionState = {};
-  updatePageVisibility();
   updateRideTelemetryEvent(nullptr);
 }
 
 void updateRideTelemetryEvent(lv_event_t *) {
   const ride_telemetry_presenter::ViewModel model = currentViewModel();
-  updateStatusLabel(liveStatus, model);
-  updateStatusLabel(summaryStatus, model);
+  updateStatusLabel(rideStatus, model);
 
   char value[24];
   ride_telemetry_presenter::formatSpeed(model, value, sizeof(value));
@@ -238,45 +193,9 @@ void updateRideTelemetryEvent(lv_event_t *) {
   ride_telemetry_presenter::formatElapsed(model.elapsedSeconds, value,
                                           sizeof(value));
   setLabelIfChanged(rideElapsedValue, value);
-  ride_telemetry_presenter::formatInteger(model.cyclingPowerWatts, value,
-                                          sizeof(value));
-  setLabelIfChanged(ridePowerValue, value);
-  ride_telemetry_presenter::formatCadence(model, value, sizeof(value));
-  setLabelIfChanged(rideCadenceValue, value);
 
-  ride_telemetry_presenter::formatInteger(model.averageHeartRateBpm, value,
-                                          sizeof(value));
-  setLabelIfChanged(rideAverageHeartRateValue, value);
-  ride_telemetry_presenter::formatEnergy(model, value, sizeof(value));
-  setLabelIfChanged(rideEnergyValue, value);
-  ride_telemetry_presenter::formatInteger(model.altitudeMeters, value,
-                                          sizeof(value));
-  setLabelIfChanged(rideAltitudeValue, value);
-  ride_telemetry_presenter::formatDistance(model.routeRemainingMeters, value,
-                                           sizeof(value));
-  setLabelIfChanged(rideRouteRemainingValue, value);
-  setLabelIfChanged(rideSourceValue,
-                    ride_telemetry_presenter::sourceFreshnessLabel(model));
-}
-
-void toggleRideTelemetryPage() {
-  interactionState.page =
-      ride_telemetry_layout::toggled(interactionState.page);
-  updatePageVisibility();
-  updateRideTelemetryEvent(nullptr);
-}
-
-uint8_t currentRideTelemetryPage() {
-  return ride_telemetry_layout::pageIndex(interactionState.page);
-}
-
-ride_telemetry_layout::InteractionAction handleRideTelemetryInteraction(
-    ride_telemetry_layout::InteractionEvent event) {
-  const ride_telemetry_layout::InteractionAction action =
-      ride_telemetry_layout::handleInteraction(interactionState, event);
-  if (action == ride_telemetry_layout::InteractionAction::TogglePage) {
-    updatePageVisibility();
-    updateRideTelemetryEvent(nullptr);
-  }
-  return action;
+  const ride_telemetry_presenter::BottomMetricSelection bottomMetrics =
+      ride_telemetry_presenter::selectBottomMetrics(model);
+  updateBottomMetric(rideBottomLeft, bottomMetrics.left, model);
+  updateBottomMetric(rideBottomRight, bottomMetrics.right, model);
 }

--- a/esp32/lib/gui/src/rideTelemetryScr.hpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.hpp
@@ -6,11 +6,5 @@
 #pragma once
 
 #include "globalGuiDef.h"
-#include "rideTelemetryLayout.hpp"
-
 void rideTelemetryScr(_lv_obj_t *screen);
 void updateRideTelemetryEvent(lv_event_t *event);
-void toggleRideTelemetryPage();
-uint8_t currentRideTelemetryPage();
-ride_telemetry_layout::InteractionAction handleRideTelemetryInteraction(
-    ride_telemetry_layout::InteractionEvent event);

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -20,51 +20,12 @@ int main() {
   constexpr auto rideLayout = ride_telemetry_layout::makeLayout(466, 466);
 #endif
   static_assert(ride_telemetry_layout::isValid(rideLayout));
-  assert(rideLayout.liveMetrics.size() == 6);
-  assert(rideLayout.summaryMetrics.size() == 4);
-  assert(rideLayout.status.right() <= rideLayout.pageIndicator.x);
-  assert(rideLayout.liveMetrics[0].right() <=
-         rideLayout.liveMetrics[1].x);
-  assert(rideLayout.liveMetrics[3].bottom() <=
-         rideLayout.liveMetrics[4].y);
-  assert(rideLayout.summaryMetrics[3].bottom() <= rideLayout.source.y);
-  for (const auto &metric : rideLayout.liveMetrics) {
+  assert(rideLayout.metrics.size() == 6);
+  assert(rideLayout.metrics[0].right() <= rideLayout.metrics[1].x);
+  assert(rideLayout.metrics[3].bottom() <= rideLayout.metrics[4].y);
+  for (const auto &metric : rideLayout.metrics) {
     assert(ride_telemetry_layout::fits(
         metric, rideLayout.screenWidth, rideLayout.screenHeight));
   }
-  for (const auto &metric : rideLayout.summaryMetrics) {
-    assert(ride_telemetry_layout::fits(
-        metric, rideLayout.screenWidth, rideLayout.screenHeight));
-  }
-
-  ride_telemetry_layout::InteractionState interaction{};
-  using Action = ride_telemetry_layout::InteractionAction;
-  using Event = ride_telemetry_layout::InteractionEvent;
-  using Page = ride_telemetry_layout::Page;
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::Pressed) ==
-         Action::None);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::Clicked) ==
-         Action::CycleScreen);
-  assert(interaction.page == Page::Live);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::Pressed) ==
-         Action::None);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::LongPressed) ==
-         Action::TogglePage);
-  assert(interaction.page == Page::Summary);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::Clicked) ==
-         Action::None);
-  assert(interaction.page == Page::Summary);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::Pressed) ==
-         Action::None);
-  assert(ride_telemetry_layout::handleInteraction(interaction,
-                                                  Event::LongPressed) ==
-         Action::TogglePage);
-  assert(interaction.page == Page::Live);
   return 0;
 }

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -49,6 +49,16 @@ void assertText(const char *actual, const char *expected) {
   assert(std::strcmp(actual, expected) == 0);
 }
 
+void assertBottomMetrics(
+    const ride_telemetry_presenter::ViewModel &model,
+    ride_telemetry_presenter::BottomMetric expectedLeft,
+    ride_telemetry_presenter::BottomMetric expectedRight) {
+  const auto selection =
+      ride_telemetry_presenter::selectBottomMetrics(model);
+  assert(selection.left == expectedLeft);
+  assert(selection.right == expectedRight);
+}
+
 void assertMetricUnavailableFormatting(
     const ride_telemetry_presenter::ViewModel &model) {
   char value[32];
@@ -233,6 +243,57 @@ int main() {
   ride_telemetry_presenter::formatZone(pausedModel, formatted,
                                        sizeof(formatted));
   assertText(formatted, "Z4/5");
+
+  using ride_telemetry_presenter::BottomMetric;
+  assertBottomMetrics(pausedModel, BottomMetric::Power,
+                      BottomMetric::Cadence);
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::Power, pausedModel, formatted, sizeof(formatted));
+  assertText(formatted, "321");
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::Cadence, pausedModel, formatted, sizeof(formatted));
+  assertText(formatted, "87.6");
+
+  auto zeroSensorModel = pausedModel;
+  zeroSensorModel.cyclingPowerWatts.value = 0;
+  zeroSensorModel.cyclingCadenceTenthsRpm.value = 0;
+  assertBottomMetrics(zeroSensorModel, BottomMetric::Power,
+                      BottomMetric::Cadence);
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::Power, zeroSensorModel, formatted, sizeof(formatted));
+  assertText(formatted, "0");
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::Cadence, zeroSensorModel, formatted, sizeof(formatted));
+  assertText(formatted, "0.0");
+
+  auto noSensorModel = pausedModel;
+  noSensorModel.cyclingPowerWatts.available = false;
+  noSensorModel.cyclingCadenceTenthsRpm.available = false;
+  assertBottomMetrics(noSensorModel, BottomMetric::Altitude,
+                      BottomMetric::RouteRemaining);
+  assertText(ride_telemetry_presenter::bottomMetricTitle(
+                 BottomMetric::Altitude),
+             "Altitude m");
+  assertText(ride_telemetry_presenter::bottomMetricTitle(
+                 BottomMetric::RouteRemaining),
+             "Route left");
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::Altitude, noSensorModel, formatted, sizeof(formatted));
+  assertText(formatted, "-12");
+  ride_telemetry_presenter::formatBottomMetric(
+      BottomMetric::RouteRemaining, noSensorModel, formatted,
+      sizeof(formatted));
+  assertText(formatted, "1.5 km");
+
+  auto powerOnlyModel = pausedModel;
+  powerOnlyModel.cyclingCadenceTenthsRpm.available = false;
+  assertBottomMetrics(powerOnlyModel, BottomMetric::Power,
+                      BottomMetric::RouteRemaining);
+
+  auto cadenceOnlyModel = pausedModel;
+  cadenceOnlyModel.cyclingPowerWatts.available = false;
+  assertBottomMetrics(cadenceOnlyModel, BottomMetric::Cadence,
+                      BottomMetric::RouteRemaining);
 
   uint8_t unavailableCore[sizeof(core)]{};
   unavailableCore[0] = 1;
@@ -550,6 +611,7 @@ int main() {
   assertText(formatted, "157");
   assertText(ride_telemetry_presenter::sourceFreshnessLabel(staleModel),
              "WATCH / LINK LOST");
+  assertText(ride_telemetry_presenter::statusLabel(staleModel), "LINK LOST");
 
   uint8_t endedCore[sizeof(core)];
   std::memcpy(endedCore, core, sizeof(core));


### PR DESCRIPTION
## Summary

- replace the two competing Ride Stats pages with one consistent speed-first screen
- always show speed, heart rate, HR zone, distance, and elapsed time
- use the two lower metric slots adaptively:
  - no optional sensors: Altitude and Route left
  - power only: Power and Route left
  - cadence only: Cadence and Route left
  - power and cadence: Power and Cadence
- remove the alternate average-heart/energy/source page and its page-switching state
- update the BLE documentation, implementation plan, and host-side layout/state tests

## Why

The device could previously land on a separate `PHONE GPS` stats page depending on the active page state. Meanwhile, riders without cadence or power sensors still saw placeholders for those sensors. This change makes Ride Stats deterministic and reserves optional sensor fields only for metrics that are actually available.

Zero-valued power or cadence readings remain visible after the corresponding sensor has connected; availability is tracked separately from the numeric reading.

## Validation

- passed host layout tests for `WAVESHARE_AMOLED_175`
- passed host layout tests for `WAVESHARE_AMOLED_206`
- passed workout telemetry state and protocol tests
- passed firmware identity unit test
- built `WAVESHARE_AMOLED_175` successfully: RAM 50.8%, flash 88.5%
- flashed commit `0c9248c00f16584d52f99cee8c8d71bdcd244ab6` to a physical Waveshare AMOLED 1.75 device
- verified display power, SD card, LVGL, touch initialization, BLE advertising/authentication, GPS receipt, and main UI startup from the device boot log
