### PR TITLE
Render map lines as solid filled strokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -224,6 +224,12 @@ jobs:
             tools/tests/test_map_profile_protocol.cpp \
             -o /tmp/test_map_profile_protocol
           /tmp/test_map_profile_protocol
+      - name: Filled line rasterizer host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra \
+            tools/tests/test_line_rasterizer.cpp \
+            -o /tmp/test_line_rasterizer
+          /tmp/test_line_rasterizer
       - name: Device screen protocol host tests
         run: |
           g++ -std=c++17 \

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -11,6 +11,7 @@
 #include "mapBlockFormat.hpp"
 #include "../../ble_navigation/ble_navigation.hpp"
 #include "../../gui/src/guiLayout.hpp"
+#include "../../utils/src/line_rasterizer.hpp"
 // #include "../../compass/compass.hpp"
 extern Gps gps;
 extern Storage storage;
@@ -1542,7 +1543,7 @@ bool Maps::fillPolygon(const Polygon &p,
 }
 
 /**
- * @brief Draw line directly to canvas buffer (Bresenham's algorithm)
+ * @brief Draw an opaque filled line directly to the canvas buffer
  *
  * @param canvas
  * @param x1
@@ -1560,65 +1561,8 @@ void Maps::drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
   int32_t buf_w = draw_buf->header.w;
   int32_t buf_h = draw_buf->header.h;
   uint32_t stride_pixels = draw_buf->header.stride / 2;
-  const int32_t clipMargin = (int32_t)width + 2;
-  if (!clipLineToRect(x1, y1, x2, y2, -clipMargin, -clipMargin,
-                      buf_w - 1 + clipMargin, buf_h - 1 + clipMargin))
-    return;
-
-  if (width < 2) {
-    drawLineSegment(buf, buf_w, buf_h, stride_pixels, x1, y1, x2, y2, color);
-    return;
-  }
-
-  float dx = x2 - x1;
-  float dy = y2 - y1;
-  float len = sqrtf(dx * dx + dy * dy);
-  if (len < 1.0f) {
-    if (x1 >= 0 && x1 < buf_w && y1 >= 0 && y1 < buf_h) {
-      buf[y1 * stride_pixels + x1] = color;
-    }
-    return;
-  }
-
-  dx /= len;
-  dy /= len;
-  float px = -dy;
-  float py = dx;
-
-  int16_t start = -((int16_t)width - 1) / 2;
-  int16_t end = (int16_t)width / 2;
-  for (int16_t t = start; t <= end; t++) {
-    int16_t ox = (int16_t)roundf(px * t);
-    int16_t oy = (int16_t)roundf(py * t);
-    drawLineSegment(buf, buf_w, buf_h, stride_pixels, x1 + ox, y1 + oy,
-                    x2 + ox, y2 + oy, color);
-  }
-}
-
-void Maps::drawLineSegment(uint16_t *buf, int32_t buf_w, int32_t buf_h,
-                           uint32_t stride_pixels, int16_t x1, int16_t y1,
-                           int16_t x2, int16_t y2, uint16_t color) {
-  // Bresenham's Line Algorithm
-  int dx = abs(x2 - x1), sx = x1 < x2 ? 1 : -1;
-  int dy = -abs(y2 - y1), sy = y1 < y2 ? 1 : -1;
-  int err = dx + dy, e2;
-
-  while (true) {
-    if (x1 >= 0 && x1 < buf_w && y1 >= 0 && y1 < buf_h) {
-      buf[y1 * stride_pixels + x1] = color;
-    }
-    if (x1 == x2 && y1 == y2)
-      break;
-    e2 = 2 * err;
-    if (e2 >= dy) {
-      err += dy;
-      x1 += sx;
-    }
-    if (e2 <= dx) {
-      err += dx;
-      y1 += sy;
-    }
-  }
+  line_rasterizer::drawFilledLine(buf, buf_w, buf_h, stride_pixels, x1, y1,
+                                  x2, y2, color, width);
 }
 
 /**

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -127,9 +127,6 @@ private:
   bool fillPolygon(const Polygon &p, lv_obj_t *canvas);
   void drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
                 int16_t y2, uint16_t color, uint8_t width);
-  void drawLineSegment(uint16_t *buf, int32_t buf_w, int32_t buf_h,
-                       uint32_t stride_pixels, int16_t x1, int16_t y1,
-                       int16_t x2, int16_t y2, uint16_t color);
   bool getMapBlocks(BBox &bbox, MemCache &memCache);
   bool readVectorMap(ViewPort &viewPort, MemCache &memCache, lv_obj_t *canvas,
                      uint8_t zoom, double rotation);

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -8,6 +8,7 @@
 
 #include "route_overlay.hpp"
 #include "../ble_navigation/ble_navigation.hpp"
+#include "../utils/src/line_rasterizer.hpp"
 #include "../../utils/src/gpsMath.hpp"
 #include <Arduino.h>
 #include <algorithm>
@@ -185,69 +186,14 @@ int16_t RouteOverlay::geoToScreenY(int32_t latMicro, int32_t centerMercatorY,
   return screenY;
 }
 
-void RouteOverlay::drawLineSegment(uint16_t *buf, int32_t bufW, int32_t bufH,
-                                   uint32_t stride, int16_t x1, int16_t y1,
-                                   int16_t x2, int16_t y2, uint16_t color) {
-  // Bresenham's line algorithm with bounds checking
-  int dx = abs(x2 - x1), sx = x1 < x2 ? 1 : -1;
-  int dy = -abs(y2 - y1), sy = y1 < y2 ? 1 : -1;
-  int err = dx + dy, e2;
-
-  while (true) {
-    // Bounds check before writing
-    if (x1 >= 0 && x1 < bufW && y1 >= 0 && y1 < bufH) {
-      buf[y1 * stride + x1] = color;
-    }
-
-    if (x1 == x2 && y1 == y2)
-      break;
-
-    e2 = 2 * err;
-    if (e2 >= dy) {
-      err += dy;
-      x1 += sx;
-    }
-    if (e2 <= dx) {
-      err += dx;
-      y1 += sy;
-    }
-  }
-}
-
 void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
                                  uint32_t stride, int16_t x1, int16_t y1,
                                  int16_t x2, int16_t y2, uint16_t color,
                                  int16_t thickness) {
-  // Calculate line direction
-  float dx = x2 - x1;
-  float dy = y2 - y1;
-  float len = sqrtf(dx * dx + dy * dy);
-
-  if (len < 1.0f) {
-    // Just draw a point
-    if (x1 >= 0 && x1 < bufW && y1 >= 0 && y1 < bufH) {
-      buf[y1 * stride + x1] = color;
-    }
-    return;
-  }
-
-  // Normalize direction
-  dx /= len;
-  dy /= len;
-
-  // Perpendicular direction for thickness
-  float px = -dy;
-  float py = dx;
-
-  // Draw multiple parallel lines for thickness
-  int16_t halfThick = thickness / 2;
-  for (int16_t t = -halfThick; t <= halfThick; t++) {
-    int16_t ox = (int16_t)(px * t);
-    int16_t oy = (int16_t)(py * t);
-
-    drawLineSegment(buf, bufW, bufH, stride, x1 + ox, y1 + oy, x2 + ox, y2 + oy,
-                    color);
-  }
+  const uint8_t lineWidth =
+      static_cast<uint8_t>(std::max<int16_t>(1, thickness));
+  line_rasterizer::drawFilledLine(buf, bufW, bufH, stride, x1, y1, x2, y2,
+                                  color, lineWidth);
 }
 
 void RouteOverlay::drawRoute(lv_obj_t *canvas, int32_t centerMercatorX,

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -111,12 +111,6 @@ private:
                      int16_t x1, int16_t y1, int16_t x2, int16_t y2,
                      uint16_t color, int16_t thickness);
 
-  /**
-   * @brief Draw a single pixel-width line (Bresenham's algorithm)
-   */
-  void drawLineSegment(uint16_t *buf, int32_t bufW, int32_t bufH,
-                       uint32_t stride, int16_t x1, int16_t y1, int16_t x2,
-                       int16_t y2, uint16_t color);
 };
 
 // Global route overlay instance

--- a/esp32/lib/utils/src/line_rasterizer.hpp
+++ b/esp32/lib/utils/src/line_rasterizer.hpp
@@ -224,6 +224,11 @@ inline void drawFilledLine(uint16_t *buf, int32_t width, int32_t height,
     return;
 
   lineWidth = std::max<uint8_t>(lineWidth, 1);
+  if (y2 < y1 || (y2 == y1 && x2 < x1)) {
+    std::swap(x1, x2);
+    std::swap(y1, y2);
+  }
+
   const float clipMargin = static_cast<float>(lineWidth) + 2.0f;
   float startX = x1;
   float startY = y1;
@@ -249,8 +254,13 @@ inline void drawFilledLine(uint16_t *buf, int32_t width, int32_t height,
   const float dy = endY - startY;
   const float length = std::sqrt(dx * dx + dy * dy);
   if (length < 0.0001f) {
-    const float radius = (static_cast<float>(lineWidth) - 1.0f) * 0.5f;
-    detail::fillDisc(buf, width, height, stride, startX, startY, radius, color);
+    const bool evenWidth = (lineWidth % 2) == 0;
+    const float centerOffset = evenWidth ? 0.5f : 0.0f;
+    const float radius = evenWidth
+                             ? static_cast<float>(lineWidth) * 0.5f
+                             : (static_cast<float>(lineWidth) - 1.0f) * 0.5f;
+    detail::fillDisc(buf, width, height, stride, startX + centerOffset,
+                     startY + centerOffset, radius, color);
     return;
   }
 

--- a/esp32/lib/utils/src/line_rasterizer.hpp
+++ b/esp32/lib/utils/src/line_rasterizer.hpp
@@ -1,0 +1,290 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace line_rasterizer {
+
+namespace detail {
+
+struct PointF {
+  float x;
+  float y;
+};
+
+inline void plot(uint16_t *buf, int32_t width, int32_t height,
+                 uint32_t stride, int32_t x, int32_t y, uint16_t color) {
+  if (x >= 0 && x < width && y >= 0 && y < height)
+    buf[y * stride + x] = color;
+}
+
+inline void fillSpan(uint16_t *buf, int32_t width, int32_t height,
+                     uint32_t stride, int32_t y, int32_t x1, int32_t x2,
+                     uint16_t color) {
+  if (y < 0 || y >= height || x2 < 0 || x1 >= width)
+    return;
+
+  x1 = std::max<int32_t>(x1, 0);
+  x2 = std::min<int32_t>(x2, width - 1);
+  uint16_t *row = buf + y * stride;
+  for (int32_t x = x1; x <= x2; ++x)
+    row[x] = color;
+}
+
+inline void drawThinLine(uint16_t *buf, int32_t width, int32_t height,
+                         uint32_t stride, int32_t x1, int32_t y1, int32_t x2,
+                         int32_t y2, uint16_t color) {
+  int32_t dx = std::abs(x2 - x1);
+  int32_t sx = x1 < x2 ? 1 : -1;
+  int32_t dy = -std::abs(y2 - y1);
+  int32_t sy = y1 < y2 ? 1 : -1;
+  int32_t error = dx + dy;
+
+  while (true) {
+    plot(buf, width, height, stride, x1, y1, color);
+    if (x1 == x2 && y1 == y2)
+      break;
+
+    const int32_t twiceError = 2 * error;
+    if (twiceError >= dy) {
+      error += dy;
+      x1 += sx;
+    }
+    if (twiceError <= dx) {
+      error += dx;
+      y1 += sy;
+    }
+  }
+}
+
+inline uint8_t clipOutCode(float x, float y, float minX, float minY,
+                           float maxX, float maxY) {
+  uint8_t code = 0;
+  if (x < minX)
+    code |= 1;
+  else if (x > maxX)
+    code |= 2;
+  if (y < minY)
+    code |= 4;
+  else if (y > maxY)
+    code |= 8;
+  return code;
+}
+
+inline bool clipLine(float &x1, float &y1, float &x2, float &y2, float minX,
+                     float minY, float maxX, float maxY) {
+  uint8_t code1 = clipOutCode(x1, y1, minX, minY, maxX, maxY);
+  uint8_t code2 = clipOutCode(x2, y2, minX, minY, maxX, maxY);
+
+  while (true) {
+    if ((code1 | code2) == 0)
+      return true;
+    if ((code1 & code2) != 0)
+      return false;
+
+    const uint8_t outsideCode = code1 != 0 ? code1 : code2;
+    float x = 0.0f;
+    float y = 0.0f;
+
+    if (outsideCode & 8) {
+      if (y2 == y1)
+        return false;
+      x = x1 + (x2 - x1) * (maxY - y1) / (y2 - y1);
+      y = maxY;
+    } else if (outsideCode & 4) {
+      if (y2 == y1)
+        return false;
+      x = x1 + (x2 - x1) * (minY - y1) / (y2 - y1);
+      y = minY;
+    } else if (outsideCode & 2) {
+      if (x2 == x1)
+        return false;
+      y = y1 + (y2 - y1) * (maxX - x1) / (x2 - x1);
+      x = maxX;
+    } else {
+      if (x2 == x1)
+        return false;
+      y = y1 + (y2 - y1) * (minX - x1) / (x2 - x1);
+      x = minX;
+    }
+
+    if (outsideCode == code1) {
+      x1 = x;
+      y1 = y;
+      code1 = clipOutCode(x1, y1, minX, minY, maxX, maxY);
+    } else {
+      x2 = x;
+      y2 = y;
+      code2 = clipOutCode(x2, y2, minX, minY, maxX, maxY);
+    }
+  }
+}
+
+inline void fillConvexQuad(uint16_t *buf, int32_t width, int32_t height,
+                           uint32_t stride, const PointF (&points)[4],
+                           uint16_t color) {
+  float minY = points[0].y;
+  float maxY = points[0].y;
+  for (uint8_t i = 1; i < 4; ++i) {
+    minY = std::min(minY, points[i].y);
+    maxY = std::max(maxY, points[i].y);
+  }
+
+  const int32_t firstY =
+      std::max<int32_t>(0, static_cast<int32_t>(std::ceil(minY)));
+  const int32_t lastY =
+      std::min<int32_t>(height - 1, static_cast<int32_t>(std::floor(maxY)));
+
+  for (int32_t y = firstY; y <= lastY; ++y) {
+    float minX = 0.0f;
+    float maxX = 0.0f;
+    bool foundIntersection = false;
+
+    for (uint8_t i = 0; i < 4; ++i) {
+      const PointF &a = points[i];
+      const PointF &b = points[(i + 1) % 4];
+      const float edgeMinY = std::min(a.y, b.y);
+      const float edgeMaxY = std::max(a.y, b.y);
+      if (y < edgeMinY || y > edgeMaxY)
+        continue;
+
+      if (a.y == b.y) {
+        if (std::fabs(static_cast<float>(y) - a.y) > 0.0001f)
+          continue;
+        const float edgeMinX = std::min(a.x, b.x);
+        const float edgeMaxX = std::max(a.x, b.x);
+        if (!foundIntersection) {
+          minX = edgeMinX;
+          maxX = edgeMaxX;
+          foundIntersection = true;
+        } else {
+          minX = std::min(minX, edgeMinX);
+          maxX = std::max(maxX, edgeMaxX);
+        }
+        continue;
+      }
+
+      const float t = (static_cast<float>(y) - a.y) / (b.y - a.y);
+      const float x = a.x + t * (b.x - a.x);
+      if (!foundIntersection) {
+        minX = x;
+        maxX = x;
+        foundIntersection = true;
+      } else {
+        minX = std::min(minX, x);
+        maxX = std::max(maxX, x);
+      }
+    }
+
+    if (foundIntersection) {
+      fillSpan(buf, width, height, stride, y,
+               static_cast<int32_t>(std::ceil(minX)),
+               static_cast<int32_t>(std::floor(maxX)), color);
+    }
+  }
+}
+
+inline void fillDisc(uint16_t *buf, int32_t width, int32_t height,
+                     uint32_t stride, float centerX, float centerY,
+                     float radius, uint16_t color) {
+  const int32_t firstY =
+      std::max<int32_t>(0, static_cast<int32_t>(std::ceil(centerY - radius)));
+  const int32_t lastY = std::min<int32_t>(
+      height - 1, static_cast<int32_t>(std::floor(centerY + radius)));
+  const float radiusSquared = radius * radius;
+
+  for (int32_t y = firstY; y <= lastY; ++y) {
+    const float dy = static_cast<float>(y) - centerY;
+    const float remaining = radiusSquared - dy * dy;
+    if (remaining < 0.0f)
+      continue;
+
+    const float xRadius = std::sqrt(remaining);
+    fillSpan(buf, width, height, stride, y,
+             static_cast<int32_t>(std::ceil(centerX - xRadius)),
+             static_cast<int32_t>(std::floor(centerX + xRadius)), color);
+  }
+}
+
+} // namespace detail
+
+/**
+ * Draws an opaque, filled line directly into an RGB565 pixel buffer.
+ *
+ * Thick lines are rasterized as a filled rectangle with round end caps. This
+ * avoids the unwritten pixels produced by approximating thickness with several
+ * rounded, parallel one-pixel Bresenham lines.
+ */
+inline void drawFilledLine(uint16_t *buf, int32_t width, int32_t height,
+                           uint32_t stride, int16_t x1, int16_t y1, int16_t x2,
+                           int16_t y2, uint16_t color, uint8_t lineWidth) {
+  if (buf == nullptr || width <= 0 || height <= 0 ||
+      stride < static_cast<uint32_t>(width))
+    return;
+
+  lineWidth = std::max<uint8_t>(lineWidth, 1);
+  const float clipMargin = static_cast<float>(lineWidth) + 2.0f;
+  float startX = x1;
+  float startY = y1;
+  float endX = x2;
+  float endY = y2;
+  if (!detail::clipLine(startX, startY, endX, endY, -clipMargin, -clipMargin,
+                        static_cast<float>(width - 1) + clipMargin,
+                        static_cast<float>(height - 1) + clipMargin)) {
+    return;
+  }
+
+  if (lineWidth == 1) {
+    detail::drawThinLine(
+        buf, width, height, stride,
+        static_cast<int32_t>(std::round(startX)),
+        static_cast<int32_t>(std::round(startY)),
+        static_cast<int32_t>(std::round(endX)),
+        static_cast<int32_t>(std::round(endY)), color);
+    return;
+  }
+
+  const float dx = endX - startX;
+  const float dy = endY - startY;
+  const float length = std::sqrt(dx * dx + dy * dy);
+  if (length < 0.0001f) {
+    const float radius = (static_cast<float>(lineWidth) - 1.0f) * 0.5f;
+    detail::fillDisc(buf, width, height, stride, startX, startY, radius, color);
+    return;
+  }
+
+  float normalX = -dy / length;
+  float normalY = dx / length;
+  if (normalY < 0.0f || (normalY == 0.0f && normalX < 0.0f)) {
+    normalX = -normalX;
+    normalY = -normalY;
+  }
+
+  const int16_t lowerOffset =
+      -static_cast<int16_t>((lineWidth - 1) / 2);
+  const int16_t upperOffset = static_cast<int16_t>(lineWidth / 2);
+  const float centerOffset =
+      (static_cast<float>(lowerOffset) + upperOffset) * 0.5f;
+  const float radius =
+      (static_cast<float>(upperOffset) - lowerOffset) * 0.5f;
+
+  const detail::PointF quad[4] = {
+      {startX + normalX * lowerOffset, startY + normalY * lowerOffset},
+      {startX + normalX * upperOffset, startY + normalY * upperOffset},
+      {endX + normalX * upperOffset, endY + normalY * upperOffset},
+      {endX + normalX * lowerOffset, endY + normalY * lowerOffset},
+  };
+  detail::fillConvexQuad(buf, width, height, stride, quad, color);
+
+  const float shiftedStartX = startX + normalX * centerOffset;
+  const float shiftedStartY = startY + normalY * centerOffset;
+  const float shiftedEndX = endX + normalX * centerOffset;
+  const float shiftedEndY = endY + normalY * centerOffset;
+  detail::fillDisc(buf, width, height, stride, shiftedStartX, shiftedStartY,
+                   radius, color);
+  detail::fillDisc(buf, width, height, stride, shiftedEndX, shiftedEndY, radius,
+                   color);
+}
+
+} // namespace line_rasterizer

--- a/esp32/tools/tests/test_line_rasterizer.cpp
+++ b/esp32/tools/tests/test_line_rasterizer.cpp
@@ -1,0 +1,104 @@
+#include "../../lib/utils/src/line_rasterizer.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+namespace {
+
+constexpr int32_t WIDTH = 40;
+constexpr int32_t HEIGHT = 40;
+constexpr uint32_t STRIDE = 44;
+constexpr uint16_t BACKGROUND = 0x0000;
+constexpr uint16_t FOREGROUND = 0xA55A;
+
+using Buffer = std::vector<uint16_t>;
+
+Buffer makeBuffer() {
+  return Buffer(STRIDE * HEIGHT, BACKGROUND);
+}
+
+bool isSet(const Buffer &buffer, int32_t x, int32_t y) {
+  return buffer[y * STRIDE + x] == FOREGROUND;
+}
+
+void assertPaddingUntouched(const Buffer &buffer) {
+  for (int32_t y = 0; y < HEIGHT; ++y) {
+    for (uint32_t x = WIDTH; x < STRIDE; ++x)
+      assert(buffer[y * STRIDE + x] == BACKGROUND);
+  }
+}
+
+void assertRowHasNoInteriorHoles(const Buffer &buffer, int32_t y) {
+  int32_t first = -1;
+  int32_t last = -1;
+  for (int32_t x = 0; x < WIDTH; ++x) {
+    if (isSet(buffer, x, y)) {
+      if (first < 0)
+        first = x;
+      last = x;
+    }
+  }
+
+  assert(first >= 0);
+  for (int32_t x = first; x <= last; ++x)
+    assert(isSet(buffer, x, y));
+}
+
+} // namespace
+
+int main() {
+  {
+    Buffer horizontal = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        horizontal.data(), WIDTH, HEIGHT, STRIDE, 5, 10, 30, 10, FOREGROUND, 4);
+
+    for (int32_t y = 9; y <= 12; ++y) {
+      for (int32_t x = 5; x <= 30; ++x)
+        assert(isSet(horizontal, x, y));
+    }
+    assert(!isSet(horizontal, 15, 8));
+    assert(!isSet(horizontal, 15, 13));
+    assertPaddingUntouched(horizontal);
+
+    Buffer reversed = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        reversed.data(), WIDTH, HEIGHT, STRIDE, 30, 10, 5, 10, FOREGROUND, 4);
+    assert(horizontal == reversed);
+  }
+
+  {
+    Buffer diagonal = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        diagonal.data(), WIDTH, HEIGHT, STRIDE, 5, 5, 32, 32, FOREGROUND, 8);
+
+    for (int32_t y = 7; y <= 30; ++y)
+      assertRowHasNoInteriorHoles(diagonal, y);
+    assertPaddingUntouched(diagonal);
+  }
+
+  {
+    Buffer clipped = makeBuffer();
+    line_rasterizer::drawFilledLine(clipped.data(), WIDTH, HEIGHT, STRIDE, -300,
+                                    20, 300, 20, FOREGROUND, 4);
+    for (int32_t y = 19; y <= 22; ++y) {
+      for (int32_t x = 0; x < WIDTH; ++x)
+        assert(isSet(clipped, x, y));
+    }
+    assertPaddingUntouched(clipped);
+  }
+
+  {
+    Buffer polyline = makeBuffer();
+    line_rasterizer::drawFilledLine(polyline.data(), WIDTH, HEIGHT, STRIDE, 5,
+                                    30, 20, 10, FOREGROUND, 6);
+    line_rasterizer::drawFilledLine(polyline.data(), WIDTH, HEIGHT, STRIDE, 20,
+                                    10, 35, 30, FOREGROUND, 6);
+    assert(isSet(polyline, 20, 10));
+    assertRowHasNoInteriorHoles(polyline, 10);
+    assertPaddingUntouched(polyline);
+  }
+
+  return 0;
+}

--- a/esp32/tools/tests/test_line_rasterizer.cpp
+++ b/esp32/tools/tests/test_line_rasterizer.cpp
@@ -23,6 +23,15 @@ bool isSet(const Buffer &buffer, int32_t x, int32_t y) {
   return buffer[y * STRIDE + x] == FOREGROUND;
 }
 
+int32_t countSet(const Buffer &buffer) {
+  int32_t count = 0;
+  for (int32_t y = 0; y < HEIGHT; ++y) {
+    for (int32_t x = 0; x < WIDTH; ++x)
+      count += isSet(buffer, x, y);
+  }
+  return count;
+}
+
 void assertPaddingUntouched(const Buffer &buffer) {
   for (int32_t y = 0; y < HEIGHT; ++y) {
     for (uint32_t x = WIDTH; x < STRIDE; ++x)
@@ -46,9 +55,30 @@ void assertRowHasNoInteriorHoles(const Buffer &buffer, int32_t y) {
     assert(isSet(buffer, x, y));
 }
 
+void assertRowEquals(const Buffer &buffer, int32_t y, int32_t first,
+                     int32_t last) {
+  for (int32_t x = 0; x < WIDTH; ++x)
+    assert(isSet(buffer, x, y) == (x >= first && x <= last));
+}
+
 } // namespace
 
 int main() {
+  {
+    Buffer thin = makeBuffer();
+    line_rasterizer::drawFilledLine(thin.data(), WIDTH, HEIGHT, STRIDE, 4, 5,
+                                    9, 10, FOREGROUND, 1);
+    for (int32_t i = 0; i <= 5; ++i)
+      assert(isSet(thin, 4 + i, 5 + i));
+    assert(countSet(thin) == 6);
+
+    Buffer reversed = makeBuffer();
+    line_rasterizer::drawFilledLine(reversed.data(), WIDTH, HEIGHT, STRIDE, 9,
+                                    10, 4, 5, FOREGROUND, 1);
+    assert(thin == reversed);
+    assertPaddingUntouched(thin);
+  }
+
   {
     Buffer horizontal = makeBuffer();
     line_rasterizer::drawFilledLine(
@@ -76,6 +106,41 @@ int main() {
     for (int32_t y = 7; y <= 30; ++y)
       assertRowHasNoInteriorHoles(diagonal, y);
     assertPaddingUntouched(diagonal);
+
+    Buffer reversed = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        reversed.data(), WIDTH, HEIGHT, STRIDE, 32, 32, 5, 5, FOREGROUND, 8);
+    assert(diagonal == reversed);
+  }
+
+  {
+    Buffer diagonal = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        diagonal.data(), WIDTH, HEIGHT, STRIDE, 2, 3, 13, 29, FOREGROUND, 2);
+
+    Buffer reversed = makeBuffer();
+    line_rasterizer::drawFilledLine(
+        reversed.data(), WIDTH, HEIGHT, STRIDE, 13, 29, 2, 3, FOREGROUND, 2);
+    assert(diagonal == reversed);
+    assert(isSet(diagonal, 2, 3));
+    assert(isSet(diagonal, 13, 29));
+    assert(countSet(diagonal) > 20);
+    assertPaddingUntouched(diagonal);
+  }
+
+  {
+    Buffer steep = makeBuffer();
+    line_rasterizer::drawFilledLine(steep.data(), WIDTH, HEIGHT, STRIDE, 30, 3,
+                                    18, 34, FOREGROUND, 7);
+
+    Buffer reversed = makeBuffer();
+    line_rasterizer::drawFilledLine(reversed.data(), WIDTH, HEIGHT, STRIDE, 18,
+                                    34, 30, 3, FOREGROUND, 7);
+    assert(steep == reversed);
+    assert(isSet(steep, 30, 3));
+    assert(isSet(steep, 18, 34));
+    assert(countSet(steep) > 150);
+    assertPaddingUntouched(steep);
   }
 
   {
@@ -87,6 +152,64 @@ int main() {
         assert(isSet(clipped, x, y));
     }
     assertPaddingUntouched(clipped);
+  }
+
+  {
+    Buffer verticallyClipped = makeBuffer();
+    line_rasterizer::drawFilledLine(verticallyClipped.data(), WIDTH, HEIGHT,
+                                    STRIDE, 20, -300, 20, 300, FOREGROUND, 4);
+    for (int32_t y = 0; y < HEIGHT; ++y) {
+      for (int32_t x = 19; x <= 22; ++x)
+        assert(isSet(verticallyClipped, x, y));
+    }
+    assertPaddingUntouched(verticallyClipped);
+
+    Buffer rejected = makeBuffer();
+    line_rasterizer::drawFilledLine(rejected.data(), WIDTH, HEIGHT, STRIDE,
+                                    -300, -300, -200, -250, FOREGROUND, 8);
+    assert(rejected == makeBuffer());
+  }
+
+  {
+    Buffer capped = makeBuffer();
+    line_rasterizer::drawFilledLine(capped.data(), WIDTH, HEIGHT, STRIDE, 10,
+                                    15, 25, 15, FOREGROUND, 4);
+    assert(isSet(capped, 9, 15));
+    assert(isSet(capped, 26, 15));
+    assert(!isSet(capped, 8, 15));
+    assert(!isSet(capped, 27, 15));
+    assertPaddingUntouched(capped);
+  }
+
+  {
+    Buffer narrowPoint = makeBuffer();
+    line_rasterizer::drawFilledLine(narrowPoint.data(), WIDTH, HEIGHT, STRIDE,
+                                    20, 20, 20, 20, FOREGROUND, 2);
+    assertRowEquals(narrowPoint, 20, 20, 21);
+    assertRowEquals(narrowPoint, 21, 20, 21);
+    assert(countSet(narrowPoint) == 4);
+    assertPaddingUntouched(narrowPoint);
+
+    Buffer point = makeBuffer();
+    line_rasterizer::drawFilledLine(point.data(), WIDTH, HEIGHT, STRIDE, 20,
+                                    20, 20, 20, FOREGROUND, 4);
+    assertRowEquals(point, 19, 20, 21);
+    assertRowEquals(point, 20, 19, 22);
+    assertRowEquals(point, 21, 19, 22);
+    assertRowEquals(point, 22, 20, 21);
+    assert(countSet(point) == 12);
+    assertPaddingUntouched(point);
+
+    Buffer oddPoint = makeBuffer();
+    line_rasterizer::drawFilledLine(oddPoint.data(), WIDTH, HEIGHT, STRIDE, 20,
+                                    20, 20, 20, FOREGROUND, 5);
+    assertRowEquals(oddPoint, 18, 20, 20);
+    assertRowEquals(oddPoint, 19, 19, 21);
+    assertRowEquals(oddPoint, 20, 18, 22);
+    assertRowEquals(oddPoint, 21, 19, 21);
+    assertRowEquals(oddPoint, 22, 20, 20);
+    assert(countSet(oddPoint) == 13);
+    assertPaddingUntouched(oddPoint);
   }
 
   {


### PR DESCRIPTION
## What changed

- replace parallel one-pixel Bresenham traces with a shared filled-stroke rasterizer
- use the rasterizer for both vector-map streets and the navigation route overlay
- preserve clipping, RGB565 stride handling, thin-line rendering, and round end caps
- add host regression coverage for continuous horizontal, diagonal, clipped, reversed, and joined strokes

## Why

Thick lines were built from several rounded parallel traces. For some angles, multiple offsets rounded to the same pixel while leaving adjacent pixels unwritten, allowing the black map background to show through as dots or gaps.

The new rasterizer fills the complete stroke body and end caps, so roads and route lines render as continuous opaque color like buildings and parks.

## Validation

- `g++ -std=c++17 -Wall -Wextra tools/tests/test_line_rasterizer.cpp`
- `pio run -e WAVESHARE_AMOLED_175`
- flashed to the connected Waveshare AMOLED 1.75 device
- verified successful BLE authentication and live map rendering
- visually confirmed on hardware that map and route lines are fully filled
