### PR TITLE
Fix App Store App Intent descriptions

### DIFF
--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
@@ -62,7 +62,7 @@ enum WorkoutLiveActivityIntentExecution {
 struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Mark Workout Segment"
     static let description = IntentDescription(
-        "Marks a segment in the active BikeComputer workout on Apple Watch."
+        "Marks a segment in the active BikeComputer workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =
@@ -94,7 +94,7 @@ struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
 struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Pause Workout"
     static let description = IntentDescription(
-        "Pauses the active BikeComputer workout on Apple Watch."
+        "Pauses the active BikeComputer workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =
@@ -126,7 +126,7 @@ struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
 struct BikeComputerResumeWorkoutIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Resume Workout"
     static let description = IntentDescription(
-        "Resumes the paused BikeComputer workout on Apple Watch."
+        "Resumes the paused BikeComputer workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -204,6 +204,22 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
             "the Live Activity extension must be iOS 17 in Debug and Release",
         )
 
+    def test_app_intent_descriptions_avoid_reserved_product_names(self):
+        intent_source = (
+            IOS_PROJECT
+            / "WorkoutLiveActivityShared"
+            / "WorkoutLiveActivityIntents.swift"
+        ).read_text()
+        descriptions = re.findall(
+            r'IntentDescription\(\s*"([^"]+)"\s*\)',
+            intent_source,
+        )
+
+        self.assertGreaterEqual(len(descriptions), 3)
+        for description in descriptions:
+            with self.subTest(description=description):
+                self.assertNotRegex(description.lower(), r"\bapple\b")
+
     def test_privacy_manifests_distinguish_backend_collection_from_healthkit(self):
         ios_privacy = load_plist(
             IOS_PROJECT / "BikeComputer" / "PrivacyInfo.xcprivacy"


### PR DESCRIPTION
## Summary
- remove reserved product wording from Live Activity App Intent descriptions
- add a regression test covering App Store reserved-name validation

## Verification
- workout release asset tests pass
- iOS simulator platform tests pass

## Context
App Store upload rejected build 8 with error 90626 because App Intent descriptions contained a reserved product name.