### PR TITLE
Fix workout telemetry delivery to bike computer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -164,7 +164,10 @@ Workout telemetry uses the `WTLM` prefix plus the same 16-byte native payload;
 the resulting fallback plaintext is exactly 20 bytes. Ownership-v2 protection
 expands it to a 42-byte wire write, while a native logical frame becomes a
 38-byte wire write on protected channel `6`. The ownership handshake already
-requires a sufficient ATT MTU. Devices must keep capability bit `7` clear until
+requires a sufficient ATT MTU. The app also prefers acknowledged `WTLM` when
+`2A6E` supports write-with-response but the native workout characteristic only
+supports write-without-response, keeping each correlated pair serialized.
+Devices must keep capability bit `7` clear until
 their authenticated parser, RAM-only state, and Ride Stats presentation are all
 available. The Waveshare targets implement that complete path and advertise bit
 `7`; new targets must meet the same gate before enabling it.

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -37,7 +37,11 @@ firmware field to wrap.
 
 If iOS has cached an older GATT table and does not discover `2A6F`, `2A72`,
 `2A73`, or the workout characteristic, the app falls back to framed binary
-writes over authenticated `2A6E`.
+writes over authenticated `2A6E`. Workout telemetry also uses its `2A6E`
+fallback when that channel supports acknowledged writes but the discovered
+native workout characteristic supports only write-without-response. This keeps
+each correlated core-plus-extended publication serialized through response
+callbacks.
 Fallback frame prefixes:
 
 | Prefix | Payload |
@@ -281,12 +285,13 @@ Waveshare firmware uses the optional Unix time to sync the onboard PCF85063 RTC.
 
 ## Watch Workout Telemetry (`9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003`)
 
-Workout telemetry is iOS-to-device, write-without-response, RAM-only, and
-accepted only after the existing local authentication handshake. The logical
-native payload is exactly 16 bytes. In an ownership-v2 session it is carried in
-an `S2` frame on protected channel `6`, for a 38-byte native wire write. A
-cached GATT table carries the same logical payload in the authenticated `2A6E`
-navigation-channel fallback instead:
+Workout telemetry is iOS-to-device, RAM-only, and accepted only after the
+existing local authentication handshake. The logical native payload is exactly
+16 bytes. In an ownership-v2 session it is carried in an `S2` frame on protected
+channel `6`, for a 38-byte native wire write. Current firmware exposes that
+native characteristic as write-without-response and exposes acknowledged writes
+on authenticated `2A6E`, so iOS uses the navigation-channel fallback to sequence
+each correlated pair. A cached GATT table uses the same fallback:
 
 ```text
 "WTLM" | 16-byte workout frame
@@ -296,6 +301,9 @@ The fallback plaintext is exactly 20 bytes before ownership-v2 protection and
 the protected fallback wire write is 42 bytes. Native and fallback payloads use
 the same parser after their authenticated channel is unwrapped. The ownership
 handshake already requires an ATT MTU large enough for either protected write.
+iOS prefers an acknowledged native workout characteristic when available,
+otherwise prefers acknowledged `WTLM`, and uses native write-without-response
+when the navigation transport is also unacknowledged.
 iOS sends no workout frames unless capability bit `7` is present, so older
 firmware continues using the existing GPS ride fields unchanged.
 

--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -75,9 +75,11 @@ BLE capability bit 7.
   installation or install ownership-v2 firmware through the supported flow.
 - Old app + ownership-v2 firmware: authentication is intentionally rejected;
   update the app before installing the firmware.
-- New app + new firmware: authenticated native workout characteristics are
-  preferred, with the documented 20-byte plaintext `WTLM` fallback (42 bytes
-  after ownership-v2 wire protection) where required.
+- New app + new firmware: the app prefers acknowledged workout delivery. With
+  current firmware it uses the documented 20-byte plaintext `WTLM` fallback
+  over acknowledged `2A6E` (42 bytes after ownership-v2 wire protection) so
+  each core-plus-extended pair is serialized; native delivery remains available
+  for compatible transport combinations.
 
 Do not advertise capability bit 7 in any firmware release that lacks the frame
 parser, RAM-only workout state, staleness handling, and Ride Stats UI.

--- a/docs/watchos-workout-companion-implementation-plan.md
+++ b/docs/watchos-workout-companion-implementation-plan.md
@@ -638,8 +638,11 @@ Capability negotiation:
   and Ride Stats presentation are all available;
 - old firmware ignores the feature and continues receiving existing GPS data.
 
-For cached GATT tables where the characteristic is not discovered, support the
-existing authenticated command channel fallback:
+Use the existing authenticated command-channel fallback when a cached GATT
+table does not expose the characteristic. Also prefer it when `2A6E` supports
+write-with-response but the native workout characteristic supports only
+write-without-response, so each correlated core-plus-extended pair is
+serialized through acknowledgements:
 
     WTLM | 16-byte workout frame
 
@@ -943,7 +946,8 @@ Exit criteria:
 - Core and extended packet exact bytes.
 - Numeric saturation and sentinel behavior.
 - Capability bit absent/present.
-- Native characteristic and WTLM fallback selection.
+- Acknowledged native, acknowledged WTLM fallback, and unacknowledged native
+  routing selection.
 - Reconnect sends the latest full state once.
 - Workout end does not stop navigation and vice versa.
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -1676,6 +1676,91 @@ class BLEManager: NSObject, ObservableObject {
         let coalescingKey = isCore
             ? DeviceBLEProtocol.workoutTelemetryCoreCoalescingKey
             : DeviceBLEProtocol.workoutTelemetryExtendedCoalescingKey
+        guard let write = workoutTelemetryWrite(
+            frame,
+            navigationEndpoint: navigationEndpoint,
+            coalescingKey: coalescingKey,
+            onWrite: onWrite,
+            onDrop: onDrop,
+            onWriteFailure: onWriteFailure
+        ) else { return false }
+        let didEnqueue = navigationWriteQueue.enqueueCoalescing(
+            write,
+            prioritized: prioritized && isCore
+        )
+        guard didEnqueue else {
+            log("Workout telemetry frame not queued: write queue unavailable")
+            return false
+        }
+        flushPendingNavigationWrites(endpoint: navigationEndpoint)
+        scheduleNavigationFlushRetryIfNeeded()
+        return true
+    }
+
+    /// Admits the correlated core and extended frames as one queue transaction.
+    /// Firmware publishes a generated update only after both halves arrive, so
+    /// exposing the core to the transport before the extended frame is admitted
+    /// can leave the device displaying no workout state under backpressure.
+    @discardableResult
+    func sendWorkoutTelemetryPair(
+        core: Data,
+        extended: Data,
+        prioritized: Bool,
+        onWrite: @escaping (Data) -> Void,
+        onDrop: @escaping (Data) -> Void,
+        onWriteFailure: @escaping (Data) -> Void
+    ) -> Bool {
+        guard core.count == DeviceBLEProtocol.workoutTelemetryFrameLength,
+              core.first == 1,
+              extended.count == DeviceBLEProtocol.workoutTelemetryFrameLength,
+              extended.first == 2,
+              isConnected,
+              isNavigationReady,
+              hasReceivedDeviceCapabilities,
+              supportsWorkoutTelemetry,
+              let navigationEndpoint = navigationWriteEndpoint,
+              let coreWrite = workoutTelemetryWrite(
+                  core,
+                  navigationEndpoint: navigationEndpoint,
+                  coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryCoreCoalescingKey,
+                  onWrite: { onWrite(core) },
+                  onDrop: { onDrop(core) },
+                  onWriteFailure: { onWriteFailure(core) }
+              ),
+              let extendedWrite = workoutTelemetryWrite(
+                  extended,
+                  navigationEndpoint: navigationEndpoint,
+                  coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryExtendedCoalescingKey,
+                  onWrite: { onWrite(extended) },
+                  onDrop: { onDrop(extended) },
+                  onWriteFailure: { onWriteFailure(extended) }
+              ) else {
+            return false
+        }
+
+        let writes = [coreWrite, extendedWrite]
+        let didEnqueue = prioritized
+            ? navigationWriteQueue.enqueuePrioritizedAtomically(writes)
+            : navigationWriteQueue.enqueueAtomically(writes)
+        guard didEnqueue else {
+            log("Workout telemetry pair not queued: insufficient write queue capacity")
+            return false
+        }
+        flushPendingNavigationWrites(endpoint: navigationEndpoint)
+        scheduleNavigationFlushRetryIfNeeded()
+        return true
+    }
+
+    private func workoutTelemetryWrite(
+        _ frame: Data,
+        navigationEndpoint: NavigationWriteEndpoint,
+        coalescingKey: String,
+        onWrite: (() -> Void)?,
+        onDrop: (() -> Void)?,
+        onWriteFailure: (() -> Void)?
+    ) -> NavigationWrite? {
         let payload: Data
         let label: String
         let transportWrite: ((Data) -> Void)?
@@ -1684,7 +1769,7 @@ class BLEManager: NSObject, ObservableObject {
 
         if let testEndpoint = workoutTelemetryWriteEndpointForTesting {
             guard frame.count <= testEndpoint.maximumWriteLength else {
-                return false
+                return nil
             }
             payload = frame
             label = "native workout telemetry"
@@ -1693,11 +1778,48 @@ class BLEManager: NSObject, ObservableObject {
             transportExpectsWriteResponse = false
         } else if let peripheral = connectedPeripheral,
                   let characteristic = workoutTelemetryCharacteristic,
+                  characteristic.properties.contains(.write) {
+            guard frame.count <= peripheral.maximumWriteValueLength(
+                for: .withResponse
+            ) else {
+                return nil
+            }
+            payload = frame
+            label = "native workout telemetry"
+            transportCanSend = { [weak self] in
+                self?.writeWithResponseInFlight == false
+            }
+            transportExpectsWriteResponse = true
+            transportWrite = { [weak self, weak peripheral, weak characteristic] data in
+                guard let self, let peripheral, let characteristic else { return }
+                self.writeDeviceData(
+                    data,
+                    to: characteristic,
+                    on: peripheral,
+                    type: .withResponse
+                )
+            }
+        } else if navigationEndpoint.expectsWriteResponse {
+            var fallback = Data(
+                DeviceBLEProtocol.workoutTelemetryFallbackPrefix.utf8
+            )
+            fallback.append(frame)
+            guard fallback.count == 20,
+                  fallback.count <= navigationEndpoint.maximumWriteLength else {
+                return nil
+            }
+            payload = fallback
+            label = "fallback workout telemetry"
+            transportWrite = nil
+            transportCanSend = nil
+            transportExpectsWriteResponse = nil
+        } else if let peripheral = connectedPeripheral,
+                  let characteristic = workoutTelemetryCharacteristic,
                   characteristic.properties.contains(.writeWithoutResponse) {
             guard frame.count <= peripheral.maximumWriteValueLength(
                 for: .withoutResponse
             ) else {
-                return false
+                return nil
             }
             payload = frame
             label = "native workout telemetry"
@@ -1715,11 +1837,13 @@ class BLEManager: NSObject, ObservableObject {
                 )
             }
         } else {
-            var fallback = Data(DeviceBLEProtocol.workoutTelemetryFallbackPrefix.utf8)
+            var fallback = Data(
+                DeviceBLEProtocol.workoutTelemetryFallbackPrefix.utf8
+            )
             fallback.append(frame)
             guard fallback.count == 20,
                   fallback.count <= navigationEndpoint.maximumWriteLength else {
-                return false
+                return nil
             }
             payload = fallback
             label = "fallback workout telemetry"
@@ -1728,7 +1852,7 @@ class BLEManager: NSObject, ObservableObject {
             transportExpectsWriteResponse = nil
         }
 
-        let write = NavigationWrite(
+        return NavigationWrite(
             data: payload,
             label: label,
             transportWrite: transportWrite,
@@ -1739,17 +1863,6 @@ class BLEManager: NSObject, ObservableObject {
             transportExpectsWriteResponse: transportExpectsWriteResponse,
             coalescingKey: coalescingKey
         )
-        let didEnqueue = navigationWriteQueue.enqueueCoalescing(
-            write,
-            prioritized: prioritized && isCore
-        )
-        guard didEnqueue else {
-            log("Workout telemetry frame not queued: write queue unavailable")
-            return false
-        }
-        flushPendingNavigationWrites(endpoint: navigationEndpoint)
-        scheduleNavigationFlushRetryIfNeeded()
-        return true
     }
 
     /// Persist and send a runtime map setting to ESP32 when supported.

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -50,6 +50,31 @@ struct WorkoutTelemetryWriteEndpoint {
     }
 }
 
+enum WorkoutTelemetryWriteRoute: Equatable {
+    case nativeWithResponse
+    case navigationFallback
+    case nativeWithoutResponse
+}
+
+enum WorkoutTelemetryWriteRouting {
+    static func route(
+        hasNativeWriteWithResponse: Bool,
+        hasNativeWriteWithoutResponse: Bool,
+        navigationExpectsWriteResponse: Bool
+    ) -> WorkoutTelemetryWriteRoute {
+        if hasNativeWriteWithResponse {
+            return .nativeWithResponse
+        }
+        if navigationExpectsWriteResponse {
+            return .navigationFallback
+        }
+        if hasNativeWriteWithoutResponse {
+            return .nativeWithoutResponse
+        }
+        return .navigationFallback
+    }
+}
+
 enum DeviceBLEProtocol {
     static let serviceUUIDString = "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1800"
     static let navigationCharacteristicUUIDString = "2A6E"
@@ -586,7 +611,9 @@ class BLEManager: NSObject, ObservableObject {
     private var navigationWriteEndpoint: NavigationWriteEndpoint?
     private var navigationWriteQueue = NavigationWriteQueue(
         maxCount: DeviceBLEProtocol.fallbackWriteQueueCapacity,
-        priorityMaxCount: 2
+        // One complete workout pair plus the latest destination status must be
+        // able to coexist while an acknowledged write is in flight.
+        priorityMaxCount: 3
     )
     private var lastNavigationQueuePendingLogAt = Date.distantPast
     private var isConnecting: Bool = false
@@ -1767,21 +1794,25 @@ class BLEManager: NSObject, ObservableObject {
         let transportCanSend: (() -> Bool)?
         let transportExpectsWriteResponse: Bool?
 
-        if let testEndpoint = workoutTelemetryWriteEndpointForTesting {
-            guard frame.count <= testEndpoint.maximumWriteLength else {
-                return nil
-            }
-            payload = frame
-            label = "native workout telemetry"
-            transportWrite = testEndpoint.write
-            transportCanSend = testEndpoint.canSend
-            transportExpectsWriteResponse = false
-        } else if let peripheral = connectedPeripheral,
-                  let characteristic = workoutTelemetryCharacteristic,
-                  characteristic.properties.contains(.write) {
-            guard frame.count <= peripheral.maximumWriteValueLength(
-                for: .withResponse
-            ) else {
+        let testEndpoint = workoutTelemetryWriteEndpointForTesting
+        let characteristic = workoutTelemetryCharacteristic
+        let route = WorkoutTelemetryWriteRouting.route(
+            hasNativeWriteWithResponse:
+                characteristic?.properties.contains(.write) == true,
+            hasNativeWriteWithoutResponse:
+                testEndpoint != nil ||
+                characteristic?.properties.contains(.writeWithoutResponse) == true,
+            navigationExpectsWriteResponse:
+                navigationEndpoint.expectsWriteResponse
+        )
+
+        switch route {
+        case .nativeWithResponse:
+            guard let peripheral = connectedPeripheral,
+                  let characteristic,
+                  frame.count <= peripheral.maximumWriteValueLength(
+                    for: .withResponse
+                  ) else {
                 return nil
             }
             payload = frame
@@ -1799,7 +1830,7 @@ class BLEManager: NSObject, ObservableObject {
                     type: .withResponse
                 )
             }
-        } else if navigationEndpoint.expectsWriteResponse {
+        case .navigationFallback:
             var fallback = Data(
                 DeviceBLEProtocol.workoutTelemetryFallbackPrefix.utf8
             )
@@ -1813,12 +1844,24 @@ class BLEManager: NSObject, ObservableObject {
             transportWrite = nil
             transportCanSend = nil
             transportExpectsWriteResponse = nil
-        } else if let peripheral = connectedPeripheral,
-                  let characteristic = workoutTelemetryCharacteristic,
-                  characteristic.properties.contains(.writeWithoutResponse) {
-            guard frame.count <= peripheral.maximumWriteValueLength(
-                for: .withoutResponse
-            ) else {
+        case .nativeWithoutResponse:
+            if let testEndpoint {
+                guard frame.count <= testEndpoint.maximumWriteLength else {
+                    return nil
+                }
+                payload = frame
+                label = "native workout telemetry"
+                transportWrite = testEndpoint.write
+                transportCanSend = testEndpoint.canSend
+                transportExpectsWriteResponse = false
+                break
+            }
+            guard let peripheral = connectedPeripheral,
+                  let characteristic,
+                  characteristic.properties.contains(.writeWithoutResponse),
+                  frame.count <= peripheral.maximumWriteValueLength(
+                    for: .withoutResponse
+                  ) else {
                 return nil
             }
             payload = frame
@@ -1836,20 +1879,6 @@ class BLEManager: NSObject, ObservableObject {
                     type: .withoutResponse
                 )
             }
-        } else {
-            var fallback = Data(
-                DeviceBLEProtocol.workoutTelemetryFallbackPrefix.utf8
-            )
-            fallback.append(frame)
-            guard fallback.count == 20,
-                  fallback.count <= navigationEndpoint.maximumWriteLength else {
-                return nil
-            }
-            payload = fallback
-            label = "fallback workout telemetry"
-            transportWrite = nil
-            transportCanSend = nil
-            transportExpectsWriteResponse = nil
         }
 
         return NavigationWrite(
@@ -2825,6 +2854,16 @@ class BLEManager: NSObject, ObservableObject {
         _ endpoint: WorkoutTelemetryWriteEndpoint?
     ) {
         workoutTelemetryWriteEndpointForTesting = endpoint
+    }
+
+    func installNavigationWriteQueueForTesting(
+        maxCount: Int,
+        priorityMaxCount: Int = 3
+    ) {
+        navigationWriteQueue = NavigationWriteQueue(
+            maxCount: maxCount,
+            priorityMaxCount: priorityMaxCount
+        )
     }
 #endif
 
@@ -4378,8 +4417,8 @@ extension BLEManager: CBPeripheralDelegate {
             }
 
             if characteristic.uuid == workoutTelemetryCharacteristicUUID {
-                guard characteristic.properties.contains(.writeWithoutResponse) else {
-                    log("Workout telemetry characteristic is not writable without response")
+                guard preferredWriteType(for: characteristic) != nil else {
+                    log("Workout telemetry characteristic is not writable")
                     continue
                 }
                 workoutTelemetryCharacteristic = characteristic

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutDeviceRelay.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutDeviceRelay.swift
@@ -735,26 +735,70 @@ final class WorkoutDeviceRelay {
         )
 
         var needsRetry = false
-        for transmission in schedule.transmissions {
-            let accepted = bleManager.sendWorkoutTelemetryFrame(
-                transmission.data,
-                prioritized: transmission.prioritized,
-                onWrite: { [weak self] in
+        if schedule.transmissions.count == 2,
+           let core = schedule.transmissions.first(where: { $0.kind == .core }),
+           let extended = schedule.transmissions.first(where: {
+               $0.kind == .extended
+           }) {
+            let transmissionsByData = Dictionary(
+                uniqueKeysWithValues: schedule.transmissions.map {
+                    ($0.data, $0)
+                }
+            )
+            let accepted = bleManager.sendWorkoutTelemetryPair(
+                core: core.data,
+                extended: extended.data,
+                prioritized: core.prioritized || extended.prioritized,
+                onWrite: { [weak self] data in
+                    guard let transmission = transmissionsByData[data] else {
+                        return
+                    }
                     self?.completeWrite(transmission)
                 },
-                onDrop: { [weak self] in
+                onDrop: { [weak self] data in
+                    guard let transmission = transmissionsByData[data] else {
+                        return
+                    }
                     self?.dropWrite(transmission)
                 },
-                onWriteFailure: { [weak self] in
+                onWriteFailure: { [weak self] data in
+                    guard let transmission = transmissionsByData[data] else {
+                        return
+                    }
                     self?.failWrite(transmission)
                 }
             )
             if !accepted {
-                scheduler.didNotWrite(
-                    kind: transmission.kind,
-                    data: transmission.data
-                )
+                for transmission in schedule.transmissions {
+                    scheduler.didNotWrite(
+                        kind: transmission.kind,
+                        data: transmission.data
+                    )
+                }
                 needsRetry = true
+            }
+        } else {
+            for transmission in schedule.transmissions {
+                let accepted = bleManager.sendWorkoutTelemetryFrame(
+                    transmission.data,
+                    prioritized: transmission.prioritized,
+                    onWrite: { [weak self] in
+                        self?.completeWrite(transmission)
+                    },
+                    onDrop: { [weak self] in
+                        self?.dropWrite(transmission)
+                    },
+                    onWriteFailure: { [weak self] in
+                        self?.failWrite(transmission)
+                    }
+                )
+                if !accepted {
+                    scheduler.didNotWrite(
+                        kind: transmission.kind,
+                        data: transmission.data
+                    )
+                    needsRetry = true
+                }
             }
         }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -579,6 +579,7 @@ struct NavigationProtocolTests {
         testWorkoutDeviceTelemetryMapping()
         testWorkoutDeviceRelayScheduling()
         testWorkoutDeviceRelayPublicationIntegration()
+        testWorkoutDeviceRelayRegularRetryIntegration()
         testWorkoutTelemetryBLETransport()
         testDevicePacketRouting()
         testDeviceSoundProtocol()
@@ -9311,6 +9312,124 @@ struct NavigationProtocolTests {
         withExtendedLifetime(relay) {}
     }
 
+    @MainActor
+    static func testWorkoutDeviceRelayRegularRetryIntegration() {
+        let clock = TestClock(Date(timeIntervalSince1970: 30_000))
+        let sessionID = UUID(uuidString: "BBBBBBBB-CCCC-DDDD-EEEE-FFFFFFFFFFFF")!
+        let store = WorkoutMetricsStore(now: clock.now)
+        store.attachMirroredSession(at: clock.now())
+        _ = store.ingestBatch([
+            WorkoutEnvelopeV1(
+                kind: .snapshot,
+                sessionID: sessionID,
+                sessionToken: 92,
+                sequence: 1,
+                capturedAt: clock.now(),
+                snapshot: WorkoutSnapshotV1(
+                    state: .running,
+                    startDate: clock.now()
+                )
+            ),
+        ], receivedAt: clock.now())
+
+        let initialSample = WorkoutDeviceTelemetryMapper.sample(
+            presentation: store.presentation,
+            envelope: store.currentEnvelope
+        )!
+        let initialFrames = WorkoutDeviceFrameBuilder.frames(for: initialSample)!
+        var primedScheduler = WorkoutDeviceRelayScheduler()
+        let initialSchedule = primedScheduler.update(
+            frames: initialFrames,
+            transportReady: true,
+            at: clock.now()
+        )
+        for transmission in initialSchedule.transmissions {
+            primedScheduler.didWrite(
+                kind: transmission.kind,
+                data: transmission.data,
+                at: clock.now()
+            )
+        }
+
+        let manager = BLEManager()
+        manager.installNavigationWriteQueueForTesting(maxCount: 2)
+        var transportReady = false
+        var writes: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            expectsWriteResponse: true,
+            canSend: { transportReady },
+            write: { writes.append($0) }
+        ))
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        let capability = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.workoutTelemetryCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(capability),
+               "regular retry manager receives workout capability")
+
+        let relay = WorkoutDeviceRelay(
+            store: store,
+            bleManager: manager,
+            now: clock.now,
+            scheduler: primedScheduler
+        )
+        assert(manager.requestDeviceCapabilities(),
+               "first ordinary write fills the regular queue")
+        assert(manager.requestDeviceCapabilities(),
+               "second ordinary write fills the regular queue")
+
+        clock.advance(by: 1)
+        let heartRate = WorkoutMetricV1(
+            value: 130,
+            unit: .beatsPerMinute,
+            capturedAt: clock.now(),
+            source: .healthKit
+        )
+        _ = store.ingestBatch([
+            WorkoutEnvelopeV1(
+                kind: .snapshot,
+                sessionID: sessionID,
+                sessionToken: 92,
+                sequence: 2,
+                capturedAt: clock.now(),
+                snapshot: WorkoutSnapshotV1(
+                    state: .running,
+                    startDate: Date(timeIntervalSince1970: 30_000),
+                    currentHeartRate: heartRate,
+                    availability: [.currentHeartRate]
+                )
+            ),
+        ], receivedAt: clock.now())
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+        assert(writes.isEmpty,
+               "a regular pair exposes neither half when only a full queue is available")
+
+        transportReady = true
+        manager.completeNavigationWriteForTesting(error: nil)
+        manager.completeNavigationWriteForTesting(error: nil)
+        manager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(writes.map { String(data: $0.prefix(4), encoding: .utf8) },
+                    ["CAPS", "CAPS"],
+                    "failed atomic admission preserves existing regular traffic")
+
+        assert(waitForMainLoop(timeout: 1) {
+            writes.filter {
+                String(data: $0.prefix(4), encoding: .utf8) ==
+                    DeviceBLEProtocol.workoutTelemetryFallbackPrefix
+            }.count == 1
+        }, "relay retries the non-prioritized pair after capacity becomes available")
+        manager.completeNavigationWriteForTesting(error: nil)
+        let workoutWrites = writes.filter {
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.workoutTelemetryFallbackPrefix
+        }
+        assertEqual(workoutWrites.map { $0[4] }, [1, 2],
+                    "regular-lane retry delivers one adjacent correlated pair")
+        manager.completeNavigationWriteForTesting(error: nil)
+        withExtendedLifetime(relay) {}
+    }
+
     static func testWorkoutTelemetryBLETransport() {
         let channelManager = BLEManager()
         let nativeWorkoutPayload = Data(ownershipHex:
@@ -9339,6 +9458,25 @@ struct NavigationProtocolTests {
         let extendedFrame = WorkoutDeviceFrameBuilder.frames(
             for: workoutDeviceSample()
         )!.extended
+
+        assertEqual(WorkoutTelemetryWriteRouting.route(
+            hasNativeWriteWithResponse: true,
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: true
+        ), .nativeWithResponse,
+                    "an acknowledged native workout characteristic is preferred")
+        assertEqual(WorkoutTelemetryWriteRouting.route(
+            hasNativeWriteWithResponse: false,
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: true
+        ), .navigationFallback,
+                    "current firmware uses acknowledged WTLM despite native write-without-response")
+        assertEqual(WorkoutTelemetryWriteRouting.route(
+            hasNativeWriteWithResponse: false,
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: false
+        ), .nativeWithoutResponse,
+                    "native write-without-response remains available for unacknowledged navigation transports")
 
         let unauthenticated = BLEManager()
         assert(unauthenticated.handleDeviceCapabilitiesNotification(capability),
@@ -9406,7 +9544,7 @@ struct NavigationProtocolTests {
         var laterNavigationWrites: [Data] = []
         nativeManager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
             maximumWriteLength: 20,
-            expectsWriteResponse: true,
+            expectsWriteResponse: false,
             canSend: { true },
             write: { laterNavigationWrites.append($0) }
         ))
@@ -9436,12 +9574,19 @@ struct NavigationProtocolTests {
         atomicPairManager.isNavigationReady = true
         var atomicTransportReady = false
         var atomicPairWrites: [Data] = []
+        var unexpectedAtomicNativeWrites: [Data] = []
         atomicPairManager.installNavigationWriteEndpoint(
             NavigationWriteEndpoint(
                 maximumWriteLength: 20,
                 expectsWriteResponse: true,
                 canSend: { atomicTransportReady },
                 write: { atomicPairWrites.append($0) }
+            )
+        )
+        atomicPairManager.installWorkoutTelemetryWriteEndpoint(
+            WorkoutTelemetryWriteEndpoint(
+                maximumWriteLength: 20,
+                write: { unexpectedAtomicNativeWrites.append($0) }
             )
         )
         assert(atomicPairManager.requestDeviceCapabilities(),
@@ -9467,6 +9612,89 @@ struct NavigationProtocolTests {
                     "the response callback drains the paired extended frame")
         assertEqual(Data(atomicPairWrites[1].dropFirst(4)), extendedFrame,
                     "the correlated extended frame remains adjacent to its core")
+        assert(unexpectedAtomicNativeWrites.isEmpty,
+               "an acknowledged navigation endpoint bypasses native write-without-response")
+        atomicPairManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(
+            atomicPairWrites[2],
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+                Data([DeviceBLEProtocol.deviceCapabilitiesVersion]),
+            "ordinary reconnect traffic drains after the complete workout pair"
+        )
+
+        func destinationStatusPrefix(_ data: Data) -> String? {
+            String(data: data.prefix(4), encoding: .utf8)
+        }
+
+        let statusFirstManager = BLEManager()
+        assert(statusFirstManager.handleDeviceCapabilitiesNotification(capability),
+               "status-first manager receives workout capability")
+        statusFirstManager.isConnected = true
+        statusFirstManager.isNavigationReady = true
+        var statusFirstReady = false
+        var statusFirstWrites: [Data] = []
+        statusFirstManager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 64,
+            expectsWriteResponse: true,
+            canSend: { statusFirstReady },
+            write: { statusFirstWrites.append($0) }
+        ))
+        assert(statusFirstManager.sendDestinationStatus(
+            generation: 7,
+            token: 11,
+            status: .calculating,
+            message: "Starting"
+        ), "destination status is admitted before an urgent workout pair")
+        assert(statusFirstManager.sendWorkoutTelemetryPair(
+            core: frame,
+            extended: extendedFrame,
+            prioritized: true,
+            onWrite: { _ in },
+            onDrop: { _ in },
+            onWriteFailure: { _ in }
+        ), "urgent workout pair coexists with an earlier destination status")
+        statusFirstReady = true
+        statusFirstManager.completeNavigationWriteForTesting(error: nil)
+        statusFirstManager.completeNavigationWriteForTesting(error: nil)
+        statusFirstManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(statusFirstWrites.map(destinationStatusPrefix),
+                    ["DNST", "WTLM", "WTLM"],
+                    "an earlier destination status is preserved ahead of the adjacent pair")
+
+        let pairFirstManager = BLEManager()
+        assert(pairFirstManager.handleDeviceCapabilitiesNotification(capability),
+               "pair-first manager receives workout capability")
+        pairFirstManager.isConnected = true
+        pairFirstManager.isNavigationReady = true
+        var pairFirstReady = false
+        var pairFirstWrites: [Data] = []
+        pairFirstManager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 64,
+            expectsWriteResponse: true,
+            canSend: { pairFirstReady },
+            write: { pairFirstWrites.append($0) }
+        ))
+        assert(pairFirstManager.sendWorkoutTelemetryPair(
+            core: frame,
+            extended: extendedFrame,
+            prioritized: true,
+            onWrite: { _ in },
+            onDrop: { _ in },
+            onWriteFailure: { _ in }
+        ), "urgent workout pair is admitted before a destination status")
+        assert(pairFirstManager.sendDestinationStatus(
+            generation: 8,
+            token: 12,
+            status: .started,
+            message: "Started"
+        ), "destination status coexists with an earlier urgent workout pair")
+        pairFirstReady = true
+        pairFirstManager.completeNavigationWriteForTesting(error: nil)
+        pairFirstManager.completeNavigationWriteForTesting(error: nil)
+        pairFirstManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(pairFirstWrites.map(destinationStatusPrefix),
+                    ["WTLM", "WTLM", "DNST"],
+                    "the adjacent pair is preserved ahead of a later destination status")
 
         let coalescingManager = BLEManager()
         assert(coalescingManager.handleDeviceCapabilitiesNotification(capability),

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8985,6 +8985,8 @@ struct NavigationProtocolTests {
                     "authentication sends both latest workout frames")
         assert(schedule.transmissions.first?.prioritized == true,
                "initial core synchronization uses the priority lane")
+        assert(schedule.transmissions.count == 2,
+               "a generated workout update always schedules a complete pair")
         let initialPairGeneration = schedule.transmissions[0].data[1] >> 6
         assert(initialPairGeneration > 0,
                "new relay frames carry a non-zero pair generation")
@@ -9426,6 +9428,45 @@ struct NavigationProtocolTests {
                     [Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
                         Data([DeviceBLEProtocol.deviceCapabilitiesVersion])],
                     "native workout traffic cannot wedge later response-backed navigation writes")
+
+        let atomicPairManager = BLEManager()
+        assert(atomicPairManager.handleDeviceCapabilitiesNotification(capability),
+               "atomic pair manager receives workout capability")
+        atomicPairManager.isConnected = true
+        atomicPairManager.isNavigationReady = true
+        var atomicTransportReady = false
+        var atomicPairWrites: [Data] = []
+        atomicPairManager.installNavigationWriteEndpoint(
+            NavigationWriteEndpoint(
+                maximumWriteLength: 20,
+                expectsWriteResponse: true,
+                canSend: { atomicTransportReady },
+                write: { atomicPairWrites.append($0) }
+            )
+        )
+        assert(atomicPairManager.requestDeviceCapabilities(),
+               "ordinary reconnect traffic is queued before workout telemetry")
+        assert(atomicPairManager.sendWorkoutTelemetryPair(
+            core: frame,
+            extended: extendedFrame,
+            prioritized: true,
+            onWrite: { _ in },
+            onDrop: { _ in },
+            onWriteFailure: { _ in }
+        ), "a complete workout pair is admitted atomically under backpressure")
+        assert(atomicPairWrites.isEmpty,
+               "blocked transport exposes neither half of the pair")
+        atomicTransportReady = true
+        atomicPairManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(atomicPairWrites.count, 1,
+                    "acknowledged transport sends only the core before its response")
+        assertEqual(Data(atomicPairWrites[0].dropFirst(4)), frame,
+                    "the prioritized core precedes ordinary reconnect traffic")
+        atomicPairManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(atomicPairWrites.count, 2,
+                    "the response callback drains the paired extended frame")
+        assertEqual(Data(atomicPairWrites[1].dropFirst(4)), extendedFrame,
+                    "the correlated extended frame remains adjacent to its core")
 
         let coalescingManager = BLEManager()
         assert(coalescingManager.handleDeviceCapabilitiesNotification(capability),


### PR DESCRIPTION
## Summary

- enqueue correlated workout core and extended telemetry frames as one atomic BLE queue transaction
- prefer acknowledged `WTLM` delivery when the native workout characteristic is write-without-response
- preserve destination status messages alongside urgent workout pairs in the priority lane
- add regression coverage for queue backpressure, retry wiring, routing selection, and both priority-lane orderings
- align BLE protocol, release, contributor, and implementation-plan documentation with the implemented transport preference

## Root cause

The iPhone relay admitted the two generated workout frames with separate queue operations. The core frame could begin transmitting before the extended frame had been admitted, while map traffic and write backpressure could leave the extended frame stalled. Firmware intentionally publishes workout state only after both matching frames arrive, so the bike computer continued showing blank stats even though the iPhone and Watch had live metrics.

## Impact

Workout elapsed time, heart rate, altitude, distance, and related metrics now reach the bike computer as a complete generation, including after reconnects and while other BLE traffic is queued. The queue also preserves destination status traffic when an urgent workout pair is pending.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `./ios-app/scripts/run-workout-contract-tests.sh`
- unsigned Release iOS app-container build and `verify-release-container.sh`
- adversarial regression check: restoring the old split-send relay makes the new backpressure test fail
- deep P0/P1/P2 review loop: 3 iterations, 6 findings fixed, final confirming pass clean
- exact-head CI: 16/16 checks passed on `6009606aab46a0468b27fe1a037aaf6de66265fc`
- physical iPhone + embedded Watch app Debug build with Xcode
- deep code-signature verification
- installed BikeComputer 1.1 (7) on the connected iPhone
- fresh workout confirmed elapsed time, heart rate, and altitude on the ESP display
