### PR TITLE
Fix false Apple Watch install prompt when starting workouts

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -5,7 +5,6 @@ private enum WorkoutStartAvailabilityAlert: String, Identifiable {
     case unsupported
     case activationFailed
     case noPairedWatch
-    case companionAppNotInstalled
 
     var id: String { rawValue }
 
@@ -15,8 +14,6 @@ private enum WorkoutStartAvailabilityAlert: String, Identifiable {
             return "Apple Watch Required"
         case .activationFailed:
             return "Unable to Check Apple Watch"
-        case .companionAppNotInstalled:
-            return "Install BikeComputer on Apple Watch"
         }
     }
 
@@ -28,8 +25,6 @@ private enum WorkoutStartAvailabilityAlert: String, Identifiable {
             return "BikeComputer couldn’t check your Apple Watch. Make sure Bluetooth and Wi-Fi are on, then try again."
         case .noPairedWatch:
             return "You need the BikeComputer app on an Apple Watch to start tracking your workout. Pair an Apple Watch with this iPhone first."
-        case .companionAppNotInstalled:
-            return "Open the Watch app on this iPhone, tap My Watch, then install BikeComputer under Available Apps."
         }
     }
 }
@@ -62,11 +57,11 @@ struct WorkoutStartButton<Label: View>: View {
     }
 
     private func handle(_ availability: WorkoutWatchAvailabilityV1) {
-        switch availability {
-        case .activating:
+        switch WorkoutStartAvailabilityPolicyV1.resolve(availability) {
+        case .waitForActivation:
             pendingStart = true
             watchAvailability.activate()
-        case .ready:
+        case .attemptHealthKitLaunch:
             pendingStart = false
             action()
         case .unsupported:
@@ -78,9 +73,6 @@ struct WorkoutStartButton<Label: View>: View {
         case .noPairedWatch:
             pendingStart = false
             presentedAlert = .noPairedWatch
-        case .companionAppNotInstalled:
-            pendingStart = false
-            presentedAlert = .companionAppNotInstalled
         }
     }
 

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutWatchAvailability.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutWatchAvailability.swift
@@ -28,3 +28,35 @@ nonisolated enum WorkoutWatchAvailabilityPolicyV1 {
         return .ready(isReachable: isReachable)
     }
 }
+
+nonisolated enum WorkoutStartAvailabilityDecisionV1: Equatable, Sendable {
+    case waitForActivation
+    case attemptHealthKitLaunch
+    case unsupported
+    case activationFailed
+    case noPairedWatch
+}
+
+/// Decides whether an iPhone start request should reach HealthKit.
+///
+/// WatchConnectivity installation state is advisory here. Its companion-app
+/// catalogue can lag the actual Watch installation, while HealthKit's Watch
+/// launch API provides the authoritative success or failure result.
+nonisolated enum WorkoutStartAvailabilityPolicyV1 {
+    static func resolve(
+        _ availability: WorkoutWatchAvailabilityV1
+    ) -> WorkoutStartAvailabilityDecisionV1 {
+        switch availability {
+        case .activating:
+            return .waitForActivation
+        case .ready, .companionAppNotInstalled:
+            return .attemptHealthKitLaunch
+        case .unsupported:
+            return .unsupported
+        case .activationFailed:
+            return .activationFailed
+        case .noPairedWatch:
+            return .noPairedWatch
+        }
+    }
+}

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -4979,18 +4979,50 @@ private struct WorkoutContractTestSuite {
                 isCompanionAppInstalled: false,
                 isReachable: false
             ) == .companionAppNotInstalled,
-            "a paired Watch without BikeComputer must get install guidance"
+            "WatchConnectivity's reported companion-install state must remain available for non-start uses"
+        )
+        expect(
+            WorkoutStartAvailabilityPolicyV1.resolve(.activating)
+                == .waitForActivation,
+            "the start flow must wait for WatchConnectivity activation before deciding"
+        )
+        expect(
+            WorkoutStartAvailabilityPolicyV1.resolve(.unsupported)
+                == .unsupported,
+            "unsupported iPhones must remain blocked"
+        )
+        expect(
+            WorkoutStartAvailabilityPolicyV1.resolve(.activationFailed)
+                == .activationFailed,
+            "WatchConnectivity activation failures must remain recoverable"
+        )
+        expect(
+            WorkoutStartAvailabilityPolicyV1.resolve(.noPairedWatch)
+                == .noPairedWatch,
+            "an iPhone without a paired Watch must remain blocked"
+        )
+        expect(
+            WorkoutStartAvailabilityPolicyV1.resolve(
+                .companionAppNotInstalled
+            ) == .attemptHealthKitLaunch,
+            "a negative WatchConnectivity install flag must still attempt the authoritative HealthKit launch"
         )
         for isReachable in [false, true] {
+            let availability = WorkoutWatchAvailabilityPolicyV1.resolve(
+                isSupported: true,
+                isActivated: true,
+                isPaired: true,
+                isCompanionAppInstalled: true,
+                isReachable: isReachable
+            )
             expect(
-                WorkoutWatchAvailabilityPolicyV1.resolve(
-                    isSupported: true,
-                    isActivated: true,
-                    isPaired: true,
-                    isCompanionAppInstalled: true,
-                    isReachable: isReachable
-                ) == .ready(isReachable: isReachable),
+                availability == .ready(isReachable: isReachable),
                 "an installed companion must be start-ready regardless of immediate messaging reachability"
+            )
+            expect(
+                WorkoutStartAvailabilityPolicyV1.resolve(availability)
+                    == .attemptHealthKitLaunch,
+                "a ready Watch must attempt the HealthKit launch regardless of reachability"
             )
         }
     }
@@ -5178,7 +5210,7 @@ private struct WorkoutContractTestSuite {
             .count - 1
         expect(
             iPhoneAvailabilityCount == 4,
-            "all four iPhone compact, dashboard, failed, and disconnected start routes must use Watch availability gating"
+            "all four iPhone compact, dashboard, failed, and disconnected start routes must use the Watch availability flow"
         )
         expect(
             !iPhoneSource.contains("WorkoutStartDisclosureV1"),
@@ -5191,24 +5223,24 @@ private struct WorkoutContractTestSuite {
         }
         expect(
             iPhoneConfirmationComponent.contains(
-                "case .ready:\n            pendingStart = false\n            action()"
+                "switch WorkoutStartAvailabilityPolicyV1.resolve(availability)"
             )
                 && iPhoneConfirmationComponent.contains(
-                    "case .companionAppNotInstalled:"
+                    "case .attemptHealthKitLaunch:\n            pendingStart = false\n            action()"
                 ),
-            "the iPhone component must start ready Watches directly and gate missing companion apps"
+            "the iPhone component must let the start policy reach the authoritative HealthKit launch"
         )
         expect(
             compactIPhoneConfirmation.contains(
                 "YouneedtheBikeComputerapponanAppleWatchtostarttrackingyourworkout"
             )
                 && compactIPhoneConfirmation.contains(
-                    "OpentheWatchapponthisiPhone,tapMyWatch,theninstallBikeComputerunderAvailableApps"
-                )
-                && compactIPhoneConfirmation.contains(
                     ".alert(item:$presentedAlert)"
+                )
+                && !iPhoneConfirmationComponent.contains(
+                    "Install BikeComputer on Apple Watch"
                 ),
-            "iPhone unavailable states must provide paired-Watch and companion-install guidance"
+            "iPhone must keep paired-Watch guidance without blocking on a stale companion-install flag"
         )
 
         expect(


### PR DESCRIPTION
## What changed

- Treat `WCSession.isWatchAppInstalled == false` as advisory for iPhone workout starts.
- Route both ready and reported-not-installed states to the authoritative HealthKit Watch launch.
- Keep unsupported iOS, WatchConnectivity activation failures, and no-paired-Watch states blocked with their existing guidance.
- Remove the misleading “Install BikeComputer on Apple Watch” preflight alert.
- Add regression coverage for the start decision policy and all iPhone workout-start surfaces.

## Why

The iPhone start button treated WatchConnectivity’s companion-install flag as a hard gate. That flag can report a false negative even when BikeComputer is installed and a Watch-owned workout successfully mirrors to the iPhone. The UI therefore blocked the real HealthKit launch and showed incorrect installation guidance.

HealthKit’s Watch launch completion is now the source of truth. If the Watch app is genuinely unavailable, the existing launch-failure state displays the appropriate workout error after the actual attempt.

## User impact

Riders with an installed BikeComputer Watch app will no longer be blocked by a stale WatchConnectivity install flag. Real launch failures remain visible through the existing Apple Watch unavailable status and details flow.

## Validation

- `./scripts/run-workout-contract-tests.sh`
- `xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath /private/tmp/open-bike-watch-start-fix-derived.AjzN3k CODE_SIGNING_ALLOWED=NO build`
- Full simulator build included the embedded Watch app and Watch complication.

Physical iPhone/Apple Watch validation is not included in this PR handoff.
