### PR TITLE
Improve iPhone workout heart rate zones

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift
@@ -35,6 +35,7 @@ nonisolated struct WorkoutServiceActivityTracker: Sendable {
 final class WorkoutMetricsStore: ObservableObject {
     @Published private(set) var presentation: WorkoutMirrorPresentationV1
     @Published private(set) var shouldMaintainWorkoutServices: Bool
+    @Published private(set) var currentHeartRateZoneElapsedTime: TimeInterval?
 
     private var reducer: WorkoutMirrorStateReducer
     private var iPhoneTelemetry: WorkoutIPhoneTelemetryV1 = .empty
@@ -43,6 +44,8 @@ final class WorkoutMetricsStore: ObservableObject {
     private var lastNavigationDistanceMeters: Double?
     private var completedNavigationDistanceMeters: Double = 0
     private var wasNavigationDistanceAdvancing = false
+    private var heartRateZoneDurationAccumulator =
+        WorkoutHeartRateZoneDurationAccumulator()
     private let now: () -> Date
     private var workoutServiceActivityTracker: WorkoutServiceActivityTracker
 
@@ -88,6 +91,7 @@ final class WorkoutMetricsStore: ObservableObject {
         )
         var workoutServiceActivityTracker = WorkoutServiceActivityTracker()
         self.presentation = presentation
+        currentHeartRateZoneElapsedTime = nil
         shouldMaintainWorkoutServices =
             workoutServiceActivityTracker.shouldMaintainServices(
                 for: presentation,
@@ -304,6 +308,19 @@ final class WorkoutMetricsStore: ObservableObject {
                 for: next,
                 at: referenceDate
             )
+        let nextHeartRateZoneElapsedTime =
+            heartRateZoneDurationAccumulator.update(
+                sessionID: next.sessionID,
+                elapsedTime: next.snapshot.elapsedTime?.value,
+                currentZone: next.snapshot.currentHeartRateZone,
+                authoritativeDurations:
+                    next.snapshot.heartRateZoneDurations
+            )
+        if nextHeartRateZoneElapsedTime
+            != currentHeartRateZoneElapsedTime {
+            currentHeartRateZoneElapsedTime =
+                nextHeartRateZoneElapsedTime
+        }
         if nextShouldMaintainWorkoutServices
             != shouldMaintainWorkoutServices {
             shouldMaintainWorkoutServices =

--- a/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
@@ -1,0 +1,108 @@
+import SwiftUI
+
+struct HeartRateZoneStrip: View {
+    let currentZone: UInt8?
+
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
+
+    private let zoneCount = 5
+    private let spacing: CGFloat = 6
+
+    @ViewBuilder
+    var body: some View {
+        if let normalizedCurrentZone {
+            GeometryReader { proxy in
+                let availableWidth = max(
+                    proxy.size.width - spacing * CGFloat(zoneCount - 1),
+                    0
+                )
+                let inactiveWidth = availableWidth * 0.125
+                let activeWidth = availableWidth - inactiveWidth * 4
+
+                HStack(spacing: spacing) {
+                    ForEach(1...zoneCount, id: \.self) { zone in
+                        let isCurrent = zone == normalizedCurrentZone
+
+                        ZStack {
+                            RoundedRectangle(cornerRadius: 11, style: .continuous)
+                                .fill(
+                                    HeartRateZonePalette.color(for: zone)
+                                        .opacity(isCurrent ? 1 : 0.62)
+                                )
+
+                            if isCurrent {
+                                HStack(spacing: 7) {
+                                    Image(systemName: "heart.fill")
+                                        .accessibilityHidden(true)
+                                    Text("ZONE \(zone)")
+                                        .lineLimit(1)
+                                }
+                                .font(.headline.weight(.heavy))
+                                .foregroundStyle(
+                                    HeartRateZonePalette.foregroundColor(for: zone)
+                                )
+                                .minimumScaleFactor(0.72)
+                                .padding(.horizontal, 10)
+                                .transition(.opacity)
+                            }
+                        }
+                        .frame(width: isCurrent ? activeWidth : inactiveWidth)
+                    }
+                }
+                .animation(.easeInOut(duration: 0.25), value: normalizedCurrentZone)
+            }
+            .frame(height: dynamicTypeSize.isAccessibilitySize ? 58 : 48)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Heart rate zone")
+            .accessibilityValue("Zone \(normalizedCurrentZone) of \(zoneCount)")
+        }
+    }
+
+    private var normalizedCurrentZone: Int? {
+        guard let currentZone,
+              (1...zoneCount).contains(Int(currentZone)) else {
+            return nil
+        }
+        return Int(currentZone)
+    }
+
+}
+
+private enum HeartRateZonePalette {
+    static func color(for zone: Int) -> Color {
+        switch zone {
+        case 1:
+            return Color(red: 0.08, green: 0.36, blue: 0.60)
+        case 2:
+            return Color(red: 0.05, green: 0.48, blue: 0.44)
+        case 3:
+            return Color(red: 0.68, green: 0.95, blue: 0.03)
+        case 4:
+            return Color(red: 0.88, green: 0.45, blue: 0.06)
+        default:
+            return Color(red: 0.72, green: 0.03, blue: 0.32)
+        }
+    }
+
+    static func foregroundColor(for zone: Int) -> Color {
+        switch zone {
+        case 3, 4:
+            return .black
+        default:
+            return .white
+        }
+    }
+}
+
+struct HeartRateZoneStrip_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 16) {
+            HeartRateZoneStrip(currentZone: 1)
+            HeartRateZoneStrip(currentZone: 3)
+            HeartRateZoneStrip(currentZone: 5)
+            HeartRateZoneStrip(currentZone: nil)
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -391,11 +391,16 @@ struct RideMetricsPanel: View {
     }
 
     private var workoutMetrics: some View {
-        workoutMetricGrid(
-            metrics: workoutMetricValues,
-            columnCount: 3,
-            isExpanded: false
-        )
+        VStack(spacing: 12) {
+            HeartRateZoneStrip(currentZone: displayedHeartRateZone)
+                .padding(.horizontal, 8)
+
+            workoutMetricGrid(
+                metrics: workoutMetricValues,
+                columnCount: 3,
+                isExpanded: false
+            )
+        }
     }
 
     private var expandedWorkoutMetrics: some View {
@@ -405,19 +410,46 @@ struct RideMetricsPanel: View {
                 RideMetricColumn(
                     value: speed.value,
                     unit: speed.unit,
+                    valueSymbol: speed.valueSymbol,
+                    accessibilityUnit: speed.accessibilityUnit,
                     label: speed.label,
                     isExpanded: true,
-                    isHero: true
+                    isHero: true,
+                    showsLabel: false
                 )
                 .frame(maxWidth: .infinity)
             }
 
+            HeartRateZoneStrip(currentZone: displayedHeartRateZone)
+
             workoutMetricGrid(
-                metrics: metrics.filter { $0.id != "speed" },
+                metrics: expandedWorkoutMetricValues(from: metrics),
                 columnCount: 2,
                 isExpanded: true
             )
         }
+    }
+
+    private func expandedWorkoutMetricValues(
+        from metrics: [RideMetric]
+    ) -> [RideMetric] {
+        var expandedMetrics = [RideMetric]()
+        if let heartRate = metrics.first(where: { $0.id == "heart rate" }) {
+            expandedMetrics.append(heartRate)
+        }
+        expandedMetrics.append(
+            RideMetric(
+                value: WorkoutValueFormatter.duration(
+                    displayedHeartRateZoneElapsedTime
+                ),
+                showsHeartInLabel: true,
+                label: "time in zone"
+            )
+        )
+        expandedMetrics.append(contentsOf: metrics.filter {
+            $0.id != "speed" && $0.id != "heart rate"
+        })
+        return expandedMetrics
     }
 
     private var workoutMetricValues: [RideMetric] {
@@ -429,7 +461,7 @@ struct RideMetricsPanel: View {
         var metrics = [
             RideMetric(
                 value: WorkoutValueFormatter.duration(snapshot.elapsedTime?.value),
-                label: "elapsed"
+                label: "workout time"
             ),
         ]
 
@@ -493,14 +525,9 @@ struct RideMetricsPanel: View {
                         ? nil
                         : snapshot.currentHeartRate?.value
                 ),
-                unit: "bpm",
+                valueSymbol: "heart.fill",
+                accessibilityUnit: "beats per minute",
                 label: "heart rate"
-            ),
-            RideMetric(
-                value: suppressInstantaneous
-                    ? "--"
-                    : heartRateZone(snapshot),
-                label: "heart zone"
             ),
             RideMetric(
                 value: WorkoutValueFormatter.energy(snapshot.activeEnergy?.value),
@@ -532,6 +559,9 @@ struct RideMetricsPanel: View {
                 RideMetricColumn(
                     value: metric.value,
                     unit: metric.unit,
+                    valueSymbol: metric.valueSymbol,
+                    accessibilityUnit: metric.accessibilityUnit,
+                    showsHeartInLabel: metric.showsHeartInLabel,
                     label: metric.label,
                     isExpanded: isExpanded
                 )
@@ -787,9 +817,16 @@ struct RideMetricsPanel: View {
         return "m"
     }
 
-    private func heartRateZone(_ snapshot: WorkoutSnapshotV1) -> String {
-        guard let zone = snapshot.currentHeartRateZone else { return "--" }
-        return "Zone \(zone)"
+    private var displayedHeartRateZone: UInt8? {
+        suppressInstantaneousMetrics
+            ? nil
+            : workoutStore.presentation.snapshot.currentHeartRateZone
+    }
+
+    private var displayedHeartRateZoneElapsedTime: TimeInterval? {
+        suppressInstantaneousMetrics
+            ? nil
+            : workoutStore.currentHeartRateZoneElapsedTime
     }
 
     private func altitudeValue(_ altitude: Double?) -> String {
@@ -834,11 +871,24 @@ private struct RideSegmentControlLabel: View {
 private struct RideMetric: Identifiable {
     let value: String
     let unit: String?
+    let valueSymbol: String?
+    let accessibilityUnit: String?
+    let showsHeartInLabel: Bool
     let label: String
 
-    init(value: String, unit: String? = nil, label: String) {
+    init(
+        value: String,
+        unit: String? = nil,
+        valueSymbol: String? = nil,
+        accessibilityUnit: String? = nil,
+        showsHeartInLabel: Bool = false,
+        label: String
+    ) {
         self.value = value
         self.unit = unit
+        self.valueSymbol = valueSymbol
+        self.accessibilityUnit = accessibilityUnit
+        self.showsHeartInLabel = showsHeartInLabel
         self.label = label
     }
 
@@ -848,9 +898,13 @@ private struct RideMetric: Identifiable {
 private struct RideMetricColumn: View {
     let value: String
     let unit: String?
+    let valueSymbol: String?
+    let accessibilityUnit: String?
+    var showsHeartInLabel = false
     let label: String
     let isExpanded: Bool
     var isHero = false
+    var showsLabel = true
 
     var body: some View {
         VStack(spacing: isExpanded ? 4 : 2) {
@@ -865,18 +919,44 @@ private struct RideMetricColumn: View {
                         .font(unitFont)
                         .foregroundColor(.secondary)
                 }
+
+                if let valueSymbol, value != "--" {
+                    Image(systemName: valueSymbol)
+                        .font(symbolFont)
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+                }
             }
                 .lineLimit(1)
                 .minimumScaleFactor(0.55)
 
-            Text(label)
-                .font(labelFont)
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .minimumScaleFactor(0.7)
+            if showsLabel {
+                metricLabel
+                    .font(labelFont)
+                    .foregroundColor(.secondary)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+            }
         }
         .frame(maxWidth: .infinity)
-        .accessibilityElement(children: .combine)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(label), \(value) \(accessibilityUnit ?? unit ?? "")"
+        )
+    }
+
+    @ViewBuilder
+    private var metricLabel: some View {
+        if showsHeartInLabel {
+            HStack(spacing: 4) {
+                Text("time in")
+                Image(systemName: "heart.fill")
+                    .accessibilityHidden(true)
+                Text("zone")
+            }
+        } else {
+            Text(label)
+        }
     }
 
     private var valueFont: Font {
@@ -892,6 +972,13 @@ private struct RideMetricColumn: View {
             size: isHero ? 28 : isExpanded ? 24 : 16,
             weight: .semibold,
             design: .rounded
+        )
+    }
+
+    private var symbolFont: Font {
+        .system(
+            size: isHero ? 28 : isExpanded ? 24 : 18,
+            weight: .semibold
         )
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -247,7 +247,7 @@ struct WorkoutCompactCard: View {
                 Text(title)
                     .font(.subheadline.weight(.semibold))
                     .lineLimit(1)
-                Text(detail)
+                detail
                     .font(.caption)
                     .foregroundStyle(.secondary)
                     .lineLimit(1)
@@ -322,40 +322,60 @@ struct WorkoutCompactCard: View {
         }
     }
 
-    private var detail: String {
+    @ViewBuilder
+    private var detail: some View {
         let presentation = store.presentation
         switch presentation.connectionState {
         case .unsupported:
-            return "Requires iOS 17 and watchOS 10"
+            Text("Requires iOS 17 and watchOS 10")
         case .idle:
-            return "Recorded and saved by Apple Watch"
+            Text("Recorded and saved by Apple Watch")
         case .launchingWatch:
-            return "Keep your Watch unlocked"
+            Text("Keep your Watch unlocked")
         case .awaitingFirstSnapshot:
-            return "Waiting for live metrics"
+            Text("Waiting for live metrics")
         case .failed:
-            return errorDetail(
-                presentation.errorCode,
-                context: WorkoutErrorCopyV1.context(for: presentation)
+            Text(
+                errorDetail(
+                    presentation.errorCode,
+                    context: WorkoutErrorCopyV1.context(for: presentation)
+                )
             )
         case .ended:
-            return summaryDetail(presentation.finalSnapshot ?? presentation.snapshot)
+            Text(
+                summaryDetail(
+                    presentation.finalSnapshot ?? presentation.snapshot
+                )
+            )
         case .disconnected:
             if !presentation.isWorkoutActive {
-                return errorDetail(
-                    presentation.errorCode ?? .watchUnavailable,
-                    context: WorkoutErrorCopyV1.context(for: presentation)
+                Text(
+                    errorDetail(
+                        presentation.errorCode ?? .watchUnavailable,
+                        context: WorkoutErrorCopyV1.context(for: presentation)
+                    )
                 )
+            } else if let errorCode = presentation.errorCode {
+                Text(
+                    errorDetail(
+                        errorCode,
+                        context: WorkoutErrorCopyV1.context(for: presentation)
+                    )
+                )
+            } else {
+                liveDetail(presentation.snapshot)
             }
-            fallthrough
         case .connected, .stale:
             if let errorCode = presentation.errorCode {
-                return errorDetail(
-                    errorCode,
-                    context: WorkoutErrorCopyV1.context(for: presentation)
+                Text(
+                    errorDetail(
+                        errorCode,
+                        context: WorkoutErrorCopyV1.context(for: presentation)
+                    )
                 )
+            } else {
+                liveDetail(presentation.snapshot)
             }
-            return liveDetail(presentation.snapshot)
         }
     }
 
@@ -381,11 +401,27 @@ struct WorkoutCompactCard: View {
         }
     }
 
-    private func liveDetail(_ snapshot: WorkoutSnapshotV1) -> String {
+    private func liveDetail(_ snapshot: WorkoutSnapshotV1) -> some View {
         let elapsed = WorkoutValueFormatter.duration(snapshot.elapsedTime?.value)
         let heart = WorkoutValueFormatter.heartRate(snapshot.currentHeartRate?.value)
         let speed = WorkoutValueFormatter.speed(snapshot.currentSpeed?.value)
-        return "\(elapsed)  •  \(heart) BPM  •  \(speed) KM/H"
+        return HStack(spacing: 3) {
+            Text(elapsed)
+            Text("•")
+            Text(heart)
+            if heart != "--" {
+                Image(systemName: "heart.fill")
+                    .foregroundStyle(.red)
+                    .accessibilityHidden(true)
+            }
+            Text("•")
+            Text(speed)
+            Text("KM/H")
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "Workout time \(elapsed), heart rate \(heart) beats per minute, speed \(speed) kilometers per hour"
+        )
     }
 
     private func summaryDetail(_ snapshot: WorkoutSnapshotV1) -> String {
@@ -563,7 +599,7 @@ struct WorkoutDashboardView: View {
                 Text(WorkoutValueFormatter.duration(snapshot.elapsedTime?.value))
                     .font(.system(size: 42, weight: .semibold, design: .rounded))
                     .monospacedDigit()
-                    .accessibilityLabel("Elapsed time")
+                    .accessibilityLabel("Workout time")
 
                 if snapshot.lastCompletedSegment != nil,
                    store.presentation.isWorkoutActive {

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -137,57 +137,65 @@ struct WorkoutFinishButton<Label: View>: View {
         } label: {
             label()
         }
-        .confirmationDialog(
-            "Finish this ride?",
-            isPresented: finishOptionsPresented
-        ) {
-            if case .options(let sessionID) = finishPrompt {
-                Button("End and Save") {
-                    finishPrompt = nil
-                    guard store.presentation.sessionID == sessionID else { return }
-                    onEndAndSave()
-                }
-                Button("Discard Workout", role: .destructive) {
-                    requestDiscardConfirmation(for: sessionID)
-                }
-                Button("Keep Riding", role: .cancel) {
-                    finishPrompt = nil
-                }
-            }
-        } message: {
-            Text("Apple Watch performs the save. If it is unreachable, the workout continues there.")
-        }
-        .alert(
-            WorkoutDiscardDisclosureV1.title,
-            isPresented: discardConfirmationPresented
-        ) {
-            if case .discardConfirmation(let sessionID) = finishPrompt {
-                Button(WorkoutDiscardDisclosureV1.cancelTitle, role: .cancel) {
-                    WorkoutDiscardDisclosureV1.perform(
-                        .cancel,
-                        expectedSessionID: sessionID,
-                        currentSessionID: store.presentation.sessionID,
-                        discard: onDiscard
-                    )
-                }
-                Button(
-                    WorkoutDiscardDisclosureV1.confirmTitle,
-                    role: .destructive
-                ) {
-                    WorkoutDiscardDisclosureV1.perform(
-                        .confirmDiscard,
-                        expectedSessionID: sessionID,
-                        currentSessionID: store.presentation.sessionID,
-                        discard: onDiscard
-                    )
-                }
-            }
-        } message: {
-            Text(WorkoutDiscardDisclosureV1.message)
+        .background {
+            finishPromptPresenter
         }
         .onChange(of: store.presentation.sessionID) { _ in
             finishPrompt = nil
         }
+    }
+
+    private var finishPromptPresenter: some View {
+        Color.clear
+            .tint(.accentColor)
+            .confirmationDialog(
+                "Finish this ride?",
+                isPresented: finishOptionsPresented
+            ) {
+                if case .options(let sessionID) = finishPrompt {
+                    Button("End and Save") {
+                        finishPrompt = nil
+                        guard store.presentation.sessionID == sessionID else { return }
+                        onEndAndSave()
+                    }
+                    Button("Discard Workout", role: .destructive) {
+                        requestDiscardConfirmation(for: sessionID)
+                    }
+                    Button("Keep Riding", role: .cancel) {
+                        finishPrompt = nil
+                    }
+                }
+            } message: {
+                Text("Apple Watch performs the save. If it is unreachable, the workout continues there.")
+            }
+            .alert(
+                WorkoutDiscardDisclosureV1.title,
+                isPresented: discardConfirmationPresented
+            ) {
+                if case .discardConfirmation(let sessionID) = finishPrompt {
+                    Button(WorkoutDiscardDisclosureV1.cancelTitle, role: .cancel) {
+                        WorkoutDiscardDisclosureV1.perform(
+                            .cancel,
+                            expectedSessionID: sessionID,
+                            currentSessionID: store.presentation.sessionID,
+                            discard: onDiscard
+                        )
+                    }
+                    Button(
+                        WorkoutDiscardDisclosureV1.confirmTitle,
+                        role: .destructive
+                    ) {
+                        WorkoutDiscardDisclosureV1.perform(
+                            .confirmDiscard,
+                            expectedSessionID: sessionID,
+                            currentSessionID: store.presentation.sessionID,
+                            discard: onDiscard
+                        )
+                    }
+                }
+            } message: {
+                Text(WorkoutDiscardDisclosureV1.message)
+            }
     }
 
     private var finishOptionsPresented: Binding<Bool> {
@@ -570,21 +578,33 @@ struct WorkoutDashboardView: View {
                     .foregroundStyle(.secondary)
                 }
 
+                VStack(alignment: .leading, spacing: 6) {
+                    HeartRateZoneStrip(
+                        currentZone: snapshot.currentHeartRateZone
+                    )
+                    Text(
+                        snapshot.currentHeartRateZone == nil
+                            ? "Waiting for heart rate"
+                            : "Configured max HR"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
+                .padding(12)
+                .background(
+                    .background,
+                    in: RoundedRectangle(cornerRadius: 14)
+                )
+
                 LazyVGrid(columns: columns, spacing: 12) {
                     metric(
                         "Heart Rate",
                         WorkoutValueFormatter.heartRate(snapshot.currentHeartRate?.value),
-                        "BPM",
-                        "heart.fill",
-                        .red
-                    )
-                    metric(
-                        "Heart Zone",
-                        zoneValue(snapshot),
                         "",
-                        "waveform.path.ecg",
-                        .pink,
-                        source: "Configured max HR"
+                        "heart.fill",
+                        .red,
+                        valueSymbol: "heart.fill",
+                        accessibilityUnit: "beats per minute"
                     )
                     metric(
                         "Speed",
@@ -827,7 +847,9 @@ struct WorkoutDashboardView: View {
         _ unit: String,
         _ icon: String,
         _ color: Color,
-        source: String? = nil
+        source: String? = nil,
+        valueSymbol: String? = nil,
+        accessibilityUnit: String? = nil
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             Label(title, systemImage: icon)
@@ -839,9 +861,16 @@ struct WorkoutDashboardView: View {
                     .monospacedDigit()
                     .minimumScaleFactor(0.7)
                     .lineLimit(1)
-                Text(unit)
-                    .font(.caption2.weight(.medium))
-                    .foregroundStyle(.secondary)
+                if let valueSymbol {
+                    Image(systemName: valueSymbol)
+                        .font(.system(size: 18, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+                } else {
+                    Text(unit)
+                        .font(.caption2.weight(.medium))
+                        .foregroundStyle(.secondary)
+                }
             }
             if let source {
                 Text(source)
@@ -854,7 +883,9 @@ struct WorkoutDashboardView: View {
         .padding(12)
         .background(.background, in: RoundedRectangle(cornerRadius: 14))
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title), \(value) \(unit)")
+        .accessibilityLabel(
+            "\(title), \(value) \(accessibilityUnit ?? unit)"
+        )
     }
 
     private func errorBanner(_ code: WorkoutSafeErrorCodeV1) -> some View {
@@ -913,11 +944,6 @@ struct WorkoutDashboardView: View {
     private func captureAgeLabel(_ age: TimeInterval) -> String {
         if age < 1 { return "Captured now" }
         return "Captured \(Int(age.rounded(.down)))s ago"
-    }
-
-    private func zoneValue(_ snapshot: WorkoutSnapshotV1) -> String {
-        guard let zone = snapshot.currentHeartRateZone else { return "--" }
-        return "Zone \(zone)"
     }
 
     private func altitudeValue(_ altitude: Double?) -> String {

--- a/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
+++ b/ios-app/BikeComputer/BikeComputerLiveActivity/WorkoutLiveActivityViews.swift
@@ -129,7 +129,8 @@ struct WorkoutLiveActivityMetricStrip: View {
                 value: WorkoutLiveActivityFormatting.heartRate(
                     state.currentHeartRateBPM
                 ),
-                unit: "BPM",
+                valueSymbol: "heart.fill",
+                accessibilityUnit: "beats per minute",
                 label: "Heart rate",
                 compact: compact
             )
@@ -140,7 +141,9 @@ struct WorkoutLiveActivityMetricStrip: View {
 
 private struct WorkoutLiveActivityMetric: View {
     let value: String
-    let unit: String
+    var unit: String? = nil
+    var valueSymbol: String? = nil
+    var accessibilityUnit: String? = nil
     let label: String
     let compact: Bool
 
@@ -154,9 +157,16 @@ private struct WorkoutLiveActivityMetric: View {
                             : .title3.bold().monospacedDigit()
                     )
                     .minimumScaleFactor(0.65)
-                Text(unit)
-                    .font(.system(size: compact ? 7 : 9, weight: .semibold))
-                    .foregroundStyle(.secondary)
+                if let unit {
+                    Text(unit)
+                        .font(.system(size: compact ? 7 : 9, weight: .semibold))
+                        .foregroundStyle(.secondary)
+                } else if let valueSymbol, value != "—" {
+                    Image(systemName: valueSymbol)
+                        .font(.system(size: compact ? 9 : 13, weight: .semibold))
+                        .foregroundStyle(.red)
+                        .accessibilityHidden(true)
+                }
             }
             if !compact {
                 Text(label.uppercased())
@@ -167,7 +177,9 @@ private struct WorkoutLiveActivityMetric: View {
         }
         .frame(maxWidth: .infinity)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(label), \(value) \(unit)")
+        .accessibilityLabel(
+            "\(label), \(value) \(accessibilityUnit ?? unit ?? "")"
+        )
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -472,6 +472,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var cyclingCadence: WorkoutMetricV1?
     private var terminalRouteDistance: WorkoutMetricCandidate?
     private var segmentAccumulator = WorkoutSegmentAccumulator()
+    private var heartRateZoneDurationAccumulator =
+        WorkoutHeartRateZoneDurationAccumulator()
+    private var heartRateZoneCheckpointPersistenceGate =
+        WorkoutHeartRateZoneCheckpointPersistenceGate()
 
     override convenience init() {
 #if DEBUG
@@ -4086,6 +4090,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         _ recoveredIdentity: WatchWorkoutRecoveryStore.Identity
     ) {
         identity = recoveredIdentity
+        heartRateZoneDurationAccumulator.restore(
+            sessionID: recoveredIdentity.sessionID,
+            checkpoint: recoveredIdentity.heartRateZoneCheckpoint
+        )
+        heartRateZoneCheckpointPersistenceGate.reset()
         remoteControlGate = WorkoutRemoteControlSequenceGate(
             checkpoint: recoveredIdentity.remoteControlCheckpoint
         )
@@ -4699,7 +4708,23 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         let currentHeartRateZone = WorkoutHeartRateZoneProfile(
             maximumHeartRateBPM: maximumHeartRateBPM
         ).zone(for: currentHeartRate?.value)
-        if currentHeartRateZone != nil {
+        let previousHeartRateZoneCheckpoint =
+            heartRateZoneDurationAccumulator.checkpoint
+        _ = heartRateZoneDurationAccumulator.update(
+            sessionID: identity?.sessionID,
+            elapsedTime: elapsedTime?.value,
+            currentZone: currentHeartRateZone
+        )
+        heartRateZoneCheckpointPersistenceGate.observeTransition(
+            from: previousHeartRateZoneCheckpoint,
+            to: heartRateZoneDurationAccumulator.checkpoint
+        )
+        persistHeartRateZoneCheckpointIfNeeded(at: capturedAt)
+        let heartRateZoneDurations =
+            heartRateZoneDurationAccumulator.authoritativeDurations(
+                capturedAt: capturedAt
+            )
+        if currentHeartRateZone != nil || heartRateZoneDurations != nil {
             availability.insert(.heartRateZone)
         }
 
@@ -4725,16 +4750,35 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             cyclingPower: cyclingPower,
             cyclingCadence: cyclingCadence,
             currentHeartRateZone: currentHeartRateZone,
-            heartRateZoneCount: currentHeartRateZone == nil
+            heartRateZoneCount:
+                currentHeartRateZone == nil
+                    && heartRateZoneDurations == nil
                 ? nil
                 : WorkoutHeartRateZoneProfile.zoneCount,
-            heartRateZoneDurations: nil,
+            heartRateZoneDurations: heartRateZoneDurations,
             location: location,
             lastCompletedSegment: segmentAccumulator.lastCompletedSegment,
             availability: availability,
             errorCode: lastErrorCode,
             terminalOutcome: terminalOutcome
         )
+    }
+
+    private func persistHeartRateZoneCheckpointIfNeeded(at capturedAt: Date) {
+        guard let checkpoint = heartRateZoneDurationAccumulator.checkpoint,
+              heartRateZoneCheckpointPersistenceGate.shouldAttempt(
+                  at: capturedAt
+              ) else {
+            return
+        }
+        do {
+            try recoveryStore.persistHeartRateZoneCheckpoint(checkpoint)
+            identity = recoveryStore.recoveredIdentity ?? identity
+            heartRateZoneCheckpointPersistenceGate.markSucceeded()
+        } catch {
+            // Zone time remains live in memory. Retry the durable checkpoint
+            // after the bounded attempt interval.
+        }
     }
 
     private func makeLocation(
@@ -4888,6 +4932,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         cyclingPower = nil
         cyclingCadence = nil
         terminalRouteDistance = nil
+        heartRateZoneDurationAccumulator.reset()
+        heartRateZoneCheckpointPersistenceGate.reset()
         lastErrorCode = nil
     }
 

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
@@ -185,6 +185,8 @@ nonisolated final class WatchWorkoutRecoveryStore {
         var remoteSegmentIntent: RemoteSegmentIntent? = nil
         var remoteTerminalAcknowledgement:
             RemoteTerminalAcknowledgement? = nil
+        var heartRateZoneCheckpoint:
+            WorkoutHeartRateZoneDurationAccumulator.Checkpoint? = nil
         var finishRequest: FinishRequest?
         /// A rider-confirmed corrupt-state reset cannot recover the lost
         /// Save/Discard choice. Keep that provenance durable until the rider
@@ -685,6 +687,17 @@ nonisolated final class WatchWorkoutRecoveryStore {
             return
         }
         identity.remoteSegmentIntent = nil
+        try persist(identity)
+        self.identity = identity
+    }
+
+    func persistHeartRateZoneCheckpoint(
+        _ checkpoint: WorkoutHeartRateZoneDurationAccumulator.Checkpoint
+    ) throws {
+        guard checkpoint.isValid, var identity else {
+            throw RecoveryStoreError.missingOrInvalidIdentity
+        }
+        identity.heartRateZoneCheckpoint = checkpoint
         try persist(identity)
         self.identity = identity
     }

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -751,7 +751,13 @@ final class WatchWorkoutManagerTests: XCTestCase {
             WorkoutHeartRateZoneProfile.zoneCount
         )
         XCTAssertTrue(manager.snapshot.availability.contains(.heartRateZone))
-        XCTAssertNil(manager.snapshot.heartRateZoneDurations)
+        XCTAssertEqual(
+            manager.snapshot.heartRateZoneDurations?.secondsByZone,
+            Array(
+                repeating: 0,
+                count: Int(WorkoutHeartRateZoneProfile.zoneCount)
+            )
+        )
 
         receiver.session(
             WCSession.default,

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
@@ -47,9 +47,30 @@ nonisolated struct WorkoutHeartRateZoneProfile: Equatable, Sendable {
 /// Accumulates workout elapsed time by heart-rate zone for the iPhone UI.
 /// Using the workout's elapsed metric keeps the value frozen while paused.
 nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
+    struct Checkpoint: Codable, Equatable, Sendable {
+        let previousElapsedTime: TimeInterval?
+        let previousZone: UInt8?
+        let secondsByZone: [TimeInterval]
+
+        var isValid: Bool {
+            previousElapsedTime.map { $0.isFinite && $0 >= 0 } ?? true
+                && previousZone.map {
+                    $0 > 0
+                        && $0 <= WorkoutHeartRateZoneProfile.zoneCount
+                } ?? true
+                && secondsByZone.count
+                    == Int(WorkoutHeartRateZoneProfile.zoneCount)
+                && secondsByZone.allSatisfy { $0.isFinite && $0 >= 0 }
+                && previousElapsedTime.map {
+                    secondsByZone.reduce(0, +) <= $0 + 0.001
+                } ?? true
+        }
+    }
+
     private var sessionID: UUID?
     private var previousElapsedTime: TimeInterval?
     private var previousZone: UInt8?
+    private var hasObservedZone = false
     private var secondsByZone = Array(
         repeating: TimeInterval.zero,
         count: Int(WorkoutHeartRateZoneProfile.zoneCount)
@@ -75,6 +96,9 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
             value.isFinite && value >= 0 ? value : nil
         }
         let validCurrentZone = Self.validZone(currentZone)
+        if validCurrentZone != nil {
+            hasObservedZone = true
+        }
 
         if let authoritativeDurations,
            authoritativeDurations.secondsByZone.count
@@ -82,7 +106,10 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
            authoritativeDurations.secondsByZone.allSatisfy({
                $0.isFinite && $0 >= 0
            }) {
-            secondsByZone = authoritativeDurations.secondsByZone
+            secondsByZone = zip(
+                secondsByZone,
+                authoritativeDurations.secondsByZone
+            ).map(max)
         } else if let previousElapsedTime,
                   let validElapsedTime,
                   validElapsedTime >= previousElapsedTime,
@@ -91,17 +118,55 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
                 validElapsedTime - previousElapsedTime
         }
 
-        previousElapsedTime = validElapsedTime ?? previousElapsedTime
-        previousZone = validCurrentZone
+        let canAdvanceCursor = validElapsedTime.map { elapsedTime in
+            previousElapsedTime.map { elapsedTime >= $0 } ?? true
+        } ?? true
+        if canAdvanceCursor {
+            previousElapsedTime = validElapsedTime ?? previousElapsedTime
+            previousZone = validCurrentZone
+        }
 
         guard let validCurrentZone else { return nil }
         return secondsByZone[Int(validCurrentZone - 1)]
+    }
+
+    func authoritativeDurations(
+        capturedAt: Date
+    ) -> WorkoutZoneDurationsV1? {
+        guard sessionID != nil, hasObservedZone else { return nil }
+        return WorkoutZoneDurationsV1(
+            capturedAt: capturedAt,
+            secondsByZone: secondsByZone
+        )
+    }
+
+    var checkpoint: Checkpoint? {
+        guard sessionID != nil, hasObservedZone else { return nil }
+        return Checkpoint(
+            previousElapsedTime: previousElapsedTime,
+            previousZone: previousZone,
+            secondsByZone: secondsByZone
+        )
+    }
+
+    mutating func restore(
+        sessionID: UUID,
+        checkpoint: Checkpoint?
+    ) {
+        reset()
+        guard let checkpoint, checkpoint.isValid else { return }
+        self.sessionID = sessionID
+        previousElapsedTime = checkpoint.previousElapsedTime
+        previousZone = checkpoint.previousZone
+        secondsByZone = checkpoint.secondsByZone
+        hasObservedZone = true
     }
 
     mutating func reset() {
         sessionID = nil
         previousElapsedTime = nil
         previousZone = nil
+        hasObservedZone = false
         secondsByZone = Array(
             repeating: .zero,
             count: Int(WorkoutHeartRateZoneProfile.zoneCount)
@@ -115,6 +180,47 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
             return nil
         }
         return zone
+    }
+}
+
+/// Coalesces recovery writes when heart rate oscillates around a zone boundary.
+/// A pending transition is retained until a durable write succeeds.
+nonisolated struct WorkoutHeartRateZoneCheckpointPersistenceGate: Sendable {
+    static let minimumAttemptInterval: TimeInterval = 15
+
+    private(set) var hasPendingTransition = false
+    private var lastAttemptAt: Date?
+
+    mutating func observeTransition(
+        from previous: WorkoutHeartRateZoneDurationAccumulator.Checkpoint?,
+        to current: WorkoutHeartRateZoneDurationAccumulator.Checkpoint?
+    ) {
+        if previous?.previousZone != current?.previousZone {
+            hasPendingTransition = true
+        }
+    }
+
+    mutating func shouldAttempt(at date: Date) -> Bool {
+        guard hasPendingTransition,
+              date.timeIntervalSinceReferenceDate.isFinite else {
+            return false
+        }
+        if let lastAttemptAt,
+           date.timeIntervalSince(lastAttemptAt)
+                < Self.minimumAttemptInterval {
+            return false
+        }
+        lastAttemptAt = date
+        return true
+    }
+
+    mutating func markSucceeded() {
+        hasPendingTransition = false
+    }
+
+    mutating func reset() {
+        hasPendingTransition = false
+        lastAttemptAt = nil
     }
 }
 

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
@@ -44,6 +44,80 @@ nonisolated struct WorkoutHeartRateZoneProfile: Equatable, Sendable {
     }
 }
 
+/// Accumulates workout elapsed time by heart-rate zone for the iPhone UI.
+/// Using the workout's elapsed metric keeps the value frozen while paused.
+nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
+    private var sessionID: UUID?
+    private var previousElapsedTime: TimeInterval?
+    private var previousZone: UInt8?
+    private var secondsByZone = Array(
+        repeating: TimeInterval.zero,
+        count: Int(WorkoutHeartRateZoneProfile.zoneCount)
+    )
+
+    mutating func update(
+        sessionID newSessionID: UUID?,
+        elapsedTime: TimeInterval?,
+        currentZone: UInt8?,
+        authoritativeDurations: WorkoutZoneDurationsV1? = nil
+    ) -> TimeInterval? {
+        guard let newSessionID else {
+            reset()
+            return nil
+        }
+
+        if sessionID != newSessionID {
+            reset()
+            sessionID = newSessionID
+        }
+
+        let validElapsedTime = elapsedTime.flatMap { value in
+            value.isFinite && value >= 0 ? value : nil
+        }
+        let validCurrentZone = Self.validZone(currentZone)
+
+        if let authoritativeDurations,
+           authoritativeDurations.secondsByZone.count
+                == Int(WorkoutHeartRateZoneProfile.zoneCount),
+           authoritativeDurations.secondsByZone.allSatisfy({
+               $0.isFinite && $0 >= 0
+           }) {
+            secondsByZone = authoritativeDurations.secondsByZone
+        } else if let previousElapsedTime,
+                  let validElapsedTime,
+                  validElapsedTime >= previousElapsedTime,
+                  let previousZone {
+            secondsByZone[Int(previousZone - 1)] +=
+                validElapsedTime - previousElapsedTime
+        }
+
+        previousElapsedTime = validElapsedTime ?? previousElapsedTime
+        previousZone = validCurrentZone
+
+        guard let validCurrentZone else { return nil }
+        return secondsByZone[Int(validCurrentZone - 1)]
+    }
+
+    mutating func reset() {
+        sessionID = nil
+        previousElapsedTime = nil
+        previousZone = nil
+        secondsByZone = Array(
+            repeating: .zero,
+            count: Int(WorkoutHeartRateZoneProfile.zoneCount)
+        )
+    }
+
+    private static func validZone(_ zone: UInt8?) -> UInt8? {
+        guard let zone,
+              zone > 0,
+              zone <= WorkoutHeartRateZoneProfile.zoneCount else {
+            return nil
+        }
+        return zone
+    }
+}
+
 nonisolated enum WorkoutHeartRateZoneSettings {
     static let maximumHeartRateBPMKey =
         "BikeComputer.workout.maximumHeartRateBPM"

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -73,6 +73,9 @@ private struct WorkoutContractTestSuite {
         testHeartRateZonePayloadIsCoherent()
         testHeartRateZoneProfileAndPersistence()
         testHeartRateZoneDurationAccumulator()
+#if WORKOUT_CONTRACT_HOST
+        testWorkoutMetricsStoreUsesAuthoritativeCoalescedZoneTotals()
+#endif
         testAltitudeRequiresVerticalAccuracy()
         testUnknownErrorCodesBecomeSafeGenericCodes()
         testSequenceGateRejectsDuplicatesAndOlderSnapshots()
@@ -1133,6 +1136,12 @@ private struct WorkoutContractTestSuite {
             "the first observed zone starts at zero without inventing history"
         )
         expect(
+            accumulator.authoritativeDurations(
+                capturedAt: Date(timeIntervalSinceReferenceDate: 800_000_410)
+            )?.secondsByZone == [0, 0, 0, 0, 0],
+            "the workout owner publishes an authoritative five-zone baseline"
+        )
+        expect(
             accumulator.update(
                 sessionID: firstSession,
                 elapsedTime: 15,
@@ -1175,7 +1184,7 @@ private struct WorkoutContractTestSuite {
 
         let authoritative = WorkoutZoneDurationsV1(
             capturedAt: Date(timeIntervalSinceReferenceDate: 800_000_425),
-            secondsByZone: [1, 2, 3, 4, 5]
+            secondsByZone: [1, 12, 8, 4, 5]
         )
         expect(
             accumulator.update(
@@ -1185,6 +1194,129 @@ private struct WorkoutContractTestSuite {
                 authoritativeDurations: authoritative
             ) == 4,
             "authoritative Watch zone durations replace the local fallback"
+        )
+        expect(
+            accumulator.authoritativeDurations(
+                capturedAt: authoritative.capturedAt
+            ) == authoritative,
+            "authoritative zone totals survive transport coalescing"
+        )
+        let regressingAuthoritative = WorkoutZoneDurationsV1(
+            capturedAt: authoritative.capturedAt.addingTimeInterval(1),
+            secondsByZone: [0, 0, 0, 0, 0]
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 30,
+                currentZone: 4,
+                authoritativeDurations: regressingAuthoritative
+            ) == 4,
+            "a recovered authoritative snapshot cannot move zone time backward"
+        )
+
+        var recoveredAccumulator = WorkoutHeartRateZoneDurationAccumulator()
+        var zoneEntryAccumulator = WorkoutHeartRateZoneDurationAccumulator()
+        _ = zoneEntryAccumulator.update(
+            sessionID: secondSession,
+            elapsedTime: 10,
+            currentZone: 2
+        )
+        let zoneEntryCheckpoint = zoneEntryAccumulator.checkpoint
+        _ = zoneEntryAccumulator.update(
+            sessionID: secondSession,
+            elapsedTime: 15,
+            currentZone: 2
+        )
+        recoveredAccumulator.restore(
+            sessionID: secondSession,
+            checkpoint: zoneEntryCheckpoint
+        )
+        expect(
+            recoveredAccumulator.update(
+                sessionID: secondSession,
+                elapsedTime: 30,
+                currentZone: 2
+            ) == 20,
+            "Watch recovery reconstructs the uninterrupted current-zone interval from its entry checkpoint"
+        )
+        expect(
+            recoveredAccumulator.update(
+                sessionID: secondSession,
+                elapsedTime: 0,
+                currentZone: 2
+            ) == 20,
+            "a temporarily regressed recovered clock does not change zone totals"
+        )
+        expect(
+            recoveredAccumulator.update(
+                sessionID: secondSession,
+                elapsedTime: 1,
+                currentZone: 2
+            ) == 20,
+            "successive regressed clock values cannot double-count recovered time"
+        )
+        expect(
+            recoveredAccumulator.update(
+                sessionID: secondSession,
+                elapsedTime: 31,
+                currentZone: 2
+            ) == 21,
+            "zone accumulation resumes only after the recovered clock passes its checkpoint"
+        )
+
+        var persistenceGate =
+            WorkoutHeartRateZoneCheckpointPersistenceGate()
+        let firstCheckpoint = zoneEntryCheckpoint
+        persistenceGate.observeTransition(from: nil, to: firstCheckpoint)
+        let firstAttemptAt = Date(
+            timeIntervalSinceReferenceDate: 800_000_430
+        )
+        expect(
+            persistenceGate.shouldAttempt(at: firstAttemptAt),
+            "the first observed zone checkpoints immediately"
+        )
+        persistenceGate.markSucceeded()
+        let changedZoneCheckpoint =
+            WorkoutHeartRateZoneDurationAccumulator.Checkpoint(
+                previousElapsedTime: 11,
+                previousZone: 3,
+                secondsByZone: [0, 1, 0, 0, 0]
+            )
+        persistenceGate.observeTransition(
+            from: firstCheckpoint,
+            to: changedZoneCheckpoint
+        )
+        expect(
+            !persistenceGate.shouldAttempt(
+                at: firstAttemptAt.addingTimeInterval(1)
+            ),
+            "rapid zone oscillation is coalesced instead of writing every second"
+        )
+        let returnedZoneCheckpoint =
+            WorkoutHeartRateZoneDurationAccumulator.Checkpoint(
+                previousElapsedTime: 12,
+                previousZone: 2,
+                secondsByZone: [0, 1, 1, 0, 0]
+            )
+        persistenceGate.observeTransition(
+            from: changedZoneCheckpoint,
+            to: returnedZoneCheckpoint
+        )
+        expect(
+            persistenceGate.shouldAttempt(
+                at: firstAttemptAt.addingTimeInterval(15)
+            ),
+            "a coalesced transition remains pending until the bounded retry"
+        )
+        expect(
+            persistenceGate.hasPendingTransition,
+            "a persistence attempt alone does not discard an unsaved transition"
+        )
+        persistenceGate.markSucceeded()
+        expect(
+            !persistenceGate.hasPendingTransition,
+            "only a successful durable write clears the pending transition"
         )
         expect(
             accumulator.update(
@@ -1203,6 +1335,116 @@ private struct WorkoutContractTestSuite {
             "clearing the session clears the displayed zone duration"
         )
     }
+
+#if WORKOUT_CONTRACT_HOST
+    private mutating func testWorkoutMetricsStoreUsesAuthoritativeCoalescedZoneTotals() {
+        let start = Date(timeIntervalSinceReferenceDate: 800_000_500)
+        let sessionID = UUID(
+            uuidString: "72C8E2D9-3EC0-4C9A-A101-333333333333"
+        )!
+        var currentDate = start.addingTimeInterval(10)
+        let store = WorkoutMetricsStore(now: { currentDate })
+        store.attachMirroredSession(at: currentDate)
+
+        func zoneSnapshot(
+            elapsedTime: TimeInterval,
+            zone: UInt8,
+            secondsByZone: [TimeInterval],
+            capturedAt: Date
+        ) -> WorkoutSnapshotV1 {
+            WorkoutSnapshotV1(
+                state: .running,
+                startDate: start,
+                elapsedTime: WorkoutMetricV1(
+                    value: elapsedTime,
+                    unit: .seconds,
+                    capturedAt: capturedAt
+                ),
+                currentHeartRateZone: zone,
+                heartRateZoneCount: WorkoutHeartRateZoneProfile.zoneCount,
+                heartRateZoneDurations: WorkoutZoneDurationsV1(
+                    capturedAt: capturedAt,
+                    secondsByZone: secondsByZone
+                ),
+                availability: [.elapsedTime, .heartRateZone]
+            )
+        }
+
+        _ = store.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sequence: 1,
+                    capturedAt: currentDate,
+                    snapshot: zoneSnapshot(
+                        elapsedTime: 10,
+                        zone: 2,
+                        secondsByZone: [0, 0, 0, 0, 0],
+                        capturedAt: currentDate
+                    )
+                ),
+            ],
+            receivedAt: currentDate
+        )
+
+        let zoneThreeDate = start.addingTimeInterval(20)
+        let zoneFourDate = start.addingTimeInterval(30)
+        currentDate = zoneFourDate
+        _ = store.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sequence: 2,
+                    capturedAt: zoneThreeDate,
+                    snapshot: zoneSnapshot(
+                        elapsedTime: 20,
+                        zone: 3,
+                        secondsByZone: [0, 10, 0, 0, 0],
+                        capturedAt: zoneThreeDate
+                    )
+                ),
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sequence: 3,
+                    capturedAt: zoneFourDate,
+                    snapshot: zoneSnapshot(
+                        elapsedTime: 30,
+                        zone: 4,
+                        secondsByZone: [0, 10, 10, 0, 0],
+                        capturedAt: zoneFourDate
+                    )
+                ),
+            ],
+            receivedAt: currentDate
+        )
+        expect(
+            store.currentHeartRateZoneElapsedTime == 0,
+            "the store publishes the latest zone from a coalesced Watch batch"
+        )
+
+        currentDate = start.addingTimeInterval(50)
+        _ = store.ingestBatch(
+            [
+                makeEnvelope(
+                    sessionID: sessionID,
+                    sequence: 4,
+                    capturedAt: currentDate,
+                    snapshot: zoneSnapshot(
+                        elapsedTime: 50,
+                        zone: 2,
+                        secondsByZone: [0, 10, 10, 20, 0],
+                        capturedAt: currentDate
+                    )
+                ),
+            ],
+            receivedAt: currentDate
+        )
+        expect(
+            store.currentHeartRateZoneElapsedTime == 10,
+            "authoritative Watch totals prevent a coalesced gap from inflating the stale zone"
+        )
+    }
+#endif
 
     private mutating func testAltitudeRequiresVerticalAccuracy() {
         let now = Date(timeIntervalSinceReferenceDate: 800_000_450)
@@ -3007,6 +3249,14 @@ private struct WorkoutContractTestSuite {
             let identity = try firstStore.begin(startDate: start)
             expect(identity.sessionToken != 0, "persisted workout token must be nonzero")
             expect(firstStore.nextSequence() == 1, "first transport sequence should be one")
+            var zoneAccumulator = WorkoutHeartRateZoneDurationAccumulator()
+            _ = zoneAccumulator.update(
+                sessionID: identity.sessionID,
+                elapsedTime: 10,
+                currentZone: 2
+            )
+            let zoneCheckpoint = zoneAccumulator.checkpoint!
+            try firstStore.persistHeartRateZoneCheckpoint(zoneCheckpoint)
             let finishRequestedAt = start.addingTimeInterval(90)
             try firstStore.markFinishing(
                 disposition: .save,
@@ -3029,6 +3279,11 @@ private struct WorkoutContractTestSuite {
                         requestedAt: finishRequestedAt
                     ),
                 "relaunch must recover the requested save phase and exact stop date"
+            )
+            expect(
+                recoveredStore.recoveredIdentity?.heartRateZoneCheckpoint
+                    == zoneCheckpoint,
+                "relaunch must recover the exact heart-rate zone checkpoint"
             )
             try recoveredStore.markCollectionEnded()
             let collectionEndedStore = WatchWorkoutRecoveryStore(persistence: persistence)
@@ -3238,7 +3493,35 @@ private struct WorkoutContractTestSuite {
         }
         controlled.failsSave = false
         do {
-            _ = try controlledStore.begin(startDate: start)
+            let identity = try controlledStore.begin(startDate: start)
+            var zoneAccumulator = WorkoutHeartRateZoneDurationAccumulator()
+            _ = zoneAccumulator.update(
+                sessionID: identity.sessionID,
+                elapsedTime: 20,
+                currentZone: 3
+            )
+            let zoneCheckpoint = zoneAccumulator.checkpoint!
+            controlled.failsSave = true
+            do {
+                try controlledStore.persistHeartRateZoneCheckpoint(
+                    zoneCheckpoint
+                )
+                expect(false, "a failed zone checkpoint write must throw")
+            } catch {
+                expect(
+                    controlledStore.recoveredIdentity?
+                        .heartRateZoneCheckpoint == nil,
+                    "a failed zone checkpoint write must not publish unsaved state"
+                )
+            }
+            controlled.failsSave = false
+            try controlledStore.persistHeartRateZoneCheckpoint(zoneCheckpoint)
+            expect(
+                WatchWorkoutRecoveryStore(persistence: controlled)
+                    .recoveredIdentity?.heartRateZoneCheckpoint
+                    == zoneCheckpoint,
+                "a retried zone checkpoint write must survive store recreation"
+            )
             controlled.failsSave = true
             do {
                 try controlledStore.markFinishing(
@@ -5795,10 +6078,26 @@ private struct WorkoutContractTestSuite {
             .appendingPathComponent("BikeComputer/Views/WorkoutViews.swift")
         let heartRateZoneStripURL = iosAppDirectory
             .appendingPathComponent("BikeComputer/Views/HeartRateZoneStrip.swift")
+        let liveActivityURL = iosAppDirectory
+            .appendingPathComponent(
+                "BikeComputerLiveActivity/WorkoutLiveActivityViews.swift"
+            )
+        let watchWorkoutManagerURL = iosAppDirectory
+            .appendingPathComponent(
+                "BikeComputerWatch/Managers/WatchWorkoutManager.swift"
+            )
         guard let content = try? String(contentsOf: contentURL, encoding: .utf8),
               let navigation = try? String(contentsOf: navigationURL, encoding: .utf8),
               let route = try? String(contentsOf: routeURL, encoding: .utf8),
               let workout = try? String(contentsOf: workoutURL, encoding: .utf8),
+              let liveActivity = try? String(
+                contentsOf: liveActivityURL,
+                encoding: .utf8
+              ),
+              let watchWorkoutManager = try? String(
+                contentsOf: watchWorkoutManagerURL,
+                encoding: .utf8
+              ),
               let heartRateZoneStrip = try? String(
                 contentsOf: heartRateZoneStripURL,
                 encoding: .utf8
@@ -5810,6 +6109,9 @@ private struct WorkoutContractTestSuite {
         let compactContent = content.filter { !$0.isWhitespace }
         let compactNavigation = navigation.filter { !$0.isWhitespace }
         let compactWorkout = workout.filter { !$0.isWhitespace }
+        let compactLiveActivity = liveActivity.filter { !$0.isWhitespace }
+        let compactWatchWorkoutManager =
+            watchWorkoutManager.filter { !$0.isWhitespace }
         let compactHeartRateZoneStrip =
             heartRateZoneStrip.filter { !$0.isWhitespace }
         expect(
@@ -6017,8 +6319,38 @@ private struct WorkoutContractTestSuite {
                 )
                 && compactWorkout.contains(
                     "valueSymbol:\"heart.fill\",accessibilityUnit:\"beatsperminute\""
+                )
+                && compactWorkout.contains(
+                    "Image(systemName:\"heart.fill\").foregroundStyle(.red).accessibilityHidden(true)"
+                )
+                && !compactWorkout.contains(
+                    "return\"\\(elapsed)••\\(heart)BPM"
+                )
+                && compactLiveActivity.contains(
+                    "valueSymbol:\"heart.fill\",accessibilityUnit:\"beatsperminute\",label:\"Heartrate\""
+                )
+                && !compactLiveActivity.contains(
+                    "unit:\"BPM\",label:\"Heartrate\""
+                )
+                && compactWorkout.contains(
+                    ".accessibilityLabel(\"Workouttime\")"
                 ),
-            "iPhone ride surfaces must move the active Zone N label between five colored positions and replace BPM with a red heart"
+            "every iPhone current-heart-rate surface must use a red heart, and workout time must use the requested accessible label"
+        )
+        expect(
+            compactWatchWorkoutManager.contains(
+                "heartRateZoneDurationAccumulator.update(sessionID:identity?.sessionID,elapsedTime:elapsedTime?.value,currentZone:currentHeartRateZone)"
+            )
+                && compactWatchWorkoutManager.contains(
+                    "heartRateZoneDurations:heartRateZoneDurations"
+                )
+                && compactWatchWorkoutManager.contains(
+                    "heartRateZoneDurationAccumulator.restore(sessionID:recoveredIdentity.sessionID,checkpoint:recoveredIdentity.heartRateZoneCheckpoint)"
+                )
+                && compactWatchWorkoutManager.contains(
+                    "recoveryStore.persistHeartRateZoneCheckpoint(checkpoint)"
+                ),
+            "the Watch workout owner must publish authoritative zone totals before iPhone transport coalescing"
         )
         for control in [
             "\"Segment\"",

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -72,6 +72,7 @@ private struct WorkoutContractTestSuite {
         testComponentTimestampsStayWithinWorkoutWindow()
         testHeartRateZonePayloadIsCoherent()
         testHeartRateZoneProfileAndPersistence()
+        testHeartRateZoneDurationAccumulator()
         testAltitudeRequiresVerticalAccuracy()
         testUnknownErrorCodesBecomeSafeGenericCodes()
         testSequenceGateRejectsDuplicatesAndOlderSnapshots()
@@ -1111,6 +1112,95 @@ private struct WorkoutContractTestSuite {
             WorkoutHeartRateZoneSyncContext.maximumHeartRateBPM(from: [:])
                 == nil,
             "missing Watch sync context leaves the current/default value unchanged"
+        )
+    }
+
+    private mutating func testHeartRateZoneDurationAccumulator() {
+        let firstSession = UUID(
+            uuidString: "72C8E2D9-3EC0-4C9A-A101-111111111111"
+        )!
+        let secondSession = UUID(
+            uuidString: "72C8E2D9-3EC0-4C9A-A101-222222222222"
+        )!
+        var accumulator = WorkoutHeartRateZoneDurationAccumulator()
+
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 10,
+                currentZone: 2
+            ) == 0,
+            "the first observed zone starts at zero without inventing history"
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 15,
+                currentZone: 2
+            ) == 5,
+            "workout elapsed time accumulates in the current zone"
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 20,
+                currentZone: 3
+            ) == 0,
+            "moving zones attributes the preceding interval to the old zone"
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 24,
+                currentZone: 3
+            ) == 4,
+            "the new zone begins accumulating on the next elapsed update"
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 24,
+                currentZone: 3
+            ) == 4,
+            "a paused workout does not advance time in zone"
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 27,
+                currentZone: 2
+            ) == 10,
+            "returning to a zone shows its cumulative workout time"
+        )
+
+        let authoritative = WorkoutZoneDurationsV1(
+            capturedAt: Date(timeIntervalSinceReferenceDate: 800_000_425),
+            secondsByZone: [1, 2, 3, 4, 5]
+        )
+        expect(
+            accumulator.update(
+                sessionID: firstSession,
+                elapsedTime: 30,
+                currentZone: 4,
+                authoritativeDurations: authoritative
+            ) == 4,
+            "authoritative Watch zone durations replace the local fallback"
+        )
+        expect(
+            accumulator.update(
+                sessionID: secondSession,
+                elapsedTime: 5,
+                currentZone: 1
+            ) == 0,
+            "a new workout session resets accumulated zone time"
+        )
+        expect(
+            accumulator.update(
+                sessionID: nil,
+                elapsedTime: nil,
+                currentZone: nil
+            ) == nil,
+            "clearing the session clears the displayed zone duration"
         )
     }
 
@@ -5383,6 +5473,12 @@ private struct WorkoutContractTestSuite {
             .appendingPathComponent(
                 "BikeComputer/BikeComputer/Views/NavigationDetailsView.swift"
             )
+        let heartRateZoneStripURL = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .appendingPathComponent(
+                "BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift"
+            )
         let summaryWatchViewURL = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
@@ -5406,6 +5502,10 @@ private struct WorkoutContractTestSuite {
                 contentsOf: navigationDetailsViewURL,
                 encoding: .utf8
               ),
+              let heartRateZoneStripSource = try? String(
+                contentsOf: heartRateZoneStripURL,
+                encoding: .utf8
+              ),
               let summaryWatchViewSource = try? String(
                 contentsOf: summaryWatchViewURL,
                 encoding: .utf8
@@ -5416,7 +5516,6 @@ private struct WorkoutContractTestSuite {
 
         for metricTitle in [
             "Heart Rate",
-            "Heart Zone",
             "Speed",
             "Distance",
             "Energy",
@@ -5468,9 +5567,10 @@ private struct WorkoutContractTestSuite {
             liveWatchViewSource.filter { !$0.isWhitespace }
         let compactNavigationDetailsViewSource =
             navigationDetailsViewSource.filter { !$0.isWhitespace }
+        let compactHeartRateZoneStripSource =
+            heartRateZoneStripSource.filter { !$0.isWhitespace }
         for metricBinding in [
-            "metric(\"HeartRate\",WorkoutValueFormatter.heartRate(snapshot.currentHeartRate?.value),\"BPM\"",
-            "metric(\"HeartZone\",zoneValue(snapshot),\"\"",
+            "metric(\"HeartRate\",WorkoutValueFormatter.heartRate(snapshot.currentHeartRate?.value),\"\",\"heart.fill\",.red,valueSymbol:\"heart.fill\",accessibilityUnit:\"beatsperminute\")",
             "metric(\"Speed\",WorkoutValueFormatter.speed(snapshot.currentSpeed?.value),\"KM/H\"",
             "metric(\"Distance\",WorkoutValueFormatter.distance(snapshot.cyclingDistance?.value),WorkoutValueFormatter.distanceUnit(snapshot.cyclingDistance?.value)",
             "metric(\"Energy\",WorkoutValueFormatter.energy(snapshot.activeEnergy?.value),\"KCAL\"",
@@ -5484,6 +5584,30 @@ private struct WorkoutContractTestSuite {
                 "each workout metric title must remain bound to its matching snapshot value"
             )
         }
+        expect(
+            compactSource.contains(
+                "HeartRateZoneStrip(currentZone:snapshot.currentHeartRateZone)"
+            )
+                && compactHeartRateZoneStripSource.contains(
+                    "ForEach(1...zoneCount,id:\\.self)"
+                )
+                && compactHeartRateZoneStripSource.contains(
+                    "Text(\"ZONE\\(zone)\")"
+                )
+                && compactHeartRateZoneStripSource.contains(
+                    "Image(systemName:\"heart.fill\")"
+                )
+                && compactHeartRateZoneStripSource.contains(
+                    "ifletnormalizedCurrentZone{GeometryReader"
+                )
+                && compactHeartRateZoneStripSource.contains(
+                    ".frame(width:isCurrent?activeWidth:inactiveWidth)"
+                )
+                && !compactHeartRateZoneStripSource.contains(
+                    "letequalWidth="
+                ),
+            "dashboard heart zones must stay hidden until a valid zone exists, then expand the active heart-labeled position"
+        )
         expect(
             compactSource.contains(
                 "Button(action:onMarkSegment){HStack(spacing:6){WorkoutSegmentNumberBadge(number:currentSegmentNumber,diameter:22)Text(\"Segment\")}}"
@@ -5502,6 +5626,15 @@ private struct WorkoutContractTestSuite {
                 )
                 && compactSource.contains(
                     "Button(\"DiscardWorkout\",role:.destructive){requestDiscardConfirmation(for:sessionID)}"
+                )
+                && compactSource.contains(
+                    ".background{finishPromptPresenter}"
+                )
+                && compactSource.contains(
+                    "privatevarfinishPromptPresenter:someView{Color.clear.tint(.accentColor).confirmationDialog("
+                )
+                && compactSource.contains(
+                    "Button(WorkoutDiscardDisclosureV1.cancelTitle,role:.cancel)"
                 )
                 && compactSource.contains(
                     "WorkoutDiscardDisclosureV1.perform(.confirmDiscard,expectedSessionID:sessionID,currentSessionID:store.presentation.sessionID,discard:onDiscard)"
@@ -5660,10 +5793,16 @@ private struct WorkoutContractTestSuite {
             .appendingPathComponent("BikeComputer/Views/RouteInputView.swift")
         let workoutURL = iosAppDirectory
             .appendingPathComponent("BikeComputer/Views/WorkoutViews.swift")
+        let heartRateZoneStripURL = iosAppDirectory
+            .appendingPathComponent("BikeComputer/Views/HeartRateZoneStrip.swift")
         guard let content = try? String(contentsOf: contentURL, encoding: .utf8),
               let navigation = try? String(contentsOf: navigationURL, encoding: .utf8),
               let route = try? String(contentsOf: routeURL, encoding: .utf8),
-              let workout = try? String(contentsOf: workoutURL, encoding: .utf8) else {
+              let workout = try? String(contentsOf: workoutURL, encoding: .utf8),
+              let heartRateZoneStrip = try? String(
+                contentsOf: heartRateZoneStripURL,
+                encoding: .utf8
+              ) else {
             expect(false, "main ride-control source files must be available")
             return
         }
@@ -5671,6 +5810,8 @@ private struct WorkoutContractTestSuite {
         let compactContent = content.filter { !$0.isWhitespace }
         let compactNavigation = navigation.filter { !$0.isWhitespace }
         let compactWorkout = workout.filter { !$0.isWhitespace }
+        let compactHeartRateZoneStrip =
+            heartRateZoneStrip.filter { !$0.isWhitespace }
         expect(
             route.contains("Search destination")
                 && !route.contains("Search for a destination"),
@@ -5772,10 +5913,28 @@ private struct WorkoutContractTestSuite {
                     "metrics.first(where:{$0.id==\"speed\"})"
                 )
                 && compactNavigation.contains(
-                    "isExpanded:true,isHero:true"
+                    "isExpanded:true,isHero:true,showsLabel:false"
                 )
                 && compactNavigation.contains(
-                    "metrics:metrics.filter{$0.id!=\"speed\"},columnCount:2,isExpanded:true"
+                    "metrics:expandedWorkoutMetricValues(from:metrics),columnCount:2,isExpanded:true"
+                )
+                && compactNavigation.contains(
+                    "ifletheartRate=metrics.first(where:{$0.id==\"heartrate\"}){expandedMetrics.append(heartRate)}"
+                )
+                && compactNavigation.contains(
+                    "WorkoutValueFormatter.duration(displayedHeartRateZoneElapsedTime),showsHeartInLabel:true,label:\"timeinzone\""
+                )
+                && compactNavigation.contains(
+                    "ifshowsHeartInLabel{HStack(spacing:4){Text(\"timein\")Image(systemName:\"heart.fill\").accessibilityHidden(true)Text(\"zone\")}}"
+                )
+                && compactNavigation.contains(
+                    "ifshowsLabel{metricLabel"
+                )
+                && compactNavigation.contains(
+                    "label:\"workouttime\""
+                )
+                && !compactNavigation.contains(
+                    "label:\"elapsed\""
                 )
                 && compactNavigation.contains(
                     "expandedNavigationMetrics"
@@ -5795,7 +5954,7 @@ private struct WorkoutContractTestSuite {
                 && compactNavigation.contains(
                     ".padding(.bottom,4)"
                 ),
-            "expanded ride stats must feature a larger centered speed above a two-column grid, keep measurement units secondary, use taller controls, and avoid excess space below them"
+            "expanded ride stats must hide the speed caption and place heart rate plus time in zone first below the zone strip"
         )
         expect(
             compactContent.contains(
@@ -5814,7 +5973,6 @@ private struct WorkoutContractTestSuite {
             "WorkoutValueFormatter.distance(snapshot.cyclingDistance?.value)",
             "altitudeValue(suppressInstantaneous?nil:snapshot.location?.altitude)",
             "WorkoutValueFormatter.heartRate(suppressInstantaneous?nil:snapshot.currentHeartRate?.value)",
-            "suppressInstantaneous?\"--\":heartRateZone(snapshot)",
             "WorkoutValueFormatter.energy(snapshot.activeEnergy?.value)",
         ] {
             expect(
@@ -5830,7 +5988,6 @@ private struct WorkoutContractTestSuite {
             "label:\"distance\"",
             "label:\"altitude\"",
             "label:\"heartrate\"",
-            "label:\"heartzone\"",
             "label:\"energy\"",
         ] {
             guard let range = compactNavigation.range(
@@ -5846,8 +6003,22 @@ private struct WorkoutContractTestSuite {
             previousMetricIndex = range.upperBound
         }
         expect(
-            compactNavigation.contains("return\"Zone\\(zone)\""),
-            "the main ride panel must render the zone as Zone N"
+            compactNavigation.contains(
+                "HeartRateZoneStrip(currentZone:displayedHeartRateZone)"
+            )
+                && compactNavigation.contains(
+                    "privatevardisplayedHeartRateZone:UInt8?{suppressInstantaneousMetrics?nil:workoutStore.presentation.snapshot.currentHeartRateZone}"
+                )
+                && compactHeartRateZoneStrip.contains(
+                    "Text(\"ZONE\\(zone)\")"
+                )
+                && compactNavigation.contains(
+                    "valueSymbol:\"heart.fill\",accessibilityUnit:\"beatsperminute\",label:\"heartrate\""
+                )
+                && compactWorkout.contains(
+                    "valueSymbol:\"heart.fill\",accessibilityUnit:\"beatsperminute\""
+                ),
+            "iPhone ride surfaces must move the active Zone N label between five colored positions and replace BPM with a red heart"
         )
         for control in [
             "\"Segment\"",

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -101,10 +101,12 @@ content is uploaded to a backend.
   are available.
 - **Discard Workout** requires a second confirmation and saves no workout or
   route.
-- The Watch persists only the minimum session identity and finalization state
-  needed to recover an interrupted active workout. A relaunched Watch app asks
-  HealthKit for the active session, reattaches its delegates and builder, and
-  reconciles an interrupted save or discard without creating a duplicate.
+- The Watch persists only the minimum recovery state needed for an interrupted
+  active workout: session identity, finalization state, and a derived five-zone
+  time checkpoint. A relaunched Watch app asks HealthKit for the active session,
+  reattaches its delegates and builder, restores cumulative time in zone, and
+  reconciles an interrupted save or discard without creating a duplicate. It
+  does not persist raw heart-rate samples.
 - Completed Health records can be reviewed or deleted in Apple's Health or
   Fitness apps.
 

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -31,6 +31,7 @@ xcrun swiftc \
   ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
@@ -46,6 +47,7 @@ xcrun swiftc \
   -default-isolation MainActor \
   -o "${CYCLING_SENSOR_OUT}" \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \

--- a/ios-app/scripts/run-workout-contract-tests.sh
+++ b/ios-app/scripts/run-workout-contract-tests.sh
@@ -22,6 +22,7 @@ xcrun swiftc \
   ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutWatchAvailability.swift \
   ios-app/BikeComputer/WorkoutShared/WatchWorkoutLaunchRequest.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift \
   ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift \
   ios-app/BikeComputerTests/WorkoutContractTests.swift
 


### PR DESCRIPTION
## Summary

- replace current-heart-rate BPM labels with a red heart across the iPhone workout UI and Live Activity
- add the ordered five-color zone strip, cumulative time-in-zone tile, workout-time wording, and requested finish-dialog styling
- make Watch-owned zone totals authoritative across transport coalescing and app recovery, with monotonic elapsed handling and bounded durable checkpoint writes
- add regression coverage for batching, recovery, failed persistence, and boundary oscillation

## User impact

The iPhone workout and navigation metrics now surface heart-rate intensity in the approved Apple Workout-inspired layout. Time in zone stays cumulative across pauses, reconnects, batched snapshots, and Watch process recovery, while destructive workout choices remain visually distinct.

## Root cause

The original iPhone-only zone accumulator could attribute coalesced snapshot gaps to a stale zone and lost state across process recovery. Current-heart-rate presentation was also inconsistent on compact and Live Activity surfaces.

## Validation

- `./ios-app/scripts/run-workout-contract-tests.sh`
- `./ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination "generic/platform=iOS" CODE_SIGNING_ALLOWED=NO build`
- four-pass deep review loop with P0/P1/P2 gate and a clean final confirming pass
- `git diff --check`
- connected-iPhone install was not rerun for the final review-fix commit because the iPhone was unavailable

## Contributor License Agreement

Choose the statement that applies:

- [ ] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: 

- [ ] I have the right to submit this contribution and have identified all third-party material and applicable license notices.