### PR TITLE
Add heart rate visuals to device Ride Stats

### DIFF
--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -11,6 +11,7 @@
 #include "../../route_overlay/route_overlay.hpp"
 #include "destinationPickerLayout.hpp"
 #include "guiLayout.hpp"
+#include "mapTileTransition.hpp"
 // #include "../../compass/compass.hpp"
 
 bool isMainScreen = false; // Flag to indicate main screen is selected
@@ -63,6 +64,7 @@ static lv_obj_t *mapGuidanceArrow;
 static lv_obj_t *mapGuidanceDistance;
 static lv_obj_t *mapGuidanceDestinationPicker;
 static lv_obj_t *mapGuidanceCycleStrip;
+static map_tile_transition::State mapTileTransition;
 static uint32_t mapGuidanceCatalogRevision = UINT32_MAX;
 static uint32_t mapGuidanceStatusRevision = UINT32_MAX;
 static bool mapGuidancePickerExpanded = true;
@@ -116,6 +118,7 @@ static void tapCycleScreenEvent(lv_event_t *event);
 static void mapGuidanceOverlayTapEvent(lv_event_t *event);
 static void updateMapGuidanceOverlay();
 static void refreshMapGuidanceOverlayAsync(void *userData);
+static void revealPendingMapTileIfReady();
 
 static int16_t mapInteractionAnchorX() {
   return gui_layout::mapScreenAnchorX(TFT_WIDTH, mapView.mapScrWidth);
@@ -875,6 +878,8 @@ void updateMap(lv_event_t *event) {
     mapView.displayMap();
     mapView.redrawMap = false; // Clear after display
   }
+
+  revealPendingMapTileIfReady();
 }
 
 /**
@@ -1347,24 +1352,33 @@ static void showMainTile(tileName tile) {
     return;
   }
 
-  lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_add_flag(batteryStatusTile, LV_OBJ_FLAG_HIDDEN);
+  const bool mapWasVisible = !lv_obj_has_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
 
   activeTile = tile;
   canScrollMap = tile == MAP;
   if (isMapBackedTile(activeTile)) {
+    // Keep the currently visible non-map tile in front until the new map
+    // profile has rendered into the back buffer. Revealing mapTile first can
+    // briefly expose its previous full-map frame while Map + Navigation is
+    // still rendering (or while the screen-cycle button remains pressed and
+    // interrupts that first render).
+    if (!mapWasVisible) {
+      lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
+    }
+    mapTileTransition.begin();
     zoom = currentMapStyleSettings().zoomLevel;
     mapView.isPosMoved = true;
+  } else {
+    mapTileTransition.cancel();
+    lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(batteryStatusTile, LV_OBJ_FLAG_HIDDEN);
   }
 
   switch (tile) {
   case MAP_GUIDANCE:
-    lv_obj_clear_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_move_foreground(mapGuidanceOverlay);
     mapView.followGps = true;
     applyMapRotationForActiveTile();
     mapGuidanceHadNavigationData = hasCurrentNavigationData();
@@ -1391,12 +1405,31 @@ static void showMainTile(tileName tile) {
     break;
   case MAP:
   default:
-    lv_obj_clear_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
     mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to map screen");
     break;
   }
+}
+
+static void revealPendingMapTileIfReady() {
+  if (!mapTileTransition.canReveal(mapView.isPosMoved, mapView.redrawMap)) {
+    return;
+  }
+
+  lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(batteryStatusTile, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
+
+  if (activeTile == MAP_GUIDANCE) {
+    lv_obj_clear_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_move_foreground(mapGuidanceOverlay);
+  } else {
+    lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
+  }
+
+  mapTileTransition.complete();
 }
 
 void showNextMainScreen() {

--- a/esp32/lib/gui/src/mapTileTransition.hpp
+++ b/esp32/lib/gui/src/mapTileTransition.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace map_tile_transition {
+
+struct State {
+  bool pending = false;
+
+  constexpr void begin() { pending = true; }
+  constexpr void cancel() { pending = false; }
+
+  constexpr bool canReveal(bool positionMoved, bool redrawPending) const {
+    return pending && !positionMoved && !redrawPending;
+  }
+
+  constexpr void complete() { pending = false; }
+};
+
+} // namespace map_tile_transition

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -63,6 +63,61 @@ struct ValueWithHeartLayout {
   int32_t gap = 0;
 };
 
+enum class MetricValueFontTier : uint8_t {
+  RegularCompact,
+  RegularLarge,
+};
+
+struct HeartRatePresentation {
+  bool showHeart = false;
+  MetricValueFontTier fontTier = MetricValueFontTier::RegularCompact;
+};
+
+constexpr HeartRatePresentation makeHeartRatePresentation(
+    int32_t screenWidth, bool heartRateAvailable) {
+  return {
+      heartRateAvailable,
+      useLargeMetricValueFont(screenWidth)
+          ? MetricValueFontTier::RegularLarge
+          : MetricValueFontTier::RegularCompact,
+  };
+}
+
+enum class ZoneUpdateAction : uint8_t {
+  None,
+  Hide,
+  Show,
+};
+
+struct ZoneUpdate {
+  ZoneUpdateAction action = ZoneUpdateAction::None;
+  int8_t zoneIndex = -1;
+};
+
+constexpr ZoneUpdate makeZoneUpdate(int8_t displayedZoneIndex,
+                                    int8_t nextZoneIndex) {
+  if (displayedZoneIndex == nextZoneIndex) {
+    return {ZoneUpdateAction::None, nextZoneIndex};
+  }
+  return {
+      nextZoneIndex < 0 ? ZoneUpdateAction::Hide : ZoneUpdateAction::Show,
+      nextZoneIndex,
+  };
+}
+
+constexpr uint32_t zoneColorHex(std::size_t index, bool active) {
+  constexpr std::array<uint32_t, kHeartRateZoneCount> activeColors = {
+      0x145C99, 0x0D7A70, 0xADF208, 0xE0730F, 0xB80852};
+  // Active colors composited at 62% opacity over the black background.
+  constexpr std::array<uint32_t, kHeartRateZoneCount> inactiveColors = {
+      0x0C395F, 0x084C45, 0x6B9605, 0x8B4709, 0x720533};
+  return active ? activeColors[index] : inactiveColors[index];
+}
+
+constexpr uint32_t zoneForegroundColorHex(std::size_t index) {
+  return index == 2 || index == 3 ? 0x000000 : 0xFFFFFF;
+}
+
 constexpr int32_t heartRateHeartSize(int32_t screenWidth) {
   return useLargeMetricValueFont(screenWidth) ? 30 : 24;
 }

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -71,17 +71,10 @@ enum class MetricValueFontTier : uint8_t {
 struct HeartRatePresentation {
   bool showHeart = false;
   MetricValueFontTier fontTier = MetricValueFontTier::RegularCompact;
+  Rect unavailableValue{};
+  int32_t maximumValueWidth = 0;
+  int32_t fontSelectionWidth = 0;
 };
-
-constexpr HeartRatePresentation makeHeartRatePresentation(
-    int32_t screenWidth, bool heartRateAvailable) {
-  return {
-      heartRateAvailable,
-      useLargeMetricValueFont(screenWidth)
-          ? MetricValueFontTier::RegularLarge
-          : MetricValueFontTier::RegularCompact,
-  };
-}
 
 enum class ZoneUpdateAction : uint8_t {
   None,
@@ -92,6 +85,20 @@ enum class ZoneUpdateAction : uint8_t {
 struct ZoneUpdate {
   ZoneUpdateAction action = ZoneUpdateAction::None;
   int8_t zoneIndex = -1;
+};
+
+struct ZonePresentation {
+  ZoneUpdate update{};
+  std::array<bool, kHeartRateZoneCount> segmentVisible{};
+  std::array<Rect, kHeartRateZoneCount> segments{};
+  std::array<uint32_t, kHeartRateZoneCount> segmentColors{};
+  bool heartVisible = false;
+  bool labelVisible = false;
+  Rect heart{};
+  Rect label{};
+  uint32_t foregroundColor = 0xFFFFFF;
+  uint8_t labelZoneNumber = 0;
+  std::array<char, 7> labelText{};
 };
 
 constexpr ZoneUpdate makeZoneUpdate(int8_t displayedZoneIndex,
@@ -124,6 +131,27 @@ constexpr int32_t heartRateHeartSize(int32_t screenWidth) {
 
 constexpr int32_t heartRateHeartGap(int32_t screenWidth) {
   return useLargeMetricValueFont(screenWidth) ? 8 : 6;
+}
+
+constexpr HeartRatePresentation makeHeartRatePresentation(
+    const Rect &metric, int32_t screenWidth, bool heartRateAvailable) {
+  HeartRatePresentation presentation{};
+  presentation.showHeart = heartRateAvailable;
+  presentation.fontTier =
+      useLargeMetricValueFont(screenWidth)
+          ? MetricValueFontTier::RegularLarge
+          : MetricValueFontTier::RegularCompact;
+  presentation.unavailableValue = {
+      metric.x,
+      metric.y + kMetricValueOffsetY,
+      metric.width,
+      metricValueLineHeight(screenWidth),
+  };
+  presentation.maximumValueWidth =
+      metric.width - heartRateHeartSize(screenWidth) -
+      heartRateHeartGap(screenWidth);
+  presentation.fontSelectionWidth = presentation.maximumValueWidth - 4;
+  return presentation;
 }
 
 constexpr ValueWithHeartLayout makeHeartRateValueLayout(
@@ -199,6 +227,36 @@ constexpr ZoneStripLayout makeZoneStripLayout(const Rect &metric,
       labelLineHeight,
   };
   return layout;
+}
+
+constexpr ZonePresentation makeZonePresentation(
+    const Rect &metric, int32_t screenWidth, int8_t displayedZoneIndex,
+    int8_t nextZoneIndex) {
+  ZonePresentation presentation{};
+  presentation.update = makeZoneUpdate(displayedZoneIndex, nextZoneIndex);
+  if (presentation.update.action != ZoneUpdateAction::Show) {
+    return presentation;
+  }
+
+  const std::size_t activeIndex =
+      static_cast<std::size_t>(presentation.update.zoneIndex);
+  const ZoneStripLayout strip =
+      makeZoneStripLayout(metric, screenWidth, activeIndex);
+  for (std::size_t index = 0; index < kHeartRateZoneCount; ++index) {
+    presentation.segmentVisible[index] = true;
+    presentation.segments[index] = strip.segments[index];
+    presentation.segmentColors[index] =
+        zoneColorHex(index, index == activeIndex);
+  }
+  presentation.heartVisible = true;
+  presentation.labelVisible = true;
+  presentation.heart = strip.heart;
+  presentation.label = strip.label;
+  presentation.foregroundColor = zoneForegroundColorHex(activeIndex);
+  presentation.labelZoneNumber = static_cast<uint8_t>(activeIndex + 1);
+  presentation.labelText = {'Z', 'O', 'N', 'E', ' ',
+                            static_cast<char>('1' + activeIndex), '\0'};
+  return presentation;
 }
 
 constexpr Layout makeLayout(int32_t width, int32_t height) {

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -23,6 +23,13 @@ constexpr int32_t metricValueLineHeight(int32_t screenWidth) {
   return useLargeMetricValueFont(screenWidth) ? 60 : 46;
 }
 
+constexpr std::size_t kHeartRateZoneCount = 5;
+constexpr int32_t kZoneStripGap = 4;
+
+constexpr int32_t zoneStripHeight(int32_t screenWidth) {
+  return useLargeMetricValueFont(screenWidth) ? 48 : 40;
+}
+
 struct Rect {
   int32_t x = 0;
   int32_t y = 0;
@@ -42,6 +49,61 @@ struct Layout {
   Rect heroUnit{};
   std::array<Rect, 6> metrics{};
 };
+
+struct ZoneStripLayout {
+  Rect bounds{};
+  std::array<Rect, kHeartRateZoneCount> segments{};
+  Rect heart{};
+  Rect label{};
+};
+
+constexpr ZoneStripLayout makeZoneStripLayout(const Rect &metric,
+                                               int32_t screenWidth,
+                                               std::size_t activeIndex) {
+  ZoneStripLayout layout{};
+  const int32_t height = zoneStripHeight(screenWidth);
+  layout.bounds = {
+      metric.x,
+      metric.y + kMetricValueOffsetY +
+          (metricValueLineHeight(screenWidth) - height) / 2,
+      metric.width,
+      height,
+  };
+
+  const int32_t availableWidth =
+      layout.bounds.width -
+      kZoneStripGap * static_cast<int32_t>(kHeartRateZoneCount - 1);
+  const int32_t inactiveWidth = availableWidth / 8;
+  const int32_t activeWidth =
+      availableWidth -
+      inactiveWidth * static_cast<int32_t>(kHeartRateZoneCount - 1);
+  int32_t x = layout.bounds.x;
+  for (std::size_t index = 0; index < kHeartRateZoneCount; ++index) {
+    const int32_t width = index == activeIndex ? activeWidth : inactiveWidth;
+    layout.segments[index] = {x, layout.bounds.y, width, height};
+    x += width + kZoneStripGap;
+  }
+
+  const Rect &active = layout.segments[activeIndex];
+  constexpr int32_t heartSize = 14;
+  constexpr int32_t contentPadding = 5;
+  constexpr int32_t heartLabelGap = 3;
+  constexpr int32_t labelLineHeight = 17;
+  layout.heart = {
+      active.x + contentPadding,
+      active.y + (active.height - heartSize) / 2,
+      heartSize,
+      heartSize,
+  };
+  layout.label = {
+      layout.heart.right() + heartLabelGap,
+      active.y + (active.height - labelLineHeight) / 2,
+      active.right() - contentPadding -
+          (layout.heart.right() + heartLabelGap),
+      labelLineHeight,
+  };
+  return layout;
+}
 
 constexpr Layout makeLayout(int32_t width, int32_t height) {
   constexpr int32_t columnGap = 12;

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -57,6 +57,47 @@ struct ZoneStripLayout {
   Rect label{};
 };
 
+struct ValueWithHeartLayout {
+  Rect value{};
+  Rect heart{};
+  int32_t gap = 0;
+};
+
+constexpr int32_t heartRateHeartSize(int32_t screenWidth) {
+  return useLargeMetricValueFont(screenWidth) ? 30 : 24;
+}
+
+constexpr int32_t heartRateHeartGap(int32_t screenWidth) {
+  return useLargeMetricValueFont(screenWidth) ? 8 : 6;
+}
+
+constexpr ValueWithHeartLayout makeHeartRateValueLayout(
+    const Rect &metric, int32_t screenWidth, int32_t requestedTextWidth) {
+  const int32_t heartSize = heartRateHeartSize(screenWidth);
+  const int32_t gap = heartRateHeartGap(screenWidth);
+  const int32_t maximumTextWidth = metric.width - gap - heartSize;
+  const int32_t textWidth = requestedTextWidth < 0
+                                ? 0
+                                : (requestedTextWidth > maximumTextWidth
+                                       ? maximumTextWidth
+                                       : requestedTextWidth);
+  const int32_t groupWidth = textWidth + gap + heartSize;
+  const int32_t valueY = metric.y + kMetricValueOffsetY;
+  const int32_t valueHeight = metricValueLineHeight(screenWidth);
+  const int32_t groupX = metric.x + (metric.width - groupWidth) / 2;
+
+  ValueWithHeartLayout layout{};
+  layout.value = {groupX, valueY, textWidth, valueHeight};
+  layout.heart = {
+      layout.value.right() + gap,
+      valueY + (valueHeight - heartSize) / 2,
+      heartSize,
+      heartSize,
+  };
+  layout.gap = gap;
+  return layout;
+}
+
 constexpr ZoneStripLayout makeZoneStripLayout(const Rect &metric,
                                                int32_t screenWidth,
                                                std::size_t activeIndex) {

--- a/esp32/lib/gui/src/rideTelemetryPresenter.hpp
+++ b/esp32/lib/gui/src/rideTelemetryPresenter.hpp
@@ -172,16 +172,15 @@ inline void formatElapsed(
   }
 }
 
-inline void formatZone(const ViewModel &model, char *buffer,
-                       std::size_t size) {
+inline int8_t fiveZoneIndex(const ViewModel &model) {
   if (!model.currentHeartRateZone.available ||
-      !model.heartRateZoneCount.available) {
-    unavailable(buffer, size);
-    return;
+      !model.heartRateZoneCount.available ||
+      model.heartRateZoneCount.value != 5 ||
+      model.currentHeartRateZone.value < 1 ||
+      model.currentHeartRateZone.value > 5) {
+    return -1;
   }
-  std::snprintf(buffer, size, "Z%u/%u",
-                static_cast<unsigned>(model.currentHeartRateZone.value),
-                static_cast<unsigned>(model.heartRateZoneCount.value));
+  return static_cast<int8_t>(model.currentHeartRateZone.value - 1);
 }
 
 inline void formatEnergy(const ViewModel &model, char *buffer,

--- a/esp32/lib/gui/src/rideTelemetryPresenter.hpp
+++ b/esp32/lib/gui/src/rideTelemetryPresenter.hpp
@@ -183,12 +183,6 @@ inline int8_t fiveZoneIndex(const ViewModel &model) {
   return static_cast<int8_t>(model.currentHeartRateZone.value - 1);
 }
 
-inline void formatFiveZoneLabel(uint8_t zeroBasedZoneIndex, char *buffer,
-                                std::size_t size) {
-  std::snprintf(buffer, size, "ZONE %u",
-                static_cast<unsigned>(zeroBasedZoneIndex + 1));
-}
-
 inline void formatEnergy(const ViewModel &model, char *buffer,
                          std::size_t size) {
   if (!model.activeEnergyTenthsKilocalorie.available) {

--- a/esp32/lib/gui/src/rideTelemetryPresenter.hpp
+++ b/esp32/lib/gui/src/rideTelemetryPresenter.hpp
@@ -183,6 +183,12 @@ inline int8_t fiveZoneIndex(const ViewModel &model) {
   return static_cast<int8_t>(model.currentHeartRateZone.value - 1);
 }
 
+inline void formatFiveZoneLabel(uint8_t zeroBasedZoneIndex, char *buffer,
+                                std::size_t size) {
+  std::snprintf(buffer, size, "ZONE %u",
+                static_cast<unsigned>(zeroBasedZoneIndex + 1));
+}
+
 inline void formatEnergy(const ViewModel &model, char *buffer,
                          std::size_t size) {
   if (!model.activeEnergyTenthsKilocalorie.available) {

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -179,15 +179,6 @@ MetricLabels createMetric(lv_obj_t *page, const char *title,
   return labels;
 }
 
-lv_color_t zoneColor(std::size_t index, bool active) {
-  return lv_color_hex(ride_telemetry_layout::zoneColorHex(index, active));
-}
-
-lv_color_t zoneForegroundColor(std::size_t index) {
-  return lv_color_hex(
-      ride_telemetry_layout::zoneForegroundColorHex(index));
-}
-
 void drawHeartIcon(lv_event_t *event) {
   if (lv_event_get_code(event) != LV_EVENT_DRAW_POST_END) {
     return;
@@ -264,16 +255,18 @@ void createZoneMetric(lv_obj_t *page,
 }
 
 void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
-  const ride_telemetry_layout::ZoneUpdate update =
-      ride_telemetry_layout::makeZoneUpdate(
-          displayedZoneIndex,
+  const ride_telemetry_layout::ZonePresentation presentation =
+      ride_telemetry_layout::makeZonePresentation(
+          rideLayout.metrics[1], rideLayout.screenWidth, displayedZoneIndex,
           ride_telemetry_presenter::fiveZoneIndex(model));
-  if (update.action == ride_telemetry_layout::ZoneUpdateAction::None) {
+  if (presentation.update.action ==
+      ride_telemetry_layout::ZoneUpdateAction::None) {
     return;
   }
-  displayedZoneIndex = update.zoneIndex;
+  displayedZoneIndex = presentation.update.zoneIndex;
 
-  if (update.action == ride_telemetry_layout::ZoneUpdateAction::Hide) {
+  if (presentation.update.action ==
+      ride_telemetry_layout::ZoneUpdateAction::Hide) {
     for (lv_obj_t *segment : rideZoneSegments) {
       lv_obj_add_flag(segment, LV_OBJ_FLAG_HIDDEN);
     }
@@ -282,36 +275,40 @@ void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
     return;
   }
 
-  const std::size_t activeIndex =
-      static_cast<std::size_t>(update.zoneIndex);
-  const ride_telemetry_layout::ZoneStripLayout layout =
-      ride_telemetry_layout::makeZoneStripLayout(rideLayout.metrics[1],
-                                                 rideLayout.screenWidth,
-                                                 activeIndex);
   for (std::size_t index = 0; index < rideZoneSegments.size(); ++index) {
-    const ride_telemetry_layout::Rect &segmentRect = layout.segments[index];
+    const ride_telemetry_layout::Rect &segmentRect =
+        presentation.segments[index];
     lv_obj_set_pos(rideZoneSegments[index], segmentRect.x, segmentRect.y);
     lv_obj_set_size(rideZoneSegments[index], segmentRect.width,
                     segmentRect.height);
-    lv_obj_set_style_bg_color(rideZoneSegments[index],
-                              zoneColor(index, index == activeIndex), 0);
-    lv_obj_clear_flag(rideZoneSegments[index], LV_OBJ_FLAG_HIDDEN);
+    lv_obj_set_style_bg_color(
+        rideZoneSegments[index],
+        lv_color_hex(presentation.segmentColors[index]), 0);
+    if (presentation.segmentVisible[index]) {
+      lv_obj_clear_flag(rideZoneSegments[index], LV_OBJ_FLAG_HIDDEN);
+    }
   }
 
-  const lv_color_t foreground = zoneForegroundColor(activeIndex);
-  lv_obj_set_pos(rideZoneHeart, layout.heart.x, layout.heart.y);
-  lv_obj_set_size(rideZoneHeart, layout.heart.width, layout.heart.height);
+  const lv_color_t foreground =
+      lv_color_hex(presentation.foregroundColor);
+  lv_obj_set_pos(rideZoneHeart, presentation.heart.x,
+                 presentation.heart.y);
+  lv_obj_set_size(rideZoneHeart, presentation.heart.width,
+                  presentation.heart.height);
   lv_obj_set_style_text_color(rideZoneHeart, foreground, 0);
-  lv_obj_clear_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+  if (presentation.heartVisible) {
+    lv_obj_clear_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+  }
 
-  lv_obj_set_pos(rideZoneLabel, layout.label.x, layout.label.y);
-  lv_obj_set_size(rideZoneLabel, layout.label.width, layout.label.height);
+  lv_obj_set_pos(rideZoneLabel, presentation.label.x,
+                 presentation.label.y);
+  lv_obj_set_size(rideZoneLabel, presentation.label.width,
+                  presentation.label.height);
   lv_obj_set_style_text_color(rideZoneLabel, foreground, 0);
-  char label[8];
-  ride_telemetry_presenter::formatFiveZoneLabel(
-      static_cast<uint8_t>(activeIndex), label, sizeof(label));
-  setLabelIfChanged(rideZoneLabel, label);
-  lv_obj_clear_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
+  setLabelIfChanged(rideZoneLabel, presentation.labelText.data());
+  if (presentation.labelVisible) {
+    lv_obj_clear_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
+  }
 }
 
 void updateHeartRateMetric(
@@ -322,29 +319,27 @@ void updateHeartRateMetric(
                                           sizeof(value));
   const ride_telemetry_layout::HeartRatePresentation presentation =
       ride_telemetry_layout::makeHeartRatePresentation(
-          rideLayout.screenWidth, model.currentHeartRateBpm.available);
+          metric, rideLayout.screenWidth,
+          model.currentHeartRateBpm.available);
 
   if (!presentation.showHeart) {
-    lv_obj_set_pos(rideHeartRateValue, metric.x,
-                   metric.y + ride_telemetry_layout::kMetricValueOffsetY);
-    lv_obj_set_width(rideHeartRateValue, metric.width);
+    lv_obj_set_pos(rideHeartRateValue, presentation.unavailableValue.x,
+                   presentation.unavailableValue.y);
+    lv_obj_set_width(rideHeartRateValue,
+                     presentation.unavailableValue.width);
     lv_obj_set_style_text_align(rideHeartRateValue, LV_TEXT_ALIGN_CENTER, 0);
     setMetricValueIfChanged(rideHeartRateValue, value);
     lv_obj_add_flag(rideHeartRateHeart, LV_OBJ_FLAG_HIDDEN);
     return;
   }
 
-  const int32_t maximumValueWidth =
-      metric.width -
-      ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
-      ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth);
-  lv_obj_set_width(rideHeartRateValue, maximumValueWidth);
+  lv_obj_set_width(rideHeartRateValue, presentation.maximumValueWidth);
   // Select against the stable maximum width, not the tightly measured label
   // width from the previous refresh. Ordinary heart rates therefore keep the
   // normal metric size, while anomalous protocol-valid values still shrink
   // enough to remain fully visible beside the heart.
   const lv_font_t *font = metricValueFontForWidth(
-      value, maximumValueWidth - 4,
+      value, presentation.fontSelectionWidth,
       presentation.fontTier ==
           ride_telemetry_layout::MetricValueFontTier::RegularLarge);
   if (lv_obj_get_style_text_font(rideHeartRateValue, LV_PART_MAIN) != font) {

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -30,6 +30,7 @@ lv_obj_t *ridePage = nullptr;
 lv_obj_t *rideStatus = nullptr;
 lv_obj_t *rideSpeedValue = nullptr;
 lv_obj_t *rideHeartRateValue = nullptr;
+lv_obj_t *rideHeartRateHeart = nullptr;
 lv_obj_t *rideDistanceValue = nullptr;
 lv_obj_t *rideElapsedValue = nullptr;
 std::array<lv_obj_t *, ride_telemetry_layout::kHeartRateZoneCount>
@@ -196,6 +197,11 @@ void drawHeartIcon(lv_event_t *event) {
   lv_layer_t *layer = lv_event_get_layer(event);
   lv_area_t coordinates{};
   lv_obj_get_coords(heart, &coordinates);
+  const int32_t width = lv_area_get_width(&coordinates);
+  const int32_t height = lv_area_get_height(&coordinates);
+  const int32_t lobeEnd = width / 2;
+  const int32_t rightLobeStart = lobeEnd - 1;
+  const int32_t triangleTop = height * 2 / 7;
 
   lv_draw_rect_dsc_t circle{};
   lv_draw_rect_dsc_init(&circle);
@@ -204,9 +210,10 @@ void drawHeartIcon(lv_event_t *event) {
   circle.radius = LV_RADIUS_CIRCLE;
 
   lv_area_t leftCircle = {coordinates.x1, coordinates.y1,
-                          coordinates.x1 + 7, coordinates.y1 + 7};
-  lv_area_t rightCircle = {coordinates.x1 + 6, coordinates.y1,
-                           coordinates.x1 + 13, coordinates.y1 + 7};
+                          coordinates.x1 + lobeEnd,
+                          coordinates.y1 + lobeEnd};
+  lv_area_t rightCircle = {coordinates.x1 + rightLobeStart, coordinates.y1,
+                           coordinates.x2, coordinates.y1 + lobeEnd};
   lv_draw_rect(layer, &circle, &leftCircle);
   lv_draw_rect(layer, &circle, &rightCircle);
 
@@ -214,10 +221,21 @@ void drawHeartIcon(lv_event_t *event) {
   lv_draw_triangle_dsc_init(&triangle);
   triangle.bg_color = circle.bg_color;
   triangle.bg_opa = LV_OPA_COVER;
-  triangle.p[0] = {coordinates.x1, coordinates.y1 + 4};
-  triangle.p[1] = {coordinates.x1 + 13, coordinates.y1 + 4};
-  triangle.p[2] = {coordinates.x1 + 6, coordinates.y1 + 13};
+  triangle.p[0] = {coordinates.x1, coordinates.y1 + triangleTop};
+  triangle.p[1] = {coordinates.x2, coordinates.y1 + triangleTop};
+  triangle.p[2] = {coordinates.x1 + width / 2, coordinates.y2};
   lv_draw_triangle(layer, &triangle);
+}
+
+lv_obj_t *createHeartIcon(lv_obj_t *page) {
+  lv_obj_t *heart = lv_obj_create(page);
+  lv_obj_remove_style_all(heart);
+  lv_obj_add_event_cb(heart, drawHeartIcon, LV_EVENT_DRAW_POST_END, nullptr);
+  lv_obj_clear_flag(
+      heart, static_cast<lv_obj_flag_t>(LV_OBJ_FLAG_SCROLLABLE |
+                                        LV_OBJ_FLAG_CLICKABLE));
+  lv_obj_add_flag(heart, LV_OBJ_FLAG_HIDDEN);
+  return heart;
 }
 
 void createZoneMetric(lv_obj_t *page,
@@ -236,14 +254,7 @@ void createZoneMetric(lv_obj_t *page,
     lv_obj_add_flag(segment, LV_OBJ_FLAG_HIDDEN);
   }
 
-  rideZoneHeart = lv_obj_create(page);
-  lv_obj_remove_style_all(rideZoneHeart);
-  lv_obj_add_event_cb(rideZoneHeart, drawHeartIcon,
-                      LV_EVENT_DRAW_POST_END, nullptr);
-  lv_obj_clear_flag(
-      rideZoneHeart, static_cast<lv_obj_flag_t>(LV_OBJ_FLAG_SCROLLABLE |
-                                                LV_OBJ_FLAG_CLICKABLE));
-  lv_obj_add_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+  rideZoneHeart = createHeartIcon(page);
 
   rideZoneLabel = lv_label_create(page);
   lv_obj_set_style_text_font(rideZoneLabel, &lv_font_montserrat_14, 0);
@@ -297,6 +308,48 @@ void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
                 static_cast<unsigned>(activeIndex + 1));
   setLabelIfChanged(rideZoneLabel, label);
   lv_obj_clear_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
+}
+
+void updateHeartRateMetric(
+    const ride_telemetry_presenter::ViewModel &model) {
+  const ride_telemetry_layout::Rect &metric = rideLayout.metrics[0];
+  char value[24];
+  ride_telemetry_presenter::formatInteger(model.currentHeartRateBpm, value,
+                                          sizeof(value));
+
+  if (!model.currentHeartRateBpm.available) {
+    lv_obj_set_pos(rideHeartRateValue, metric.x,
+                   metric.y + ride_telemetry_layout::kMetricValueOffsetY);
+    lv_obj_set_width(rideHeartRateValue, metric.width);
+    lv_obj_set_style_text_align(rideHeartRateValue, LV_TEXT_ALIGN_CENTER, 0);
+    setMetricValueIfChanged(rideHeartRateValue, value);
+    lv_obj_add_flag(rideHeartRateHeart, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  const int32_t maximumValueWidth =
+      metric.width -
+      ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
+      ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth);
+  lv_obj_set_width(rideHeartRateValue, maximumValueWidth);
+  setMetricValueIfChanged(rideHeartRateValue, value);
+  const lv_font_t *font =
+      lv_obj_get_style_text_font(rideHeartRateValue, LV_PART_MAIN);
+  const int32_t textWidth = lv_text_get_width(
+      value, static_cast<uint32_t>(std::strlen(value)), font, 0);
+  const ride_telemetry_layout::ValueWithHeartLayout layout =
+      ride_telemetry_layout::makeHeartRateValueLayout(
+          metric, rideLayout.screenWidth, textWidth);
+
+  lv_obj_set_pos(rideHeartRateValue, layout.value.x, layout.value.y);
+  lv_obj_set_width(rideHeartRateValue, layout.value.width);
+  lv_obj_set_style_text_align(rideHeartRateValue, LV_TEXT_ALIGN_LEFT, 0);
+
+  lv_obj_set_pos(rideHeartRateHeart, layout.heart.x, layout.heart.y);
+  lv_obj_set_size(rideHeartRateHeart, layout.heart.width,
+                  layout.heart.height);
+  lv_obj_set_style_text_color(rideHeartRateHeart, lv_color_hex(0xFF3B30), 0);
+  lv_obj_clear_flag(rideHeartRateHeart, LV_OBJ_FLAG_HIDDEN);
 }
 
 ride_telemetry_presenter::ViewModel currentViewModel() {
@@ -377,7 +430,8 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_label_set_text_static(speedUnit, "km/h");
 
   rideHeartRateValue =
-      createMetric(ridePage, "Heart bpm", rideLayout.metrics[0]).value;
+      createMetric(ridePage, "Heart rate", rideLayout.metrics[0]).value;
+  rideHeartRateHeart = createHeartIcon(ridePage);
   createZoneMetric(ridePage, rideLayout.metrics[1]);
   rideDistanceValue =
       createMetric(ridePage, "Distance", rideLayout.metrics[2]).value;
@@ -398,9 +452,7 @@ void updateRideTelemetryEvent(lv_event_t *) {
   char value[24];
   ride_telemetry_presenter::formatSpeed(model, value, sizeof(value));
   setLabelIfChanged(rideSpeedValue, value);
-  ride_telemetry_presenter::formatInteger(model.currentHeartRateBpm, value,
-                                          sizeof(value));
-  setMetricValueIfChanged(rideHeartRateValue, value);
+  updateHeartRateMetric(model);
   updateZoneMetric(model);
   ride_telemetry_presenter::formatDistance(model.distanceMeters, value,
                                            sizeof(value));

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -30,9 +30,13 @@ lv_obj_t *ridePage = nullptr;
 lv_obj_t *rideStatus = nullptr;
 lv_obj_t *rideSpeedValue = nullptr;
 lv_obj_t *rideHeartRateValue = nullptr;
-lv_obj_t *rideZoneValue = nullptr;
 lv_obj_t *rideDistanceValue = nullptr;
 lv_obj_t *rideElapsedValue = nullptr;
+std::array<lv_obj_t *, ride_telemetry_layout::kHeartRateZoneCount>
+    rideZoneSegments{};
+lv_obj_t *rideZoneHeart = nullptr;
+lv_obj_t *rideZoneLabel = nullptr;
+int8_t displayedZoneIndex = -2;
 MetricLabels rideBottomLeft{};
 MetricLabels rideBottomRight{};
 ride_telemetry_layout::Layout rideLayout{};
@@ -138,16 +142,22 @@ lv_obj_t *createHeader(lv_obj_t *page) {
   return status;
 }
 
+lv_obj_t *createMetricTitle(lv_obj_t *page, const char *title,
+                            const ride_telemetry_layout::Rect &rect) {
+  lv_obj_t *label = lv_label_create(page);
+  lv_obj_set_width(label, rect.width);
+  lv_obj_set_pos(label, rect.x, rect.y);
+  lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
+  lv_obj_set_style_text_color(label, lv_color_hex(0x999999), 0);
+  lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_text(label, title);
+  return label;
+}
+
 MetricLabels createMetric(lv_obj_t *page, const char *title,
                           const ride_telemetry_layout::Rect &rect) {
   MetricLabels labels{};
-  labels.title = lv_label_create(page);
-  lv_obj_set_width(labels.title, rect.width);
-  lv_obj_set_pos(labels.title, rect.x, rect.y);
-  lv_obj_set_style_text_font(labels.title, &lv_font_montserrat_18, 0);
-  lv_obj_set_style_text_color(labels.title, lv_color_hex(0x999999), 0);
-  lv_obj_set_style_text_align(labels.title, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_text(labels.title, title);
+  labels.title = createMetricTitle(page, title, rect);
 
   labels.value = lv_label_create(page);
   lv_obj_set_width(labels.value, rect.width);
@@ -159,6 +169,134 @@ MetricLabels createMetric(lv_obj_t *page, const char *title,
   lv_label_set_long_mode(labels.value, LV_LABEL_LONG_CLIP);
   setMetricValueIfChanged(labels.value, "--");
   return labels;
+}
+
+lv_color_t zoneColor(std::size_t index, bool active) {
+  // Matches HeartRateZonePalette in the iPhone app. Inactive values are the
+  // same colors composited at 62% opacity over the black screen background.
+  constexpr std::array<uint32_t,
+                       ride_telemetry_layout::kHeartRateZoneCount>
+      activeColors = {0x145C99, 0x0D7A70, 0xADF208, 0xE0730F, 0xB80852};
+  constexpr std::array<uint32_t,
+                       ride_telemetry_layout::kHeartRateZoneCount>
+      inactiveColors = {0x0C395F, 0x084C45, 0x6B9605, 0x8B4709, 0x720533};
+  return lv_color_hex(active ? activeColors[index] : inactiveColors[index]);
+}
+
+lv_color_t zoneForegroundColor(std::size_t index) {
+  return index == 2 || index == 3 ? lv_color_black() : lv_color_white();
+}
+
+void drawHeartIcon(lv_event_t *event) {
+  if (lv_event_get_code(event) != LV_EVENT_DRAW_POST_END) {
+    return;
+  }
+
+  lv_obj_t *heart = static_cast<lv_obj_t *>(lv_event_get_target(event));
+  lv_layer_t *layer = lv_event_get_layer(event);
+  lv_area_t coordinates{};
+  lv_obj_get_coords(heart, &coordinates);
+
+  lv_draw_rect_dsc_t circle{};
+  lv_draw_rect_dsc_init(&circle);
+  circle.bg_color = lv_obj_get_style_text_color(heart, LV_PART_MAIN);
+  circle.bg_opa = LV_OPA_COVER;
+  circle.radius = LV_RADIUS_CIRCLE;
+
+  lv_area_t leftCircle = {coordinates.x1, coordinates.y1,
+                          coordinates.x1 + 7, coordinates.y1 + 7};
+  lv_area_t rightCircle = {coordinates.x1 + 6, coordinates.y1,
+                           coordinates.x1 + 13, coordinates.y1 + 7};
+  lv_draw_rect(layer, &circle, &leftCircle);
+  lv_draw_rect(layer, &circle, &rightCircle);
+
+  lv_draw_triangle_dsc_t triangle{};
+  lv_draw_triangle_dsc_init(&triangle);
+  triangle.bg_color = circle.bg_color;
+  triangle.bg_opa = LV_OPA_COVER;
+  triangle.p[0] = {coordinates.x1, coordinates.y1 + 4};
+  triangle.p[1] = {coordinates.x1 + 13, coordinates.y1 + 4};
+  triangle.p[2] = {coordinates.x1 + 6, coordinates.y1 + 13};
+  lv_draw_triangle(layer, &triangle);
+}
+
+void createZoneMetric(lv_obj_t *page,
+                      const ride_telemetry_layout::Rect &rect) {
+  displayedZoneIndex = -2;
+  createMetricTitle(page, "HR zone", rect);
+
+  for (lv_obj_t *&segment : rideZoneSegments) {
+    segment = lv_obj_create(page);
+    lv_obj_remove_style_all(segment);
+    lv_obj_set_style_radius(segment, 10, 0);
+    lv_obj_set_style_bg_opa(segment, LV_OPA_COVER, 0);
+    lv_obj_clear_flag(
+        segment, static_cast<lv_obj_flag_t>(LV_OBJ_FLAG_SCROLLABLE |
+                                            LV_OBJ_FLAG_CLICKABLE));
+    lv_obj_add_flag(segment, LV_OBJ_FLAG_HIDDEN);
+  }
+
+  rideZoneHeart = lv_obj_create(page);
+  lv_obj_remove_style_all(rideZoneHeart);
+  lv_obj_add_event_cb(rideZoneHeart, drawHeartIcon,
+                      LV_EVENT_DRAW_POST_END, nullptr);
+  lv_obj_clear_flag(
+      rideZoneHeart, static_cast<lv_obj_flag_t>(LV_OBJ_FLAG_SCROLLABLE |
+                                                LV_OBJ_FLAG_CLICKABLE));
+  lv_obj_add_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+
+  rideZoneLabel = lv_label_create(page);
+  lv_obj_set_style_text_font(rideZoneLabel, &lv_font_montserrat_14, 0);
+  lv_obj_set_style_text_align(rideZoneLabel, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_long_mode(rideZoneLabel, LV_LABEL_LONG_CLIP);
+  lv_obj_add_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
+}
+
+void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
+  const int8_t zoneIndex = ride_telemetry_presenter::fiveZoneIndex(model);
+  if (zoneIndex == displayedZoneIndex) {
+    return;
+  }
+  displayedZoneIndex = zoneIndex;
+
+  if (zoneIndex < 0) {
+    for (lv_obj_t *segment : rideZoneSegments) {
+      lv_obj_add_flag(segment, LV_OBJ_FLAG_HIDDEN);
+    }
+    lv_obj_add_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  const std::size_t activeIndex = static_cast<std::size_t>(zoneIndex);
+  const ride_telemetry_layout::ZoneStripLayout layout =
+      ride_telemetry_layout::makeZoneStripLayout(rideLayout.metrics[1],
+                                                 rideLayout.screenWidth,
+                                                 activeIndex);
+  for (std::size_t index = 0; index < rideZoneSegments.size(); ++index) {
+    const ride_telemetry_layout::Rect &segmentRect = layout.segments[index];
+    lv_obj_set_pos(rideZoneSegments[index], segmentRect.x, segmentRect.y);
+    lv_obj_set_size(rideZoneSegments[index], segmentRect.width,
+                    segmentRect.height);
+    lv_obj_set_style_bg_color(rideZoneSegments[index],
+                              zoneColor(index, index == activeIndex), 0);
+    lv_obj_clear_flag(rideZoneSegments[index], LV_OBJ_FLAG_HIDDEN);
+  }
+
+  const lv_color_t foreground = zoneForegroundColor(activeIndex);
+  lv_obj_set_pos(rideZoneHeart, layout.heart.x, layout.heart.y);
+  lv_obj_set_size(rideZoneHeart, layout.heart.width, layout.heart.height);
+  lv_obj_set_style_text_color(rideZoneHeart, foreground, 0);
+  lv_obj_clear_flag(rideZoneHeart, LV_OBJ_FLAG_HIDDEN);
+
+  lv_obj_set_pos(rideZoneLabel, layout.label.x, layout.label.y);
+  lv_obj_set_size(rideZoneLabel, layout.label.width, layout.label.height);
+  lv_obj_set_style_text_color(rideZoneLabel, foreground, 0);
+  char label[8];
+  std::snprintf(label, sizeof(label), "ZONE %u",
+                static_cast<unsigned>(activeIndex + 1));
+  setLabelIfChanged(rideZoneLabel, label);
+  lv_obj_clear_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
 }
 
 ride_telemetry_presenter::ViewModel currentViewModel() {
@@ -240,8 +378,7 @@ void rideTelemetryScr(_lv_obj_t *screen) {
 
   rideHeartRateValue =
       createMetric(ridePage, "Heart bpm", rideLayout.metrics[0]).value;
-  rideZoneValue =
-      createMetric(ridePage, "HR zone", rideLayout.metrics[1]).value;
+  createZoneMetric(ridePage, rideLayout.metrics[1]);
   rideDistanceValue =
       createMetric(ridePage, "Distance", rideLayout.metrics[2]).value;
   rideElapsedValue =
@@ -264,8 +401,7 @@ void updateRideTelemetryEvent(lv_event_t *) {
   ride_telemetry_presenter::formatInteger(model.currentHeartRateBpm, value,
                                           sizeof(value));
   setMetricValueIfChanged(rideHeartRateValue, value);
-  ride_telemetry_presenter::formatZone(model, value, sizeof(value));
-  setMetricValueIfChanged(rideZoneValue, value);
+  updateZoneMetric(model);
   ride_telemetry_presenter::formatDistance(model.distanceMeters, value,
                                            sizeof(value));
   setMetricValueIfChanged(rideDistanceValue, value);

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -73,12 +73,12 @@ const lv_font_t *firstFittingFont(
   return selected < N ? fonts[selected] : fonts[N - 1];
 }
 
-const lv_font_t *metricValueFont(lv_obj_t *label, const char *text) {
-  const int32_t availableWidth = lv_obj_get_width(label) - 4;
+const lv_font_t *metricValueFontForWidth(const char *text,
+                                         int32_t availableWidth,
+                                         bool useLargeFont) {
   const uint32_t textLength = static_cast<uint32_t>(std::strlen(text));
 
-  if (ride_telemetry_layout::useLargeMetricValueFont(
-          rideLayout.screenWidth)) {
+  if (useLargeFont) {
     constexpr std::size_t fontCount = 7;
     const std::array<const lv_font_t *, fontCount> fonts = {
         &ride_value_font_64,     &ride_value_font_56,
@@ -99,12 +99,11 @@ const lv_font_t *metricValueFont(lv_obj_t *label, const char *text) {
   return firstFittingFont(fonts, text, textLength, availableWidth);
 }
 
-const lv_font_t *preferredMetricValueFont() {
-  if (ride_telemetry_layout::useLargeMetricValueFont(
-          rideLayout.screenWidth)) {
-    return &ride_value_font_64;
-  }
-  return &lv_font_montserrat_42;
+const lv_font_t *metricValueFont(lv_obj_t *label, const char *text) {
+  return metricValueFontForWidth(
+      text, lv_obj_get_width(label) - 4,
+      ride_telemetry_layout::useLargeMetricValueFont(
+          rideLayout.screenWidth));
 }
 
 void setLabelIfChanged(lv_obj_t *label, const char *text) {
@@ -181,19 +180,12 @@ MetricLabels createMetric(lv_obj_t *page, const char *title,
 }
 
 lv_color_t zoneColor(std::size_t index, bool active) {
-  // Matches HeartRateZonePalette in the iPhone app. Inactive values are the
-  // same colors composited at 62% opacity over the black screen background.
-  constexpr std::array<uint32_t,
-                       ride_telemetry_layout::kHeartRateZoneCount>
-      activeColors = {0x145C99, 0x0D7A70, 0xADF208, 0xE0730F, 0xB80852};
-  constexpr std::array<uint32_t,
-                       ride_telemetry_layout::kHeartRateZoneCount>
-      inactiveColors = {0x0C395F, 0x084C45, 0x6B9605, 0x8B4709, 0x720533};
-  return lv_color_hex(active ? activeColors[index] : inactiveColors[index]);
+  return lv_color_hex(ride_telemetry_layout::zoneColorHex(index, active));
 }
 
 lv_color_t zoneForegroundColor(std::size_t index) {
-  return index == 2 || index == 3 ? lv_color_black() : lv_color_white();
+  return lv_color_hex(
+      ride_telemetry_layout::zoneForegroundColorHex(index));
 }
 
 void drawHeartIcon(lv_event_t *event) {
@@ -272,13 +264,16 @@ void createZoneMetric(lv_obj_t *page,
 }
 
 void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
-  const int8_t zoneIndex = ride_telemetry_presenter::fiveZoneIndex(model);
-  if (zoneIndex == displayedZoneIndex) {
+  const ride_telemetry_layout::ZoneUpdate update =
+      ride_telemetry_layout::makeZoneUpdate(
+          displayedZoneIndex,
+          ride_telemetry_presenter::fiveZoneIndex(model));
+  if (update.action == ride_telemetry_layout::ZoneUpdateAction::None) {
     return;
   }
-  displayedZoneIndex = zoneIndex;
+  displayedZoneIndex = update.zoneIndex;
 
-  if (zoneIndex < 0) {
+  if (update.action == ride_telemetry_layout::ZoneUpdateAction::Hide) {
     for (lv_obj_t *segment : rideZoneSegments) {
       lv_obj_add_flag(segment, LV_OBJ_FLAG_HIDDEN);
     }
@@ -287,7 +282,8 @@ void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
     return;
   }
 
-  const std::size_t activeIndex = static_cast<std::size_t>(zoneIndex);
+  const std::size_t activeIndex =
+      static_cast<std::size_t>(update.zoneIndex);
   const ride_telemetry_layout::ZoneStripLayout layout =
       ride_telemetry_layout::makeZoneStripLayout(rideLayout.metrics[1],
                                                  rideLayout.screenWidth,
@@ -312,8 +308,8 @@ void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
   lv_obj_set_size(rideZoneLabel, layout.label.width, layout.label.height);
   lv_obj_set_style_text_color(rideZoneLabel, foreground, 0);
   char label[8];
-  std::snprintf(label, sizeof(label), "ZONE %u",
-                static_cast<unsigned>(activeIndex + 1));
+  ride_telemetry_presenter::formatFiveZoneLabel(
+      static_cast<uint8_t>(activeIndex), label, sizeof(label));
   setLabelIfChanged(rideZoneLabel, label);
   lv_obj_clear_flag(rideZoneLabel, LV_OBJ_FLAG_HIDDEN);
 }
@@ -324,8 +320,11 @@ void updateHeartRateMetric(
   char value[24];
   ride_telemetry_presenter::formatInteger(model.currentHeartRateBpm, value,
                                           sizeof(value));
+  const ride_telemetry_layout::HeartRatePresentation presentation =
+      ride_telemetry_layout::makeHeartRatePresentation(
+          rideLayout.screenWidth, model.currentHeartRateBpm.available);
 
-  if (!model.currentHeartRateBpm.available) {
+  if (!presentation.showHeart) {
     lv_obj_set_pos(rideHeartRateValue, metric.x,
                    metric.y + ride_telemetry_layout::kMetricValueOffsetY);
     lv_obj_set_width(rideHeartRateValue, metric.width);
@@ -340,10 +339,14 @@ void updateHeartRateMetric(
       ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
       ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth);
   lv_obj_set_width(rideHeartRateValue, maximumValueWidth);
-  // A heart rate is at most three digits here, so it fits beside the heart at
-  // the regular tile size. Do not re-run adaptive sizing against the tightly
-  // measured label width on each refresh or the font progressively shrinks.
-  const lv_font_t *font = preferredMetricValueFont();
+  // Select against the stable maximum width, not the tightly measured label
+  // width from the previous refresh. Ordinary heart rates therefore keep the
+  // normal metric size, while anomalous protocol-valid values still shrink
+  // enough to remain fully visible beside the heart.
+  const lv_font_t *font = metricValueFontForWidth(
+      value, maximumValueWidth - 4,
+      presentation.fontTier ==
+          ride_telemetry_layout::MetricValueFontTier::RegularLarge);
   if (lv_obj_get_style_text_font(rideHeartRateValue, LV_PART_MAIN) != font) {
     lv_obj_set_style_text_font(rideHeartRateValue, font, 0);
   }

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -99,6 +99,14 @@ const lv_font_t *metricValueFont(lv_obj_t *label, const char *text) {
   return firstFittingFont(fonts, text, textLength, availableWidth);
 }
 
+const lv_font_t *preferredMetricValueFont() {
+  if (ride_telemetry_layout::useLargeMetricValueFont(
+          rideLayout.screenWidth)) {
+    return &ride_value_font_64;
+  }
+  return &lv_font_montserrat_42;
+}
+
 void setLabelIfChanged(lv_obj_t *label, const char *text) {
   if (label == nullptr || text == nullptr) {
     return;
@@ -332,9 +340,14 @@ void updateHeartRateMetric(
       ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
       ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth);
   lv_obj_set_width(rideHeartRateValue, maximumValueWidth);
-  setMetricValueIfChanged(rideHeartRateValue, value);
-  const lv_font_t *font =
-      lv_obj_get_style_text_font(rideHeartRateValue, LV_PART_MAIN);
+  // A heart rate is at most three digits here, so it fits beside the heart at
+  // the regular tile size. Do not re-run adaptive sizing against the tightly
+  // measured label width on each refresh or the font progressively shrinks.
+  const lv_font_t *font = preferredMetricValueFont();
+  if (lv_obj_get_style_text_font(rideHeartRateValue, LV_PART_MAIN) != font) {
+    lv_obj_set_style_text_font(rideHeartRateValue, font, 0);
+  }
+  setLabelIfChanged(rideHeartRateValue, value);
   const int32_t textWidth = lv_text_get_width(
       value, static_cast<uint32_t>(std::strlen(value)), font, 0);
   const ride_telemetry_layout::ValueWithHeartLayout layout =

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -71,7 +71,7 @@ int main() {
   constexpr int32_t representativeHeartRateTextWidth = 100;
   const auto unavailableHeartRate =
       ride_telemetry_layout::makeHeartRatePresentation(
-          rideLayout.screenWidth, false);
+          rideLayout.metrics[0], rideLayout.screenWidth, false);
   assert(!unavailableHeartRate.showHeart);
 #if defined(WAVESHARE_AMOLED_206)
   assert(unavailableHeartRate.fontTier ==
@@ -83,9 +83,16 @@ int main() {
   for (bool available : {true, true, true, false, true}) {
     const auto presentation =
         ride_telemetry_layout::makeHeartRatePresentation(
-            rideLayout.screenWidth, available);
+            rideLayout.metrics[0], rideLayout.screenWidth, available);
     assert(presentation.showHeart == available);
     assert(presentation.fontTier == unavailableHeartRate.fontTier);
+    assert(presentation.maximumValueWidth ==
+           unavailableHeartRate.maximumValueWidth);
+    assert(presentation.fontSelectionWidth ==
+           unavailableHeartRate.fontSelectionWidth);
+    assert(presentation.unavailableValue.x == rideLayout.metrics[0].x);
+    assert(presentation.unavailableValue.width ==
+           rideLayout.metrics[0].width);
   }
   const auto heartRate = ride_telemetry_layout::makeHeartRateValueLayout(
       rideLayout.metrics[0], rideLayout.screenWidth,
@@ -99,38 +106,98 @@ int main() {
   assert(heartRate.heart.width ==
          ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth));
   assert(heartRate.value.width == representativeHeartRateTextWidth);
-  const int32_t maximumHeartRateTextWidth =
-      rideLayout.metrics[0].width -
-      ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
-      ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth) - 4;
   const std::array<ride_metric_font_selection::Candidate, 3>
-      maximumAcceptedHeartRateCandidates = {{
-          {maximumHeartRateTextWidth + 1, true},
-          {maximumHeartRateTextWidth, true},
-          {1, true},
-      }};
+      ordinaryHeartRateCandidates = {{{100, true}, {90, true}, {80, true}}};
+  for (int heartRateBpm : {157, 158, 158, 159}) {
+    (void)heartRateBpm;
+    assert(ride_metric_font_selection::firstFittingIndex(
+               ordinaryHeartRateCandidates,
+               unavailableHeartRate.fontSelectionWidth) == 0);
+  }
+#if defined(WAVESHARE_AMOLED_206)
+  const std::array<ride_metric_font_selection::Candidate, 4>
+      maximumAcceptedHeartRateCandidates =
+          {{{126, true}, {114, true}, {72, true}, {54, true}}};
+#else
+  const std::array<ride_metric_font_selection::Candidate, 7>
+      maximumAcceptedHeartRateCandidates = {{{198, true}, {168, true},
+                                              {145, true}, {126, true},
+                                              {114, true}, {72, true},
+                                              {54, true}}};
+#endif
   const std::size_t maximumAcceptedHeartRateFont =
       ride_metric_font_selection::firstFittingIndex(
-          maximumAcceptedHeartRateCandidates, maximumHeartRateTextWidth);
-  assert(maximumAcceptedHeartRateFont == 1);
+          maximumAcceptedHeartRateCandidates,
+          unavailableHeartRate.fontSelectionWidth);
+#if defined(WAVESHARE_AMOLED_206)
+  assert(maximumAcceptedHeartRateFont == 0);
+#else
+  assert(maximumAcceptedHeartRateFont == 2);
+#endif
   assert(maximumAcceptedHeartRateCandidates[maximumAcceptedHeartRateFont]
-             .width <= maximumHeartRateTextWidth);
+             .width <= unavailableHeartRate.fontSelectionWidth);
+  const auto maximumHeartRateLayout =
+      ride_telemetry_layout::makeHeartRateValueLayout(
+          rideLayout.metrics[0], rideLayout.screenWidth,
+          maximumAcceptedHeartRateCandidates[maximumAcceptedHeartRateFont]
+              .width);
+  assert(maximumHeartRateLayout.value.right() +
+             maximumHeartRateLayout.gap ==
+         maximumHeartRateLayout.heart.x);
+  assert(maximumHeartRateLayout.heart.right() <=
+         rideLayout.metrics[0].right());
   using ride_telemetry_layout::ZoneUpdateAction;
   int8_t displayedZone = -2;
-  auto zoneUpdate =
-      ride_telemetry_layout::makeZoneUpdate(displayedZone, -1);
-  assert(zoneUpdate.action == ZoneUpdateAction::Hide);
-  displayedZone = zoneUpdate.zoneIndex;
-  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 0);
-  assert(zoneUpdate.action == ZoneUpdateAction::Show);
-  displayedZone = zoneUpdate.zoneIndex;
-  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 0);
-  assert(zoneUpdate.action == ZoneUpdateAction::None);
-  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 4);
-  assert(zoneUpdate.action == ZoneUpdateAction::Show);
-  displayedZone = zoneUpdate.zoneIndex;
-  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, -1);
-  assert(zoneUpdate.action == ZoneUpdateAction::Hide);
+  auto zonePresentation = ride_telemetry_layout::makeZonePresentation(
+      rideLayout.metrics[1], rideLayout.screenWidth, displayedZone, -1);
+  assert(zonePresentation.update.action == ZoneUpdateAction::Hide);
+  assert(!zonePresentation.heartVisible);
+  assert(!zonePresentation.labelVisible);
+  for (bool visible : zonePresentation.segmentVisible) {
+    assert(!visible);
+  }
+  displayedZone = zonePresentation.update.zoneIndex;
+  for (int8_t nextZone : {int8_t{0}, int8_t{0}, int8_t{4}, int8_t{-1}}) {
+    zonePresentation = ride_telemetry_layout::makeZonePresentation(
+        rideLayout.metrics[1], rideLayout.screenWidth, displayedZone,
+        nextZone);
+    if (nextZone == displayedZone) {
+      assert(zonePresentation.update.action == ZoneUpdateAction::None);
+      continue;
+    }
+    if (nextZone < 0) {
+      assert(zonePresentation.update.action == ZoneUpdateAction::Hide);
+      assert(!zonePresentation.heartVisible);
+      assert(!zonePresentation.labelVisible);
+      for (bool visible : zonePresentation.segmentVisible) {
+        assert(!visible);
+      }
+    } else {
+      assert(zonePresentation.update.action == ZoneUpdateAction::Show);
+      assert(zonePresentation.heartVisible);
+      assert(zonePresentation.labelVisible);
+      assert(zonePresentation.labelZoneNumber == nextZone + 1);
+      assert(zonePresentation.labelText[0] == 'Z');
+      assert(zonePresentation.labelText[5] == '1' + nextZone);
+      assert(zonePresentation.labelText[6] == '\0');
+      assert(zonePresentation.foregroundColor ==
+             ride_telemetry_layout::zoneForegroundColorHex(nextZone));
+      for (std::size_t index = 0;
+           index < ride_telemetry_layout::kHeartRateZoneCount; ++index) {
+        assert(zonePresentation.segmentVisible[index]);
+        assert(zonePresentation.segmentColors[index] ==
+               ride_telemetry_layout::zoneColorHex(
+                   index, index == static_cast<std::size_t>(nextZone)));
+      }
+      assert(zonePresentation.segments[nextZone].width >
+             zonePresentation.segments[(nextZone + 1) % 5].width);
+      assert(zonePresentation.heart.x >=
+             zonePresentation.segments[nextZone].x);
+      assert(zonePresentation.label.right() <=
+             zonePresentation.segments[nextZone].right());
+    }
+    displayedZone = zonePresentation.update.zoneIndex;
+  }
   for (std::size_t activeIndex = 0;
        activeIndex < ride_telemetry_layout::kHeartRateZoneCount;
        ++activeIndex) {

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -1,6 +1,7 @@
 #include "../../lib/gui/src/batteryStatusLayout.hpp"
 #include "../../lib/gui/src/destinationPickerLayout.hpp"
 #include "../../lib/gui/src/guiLayout.hpp"
+#include "../../lib/gui/src/mapTileTransition.hpp"
 #include "../../lib/gui/src/rideMetricFontSelection.hpp"
 #include "../../lib/gui/src/rideTelemetryLayout.hpp"
 #include "../../lib/maps/src/mapLineStyle.hpp"
@@ -8,6 +9,19 @@
 #include <cassert>
 
 int main() {
+  map_tile_transition::State mapTransition;
+  assert(!mapTransition.canReveal(false, false));
+  mapTransition.begin();
+  assert(!mapTransition.canReveal(true, true));
+  assert(!mapTransition.canReveal(true, false));
+  assert(!mapTransition.canReveal(false, true));
+  assert(mapTransition.canReveal(false, false));
+  mapTransition.complete();
+  assert(!mapTransition.canReveal(false, false));
+  mapTransition.begin();
+  mapTransition.cancel();
+  assert(!mapTransition.canReveal(false, false));
+
 #if defined(WAVESHARE_AMOLED_206)
   // 2.06-inch viewport: 502px screen with 72px reserved UI space.
   assert(gui_layout::mapViewportHeight(502) == 430);

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -69,6 +69,24 @@ int main() {
         metric, rideLayout.screenWidth, rideLayout.screenHeight));
   }
   constexpr int32_t representativeHeartRateTextWidth = 100;
+  const auto unavailableHeartRate =
+      ride_telemetry_layout::makeHeartRatePresentation(
+          rideLayout.screenWidth, false);
+  assert(!unavailableHeartRate.showHeart);
+#if defined(WAVESHARE_AMOLED_206)
+  assert(unavailableHeartRate.fontTier ==
+         ride_telemetry_layout::MetricValueFontTier::RegularCompact);
+#else
+  assert(unavailableHeartRate.fontTier ==
+         ride_telemetry_layout::MetricValueFontTier::RegularLarge);
+#endif
+  for (bool available : {true, true, true, false, true}) {
+    const auto presentation =
+        ride_telemetry_layout::makeHeartRatePresentation(
+            rideLayout.screenWidth, available);
+    assert(presentation.showHeart == available);
+    assert(presentation.fontTier == unavailableHeartRate.fontTier);
+  }
   const auto heartRate = ride_telemetry_layout::makeHeartRateValueLayout(
       rideLayout.metrics[0], rideLayout.screenWidth,
       representativeHeartRateTextWidth);
@@ -81,11 +99,47 @@ int main() {
   assert(heartRate.heart.width ==
          ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth));
   assert(heartRate.value.width == representativeHeartRateTextWidth);
+  const int32_t maximumHeartRateTextWidth =
+      rideLayout.metrics[0].width -
+      ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth) -
+      ride_telemetry_layout::heartRateHeartGap(rideLayout.screenWidth) - 4;
+  const std::array<ride_metric_font_selection::Candidate, 3>
+      maximumAcceptedHeartRateCandidates = {{
+          {maximumHeartRateTextWidth + 1, true},
+          {maximumHeartRateTextWidth, true},
+          {1, true},
+      }};
+  const std::size_t maximumAcceptedHeartRateFont =
+      ride_metric_font_selection::firstFittingIndex(
+          maximumAcceptedHeartRateCandidates, maximumHeartRateTextWidth);
+  assert(maximumAcceptedHeartRateFont == 1);
+  assert(maximumAcceptedHeartRateCandidates[maximumAcceptedHeartRateFont]
+             .width <= maximumHeartRateTextWidth);
+  using ride_telemetry_layout::ZoneUpdateAction;
+  int8_t displayedZone = -2;
+  auto zoneUpdate =
+      ride_telemetry_layout::makeZoneUpdate(displayedZone, -1);
+  assert(zoneUpdate.action == ZoneUpdateAction::Hide);
+  displayedZone = zoneUpdate.zoneIndex;
+  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 0);
+  assert(zoneUpdate.action == ZoneUpdateAction::Show);
+  displayedZone = zoneUpdate.zoneIndex;
+  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 0);
+  assert(zoneUpdate.action == ZoneUpdateAction::None);
+  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, 4);
+  assert(zoneUpdate.action == ZoneUpdateAction::Show);
+  displayedZone = zoneUpdate.zoneIndex;
+  zoneUpdate = ride_telemetry_layout::makeZoneUpdate(displayedZone, -1);
+  assert(zoneUpdate.action == ZoneUpdateAction::Hide);
   for (std::size_t activeIndex = 0;
        activeIndex < ride_telemetry_layout::kHeartRateZoneCount;
        ++activeIndex) {
     const auto zoneStrip = ride_telemetry_layout::makeZoneStripLayout(
         rideLayout.metrics[1], rideLayout.screenWidth, activeIndex);
+    assert(ride_telemetry_layout::zoneColorHex(activeIndex, true) !=
+           ride_telemetry_layout::zoneColorHex(activeIndex, false));
+    assert(ride_telemetry_layout::zoneForegroundColorHex(activeIndex) ==
+           (activeIndex == 2 || activeIndex == 3 ? 0x000000U : 0xFFFFFFU));
     assert(zoneStrip.bounds.x == rideLayout.metrics[1].x);
     assert(zoneStrip.bounds.right() == rideLayout.metrics[1].right());
     assert(zoneStrip.bounds.y >= rideLayout.metrics[1].y +

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -68,6 +68,19 @@ int main() {
     assert(ride_telemetry_layout::fits(
         metric, rideLayout.screenWidth, rideLayout.screenHeight));
   }
+  constexpr int32_t representativeHeartRateTextWidth = 100;
+  const auto heartRate = ride_telemetry_layout::makeHeartRateValueLayout(
+      rideLayout.metrics[0], rideLayout.screenWidth,
+      representativeHeartRateTextWidth);
+  assert(heartRate.value.x >= rideLayout.metrics[0].x);
+  assert(heartRate.value.y >= rideLayout.metrics[0].y +
+                                  ride_telemetry_layout::kMetricValueOffsetY);
+  assert(heartRate.value.right() + heartRate.gap == heartRate.heart.x);
+  assert(heartRate.heart.right() <= rideLayout.metrics[0].right());
+  assert(heartRate.heart.bottom() <= rideLayout.metrics[0].bottom());
+  assert(heartRate.heart.width ==
+         ride_telemetry_layout::heartRateHeartSize(rideLayout.screenWidth));
+  assert(heartRate.value.width == representativeHeartRateTextWidth);
   for (std::size_t activeIndex = 0;
        activeIndex < ride_telemetry_layout::kHeartRateZoneCount;
        ++activeIndex) {

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -43,18 +43,6 @@ int main() {
   static_assert(destination_picker_layout::bottomPadding(410, 502, 3) == 4);
   static_assert(!destination_picker_layout::needsScrolling(88 * 3, 3, 280));
   static_assert(destination_picker_layout::needsScrolling(116 * 3, 3, 280));
-  // For Z10/255, the compact 64 px candidate is too wide and the 56 px
-  // candidate lacks Z. Selection must skip the seemingly fitting placeholder
-  // width and use the first complete Montserrat fallback.
-  constexpr std::array<ride_metric_font_selection::Candidate, 4>
-      zoneCandidates{{
-          {241, true},
-          {202, false},
-          {190, true},
-          {170, true},
-      }};
-  static_assert(ride_metric_font_selection::firstFittingIndex(zoneCandidates,
-                                                               205) == 2);
   static_assert(map_line_style::displayColor(1, 0xF567, 7, false) ==
                 0xF567);
   static_assert(map_line_style::displayColor(1, 0xF567, 7, true) ==
@@ -79,6 +67,38 @@ int main() {
   for (const auto &metric : rideLayout.metrics) {
     assert(ride_telemetry_layout::fits(
         metric, rideLayout.screenWidth, rideLayout.screenHeight));
+  }
+  for (std::size_t activeIndex = 0;
+       activeIndex < ride_telemetry_layout::kHeartRateZoneCount;
+       ++activeIndex) {
+    const auto zoneStrip = ride_telemetry_layout::makeZoneStripLayout(
+        rideLayout.metrics[1], rideLayout.screenWidth, activeIndex);
+    assert(zoneStrip.bounds.x == rideLayout.metrics[1].x);
+    assert(zoneStrip.bounds.right() == rideLayout.metrics[1].right());
+    assert(zoneStrip.bounds.y >= rideLayout.metrics[1].y +
+                                     ride_telemetry_layout::kMetricValueOffsetY);
+    assert(zoneStrip.bounds.bottom() <= rideLayout.metrics[1].bottom());
+    assert(zoneStrip.segments.front().x == zoneStrip.bounds.x);
+    assert(zoneStrip.segments.back().right() == zoneStrip.bounds.right());
+    for (std::size_t index = 0; index < zoneStrip.segments.size(); ++index) {
+      const auto &segment = zoneStrip.segments[index];
+      assert(segment.y == zoneStrip.bounds.y);
+      assert(segment.height == zoneStrip.bounds.height);
+      assert(segment.width > 0);
+      if (index == activeIndex) {
+        assert(segment.width >
+               zoneStrip.segments[(index + 1) %
+                                  zoneStrip.segments.size()]
+                   .width);
+        assert(zoneStrip.heart.x >= segment.x);
+        assert(zoneStrip.label.right() <= segment.right());
+        assert(zoneStrip.label.width >= 58);
+      }
+      if (index + 1 < zoneStrip.segments.size()) {
+        assert(segment.right() + ride_telemetry_layout::kZoneStripGap ==
+               zoneStrip.segments[index + 1].x);
+      }
+    }
   }
   return 0;
 }

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -246,6 +246,12 @@ int main() {
                                           formatted, sizeof(formatted));
   assertText(formatted, "1:01:01");
   assert(ride_telemetry_presenter::fiveZoneIndex(pausedModel) == 3);
+  ride_telemetry_presenter::formatFiveZoneLabel(0, formatted,
+                                                 sizeof(formatted));
+  assertText(formatted, "ZONE 1");
+  ride_telemetry_presenter::formatFiveZoneLabel(4, formatted,
+                                                 sizeof(formatted));
+  assertText(formatted, "ZONE 5");
   auto unavailableZoneModel = pausedModel;
   unavailableZoneModel.currentHeartRateZone.available = false;
   assert(ride_telemetry_presenter::fiveZoneIndex(unavailableZoneModel) == -1);

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -246,12 +246,6 @@ int main() {
                                           formatted, sizeof(formatted));
   assertText(formatted, "1:01:01");
   assert(ride_telemetry_presenter::fiveZoneIndex(pausedModel) == 3);
-  ride_telemetry_presenter::formatFiveZoneLabel(0, formatted,
-                                                 sizeof(formatted));
-  assertText(formatted, "ZONE 1");
-  ride_telemetry_presenter::formatFiveZoneLabel(4, formatted,
-                                                 sizeof(formatted));
-  assertText(formatted, "ZONE 5");
   auto unavailableZoneModel = pausedModel;
   unavailableZoneModel.currentHeartRateZone.available = false;
   assert(ride_telemetry_presenter::fiveZoneIndex(unavailableZoneModel) == -1);

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -245,9 +245,13 @@ int main() {
   ride_telemetry_presenter::formatElapsed(pausedModel.elapsedSeconds,
                                           formatted, sizeof(formatted));
   assertText(formatted, "1:01:01");
-  ride_telemetry_presenter::formatZone(pausedModel, formatted,
-                                       sizeof(formatted));
-  assertText(formatted, "Z4/5");
+  assert(ride_telemetry_presenter::fiveZoneIndex(pausedModel) == 3);
+  auto unavailableZoneModel = pausedModel;
+  unavailableZoneModel.currentHeartRateZone.available = false;
+  assert(ride_telemetry_presenter::fiveZoneIndex(unavailableZoneModel) == -1);
+  auto nonFiveZoneModel = pausedModel;
+  nonFiveZoneModel.heartRateZoneCount.value = 6;
+  assert(ride_telemetry_presenter::fiveZoneIndex(nonFiveZoneModel) == -1);
 
   using ride_telemetry_presenter::BottomMetric;
   assertBottomMetrics(pausedModel, BottomMetric::Power,


### PR DESCRIPTION
## Summary

- replace the numeric HR zone value on the firmware Ride Stats screen with a compact five-color zone strip
- expand the current zone in its fixed row position with a heart icon and `ZONE X`
- keep the strip hidden until valid five-zone workout telemetry arrives
- replace the heart-rate tile's `bpm` treatment with a red heart beside the current value
- render ordinary heart-rate readings at the normal metric-tile size while retaining adaptive fitting for unusually long protocol values
- preserve the adaptive tile layout on both supported Waveshare displays
- keep the previous screen visible until a newly filtered map frame is complete, preventing the stale full-map flash when cycling from Battery to Map + Navigation

## Validation

- `PYTHONPATH=tools python3 -m unittest tools.tests.test_firmware_build_identity`
- `g++ -std=c++17 -Wall -Wextra -Werror -DWAVESHARE_AMOLED_175 -I. tools/tests/test_gui_layout.cpp -o /tmp/test_gui_layout_175 && /tmp/test_gui_layout_175`
- `g++ -std=c++17 -Wall -Wextra -Werror -DWAVESHARE_AMOLED_206 -I. tools/tests/test_gui_layout.cpp -o /tmp/test_gui_layout_206 && /tmp/test_gui_layout_206`
- map transition state coverage verifies that an interrupted, position-pending, or display-pending render cannot reveal the stale map frame
- `g++ -std=c++17 -Wall -Wextra -Werror -I. tools/tests/test_workout_telemetry_state.cpp -o /tmp/test_workout_telemetry_state && /tmp/test_workout_telemetry_state`
- `pio run -e WAVESHARE_AMOLED_175 -e WAVESHARE_AMOLED_206`
- flashed commit `30b05b0c1e612f20860efae25d05378298d7aa24` to the connected Waveshare 1.75 device on `/dev/cu.usbmodem101`; upload hashes verified and serial boot reached display, LVGL, BLE authentication, settings sync, and a healthy UI loop
- flashed latest head `ae6196a8a08deb9c8e4b71d88f7bfc46d187bb15` to the connected Waveshare 1.75 device on `/dev/cu.usbmodem101`; all upload-region hashes verified, binary SHA-256 is `73cc48a2950cdf5a5af0b647ba68b20b4a57537ccc428de74687d7452e98d984`, and reset reached Arduino_GFX display setup, LVGL, BLE advertising, and a live UI loop. This reset reported AXP2101, TCA9554, and SD unavailable, so the transition itself still needs visual confirmation.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting this pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.


