### PR TITLE
Prepare firmware v0.3.1

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.3.0
-revision = 89
+version = 0.3.1
+revision = 90
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
## Summary
- bump firmware version to 0.3.1
- increment firmware revision to 90

## Validation
- `PYTHONPATH=tools python3 -m unittest tools.tests.test_firmware_build_identity`
- `pio run -e WAVESHARE_AMOLED_175 -e WAVESHARE_AMOLED_206`
- verified both binaries embed version 0.3.1 and commit 84ae26352e5bb6f18531b65f98e6935764839211