### PR TITLE
Simplify pairing confirmation after device approval

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/BikeComputersSettingsView.swift
@@ -334,22 +334,6 @@ private struct PairBikeComputerSheet: View {
                 }
 
                 if let prompt = matchingPrompt {
-                    Section {
-                        Text(prompt.formattedCode)
-                            .font(.system(size: 44, weight: .semibold, design: .rounded))
-                            .monospacedDigit()
-                            .frame(maxWidth: .infinity)
-                            .accessibilityLabel("Pairing code \(prompt.formattedCode)")
-                    } header: {
-                        Text("Confirm the Code")
-                    } footer: {
-                        if prompt.isReplacingExistingRegistration {
-                            Text("This Bike Computer was reset. Match this code, then press either button on the device to replace its old registration on this iPhone.")
-                        } else {
-                            Text("If this exact code is also displayed on your Bike Computer, press either button on the device to confirm physical access.")
-                        }
-                    }
-
                     if bleManager.isPairingConfirmationSubmitting {
                         Section {
                             HStack(spacing: 12) {
@@ -360,14 +344,28 @@ private struct PairBikeComputerSheet: View {
                     } else if bleManager.isPairingConfirmedOnDevice {
                         Section {
                             Button(
-                                prompt.isReplacingExistingRegistration
-                                    ? "Codes Match — Replace Registration"
-                                    : "Codes Match — Register This iPhone",
+                                "Codes Match",
                                 role: prompt.isReplacingExistingRegistration
                                     ? .destructive
                                     : nil
                             ) {
                                 bleManager.confirmPairingAfterCodeMatch()
+                            }
+                        }
+                    } else {
+                        Section {
+                            Text(prompt.formattedCode)
+                                .font(.system(size: 44, weight: .semibold, design: .rounded))
+                                .monospacedDigit()
+                                .frame(maxWidth: .infinity)
+                                .accessibilityLabel("Pairing code \(prompt.formattedCode)")
+                        } header: {
+                            Text("Confirm the Code")
+                        } footer: {
+                            if prompt.isReplacingExistingRegistration {
+                                Text("This Bike Computer was reset. Match this code, then press either button on the device to replace its old registration on this iPhone.")
+                            } else {
+                                Text("If this exact code is also displayed on your Bike Computer, press either button on the device to confirm physical access.")
                             }
                         }
                     }


### PR DESCRIPTION
## Summary

- keep the comparison code and physical-button instructions visible until the Bike Computer confirms its hardware button press
- replace that content with a single **Codes Match** button after device confirmation
- preserve destructive styling when replacing an existing registration

## Why

The registration sheet repeated the code and instructions after the physical confirmation step. The first simplification also removed the useful pre-confirmation state. This keeps the comparison guidance while it is needed and reduces the completed hardware-confirmation state to the single next action.

## Validation

- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- signed Debug build installed and launched on the connected iPhone (`Ultra`), with `BikeComputer` 1.1 (7) verified through `devicectl`
