### PR TITLE
Refine map screen defaults and controls

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -456,7 +456,7 @@ Current setting IDs:
 | `6` | Map rotation mode | `0` north-up, `1` course-up |
 | `7` | Map zoom level | `0...5` |
 | `8` | Map visibility and global navigation-overlay mask | bit 0 buildings, bit 1 parks/green space, bit 2 paths/footways, bit 3 major roads, bit 4 residential/other local roads, bit 5 water, bit 6 railways, bit 7 other areas, bit 8 route overlay, bit 9 current position marker, bit 10 service roads, bit 11 tracks, bit 12 extended-mask marker |
-| `9` | Map street line width boost | `0...24` px added to known road/path line style widths; legacy unknown lines are boosted when their stored style width is at least 3px; final rendered width is capped at 24px |
+| `9` | Map street width | Absolute rendered width is `1...24` px. The wire value remains `width - 4` (`-3...20`) so older apps that send a boost remain compatible. |
 | `10` | Map current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a white dot when no route is loaded and a white arrow while navigating. |
 | `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device through the enabled main screens. Map drags and long presses are ignored by this shortcut. |
 | `12` | Device brightness | `5...100` percent on supported hardware |
@@ -468,7 +468,7 @@ Current setting IDs:
 | `18` | Map + Navigation route line width | `2...48` |
 | `19` | Map + Navigation zoom level | `0...5` |
 | `20` | Map + Navigation feature visibility mask | feature bits and the extended-mask marker use the same meanings as ID `8`; navigation overlay bits remain global via ID `8` |
-| `21` | Map + Navigation street line width boost | `0...24` px |
+| `21` | Map + Navigation street width | Absolute rendered width is `1...24` px, encoded as `width - 4` (`-3...20`) for compatibility. |
 | `22` | Map + Navigation current-position marker scale | `1...5` |
 | `23` | Connected phone battery level | transient whole-number percentage `0...100`; iOS sends it after authentication and whenever the phone battery level changes. Firmware clears it on disconnect. |
 | `24` | Connected phone charging state | transient `0` not charging, `1` charging; iOS sends it after authentication and whenever the public battery state changes. Firmware clears it on disconnect. |
@@ -487,11 +487,12 @@ the persisted Map values. Map rotation mode remains Map-only; Map + Navigation
 automatically uses course-up while navigating. Route and current-position
 overlay visibility remains shared by both profiles.
 
-Fresh Map + Navigation profiles default to low detail with Major Roads and
-Residential & Local Roads visible. Buildings, Service Roads, Paths & Footways,
-Tracks, Railways, and Other Areas default to hidden; green space and water
-remain visible. Existing persisted or migrated profiles keep their saved
-values.
+Fresh Map profiles default to high detail, zoom level `3`, a `4` px route line,
+`4` px streets, and a `2x` position marker. Fresh Map + Navigation profiles
+default to low detail, zoom level `3`, a `15` px route line, `4` px streets, a
+`2x` position marker, and only Major Roads, Residential & Local Roads, and
+Water visible. Existing customized profiles keep their saved values; profiles
+that still exactly match the former recommendations migrate once.
 
 Apps that support the extended visibility classes set marker bit `12`. Without
 that marker, firmware preserves the legacy behavior by applying bit `4` to both

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1862,15 +1862,16 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                   mapRenderSettings.mapStyle.routeLineWidth);
     break;
   case 9:
-    mapRenderSettings.mapStyle.streetLineWidthBoost =
-        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    mapRenderSettings.mapStyle.streetLineWidth = static_cast<uint8_t>(
+        map_profile_protocol::absoluteStreetWidthFromLegacyBoost(
+            map_profile_protocol::clampValue(settingId, settingValue)));
     if (mirrorLegacyMapProfile) {
-      mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
-          mapRenderSettings.mapStyle.streetLineWidthBoost;
+      mapRenderSettings.mapNavigationStyle.streetLineWidth =
+          mapRenderSettings.mapStyle.streetLineWidth;
     }
     persistMapProfileSetting();
-    Serial.printf("BLE Settings: streetLineWidthBoost = %d (saved)\n",
-                  mapRenderSettings.mapStyle.streetLineWidthBoost);
+    Serial.printf("BLE Settings: streetLineWidth = %d px (saved)\n",
+                  mapRenderSettings.mapStyle.streetLineWidth);
     break;
   case 10:
     mapRenderSettings.mapStyle.positionMarkerScale =
@@ -2011,8 +2012,10 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     persistMapProfileSetting();
     break;
   case 21:
-    mapRenderSettings.mapNavigationStyle.streetLineWidthBoost =
-        (uint8_t)map_profile_protocol::clampValue(settingId, settingValue);
+    mapRenderSettings.mapNavigationStyle.streetLineWidth =
+        static_cast<uint8_t>(
+            map_profile_protocol::absoluteStreetWidthFromLegacyBoost(
+                map_profile_protocol::clampValue(settingId, settingValue)));
     persistMapProfileSetting();
     break;
   case 22:
@@ -2372,7 +2375,7 @@ public:
 /**
  * @brief Settings characteristic callback - receives runtime config from iOS
  * app Format: [settingId:1][value:4] = 5 bytes Setting IDs: 1=minPolygonSize,
- * 2=detailLevel, 3=routeLineWidth, 9=streetLineWidthBoost,
+ * 2=detailLevel, 3=routeLineWidth, 9=streetLineWidth,
  * 10=positionMarkerScale
  */
 class MySettingsCharacteristicCallbacks : public NimBLECharacteristicCallbacks {
@@ -2500,13 +2503,13 @@ static void loadSettingsFromNVS() {
   prefs.end();
 
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
-                "detailLevel=%d, routeWidth=%d, streetBoost=%d, "
+                "detailLevel=%d, routeWidth=%d, streetWidth=%d, "
                 "markerScale=%d, tapSwitch=%d, "
                 "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
                 mapRenderSettings.mapStyle.minPolygonSize,
                 mapRenderSettings.mapStyle.detailLevel,
                 mapRenderSettings.mapStyle.routeLineWidth,
-                mapRenderSettings.mapStyle.streetLineWidthBoost,
+                mapRenderSettings.mapStyle.streetLineWidth,
                 mapRenderSettings.mapStyle.positionMarkerScale,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -89,17 +89,29 @@ static inline uint32_t normalizedMapFeatureVisibilityMask(uint32_t mask) {
 
 struct ScreenMapRenderSettings {
   uint8_t minPolygonSize = 0; // 0-50: Skip polygons smaller than N pixels²
-  uint8_t detailLevel = 2;    // 0=Low, 1=Med, 2=High
-  uint8_t routeLineWidth = 4; // 2-48: Route overlay line width in pixels
-  uint8_t streetLineWidthBoost = 0; // 0-24: Extra map street width in pixels
+  uint8_t detailLevel = map_profile_protocol::MAP_DEFAULT_DETAIL_LEVEL;
+  uint8_t routeLineWidth = map_profile_protocol::MAP_DEFAULT_ROUTE_LINE_WIDTH;
+  uint8_t streetLineWidth = map_profile_protocol::DEFAULT_STREET_WIDTH;
   uint8_t positionMarkerScale = 2;  // 1-5: Current-position marker scale
-  uint8_t zoomLevel = 2;             // 0-5: Zoom level (0=super, 2=default)
+  uint8_t zoomLevel = map_profile_protocol::MAP_DEFAULT_ZOOM_LEVEL;
   uint32_t visibilityMask = MAP_VISIBILITY_EXTENDED_FEATURE_MASK;
 };
 
 struct MapRenderSettings {
   ScreenMapRenderSettings mapStyle;
-  ScreenMapRenderSettings mapNavigationStyle;
+  ScreenMapRenderSettings mapNavigationStyle = [] {
+    ScreenMapRenderSettings settings;
+    settings.detailLevel =
+        map_profile_protocol::MAP_NAVIGATION_DEFAULT_DETAIL_LEVEL;
+    settings.routeLineWidth =
+        map_profile_protocol::MAP_NAVIGATION_DEFAULT_ROUTE_LINE_WIDTH;
+    settings.streetLineWidth = map_profile_protocol::DEFAULT_STREET_WIDTH;
+    settings.positionMarkerScale = 2;
+    settings.zoomLevel = map_profile_protocol::MAP_NAVIGATION_DEFAULT_ZOOM_LEVEL;
+    settings.visibilityMask =
+        map_profile_protocol::MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK;
+    return settings;
+  }();
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
   uint8_t enabledScreensMask =

--- a/esp32/lib/ble_navigation/map_profile_persistence.hpp
+++ b/esp32/lib/ble_navigation/map_profile_persistence.hpp
@@ -11,16 +11,25 @@ inline void load(Store &store, Profile &mapStyle,
                  Profile &mapNavigationStyle) {
   const bool hasStoredMapStyle =
       store.isKey("minPolySize") || store.isKey("detailLevel") ||
-      store.isKey("routeWidth") || store.isKey("streetBoost") ||
+      store.isKey("routeWidth") || store.isKey("streetWidth") ||
+      store.isKey("streetBoost") ||
       store.isKey("markerScale") || store.isKey("zoomLevel") ||
       store.isKey("visMask");
 
   mapStyle.minPolygonSize = store.getUChar("minPolySize", 0);
-  mapStyle.detailLevel = store.getUChar("detailLevel", 2);
-  mapStyle.routeLineWidth = store.getUChar("routeWidth", 4);
-  mapStyle.streetLineWidthBoost = store.getUChar("streetBoost", 0);
+  mapStyle.detailLevel = store.getUChar(
+      "detailLevel", map_profile_protocol::MAP_DEFAULT_DETAIL_LEVEL);
+  mapStyle.routeLineWidth = store.getUChar(
+      "routeWidth", map_profile_protocol::MAP_DEFAULT_ROUTE_LINE_WIDTH);
+  mapStyle.streetLineWidth = static_cast<uint8_t>(
+      store.isKey("streetWidth")
+          ? map_profile_protocol::clampAbsoluteStreetWidth(store.getUChar(
+                "streetWidth", map_profile_protocol::DEFAULT_STREET_WIDTH))
+          : map_profile_protocol::absoluteStreetWidthFromLegacyBoost(
+                store.getUChar("streetBoost", 0)));
   mapStyle.positionMarkerScale = store.getUChar("markerScale", 2);
-  mapStyle.zoomLevel = store.getUChar("zoomLevel", 4);
+  mapStyle.zoomLevel = store.getUChar(
+      "zoomLevel", map_profile_protocol::MAP_DEFAULT_ZOOM_LEVEL);
   const uint32_t storedMapVisibility = store.getUInt("visMask", 0x3FF);
   mapStyle.visibilityMask =
       map_profile_protocol::normalizedFeatureVisibilityMask(storedMapVisibility);
@@ -34,12 +43,28 @@ inline void load(Store &store, Profile &mapStyle,
               ? mapStyle.detailLevel
               : map_profile_protocol::MAP_NAVIGATION_DEFAULT_DETAIL_LEVEL);
   mapNavigationStyle.routeLineWidth =
-      store.getUChar("navRouteW", mapStyle.routeLineWidth);
-  mapNavigationStyle.streetLineWidthBoost =
-      store.getUChar("navStreetB", mapStyle.streetLineWidthBoost);
+      store.getUChar("navRouteW",
+                     hasStoredMapStyle
+                         ? mapStyle.routeLineWidth
+                         : map_profile_protocol::
+                               MAP_NAVIGATION_DEFAULT_ROUTE_LINE_WIDTH);
+  if (store.isKey("navStreetW")) {
+    mapNavigationStyle.streetLineWidth = static_cast<uint8_t>(
+        map_profile_protocol::clampAbsoluteStreetWidth(store.getUChar(
+            "navStreetW", map_profile_protocol::DEFAULT_STREET_WIDTH)));
+  } else if (store.isKey("navStreetB")) {
+    mapNavigationStyle.streetLineWidth = static_cast<uint8_t>(
+        map_profile_protocol::absoluteStreetWidthFromLegacyBoost(
+            store.getUChar("navStreetB", 0)));
+  } else {
+    mapNavigationStyle.streetLineWidth = mapStyle.streetLineWidth;
+  }
   mapNavigationStyle.positionMarkerScale =
       store.getUChar("navMarkerS", mapStyle.positionMarkerScale);
-  mapNavigationStyle.zoomLevel = store.getUChar("navZoom", mapStyle.zoomLevel);
+  mapNavigationStyle.zoomLevel = store.getUChar(
+      "navZoom", hasStoredMapStyle
+                     ? mapStyle.zoomLevel
+                     : map_profile_protocol::MAP_NAVIGATION_DEFAULT_ZOOM_LEVEL);
   mapNavigationStyle.visibilityMask =
       map_profile_protocol::normalizedFeatureVisibilityMask(store.getUInt(
           "navVis",
@@ -47,6 +72,11 @@ inline void load(Store &store, Profile &mapStyle,
                ? mapStyle.visibilityMask
                : map_profile_protocol::MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK) |
               map_profile_protocol::VISIBILITY_EXTENDED_MARKER));
+
+  if (!store.isKey("streetWidth"))
+    store.putUChar("streetWidth", mapStyle.streetLineWidth);
+  if (!store.isKey("navStreetW"))
+    store.putUChar("navStreetW", mapNavigationStyle.streetLineWidth);
 }
 
 template <typename Store, typename Profile>
@@ -85,9 +115,25 @@ inline bool persistSetting(Store &store, const Profile &mapStyle,
     }
     return true;
   case 9:
-    store.putUChar("streetBoost", mapStyle.streetLineWidthBoost);
-    if (mirrorLegacySetting)
-      store.putUChar("navStreetB", mapNavigationStyle.streetLineWidthBoost);
+    store.putUChar("streetWidth", mapStyle.streetLineWidth);
+    store.putUChar(
+        "streetBoost",
+        static_cast<uint8_t>(mapStyle.streetLineWidth >
+                                     map_profile_protocol::DEFAULT_STREET_WIDTH
+                                 ? mapStyle.streetLineWidth -
+                                       map_profile_protocol::DEFAULT_STREET_WIDTH
+                                 : 0));
+    if (mirrorLegacySetting) {
+      store.putUChar("navStreetW", mapNavigationStyle.streetLineWidth);
+      store.putUChar(
+          "navStreetB",
+          static_cast<uint8_t>(
+              mapNavigationStyle.streetLineWidth >
+                      map_profile_protocol::DEFAULT_STREET_WIDTH
+                  ? mapNavigationStyle.streetLineWidth -
+                        map_profile_protocol::DEFAULT_STREET_WIDTH
+                  : 0));
+    }
     return true;
   case 10:
     store.putUChar("markerScale", mapStyle.positionMarkerScale);
@@ -111,7 +157,15 @@ inline bool persistSetting(Store &store, const Profile &mapStyle,
                                 map_profile_protocol::VISIBILITY_EXTENDED_MARKER);
     return true;
   case 21:
-    store.putUChar("navStreetB", mapNavigationStyle.streetLineWidthBoost);
+    store.putUChar("navStreetW", mapNavigationStyle.streetLineWidth);
+    store.putUChar(
+        "navStreetB",
+        static_cast<uint8_t>(
+            mapNavigationStyle.streetLineWidth >
+                    map_profile_protocol::DEFAULT_STREET_WIDTH
+                ? mapNavigationStyle.streetLineWidth -
+                      map_profile_protocol::DEFAULT_STREET_WIDTH
+                : 0));
     return true;
   case 22:
     store.putUChar("navMarkerS", mapNavigationStyle.positionMarkerScale);

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -8,6 +8,12 @@ constexpr uint8_t CAPABILITY_MASK = 1 << 3;
 constexpr uint8_t CLIENT_VERSION = 2;
 constexpr uint8_t EXTENDED_VISIBILITY_CAPABILITY_MASK = 1 << 4;
 constexpr uint8_t EXTENDED_VISIBILITY_CLIENT_VERSION = 3;
+constexpr uint8_t DEFAULT_STREET_WIDTH = 4;
+constexpr uint8_t MAP_DEFAULT_DETAIL_LEVEL = 2;
+constexpr uint8_t MAP_DEFAULT_ROUTE_LINE_WIDTH = 4;
+constexpr uint8_t MAP_DEFAULT_ZOOM_LEVEL = 3;
+constexpr uint8_t MAP_NAVIGATION_DEFAULT_ROUTE_LINE_WIDTH = 15;
+constexpr uint8_t MAP_NAVIGATION_DEFAULT_ZOOM_LEVEL = 3;
 
 constexpr uint32_t VISIBILITY_BUILDINGS = 1u << 0;
 constexpr uint32_t VISIBILITY_GREEN_SPACE = 1u << 1;
@@ -30,8 +36,7 @@ constexpr uint32_t VISIBILITY_OVERLAY_MASK =
     VISIBILITY_ROUTE_OVERLAY | VISIBILITY_POSITION_MARKER;
 constexpr uint8_t MAP_NAVIGATION_DEFAULT_DETAIL_LEVEL = 0;
 constexpr uint32_t MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK =
-    VISIBILITY_GREEN_SPACE | VISIBILITY_MAJOR_ROADS |
-    VISIBILITY_LOCAL_STREETS | VISIBILITY_WATER;
+    VISIBILITY_MAJOR_ROADS | VISIBILITY_LOCAL_STREETS | VISIBILITY_WATER;
 
 inline bool clientSupportsIndependentProfiles(uint8_t clientVersion) {
   return clientVersion >= CLIENT_VERSION;
@@ -128,7 +133,8 @@ inline int32_t clampValue(uint8_t settingId, int32_t value) {
     break;
   case 9:
   case 21:
-    maximum = 24;
+    minimum = 1 - DEFAULT_STREET_WIDTH;
+    maximum = 24 - DEFAULT_STREET_WIDTH;
     break;
   case 10:
   case 22:
@@ -139,6 +145,18 @@ inline int32_t clampValue(uint8_t settingId, int32_t value) {
     return value;
   }
   return value < minimum ? minimum : (value > maximum ? maximum : value);
+}
+
+inline int32_t clampAbsoluteStreetWidth(int32_t width) {
+  return width < 1 ? 1 : (width > 24 ? 24 : width);
+}
+
+inline int32_t absoluteStreetWidthFromLegacyBoost(int32_t boost) {
+  return clampAbsoluteStreetWidth(DEFAULT_STREET_WIDTH + boost);
+}
+
+inline int32_t legacyStreetWidthBoostFromAbsolute(int32_t width) {
+  return clampAbsoluteStreetWidth(width) - DEFAULT_STREET_WIDTH;
 }
 
 template <typename Profile>

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -1958,11 +1958,10 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
         };
 
         Point16 p1 = transformPoint(line.points[0]);
-        int32_t streetBoost = shouldBoostLineWidth(line.typeId, line.width)
-                                  ? blockStyle.streetLineWidthBoost
-                                  : 0;
-        uint8_t lineWidth = (uint8_t)std::min<int32_t>(
-            std::max<int32_t>(line.width, 1) + streetBoost, 24);
+        uint8_t lineWidth = shouldBoostLineWidth(line.typeId, line.width)
+                                ? blockStyle.streetLineWidth
+                                : static_cast<uint8_t>(
+                                      std::max<int32_t>(line.width, 1));
 
         for (int i = 0; i < (int)line.points.size() - 1; i++) {
           if ((i & 0x0F) == 0 &&

--- a/esp32/tools/tests/test_map_profile_persistence.cpp
+++ b/esp32/tools/tests/test_map_profile_persistence.cpp
@@ -10,7 +10,7 @@ struct TestProfile {
   uint8_t minPolygonSize = 0;
   uint8_t detailLevel = 0;
   uint8_t routeLineWidth = 0;
-  uint8_t streetLineWidthBoost = 0;
+  uint8_t streetLineWidth = 0;
   uint8_t positionMarkerScale = 0;
   uint8_t zoomLevel = 0;
   uint32_t visibilityMask = 0;
@@ -59,8 +59,18 @@ int main() {
   TestProfile loadedMap;
   TestProfile loadedNavigation;
   map_profile_persistence::load(freshStore, loadedMap, loadedNavigation);
+  assert(loadedMap.detailLevel == MAP_DEFAULT_DETAIL_LEVEL);
+  assert(loadedMap.routeLineWidth == MAP_DEFAULT_ROUTE_LINE_WIDTH);
+  assert(loadedMap.streetLineWidth == DEFAULT_STREET_WIDTH);
+  assert(loadedMap.positionMarkerScale == 2);
+  assert(loadedMap.zoomLevel == MAP_DEFAULT_ZOOM_LEVEL);
   assert(loadedNavigation.detailLevel ==
          MAP_NAVIGATION_DEFAULT_DETAIL_LEVEL);
+  assert(loadedNavigation.routeLineWidth ==
+         MAP_NAVIGATION_DEFAULT_ROUTE_LINE_WIDTH);
+  assert(loadedNavigation.streetLineWidth == DEFAULT_STREET_WIDTH);
+  assert(loadedNavigation.positionMarkerScale == 2);
+  assert(loadedNavigation.zoomLevel == MAP_NAVIGATION_DEFAULT_ZOOM_LEVEL);
   assert(loadedNavigation.visibilityMask ==
          MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK);
 
@@ -69,13 +79,16 @@ int main() {
   legacyStore.putUChar("minPolySize", legacyMap.minPolygonSize);
   legacyStore.putUChar("detailLevel", legacyMap.detailLevel);
   legacyStore.putUChar("routeWidth", legacyMap.routeLineWidth);
-  legacyStore.putUChar("streetBoost", legacyMap.streetLineWidthBoost);
+  legacyStore.putUChar("streetBoost", 4);
   legacyStore.putUChar("markerScale", legacyMap.positionMarkerScale);
   legacyStore.putUChar("zoomLevel", legacyMap.zoomLevel);
   legacyStore.putUInt("visMask", legacyMap.visibilityMask);
   map_profile_persistence::load(legacyStore, loadedMap, loadedNavigation);
   assert(loadedMap.visibilityMask == VISIBILITY_EXTENDED_FEATURE_MASK);
+  assert(loadedMap.streetLineWidth == 8);
+  assert(legacyStore.getUChar("streetWidth", 0) == 8);
   assert(loadedNavigation.visibilityMask == VISIBILITY_EXTENDED_FEATURE_MASK);
+  assert(loadedNavigation.streetLineWidth == 8);
   assert(loadedNavigation.zoomLevel == legacyMap.zoomLevel);
 
   FakeStore mirroredStore;

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -17,12 +17,20 @@ int main() {
   assert(clientSupportsIndependentProfiles(3));
   assert(!clientSupportsExtendedVisibility(2));
   assert(clientSupportsExtendedVisibility(3));
+  assert(DEFAULT_STREET_WIDTH == 4);
+  assert(MAP_DEFAULT_DETAIL_LEVEL == 2);
+  assert(MAP_DEFAULT_ROUTE_LINE_WIDTH == 4);
+  assert(MAP_DEFAULT_ZOOM_LEVEL == 3);
   assert(MAP_NAVIGATION_DEFAULT_DETAIL_LEVEL == 0);
+  assert(MAP_NAVIGATION_DEFAULT_ROUTE_LINE_WIDTH == 15);
+  assert(MAP_NAVIGATION_DEFAULT_ZOOM_LEVEL == 3);
   assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_MAJOR_ROADS) !=
          0);
   assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_LOCAL_STREETS) !=
          0);
   assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_BUILDINGS) == 0);
+  assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_GREEN_SPACE) ==
+         0);
   assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_SERVICE_ROADS) ==
          0);
   assert((MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK & VISIBILITY_PATHS) == 0);
@@ -81,10 +89,19 @@ int main() {
   assert(clampValue(18, 49) == 48);
   assert(clampValue(7, 6) == 5);
   assert(clampValue(19, -1) == 0);
-  assert(clampValue(9, 25) == 24);
-  assert(clampValue(21, -1) == 0);
+  assert(clampValue(9, 25) == 20);
+  assert(clampValue(21, -4) == -3);
   assert(clampValue(10, 0) == 1);
   assert(clampValue(22, 6) == 5);
+  assert(absoluteStreetWidthFromLegacyBoost(-3) == 1);
+  assert(absoluteStreetWidthFromLegacyBoost(0) == 4);
+  assert(absoluteStreetWidthFromLegacyBoost(4) == 8);
+  assert(absoluteStreetWidthFromLegacyBoost(24) == 24);
+  assert(clampAbsoluteStreetWidth(0) == 1);
+  assert(clampAbsoluteStreetWidth(25) == 24);
+  assert(legacyStreetWidthBoostFromAbsolute(1) == -3);
+  assert(legacyStreetWidthBoostFromAbsolute(4) == 0);
+  assert(legacyStreetWidthBoostFromAbsolute(24) == 20);
 
   const TestProfile map{1};
   const TestProfile mapNavigation{2};

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -127,6 +127,7 @@ enum DeviceBLEProtocol {
     static let serviceRoadsVisibilityMask: Int32 = 1 << 10
     static let tracksVisibilityMask: Int32 = 1 << 11
     static let extendedVisibilityMarker: Int32 = 1 << 12
+    static let defaultStreetWidth: Int32 = 4
 
     static let brightnessSettingID: UInt8 = 12
     static let enabledScreensSettingID: UInt8 = 13
@@ -137,7 +138,7 @@ enum DeviceBLEProtocol {
     static let mapPlusNavigationRouteLineWidthSettingID: UInt8 = 18
     static let mapPlusNavigationZoomLevelSettingID: UInt8 = 19
     static let mapPlusNavigationVisibilityMaskSettingID: UInt8 = 20
-    static let mapPlusNavigationStreetLineWidthBoostSettingID: UInt8 = 21
+    static let mapPlusNavigationStreetLineWidthSettingID: UInt8 = 21
     static let mapPlusNavigationPositionMarkerScaleSettingID: UInt8 = 22
     static let phoneBatteryLevelSettingID: UInt8 = 23
     static let phoneBatteryChargingSettingID: UInt8 = 24
@@ -165,6 +166,18 @@ enum DeviceBLEProtocol {
 
     static func phoneBatteryChargingValue(isCharging: Bool) -> Int32 {
         isCharging ? 1 : 0
+    }
+
+    static func absoluteStreetWidth(fromLegacyBoost boost: Double) -> Double {
+        normalizedStreetWidth(Double(defaultStreetWidth) + boost)
+    }
+
+    static func normalizedStreetWidth(_ width: Double) -> Double {
+        min(max(width, 1), 24)
+    }
+
+    static func legacyStreetWidthBoost(fromAbsoluteWidth width: Int32) -> Int32 {
+        min(max(width, 1), 24) - defaultStreetWidth
     }
 
     static func hardwareLabel(model: String?, hardware: String?) -> String {
@@ -451,12 +464,12 @@ private extension CBCharacteristicProperties {
 private enum MapPlusNavigationDefaults {
     static let minPolygonSize: Double = 0
     static let detailLevel = 0
-    static let routeLineWidth: Double = 4
-    static let streetLineWidthBoost: Double = 0
+    static let routeLineWidth: Double = 15
+    static let streetLineWidth: Double = 4
     static let positionMarkerScale: Double = 2
-    static let zoomLevel = 2
+    static let zoomLevel = 3
     static let showBuildings = false
-    static let showGreenSpace = true
+    static let showGreenSpace = false
     static let showPaths = false
     static let showTracks = false
     static let showMajorRoads = true
@@ -539,14 +552,14 @@ class BLEManager: NSObject, ObservableObject {
     @Published var minPolygonSize: Double = 0
     @Published var detailLevel: Int = 2
     @Published var routeLineWidth: Double = 4
-    @Published var streetLineWidthBoost: Double = 0
+    @Published var streetLineWidth: Double = 4
     @Published var positionMarkerScale: Double = 2
     @Published var mapRotationMode: Int = 0 // 0=North Up, 1=Course Up
-    @Published var zoomLevel: Int = 2 // 0-4: 0=super-zoom, 1=closest, 4=farthest
+    @Published var zoomLevel: Int = 3 // 0-5: 0=closest, 5=farthest
     @Published var mapPlusNavigationMinPolygonSize = MapPlusNavigationDefaults.minPolygonSize
     @Published var mapPlusNavigationDetailLevel = MapPlusNavigationDefaults.detailLevel
     @Published var mapPlusNavigationRouteLineWidth = MapPlusNavigationDefaults.routeLineWidth
-    @Published var mapPlusNavigationStreetLineWidthBoost = MapPlusNavigationDefaults.streetLineWidthBoost
+    @Published var mapPlusNavigationStreetLineWidth = MapPlusNavigationDefaults.streetLineWidth
     @Published var mapPlusNavigationPositionMarkerScale = MapPlusNavigationDefaults.positionMarkerScale
     @Published var mapPlusNavigationZoomLevel = MapPlusNavigationDefaults.zoomLevel
     @Published var tapToSwitchScreens: Bool = false
@@ -698,7 +711,8 @@ class BLEManager: NSObject, ObservableObject {
         static let minPolygonSize = "mapSettings.minPolygonSize"
         static let detailLevel = "mapSettings.detailLevel"
         static let routeLineWidth = "mapSettings.routeLineWidth"
-        static let streetLineWidthBoost = "mapSettings.streetLineWidthBoost"
+        static let streetLineWidth = "mapSettings.streetLineWidth"
+        static let legacyStreetLineWidthBoost = "mapSettings.streetLineWidthBoost"
         static let positionMarkerScale = "mapSettings.positionMarkerScale"
         static let mapRotationMode = "mapSettings.mapRotationMode"
         static let resetMapRotationModeToNorthUp = "mapSettings.resetMapRotationModeToNorthUp.v1"
@@ -706,7 +720,8 @@ class BLEManager: NSObject, ObservableObject {
         static let mapPlusNavigationMinPolygonSize = "mapPlusNavigationSettings.minPolygonSize"
         static let mapPlusNavigationDetailLevel = "mapPlusNavigationSettings.detailLevel"
         static let mapPlusNavigationRouteLineWidth = "mapPlusNavigationSettings.routeLineWidth"
-        static let mapPlusNavigationStreetLineWidthBoost = "mapPlusNavigationSettings.streetLineWidthBoost"
+        static let mapPlusNavigationStreetLineWidth = "mapPlusNavigationSettings.streetLineWidth"
+        static let legacyMapPlusNavigationStreetLineWidthBoost = "mapPlusNavigationSettings.streetLineWidthBoost"
         static let mapPlusNavigationPositionMarkerScale = "mapPlusNavigationSettings.positionMarkerScale"
         static let mapPlusNavigationZoomLevel = "mapPlusNavigationSettings.zoomLevel"
         static let mapPlusNavigationShowBuildings = "mapPlusNavigationSettings.showBuildings"
@@ -720,6 +735,7 @@ class BLEManager: NSObject, ObservableObject {
         static let mapPlusNavigationShowRailways = "mapPlusNavigationSettings.showRailways"
         static let mapPlusNavigationShowOtherAreas = "mapPlusNavigationSettings.showOtherAreas"
         static let mapPlusNavigationProfileMigrated = "mapPlusNavigationSettings.migrated.v1"
+        static let recommendedMapDefaultsMigrated = "mapSettings.recommendedDefaults.v2"
         static let tapToSwitchScreens = "deviceSettings.tapToSwitchScreens"
         static let enabledDeviceScreensMask = "deviceSettings.enabledScreensMask"
         static let defaultDeviceScreen = "deviceSettings.defaultScreen"
@@ -812,7 +828,16 @@ class BLEManager: NSObject, ObservableObject {
         minPolygonSize = defaults.double(forKey: SettingsKeys.minPolygonSize)
         detailLevel = defaults.object(forKey: SettingsKeys.detailLevel) as? Int ?? 2
         routeLineWidth = defaults.object(forKey: SettingsKeys.routeLineWidth) as? Double ?? 4.0
-        streetLineWidthBoost = defaults.object(forKey: SettingsKeys.streetLineWidthBoost) as? Double ?? 0.0
+        if let storedWidth = defaults.object(forKey: SettingsKeys.streetLineWidth) as? Double {
+            streetLineWidth = DeviceBLEProtocol.normalizedStreetWidth(storedWidth)
+        } else {
+            let legacyBoost = defaults.object(
+                forKey: SettingsKeys.legacyStreetLineWidthBoost
+            ) as? Double ?? 0
+            streetLineWidth = DeviceBLEProtocol.absoluteStreetWidth(
+                fromLegacyBoost: legacyBoost
+            )
+        }
         positionMarkerScale = defaults.object(forKey: SettingsKeys.positionMarkerScale) as? Double ?? 2.0
         if defaults.bool(forKey: SettingsKeys.resetMapRotationModeToNorthUp) {
             mapRotationMode = defaults.object(forKey: SettingsKeys.mapRotationMode) as? Int ?? 0
@@ -821,7 +846,7 @@ class BLEManager: NSObject, ObservableObject {
             defaults.set(0, forKey: SettingsKeys.mapRotationMode)
             defaults.set(true, forKey: SettingsKeys.resetMapRotationModeToNorthUp)
         }
-        zoomLevel = defaults.object(forKey: SettingsKeys.zoomLevel) as? Int ?? 2
+        zoomLevel = defaults.object(forKey: SettingsKeys.zoomLevel) as? Int ?? 3
         tapToSwitchScreens = defaults.object(forKey: SettingsKeys.tapToSwitchScreens) as? Bool ?? false
         var storedScreensMask = defaults.object(forKey: SettingsKeys.enabledDeviceScreensMask) as? Int
             ?? DeviceScreen.allScreensMask
@@ -875,7 +900,8 @@ class BLEManager: NSObject, ObservableObject {
             SettingsKeys.minPolygonSize,
             SettingsKeys.detailLevel,
             SettingsKeys.routeLineWidth,
-            SettingsKeys.streetLineWidthBoost,
+            SettingsKeys.streetLineWidth,
+            SettingsKeys.legacyStreetLineWidthBoost,
             SettingsKeys.positionMarkerScale,
             SettingsKeys.zoomLevel,
             SettingsKeys.showBuildings,
@@ -899,7 +925,7 @@ class BLEManager: NSObject, ObservableObject {
             mapPlusNavigationMinPolygonSize = minPolygonSize
             mapPlusNavigationDetailLevel = detailLevel
             mapPlusNavigationRouteLineWidth = routeLineWidth
-            mapPlusNavigationStreetLineWidthBoost = streetLineWidthBoost
+            mapPlusNavigationStreetLineWidth = streetLineWidth
             mapPlusNavigationPositionMarkerScale = positionMarkerScale
             mapPlusNavigationZoomLevel = zoomLevel
             mapPlusNavigationShowBuildings = showBuildings
@@ -922,9 +948,21 @@ class BLEManager: NSObject, ObservableObject {
             mapPlusNavigationRouteLineWidth = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationRouteLineWidth
             ) as? Double ?? MapPlusNavigationDefaults.routeLineWidth
-            mapPlusNavigationStreetLineWidthBoost = defaults.object(
-                forKey: SettingsKeys.mapPlusNavigationStreetLineWidthBoost
-            ) as? Double ?? MapPlusNavigationDefaults.streetLineWidthBoost
+            if let storedWidth = defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationStreetLineWidth
+            ) as? Double {
+                mapPlusNavigationStreetLineWidth = DeviceBLEProtocol.normalizedStreetWidth(
+                    storedWidth
+                )
+            } else if let legacyBoost = defaults.object(
+                forKey: SettingsKeys.legacyMapPlusNavigationStreetLineWidthBoost
+            ) as? Double {
+                mapPlusNavigationStreetLineWidth = DeviceBLEProtocol.absoluteStreetWidth(
+                    fromLegacyBoost: legacyBoost
+                )
+            } else {
+                mapPlusNavigationStreetLineWidth = MapPlusNavigationDefaults.streetLineWidth
+            }
             mapPlusNavigationPositionMarkerScale = defaults.object(
                 forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale
             ) as? Double ?? MapPlusNavigationDefaults.positionMarkerScale
@@ -962,9 +1000,44 @@ class BLEManager: NSObject, ObservableObject {
                 forKey: SettingsKeys.mapPlusNavigationShowOtherAreas
             ) as? Bool ?? MapPlusNavigationDefaults.showOtherAreas
         }
+        let shouldMigrateRecommendedDefaults = !defaults.bool(
+            forKey: SettingsKeys.recommendedMapDefaultsMigrated
+        )
+        if shouldMigrateRecommendedDefaults {
+            if detailLevel == 2,
+               routeLineWidth == 4,
+               streetLineWidth == 4,
+               positionMarkerScale == 2,
+               zoomLevel == 2 {
+                zoomLevel = 3
+            }
+            if mapPlusNavigationDetailLevel == 0,
+               mapPlusNavigationRouteLineWidth == 4,
+               mapPlusNavigationStreetLineWidth == 4,
+               mapPlusNavigationPositionMarkerScale == 2,
+               mapPlusNavigationZoomLevel == 2,
+               !mapPlusNavigationShowBuildings,
+               mapPlusNavigationShowGreenSpace,
+               !mapPlusNavigationShowPaths,
+               !mapPlusNavigationShowTracks,
+               mapPlusNavigationShowMajorRoads,
+               mapPlusNavigationShowLocalStreets,
+               !mapPlusNavigationShowServiceRoads,
+               mapPlusNavigationShowWater,
+               !mapPlusNavigationShowRailways,
+               !mapPlusNavigationShowOtherAreas {
+                mapPlusNavigationRouteLineWidth = 15
+                mapPlusNavigationZoomLevel = 3
+                mapPlusNavigationShowGreenSpace = false
+            }
+            defaults.set(true, forKey: SettingsKeys.recommendedMapDefaultsMigrated)
+        }
         showRouteOverlay = defaults.object(forKey: SettingsKeys.showRouteOverlay) as? Bool ?? true
         showCurrentPosition = defaults.object(forKey: SettingsKeys.showCurrentPosition) as? Bool ?? true
-        if shouldMigrateMapPlusNavigationProfile {
+        if shouldMigrateMapPlusNavigationProfile ||
+            shouldMigrateRecommendedDefaults ||
+            defaults.object(forKey: SettingsKeys.streetLineWidth) == nil ||
+            defaults.object(forKey: SettingsKeys.mapPlusNavigationStreetLineWidth) == nil {
             defaults.set(true, forKey: SettingsKeys.mapPlusNavigationProfileMigrated)
             saveSettings()
         }
@@ -1018,14 +1091,14 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(minPolygonSize, forKey: SettingsKeys.minPolygonSize)
         defaults.set(detailLevel, forKey: SettingsKeys.detailLevel)
         defaults.set(routeLineWidth, forKey: SettingsKeys.routeLineWidth)
-        defaults.set(streetLineWidthBoost, forKey: SettingsKeys.streetLineWidthBoost)
+        defaults.set(streetLineWidth, forKey: SettingsKeys.streetLineWidth)
         defaults.set(positionMarkerScale, forKey: SettingsKeys.positionMarkerScale)
         defaults.set(mapRotationMode, forKey: SettingsKeys.mapRotationMode)
         defaults.set(zoomLevel, forKey: SettingsKeys.zoomLevel)
         defaults.set(mapPlusNavigationMinPolygonSize, forKey: SettingsKeys.mapPlusNavigationMinPolygonSize)
         defaults.set(mapPlusNavigationDetailLevel, forKey: SettingsKeys.mapPlusNavigationDetailLevel)
         defaults.set(mapPlusNavigationRouteLineWidth, forKey: SettingsKeys.mapPlusNavigationRouteLineWidth)
-        defaults.set(mapPlusNavigationStreetLineWidthBoost, forKey: SettingsKeys.mapPlusNavigationStreetLineWidthBoost)
+        defaults.set(mapPlusNavigationStreetLineWidth, forKey: SettingsKeys.mapPlusNavigationStreetLineWidth)
         defaults.set(mapPlusNavigationPositionMarkerScale, forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale)
         defaults.set(mapPlusNavigationZoomLevel, forKey: SettingsKeys.mapPlusNavigationZoomLevel)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
@@ -1910,7 +1983,15 @@ class BLEManager: NSObject, ObservableObject {
             log("Independent map setting id=\(id) not sent: connected firmware does not advertise support")
             return
         }
-        guard sendSettingPacket(id: id, value: value, label: "setting id=\(id)") else {
+        let deviceValue: Int32
+        if id == 9 || id == DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID {
+            deviceValue = DeviceBLEProtocol.legacyStreetWidthBoost(
+                fromAbsoluteWidth: value
+            )
+        } else {
+            deviceValue = value
+        }
+        guard sendSettingPacket(id: id, value: deviceValue, label: "setting id=\(id)") else {
             log("Settings characteristic unsupported; saved local setting id=\(id), value=\(value)")
             return
         }
@@ -2009,7 +2090,7 @@ class BLEManager: NSObject, ObservableObject {
             mapPlusNavigationShowRailways = showRailways
             mapPlusNavigationShowOtherAreas = showOtherAreas
         case 9:
-            mapPlusNavigationStreetLineWidthBoost = streetLineWidthBoost
+            mapPlusNavigationStreetLineWidth = streetLineWidth
         case 10:
             mapPlusNavigationPositionMarkerScale = positionMarkerScale
         default:
@@ -2041,8 +2122,8 @@ class BLEManager: NSObject, ObservableObject {
                         value: Int32(mapPlusNavigationDetailLevel))
             sendSetting(id: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID,
                         value: Int32(mapPlusNavigationRouteLineWidth))
-            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID,
-                        value: Int32(mapPlusNavigationStreetLineWidthBoost))
+            sendSetting(id: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID,
+                        value: Int32(mapPlusNavigationStreetLineWidth))
             sendSetting(id: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID,
                         value: Int32(mapPlusNavigationPositionMarkerScale))
             sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
@@ -2055,7 +2136,7 @@ class BLEManager: NSObject, ObservableObject {
             sendSetting(id: 1, value: Int32(minPolygonSize))
             sendSetting(id: 2, value: Int32(detailLevel))
             sendSetting(id: 3, value: Int32(routeLineWidth))
-            sendSetting(id: 9, value: Int32(streetLineWidthBoost))
+            sendSetting(id: 9, value: Int32(streetLineWidth))
             sendSetting(id: 10, value: Int32(positionMarkerScale))
             sendSetting(id: 7, value: Int32(zoomLevel))
         }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -842,18 +842,6 @@ private struct UICustomizationSettingsView: View {
             .disabled(!bleManager.supportsDeviceSettings ||
                       !bleManager.hasReceivedDeviceCapabilities)
 
-            Section(header: Text("Map Mode"), footer: Text("Applies only to the Map screen. Map + Navigation automatically uses course-up while navigating.")) {
-                Picker("Rotation", selection: $bleManager.mapRotationMode) {
-                    Text("North Up").tag(0)
-                    Text("Course Up").tag(1)
-                }
-                .pickerStyle(.segmented)
-                .onChange(of: bleManager.mapRotationMode) { newValue in
-                    bleManager.sendSetting(id: 6, value: Int32(newValue))
-                }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
-
             Section(header: Text("Navigation Overlays"), footer: Text("Show or hide live navigation layers drawn above both map screens.")) {
                 Toggle("Route Line", isOn: $bleManager.showRouteOverlay)
                     .onChange(of: bleManager.showRouteOverlay) { _ in bleManager.sendVisibilityMask() }
@@ -923,8 +911,8 @@ private struct MapStyleSettingsView: View {
         binding(map: \.routeLineWidth, mapPlusNavigation: \.mapPlusNavigationRouteLineWidth)
     }
 
-    private var streetLineWidthBoost: Binding<Double> {
-        binding(map: \.streetLineWidthBoost, mapPlusNavigation: \.mapPlusNavigationStreetLineWidthBoost)
+    private var streetLineWidth: Binding<Double> {
+        binding(map: \.streetLineWidth, mapPlusNavigation: \.mapPlusNavigationStreetLineWidth)
     }
 
     private var positionMarkerScale: Binding<Double> {
@@ -1003,6 +991,19 @@ private struct MapStyleSettingsView: View {
 
     var body: some View {
         Form {
+            if screen == .map {
+                Section(header: Text("Map Mode")) {
+                    Picker("Rotation", selection: $bleManager.mapRotationMode) {
+                        Text("North Up").tag(0)
+                        Text("Course Up").tag(1)
+                    }
+                    .pickerStyle(.segmented)
+                    .onChange(of: bleManager.mapRotationMode) { newValue in
+                        bleManager.sendSetting(id: 6, value: Int32(newValue))
+                    }
+                }
+            }
+
             Section(header: Text("Roads & Paths"), footer: Text("Service roads commonly include driveways and internal compound roads. Separate Service Roads and Tracks require current v2 map downloads; legacy maps keep each pair combined.")) {
                 Toggle("Major Roads", isOn: showMajorRoads)
                     .onChange(of: showMajorRoads.wrappedValue) { _ in sendVisibilityMask() }
@@ -1070,15 +1071,15 @@ private struct MapStyleSettingsView: View {
                 settingSlider(title: "Route Line Width", value: routeLineWidth, range: 2...48, prefix: "", suffix: " px") { newValue in
                     sendSetting(mapID: 3, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID, value: Int32(newValue))
                 }
-                settingSlider(title: "Street Width Boost", value: streetLineWidthBoost, range: 0...24, prefix: "+", suffix: " px") { newValue in
-                    sendSetting(mapID: 9, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID, value: Int32(newValue))
+                settingSlider(title: "Street Width", value: streetLineWidth, range: 1...24, prefix: "", suffix: " px") { newValue in
+                    sendSetting(mapID: 9, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID, value: Int32(newValue))
                 }
                 settingSlider(title: "Position Marker Size", value: positionMarkerScale, range: 1...5, prefix: "", suffix: "x") { newValue in
                     sendSetting(mapID: 10, mapPlusNavigationID: DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID, value: Int32(newValue))
                 }
             }
 
-            Section(header: Text("Zoom Level"), footer: Text("0 = Super Zoom, 5 = Farthest")) {
+            Section(header: Text("Zoom Level"), footer: Text("0 = Closest, 5 = Farthest")) {
                 Picker("Zoom", selection: zoomLevel) {
                     ForEach(0...5, id: \.self) { level in
                         Text("\(level)").tag(level)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8433,6 +8433,11 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.serviceRoadsVisibilityMask, 0x400, "service roads use visibility bit 10")
         assertEqual(DeviceBLEProtocol.tracksVisibilityMask, 0x800, "tracks use visibility bit 11")
         assertEqual(DeviceBLEProtocol.extendedVisibilityMarker, 0x1000, "extended visibility uses marker bit 12")
+        assertEqual(DeviceBLEProtocol.defaultStreetWidth, 4, "street width defaults to 4 px")
+        assertEqual(DeviceBLEProtocol.absoluteStreetWidth(fromLegacyBoost: 0), 4, "legacy zero boost migrates to the default absolute width")
+        assertEqual(DeviceBLEProtocol.absoluteStreetWidth(fromLegacyBoost: 4), 8, "legacy boosts migrate relative to the default width")
+        assertEqual(DeviceBLEProtocol.legacyStreetWidthBoost(fromAbsoluteWidth: 1), -3, "one-pixel streets retain the legacy wire encoding")
+        assertEqual(DeviceBLEProtocol.legacyStreetWidthBoost(fromAbsoluteWidth: 4), 0, "default street width uses a zero wire boost")
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
@@ -8442,7 +8447,7 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID, 18, "Map + Navigation route width uses setting ID 18")
         assertEqual(DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID, 19, "Map + Navigation zoom uses setting ID 19")
         assertEqual(DeviceBLEProtocol.mapPlusNavigationVisibilityMaskSettingID, 20, "Map + Navigation visibility uses setting ID 20")
-        assertEqual(DeviceBLEProtocol.mapPlusNavigationStreetLineWidthBoostSettingID, 21, "Map + Navigation street width uses setting ID 21")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID, 21, "Map + Navigation street width uses setting ID 21")
         assertEqual(DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID, 22, "Map + Navigation marker scale uses setting ID 22")
         assertEqual(DeviceBLEProtocol.phoneBatteryLevelSettingID, 23, "phone battery level uses firmware setting ID 23")
         assertEqual(DeviceBLEProtocol.phoneBatteryChargingSettingID, 24, "phone charging state uses firmware setting ID 24")
@@ -11589,6 +11594,7 @@ struct NavigationProtocolTests {
             "mapSettings.minPolygonSize",
             "mapSettings.detailLevel",
             "mapSettings.routeLineWidth",
+            "mapSettings.streetLineWidth",
             "mapSettings.streetLineWidthBoost",
             "mapSettings.positionMarkerScale",
             "mapSettings.mapRotationMode",
@@ -11608,6 +11614,7 @@ struct NavigationProtocolTests {
             "mapPlusNavigationSettings.minPolygonSize",
             "mapPlusNavigationSettings.detailLevel",
             "mapPlusNavigationSettings.routeLineWidth",
+            "mapPlusNavigationSettings.streetLineWidth",
             "mapPlusNavigationSettings.streetLineWidthBoost",
             "mapPlusNavigationSettings.positionMarkerScale",
             "mapPlusNavigationSettings.zoomLevel",
@@ -11622,6 +11629,7 @@ struct NavigationProtocolTests {
             "mapPlusNavigationSettings.showRailways",
             "mapPlusNavigationSettings.showOtherAreas",
             "mapPlusNavigationSettings.migrated.v1",
+            "mapSettings.recommendedDefaults.v2",
             "deviceSettings.enabledScreensMask",
             "deviceSettings.defaultScreen",
             "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1",
@@ -11632,12 +11640,24 @@ struct NavigationProtocolTests {
 
         let freshManager = BLEManager()
         assertEqual(freshManager.defaultDeviceScreen, .mapPlusNavigation, "fresh installs default to Map + Navigation")
+        assertEqual(freshManager.detailLevel, 2, "fresh Map profiles default to high detail")
+        assertEqual(freshManager.zoomLevel, 3, "fresh Map profiles default to zoom level 3")
+        assertEqual(freshManager.routeLineWidth, 4, "fresh Map profiles default to a 4 px route")
+        assertEqual(freshManager.streetLineWidth, 4, "fresh Map profiles default to 4 px streets")
         assertEqual(freshManager.mapPlusNavigationDetailLevel, 0,
                     "fresh Map + Navigation profiles default to low detail")
+        assertEqual(freshManager.mapPlusNavigationZoomLevel, 3,
+                    "fresh Map + Navigation profiles default to zoom level 3")
+        assertEqual(freshManager.mapPlusNavigationRouteLineWidth, 15,
+                    "fresh Map + Navigation profiles default to a 15 px route")
+        assertEqual(freshManager.mapPlusNavigationStreetLineWidth, 4,
+                    "fresh Map + Navigation profiles default to 4 px streets")
+        assertEqual(freshManager.mapPlusNavigationPositionMarkerScale, 2,
+                    "fresh Map + Navigation profiles keep a 2x position marker")
         assert(!freshManager.mapPlusNavigationShowBuildings,
                "fresh Map + Navigation profiles hide buildings")
-        assert(freshManager.mapPlusNavigationShowGreenSpace,
-               "fresh Map + Navigation profiles keep green space visible")
+        assert(!freshManager.mapPlusNavigationShowGreenSpace,
+               "fresh Map + Navigation profiles hide green space")
         assert(!freshManager.mapPlusNavigationShowPaths,
                "fresh Map + Navigation profiles hide paths and footways")
         assert(!freshManager.mapPlusNavigationShowTracks,
@@ -11680,14 +11700,59 @@ struct NavigationProtocolTests {
         let freshDetailPacket = freshProfilePackets.first {
             $0.count == 9 && $0[4] == DeviceBLEProtocol.mapPlusNavigationDetailLevelSettingID
         }
+        let freshRoutePacket = freshProfilePackets.first {
+            $0.count == 9 && $0[4] == DeviceBLEProtocol.mapPlusNavigationRouteLineWidthSettingID
+        }
+        let freshStreetPacket = freshProfilePackets.first {
+            $0.count == 9 && $0[4] == DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID
+        }
+        let freshZoomPacket = freshProfilePackets.first {
+            $0.count == 9 && $0[4] == DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID
+        }
         assert(freshVisibilityPacket != nil,
                "fresh Map + Navigation visibility is sent after capability negotiation")
         assert(freshDetailPacket != nil,
                "fresh Map + Navigation detail is sent after capability negotiation")
-        assertEqual(readInt32LE(freshVisibilityPacket!, offset: 5), 0x103A,
-                    "fresh Map + Navigation sends only green space, major roads, local roads, and water")
+        assertEqual(readInt32LE(freshVisibilityPacket!, offset: 5), 0x1038,
+                    "fresh Map + Navigation sends only major roads, local roads, and water")
         assertEqual(readInt32LE(freshDetailPacket!, offset: 5), 0,
                     "fresh Map + Navigation sends low detail")
+        assertEqual(readInt32LE(freshRoutePacket!, offset: 5), 15,
+                    "fresh Map + Navigation sends a 15 px route")
+        assertEqual(readInt32LE(freshStreetPacket!, offset: 5), 0,
+                    "fresh Map + Navigation encodes its 4 px street width compatibly")
+        assertEqual(readInt32LE(freshZoomPacket!, offset: 5), 3,
+                    "fresh Map + Navigation sends zoom level 3")
+        freshManager.streetLineWidth = 7
+        freshManager.sendSetting(id: 9, value: 7)
+        let customStreetPacket = freshProfilePackets.last { $0.count == 9 && $0[4] == 9 }
+        assertEqual(readInt32LE(customStreetPacket!, offset: 5), 3,
+                    "a displayed 7 px street width uses the compatible +3 wire value")
+
+        defaults.set(true, forKey: "mapPlusNavigationSettings.migrated.v1")
+        defaults.removeObject(forKey: "mapSettings.recommendedDefaults.v2")
+        defaults.set(0, forKey: "mapPlusNavigationSettings.detailLevel")
+        defaults.set(4.0, forKey: "mapPlusNavigationSettings.routeLineWidth")
+        defaults.set(4.0, forKey: "mapPlusNavigationSettings.streetLineWidth")
+        defaults.set(2.0, forKey: "mapPlusNavigationSettings.positionMarkerScale")
+        defaults.set(2, forKey: "mapPlusNavigationSettings.zoomLevel")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showBuildings")
+        defaults.set(true, forKey: "mapPlusNavigationSettings.showGreenSpace")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showPaths")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showTracks")
+        defaults.set(true, forKey: "mapPlusNavigationSettings.showMajorRoads")
+        defaults.set(true, forKey: "mapPlusNavigationSettings.showLocalStreets")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showServiceRoads")
+        defaults.set(true, forKey: "mapPlusNavigationSettings.showWater")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showRailways")
+        defaults.set(false, forKey: "mapPlusNavigationSettings.showOtherAreas")
+        let recommendedDefaultsMigratedManager = BLEManager()
+        assertEqual(recommendedDefaultsMigratedManager.mapPlusNavigationRouteLineWidth, 15,
+                    "the former Map + Navigation route default migrates to 15 px")
+        assertEqual(recommendedDefaultsMigratedManager.mapPlusNavigationZoomLevel, 3,
+                    "the former Map + Navigation zoom default migrates to level 3")
+        assert(!recommendedDefaultsMigratedManager.mapPlusNavigationShowGreenSpace,
+               "the former Map + Navigation visibility preset drops green space")
 
         defaults.set(DeviceScreen.map.rawValue, forKey: "deviceSettings.defaultScreen")
         defaults.removeObject(forKey: "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1")
@@ -11696,6 +11761,8 @@ struct NavigationProtocolTests {
 
         defaults.set(1, forKey: "mapSettings.detailLevel")
         defaults.set(4, forKey: "mapSettings.zoomLevel")
+        defaults.removeObject(forKey: "mapSettings.streetLineWidth")
+        defaults.set(4, forKey: "mapSettings.streetLineWidthBoost")
         defaults.set(false, forKey: "mapSettings.showBuildings")
         defaults.set(false, forKey: "mapSettings.showPaths")
         defaults.set(false, forKey: "mapSettings.showLocalStreets")
@@ -11705,6 +11772,8 @@ struct NavigationProtocolTests {
         defaults.removeObject(forKey: "mapPlusNavigationSettings.showServiceRoads")
         defaults.removeObject(forKey: "mapPlusNavigationSettings.migrated.v1")
         let migratedProfileManager = BLEManager()
+        assertEqual(migratedProfileManager.streetLineWidth, 8,
+                    "legacy Map street boosts migrate to absolute widths")
         assertEqual(migratedProfileManager.mapPlusNavigationDetailLevel, 1,
                     "existing shared detail migrates into Map + Navigation")
         assertEqual(migratedProfileManager.mapPlusNavigationZoomLevel, 4,


### PR DESCRIPTION
## Summary

- set Map defaults to High detail, zoom 3, a 4 px route, 4 px streets, and a 2x position marker
- set Map + Navigation defaults to Low detail, zoom 3, a 15 px route, 4 px streets, a 2x marker, and only Major Roads, Residential & Local Roads, and Water
- display and persist Street Width as an absolute pixel width while keeping the BLE wire value compatible with older app and firmware builds
- move Map Mode into the Map screen settings and update the zoom wording to Closest/Farthest
- migrate untouched former recommendations while preserving customized profiles

## Verification

- `g++ -std=c++17 esp32/tools/tests/test_map_profile_protocol.cpp`
- `g++ -std=c++17 esp32/tools/tests/test_map_profile_persistence.cpp`
- `ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -quiet -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination "generic/platform=iOS Simulator" CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

Hardware-targeted PlatformIO build not run because no physical board target was selected for this task.