### PR TITLE
Hide map recovery status during launch

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -426,9 +426,19 @@ enum OfflineMapDownloadingSectionPresentation {
         isBusy: Bool,
         hasPendingJob: Bool,
         hasPendingActivation: Bool,
+        isServerRecoveryCheckPending: Bool,
+        hasCurrentJob: Bool,
+        hasDownloadedPack: Bool,
         errorMessage: String?
     ) -> Bool {
-        isBusy || hasPendingJob || hasPendingActivation || errorMessage != nil
+        let isOnlyCheckingForServerMaps = isServerRecoveryCheckPending &&
+            !hasCurrentJob &&
+            !hasDownloadedPack &&
+            !hasPendingActivation &&
+            errorMessage == nil
+        guard !isOnlyCheckingForServerMaps else { return false }
+
+        return isBusy || hasPendingJob || hasPendingActivation || errorMessage != nil
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -84,6 +84,9 @@ struct SettingsView: View {
                     isBusy: offlineMapManager.isBusy,
                     hasPendingJob: offlineMapManager.hasPendingMapJob,
                     hasPendingActivation: offlineMapManager.hasPendingDeviceActivation,
+                    isServerRecoveryCheckPending: offlineMapManager.isServerRecoveryCheckPending,
+                    hasCurrentJob: offlineMapManager.currentJob != nil,
+                    hasDownloadedPack: offlineMapManager.downloadedPackURL != nil,
                     errorMessage: offlineMapManager.errorMessage
                 ) {
                     DownloadingMapsSettingsSection(manager: offlineMapManager)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -4809,6 +4809,9 @@ struct NavigationProtocolTests {
                 isBusy: false,
                 hasPendingJob: true,
                 hasPendingActivation: false,
+                isServerRecoveryCheckPending: false,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
                 errorMessage: nil
             ),
             "paused persisted jobs keep the resume section reachable"
@@ -4818,6 +4821,9 @@ struct NavigationProtocolTests {
                 isBusy: false,
                 hasPendingJob: false,
                 hasPendingActivation: false,
+                isServerRecoveryCheckPending: false,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
                 errorMessage: nil
             ),
             "idle map settings omit an empty downloading section"
@@ -4827,9 +4833,60 @@ struct NavigationProtocolTests {
                 isBusy: false,
                 hasPendingJob: false,
                 hasPendingActivation: true,
+                isServerRecoveryCheckPending: false,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
                 errorMessage: nil
             ),
             "device-owned activation keeps its status section visible"
+        )
+        assert(
+            !OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: true,
+                hasPendingJob: true,
+                hasPendingActivation: false,
+                isServerRecoveryCheckPending: true,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
+                errorMessage: nil
+            ),
+            "launch recovery checks stay hidden until a real map job is found"
+        )
+        assert(
+            OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: true,
+                hasPendingJob: true,
+                hasPendingActivation: true,
+                isServerRecoveryCheckPending: true,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
+                errorMessage: nil
+            ),
+            "device activation remains visible during a server recovery check"
+        )
+        assert(
+            OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: true,
+                hasPendingJob: true,
+                hasPendingActivation: false,
+                isServerRecoveryCheckPending: true,
+                hasCurrentJob: false,
+                hasDownloadedPack: false,
+                errorMessage: "Map server unavailable"
+            ),
+            "launch recovery errors remain visible"
+        )
+        assert(
+            OfflineMapDownloadingSectionPresentation.isVisible(
+                isBusy: true,
+                hasPendingJob: true,
+                hasPendingActivation: false,
+                isServerRecoveryCheckPending: true,
+                hasCurrentJob: true,
+                hasDownloadedPack: false,
+                errorMessage: nil
+            ),
+            "a recovered map job remains visible"
         )
         assert(
             OfflineMapAutomaticRecoveryTrigger.shouldResume(


### PR DESCRIPTION
## Summary

- hide the map download progress section while launch recovery is only checking the server for recoverable jobs
- continue showing genuine recovered jobs, pending device activation, and recovery errors
- add regression coverage for the launch-only recovery state

## Root cause

The startup recovery probe temporarily set both `isBusy` and `hasPendingMapJob`. Settings interpreted those internal flags as an active map preparation and briefly rendered the status and pause controls before the server check completed.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/open-bike-map-settings-recovery-build CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
