### PR TITLE
Add workout averages and heart rate zone summary

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
@@ -68,7 +68,7 @@ struct HeartRateZoneStrip: View {
 
 }
 
-private enum HeartRateZonePalette {
+enum HeartRateZonePalette {
     static func color(for zone: Int) -> Color {
         switch zone {
         case 1:
@@ -94,6 +94,118 @@ private enum HeartRateZonePalette {
     }
 }
 
+struct HeartRateZoneBreakdown: View {
+    let durations: WorkoutZoneDurationsV1?
+    let maximumHeartRateBPM: Int
+
+    private let zoneCount = Int(WorkoutHeartRateZoneProfile.zoneCount)
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Heart Rate Zones", systemImage: "heart.fill")
+                .font(.headline)
+                .foregroundStyle(.red)
+
+            if let secondsByZone {
+                VStack(spacing: 13) {
+                    ForEach(1...zoneCount, id: \.self) { zone in
+                        zoneRow(
+                            zone: zone,
+                            duration: secondsByZone[zone - 1],
+                            longestDuration: secondsByZone.max() ?? 0
+                        )
+                    }
+                }
+
+                Text(
+                    "Based on your configured maximum heart rate of \(maximumHeartRateBPM) BPM."
+                )
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+            } else {
+                Text("Heart rate zone data was not available for this workout.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background, in: RoundedRectangle(cornerRadius: 14))
+        .accessibilityElement(children: .contain)
+    }
+
+    private func zoneRow(
+        zone: Int,
+        duration: TimeInterval,
+        longestDuration: TimeInterval
+    ) -> some View {
+        let color = HeartRateZonePalette.color(for: zone)
+        let fraction = longestDuration > 0
+            ? min(max(duration / longestDuration, 0), 1)
+            : 0
+
+        return VStack(alignment: .leading, spacing: 6) {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Text("Zone \(zone)")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(color)
+
+                Text(WorkoutValueFormatter.duration(duration))
+                    .font(.subheadline.monospacedDigit())
+
+                Spacer(minLength: 8)
+
+                Text(rangeLabel(for: zone))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            GeometryReader { proxy in
+                ZStack(alignment: .leading) {
+                    Capsule()
+                        .fill(color.opacity(0.16))
+                    Capsule()
+                        .fill(color)
+                        .frame(width: proxy.size.width * fraction)
+                }
+            }
+            .frame(height: 8)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "Zone \(zone), \(WorkoutValueFormatter.duration(duration)), \(rangeLabel(for: zone))"
+        )
+    }
+
+    private var secondsByZone: [TimeInterval]? {
+        guard let values = durations?.secondsByZone,
+              values.count == zoneCount,
+              values.allSatisfy({ $0.isFinite && $0 >= 0 }) else {
+            return nil
+        }
+        return values
+    }
+
+    private func rangeLabel(for zone: Int) -> String {
+        let profile = WorkoutHeartRateZoneProfile(
+            maximumHeartRateBPM: maximumHeartRateBPM
+        )
+        guard let range = profile.bpmRange(for: UInt8(zone)) else {
+            return "-- BPM"
+        }
+        switch (range.lowerBound, range.upperBound) {
+        case (nil, let upper?):
+            return "<\(upper + 1) BPM"
+        case (let lower?, nil):
+            return "\(lower)+ BPM"
+        case (let lower?, let upper?):
+            return "\(lower)–\(upper) BPM"
+        default:
+            return "-- BPM"
+        }
+    }
+}
+
 struct HeartRateZoneStrip_Previews: PreviewProvider {
     static var previews: some View {
         VStack(spacing: 16) {
@@ -101,6 +213,13 @@ struct HeartRateZoneStrip_Previews: PreviewProvider {
             HeartRateZoneStrip(currentZone: 3)
             HeartRateZoneStrip(currentZone: 5)
             HeartRateZoneStrip(currentZone: nil)
+            HeartRateZoneBreakdown(
+                durations: WorkoutZoneDurationsV1(
+                    capturedAt: Date(),
+                    secondsByZone: [109, 42, 55, 149, 704]
+                ),
+                maximumHeartRateBPM: 190
+            )
         }
         .padding()
         .previewLayout(.sizeThatFits)

--- a/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/HeartRateZoneStrip.swift
@@ -96,9 +96,6 @@ enum HeartRateZonePalette {
 
 struct HeartRateZoneBreakdown: View {
     let durations: WorkoutZoneDurationsV1?
-    let maximumHeartRateBPM: Int
-
-    private let zoneCount = Int(WorkoutHeartRateZoneProfile.zoneCount)
 
     var body: some View {
         VStack(alignment: .leading, spacing: 14) {
@@ -106,22 +103,27 @@ struct HeartRateZoneBreakdown: View {
                 .font(.headline)
                 .foregroundStyle(.red)
 
-            if let secondsByZone {
+            if let presentation {
                 VStack(spacing: 13) {
-                    ForEach(1...zoneCount, id: \.self) { zone in
-                        zoneRow(
-                            zone: zone,
-                            duration: secondsByZone[zone - 1],
-                            longestDuration: secondsByZone.max() ?? 0
-                        )
+                    ForEach(presentation.rows, id: \.zone) { row in
+                        zoneRow(row)
                     }
                 }
 
-                Text(
-                    "Based on your configured maximum heart rate of \(maximumHeartRateBPM) BPM."
-                )
-                .font(.caption2)
-                .foregroundStyle(.secondary)
+                if let maximumHeartRateBPM =
+                    presentation.maximumHeartRateBPM {
+                    Text(
+                        "Based on the maximum heart rate used for this workout: \(maximumHeartRateBPM) BPM."
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                } else {
+                    Text(
+                        "Heart-rate ranges are unavailable because this workout did not record its maximum-heart-rate profile."
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                }
             } else {
                 Text("Heart rate zone data was not available for this workout.")
                     .font(.subheadline)
@@ -135,27 +137,22 @@ struct HeartRateZoneBreakdown: View {
     }
 
     private func zoneRow(
-        zone: Int,
-        duration: TimeInterval,
-        longestDuration: TimeInterval
+        _ row: WorkoutHeartRateZoneBreakdownRowV1
     ) -> some View {
-        let color = HeartRateZonePalette.color(for: zone)
-        let fraction = longestDuration > 0
-            ? min(max(duration / longestDuration, 0), 1)
-            : 0
+        let color = HeartRateZonePalette.color(for: row.zone)
 
         return VStack(alignment: .leading, spacing: 6) {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
-                Text("Zone \(zone)")
+                Text("Zone \(row.zone)")
                     .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(color)
+                    .foregroundStyle(.primary)
 
-                Text(WorkoutValueFormatter.duration(duration))
+                Text(row.durationLabel)
                     .font(.subheadline.monospacedDigit())
 
                 Spacer(minLength: 8)
 
-                Text(rangeLabel(for: zone))
+                Text(row.bpmRangeLabel)
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
@@ -166,43 +163,21 @@ struct HeartRateZoneBreakdown: View {
                         .fill(color.opacity(0.16))
                     Capsule()
                         .fill(color)
-                        .frame(width: proxy.size.width * fraction)
+                        .frame(
+                            width: proxy.size.width
+                                * row.fractionOfLongestDuration
+                        )
                 }
             }
             .frame(height: 8)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel(
-            "Zone \(zone), \(WorkoutValueFormatter.duration(duration)), \(rangeLabel(for: zone))"
-        )
+        .accessibilityLabel(row.accessibilityLabel)
     }
 
-    private var secondsByZone: [TimeInterval]? {
-        guard let values = durations?.secondsByZone,
-              values.count == zoneCount,
-              values.allSatisfy({ $0.isFinite && $0 >= 0 }) else {
-            return nil
-        }
-        return values
-    }
-
-    private func rangeLabel(for zone: Int) -> String {
-        let profile = WorkoutHeartRateZoneProfile(
-            maximumHeartRateBPM: maximumHeartRateBPM
-        )
-        guard let range = profile.bpmRange(for: UInt8(zone)) else {
-            return "-- BPM"
-        }
-        switch (range.lowerBound, range.upperBound) {
-        case (nil, let upper?):
-            return "<\(upper + 1) BPM"
-        case (let lower?, nil):
-            return "\(lower)+ BPM"
-        case (let lower?, let upper?):
-            return "\(lower)–\(upper) BPM"
-        default:
-            return "-- BPM"
-        }
+    private var presentation:
+        WorkoutHeartRateZoneBreakdownPresentationV1? {
+        WorkoutHeartRateZoneBreakdownPresentationV1.make(durations: durations)
     }
 }
 
@@ -216,9 +191,9 @@ struct HeartRateZoneStrip_Previews: PreviewProvider {
             HeartRateZoneBreakdown(
                 durations: WorkoutZoneDurationsV1(
                     capturedAt: Date(),
-                    secondsByZone: [109, 42, 55, 149, 704]
-                ),
-                maximumHeartRateBPM: 190
+                    secondsByZone: [109, 42, 55, 149, 704],
+                    maximumHeartRateBPM: 190
+                )
             )
         }
         .padding()

--- a/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/NavigationDetailsView.swift
@@ -446,6 +446,26 @@ struct RideMetricsPanel: View {
                 label: "time in zone"
             )
         )
+        let snapshot = workoutStore.presentation.snapshot
+        expandedMetrics.append(
+            RideMetric(
+                value: WorkoutValueFormatter.heartRate(
+                    snapshot.averageHeartRate?.value
+                ),
+                unit: "BPM",
+                label: "average heart rate"
+            )
+        )
+        expandedMetrics.append(
+            RideMetric(
+                value: WorkoutValueFormatter.averageSpeed(
+                    distanceMeters: snapshot.cyclingDistance?.value,
+                    elapsedSeconds: snapshot.elapsedTime?.value
+                ),
+                unit: "km/h",
+                label: "average speed"
+            )
+        )
         expandedMetrics.append(contentsOf: metrics.filter {
             $0.id != "speed" && $0.id != "heart rate"
         })

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -698,9 +698,7 @@ struct WorkoutDashboardView: View {
 
                 if store.presentation.connectionState == .ended {
                     HeartRateZoneBreakdown(
-                        durations: snapshot.heartRateZoneDurations,
-                        maximumHeartRateBPM:
-                            WorkoutHeartRateZoneSettings.maximumHeartRateBPM()
+                        durations: snapshot.heartRateZoneDurations
                     )
                 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -678,11 +678,29 @@ struct WorkoutDashboardView: View {
                         .red.opacity(0.8)
                     )
                     metric(
+                        "Average Speed",
+                        WorkoutValueFormatter.averageSpeed(
+                            distanceMeters: snapshot.cyclingDistance?.value,
+                            elapsedSeconds: snapshot.elapsedTime?.value
+                        ),
+                        "KM/H",
+                        "speedometer",
+                        .cyan.opacity(0.8)
+                    )
+                    metric(
                         "Altitude",
                         altitudeValue(snapshot.location?.altitude),
                         "M",
                         "mountain.2.fill",
                         .indigo
+                    )
+                }
+
+                if store.presentation.connectionState == .ended {
+                    HeartRateZoneBreakdown(
+                        durations: snapshot.heartRateZoneDurations,
+                        maximumHeartRateBPM:
+                            WorkoutHeartRateZoneSettings.maximumHeartRateBPM()
                     )
                 }
 

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -476,6 +476,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         WorkoutHeartRateZoneDurationAccumulator()
     private var heartRateZoneCheckpointPersistenceGate =
         WorkoutHeartRateZoneCheckpointPersistenceGate()
+    private var heartRateZoneRuntimeSessionID: UUID?
+    private var heartRateZoneRuntimeMaximumHeartRateBPM: Int?
 
     override convenience init() {
 #if DEBUG
@@ -1184,7 +1186,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         }
 
         do {
-            identity = try recoveryStore.begin(startDate: startDate)
+            let workoutIdentity = try recoveryStore.begin(
+                startDate: startDate,
+                heartRateZoneMaximumHeartRateBPM: maximumHeartRateBPM
+            )
+            adoptRecoveredIdentityForRuntime(workoutIdentity)
             let session = try HKWorkoutSession(
                 healthStore: healthStore,
                 configuration: configuration
@@ -1883,11 +1889,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         }
 
         switch request.phase {
-        case .workoutSaved:
-            completeDetachedFinalization(
-                summary: makeDetachedSavedSummary(identity: recoveredIdentity)
-            )
-        case .finishAttempted:
+        case .workoutSaved, .finishAttempted:
             await reconcileDetachedSave()
         case .requested, .collectionEnded:
             finishRequestError = .reconciliationFailed
@@ -1905,7 +1907,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             guard lifecycle.finishDisposition == request.disposition else {
                 return false
             }
-            identity = recoveredIdentity
+            adoptRecoveredIdentityForRuntime(recoveredIdentity)
             return true
         }
         guard lifecycle.apply(.requestStart),
@@ -1913,7 +1915,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
               lifecycle.apply(.requestEnd(request.disposition)) else {
             return false
         }
-        identity = recoveredIdentity
+        adoptRecoveredIdentityForRuntime(recoveredIdentity)
         return true
     }
 
@@ -1926,13 +1928,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             finishRequestError = .reconciliationFailed
             return
         }
-        if request.phase == .workoutSaved {
-            completeDetachedFinalization(
-                summary: makeDetachedSavedSummary(identity: identity)
-            )
-            return
-        }
-        guard request.phase == .finishAttempted else {
+        let expectedPhase = request.phase
+        guard expectedPhase == .workoutSaved
+                || expectedPhase == .finishAttempted else {
             finishRequestError = .reconciliationFailed
             publishSnapshotImmediately()
             return
@@ -1954,11 +1952,17 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                       currentIdentity.startDate.timeIntervalSince(expectedStartDate)
                   ) <= 2,
                   currentIdentity.finishRequest?.disposition == .save,
-                  currentIdentity.finishRequest?.phase == .finishAttempted else {
+                  currentIdentity.finishRequest?.phase == expectedPhase else {
                 finishRequestError = .reconciliationFailed
                 return
             }
             guard let workout else {
+                if expectedPhase == .workoutSaved {
+                    completeDetachedFinalization(
+                        summary: makeDetachedSavedSummary(identity: identity)
+                    )
+                    return
+                }
                 // Query visibility is not authoritative evidence that a prior
                 // finishWorkout call failed. Keep commit-unknown recovery
                 // reconciliation-only to prevent a duplicate HealthKit save.
@@ -1967,7 +1971,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 return
             }
             reconciledSavedWorkout = workout
-            try? recoveryStore.markWorkoutSaved()
+            if expectedPhase == .finishAttempted {
+                try? recoveryStore.markWorkoutSaved()
+            }
             if let durableIdentity = recoveryStore.recoveredIdentity {
                 self.identity = durableIdentity
             }
@@ -1978,6 +1984,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
                 )
             )
         } catch {
+            if expectedPhase == .workoutSaved {
+                completeDetachedFinalization(
+                    summary: makeDetachedSavedSummary(identity: identity)
+                )
+                return
+            }
             finishRequestError = .reconciliationFailed
             publishSnapshotImmediately()
         }
@@ -2795,7 +2807,10 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         )?.sessionID
         self.summary = terminalSummary
         _ = lifecycle.apply(.sessionEnded)
-        let terminalSnapshot = makeSnapshot(capturedAt: Date())
+        let terminalSnapshot = makeTerminalSnapshot(
+            summary: terminalSummary,
+            capturedAt: Date()
+        )
         confirmedTerminalSnapshot = terminalSnapshot
         guard publishSnapshotImmediately(snapshotOverride: terminalSnapshot) else {
             // Keep the durable identity until a transportable terminal
@@ -2808,6 +2823,91 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         }
         isTerminalPublicationPending = false
         return true
+    }
+
+    private func makeTerminalSnapshot(
+        summary: WatchWorkoutSummary,
+        capturedAt: Date
+    ) -> WorkoutSnapshotV1 {
+        if session == nil,
+           !heartRateZoneDurationAccumulator.hasCompleteTerminalDurations(
+             elapsedTime: summary.duration
+           ) {
+            // A detached checkpoint can lag the final workout or predate an
+            // unpersisted zone transition. Do not present partial bins as an
+            // exact ended-workout breakdown.
+            heartRateZoneDurationAccumulator.reset()
+        }
+        let base = makeSnapshot(capturedAt: capturedAt)
+        var availability = base.availability
+
+        let elapsedTime = summary.duration.flatMap { value in
+            guard value.isFinite, value >= 0 else { return nil }
+            availability.insert(.elapsedTime)
+            return WorkoutMetricV1(
+                value: value,
+                unit: .seconds,
+                capturedAt: capturedAt,
+                source: .healthKit
+            )
+        } ?? base.elapsedTime
+        let summaryAverageHeartRate = summary.averageHeartRate.flatMap {
+            positiveMetric(
+                $0,
+                unit: .beatsPerMinute,
+                capturedAt: capturedAt
+            )
+        }
+        if summaryAverageHeartRate != nil {
+            availability.insert(.averageHeartRate)
+        }
+        let averageHeartRate = summaryAverageHeartRate
+            ?? base.averageHeartRate
+        let summaryActiveEnergy = summary.activeEnergyKilocalories.flatMap {
+            nonnegativeMetric(
+                $0,
+                unit: .kilocalories,
+                capturedAt: capturedAt
+            )
+        }
+        if summaryActiveEnergy != nil {
+            availability.insert(.activeEnergy)
+        }
+        let activeEnergy = summaryActiveEnergy ?? base.activeEnergy
+        let summaryCyclingDistance = summary.distanceMeters.flatMap {
+            nonnegativeMetric(
+                $0,
+                unit: .meters,
+                capturedAt: capturedAt
+            )
+        }
+        if summaryCyclingDistance != nil {
+            availability.insert(.cyclingDistance)
+        }
+        let cyclingDistance = reconciledSavedWorkout == nil
+            ? base.cyclingDistance ?? summaryCyclingDistance
+            : summaryCyclingDistance ?? base.cyclingDistance
+
+        return WorkoutSnapshotV1(
+            state: base.state,
+            startDate: base.startDate,
+            elapsedTime: elapsedTime,
+            currentHeartRate: base.currentHeartRate,
+            averageHeartRate: averageHeartRate,
+            activeEnergy: activeEnergy,
+            cyclingDistance: cyclingDistance,
+            currentSpeed: base.currentSpeed,
+            cyclingPower: base.cyclingPower,
+            cyclingCadence: base.cyclingCadence,
+            currentHeartRateZone: base.currentHeartRateZone,
+            heartRateZoneCount: base.heartRateZoneCount,
+            heartRateZoneDurations: base.heartRateZoneDurations,
+            location: base.location,
+            lastCompletedSegment: base.lastCompletedSegment,
+            availability: availability,
+            errorCode: base.errorCode,
+            terminalOutcome: base.terminalOutcome
+        )
     }
 
     private func finishTerminalRuntimeAfterPublication(_ didPublish: Bool) {
@@ -4043,6 +4143,29 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         )
     }
 
+    func setCumulativeMetricsForTesting(
+        averageHeartRateBPM: Double,
+        activeEnergyKilocalories: Double,
+        distanceMeters: Double,
+        capturedAt: Date
+    ) {
+        averageHeartRate = positiveMetric(
+            averageHeartRateBPM,
+            unit: .beatsPerMinute,
+            capturedAt: capturedAt
+        )
+        activeEnergy = nonnegativeMetric(
+            activeEnergyKilocalories,
+            unit: .kilocalories,
+            capturedAt: capturedAt
+        )
+        healthKitDistance = WorkoutMetricCandidate(
+            value: distanceMeters,
+            capturedAt: capturedAt,
+            source: .healthKit
+        )
+    }
+
     func closeFinalSegmentForTesting(at endDate: Date) async -> Bool {
         await closeFinalSegmentIfNeeded(in: builder, at: endDate)
     }
@@ -4090,6 +4213,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         _ recoveredIdentity: WatchWorkoutRecoveryStore.Identity
     ) {
         identity = recoveredIdentity
+        if heartRateZoneRuntimeSessionID != recoveredIdentity.sessionID {
+            heartRateZoneRuntimeSessionID = recoveredIdentity.sessionID
+            heartRateZoneRuntimeMaximumHeartRateBPM =
+                recoveredIdentity.heartRateZoneMaximumHeartRateBPM
+                    ?? maximumHeartRateBPM
+        }
         heartRateZoneDurationAccumulator.restore(
             sessionID: recoveredIdentity.sessionID,
             checkpoint: recoveredIdentity.heartRateZoneCheckpoint
@@ -4705,8 +4834,12 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         if location != nil { availability.insert(.location) }
         if location?.altitude != nil { availability.insert(.altitude) }
 
+        let heartRateZoneMaximumHeartRateBPM =
+            heartRateZoneRuntimeMaximumHeartRateBPM
+                ?? identity?.heartRateZoneMaximumHeartRateBPM
+                ?? maximumHeartRateBPM
         let currentHeartRateZone = WorkoutHeartRateZoneProfile(
-            maximumHeartRateBPM: maximumHeartRateBPM
+            maximumHeartRateBPM: heartRateZoneMaximumHeartRateBPM
         ).zone(for: currentHeartRate?.value)
         let previousHeartRateZoneCheckpoint =
             heartRateZoneDurationAccumulator.checkpoint
@@ -4722,7 +4855,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         persistHeartRateZoneCheckpointIfNeeded(at: capturedAt)
         let heartRateZoneDurations =
             heartRateZoneDurationAccumulator.authoritativeDurations(
-                capturedAt: capturedAt
+                capturedAt: capturedAt,
+                maximumHeartRateBPM:
+                    identity?.heartRateZoneMaximumHeartRateBPM
             )
         if currentHeartRateZone != nil || heartRateZoneDurations != nil {
             availability.insert(.heartRateZone)
@@ -4934,6 +5069,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         terminalRouteDistance = nil
         heartRateZoneDurationAccumulator.reset()
         heartRateZoneCheckpointPersistenceGate.reset()
+        heartRateZoneRuntimeSessionID = nil
+        heartRateZoneRuntimeMaximumHeartRateBPM = nil
         lastErrorCode = nil
     }
 

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutRecoveryStore.swift
@@ -187,6 +187,7 @@ nonisolated final class WatchWorkoutRecoveryStore {
             RemoteTerminalAcknowledgement? = nil
         var heartRateZoneCheckpoint:
             WorkoutHeartRateZoneDurationAccumulator.Checkpoint? = nil
+        var heartRateZoneMaximumHeartRateBPM: Int? = nil
         var finishRequest: FinishRequest?
         /// A rider-confirmed corrupt-state reset cannot recover the lost
         /// Save/Discard choice. Keep that provenance durable until the rider
@@ -415,7 +416,10 @@ nonisolated final class WatchWorkoutRecoveryStore {
         identity?.corruptResetPendingFinishChoice == true
     }
 
-    func begin(startDate: Date) throws -> Identity {
+    func begin(
+        startDate: Date,
+        heartRateZoneMaximumHeartRateBPM: Int? = nil
+    ) throws -> Identity {
         guard [.missing, .valid].contains(loadState), identity == nil else {
             throw RecoveryStoreError.unreadableOrOccupiedState
         }
@@ -426,6 +430,11 @@ nonisolated final class WatchWorkoutRecoveryStore {
             transportGenerationID: UUID(),
             startDate: startDate,
             sequenceHighWatermark: 0,
+            heartRateZoneMaximumHeartRateBPM:
+                heartRateZoneMaximumHeartRateBPM.map {
+                    WorkoutHeartRateZoneProfile
+                        .clampedMaximumHeartRateBPM($0)
+                },
             finishRequest: nil,
             corruptResetPendingFinishChoice: nil,
             corruptResetSyntheticCleanupIdentity: nil
@@ -1180,6 +1189,11 @@ nonisolated final class WatchWorkoutRecoveryStore {
     }
 
     private static func validatedIdentity(_ identity: Identity) -> Identity? {
+        let heartRateZoneMaximumIsValid =
+            identity.heartRateZoneMaximumHeartRateBPM.map {
+                WorkoutHeartRateZoneProfile.supportedMaximumHeartRateBPM
+                    .contains($0)
+            } ?? true
         guard identity.sessionID != zeroUUID,
               identity.healthKitSessionID.map({ $0 != zeroUUID }) ?? true,
               identity.sessionToken != 0,
@@ -1187,6 +1201,7 @@ nonisolated final class WatchWorkoutRecoveryStore {
               identity.startDate.timeIntervalSinceReferenceDate.isFinite,
               identity.remoteControlCheckpoint?.isValid ?? true,
               identity.remoteSegmentIntent?.isValid ?? true,
+              heartRateZoneMaximumIsValid,
               identity.finishRequest?.requestedAt.timeIntervalSinceReferenceDate.isFinite
                 ?? true else {
             return nil

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/LiveWorkoutView.swift
@@ -126,6 +126,26 @@ struct LiveWorkoutView: View {
 
                 LazyVGrid(columns: columns, spacing: 8) {
                     metric(
+                        title: "Speed",
+                        value: WorkoutValueFormatter.speed(
+                            manager.snapshot.currentSpeed?.value
+                        ),
+                        unit: "KM/H",
+                        icon: "speedometer",
+                        color: .cyan
+                    )
+                    metric(
+                        title: "Distance",
+                        value: WorkoutValueFormatter.distance(
+                            manager.snapshot.cyclingDistance?.value
+                        ),
+                        unit: WorkoutValueFormatter.distanceUnit(
+                            manager.snapshot.cyclingDistance?.value
+                        ),
+                        icon: "point.topleft.down.to.point.bottomright.curvepath",
+                        color: .green
+                    )
+                    metric(
                         title: "Heart",
                         value: WorkoutValueFormatter.heartRate(
                             manager.snapshot.currentHeartRate?.value
@@ -142,23 +162,22 @@ struct LiveWorkoutView: View {
                         color: .pink
                     )
                     metric(
-                        title: "Distance",
-                        value: WorkoutValueFormatter.distance(
-                            manager.snapshot.cyclingDistance?.value
+                        title: "Avg Heart",
+                        value: WorkoutValueFormatter.heartRate(
+                            manager.snapshot.averageHeartRate?.value
                         ),
-                        unit: WorkoutValueFormatter.distanceUnit(
-                            manager.snapshot.cyclingDistance?.value
-                        ),
-                        icon: "point.topleft.down.to.point.bottomright.curvepath",
-                        color: .green
+                        unit: "BPM",
+                        icon: "heart.text.square.fill",
+                        color: .red
                     )
                     metric(
-                        title: "Speed",
-                        value: WorkoutValueFormatter.speed(
-                            manager.snapshot.currentSpeed?.value
+                        title: "Avg Speed",
+                        value: WorkoutValueFormatter.averageSpeed(
+                            distanceMeters: manager.snapshot.cyclingDistance?.value,
+                            elapsedSeconds: manager.snapshot.elapsedTime?.value
                         ),
                         unit: "KM/H",
-                        icon: "speedometer",
+                        icon: "gauge.with.dots.needle.50percent",
                         color: .cyan
                     )
                     metric(

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutSummaryView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutSummaryView.swift
@@ -36,6 +36,10 @@ struct WorkoutSummaryView: View {
                     )
                     summaryRow("Energy", "\(WorkoutValueFormatter.energy(summary.activeEnergyKilocalories)) KCAL")
                     summaryRow("Avg Heart", "\(WorkoutValueFormatter.heartRate(summary.averageHeartRate)) BPM")
+                    summaryRow(
+                        "Avg Speed",
+                        "\(WorkoutValueFormatter.averageSpeed(distanceMeters: summary.distanceMeters, elapsedSeconds: summary.duration)) KM/H"
+                    )
                     summaryRow("Route", routeStatusLabel)
                 } else {
                     Text("No workout or route was saved to Health.")

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -696,7 +696,10 @@ final class WatchWorkoutManagerTests: XCTestCase {
         )
         let capturedAt = Date()
         let startDate = capturedAt.addingTimeInterval(-30)
-        let identity = try recoveryStore.begin(startDate: startDate)
+        let identity = try recoveryStore.begin(
+            startDate: startDate,
+            heartRateZoneMaximumHeartRateBPM: 200
+        )
         let healthStore = HKHealthStore()
         let configuration = HKWorkoutConfiguration()
         configuration.activityType = .cycling
@@ -758,6 +761,10 @@ final class WatchWorkoutManagerTests: XCTestCase {
                 count: Int(WorkoutHeartRateZoneProfile.zoneCount)
             )
         )
+        XCTAssertEqual(
+            manager.snapshot.heartRateZoneDurations?.maximumHeartRateBPM,
+            200
+        )
 
         receiver.session(
             WCSession.default,
@@ -768,7 +775,15 @@ final class WatchWorkoutManagerTests: XCTestCase {
         )
         try await waitUntil { manager.maximumHeartRateBPM == 240 }
         XCTAssertEqual(manager.maximumHeartRateBPM, 240)
-        XCTAssertEqual(manager.snapshot.currentHeartRateZone, 2)
+        XCTAssertEqual(
+            manager.snapshot.currentHeartRateZone,
+            4,
+            "an active workout must retain the profile that owns its accumulated bins"
+        )
+        XCTAssertEqual(
+            manager.snapshot.heartRateZoneDurations?.maximumHeartRateBPM,
+            200
+        )
         XCTAssertEqual(
             WorkoutHeartRateZoneSettings.maximumHeartRateBPM(from: defaults),
             240
@@ -784,6 +799,63 @@ final class WatchWorkoutManagerTests: XCTestCase {
             heartRateZoneDefaults: defaults
         )
         XCTAssertEqual(reloadedManager.maximumHeartRateBPM, 240)
+    }
+
+    func testLegacyRecoveredZoneProfileStaysFrozenAndUnattributed() throws {
+        let defaultsSuiteName = "WatchWorkoutManagerLegacyHeartRateZoneTests"
+        let defaults = try XCTUnwrap(
+            UserDefaults(suiteName: defaultsSuiteName)
+        )
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        defer { defaults.removePersistentDomain(forName: defaultsSuiteName) }
+        WorkoutHeartRateZoneSettings.saveMaximumHeartRateBPM(
+            200,
+            to: defaults
+        )
+
+        let recoveryStore = WatchWorkoutRecoveryStore(
+            persistence: ToggleRecoveryPersistence()
+        )
+        let capturedAt = Date()
+        let identity = try recoveryStore.begin(
+            startDate: capturedAt.addingTimeInterval(-30)
+        )
+        XCTAssertNil(identity.heartRateZoneMaximumHeartRateBPM)
+
+        let healthStore = HKHealthStore()
+        let configuration = HKWorkoutConfiguration()
+        configuration.activityType = .cycling
+        configuration.locationType = .outdoor
+        let session = try HKWorkoutSession(
+            healthStore: healthStore,
+            configuration: configuration
+        )
+        let manager = WatchWorkoutManager(
+            healthStore: healthStore,
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            initializeOnLaunch: false,
+            heartRateZoneDefaults: defaults
+        )
+        manager.configureMirrorRuntimeForTesting(
+            session: session,
+            identity: identity,
+            state: .running
+        )
+        manager.setCurrentHeartRateForTesting(160, capturedAt: capturedAt)
+
+        XCTAssertTrue(manager.publishMirrorSnapshotForTesting())
+        XCTAssertEqual(manager.snapshot.currentHeartRateZone, 4)
+        XCTAssertNil(
+            manager.snapshot.heartRateZoneDurations?.maximumHeartRateBPM,
+            "a legacy workout must not claim the current setting as historical provenance"
+        )
+
+        manager.setMaximumHeartRateBPM(240)
+        XCTAssertEqual(manager.snapshot.currentHeartRateZone, 4)
+        XCTAssertNil(
+            manager.snapshot.heartRateZoneDurations?.maximumHeartRateBPM
+        )
     }
 
     func testActiveSessionIDSurvivesInitialMirrorPublicationFailure() throws {
@@ -3778,7 +3850,6 @@ final class WatchWorkoutManagerTests: XCTestCase {
             refreshAuthorization: { await authorizationRefresh.run() },
             initializeOnLaunch: false
         )
-
         manager.retrySetup()
         try await waitUntil { recovery.callCount == 1 }
         recovery.completeWithoutSession()
@@ -7224,7 +7295,6 @@ final class WatchWorkoutManagerTests: XCTestCase {
             },
             initializeOnLaunch: false
         )
-
         manager.retrySetup()
         try await waitUntil { recovery.callCount == 1 }
         manager.handleActiveWorkoutRecovery()
@@ -7494,6 +7564,8 @@ final class WatchWorkoutManagerTests: XCTestCase {
 
     func testDetachedSavedIdentityArchivesTombstoneAndReleasesUI() async throws {
         let recovery = RecoveryProbe()
+        let startDate = Date().addingTimeInterval(-600)
+        let endDate = startDate.addingTimeInterval(600)
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(
                 "BikeComputer.WatchManagerTests.\(UUID().uuidString)",
@@ -7505,26 +7577,90 @@ final class WatchWorkoutManagerTests: XCTestCase {
                 fileURL: directory.appendingPathComponent("active.plist")
             )
         )
-        let originalIdentity = try recoveryStore.begin(startDate: Date())
-        try recoveryStore.markFinishing(disposition: .save, requestedAt: Date())
+        let originalIdentity = try recoveryStore.begin(
+            startDate: startDate,
+            heartRateZoneMaximumHeartRateBPM: 200
+        )
+        var zoneAccumulator = WorkoutHeartRateZoneDurationAccumulator()
+        _ = zoneAccumulator.update(
+            sessionID: originalIdentity.sessionID,
+            elapsedTime: 0,
+            currentZone: 3
+        )
+        _ = zoneAccumulator.update(
+            sessionID: originalIdentity.sessionID,
+            elapsedTime: 585,
+            currentZone: 3
+        )
+        try recoveryStore.persistHeartRateZoneCheckpoint(
+            try XCTUnwrap(zoneAccumulator.checkpoint)
+        )
+        try recoveryStore.markFinishing(
+            disposition: .save,
+            requestedAt: endDate
+        )
         try recoveryStore.markCollectionEnded()
         try recoveryStore.markFinishAttempted()
         try recoveryStore.markWorkoutSaved()
+        let savedWorkout = HKWorkout(
+            activityType: .cycling,
+            start: startDate,
+            end: endDate,
+            duration: 600,
+            totalEnergyBurned: HKQuantity(
+                unit: .kilocalorie(),
+                doubleValue: 350
+            ),
+            totalDistance: HKQuantity(unit: .meter(), doubleValue: 5_000),
+            metadata: [
+                HKMetadataKeyExternalUUID:
+                    originalIdentity.sessionID.uuidString,
+            ]
+        )
+        var savedWorkoutLookupCount = 0
         let manager = WatchWorkoutManager(
             healthStore: HKHealthStore(),
             routeRecorder: WatchRouteRecorder(),
             recoveryStore: recoveryStore,
             recoverActiveWorkoutSession: { await recovery.run() },
+            savedWorkoutLookup: { _, _ in
+                savedWorkoutLookupCount += 1
+                return savedWorkout
+            },
             initializeOnLaunch: false
+        )
+        manager.setCumulativeMetricsForTesting(
+            averageHeartRateBPM: 99,
+            activeEnergyKilocalories: 10,
+            distanceMeters: 100,
+            capturedAt: endDate
         )
 
         manager.retrySetup()
         try await waitUntil { recovery.callCount == 1 }
         recovery.completeWithoutSession()
         try await waitUntil { !manager.isRecovering && manager.state == .ended }
+        XCTAssertEqual(savedWorkoutLookupCount, 1)
         XCTAssertFalse(manager.isAwaitingDetachedSessionCleanup)
-        XCTAssertNotNil(manager.summary)
+        let summary = try XCTUnwrap(manager.summary)
+        XCTAssertEqual(summary.duration, 600)
+        XCTAssertEqual(summary.distanceMeters, 5_000)
+        XCTAssertEqual(summary.activeEnergyKilocalories, 350)
+        XCTAssertEqual(
+            WorkoutValueFormatter.averageSpeed(
+                distanceMeters: summary.distanceMeters,
+                elapsedSeconds: summary.duration
+            ),
+            "30.0"
+        )
         XCTAssertEqual(manager.snapshot.state, .ended)
+        XCTAssertEqual(manager.snapshot.elapsedTime?.value, 600)
+        XCTAssertEqual(manager.snapshot.cyclingDistance?.value, 5_000)
+        XCTAssertEqual(manager.snapshot.activeEnergy?.value, 350)
+        XCTAssertNil(
+            manager.snapshot.heartRateZoneDurations,
+            "an incomplete detached checkpoint must not be presented as exact final zone totals"
+        )
         XCTAssertEqual(manager.latestEnvelope?.snapshot?.state, .ended)
         XCTAssertNil(recoveryStore.recoveredIdentity)
         XCTAssertEqual(

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift
@@ -88,6 +88,17 @@ nonisolated struct WorkoutMetricV1: Codable, Equatable, Sendable {
 nonisolated struct WorkoutZoneDurationsV1: Codable, Equatable, Sendable {
     let capturedAt: Date
     let secondsByZone: [Double]
+    let maximumHeartRateBPM: Int?
+
+    init(
+        capturedAt: Date,
+        secondsByZone: [Double],
+        maximumHeartRateBPM: Int? = nil
+    ) {
+        self.capturedAt = capturedAt
+        self.secondsByZone = secondsByZone
+        self.maximumHeartRateBPM = maximumHeartRateBPM
+    }
 }
 
 nonisolated struct WorkoutLocationV1: Codable, Equatable, Sendable {
@@ -522,6 +533,11 @@ nonisolated enum WorkoutContractCodec {
                   !durations.secondsByZone.isEmpty,
                   durations.secondsByZone.allSatisfy({ $0.isFinite && $0 >= 0 }),
                   Int(zoneCount) == durations.secondsByZone.count else {
+                throw WorkoutContractError.invalidZone
+            }
+            if let maximumHeartRateBPM = durations.maximumHeartRateBPM,
+               !WorkoutHeartRateZoneProfile.supportedMaximumHeartRateBPM
+                    .contains(maximumHeartRateBPM) {
                 throw WorkoutContractError.invalidZone
             }
         }

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+nonisolated struct WorkoutHeartRateZoneBPMRange: Equatable, Sendable {
+    let lowerBound: Int?
+    let upperBound: Int?
+}
+
 /// BikeComputer's watchOS 10-compatible heart-rate zone model.
 ///
 /// These zones are intentionally app-defined rather than presented as Apple's
@@ -40,6 +45,51 @@ nonisolated struct WorkoutHeartRateZoneProfile: Equatable, Sendable {
         case ..<0.80: return 3
         case ..<0.90: return 4
         default: return 5
+        }
+    }
+
+    func bpmRange(for zone: UInt8) -> WorkoutHeartRateZoneBPMRange? {
+        guard zone > 0, zone <= Self.zoneCount else { return nil }
+
+        let zone2LowerBound = Int(
+            ceil(Double(maximumHeartRateBPM) * 0.60)
+        )
+        let zone3LowerBound = Int(
+            ceil(Double(maximumHeartRateBPM) * 0.70)
+        )
+        let zone4LowerBound = Int(
+            ceil(Double(maximumHeartRateBPM) * 0.80)
+        )
+        let zone5LowerBound = Int(
+            ceil(Double(maximumHeartRateBPM) * 0.90)
+        )
+
+        switch zone {
+        case 1:
+            return WorkoutHeartRateZoneBPMRange(
+                lowerBound: nil,
+                upperBound: zone2LowerBound - 1
+            )
+        case 2:
+            return WorkoutHeartRateZoneBPMRange(
+                lowerBound: zone2LowerBound,
+                upperBound: zone3LowerBound - 1
+            )
+        case 3:
+            return WorkoutHeartRateZoneBPMRange(
+                lowerBound: zone3LowerBound,
+                upperBound: zone4LowerBound - 1
+            )
+        case 4:
+            return WorkoutHeartRateZoneBPMRange(
+                lowerBound: zone4LowerBound,
+                upperBound: zone5LowerBound - 1
+            )
+        default:
+            return WorkoutHeartRateZoneBPMRange(
+                lowerBound: zone5LowerBound,
+                upperBound: nil
+            )
         }
     }
 }

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift
@@ -94,6 +94,84 @@ nonisolated struct WorkoutHeartRateZoneProfile: Equatable, Sendable {
     }
 }
 
+nonisolated struct WorkoutHeartRateZoneBreakdownRowV1: Equatable, Sendable {
+    let zone: Int
+    let duration: TimeInterval
+    let durationLabel: String
+    let bpmRangeLabel: String
+    let fractionOfLongestDuration: Double
+
+    var accessibilityLabel: String {
+        "Zone \(zone), \(durationLabel), \(bpmRangeLabel)"
+    }
+}
+
+nonisolated struct WorkoutHeartRateZoneBreakdownPresentationV1:
+    Equatable,
+    Sendable {
+    let maximumHeartRateBPM: Int?
+    let rows: [WorkoutHeartRateZoneBreakdownRowV1]
+
+    static func make(durations: WorkoutZoneDurationsV1?) -> Self? {
+        guard let durations,
+              durations.secondsByZone.count
+                == Int(WorkoutHeartRateZoneProfile.zoneCount),
+              durations.secondsByZone.allSatisfy({
+                  $0.isFinite && $0 >= 0
+              }) else {
+            return nil
+        }
+
+        let maximumHeartRateBPM = durations.maximumHeartRateBPM
+        guard maximumHeartRateBPM.map({
+            WorkoutHeartRateZoneProfile.supportedMaximumHeartRateBPM
+                .contains($0)
+        }) ?? true else {
+            return nil
+        }
+
+        let profile = maximumHeartRateBPM.map {
+            WorkoutHeartRateZoneProfile(maximumHeartRateBPM: $0)
+        }
+        let longestDuration = durations.secondsByZone.max() ?? 0
+        let rows = durations.secondsByZone.enumerated().map { index, duration in
+            let zone = index + 1
+            let fraction = longestDuration > 0
+                ? min(max(duration / longestDuration, 0), 1)
+                : 0
+            return WorkoutHeartRateZoneBreakdownRowV1(
+                zone: zone,
+                duration: duration,
+                durationLabel: WorkoutValueFormatter.duration(duration),
+                bpmRangeLabel: profile.map {
+                    rangeLabel($0.bpmRange(for: UInt8(zone)))
+                } ?? "Range unavailable",
+                fractionOfLongestDuration: fraction
+            )
+        }
+        return Self(
+            maximumHeartRateBPM: maximumHeartRateBPM,
+            rows: rows
+        )
+    }
+
+    private static func rangeLabel(
+        _ range: WorkoutHeartRateZoneBPMRange?
+    ) -> String {
+        guard let range else { return "-- BPM" }
+        switch (range.lowerBound, range.upperBound) {
+        case (nil, let upper?):
+            return "<\(upper + 1) BPM"
+        case (let lower?, nil):
+            return "\(lower)+ BPM"
+        case (let lower?, let upper?):
+            return "\(lower)–\(upper) BPM"
+        default:
+            return "-- BPM"
+        }
+    }
+}
+
 /// Accumulates workout elapsed time by heart-rate zone for the iPhone UI.
 /// Using the workout's elapsed metric keeps the value frozen while paused.
 nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
@@ -173,20 +251,37 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
         } ?? true
         if canAdvanceCursor {
             previousElapsedTime = validElapsedTime ?? previousElapsedTime
-            previousZone = validCurrentZone
+            if validElapsedTime != nil || validCurrentZone != nil {
+                previousZone = validCurrentZone
+            }
         }
 
         guard let validCurrentZone else { return nil }
         return secondsByZone[Int(validCurrentZone - 1)]
     }
 
+    func hasCompleteTerminalDurations(
+        elapsedTime: TimeInterval?
+    ) -> Bool {
+        guard sessionID != nil,
+              let elapsedTime,
+              elapsedTime.isFinite,
+              elapsedTime >= 0,
+              let previousElapsedTime else {
+            return false
+        }
+        return abs(previousElapsedTime - elapsedTime) <= 0.001
+    }
+
     func authoritativeDurations(
-        capturedAt: Date
+        capturedAt: Date,
+        maximumHeartRateBPM: Int? = nil
     ) -> WorkoutZoneDurationsV1? {
         guard sessionID != nil, hasObservedZone else { return nil }
         return WorkoutZoneDurationsV1(
             capturedAt: capturedAt,
-            secondsByZone: secondsByZone
+            secondsByZone: secondsByZone,
+            maximumHeartRateBPM: maximumHeartRateBPM
         )
     }
 
@@ -233,8 +328,8 @@ nonisolated struct WorkoutHeartRateZoneDurationAccumulator: Sendable {
     }
 }
 
-/// Coalesces recovery writes when heart rate oscillates around a zone boundary.
-/// A pending transition is retained until a durable write succeeds.
+/// Coalesces recovery writes while zone totals advance or heart rate crosses a
+/// boundary. A pending checkpoint is retained until a durable write succeeds.
 nonisolated struct WorkoutHeartRateZoneCheckpointPersistenceGate: Sendable {
     static let minimumAttemptInterval: TimeInterval = 15
 
@@ -245,7 +340,7 @@ nonisolated struct WorkoutHeartRateZoneCheckpointPersistenceGate: Sendable {
         from previous: WorkoutHeartRateZoneDurationAccumulator.Checkpoint?,
         to current: WorkoutHeartRateZoneDurationAccumulator.Checkpoint?
     ) {
-        if previous?.previousZone != current?.previousZone {
+        if previous != current {
             hasPendingTransition = true
         }
     }

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift
@@ -31,7 +31,9 @@ nonisolated enum WorkoutValueFormatter {
               metersPerSecond >= 0 else {
             return "--"
         }
-        return String(format: "%.1f", metersPerSecond * 3.6)
+        let kilometersPerHour = metersPerSecond * 3.6
+        guard kilometersPerHour.isFinite else { return "--" }
+        return String(format: "%.1f", kilometersPerHour)
     }
 
     static func averageSpeed(
@@ -46,7 +48,9 @@ nonisolated enum WorkoutValueFormatter {
               elapsedSeconds > 0 else {
             return "--"
         }
-        return speed(distanceMeters / elapsedSeconds)
+        let metersPerSecond = distanceMeters / elapsedSeconds
+        guard metersPerSecond.isFinite else { return "--" }
+        return speed(metersPerSecond)
     }
 
     static func energy(_ kilocalories: Double?) -> String {

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift
@@ -34,6 +34,21 @@ nonisolated enum WorkoutValueFormatter {
         return String(format: "%.1f", metersPerSecond * 3.6)
     }
 
+    static func averageSpeed(
+        distanceMeters: Double?,
+        elapsedSeconds: Double?
+    ) -> String {
+        guard let distanceMeters,
+              distanceMeters.isFinite,
+              distanceMeters >= 0,
+              let elapsedSeconds,
+              elapsedSeconds.isFinite,
+              elapsedSeconds > 0 else {
+            return "--"
+        }
+        return speed(distanceMeters / elapsedSeconds)
+    }
+
     static func energy(_ kilocalories: Double?) -> String {
         guard let kilocalories,
               kilocalories.isFinite,

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -1060,6 +1060,35 @@ private struct WorkoutContractTestSuite {
         expect(profile.zone(for: 180) == 5, "90 percent starts zone 5")
         expect(profile.zone(for: 220) == 5, "above max remains zone 5")
         expect(
+            profile.bpmRange(for: 1)
+                == WorkoutHeartRateZoneBPMRange(
+                    lowerBound: nil,
+                    upperBound: 119
+                ),
+            "zone 1 summary range should end below 60 percent"
+        )
+        expect(
+            profile.bpmRange(for: 3)
+                == WorkoutHeartRateZoneBPMRange(
+                    lowerBound: 140,
+                    upperBound: 159
+                ),
+            "middle summary ranges should match the live zone boundaries"
+        )
+        expect(
+            profile.bpmRange(for: 5)
+                == WorkoutHeartRateZoneBPMRange(
+                    lowerBound: 180,
+                    upperBound: nil
+                ),
+            "zone 5 summary range should remain open ended"
+        )
+        expect(
+            profile.bpmRange(for: 0) == nil
+                && profile.bpmRange(for: 6) == nil,
+            "unsupported zone numbers should not produce summary ranges"
+        )
+        expect(
             WorkoutHeartRateZoneProfile(maximumHeartRateBPM: 20)
                 .maximumHeartRateBPM == 100,
             "maximum heart rate clamps to the supported lower bound"
@@ -5292,6 +5321,27 @@ private struct WorkoutContractTestSuite {
         expect(WorkoutValueFormatter.whole(0) == "0", "available zero power should remain zero")
         expect(WorkoutValueFormatter.speed(nil) == "--", "missing speed should be unavailable")
         expect(WorkoutValueFormatter.speed(0) == "0.0", "available stopped speed should remain zero")
+        expect(
+            WorkoutValueFormatter.averageSpeed(
+                distanceMeters: 1_000,
+                elapsedSeconds: 200
+            ) == "18.0",
+            "average speed should derive kilometers per hour from distance and active time"
+        )
+        expect(
+            WorkoutValueFormatter.averageSpeed(
+                distanceMeters: 0,
+                elapsedSeconds: 200
+            ) == "0.0",
+            "an available zero-distance average should remain zero"
+        )
+        expect(
+            WorkoutValueFormatter.averageSpeed(
+                distanceMeters: 1_000,
+                elapsedSeconds: 0
+            ) == "--",
+            "average speed requires positive elapsed time"
+        )
         expect(WorkoutValueFormatter.distance(nil) == "--", "missing distance should be unavailable")
         expect(WorkoutValueFormatter.distance(0) == "0", "available zero distance should remain zero")
         expect(WorkoutValueFormatter.duration(nil) == "--:--", "missing elapsed time should be unavailable")
@@ -5837,6 +5887,7 @@ private struct WorkoutContractTestSuite {
             "Power",
             "Cadence",
             "Average HR",
+            "Average Speed",
             "Altitude",
         ] {
             expect(
@@ -5848,6 +5899,16 @@ private struct WorkoutContractTestSuite {
             source.contains("TimelineView(.periodic(from: Date(), by: 1))")
                 && source.contains("captureAgeLabel(age)"),
             "dashboard must render live capture age"
+        )
+        expect(
+            source.contains(
+                "if store.presentation.connectionState == .ended {"
+            )
+                && source.contains("HeartRateZoneBreakdown(")
+                && source.contains(
+                    "durations: snapshot.heartRateZoneDurations"
+                ),
+            "ended workout summaries must render the authoritative heart-rate zone breakdown"
         )
         for controlRoute in [
             "Button(action: onMarkSegment)",
@@ -6259,6 +6320,12 @@ private struct WorkoutContractTestSuite {
                     "WorkoutValueFormatter.duration(displayedHeartRateZoneElapsedTime),showsHeartInLabel:true,label:\"timeinzone\""
                 )
                 && compactNavigation.contains(
+                    "WorkoutValueFormatter.heartRate(snapshot.averageHeartRate?.value),unit:\"BPM\",label:\"averageheartrate\""
+                )
+                && compactNavigation.contains(
+                    "WorkoutValueFormatter.averageSpeed(distanceMeters:snapshot.cyclingDistance?.value,elapsedSeconds:snapshot.elapsedTime?.value),unit:\"km/h\",label:\"averagespeed\""
+                )
+                && compactNavigation.contains(
                     "ifshowsHeartInLabel{HStack(spacing:4){Text(\"timein\")Image(systemName:\"heart.fill\").accessibilityHidden(true)Text(\"zone\")}}"
                 )
                 && compactNavigation.contains(
@@ -6288,7 +6355,7 @@ private struct WorkoutContractTestSuite {
                 && compactNavigation.contains(
                     ".padding(.bottom,4)"
                 ),
-            "expanded ride stats must hide the speed caption and place heart rate plus time in zone first below the zone strip"
+            "expanded ride stats must place current and average heart-rate/speed rows below the zone strip"
         )
         expect(
             compactContent.contains(

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -6126,6 +6126,45 @@ private struct WorkoutContractTestSuite {
                 ),
             "Watch live workout must omit LIVE, expose heart-rate zone and altitude, and retain the elapsed timer"
         )
+        let orderedWatchMetrics = [
+            "metric(title:\"Speed\"",
+            "metric(title:\"Distance\"",
+            "metric(title:\"Heart\"",
+            "metric(title:\"HRZone\"",
+            "metric(title:\"AvgHeart\"",
+            "metric(title:\"AvgSpeed\""
+        ]
+        var watchMetricSearchStart = compactLiveWatchView.startIndex
+        var watchMetricsAreOrdered = true
+        for metricBinding in orderedWatchMetrics {
+            guard let metricRange = compactLiveWatchView.range(
+                of: metricBinding,
+                range: watchMetricSearchStart..<compactLiveWatchView.endIndex
+            ) else {
+                watchMetricsAreOrdered = false
+                break
+            }
+            watchMetricSearchStart = metricRange.upperBound
+        }
+        expect(
+            watchMetricsAreOrdered
+                && compactLiveWatchView.contains(
+                    "WorkoutValueFormatter.heartRate(manager.snapshot.averageHeartRate?.value)"
+                )
+                && compactLiveWatchView.contains(
+                    "WorkoutValueFormatter.averageSpeed(distanceMeters:manager.snapshot.cyclingDistance?.value,elapsedSeconds:manager.snapshot.elapsedTime?.value)"
+                ),
+            "Watch live workout must lead with Speed/Distance, then Heart/Zone, then Avg Heart/Avg Speed using live snapshot values"
+        )
+        expect(
+            compactSummaryWatchView.contains(
+                "summaryRow(\"AvgHeart\",\"\\(WorkoutValueFormatter.heartRate(summary.averageHeartRate))BPM\")"
+            )
+                && compactSummaryWatchView.contains(
+                    "summaryRow(\"AvgSpeed\",\"\\(WorkoutValueFormatter.averageSpeed(distanceMeters:summary.distanceMeters,elapsedSeconds:summary.duration))KM/H\")"
+                ),
+            "Watch saved-workout summary must show average heart rate and average speed"
+        )
         if let gridIndex = compactLiveWatchView.range(
             of: "LazyVGrid(columns:columns,spacing:8)"
         )?.lowerBound,

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -72,6 +72,7 @@ private struct WorkoutContractTestSuite {
         testComponentTimestampsStayWithinWorkoutWindow()
         testHeartRateZonePayloadIsCoherent()
         testHeartRateZoneProfileAndPersistence()
+        testHeartRateZoneBreakdownPresentation()
         testHeartRateZoneDurationAccumulator()
 #if WORKOUT_CONTRACT_HOST
         testWorkoutMetricsStoreUsesAuthoritativeCoalescedZoneTotals()
@@ -1046,6 +1047,25 @@ private struct WorkoutContractTestSuite {
         } catch {
             expect(false, "coherent zone payload should be accepted: \(error)")
         }
+
+        let invalidProfile = makeEnvelope(
+            sequence: 1,
+            capturedAt: now,
+            snapshot: WorkoutSnapshotV1(
+                state: .running,
+                startDate: now.addingTimeInterval(-60),
+                heartRateZoneCount: 2,
+                heartRateZoneDurations: WorkoutZoneDurationsV1(
+                    capturedAt: now,
+                    secondsByZone: [20, 40],
+                    maximumHeartRateBPM: 999
+                ),
+                availability: [.heartRateZone]
+            )
+        )
+        expectThrows(.invalidZone, "zone profile must stay in supported bounds") {
+            try WorkoutContractCodec.validate(invalidProfile)
+        }
     }
 
     private mutating func testHeartRateZoneProfileAndPersistence() {
@@ -1147,6 +1167,95 @@ private struct WorkoutContractTestSuite {
         )
     }
 
+    private mutating func testHeartRateZoneBreakdownPresentation() {
+        let capturedAt = Date(
+            timeIntervalSinceReferenceDate: 800_000_605
+        )
+        let presentation = WorkoutHeartRateZoneBreakdownPresentationV1.make(
+            durations: WorkoutZoneDurationsV1(
+                capturedAt: capturedAt,
+                secondsByZone: [109, 42, 55, 149, 704],
+                maximumHeartRateBPM: 200
+            )
+        )
+        expect(
+            presentation?.maximumHeartRateBPM == 200,
+            "zone breakdown must use the Watch profile carried with its bins"
+        )
+        expect(
+            presentation?.rows.map(\.zone) == [1, 2, 3, 4, 5],
+            "zone breakdown must present exactly five ordered rows"
+        )
+        expect(
+            presentation?.rows[0].durationLabel == "01:49"
+                && presentation?.rows[0].bpmRangeLabel == "<120 BPM",
+            "zone breakdown must format duration and lower open range"
+        )
+        expect(
+            presentation?.rows[2].bpmRangeLabel == "140–159 BPM"
+                && presentation?.rows[4].bpmRangeLabel == "180+ BPM",
+            "zone breakdown must match middle and upper live-zone boundaries"
+        )
+        expect(
+            presentation?.rows[4].fractionOfLongestDuration == 1
+                && abs(
+                    (presentation?.rows[3].fractionOfLongestDuration ?? 0)
+                        - 149.0 / 704.0
+                ) < 0.000_001,
+            "zone bars must scale against the longest recorded duration"
+        )
+        expect(
+            presentation?.rows[2].accessibilityLabel
+                == "Zone 3, 00:55, 140–159 BPM",
+            "zone rows must expose the same values to accessibility"
+        )
+
+        let zeroPresentation =
+            WorkoutHeartRateZoneBreakdownPresentationV1.make(
+                durations: WorkoutZoneDurationsV1(
+                    capturedAt: capturedAt,
+                    secondsByZone: [0, 0, 0, 0, 0]
+                )
+            )
+        expect(
+            zeroPresentation?.rows.allSatisfy {
+                $0.fractionOfLongestDuration == 0
+            } == true,
+            "all-zero zone durations must render zero-width progress bars"
+        )
+        expect(
+            zeroPresentation?.maximumHeartRateBPM == nil
+                && zeroPresentation?.rows.allSatisfy {
+                    $0.bpmRangeLabel == "Range unavailable"
+                } == true,
+            "legacy zone payloads must not invent historical BPM ranges from current settings"
+        )
+        expect(
+            WorkoutHeartRateZoneBreakdownPresentationV1.make(
+                durations: nil
+            ) == nil,
+            "missing zone durations must use the unavailable state"
+        )
+        expect(
+            WorkoutHeartRateZoneBreakdownPresentationV1.make(
+                durations: WorkoutZoneDurationsV1(
+                    capturedAt: capturedAt,
+                    secondsByZone: [1, 2]
+                )
+            ) == nil,
+            "malformed zone arrays must use the unavailable state"
+        )
+        expect(
+            WorkoutHeartRateZoneBreakdownPresentationV1.make(
+                durations: WorkoutZoneDurationsV1(
+                    capturedAt: capturedAt,
+                    secondsByZone: [0, 0, .nan, 0, 0]
+                )
+            ) == nil,
+            "non-finite zone durations must use the unavailable state"
+        )
+    }
+
     private mutating func testHeartRateZoneDurationAccumulator() {
         let firstSession = UUID(
             uuidString: "72C8E2D9-3EC0-4C9A-A101-111111111111"
@@ -1226,9 +1335,14 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             accumulator.authoritativeDurations(
-                capturedAt: authoritative.capturedAt
-            ) == authoritative,
-            "authoritative zone totals survive transport coalescing"
+                capturedAt: authoritative.capturedAt,
+                maximumHeartRateBPM: 200
+            ) == WorkoutZoneDurationsV1(
+                capturedAt: authoritative.capturedAt,
+                secondsByZone: authoritative.secondsByZone,
+                maximumHeartRateBPM: 200
+            ),
+            "authoritative zone totals and their profile survive transport coalescing"
         )
         let regressingAuthoritative = WorkoutZoneDurationsV1(
             capturedAt: authoritative.capturedAt.addingTimeInterval(1),
@@ -1294,6 +1408,38 @@ private struct WorkoutContractTestSuite {
             "zone accumulation resumes only after the recovered clock passes its checkpoint"
         )
 
+        var terminalCheckpointAccumulator =
+            WorkoutHeartRateZoneDurationAccumulator()
+        _ = terminalCheckpointAccumulator.update(
+            sessionID: secondSession,
+            elapsedTime: 0,
+            currentZone: 3
+        )
+        _ = terminalCheckpointAccumulator.update(
+            sessionID: secondSession,
+            elapsedTime: 585,
+            currentZone: 3
+        )
+        _ = terminalCheckpointAccumulator.update(
+            sessionID: secondSession,
+            elapsedTime: nil,
+            currentZone: nil
+        )
+        expect(
+            terminalCheckpointAccumulator.hasCompleteTerminalDurations(
+                elapsedTime: 585
+            ),
+            "a detached checkpoint is complete only at its exact authoritative elapsed time"
+        )
+        expect(
+            !terminalCheckpointAccumulator.hasCompleteTerminalDurations(
+                elapsedTime: 600
+            )
+                && !terminalCheckpointAccumulator
+                    .hasCompleteTerminalDurations(elapsedTime: nil),
+            "a stale or duration-less detached checkpoint must not claim exact final zone totals"
+        )
+
         var persistenceGate =
             WorkoutHeartRateZoneCheckpointPersistenceGate()
         let firstCheckpoint = zoneEntryCheckpoint
@@ -1347,6 +1493,23 @@ private struct WorkoutContractTestSuite {
             !persistenceGate.hasPendingTransition,
             "only a successful durable write clears the pending transition"
         )
+        let advancedSameZoneCheckpoint =
+            WorkoutHeartRateZoneDurationAccumulator.Checkpoint(
+                previousElapsedTime: 27,
+                previousZone: 2,
+                secondsByZone: [0, 16, 1, 0, 0]
+            )
+        persistenceGate.observeTransition(
+            from: returnedZoneCheckpoint,
+            to: advancedSameZoneCheckpoint
+        )
+        expect(
+            persistenceGate.shouldAttempt(
+                at: firstAttemptAt.addingTimeInterval(30)
+            ),
+            "time accumulated within one zone must checkpoint at the bounded interval"
+        )
+        persistenceGate.markSucceeded()
         expect(
             accumulator.update(
                 sessionID: secondSession,
@@ -5322,6 +5485,10 @@ private struct WorkoutContractTestSuite {
         expect(WorkoutValueFormatter.speed(nil) == "--", "missing speed should be unavailable")
         expect(WorkoutValueFormatter.speed(0) == "0.0", "available stopped speed should remain zero")
         expect(
+            WorkoutValueFormatter.speed(.greatestFiniteMagnitude) == "--",
+            "speed conversion overflow should remain unavailable"
+        )
+        expect(
             WorkoutValueFormatter.averageSpeed(
                 distanceMeters: 1_000,
                 elapsedSeconds: 200
@@ -5341,6 +5508,13 @@ private struct WorkoutContractTestSuite {
                 elapsedSeconds: 0
             ) == "--",
             "average speed requires positive elapsed time"
+        )
+        expect(
+            WorkoutValueFormatter.averageSpeed(
+                distanceMeters: .greatestFiniteMagnitude,
+                elapsedSeconds: .leastNonzeroMagnitude
+            ) == "--",
+            "average speed division overflow should remain unavailable"
         )
         expect(WorkoutValueFormatter.distance(nil) == "--", "missing distance should be unavailable")
         expect(WorkoutValueFormatter.distance(0) == "0", "available zero distance should remain zero")
@@ -6126,35 +6300,54 @@ private struct WorkoutContractTestSuite {
                 ),
             "Watch live workout must omit LIVE, expose heart-rate zone and altitude, and retain the elapsed timer"
         )
-        let orderedWatchMetrics = [
-            "metric(title:\"Speed\"",
-            "metric(title:\"Distance\"",
-            "metric(title:\"Heart\"",
-            "metric(title:\"HRZone\"",
-            "metric(title:\"AvgHeart\"",
-            "metric(title:\"AvgSpeed\""
+        let expectedWatchMetricTitles = [
+            "Speed",
+            "Distance",
+            "Heart",
+            "HRZone",
+            "AvgHeart",
+            "AvgSpeed",
+            "Energy",
+            "Power",
+            "Cadence",
+            "Altitude",
         ]
-        var watchMetricSearchStart = compactLiveWatchView.startIndex
-        var watchMetricsAreOrdered = true
-        for metricBinding in orderedWatchMetrics {
-            guard let metricRange = compactLiveWatchView.range(
-                of: metricBinding,
-                range: watchMetricSearchStart..<compactLiveWatchView.endIndex
-            ) else {
-                watchMetricsAreOrdered = false
-                break
+        var actualWatchMetricTitles: [String]?
+        if let gridStart = compactLiveWatchView.range(
+            of: "LazyVGrid(columns:columns,spacing:8)"
+        )?.upperBound,
+           let gridEnd = compactLiveWatchView.range(
+            of: "Text(WorkoutValueFormatter.duration(manager.snapshot.elapsedTime?.value))"
+           )?.lowerBound,
+           gridStart < gridEnd {
+            let grid = String(compactLiveWatchView[gridStart..<gridEnd])
+            var titles = [String]()
+            var searchStart = grid.startIndex
+            let marker = "metric(title:\""
+            while let markerRange = grid.range(
+                of: marker,
+                range: searchStart..<grid.endIndex
+            ) {
+                let titleStart = markerRange.upperBound
+                guard let titleEnd = grid[titleStart...].firstIndex(
+                    of: "\""
+                ) else {
+                    break
+                }
+                titles.append(String(grid[titleStart..<titleEnd]))
+                searchStart = grid.index(after: titleEnd)
             }
-            watchMetricSearchStart = metricRange.upperBound
+            actualWatchMetricTitles = titles
         }
         expect(
-            watchMetricsAreOrdered
+            actualWatchMetricTitles == expectedWatchMetricTitles
                 && compactLiveWatchView.contains(
                     "WorkoutValueFormatter.heartRate(manager.snapshot.averageHeartRate?.value)"
                 )
                 && compactLiveWatchView.contains(
                     "WorkoutValueFormatter.averageSpeed(distanceMeters:manager.snapshot.cyclingDistance?.value,elapsedSeconds:manager.snapshot.elapsedTime?.value)"
                 ),
-            "Watch live workout must lead with Speed/Distance, then Heart/Zone, then Avg Heart/Avg Speed using live snapshot values"
+            "Watch live workout must keep exact consecutive Speed/Distance, Heart/Zone, and Avg Heart/Avg Speed rows"
         )
         expect(
             compactSummaryWatchView.contains(
@@ -6338,6 +6531,45 @@ private struct WorkoutContractTestSuite {
                     "case.sensorSettings:NavigationView{BikeComputersSettingsView("
                 ),
             "sensor enrollment must gate cadence and power tiles and route detected sensors to My Bike Computer"
+        )
+        var expandedIPhoneLeadingMetricsAreExact = false
+        if let methodStart = compactNavigation.range(
+            of: "privatefuncexpandedWorkoutMetricValues(frommetrics:[RideMetric])->[RideMetric]{"
+        )?.upperBound,
+           let leadingEnd = compactNavigation.range(
+            of: "expandedMetrics.append(contentsOf:",
+            range: methodStart..<compactNavigation.endIndex
+           )?.lowerBound {
+            let leading = String(
+                compactNavigation[methodStart..<leadingEnd]
+            )
+            let expectedBindings = [
+                "expandedMetrics.append(heartRate)",
+                "WorkoutValueFormatter.duration(displayedHeartRateZoneElapsedTime),showsHeartInLabel:true,label:\"timeinzone\"",
+                "WorkoutValueFormatter.heartRate(snapshot.averageHeartRate?.value),unit:\"BPM\",label:\"averageheartrate\"",
+                "WorkoutValueFormatter.averageSpeed(distanceMeters:snapshot.cyclingDistance?.value,elapsedSeconds:snapshot.elapsedTime?.value),unit:\"km/h\",label:\"averagespeed\"",
+            ]
+            var searchStart = leading.startIndex
+            var bindingsAreOrdered = true
+            for binding in expectedBindings {
+                guard let range = leading.range(
+                    of: binding,
+                    range: searchStart..<leading.endIndex
+                ) else {
+                    bindingsAreOrdered = false
+                    break
+                }
+                searchStart = range.upperBound
+            }
+            let appendCount = leading.components(
+                separatedBy: "expandedMetrics.append("
+            ).count - 1
+            expandedIPhoneLeadingMetricsAreExact =
+                bindingsAreOrdered && appendCount == expectedBindings.count
+        }
+        expect(
+            expandedIPhoneLeadingMetricsAreExact,
+            "expanded iPhone metrics must keep exact consecutive Heart/Time in Zone and Average Heart/Average Speed rows"
         )
         expect(
             compactNavigation.contains(

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -32,6 +32,7 @@ xcrun swiftc \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
@@ -48,6 +49,7 @@ xcrun swiftc \
   -o "${CYCLING_SENSOR_OUT}" \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
+  ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \


### PR DESCRIPTION
## Summary

- add average heart rate and average speed tiles directly below heart rate and time in zone in the expanded iPhone workout sheet
- show average speed alongside average heart rate in the ended iPhone workout dashboard
- add an ended-workout heart rate zone breakdown with per-zone duration, proportional bars, and BPM ranges based on the configured maximum heart rate
- reorder the live Watch workout grid to Speed/Distance, Heart/HR Zone, then Avg Heart/Avg Speed
- show average heart rate and average speed in the saved-workout Watch summary
- derive average speed from workout distance and active elapsed time, with unavailable/zero handling

## User impact

Riders can see cumulative effort and pace during a workout on iPhone and Apple Watch, then review both averages and their complete heart rate zone distribution after finishing on iPhone.

## Validation

- `./ios-app/scripts/run-workout-contract-tests.sh`
- `xcodebuild -project BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination generic/platform=iOS\ Simulator -derivedDataPath /tmp/open-bike-workout-summary-derived CODE_SIGNING_ALLOWED=NO build`
