### PR TITLE
Add Phase 0 battery instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,8 +220,10 @@ jobs:
             tools/tests/test_gui_layout.cpp \
             -o /tmp/test_gui_layout_206
           /tmp/test_gui_layout_206
-      - name: Power metrics schema host tests
+      - name: Power metrics host tests
         run: |
+          PYTHONPATH=tools python -m unittest \
+            tools.tests.test_power_trace_summary
           g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_power_metrics_schema.cpp \
             -o /tmp/test_power_metrics_schema

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,10 @@ jobs:
       matrix:
         target:
           - WAVESHARE_AMOLED_175
+          - WAVESHARE_AMOLED_175_POWER_METRICS
           - WAVESHARE_AMOLED_175_SPEAKER_HONK
           - WAVESHARE_AMOLED_206
+          - WAVESHARE_AMOLED_206_POWER_METRICS
           - WAVESHARE_AMOLED_206_SPEAKER_HONK
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,12 @@ jobs:
             tools/tests/test_gui_layout.cpp \
             -o /tmp/test_gui_layout_206
           /tmp/test_gui_layout_206
+      - name: Power metrics schema host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_power_metrics_schema.cpp \
+            -o /tmp/test_power_metrics_schema
+          /tmp/test_power_metrics_schema
       - name: Map profile protocol host tests
         run: |
           g++ -std=c++17 \

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -77,9 +77,10 @@ and energy against time, calculates the exact sample p95 and peak, and reports
 run-to-run standard deviation, coefficient of variation, and range. The hash
 is calculated from the same byte stream that is parsed, and the analyzer fails
 if a raw file changes during the read. It fails closed on missing or aliased
-columns, non-finite input or derived values, duplicate timestamps, ambiguous
-voltage input, duplicate raw trace content, insufficient sample cadence, an
-uncovered window boundary, or a window with fewer than two samples.
+columns, malformed CSV, non-finite input or derived values, duplicate
+timestamps, ambiguous voltage input, duplicate raw trace content, insufficient
+sample cadence, an uncovered window boundary, or a window with fewer than two
+samples.
 
 The default normalized CSV header is `time_s,current_mA`. Units are never
 guessed from a column name. Supply either a measured voltage column or the

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -23,8 +23,9 @@ The report contains:
 - LVGL call count plus total/maximum handler time;
 - display flush count plus rotation, QSPI, and total time;
 - completed/interrupted map renders, stage timing, and render-reason counts;
-- received BLE packets by logical class, including packets later rejected by
-  authentication or payload validation;
+- logically classified BLE packets after authenticated transport framing is
+  unwrapped, including packets later rejected by session authentication or
+  application-payload validation;
 - Wi-Fi mode, transfer state/mode, audio activity, CPU frequency, and the
   number of active power-management locks; and
 - `appQueue=ios-diagnostic`, which identifies the separate

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -74,10 +74,12 @@ Use `esp32/tools/power_trace_summary.py` to derive campaign statistics from
 the saved raw source-monitor CSV files. The analyzer requires at least three
 runs by default, records each raw file's SHA-256, integrates average current
 and energy against time, calculates the exact sample p95 and peak, and reports
-run-to-run standard deviation, coefficient of variation, and range. It fails
-closed on missing columns, non-finite samples, duplicate timestamps, ambiguous
-voltage input, duplicate raw trace content, or a window with fewer than two
-samples.
+run-to-run standard deviation, coefficient of variation, and range. The hash
+is calculated from the same byte stream that is parsed, and the analyzer fails
+if a raw file changes during the read. It fails closed on missing or aliased
+columns, non-finite input or derived values, duplicate timestamps, ambiguous
+voltage input, duplicate raw trace content, insufficient sample cadence, an
+uncovered window boundary, or a window with fewer than two samples.
 
 The default normalized CSV header is `time_s,current_mA`. Units are never
 guessed from a column name. Supply either a measured voltage column or the
@@ -109,10 +111,22 @@ argument with:
 ```
 
 The start and end window are seconds relative to the first trace sample. The
-p95 is a sample percentile, which is appropriate only for the required fixed,
-high-rate capture. Do not compare traces sampled at materially different
-rates. Keep the raw CSV and generated JSON together; the JSON is a derived
-artifact and never replaces the raw trace.
+analyzer linearly interpolates current and voltage at boundaries that fall
+between source samples, so an explicit end is never silently truncated. The
+reported selected-sample count and sample-percentile distribution exclude
+those synthetic boundaries, while the JSON records their count separately.
+By default, the CLI requires an effective
+sample rate of at least 10 kS/s and rejects any interval longer than two
+nominal sample periods; use `--minimum-sample-rate-hz` and
+`--maximum-gap-factor` only when a documented measurement protocol calls for
+different limits. The p95 is a sample percentile, which is appropriate only
+for a fixed, high-rate capture. Do not compare traces sampled at materially
+different rates.
+
+Keep each complete, immutable raw CSV with its generated JSON. Output is
+written atomically, and the analyzer refuses a same-path, symlink, or hard-link
+output that aliases any raw input. The JSON is a derived artifact and never
+replaces the raw trace.
 
 ## Artifact identity
 

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -42,6 +42,12 @@ pio run -e WAVESHARE_AMOLED_175_POWER_METRICS
 pio run -e WAVESHARE_AMOLED_206_POWER_METRICS
 ```
 
+Metrics builds reserve a larger USB CDC transmit queue so each `PWRMET` record
+is enqueued as one complete line without changing the normal firmware's memory
+footprint or one-millisecond non-blocking serial timeout. Any
+`PWRMET_ERROR` line means that interval was not captured intact and must not be
+used for trace correlation.
+
 To correlate display flushes and map renders with a source-monitor trace,
 define `POWER_METRICS_PULSE_GPIO` in the selected metrics environment only
 after confirming that the pin is electrically spare on that exact board

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -68,6 +68,52 @@ Capture `PWRMET` over an electrically appropriate, battery-isolated UART when
 available, or run a separate instrumented correlation pass. Never merge a
 USB-powered trace into the battery-terminal energy results.
 
+## Trace analysis
+
+Use `esp32/tools/power_trace_summary.py` to derive campaign statistics from
+the saved raw source-monitor CSV files. The analyzer requires at least three
+runs by default, records each raw file's SHA-256, integrates average current
+and energy against time, calculates the exact sample p95 and peak, and reports
+run-to-run standard deviation, coefficient of variation, and range. It fails
+closed on missing columns, non-finite samples, duplicate timestamps, ambiguous
+voltage input, duplicate raw trace content, or a window with fewer than two
+samples.
+
+The default normalized CSV header is `time_s,current_mA`. Units are never
+guessed from a column name. Supply either a measured voltage column or the
+fixed source-monitor voltage explicitly. For example:
+
+```sh
+cd esp32
+python3 tools/power_trace_summary.py \
+  traces/static-nav-175-run-1.csv \
+  traces/static-nav-175-run-2.csv \
+  traces/static-nav-175-run-3.csv \
+  --scenario "BLE connected, static navigation" \
+  --target 1.75 \
+  --firmware-sha "$(git rev-parse HEAD)" \
+  --supply-voltage 4.0 \
+  --window-start-s 60 \
+  --window-end-s 660 \
+  --output traces/static-nav-175-summary.json
+```
+
+For an export containing, for example, `Timestamp` in milliseconds,
+`Current` in amperes, and `Voltage` in millivolts, replace the fixed-voltage
+argument with:
+
+```text
+--time-column Timestamp --time-unit ms \
+--current-column Current --current-unit A \
+--voltage-column Voltage --voltage-unit mV
+```
+
+The start and end window are seconds relative to the first trace sample. The
+p95 is a sample percentile, which is appropriate only for the required fixed,
+high-rate capture. Do not compare traces sampled at materially different
+rates. Keep the raw CSV and generated JSON together; the JSON is a derived
+artifact and never replaces the raw trace.
+
 ## Artifact identity
 
 Record this block before each measurement campaign.

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -1,0 +1,202 @@
+# Firmware battery-life hardware validation
+
+Status: **baseline measurements pending on both hardware targets**.
+
+This document is the source of truth for physical power measurements made
+during the battery-life program. A firmware build, simulator result, PMU battery
+percentage, or USB-powered observation is not a power baseline. Fill in the
+tables below only from saved source-monitor traces taken at the battery input.
+
+## Instrumentation contract
+
+Power-metrics firmware uses schema version `1` and emits one aggregate line
+every ten seconds:
+
+```text
+PWRMET v=1 intervalMs=... screen=... tile=... display=... brightness[...] loop[...] lvgl[...] flush[...] map[...] ble[...] system[...]
+```
+
+The report contains:
+
+- active screen/tile, display state, and requested/effective panel command;
+- main-loop wakes and maximum loop gap;
+- LVGL call count plus total/maximum handler time;
+- display flush count plus rotation, QSPI, and total time;
+- completed/interrupted map renders, stage timing, and render-reason counts;
+- accepted BLE packets by class;
+- Wi-Fi mode, transfer state/mode, audio activity, CPU frequency, and the
+  number of active power-management locks; and
+- `appQueue=ios-diagnostic`, which identifies the separate
+  `PWRMET_IOS v=1` queue report produced by a Debug iOS build.
+
+The accumulator schema is defined in
+`esp32/lib/power_metrics/power_metrics_schema.hpp` and has a host test in
+`esp32/tools/tests/test_power_metrics_schema.cpp`. Metrics builds are separate
+from normal firmware builds:
+
+```sh
+cd esp32
+pio run -e WAVESHARE_AMOLED_175_POWER_METRICS
+pio run -e WAVESHARE_AMOLED_206_POWER_METRICS
+```
+
+To correlate display flushes and map renders with a source-monitor trace,
+define `POWER_METRICS_PULSE_GPIO` in the selected metrics environment only
+after confirming that the pin is electrically spare on that exact board
+revision. The pulse is optional; do not guess a pin or reuse a display, touch,
+SD, USB, audio, PMU, or boot-control signal.
+
+## Required measurement setup
+
+| Field | Required value | Recorded value |
+| --- | --- | --- |
+| Source monitor | PPK, Otii, Monsoon, Joulescope, or equivalent | Pending |
+| Connection point | Battery terminals, including AXP2101/regulator losses | Pending |
+| USB power | Physically disconnected | Pending |
+| Initial fixed supply | 4.0 V | Pending |
+| Sample rate | At least 10 kS/s | Pending |
+| Steady scenario duration | 5-10 minutes | Pending |
+| Repetitions | At least three per scenario | Pending |
+| Phone placement/RF conditions | Fixed and documented | Pending |
+| Route/GPS replay fixture | Fixed and versioned | Pending |
+| SD card image | Fixed and checksummed | Pending |
+
+USB serial can change power behavior and USB power invalidates the baseline.
+Capture `PWRMET` over an electrically appropriate, battery-isolated UART when
+available, or run a separate instrumented correlation pass. Never merge a
+USB-powered trace into the battery-terminal energy results.
+
+## Artifact identity
+
+Record this block before each measurement campaign.
+
+| Field | AMOLED 1.75 | AMOLED 2.06 |
+| --- | --- | --- |
+| Measurement date/time/time zone | Pending | Pending |
+| Operator | Pending | Pending |
+| Git commit SHA | Pending | Pending |
+| PlatformIO environment | `WAVESHARE_AMOLED_175_POWER_METRICS` | `WAVESHARE_AMOLED_206_POWER_METRICS` |
+| Firmware binary SHA-256 | Pending | Pending |
+| Board model/revision/serial label | Pending | Pending |
+| Display/panel revision | Pending | Pending |
+| Battery or supply model | Pending | Pending |
+| Supply voltage at board | Pending | Pending |
+| SD make/model/capacity | Pending | Pending |
+| SD image SHA-256 | Pending | Pending |
+| iPhone model/iOS version | Pending | Pending |
+| App commit/build | Pending | Pending |
+| BLE RSSI range | Pending | Pending |
+| Brightness command | Pending | Pending |
+| Route/replay fixture SHA-256 | Pending | Pending |
+| Raw trace directory | Pending | Pending |
+
+## Scenario procedure
+
+For every applicable scenario:
+
+1. Flash the exact recorded metrics environment and verify a healthy boot.
+2. Put the device, phone, route, SD card, brightness, and RF geometry in the
+   recorded state.
+3. Start the source-monitor capture before entering the scenario.
+4. Mark the steady-state window; exclude setup/transitions from steady-state
+   averages but retain the complete raw trace.
+5. Run for 5-10 minutes, then repeat at least three times from a reproducible
+   starting state.
+6. Save the raw trace without smoothing or destructive export settings.
+7. Record average, p95, and peak current, energy per hour, event rates, latency,
+   and any visible or protocol failure.
+8. Repeat the same fixture on the other target. A scenario may be marked N/A
+   only with a reason.
+
+Deep sleep must be measured after all transient shutdown work has settled.
+Audio scenarios must include both active playback and the 60-second period
+after playback to expose rails or clocks that remain enabled.
+
+## Raw scenario results
+
+All cells are intentionally pending. Use trace filenames rather than links to
+temporary source-monitor sessions. `mWh/h` is derived from measured input
+voltage and current; projected runtime additionally requires measured usable
+battery Wh.
+
+| # | Scenario | Target | Run traces (minimum 3) | Avg mA | p95 mA | Peak mA | mWh/h | Notes/failures |
+| ---: | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
+| 1 | Deep sleep | 1.75 | Pending | — | — | — | — | Pending |
+| 1 | Deep sleep | 2.06 | Pending | — | — | — | — | Pending |
+| 2 | Disconnected waiting, first 30 s | 1.75 | Pending | — | — | — | — | Pending |
+| 2 | Disconnected waiting, first 30 s | 2.06 | Pending | — | — | — | — | Pending |
+| 3 | Disconnected waiting, after 60 s | 1.75 | Pending | — | — | — | — | Pending |
+| 3 | Disconnected waiting, after 60 s | 2.06 | Pending | — | — | — | — | Pending |
+| 4 | BLE connected, static navigation | 1.75 | Pending | — | — | — | — | Pending |
+| 4 | BLE connected, static navigation | 2.06 | Pending | — | — | — | — | Pending |
+| 5 | Scripted maneuver updates | 1.75 | Pending | — | — | — | — | Pending |
+| 5 | Scripted maneuver updates | 2.06 | Pending | — | — | — | — | Pending |
+| 6 | North-up map, stationary | 1.75 | Pending | — | — | — | — | Pending |
+| 6 | North-up map, stationary | 2.06 | Pending | — | — | — | — | Pending |
+| 7 | North-up map, 1 Hz GPS replay | 1.75 | Pending | — | — | — | — | Pending |
+| 7 | North-up map, 1 Hz GPS replay | 2.06 | Pending | — | — | — | — | Pending |
+| 8 | Course-up map, straight | 1.75 | Pending | — | — | — | — | Pending |
+| 8 | Course-up map, straight | 2.06 | Pending | — | — | — | — | Pending |
+| 9 | Course-up map, repeated turns | 1.75 | Pending | — | — | — | — | Pending |
+| 9 | Course-up map, repeated turns | 2.06 | Pending | — | — | — | — | Pending |
+| 10 | Ride-statistics screen | 1.75 | Pending | — | — | — | — | Pending |
+| 10 | Ride-statistics screen | 2.06 | Pending | — | — | — | — | Pending |
+| 11 | Battery/status screen | 1.75 | Pending | — | — | — | — | Pending |
+| 11 | Battery/status screen | 2.06 | Pending | — | — | — | — | Pending |
+| 12 | Connected dimmed state | 1.75 | Not implemented | — | — | — | — | Measure after state exists |
+| 12 | Connected dimmed state | 2.06 | Not implemented | — | — | — | — | Measure after state exists |
+| 13 | Connected display-off state | 1.75 | Not implemented | — | — | — | — | Measure after state exists |
+| 13 | Connected display-off state | 2.06 | Not implemented | — | — | — | — | Measure after state exists |
+| 14 | Transfer AP enabled, idle | 1.75 | Pending | — | — | — | — | Pending |
+| 14 | Transfer AP enabled, idle | 2.06 | Pending | — | — | — | — | Pending |
+| 15 | Map upload in progress | 1.75 | Pending | — | — | — | — | Pending |
+| 15 | Map upload in progress | 2.06 | Pending | — | — | — | — | Pending |
+| 16 | Audio playback | 1.75 | Pending | — | — | — | — | Pending |
+| 16 | Audio playback | 2.06 | Pending | — | — | — | — | Pending |
+| 17 | Sixty seconds after audio | 1.75 | Pending | — | — | — | — | Pending |
+| 17 | Sixty seconds after audio | 2.06 | Pending | — | — | — | — | Pending |
+
+## Performance and reliability results
+
+Record values from the same run windows used for the electrical results.
+
+| Metric | AMOLED 1.75 | AMOLED 2.06 | Gate |
+| --- | --- | --- | --- |
+| LVGL calls/min, static navigation | Pending | Pending | Baseline only |
+| Display flushes/min, static navigation | Pending | Pending | Baseline only |
+| Map renders/min, 1 Hz north-up replay | Pending | Pending | Baseline only |
+| SD/map read time/min | Pending | Pending | Baseline only |
+| Main-loop wakes/s | Pending | Pending | Baseline only |
+| GPS-to-visible latency p50/p95 | Pending | Pending | p95 no worse than baseline; target <250 ms |
+| Maneuver-to-visible latency p50/p95 | Pending | Pending | p95 no worse than baseline; target <250 ms |
+| BLE reconnect p50/p95 | Pending | Pending | Fast <2 s p95; slow <5 s p95 |
+| Queue depth/max/drops/retries/coalesces | Pending | Pending | No lost maneuver transition |
+| Touch/button misses | Pending | Pending | Zero in scripted run |
+| Display corruption/black wake | Pending | Pending | Zero observed |
+| SD/route/catalog/transfer errors | Pending | Pending | Zero corruption |
+
+## Baseline summary
+
+| Target | Repeatable baseline? | Run-to-run variance | Usable battery Wh measured? | Runtime projection permitted? |
+| --- | --- | --- | --- | --- |
+| AMOLED 1.75 | **No — pending** | Pending | No | No |
+| AMOLED 2.06 | **No — pending** | Pending | No | No |
+
+No later phase may claim measured savings until both targets have three
+repeatable baseline runs for the relevant comparison scenario and the observed
+difference exceeds measurement noise. Update this summary only after reviewing
+the raw traces and documenting exclusions.
+
+## Campaign review checklist
+
+- [ ] Every result names an immutable firmware SHA and binary SHA-256.
+- [ ] USB power was physically absent from electrical baseline runs.
+- [ ] Both board targets used the same controlled scenario fixture.
+- [ ] Three or more raw traces exist for every claimed comparison.
+- [ ] Steady-state windows and excluded transitions are documented.
+- [ ] Average, p95, peak, and energy were computed from raw samples.
+- [ ] `PWRMET` event rates agree with visible trace bursts where correlated.
+- [ ] iOS queue metrics show no lost maneuver transition.
+- [ ] Failures and anomalous runs remain recorded rather than silently removed.
+- [ ] Savings exceed run-to-run variance and instrument noise.
+- [ ] Actual-battery runtime uses measured usable Wh, not label capacity.

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -1,6 +1,7 @@
 # Firmware battery-life hardware validation
 
-Status: **baseline measurements pending on both hardware targets**.
+Status: **source-monitor baseline measurements pending**. Physical bring-up has
+passed on the available 1.75-inch target; 2.06-inch hardware is unavailable.
 
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
@@ -74,6 +75,29 @@ USB serial can change power behavior and USB power invalidates the baseline.
 Capture `PWRMET` over an electrically appropriate, battery-isolated UART when
 available, or run a separate instrumented correlation pass. Never merge a
 USB-powered trace into the battery-terminal energy results.
+
+## Physical bring-up observations (not an electrical baseline)
+
+These observations prove firmware identity and basic functional behavior only.
+They must not be entered into the raw scenario results or used for battery-life
+projections.
+
+| Field | AMOLED 1.75 observation |
+| --- | --- |
+| Date/time zone | 2026-07-29, Asia/Singapore |
+| Git commit SHA | `f3f703ea582725c9f5e4920eacea82a4276d65fb` |
+| Firmware binary SHA-256 | `805dc163ce6caca067f207b6777e32337a2b31ff265241c638ad928a91d04cb9` |
+| Physical target | Waveshare AMOLED 1.75; USB serial `28:84:85:3B:68:60` |
+| Flash/boot | Exact metrics build flashed and healthy boot observed |
+| Metrics transport | Four complete `PWRMET` records; zero `PWRMET_ERROR` records |
+| Touch and map interaction | Operator confirmed tap, map drag, and pinch-to-zoom work |
+| Inline USB meter | Operator reported `5.1 W`, unchanged from the previous firmware |
+| Interpretation | Coarse USB-path observation only; includes unknown USB/charging losses and has no saved high-rate trace |
+| AMOLED 2.06 | Physical hardware unavailable; build validation only |
+
+The unchanged inline-meter reading is consistent with Phase 0 being
+instrumentation-only, but its resolution and connection point cannot establish
+equivalence or savings. It is retained solely as a bring-up observation.
 
 ## Trace analysis
 

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -23,11 +23,12 @@ The report contains:
 - LVGL call count plus total/maximum handler time;
 - display flush count plus rotation, QSPI, and total time;
 - completed/interrupted map renders, stage timing, and render-reason counts;
-- accepted BLE packets by class;
+- received BLE packets by logical class, including packets later rejected by
+  authentication or payload validation;
 - Wi-Fi mode, transfer state/mode, audio activity, CPU frequency, and the
   number of active power-management locks; and
 - `appQueue=ios-diagnostic`, which identifies the separate
-  `PWRMET_IOS v=1` queue report produced by a Debug iOS build.
+  `PWRMET_IOS v=1` ten-second interval report produced by a Debug iOS build.
 
 The accumulator schema is defined in
 `esp32/lib/power_metrics/power_metrics_schema.hpp` and has a host test in

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -27,7 +27,8 @@ The report contains:
   unwrapped, including packets later rejected by session authentication or
   application-payload validation;
 - Wi-Fi mode, transfer state/mode, audio activity, CPU frequency, and the
-  number of active power-management locks; and
+  number of application-managed power-management locks (`appPmLocks`,
+  currently zero because this firmware creates none); and
 - `appQueue=ios-diagnostic`, which identifies the separate
   `PWRMET_IOS v=1` ten-second interval report produced by a Debug iOS build.
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1687,6 +1687,7 @@ static void handleGenericTransferControlPayload(const uint8_t *data, size_t len,
 
 static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                                        const char *source) {
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
   if (len == 0) {
     lastRouteHash = 0;
     lastRouteLen = 0;
@@ -1694,7 +1695,6 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                   source == nullptr ? "unknown" : source);
     bleDebugStats.routePacketCount++;
     bleDebugStats.lastRoutePacketMs = millis();
-    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
     routeOverlay.clear();
     clearCurrentNavigationData();
     power_metrics::noteMapRequest(power_metrics::MapRenderReason::Route);
@@ -1724,7 +1724,6 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                 source == nullptr ? "unknown" : source, (unsigned)len);
   bleDebugStats.routePacketCount++;
   bleDebugStats.lastRoutePacketMs = millis();
-  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
 
   if (!gpsReceivedFromApp && len >= 8) {
     int32_t routeStartLat = 0;
@@ -1746,6 +1745,7 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
 
 static void handleGpsPayload(const uint8_t *data, size_t len,
                              const char *source) {
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
   gps_position_protocol::Packet packet{};
   if (!gps_position_protocol::decodeAndApply(data, len, gps.gpsData,
                                              &packet)) {
@@ -1782,7 +1782,6 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
   );
   bleDebugStats.gpsPacketCount++;
   bleDebugStats.lastGpsPacketMs = millis();
-  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
 
   if (!gpsReceivedFromApp) {
     gpsReceivedFromApp = true;
@@ -1796,6 +1795,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
 
 static void handleWorkoutTelemetryPayload(const uint8_t *data, size_t len,
                                           const char *source) {
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Workout);
   if (!requireAuthenticated("workout telemetry")) {
     return;
   }
@@ -1804,7 +1804,6 @@ static void handleWorkoutTelemetryPayload(const uint8_t *data, size_t len,
   switch (result) {
   case workout_telemetry::ApplyResult::Applied:
   case workout_telemetry::ApplyResult::Cleared:
-    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Workout);
     // Health metrics remain RAM-only and are intentionally absent from logs.
     return;
   default:
@@ -1819,7 +1818,6 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                              const char *source) {
   bleDebugStats.settingsPacketCount++;
   bleDebugStats.lastSettingsPacketMs = millis();
-  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
   if (map_profile_protocol::isIndependentSetting(settingId)) {
     bleSessionUsesIndependentMapProfiles = true;
   }
@@ -2066,6 +2064,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
 
 static void handleMapSettingPayload(const uint8_t *data, size_t len,
                                     const char *source) {
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
   if (data == nullptr || len < 5) {
     Serial.printf("BLE: Rejected %s map setting: expected 5 bytes\n",
                   source == nullptr ? "unknown" : source);
@@ -2227,6 +2226,7 @@ public:
     }
 
     if (handleDestinationPickerPayload(value, "destination picker")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Control);
       return;
     }
 
@@ -2241,6 +2241,7 @@ public:
 
     if (hasPrefix(value, "MAPR")) {
       if (!requireAuthenticated("fallback route geometry")) {
+        power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
         return;
       }
       handleRouteGeometryPayload((const uint8_t *)value.data() + 4,
@@ -2250,6 +2251,7 @@ public:
 
     if (hasPrefix(value, "GPSP")) {
       if (!requireAuthenticated("fallback GPS position")) {
+        power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
         return;
       }
       handleGpsPayload((const uint8_t *)value.data() + 4, value.length() - 4,
@@ -2259,6 +2261,7 @@ public:
 
     if (hasPrefix(value, "MSET")) {
       if (!requireAuthenticated("fallback map setting")) {
+        power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
         return;
       }
       handleMapSettingPayload((const uint8_t *)value.data() + 4,
@@ -2267,6 +2270,7 @@ public:
     }
 
     if (hasPrefix(value, "MTRN")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("map transfer control")) {
         return;
       }
@@ -2276,6 +2280,7 @@ public:
     }
 
     if (hasPrefix(value, "MSTS")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("map transfer status")) {
         return;
       }
@@ -2285,6 +2290,7 @@ public:
     }
 
     if (hasPrefix(value, "DTRN")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("device transfer control")) {
         return;
       }
@@ -2295,10 +2301,12 @@ public:
 
     if (handleDeviceCapabilitiesCommand(value, pChar,
                                         "device capabilities")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Control);
       return;
     }
 
     if (hasPrefix(value, "DSTS")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("device transfer status")) {
         return;
       }
@@ -2308,14 +2316,17 @@ public:
     }
 
     if (handleSoundPlayCommand(value, "sound playback", "fallback")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Audio);
       return;
     }
 
     if (handlePowerButtonHonkCommand(value, "PWR honk configuration",
                                      "fallback", pChar)) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Audio);
       return;
     }
 
+    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Navigation);
     if (!requireAuthenticated("navigation instruction")) {
       return;
     }
@@ -2323,7 +2334,6 @@ public:
     Serial.printf("BLE Nav received: %u bytes\n", (unsigned)value.length());
     bleDebugStats.navPacketCount++;
     bleDebugStats.lastNavPacketMs = millis();
-    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Navigation);
     parseNavigationData(value);
   }
 };
@@ -2339,6 +2349,7 @@ public:
       return;
     }
     if (!requireAuthenticated("route geometry")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
       return;
     }
 
@@ -2358,6 +2369,7 @@ public:
       return;
     }
     if (!requireAuthenticated("GPS position")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
       return;
     }
 
@@ -2401,10 +2413,12 @@ public:
     }
 
     if (handleDestinationPickerPayload(value, "native destination picker")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Control);
       return;
     }
 
     if (hasPrefix(value, "MTRN")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("native map transfer control")) {
         return;
       }
@@ -2415,6 +2429,7 @@ public:
     }
 
     if (hasPrefix(value, "MSTS")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("native map transfer status")) {
         return;
       }
@@ -2424,6 +2439,7 @@ public:
     }
 
     if (hasPrefix(value, "DTRN")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("native device transfer control")) {
         return;
       }
@@ -2436,10 +2452,12 @@ public:
     if (handleDeviceCapabilitiesCommand(value,
                                         mapTransferStatusCharacteristic,
                                         "native device capabilities")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Control);
       return;
     }
 
     if (hasPrefix(value, "DSTS")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Transfer);
       if (!requireAuthenticated("native device transfer status")) {
         return;
       }
@@ -2449,16 +2467,19 @@ public:
     }
 
     if (handleSoundPlayCommand(value, "native sound playback", "native")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Audio);
       return;
     }
 
     if (handlePowerButtonHonkCommand(value, "native PWR honk configuration",
                                      "native",
                                      mapTransferStatusCharacteristic)) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Audio);
       return;
     }
 
     if (!requireAuthenticated("map setting")) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
       return;
     }
 
@@ -2472,6 +2493,7 @@ public:
   void onWrite(NimBLECharacteristic *pChar) override {
     std::string value = pChar->getValue();
     if (!value.empty()) {
+      power_metrics::noteBlePacket(power_metrics::BlePacketClass::Auth);
       handleAuthPayload(value);
     }
   }

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -25,6 +25,7 @@
 #include "../firmware_update/firmware_update_http.hpp"
 #include "../map_transfer_http/map_transfer_http.hpp"
 #include "../map_transfer/map_stream_compiled_trust.hpp"
+#include "../power_metrics/power_metrics.hpp"
 #include "../route_overlay/route_overlay.hpp"
 #include "../speaker/speaker.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
@@ -1693,8 +1694,10 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                   source == nullptr ? "unknown" : source);
     bleDebugStats.routePacketCount++;
     bleDebugStats.lastRoutePacketMs = millis();
+    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
     routeOverlay.clear();
     clearCurrentNavigationData();
+    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Route);
     triggerMapRedraw();
     return;
   }
@@ -1721,6 +1724,7 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
                 source == nullptr ? "unknown" : source, (unsigned)len);
   bleDebugStats.routePacketCount++;
   bleDebugStats.lastRoutePacketMs = millis();
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Route);
 
   if (!gpsReceivedFromApp && len >= 8) {
     int32_t routeStartLat = 0;
@@ -1736,6 +1740,7 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
   }
 
   routeOverlay.parseRouteData(data, len);
+  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Route);
   triggerMapRedraw();
 }
 
@@ -1777,6 +1782,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
   );
   bleDebugStats.gpsPacketCount++;
   bleDebugStats.lastGpsPacketMs = millis();
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
 
   if (!gpsReceivedFromApp) {
     gpsReceivedFromApp = true;
@@ -1784,6 +1790,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
     Serial.println("BLE GPS: First position received, transitioning to map...");
   }
 
+  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Gps);
   triggerMapRedraw();
 }
 
@@ -1797,6 +1804,7 @@ static void handleWorkoutTelemetryPayload(const uint8_t *data, size_t len,
   switch (result) {
   case workout_telemetry::ApplyResult::Applied:
   case workout_telemetry::ApplyResult::Cleared:
+    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Workout);
     // Health metrics remain RAM-only and are intentionally absent from logs.
     return;
   default:
@@ -1811,6 +1819,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                              const char *source) {
   bleDebugStats.settingsPacketCount++;
   bleDebugStats.lastSettingsPacketMs = millis();
+  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
   if (map_profile_protocol::isIndependentSetting(settingId)) {
     bleSessionUsesIndependentMapProfiles = true;
   }
@@ -2051,6 +2060,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     break;
   }
 
+  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
   triggerMapRedraw();
 }
 
@@ -2313,6 +2323,7 @@ public:
     Serial.printf("BLE Nav received: %u bytes\n", (unsigned)value.length());
     bleDebugStats.navPacketCount++;
     bleDebugStats.lastNavPacketMs = millis();
+    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Navigation);
     parseNavigationData(value);
   }
 };

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -8,6 +8,7 @@
 
 #include "mainScr.hpp"
 #include "../../ble_navigation/ble_navigation.hpp" // Access mapRenderSettings
+#include "../../power_metrics/power_metrics.hpp"
 #include "../../route_overlay/route_overlay.hpp"
 #include "destinationPickerLayout.hpp"
 #include "guiLayout.hpp"
@@ -276,6 +277,7 @@ static void applyMapRotationForActiveTile() {
       }
       mapView.updateArrowColor();
       mapView.isPosMoved = true;
+      power_metrics::noteMapRequest(power_metrics::MapRenderReason::Heading);
       log_i("Map guidance: rotation switched to %s",
             desiredMode == Maps::ROT_COURSE_UP ? "Course Up" : "North Up");
     }
@@ -291,6 +293,7 @@ static void applyMapRotationForActiveTile() {
     mapView.rotationMode = Maps::ROT_COURSE_UP;
     mapView.updateArrowColor();
     mapView.isPosMoved = true;
+    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
     log_i("Creating Map: Syncing rotation to Course Up (from settings)");
   } else if (mapRenderSettings.mapRotationMode == 0 &&
              mapView.rotationMode != Maps::ROT_NORTH_UP) {
@@ -298,6 +301,7 @@ static void applyMapRotationForActiveTile() {
     mapView.rotationRad = 0;
     mapView.updateArrowColor();
     mapView.isPosMoved = true;
+    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
     log_i("Creating Map: Syncing rotation to North Up (from settings)");
   }
 }
@@ -759,6 +763,8 @@ void updateMainScreen(lv_timer_t *t) {
                 "triggering redraw",
                 lastHeading, currentHeading, headingDiff);
           mapView.isPosMoved = true; // Force map regeneration with new rotation
+          power_metrics::noteMapRequest(
+              power_metrics::MapRenderReason::Heading);
           lastHeading = currentHeading;
         }
       } else {
@@ -784,6 +790,7 @@ void updateMainScreen(lv_timer_t *t) {
       // Also handle hardware GPS location changes (when in follow mode)
       if (gps.hasLocationChange() &&
           (mapView.followGps || activeTile == MAP_GUIDANCE)) {
+        power_metrics::noteMapRequest(power_metrics::MapRenderReason::Gps);
         mapView.followGps = true;
         mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
         mapView.redrawMap = true;
@@ -861,12 +868,15 @@ void updateMap(lv_event_t *event) {
     if (mapSet.vectorMap) {
       renderCompleted = mapView.generateVectorMap(zoom);
     } else {
+      power_metrics::MapRenderMeasurement powerMeasurement;
       mapView.generateRenderMap(zoom);
+      powerMeasurement.finish(true);
     }
     if (!renderCompleted) {
       // Keep both flags set so the map is regenerated cleanly if the user
       // remains on this screen. Do not display the partially rendered canvas.
       mapView.redrawMap = true;
+      power_metrics::noteMapRequest(power_metrics::MapRenderReason::Retry);
       return;
     }
     // Clear flag AFTER generation complete (not inside generateVectorMap)

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -12,6 +12,7 @@
 #include "mapLineStyle.hpp"
 #include "../../ble_navigation/ble_navigation.hpp"
 #include "../../gui/src/guiLayout.hpp"
+#include "../../power_metrics/power_metrics.hpp"
 #include "../../utils/src/line_rasterizer.hpp"
 // #include "../../compass/compass.hpp"
 extern Gps gps;
@@ -2731,6 +2732,12 @@ void Maps::displayMap() {
  * @param zoom -> Zoom Level
  */
 bool Maps::generateVectorMap(uint8_t zoom) {
+  power_metrics::MapRenderMeasurement powerMeasurement;
+#if POWER_METRICS
+  uint32_t powerBlocksUs = 0;
+  uint32_t powerDrawUs = 0;
+  uint32_t powerRouteUs = 0;
+#endif
   const uint32_t generateStartMs = MAPIO_TIME_MS();
   if (Maps::canvasMap == nullptr || Maps::canvasMapTemp == nullptr) {
     ESP_LOGE(TAG, "Map render skipped: canvas double buffer is unavailable");
@@ -2768,10 +2775,23 @@ bool Maps::generateVectorMap(uint8_t zoom) {
 
   // Get Map Blocks
   const uint32_t blocksStartMs = MAPIO_TIME_MS();
+#if POWER_METRICS
+  const uint32_t powerBlocksStartUs = micros();
+#endif
   if (!Maps::getMapBlocks(Maps::viewPort.bbox, Maps::memCache)) {
+#if POWER_METRICS
+    powerBlocksUs = micros() - powerBlocksStartUs;
+    powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
+                                       powerRouteUs);
+#endif
     log_i("Map block loading interrupted to service a screen-cycle input");
     return false;
   }
+#if POWER_METRICS
+  powerBlocksUs = micros() - powerBlocksStartUs;
+  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
+                                     powerRouteUs);
+#endif
   const uint32_t blocksMs = MAPIO_TIME_MS() - blocksStartMs;
 
   ESP_LOGI(TAG,
@@ -2782,11 +2802,24 @@ bool Maps::generateVectorMap(uint8_t zoom) {
 
   // Read Vector Map to Canvas (Pass calculated rotation)
   const uint32_t drawStartMs = MAPIO_TIME_MS();
+#if POWER_METRICS
+  const uint32_t powerDrawStartUs = micros();
+#endif
   if (!Maps::readVectorMap(Maps::viewPort, Maps::memCache, Maps::canvasMapTemp,
                            zoom, rotationRad)) {
+#if POWER_METRICS
+    powerDrawUs = micros() - powerDrawStartUs;
+    powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
+                                       powerRouteUs);
+#endif
     log_i("Map render interrupted to service a screen-cycle input");
     return false;
   }
+#if POWER_METRICS
+  powerDrawUs = micros() - powerDrawStartUs;
+  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
+                                     powerRouteUs);
+#endif
   const uint32_t drawMs = MAPIO_TIME_MS() - drawStartMs;
 
   if (shouldInterruptMapRenderForScreenCycle()) {
@@ -2796,6 +2829,9 @@ bool Maps::generateVectorMap(uint8_t zoom) {
 
   // Draw route overlay from iOS navigation (if available)
   const uint32_t routeStartMs = MAPIO_TIME_MS();
+#if POWER_METRICS
+  const uint32_t powerRouteStartUs = micros();
+#endif
   ESP_LOGI(TAG, "Checking for route overlay: hasRoute=%d",
            routeOverlay.hasRoute());
   if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
@@ -2818,6 +2854,11 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   } else {
     ESP_LOGI(TAG, "No route overlay to draw (no route data)");
   }
+#if POWER_METRICS
+  powerRouteUs = micros() - powerRouteStartUs;
+  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
+                                     powerRouteUs);
+#endif
   const uint32_t routeMs = MAPIO_TIME_MS() - routeStartMs;
 
   if (shouldInterruptMapRenderForScreenCycle()) {
@@ -2845,6 +2886,7 @@ bool Maps::generateVectorMap(uint8_t zoom) {
             (unsigned)Maps::memCache.blocks.size(), routeOverlay.hasRoute());
   // NOTE: isPosMoved flag is now cleared in updateMap() after display,
   // not here, to allow queued BLE updates to trigger new regenerations
+  powerMeasurement.finish(true);
   return true;
 }
 

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -14,6 +14,7 @@
 #include "../../include/hal.hpp"
 #include "display.hpp"
 #include "i2c_bus.hpp"
+#include "power_metrics.hpp"
 #include "touch.hpp"
 #include "waveshare_board.hpp"
 
@@ -152,6 +153,12 @@ static void drawDisplayTestPatterns(uint8_t appliedRotation) {
 
 void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
   uint32_t startUs = micros();
+#if POWER_METRICS
+  power_metrics::pulseBegin(power_metrics::Pulse::DisplayFlush);
+  const uint32_t rotationStartUs = startUs;
+  uint32_t rotationUs = 0;
+  uint32_t qspiStartUs = 0;
+#endif
   uint32_t w = (area->x2 - area->x1 + 1);
   uint32_t h = (area->y2 - area->y1 + 1);
   uint16_t *pixels = reinterpret_cast<uint16_t *>(px_map);
@@ -163,6 +170,9 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
   if (displayRotation == waveshare_board::display::ROTATION_90) {
     if (disp_rotation_buf == NULL) {
       Serial.println("ERROR: missing LVGL software-rotation buffer");
+#if POWER_METRICS
+      power_metrics::pulseEnd(power_metrics::Pulse::DisplayFlush);
+#endif
       lv_display_flush_ready(disp);
       return;
     }
@@ -180,6 +190,11 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
     pixels = reinterpret_cast<uint16_t *>(disp_rotation_buf);
   }
 
+#if POWER_METRICS
+  rotationUs = micros() - rotationStartUs;
+  qspiStartUs = micros();
+#endif
+
   gfx->startWrite();
   gfx->writeAddrWindow(targetX, targetY, targetW, targetH);
   gfx->writePixels(pixels, targetW * targetH);
@@ -192,6 +207,9 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
   gfx->fillRect(area->x1, area->y1, 1, 1,
                 reinterpret_cast<uint16_t *>(px_map)[0]);
 #endif
+#if POWER_METRICS
+  const uint32_t qspiUs = micros() - qspiStartUs;
+#endif
 
   // Notify application policy only after the physical panel write (including
   // the 2.06-inch commit write) has completed.
@@ -200,6 +218,10 @@ void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
   // Inform LVGL 9 that flushing is complete
   lv_display_flush_ready(disp);
   uint32_t durationUs = micros() - startUs;
+#if POWER_METRICS
+  power_metrics::noteDisplayFlush(rotationUs, qspiUs, durationUs);
+  power_metrics::pulseEnd(power_metrics::Pulse::DisplayFlush);
+#endif
   displayFlushCount++;
   lastDisplayFlushMs = millis();
   lastDisplayFlushDurationUs = durationUs;
@@ -832,6 +854,7 @@ void setupDisplay() {
   gfx->displayOn();
   delay(50);
   gfx->setBrightness(255); // Maximum brightness 0-255
+  power_metrics::noteDisplayState(power_metrics::DisplayState::On, 255, 255);
   delay(50);
 
 #ifdef WAVESHARE_DISPLAY_TEST

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "power.hpp"
+#include "power_metrics.hpp"
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "axp2101.hpp"
@@ -90,6 +91,7 @@ void Power::powerOffPeripherals() {
   if (gfx) {
     gfx->displayOff();
     gfx->fillScreen(0x0000);
+    power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 0, 0);
   }
 #endif
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
@@ -117,6 +119,7 @@ void Power::deviceSuspend() {
   lv_refr_now(display);
   if (gfx)
     gfx->displayOff();
+  power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 255, 0);
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(false);
 #endif
@@ -128,6 +131,7 @@ void Power::deviceSuspend() {
   if (gfx) {
     gfx->displayOn();
     gfx->setBrightness(255);
+    power_metrics::noteDisplayState(power_metrics::DisplayState::On, 255, 255);
   }
 #endif
   while (digitalRead(BOARD_BOOT_PIN) != 1) {

--- a/esp32/lib/power_metrics/power_metrics.cpp
+++ b/esp32/lib/power_metrics/power_metrics.cpp
@@ -1,0 +1,146 @@
+#include "power_metrics.hpp"
+
+#if POWER_METRICS
+
+#include <Arduino.h>
+#include <freertos/FreeRTOS.h>
+#include <freertos/portmacro.h>
+
+#ifndef POWER_METRICS_PULSE_GPIO
+#define POWER_METRICS_PULSE_GPIO -1
+#endif
+
+namespace power_metrics {
+namespace {
+
+portMUX_TYPE metricsMux = portMUX_INITIALIZER_UNLOCKED;
+IntervalAccumulator accumulator;
+DisplayState displayState = DisplayState::Unknown;
+uint8_t requestedBrightness = 0;
+uint8_t effectiveBrightness = 0;
+uint32_t pendingMapReasons = 0;
+bool pulseReady = false;
+
+uint32_t consumeMapReasons() {
+  portENTER_CRITICAL(&metricsMux);
+  uint32_t reasons = pendingMapReasons;
+  pendingMapReasons = 0;
+  portEXIT_CRITICAL(&metricsMux);
+  if (reasons == 0) {
+    reasons = reasonMask(MapRenderReason::Other);
+  }
+  return reasons;
+}
+
+} // namespace
+
+void begin() {
+#if POWER_METRICS_PULSE_GPIO >= 0
+  pinMode(POWER_METRICS_PULSE_GPIO, OUTPUT);
+  digitalWrite(POWER_METRICS_PULSE_GPIO, LOW);
+  pulseReady = true;
+#endif
+}
+
+void noteLoop(uint32_t nowMs) {
+  portENTER_CRITICAL(&metricsMux);
+  accumulator.noteLoop(nowMs);
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+void noteLvgl(uint32_t durationUs) {
+  portENTER_CRITICAL(&metricsMux);
+  accumulator.noteLvgl(durationUs);
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+void noteDisplayFlush(uint32_t rotationUs, uint32_t qspiUs,
+                      uint32_t totalUs) {
+  portENTER_CRITICAL(&metricsMux);
+  accumulator.noteDisplayFlush(rotationUs, qspiUs, totalUs);
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+void noteDisplayState(DisplayState state, uint8_t requested,
+                      uint8_t effective) {
+  portENTER_CRITICAL(&metricsMux);
+  displayState = state;
+  requestedBrightness = requested;
+  effectiveBrightness = effective;
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+void noteMapRequest(MapRenderReason reason) {
+  portENTER_CRITICAL(&metricsMux);
+  pendingMapReasons |= reasonMask(reason);
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+void noteBlePacket(BlePacketClass packetClass) {
+  portENTER_CRITICAL(&metricsMux);
+  accumulator.noteBlePacket(packetClass);
+  portEXIT_CRITICAL(&metricsMux);
+}
+
+RuntimeSnapshot snapshotAndReset() {
+  portENTER_CRITICAL(&metricsMux);
+  RuntimeSnapshot snapshot;
+  snapshot.interval = accumulator.snapshotAndReset();
+  snapshot.displayState = displayState;
+  snapshot.requestedBrightness = requestedBrightness;
+  snapshot.effectiveBrightness = effectiveBrightness;
+  portEXIT_CRITICAL(&metricsMux);
+  return snapshot;
+}
+
+void pulseBegin(Pulse) {
+#if POWER_METRICS_PULSE_GPIO >= 0
+  if (pulseReady) {
+    digitalWrite(POWER_METRICS_PULSE_GPIO, HIGH);
+  }
+#endif
+}
+
+void pulseEnd(Pulse) {
+#if POWER_METRICS_PULSE_GPIO >= 0
+  if (pulseReady) {
+    digitalWrite(POWER_METRICS_PULSE_GPIO, LOW);
+  }
+#endif
+}
+
+MapRenderMeasurement::MapRenderMeasurement()
+    : startUs_(micros()), reasons_(consumeMapReasons()) {
+  pulseBegin(Pulse::MapRender);
+}
+
+MapRenderMeasurement::~MapRenderMeasurement() {
+  if (!finished_) {
+    finish(false);
+  }
+}
+
+void MapRenderMeasurement::setStageDurations(uint32_t blocksUs,
+                                             uint32_t drawUs,
+                                             uint32_t routeUs) {
+  blocksUs_ = blocksUs;
+  drawUs_ = drawUs;
+  routeUs_ = routeUs;
+}
+
+void MapRenderMeasurement::finish(bool completed) {
+  if (finished_) {
+    return;
+  }
+  const uint32_t totalUs = micros() - startUs_;
+  portENTER_CRITICAL(&metricsMux);
+  accumulator.noteMapRender(completed, totalUs, blocksUs_, drawUs_, routeUs_,
+                            reasons_);
+  portEXIT_CRITICAL(&metricsMux);
+  pulseEnd(Pulse::MapRender);
+  finished_ = true;
+}
+
+} // namespace power_metrics
+
+#endif

--- a/esp32/lib/power_metrics/power_metrics.hpp
+++ b/esp32/lib/power_metrics/power_metrics.hpp
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "power_metrics_schema.hpp"
+
+#include <cstdint>
+
+#ifndef POWER_METRICS
+#define POWER_METRICS 0
+#endif
+
+namespace power_metrics {
+
+enum class DisplayState : uint8_t {
+  Unknown = 0,
+  On,
+  Off,
+};
+
+enum class Pulse : uint8_t {
+  DisplayFlush = 0,
+  MapRender,
+};
+
+struct RuntimeSnapshot {
+  IntervalData interval{};
+  DisplayState displayState = DisplayState::Unknown;
+  uint8_t requestedBrightness = 0;
+  uint8_t effectiveBrightness = 0;
+};
+
+#if POWER_METRICS
+
+void begin();
+void noteLoop(uint32_t nowMs);
+void noteLvgl(uint32_t durationUs);
+void noteDisplayFlush(uint32_t rotationUs, uint32_t qspiUs,
+                      uint32_t totalUs);
+void noteDisplayState(DisplayState state, uint8_t requestedBrightness,
+                      uint8_t effectiveBrightness);
+void noteMapRequest(MapRenderReason reason);
+void noteBlePacket(BlePacketClass packetClass);
+RuntimeSnapshot snapshotAndReset();
+void pulseBegin(Pulse pulse);
+void pulseEnd(Pulse pulse);
+
+class MapRenderMeasurement {
+public:
+  MapRenderMeasurement();
+  ~MapRenderMeasurement();
+  MapRenderMeasurement(const MapRenderMeasurement &) = delete;
+  MapRenderMeasurement &operator=(const MapRenderMeasurement &) = delete;
+
+  void setStageDurations(uint32_t blocksUs, uint32_t drawUs,
+                         uint32_t routeUs);
+  void finish(bool completed = true);
+
+private:
+  uint32_t startUs_ = 0;
+  uint32_t reasons_ = 0;
+  uint32_t blocksUs_ = 0;
+  uint32_t drawUs_ = 0;
+  uint32_t routeUs_ = 0;
+  bool finished_ = false;
+};
+
+#else
+
+inline void begin() {}
+inline void noteLoop(uint32_t) {}
+inline void noteLvgl(uint32_t) {}
+inline void noteDisplayFlush(uint32_t, uint32_t, uint32_t) {}
+inline void noteDisplayState(DisplayState, uint8_t, uint8_t) {}
+inline void noteMapRequest(MapRenderReason) {}
+inline void noteBlePacket(BlePacketClass) {}
+inline RuntimeSnapshot snapshotAndReset() { return {}; }
+inline void pulseBegin(Pulse) {}
+inline void pulseEnd(Pulse) {}
+
+class MapRenderMeasurement {
+public:
+  void setStageDurations(uint32_t, uint32_t, uint32_t) {}
+  void finish(bool = true) {}
+};
+
+#endif
+
+} // namespace power_metrics

--- a/esp32/lib/power_metrics/power_metrics_schema.hpp
+++ b/esp32/lib/power_metrics/power_metrics_schema.hpp
@@ -33,7 +33,10 @@ enum class BlePacketClass : uint8_t {
   Gps,
   Settings,
   Workout,
-  Other,
+  Transfer,
+  Audio,
+  Control,
+  Auth,
   Count,
 };
 

--- a/esp32/lib/power_metrics/power_metrics_schema.hpp
+++ b/esp32/lib/power_metrics/power_metrics_schema.hpp
@@ -1,0 +1,146 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace power_metrics {
+
+constexpr uint8_t kSchemaVersion = 1;
+
+enum class MapRenderReason : uint32_t {
+  Gps = 1u << 0,
+  Route = 1u << 1,
+  Settings = 1u << 2,
+  Heading = 1u << 3,
+  Retry = 1u << 4,
+  Other = 1u << 5,
+};
+
+constexpr uint32_t reasonMask(MapRenderReason reason) {
+  return static_cast<uint32_t>(reason);
+}
+
+constexpr std::array<MapRenderReason, 6> kMapRenderReasons = {
+    MapRenderReason::Gps,     MapRenderReason::Route,
+    MapRenderReason::Settings, MapRenderReason::Heading,
+    MapRenderReason::Retry,   MapRenderReason::Other,
+};
+
+enum class BlePacketClass : uint8_t {
+  Navigation = 0,
+  Route,
+  Gps,
+  Settings,
+  Workout,
+  Other,
+  Count,
+};
+
+struct DurationAggregate {
+  uint32_t count = 0;
+  uint64_t totalUs = 0;
+  uint32_t maxUs = 0;
+
+  void add(uint32_t durationUs) {
+    count++;
+    totalUs += durationUs;
+    if (durationUs > maxUs) {
+      maxUs = durationUs;
+    }
+  }
+};
+
+struct IntervalData {
+  uint64_t loopWakeCount = 0;
+  uint32_t maxLoopGapMs = 0;
+  DurationAggregate lvgl;
+  DurationAggregate displayFlush;
+  DurationAggregate displayRotation;
+  DurationAggregate displayQspi;
+  DurationAggregate mapRender;
+  DurationAggregate mapBlocks;
+  DurationAggregate mapDraw;
+  DurationAggregate mapRoute;
+  uint32_t mapRenderCompleted = 0;
+  uint32_t mapRenderInterrupted = 0;
+  std::array<uint32_t, kMapRenderReasons.size()> mapReasonCounts{};
+  std::array<uint32_t,
+             static_cast<std::size_t>(BlePacketClass::Count)>
+      blePacketCounts{};
+};
+
+class IntervalAccumulator {
+public:
+  void noteLoop(uint32_t nowMs) {
+    if (hasLastLoopMs_) {
+      const uint32_t gapMs = nowMs - lastLoopMs_;
+      if (gapMs > interval_.maxLoopGapMs) {
+        interval_.maxLoopGapMs = gapMs;
+      }
+    }
+    lastLoopMs_ = nowMs;
+    hasLastLoopMs_ = true;
+    interval_.loopWakeCount++;
+  }
+
+  void noteLvgl(uint32_t durationUs) { interval_.lvgl.add(durationUs); }
+
+  void noteDisplayFlush(uint32_t rotationUs, uint32_t qspiUs,
+                        uint32_t totalUs) {
+    interval_.displayRotation.add(rotationUs);
+    interval_.displayQspi.add(qspiUs);
+    interval_.displayFlush.add(totalUs);
+  }
+
+  void noteMapRender(bool completed, uint32_t totalUs, uint32_t blocksUs,
+                     uint32_t drawUs, uint32_t routeUs,
+                     uint32_t reasons) {
+    interval_.mapRender.add(totalUs);
+    interval_.mapBlocks.add(blocksUs);
+    interval_.mapDraw.add(drawUs);
+    interval_.mapRoute.add(routeUs);
+    if (completed) {
+      interval_.mapRenderCompleted++;
+    } else {
+      interval_.mapRenderInterrupted++;
+    }
+
+    if (reasons == 0) {
+      reasons = reasonMask(MapRenderReason::Other);
+    }
+    for (std::size_t index = 0; index < kMapRenderReasons.size(); index++) {
+      if ((reasons & reasonMask(kMapRenderReasons[index])) != 0) {
+        interval_.mapReasonCounts[index]++;
+      }
+    }
+  }
+
+  void noteBlePacket(BlePacketClass packetClass) {
+    const std::size_t index = static_cast<std::size_t>(packetClass);
+    if (index < interval_.blePacketCounts.size()) {
+      interval_.blePacketCounts[index]++;
+    }
+  }
+
+  IntervalData snapshotAndReset() {
+    const IntervalData snapshot = interval_;
+    interval_ = {};
+    return snapshot;
+  }
+
+  const IntervalData &current() const { return interval_; }
+
+  void resetAll() {
+    interval_ = {};
+    hasLastLoopMs_ = false;
+    lastLoopMs_ = 0;
+  }
+
+private:
+  IntervalData interval_{};
+  bool hasLastLoopMs_ = false;
+  uint32_t lastLoopMs_ = 0;
+};
+
+} // namespace power_metrics

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -22,6 +22,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 #include <math.h>
+#include <atomic>
 #include <string.h>
 
 namespace waveshare_board::speaker {
@@ -81,6 +82,7 @@ esp_codec_dev_handle_t speakerDevice = nullptr;
 QueueHandle_t soundQueue = nullptr;
 SemaphoreHandle_t powerButtonConfigMutex = nullptr;
 bool initialized = false;
+std::atomic<bool> playbackActive{false};
 bool powerButtonHonkAvailable = false;
 bool powerButtonMonitoringConfigured = false;
 float codecHardwareGainDb = 0.0f;
@@ -528,10 +530,12 @@ void speakerTask(void *) {
 
     Sound sound = static_cast<Sound>(request.sound);
     if (!initializeCodec()) {
+      playbackActive.store(false, std::memory_order_relaxed);
       Serial.println("Speaker: playback skipped because initialization failed");
       continue;
     }
 
+    playbackActive.store(true, std::memory_order_relaxed);
     if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
         ESP_CODEC_DEV_OK) {
       Serial.printf("Speaker: failed to set volume to %u%%\n",
@@ -547,6 +551,7 @@ void speakerTask(void *) {
         Serial.printf("Speaker: sound %u playback failed\n", request.sound);
       }
     }
+    playbackActive.store(false, std::memory_order_relaxed);
 
     if (uxQueueMessagesWaiting(soundQueue) == 0) {
       releaseCodecResources();
@@ -610,6 +615,8 @@ bool begin() {
 }
 
 bool isAvailable() { return soundQueue != nullptr; }
+
+bool isPlaying() { return playbackActive.load(std::memory_order_relaxed); }
 
 bool requestPlay(Sound sound, uint8_t volumePercent) {
   if (!isSupported(sound) || volumePercent > 100 || soundQueue == nullptr) {
@@ -716,6 +723,7 @@ namespace waveshare_board::speaker {
 
 bool begin() { return false; }
 bool isAvailable() { return false; }
+bool isPlaying() { return false; }
 bool requestPlay(Sound, uint8_t) { return false; }
 bool isSupported(Sound) { return false; }
 bool isPowerButtonHonkAvailable() { return false; }

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -22,7 +22,12 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 #include <math.h>
+#ifndef POWER_METRICS
+#define POWER_METRICS 0
+#endif
+#if POWER_METRICS
 #include <atomic>
+#endif
 #include <string.h>
 
 namespace waveshare_board::speaker {
@@ -82,7 +87,9 @@ esp_codec_dev_handle_t speakerDevice = nullptr;
 QueueHandle_t soundQueue = nullptr;
 SemaphoreHandle_t powerButtonConfigMutex = nullptr;
 bool initialized = false;
+#if POWER_METRICS
 std::atomic<bool> playbackActive{false};
+#endif
 bool powerButtonHonkAvailable = false;
 bool powerButtonMonitoringConfigured = false;
 float codecHardwareGainDb = 0.0f;
@@ -530,12 +537,16 @@ void speakerTask(void *) {
 
     Sound sound = static_cast<Sound>(request.sound);
     if (!initializeCodec()) {
+#if POWER_METRICS
       playbackActive.store(false, std::memory_order_relaxed);
+#endif
       Serial.println("Speaker: playback skipped because initialization failed");
       continue;
     }
 
+#if POWER_METRICS
     playbackActive.store(true, std::memory_order_relaxed);
+#endif
     if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
         ESP_CODEC_DEV_OK) {
       Serial.printf("Speaker: failed to set volume to %u%%\n",
@@ -551,7 +562,9 @@ void speakerTask(void *) {
         Serial.printf("Speaker: sound %u playback failed\n", request.sound);
       }
     }
+#if POWER_METRICS
     playbackActive.store(false, std::memory_order_relaxed);
+#endif
 
     if (uxQueueMessagesWaiting(soundQueue) == 0) {
       releaseCodecResources();
@@ -616,7 +629,13 @@ bool begin() {
 
 bool isAvailable() { return soundQueue != nullptr; }
 
-bool isPlaying() { return playbackActive.load(std::memory_order_relaxed); }
+bool isPlaying() {
+#if POWER_METRICS
+  return playbackActive.load(std::memory_order_relaxed);
+#else
+  return false;
+#endif
+}
 
 bool requestPlay(Sound sound, uint8_t volumePercent) {
   if (!isSupported(sound) || volumePercent > 100 || soundQueue == nullptr) {

--- a/esp32/lib/speaker/speaker.hpp
+++ b/esp32/lib/speaker/speaker.hpp
@@ -8,6 +8,7 @@ namespace waveshare_board::speaker {
 
 bool begin();
 bool isAvailable();
+bool isPlaying();
 bool requestPlay(Sound sound,
                  uint8_t volumePercent = DEFAULT_VOLUME_PERCENT);
 bool isSupported(Sound sound);

--- a/esp32/lib/tft/tft.cpp
+++ b/esp32/lib/tft/tft.cpp
@@ -7,6 +7,7 @@
  */
 
 #include "tft.hpp"
+#include "power_metrics.hpp"
 
 #ifndef USE_ARDUINO_GFX
 TFT_eSPI tft = TFT_eSPI();
@@ -35,6 +36,8 @@ void tftOn(uint8_t brightness)
   delay(120);
   tft.setBrightness(brightness);
 #endif
+  power_metrics::noteDisplayState(power_metrics::DisplayState::On, brightness,
+                                  brightness);
 }
 
 /**
@@ -52,6 +55,7 @@ void tftOff()
   tft.setBrightness(0);
   tft.writecommand(0x10);  // Sleep In
 #endif
+  power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 0, 0);
 }
 
 /**

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -260,6 +260,14 @@ build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_175
 
+[env:WAVESHARE_AMOLED_175_POWER_METRICS]
+extends = env:WAVESHARE_AMOLED_175
+build_flags =
+  ${env:WAVESHARE_AMOLED_175.build_flags}
+  -DPOWER_METRICS=1
+  ; Set to a verified spare output pin when correlating source-monitor traces.
+  ; -DPOWER_METRICS_PULSE_GPIO=XX
+
 [env:WAVESHARE_AMOLED_175_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_175
 build_flags =
@@ -288,6 +296,14 @@ build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_206
   -DWAVESHARE_206_FORCE_AXP_DISPLAY=1
+
+[env:WAVESHARE_AMOLED_206_POWER_METRICS]
+extends = env:WAVESHARE_AMOLED_206
+build_flags =
+  ${env:WAVESHARE_AMOLED_206.build_flags}
+  -DPOWER_METRICS=1
+  ; Set to a verified spare output pin when correlating source-monitor traces.
+  ; -DPOWER_METRICS_PULSE_GPIO=XX
 
 [env:WAVESHARE_AMOLED_206_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_206

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -520,6 +520,8 @@ static const char *powerMetricsDisplayStateName(
 
 static void logPowerMetricsReport() {
 #if POWER_METRICS
+  constexpr size_t kReportBufferSize = 2048;
+  static char report[kReportBufferSize];
   static uint32_t lastReportMs = 0;
   const uint32_t now = millis();
   if (now - lastReportMs < 10000) {
@@ -552,7 +554,8 @@ static void logPowerMetricsReport() {
     return metrics.blePacketCounts[static_cast<size_t>(packetClass)];
   };
 
-  Serial.printf(
+  const int reportLength = snprintf(
+      report, sizeof(report),
       "PWRMET v=%u intervalMs=%lu screen=%s tile=%s display=%s "
       "brightness[requested=%u effective=%u] "
       "loop[wakes=%llu maxGapMs=%lu] "
@@ -613,6 +616,21 @@ static void logPowerMetricsReport() {
       static_cast<int>(WiFi.getMode()), transferStatus.enabled,
       transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
       audioActive, getCpuFrequencyMhz());
+  if (reportLength < 0 ||
+      static_cast<size_t>(reportLength) >= sizeof(report)) {
+    Serial.printf("PWRMET_ERROR formatLength=%d capacity=%u\n", reportLength,
+                  static_cast<unsigned>(sizeof(report)));
+    return;
+  }
+
+  const size_t written = Serial.write(
+      reinterpret_cast<const uint8_t *>(report),
+      static_cast<size_t>(reportLength));
+  if (written != static_cast<size_t>(reportLength)) {
+    Serial.printf("PWRMET_ERROR serialWrite=%u/%u\n",
+                  static_cast<unsigned>(written),
+                  static_cast<unsigned>(reportLength));
+  }
 #endif
 }
 
@@ -663,11 +681,25 @@ void setup() {
   esp_log_level_set("*", ESP_LOG_DEBUG);
   esp_log_level_set("storage", ESP_LOG_DEBUG);
 
-  // Initialize Serial for debug
+  // Initialize Serial for debug. A complete PWRMET report is larger than the
+  // default 256-byte HWCDC queue, so metrics builds reserve enough space for
+  // one atomic report while keeping the normal firmware footprint unchanged.
+#if POWER_METRICS
+  constexpr size_t kPowerMetricsSerialTxBufferSize = 4096;
+  const size_t configuredSerialTxBufferSize =
+      Serial.setTxBufferSize(kPowerMetricsSerialTxBufferSize);
+#endif
   Serial.begin(115200);
   // HWCDC uses this value as both a timeout and a retry counter. Zero
   // underflows that counter when the USB host stops reading and stalls the UI.
   Serial.setTxTimeoutMs(1);
+#if POWER_METRICS
+  if (configuredSerialTxBufferSize != kPowerMetricsSerialTxBufferSize) {
+    Serial.printf("PWRMET_ERROR txBuffer=%u/%u\n",
+                  static_cast<unsigned>(configuredSerialTxBufferSize),
+                  static_cast<unsigned>(kPowerMetricsSerialTxBufferSize));
+  }
+#endif
   power_metrics::begin();
   delay(2000);              // Give time for USB CDC to attach
   log_i("Starting Setup...");

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -563,7 +563,7 @@ static void logPowerMetricsReport() {
       "blocksUs=%llu/%lu drawUs=%llu/%lu routeUs=%llu/%lu "
       "reasons=gps:%lu,route:%lu,settings:%lu,heading:%lu,retry:%lu,other:%lu] "
       "ble[connected=%d authenticated=%d "
-      "received=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
+      "logical=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
       "appQueue=ios-diagnostic] "
       "system[wifiMode=%d transfer=%d transferMode=%s audio=%d cpuMHz=%u "

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -570,7 +570,7 @@ static void logPowerMetricsReport() {
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
       "appQueue=ios-diagnostic] "
       "system[wifiMode=%d transfer=%d transferMode=%s audio=%d cpuMHz=%u "
-      "locks=0]\n",
+      "appPmLocks=0]\n",
       power_metrics::kSchemaVersion, (unsigned long)intervalMs, screenName,
       debugTileName(activeTile),
       powerMetricsDisplayStateName(snapshot.displayState),

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -562,8 +562,10 @@ static void logPowerMetricsReport() {
       "map[count=%lu completed=%lu interrupted=%lu totalUs=%llu/%lu "
       "blocksUs=%llu/%lu drawUs=%llu/%lu routeUs=%llu/%lu "
       "reasons=gps:%lu,route:%lu,settings:%lu,heading:%lu,retry:%lu,other:%lu] "
-      "ble[connected=%d authenticated=%d nav=%lu route=%lu gps=%lu "
-      "settings=%lu workout=%lu other=%lu appQueue=ios-diagnostic] "
+      "ble[connected=%d authenticated=%d "
+      "received=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
+      "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
+      "appQueue=ios-diagnostic] "
       "system[wifiMode=%d transfer=%d transferMode=%s audio=%d cpuMHz=%u "
       "locks=0]\n",
       power_metrics::kSchemaVersion, (unsigned long)intervalMs, screenName,
@@ -604,7 +606,10 @@ static void logPowerMetricsReport() {
       (unsigned long)bleCount(power_metrics::BlePacketClass::Gps),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Settings),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Workout),
-      (unsigned long)bleCount(power_metrics::BlePacketClass::Other),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Transfer),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Audio),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Control),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Auth),
       static_cast<int>(WiFi.getMode()), transferStatus.enabled,
       transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
       audioActive, getCpuFrequencyMhz());

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -70,6 +70,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "ble_navigation.hpp"
 #include "disconnected_shutdown_policy.hpp"
 #include "ownership_button_policy.hpp"
+#include "power_metrics.hpp"
 #include "guiLayout.hpp"
 #include "mainScr.hpp"
 #include "route_overlay.hpp"
@@ -504,6 +505,112 @@ static void logSystemDebugHeartbeat() {
 #endif
 }
 
+static const char *powerMetricsDisplayStateName(
+    power_metrics::DisplayState state) {
+  switch (state) {
+  case power_metrics::DisplayState::On:
+    return "on";
+  case power_metrics::DisplayState::Off:
+    return "off";
+  case power_metrics::DisplayState::Unknown:
+  default:
+    return "unknown";
+  }
+}
+
+static void logPowerMetricsReport() {
+#if POWER_METRICS
+  static uint32_t lastReportMs = 0;
+  const uint32_t now = millis();
+  if (now - lastReportMs < 10000) {
+    return;
+  }
+  const uint32_t intervalMs = now - lastReportMs;
+  lastReportMs = now;
+
+  const power_metrics::RuntimeSnapshot snapshot =
+      power_metrics::snapshotAndReset();
+  const power_metrics::IntervalData &metrics = snapshot.interval;
+  const BLEDebugStats bleStats = bleNavServer.getDebugStats();
+  const device_transfer::HttpTransferStatus transferStatus =
+      deviceTransferHttp.status();
+
+  const char *screenName = "unknown";
+  const lv_obj_t *activeScreen = lv_scr_act();
+  if (activeScreen == waitingScreen) {
+    screenName = "waiting";
+  } else if (isMainScreen) {
+    screenName = "main";
+  }
+
+  bool audioActive = false;
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  audioActive = waveshare_board::speaker::isPlaying();
+#endif
+
+  const auto bleCount = [&](power_metrics::BlePacketClass packetClass) {
+    return metrics.blePacketCounts[static_cast<size_t>(packetClass)];
+  };
+
+  Serial.printf(
+      "PWRMET v=%u intervalMs=%lu screen=%s tile=%s display=%s "
+      "brightness[requested=%u effective=%u] "
+      "loop[wakes=%llu maxGapMs=%lu] "
+      "lvgl[count=%lu totalUs=%llu maxUs=%lu] "
+      "flush[count=%lu rotationUs=%llu/%lu qspiUs=%llu/%lu "
+      "totalUs=%llu/%lu] "
+      "map[count=%lu completed=%lu interrupted=%lu totalUs=%llu/%lu "
+      "blocksUs=%llu/%lu drawUs=%llu/%lu routeUs=%llu/%lu "
+      "reasons=gps:%lu,route:%lu,settings:%lu,heading:%lu,retry:%lu,other:%lu] "
+      "ble[connected=%d authenticated=%d nav=%lu route=%lu gps=%lu "
+      "settings=%lu workout=%lu other=%lu appQueue=ios-diagnostic] "
+      "system[wifiMode=%d transfer=%d transferMode=%s audio=%d cpuMHz=%u "
+      "locks=0]\n",
+      power_metrics::kSchemaVersion, (unsigned long)intervalMs, screenName,
+      debugTileName(activeTile),
+      powerMetricsDisplayStateName(snapshot.displayState),
+      snapshot.requestedBrightness, snapshot.effectiveBrightness,
+      static_cast<unsigned long long>(metrics.loopWakeCount),
+      (unsigned long)metrics.maxLoopGapMs, (unsigned long)metrics.lvgl.count,
+      static_cast<unsigned long long>(metrics.lvgl.totalUs),
+      (unsigned long)metrics.lvgl.maxUs,
+      (unsigned long)metrics.displayFlush.count,
+      static_cast<unsigned long long>(metrics.displayRotation.totalUs),
+      (unsigned long)metrics.displayRotation.maxUs,
+      static_cast<unsigned long long>(metrics.displayQspi.totalUs),
+      (unsigned long)metrics.displayQspi.maxUs,
+      static_cast<unsigned long long>(metrics.displayFlush.totalUs),
+      (unsigned long)metrics.displayFlush.maxUs,
+      (unsigned long)metrics.mapRender.count,
+      (unsigned long)metrics.mapRenderCompleted,
+      (unsigned long)metrics.mapRenderInterrupted,
+      static_cast<unsigned long long>(metrics.mapRender.totalUs),
+      (unsigned long)metrics.mapRender.maxUs,
+      static_cast<unsigned long long>(metrics.mapBlocks.totalUs),
+      (unsigned long)metrics.mapBlocks.maxUs,
+      static_cast<unsigned long long>(metrics.mapDraw.totalUs),
+      (unsigned long)metrics.mapDraw.maxUs,
+      static_cast<unsigned long long>(metrics.mapRoute.totalUs),
+      (unsigned long)metrics.mapRoute.maxUs,
+      (unsigned long)metrics.mapReasonCounts[0],
+      (unsigned long)metrics.mapReasonCounts[1],
+      (unsigned long)metrics.mapReasonCounts[2],
+      (unsigned long)metrics.mapReasonCounts[3],
+      (unsigned long)metrics.mapReasonCounts[4],
+      (unsigned long)metrics.mapReasonCounts[5],
+      bleStats.connected, bleStats.authenticated,
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Navigation),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Route),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Gps),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Settings),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Workout),
+      (unsigned long)bleCount(power_metrics::BlePacketClass::Other),
+      static_cast<int>(WiFi.getMode()), transferStatus.enabled,
+      transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
+      audioActive, getCpuFrequencyMhz());
+#endif
+}
+
 static void processDisconnectedShutdown() {
   static disconnected_shutdown_policy::Tracker shutdownTracker;
   const bool connected = bleNavServer.isConnected();
@@ -556,6 +663,7 @@ void setup() {
   // HWCDC uses this value as both a timeout and a retry counter. Zero
   // underflows that counter when the USB host stops reading and stalls the UI.
   Serial.setTxTimeoutMs(1);
+  power_metrics::begin();
   delay(2000);              // Give time for USB CDC to attach
   log_i("Starting Setup...");
   Serial.printf("Reset reason: CPU0=%d CPU1=%d\n", esp_reset_reason(),
@@ -812,6 +920,7 @@ void setup() {
  */
 void loop() {
   uint32_t now = millis();
+  power_metrics::noteLoop(now);
   if (lastLoopMs != 0) {
     uint32_t gap = now - lastLoopMs;
     if (gap > maxLoopGapMs) {
@@ -849,6 +958,7 @@ void loop() {
     uint32_t startUs = micros();
     lv_timer_handler();
     lastLvglHandlerDurationUs = micros() - startUs;
+    power_metrics::noteLvgl(lastLvglHandlerDurationUs);
     if (lastLvglHandlerDurationUs > maxLvglHandlerDurationUs) {
       maxLvglHandlerDurationUs = lastLvglHandlerDurationUs;
     }
@@ -873,6 +983,7 @@ void loop() {
 #endif
 
   logSystemDebugHeartbeat();
+  logPowerMetricsReport();
 
 #ifndef DISABLE_WEB_SERVER
   // Deleting recursive directories in webfile server

--- a/esp32/tools/power_trace_summary.py
+++ b/esp32/tools/power_trace_summary.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
 import argparse
+import codecs
 import csv
 import hashlib
 import json
 import math
+import os
+import random
 import re
 import statistics
+import tempfile
 from array import array
-from collections.abc import MutableSequence, Sequence
+from collections.abc import Iterator, MutableSequence, Sequence
 from dataclasses import asdict, dataclass
 from pathlib import Path
+from typing import BinaryIO, Protocol
 
 
 ANALYSIS_SCHEMA_VERSION = 1
@@ -37,6 +42,10 @@ class TraceFormatError(ValueError):
     """Raised when a trace cannot produce trustworthy power statistics."""
 
 
+class _HashDigest(Protocol):
+    def update(self, data: bytes, /) -> None: ...
+
+
 @dataclass(frozen=True)
 class TraceConfiguration:
     time_column: str = "time_s"
@@ -48,8 +57,20 @@ class TraceConfiguration:
     supply_voltage_v: float | None = None
     window_start_s: float = 0.0
     window_end_s: float | None = None
+    minimum_sample_rate_hz: float | None = None
+    maximum_gap_factor: float = 2.0
 
     def validate(self) -> None:
+        configured_columns = [self.time_column, self.current_column]
+        if self.voltage_column is not None:
+            configured_columns.append(self.voltage_column)
+        if any(
+            not isinstance(column, str) or not column.strip()
+            for column in configured_columns
+        ):
+            raise ValueError("configured column names must be non-empty")
+        if len(configured_columns) != len(set(configured_columns)):
+            raise ValueError("configured column names must be distinct")
         if self.time_unit not in TIME_UNIT_SECONDS:
             raise ValueError(f"unsupported time unit: {self.time_unit}")
         if self.current_unit not in CURRENT_UNIT_AMPS:
@@ -60,15 +81,35 @@ class TraceConfiguration:
             raise ValueError(
                 "set exactly one of voltage_column or supply_voltage_v"
             )
-        if self.supply_voltage_v is not None and self.supply_voltage_v <= 0:
-            raise ValueError("supply_voltage_v must be positive")
-        if self.window_start_s < 0:
-            raise ValueError("window_start_s must be non-negative")
+        if self.supply_voltage_v is not None and (
+            not math.isfinite(self.supply_voltage_v)
+            or self.supply_voltage_v <= 0
+        ):
+            raise ValueError("supply_voltage_v must be finite and positive")
+        if not math.isfinite(self.window_start_s) or self.window_start_s < 0:
+            raise ValueError("window_start_s must be finite and non-negative")
         if (
             self.window_end_s is not None
-            and self.window_end_s <= self.window_start_s
+            and (
+                not math.isfinite(self.window_end_s)
+                or self.window_end_s <= self.window_start_s
+            )
         ):
-            raise ValueError("window_end_s must be greater than window_start_s")
+            raise ValueError(
+                "window_end_s must be finite and greater than window_start_s"
+            )
+        if self.minimum_sample_rate_hz is not None and (
+            not math.isfinite(self.minimum_sample_rate_hz)
+            or self.minimum_sample_rate_hz <= 0
+        ):
+            raise ValueError(
+                "minimum_sample_rate_hz must be finite and positive"
+            )
+        if (
+            not math.isfinite(self.maximum_gap_factor)
+            or self.maximum_gap_factor < 1.0
+        ):
+            raise ValueError("maximum_gap_factor must be finite and at least 1")
 
 
 @dataclass(frozen=True)
@@ -77,10 +118,12 @@ class TraceSummary:
     raw_sha256: str
     total_samples: int
     selected_samples: int
+    interpolated_boundary_samples: int
     first_sample_elapsed_s: float
     last_sample_elapsed_s: float
     duration_s: float
     effective_sample_rate_hz: float
+    max_sample_interval_s: float
     average_current_mA: float
     p95_current_mA: float
     peak_current_mA: float
@@ -90,12 +133,27 @@ class TraceSummary:
     mWh_per_hour: float
 
 
-def _sha256(path: Path) -> str:
-    digest = hashlib.sha256()
-    with path.open("rb") as handle:
-        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-            digest.update(chunk)
-    return digest.hexdigest()
+def _hashed_text_lines(handle: BinaryIO, digest: _HashDigest) -> Iterator[str]:
+    """Yield UTF-8 CSV lines while hashing the exact bytes being parsed."""
+    decoder = codecs.getincrementaldecoder("utf-8-sig")()
+    for raw_line in handle:
+        digest.update(raw_line)
+        decoded = decoder.decode(raw_line)
+        if decoded:
+            yield decoded
+    trailing_text = decoder.decode(b"", final=True)
+    if trailing_text:
+        yield trailing_text
+
+
+def _stat_identity(stat_result: os.stat_result) -> tuple[int, int, int, int, int]:
+    return (
+        stat_result.st_dev,
+        stat_result.st_ino,
+        stat_result.st_size,
+        stat_result.st_mtime_ns,
+        stat_result.st_ctime_ns,
+    )
 
 
 def _finite_number(raw_value: str | None, column: str, row_number: int) -> float:
@@ -114,19 +172,40 @@ def _finite_number(raw_value: str | None, column: str, row_number: int) -> float
     return value
 
 
+def _scaled_finite_number(
+    raw_value: str | None,
+    column: str,
+    row_number: int,
+    scale: float,
+) -> float:
+    value = _finite_number(raw_value, column, row_number) * scale
+    if not math.isfinite(value):
+        raise TraceFormatError(
+            f"row {row_number}: scaled {column!r} value is non-finite"
+        )
+    return value
+
+
 def _select(values: MutableSequence[float], rank: int) -> float:
-    """Return one exact order statistic using in-place three-way partitioning."""
+    """Return an exact order statistic with an introspective quickselect."""
     if rank < 0 or rank >= len(values):
         raise IndexError("order-statistic rank is outside the sample array")
 
     left = 0
     right = len(values) - 1
+    partition_work = 0
+    work_budget = max(64, len(values) * 8)
     while True:
         if left == right:
             return values[left]
 
-        middle = left + (right - left) // 2
-        pivot = sorted((values[left], values[middle], values[right]))[1]
+        span = right - left + 1
+        if partition_work + span > work_budget:
+            ordered = sorted(values[left : right + 1])
+            return ordered[rank - left]
+        partition_work += span
+
+        pivot = values[random.randrange(left, right + 1)]
         lower = left
         cursor = left
         upper = right
@@ -164,7 +243,7 @@ def sample_percentile(values: MutableSequence[float], percentile: float) -> floa
         return lower_value
     upper_value = _select(values, upper_rank)
     fraction = position - lower_rank
-    return lower_value + (upper_value - lower_value) * fraction
+    return lower_value * (1.0 - fraction) + upper_value * fraction
 
 
 def analyze_trace(path: Path, configuration: TraceConfiguration) -> TraceSummary:
@@ -181,154 +260,351 @@ def analyze_trace(path: Path, configuration: TraceConfiguration) -> TraceSummary
 
     total_samples = 0
     selected_samples = 0
+    integration_point_count = 0
+    interpolated_boundary_samples = 0
     trace_origin_s: float | None = None
     previous_trace_time_s: float | None = None
+    previous_raw_elapsed_s: float | None = None
+    previous_raw_current_a: float | None = None
+    previous_raw_voltage_v: float | None = None
     first_selected_s: float | None = None
     previous_selected_s: float | None = None
-    previous_current_a: float | None = None
-    previous_voltage_v: float | None = None
+    previous_selected_current_a: float | None = None
+    previous_selected_voltage_v: float | None = None
     current_area_a_s = 0.0
     voltage_area_v_s = 0.0
     power_area_w_s = 0.0
     peak_current_a = -math.inf
     current_samples_mA = array("d")
+    cadence_interval_count = 0
+    cadence_total_s = 0.0
+    max_sample_interval_s = 0.0
+    start_covered = False
+    end_covered = configuration.window_end_s is None
+    digest = hashlib.sha256()
 
-    with path.open("r", encoding="utf-8-sig", newline="") as handle:
-        reader = csv.DictReader(handle)
-        if reader.fieldnames is None:
-            raise TraceFormatError("trace is missing a CSV header")
-        if len(reader.fieldnames) != len(set(reader.fieldnames)):
-            raise TraceFormatError("trace CSV header contains duplicate columns")
-        missing_columns = sorted(required_columns.difference(reader.fieldnames))
-        if missing_columns:
-            raise TraceFormatError(
-                "trace is missing required column(s): " + ", ".join(missing_columns)
+    def append_selected_point(
+        elapsed_s: float,
+        current_a: float,
+        voltage_v: float,
+        *,
+        interpolated: bool,
+    ) -> None:
+        nonlocal current_area_a_s
+        nonlocal first_selected_s
+        nonlocal integration_point_count
+        nonlocal interpolated_boundary_samples
+        nonlocal peak_current_a
+        nonlocal power_area_w_s
+        nonlocal previous_selected_current_a
+        nonlocal previous_selected_s
+        nonlocal previous_selected_voltage_v
+        nonlocal selected_samples
+        nonlocal start_covered
+        nonlocal end_covered
+        nonlocal voltage_area_v_s
+
+        current_ma = current_a * 1_000.0
+        if not math.isfinite(current_ma):
+            raise TraceFormatError("selected current is outside the supported range")
+        if first_selected_s is None:
+            first_selected_s = elapsed_s
+        if previous_selected_s is not None:
+            interval_s = elapsed_s - previous_selected_s
+            if not math.isfinite(interval_s) or interval_s <= 0:
+                raise TraceFormatError(
+                    "selected window points must be strictly increasing"
+                )
+            assert previous_selected_current_a is not None
+            assert previous_selected_voltage_v is not None
+            current_area_a_s += (
+                previous_selected_current_a * 0.5 + current_a * 0.5
+            ) * interval_s
+            voltage_area_v_s += (
+                previous_selected_voltage_v * 0.5 + voltage_v * 0.5
+            ) * interval_s
+            previous_power_w = (
+                previous_selected_current_a * previous_selected_voltage_v
             )
+            current_power_w = current_a * voltage_v
+            power_area_w_s += (
+                previous_power_w * 0.5 + current_power_w * 0.5
+            ) * interval_s
 
-        for row_number, row in enumerate(reader, start=2):
-            trace_time_s = (
-                _finite_number(
+        previous_selected_s = elapsed_s
+        previous_selected_current_a = current_a
+        previous_selected_voltage_v = voltage_v
+        integration_point_count += 1
+        if interpolated:
+            interpolated_boundary_samples += 1
+        else:
+            peak_current_a = max(peak_current_a, current_a)
+            current_samples_mA.append(current_ma)
+            selected_samples += 1
+        if elapsed_s == configuration.window_start_s:
+            start_covered = True
+        if (
+            configuration.window_end_s is not None
+            and elapsed_s == configuration.window_end_s
+        ):
+            end_covered = True
+
+    def append_interpolated_boundary(boundary_s: float) -> None:
+        assert previous_raw_elapsed_s is not None
+        assert previous_raw_current_a is not None
+        assert previous_raw_voltage_v is not None
+        assert current_elapsed_s > previous_raw_elapsed_s
+        fraction = (
+            (boundary_s - previous_raw_elapsed_s)
+            / (current_elapsed_s - previous_raw_elapsed_s)
+        )
+        boundary_current_a = (
+            previous_raw_current_a * (1.0 - fraction)
+            + current_current_a * fraction
+        )
+        boundary_voltage_v = (
+            previous_raw_voltage_v * (1.0 - fraction)
+            + current_voltage_v * fraction
+        )
+        if not math.isfinite(boundary_current_a) or not math.isfinite(
+            boundary_voltage_v
+        ):
+            raise TraceFormatError("interpolated boundary value is non-finite")
+        append_selected_point(
+            boundary_s,
+            boundary_current_a,
+            boundary_voltage_v,
+            interpolated=True,
+        )
+
+    current_elapsed_s = 0.0
+    current_current_a = 0.0
+    current_voltage_v = 0.0
+    try:
+        with path.open("rb") as handle:
+            initial_identity = _stat_identity(os.fstat(handle.fileno()))
+            reader = csv.DictReader(_hashed_text_lines(handle, digest))
+            if reader.fieldnames is None:
+                raise TraceFormatError("trace is missing a CSV header")
+            if len(reader.fieldnames) != len(set(reader.fieldnames)):
+                raise TraceFormatError("trace CSV header contains duplicate columns")
+            missing_columns = sorted(required_columns.difference(reader.fieldnames))
+            if missing_columns:
+                raise TraceFormatError(
+                    "trace is missing required column(s): "
+                    + ", ".join(missing_columns)
+                )
+
+            for row_number, row in enumerate(reader, start=2):
+                if None in row:
+                    raise TraceFormatError(
+                        f"row {row_number}: contains more fields than the CSV header"
+                    )
+                trace_time_s = _scaled_finite_number(
                     row.get(configuration.time_column),
                     configuration.time_column,
                     row_number,
+                    TIME_UNIT_SECONDS[configuration.time_unit],
                 )
-                * TIME_UNIT_SECONDS[configuration.time_unit]
-            )
-            current_a = (
-                _finite_number(
+                current_current_a = _scaled_finite_number(
                     row.get(configuration.current_column),
                     configuration.current_column,
                     row_number,
+                    CURRENT_UNIT_AMPS[configuration.current_unit],
                 )
-                * CURRENT_UNIT_AMPS[configuration.current_unit]
-            )
-            if configuration.voltage_column is None:
-                voltage_v = configuration.supply_voltage_v
-                assert voltage_v is not None
-            else:
-                voltage_v = (
-                    _finite_number(
+                if configuration.voltage_column is None:
+                    current_voltage_v = configuration.supply_voltage_v
+                    assert current_voltage_v is not None
+                else:
+                    current_voltage_v = _scaled_finite_number(
                         row.get(configuration.voltage_column),
                         configuration.voltage_column,
                         row_number,
+                        VOLTAGE_UNIT_VOLTS[configuration.voltage_unit],
                     )
-                    * VOLTAGE_UNIT_VOLTS[configuration.voltage_unit]
-                )
-                if voltage_v <= 0:
+                    if current_voltage_v <= 0:
+                        raise TraceFormatError(
+                            f"row {row_number}: voltage must be positive"
+                        )
+
+                total_samples += 1
+                if trace_origin_s is None:
+                    trace_origin_s = trace_time_s
+                if (
+                    previous_trace_time_s is not None
+                    and trace_time_s <= previous_trace_time_s
+                ):
                     raise TraceFormatError(
-                        f"row {row_number}: voltage must be positive"
+                        f"row {row_number}: timestamps must be strictly increasing"
+                    )
+                previous_trace_time_s = trace_time_s
+                current_elapsed_s = trace_time_s - trace_origin_s
+                if not math.isfinite(current_elapsed_s):
+                    raise TraceFormatError(
+                        f"row {row_number}: elapsed timestamp is non-finite"
                     )
 
-            total_samples += 1
-            if trace_origin_s is None:
-                trace_origin_s = trace_time_s
-            if (
-                previous_trace_time_s is not None
-                and trace_time_s <= previous_trace_time_s
-            ):
-                raise TraceFormatError(
-                    f"row {row_number}: timestamps must be strictly increasing"
-                )
-            previous_trace_time_s = trace_time_s
-            elapsed_s = trace_time_s - trace_origin_s
-
-            if elapsed_s < configuration.window_start_s:
-                continue
-            if (
-                configuration.window_end_s is not None
-                and elapsed_s > configuration.window_end_s
-            ):
-                continue
-
-            if first_selected_s is None:
-                first_selected_s = elapsed_s
-            if previous_selected_s is not None:
-                interval_s = elapsed_s - previous_selected_s
-                assert previous_current_a is not None
-                assert previous_voltage_v is not None
-                current_area_a_s += (
-                    (previous_current_a + current_a) * 0.5 * interval_s
-                )
-                voltage_area_v_s += (
-                    (previous_voltage_v + voltage_v) * 0.5 * interval_s
-                )
-                power_area_w_s += (
-                    (
-                        previous_current_a * previous_voltage_v
-                        + current_a * voltage_v
+                if previous_raw_elapsed_s is None:
+                    if current_elapsed_s == configuration.window_start_s:
+                        append_selected_point(
+                            current_elapsed_s,
+                            current_current_a,
+                            current_voltage_v,
+                            interpolated=False,
+                        )
+                else:
+                    raw_interval_s = current_elapsed_s - previous_raw_elapsed_s
+                    segment_intersects_window = (
+                        current_elapsed_s > configuration.window_start_s
+                        and (
+                            configuration.window_end_s is None
+                            or previous_raw_elapsed_s < configuration.window_end_s
+                        )
                     )
-                    * 0.5
-                    * interval_s
-                )
+                    if segment_intersects_window:
+                        cadence_interval_count += 1
+                        cadence_total_s += raw_interval_s
+                        max_sample_interval_s = max(
+                            max_sample_interval_s, raw_interval_s
+                        )
 
-            previous_selected_s = elapsed_s
-            previous_current_a = current_a
-            previous_voltage_v = voltage_v
-            peak_current_a = max(peak_current_a, current_a)
-            current_samples_mA.append(current_a * 1_000.0)
-            selected_samples += 1
+                    if (
+                        previous_raw_elapsed_s
+                        < configuration.window_start_s
+                        < current_elapsed_s
+                    ):
+                        append_interpolated_boundary(
+                            configuration.window_start_s
+                        )
+
+                    if (
+                        current_elapsed_s >= configuration.window_start_s
+                        and (
+                            configuration.window_end_s is None
+                            or current_elapsed_s <= configuration.window_end_s
+                        )
+                    ):
+                        append_selected_point(
+                            current_elapsed_s,
+                            current_current_a,
+                            current_voltage_v,
+                            interpolated=False,
+                        )
+
+                    if (
+                        configuration.window_end_s is not None
+                        and previous_raw_elapsed_s
+                        < configuration.window_end_s
+                        < current_elapsed_s
+                    ):
+                        append_interpolated_boundary(configuration.window_end_s)
+
+                previous_raw_elapsed_s = current_elapsed_s
+                previous_raw_current_a = current_current_a
+                previous_raw_voltage_v = current_voltage_v
+
+            final_handle_identity = _stat_identity(os.fstat(handle.fileno()))
+            final_path_identity = _stat_identity(path.stat())
+            if (
+                initial_identity != final_handle_identity
+                or initial_identity != final_path_identity
+            ):
+                raise TraceFormatError("trace changed while it was being analyzed")
+    except UnicodeError as error:
+        raise TraceFormatError("trace is not valid UTF-8") from error
+    except csv.Error as error:
+        raise TraceFormatError(f"trace contains invalid CSV: {error}") from error
 
     if total_samples == 0:
         raise TraceFormatError("trace contains no data rows")
+    if not start_covered:
+        raise TraceFormatError("trace does not cover the requested window start")
+    if not end_covered:
+        raise TraceFormatError("trace does not cover the requested window end")
     if selected_samples < 2:
-        raise TraceFormatError(
-            "selected window must contain at least two samples"
-        )
+        raise TraceFormatError("selected window must contain at least two samples")
+    if integration_point_count < 2:
+        raise TraceFormatError("selected window has fewer than two integration points")
     assert first_selected_s is not None
     assert previous_selected_s is not None
     duration_s = previous_selected_s - first_selected_s
-    if duration_s <= 0:
-        raise TraceFormatError("selected window has no positive duration")
+    if not math.isfinite(duration_s) or duration_s <= 0:
+        raise TraceFormatError("selected window has no positive finite duration")
+    if cadence_interval_count < 1 or cadence_total_s <= 0:
+        raise TraceFormatError("selected window contains no source sample intervals")
+
+    effective_sample_rate_hz = cadence_interval_count / cadence_total_s
+    if configuration.minimum_sample_rate_hz is not None:
+        minimum_rate_hz = configuration.minimum_sample_rate_hz
+        if effective_sample_rate_hz < minimum_rate_hz * (1.0 - 1e-9):
+            raise TraceFormatError(
+                "effective sample rate "
+                f"{effective_sample_rate_hz:.6g} Hz is below required "
+                f"{minimum_rate_hz:.6g} Hz"
+            )
+        maximum_interval_s = configuration.maximum_gap_factor / minimum_rate_hz
+        if max_sample_interval_s > maximum_interval_s * (1.0 + 1e-9):
+            raise TraceFormatError(
+                "source trace contains a sample gap of "
+                f"{max_sample_interval_s:.9g} s; maximum allowed is "
+                f"{maximum_interval_s:.9g} s"
+            )
 
     average_current_a = current_area_a_s / duration_s
     average_voltage_v = voltage_area_v_s / duration_s
     average_power_w = power_area_w_s / duration_s
-    energy_mwh = power_area_w_s * 1_000.0 / 3_600.0
+    summary_values = {
+        "effective_sample_rate_hz": effective_sample_rate_hz,
+        "max_sample_interval_s": max_sample_interval_s,
+        "average_current_mA": average_current_a * 1_000.0,
+        "p95_current_mA": sample_percentile(current_samples_mA, 95.0),
+        "peak_current_mA": peak_current_a * 1_000.0,
+        "average_voltage_v": average_voltage_v,
+        "average_power_mW": average_power_w * 1_000.0,
+        "energy_mWh": power_area_w_s * 1_000.0 / 3_600.0,
+        "mWh_per_hour": average_power_w * 1_000.0,
+    }
+    non_finite_fields = [
+        field for field, value in summary_values.items() if not math.isfinite(value)
+    ]
+    if non_finite_fields:
+        raise TraceFormatError(
+            "derived result is non-finite: " + ", ".join(non_finite_fields)
+        )
 
     return TraceSummary(
         trace=str(path),
-        raw_sha256=_sha256(path),
+        raw_sha256=digest.hexdigest(),
         total_samples=total_samples,
         selected_samples=selected_samples,
+        interpolated_boundary_samples=interpolated_boundary_samples,
         first_sample_elapsed_s=first_selected_s,
         last_sample_elapsed_s=previous_selected_s,
         duration_s=duration_s,
-        effective_sample_rate_hz=(selected_samples - 1) / duration_s,
-        average_current_mA=average_current_a * 1_000.0,
-        p95_current_mA=sample_percentile(current_samples_mA, 95.0),
-        peak_current_mA=peak_current_a * 1_000.0,
-        average_voltage_v=average_voltage_v,
-        average_power_mW=average_power_w * 1_000.0,
-        energy_mWh=energy_mwh,
-        mWh_per_hour=average_power_w * 1_000.0,
+        effective_sample_rate_hz=summary_values["effective_sample_rate_hz"],
+        max_sample_interval_s=summary_values["max_sample_interval_s"],
+        average_current_mA=summary_values["average_current_mA"],
+        p95_current_mA=summary_values["p95_current_mA"],
+        peak_current_mA=summary_values["peak_current_mA"],
+        average_voltage_v=summary_values["average_voltage_v"],
+        average_power_mW=summary_values["average_power_mW"],
+        energy_mWh=summary_values["energy_mWh"],
+        mWh_per_hour=summary_values["mWh_per_hour"],
     )
 
 
 def _metric_statistics(runs: Sequence[TraceSummary], field: str) -> dict:
     values = [float(getattr(run, field)) for run in runs]
-    mean = statistics.fmean(values)
-    sample_stddev = statistics.stdev(values) if len(values) > 1 else 0.0
-    return {
+    if not all(math.isfinite(value) for value in values):
+        raise ValueError(f"campaign metric {field!r} contains a non-finite value")
+    try:
+        mean = statistics.fmean(values)
+        sample_stddev = statistics.stdev(values) if len(values) > 1 else 0.0
+    except OverflowError as error:
+        raise ValueError(
+            f"campaign statistics for {field!r} exceed the supported range"
+        ) from error
+    result = {
         "mean": mean,
         "minimum": min(values),
         "maximum": max(values),
@@ -342,6 +618,12 @@ def _metric_statistics(runs: Sequence[TraceSummary], field: str) -> dict:
             else None
         ),
     }
+    if any(
+        value is not None and not math.isfinite(value)
+        for value in result.values()
+    ):
+        raise ValueError(f"campaign statistics for {field!r} are non-finite")
+    return result
 
 
 def summarize_campaign(
@@ -354,7 +636,14 @@ def summarize_campaign(
 ) -> dict:
     if not runs:
         raise ValueError("campaign summary requires at least one run")
+    configuration.validate()
+    if not scenario.strip():
+        raise ValueError("scenario must be non-empty")
+    if target not in {"1.75", "2.06"}:
+        raise ValueError("target must be 1.75 or 2.06")
     raw_hashes = [run.raw_sha256 for run in runs]
+    if any(not re.fullmatch(r"[0-9a-f]{64}", value) for value in raw_hashes):
+        raise ValueError("each run must contain a lowercase SHA-256 raw hash")
     if len(raw_hashes) != len(set(raw_hashes)):
         raise ValueError("campaign contains duplicate raw trace content")
     if not FULL_GIT_SHA.fullmatch(firmware_sha):
@@ -387,6 +676,50 @@ def _full_git_sha(value: str) -> str:
     return value
 
 
+def _reject_output_alias(output: Path, traces: Sequence[Path]) -> None:
+    for trace in traces:
+        try:
+            aliases_trace = output.samefile(trace)
+        except FileNotFoundError:
+            aliases_trace = output.resolve(strict=False) == trace.resolve(
+                strict=False
+            )
+        if aliases_trace:
+            raise ValueError(
+                f"output path aliases raw trace input and is refused: {trace}"
+            )
+
+
+def _write_text_atomic(
+    output: Path,
+    rendered: str,
+    *,
+    traces: Sequence[Path],
+) -> None:
+    _reject_output_alias(output, traces)
+    temporary_path: Path | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            newline="",
+            dir=output.parent,
+            prefix=f".{output.name}.",
+            suffix=".tmp",
+            delete=False,
+        ) as handle:
+            temporary_path = Path(handle.name)
+            handle.write(rendered)
+            handle.flush()
+            os.fsync(handle.fileno())
+        _reject_output_alias(output, traces)
+        os.replace(temporary_path, output)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            temporary_path.unlink(missing_ok=True)
+
+
 def build_argument_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
@@ -411,6 +744,8 @@ def build_argument_parser() -> argparse.ArgumentParser:
     parser.add_argument("--supply-voltage", type=float)
     parser.add_argument("--window-start-s", type=float, default=0.0)
     parser.add_argument("--window-end-s", type=float)
+    parser.add_argument("--minimum-sample-rate-hz", type=float, default=10_000.0)
+    parser.add_argument("--maximum-gap-factor", type=float, default=2.0)
     parser.add_argument("--minimum-runs", type=int, default=3)
     parser.add_argument("--output", type=Path)
     return parser
@@ -430,6 +765,11 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error(
             "set exactly one of --voltage-column or --supply-voltage"
         )
+    if args.output is not None:
+        try:
+            _reject_output_alias(args.output, args.traces)
+        except (OSError, ValueError) as error:
+            parser.error(str(error))
 
     configuration = TraceConfiguration(
         time_column=args.time_column,
@@ -441,6 +781,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         supply_voltage_v=args.supply_voltage,
         window_start_s=args.window_start_s,
         window_end_s=args.window_end_s,
+        minimum_sample_rate_hz=args.minimum_sample_rate_hz,
+        maximum_gap_factor=args.maximum_gap_factor,
     )
     try:
         runs = [analyze_trace(path, configuration) for path in args.traces]
@@ -451,14 +793,19 @@ def main(argv: Sequence[str] | None = None) -> int:
             firmware_sha=args.firmware_sha,
             configuration=configuration,
         )
+        rendered = json.dumps(
+            summary,
+            indent=2,
+            sort_keys=True,
+            allow_nan=False,
+        ) + "\n"
+        if args.output is not None:
+            _write_text_atomic(args.output, rendered, traces=args.traces)
     except (OSError, TraceFormatError, ValueError) as error:
         parser.error(str(error))
 
-    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
     if args.output is None:
         print(rendered, end="")
-    else:
-        args.output.write_text(rendered, encoding="utf-8")
     return 0
 
 

--- a/esp32/tools/power_trace_summary.py
+++ b/esp32/tools/power_trace_summary.py
@@ -1,0 +1,466 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import json
+import math
+import re
+import statistics
+from array import array
+from collections.abc import MutableSequence, Sequence
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+
+ANALYSIS_SCHEMA_VERSION = 1
+FULL_GIT_SHA = re.compile(r"[0-9a-f]{40}")
+
+TIME_UNIT_SECONDS = {
+    "s": 1.0,
+    "ms": 1e-3,
+    "us": 1e-6,
+    "ns": 1e-9,
+}
+CURRENT_UNIT_AMPS = {
+    "A": 1.0,
+    "mA": 1e-3,
+    "uA": 1e-6,
+}
+VOLTAGE_UNIT_VOLTS = {
+    "V": 1.0,
+    "mV": 1e-3,
+}
+
+
+class TraceFormatError(ValueError):
+    """Raised when a trace cannot produce trustworthy power statistics."""
+
+
+@dataclass(frozen=True)
+class TraceConfiguration:
+    time_column: str = "time_s"
+    current_column: str = "current_mA"
+    voltage_column: str | None = None
+    time_unit: str = "s"
+    current_unit: str = "mA"
+    voltage_unit: str = "V"
+    supply_voltage_v: float | None = None
+    window_start_s: float = 0.0
+    window_end_s: float | None = None
+
+    def validate(self) -> None:
+        if self.time_unit not in TIME_UNIT_SECONDS:
+            raise ValueError(f"unsupported time unit: {self.time_unit}")
+        if self.current_unit not in CURRENT_UNIT_AMPS:
+            raise ValueError(f"unsupported current unit: {self.current_unit}")
+        if self.voltage_unit not in VOLTAGE_UNIT_VOLTS:
+            raise ValueError(f"unsupported voltage unit: {self.voltage_unit}")
+        if (self.voltage_column is None) == (self.supply_voltage_v is None):
+            raise ValueError(
+                "set exactly one of voltage_column or supply_voltage_v"
+            )
+        if self.supply_voltage_v is not None and self.supply_voltage_v <= 0:
+            raise ValueError("supply_voltage_v must be positive")
+        if self.window_start_s < 0:
+            raise ValueError("window_start_s must be non-negative")
+        if (
+            self.window_end_s is not None
+            and self.window_end_s <= self.window_start_s
+        ):
+            raise ValueError("window_end_s must be greater than window_start_s")
+
+
+@dataclass(frozen=True)
+class TraceSummary:
+    trace: str
+    raw_sha256: str
+    total_samples: int
+    selected_samples: int
+    first_sample_elapsed_s: float
+    last_sample_elapsed_s: float
+    duration_s: float
+    effective_sample_rate_hz: float
+    average_current_mA: float
+    p95_current_mA: float
+    peak_current_mA: float
+    average_voltage_v: float
+    average_power_mW: float
+    energy_mWh: float
+    mWh_per_hour: float
+
+
+def _sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _finite_number(raw_value: str | None, column: str, row_number: int) -> float:
+    if raw_value is None or not raw_value.strip():
+        raise TraceFormatError(f"row {row_number}: empty {column!r} value")
+    try:
+        value = float(raw_value)
+    except ValueError as error:
+        raise TraceFormatError(
+            f"row {row_number}: non-numeric {column!r} value {raw_value!r}"
+        ) from error
+    if not math.isfinite(value):
+        raise TraceFormatError(
+            f"row {row_number}: non-finite {column!r} value {raw_value!r}"
+        )
+    return value
+
+
+def _select(values: MutableSequence[float], rank: int) -> float:
+    """Return one exact order statistic using in-place three-way partitioning."""
+    if rank < 0 or rank >= len(values):
+        raise IndexError("order-statistic rank is outside the sample array")
+
+    left = 0
+    right = len(values) - 1
+    while True:
+        if left == right:
+            return values[left]
+
+        middle = left + (right - left) // 2
+        pivot = sorted((values[left], values[middle], values[right]))[1]
+        lower = left
+        cursor = left
+        upper = right
+        while cursor <= upper:
+            if values[cursor] < pivot:
+                values[lower], values[cursor] = values[cursor], values[lower]
+                lower += 1
+                cursor += 1
+            elif values[cursor] > pivot:
+                values[cursor], values[upper] = values[upper], values[cursor]
+                upper -= 1
+            else:
+                cursor += 1
+
+        if rank < lower:
+            right = lower - 1
+        elif rank > upper:
+            left = upper + 1
+        else:
+            return pivot
+
+
+def sample_percentile(values: MutableSequence[float], percentile: float) -> float:
+    """Return an exact R-type-7 percentile, reordering values in place."""
+    if not values:
+        raise ValueError("a percentile requires at least one sample")
+    if percentile < 0 or percentile > 100:
+        raise ValueError("percentile must be between 0 and 100")
+
+    position = (len(values) - 1) * percentile / 100.0
+    lower_rank = math.floor(position)
+    upper_rank = math.ceil(position)
+    lower_value = _select(values, lower_rank)
+    if upper_rank == lower_rank:
+        return lower_value
+    upper_value = _select(values, upper_rank)
+    fraction = position - lower_rank
+    return lower_value + (upper_value - lower_value) * fraction
+
+
+def analyze_trace(path: Path, configuration: TraceConfiguration) -> TraceSummary:
+    configuration.validate()
+    if not path.is_file():
+        raise TraceFormatError(f"trace does not exist or is not a file: {path}")
+
+    required_columns = {
+        configuration.time_column,
+        configuration.current_column,
+    }
+    if configuration.voltage_column is not None:
+        required_columns.add(configuration.voltage_column)
+
+    total_samples = 0
+    selected_samples = 0
+    trace_origin_s: float | None = None
+    previous_trace_time_s: float | None = None
+    first_selected_s: float | None = None
+    previous_selected_s: float | None = None
+    previous_current_a: float | None = None
+    previous_voltage_v: float | None = None
+    current_area_a_s = 0.0
+    voltage_area_v_s = 0.0
+    power_area_w_s = 0.0
+    peak_current_a = -math.inf
+    current_samples_mA = array("d")
+
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise TraceFormatError("trace is missing a CSV header")
+        if len(reader.fieldnames) != len(set(reader.fieldnames)):
+            raise TraceFormatError("trace CSV header contains duplicate columns")
+        missing_columns = sorted(required_columns.difference(reader.fieldnames))
+        if missing_columns:
+            raise TraceFormatError(
+                "trace is missing required column(s): " + ", ".join(missing_columns)
+            )
+
+        for row_number, row in enumerate(reader, start=2):
+            trace_time_s = (
+                _finite_number(
+                    row.get(configuration.time_column),
+                    configuration.time_column,
+                    row_number,
+                )
+                * TIME_UNIT_SECONDS[configuration.time_unit]
+            )
+            current_a = (
+                _finite_number(
+                    row.get(configuration.current_column),
+                    configuration.current_column,
+                    row_number,
+                )
+                * CURRENT_UNIT_AMPS[configuration.current_unit]
+            )
+            if configuration.voltage_column is None:
+                voltage_v = configuration.supply_voltage_v
+                assert voltage_v is not None
+            else:
+                voltage_v = (
+                    _finite_number(
+                        row.get(configuration.voltage_column),
+                        configuration.voltage_column,
+                        row_number,
+                    )
+                    * VOLTAGE_UNIT_VOLTS[configuration.voltage_unit]
+                )
+                if voltage_v <= 0:
+                    raise TraceFormatError(
+                        f"row {row_number}: voltage must be positive"
+                    )
+
+            total_samples += 1
+            if trace_origin_s is None:
+                trace_origin_s = trace_time_s
+            if (
+                previous_trace_time_s is not None
+                and trace_time_s <= previous_trace_time_s
+            ):
+                raise TraceFormatError(
+                    f"row {row_number}: timestamps must be strictly increasing"
+                )
+            previous_trace_time_s = trace_time_s
+            elapsed_s = trace_time_s - trace_origin_s
+
+            if elapsed_s < configuration.window_start_s:
+                continue
+            if (
+                configuration.window_end_s is not None
+                and elapsed_s > configuration.window_end_s
+            ):
+                continue
+
+            if first_selected_s is None:
+                first_selected_s = elapsed_s
+            if previous_selected_s is not None:
+                interval_s = elapsed_s - previous_selected_s
+                assert previous_current_a is not None
+                assert previous_voltage_v is not None
+                current_area_a_s += (
+                    (previous_current_a + current_a) * 0.5 * interval_s
+                )
+                voltage_area_v_s += (
+                    (previous_voltage_v + voltage_v) * 0.5 * interval_s
+                )
+                power_area_w_s += (
+                    (
+                        previous_current_a * previous_voltage_v
+                        + current_a * voltage_v
+                    )
+                    * 0.5
+                    * interval_s
+                )
+
+            previous_selected_s = elapsed_s
+            previous_current_a = current_a
+            previous_voltage_v = voltage_v
+            peak_current_a = max(peak_current_a, current_a)
+            current_samples_mA.append(current_a * 1_000.0)
+            selected_samples += 1
+
+    if total_samples == 0:
+        raise TraceFormatError("trace contains no data rows")
+    if selected_samples < 2:
+        raise TraceFormatError(
+            "selected window must contain at least two samples"
+        )
+    assert first_selected_s is not None
+    assert previous_selected_s is not None
+    duration_s = previous_selected_s - first_selected_s
+    if duration_s <= 0:
+        raise TraceFormatError("selected window has no positive duration")
+
+    average_current_a = current_area_a_s / duration_s
+    average_voltage_v = voltage_area_v_s / duration_s
+    average_power_w = power_area_w_s / duration_s
+    energy_mwh = power_area_w_s * 1_000.0 / 3_600.0
+
+    return TraceSummary(
+        trace=str(path),
+        raw_sha256=_sha256(path),
+        total_samples=total_samples,
+        selected_samples=selected_samples,
+        first_sample_elapsed_s=first_selected_s,
+        last_sample_elapsed_s=previous_selected_s,
+        duration_s=duration_s,
+        effective_sample_rate_hz=(selected_samples - 1) / duration_s,
+        average_current_mA=average_current_a * 1_000.0,
+        p95_current_mA=sample_percentile(current_samples_mA, 95.0),
+        peak_current_mA=peak_current_a * 1_000.0,
+        average_voltage_v=average_voltage_v,
+        average_power_mW=average_power_w * 1_000.0,
+        energy_mWh=energy_mwh,
+        mWh_per_hour=average_power_w * 1_000.0,
+    )
+
+
+def _metric_statistics(runs: Sequence[TraceSummary], field: str) -> dict:
+    values = [float(getattr(run, field)) for run in runs]
+    mean = statistics.fmean(values)
+    sample_stddev = statistics.stdev(values) if len(values) > 1 else 0.0
+    return {
+        "mean": mean,
+        "minimum": min(values),
+        "maximum": max(values),
+        "sample_stddev": sample_stddev,
+        "coefficient_of_variation_percent": (
+            sample_stddev / abs(mean) * 100.0 if mean != 0 else None
+        ),
+        "range_percent_of_mean": (
+            (max(values) - min(values)) / abs(mean) * 100.0
+            if mean != 0
+            else None
+        ),
+    }
+
+
+def summarize_campaign(
+    runs: Sequence[TraceSummary],
+    *,
+    scenario: str,
+    target: str,
+    firmware_sha: str,
+    configuration: TraceConfiguration,
+) -> dict:
+    if not runs:
+        raise ValueError("campaign summary requires at least one run")
+    raw_hashes = [run.raw_sha256 for run in runs]
+    if len(raw_hashes) != len(set(raw_hashes)):
+        raise ValueError("campaign contains duplicate raw trace content")
+    if not FULL_GIT_SHA.fullmatch(firmware_sha):
+        raise ValueError("firmware_sha must be a full lowercase Git SHA")
+    return {
+        "analysis_schema_version": ANALYSIS_SCHEMA_VERSION,
+        "scenario": scenario,
+        "target": target,
+        "firmware_sha": firmware_sha,
+        "configuration": asdict(configuration),
+        "run_count": len(runs),
+        "runs": [asdict(run) for run in runs],
+        "run_statistics": {
+            field: _metric_statistics(runs, field)
+            for field in (
+                "average_current_mA",
+                "p95_current_mA",
+                "peak_current_mA",
+                "mWh_per_hour",
+            )
+        },
+    }
+
+
+def _full_git_sha(value: str) -> str:
+    if not FULL_GIT_SHA.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            "expected a full 40-character lowercase Git SHA"
+        )
+    return value
+
+
+def build_argument_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Summarize battery-terminal source-monitor CSV traces without "
+            "discarding raw evidence."
+        )
+    )
+    parser.add_argument("traces", nargs="+", type=Path)
+    parser.add_argument("--scenario", required=True)
+    parser.add_argument("--target", required=True, choices=("1.75", "2.06"))
+    parser.add_argument("--firmware-sha", required=True, type=_full_git_sha)
+    parser.add_argument("--time-column", default="time_s")
+    parser.add_argument("--current-column", default="current_mA")
+    parser.add_argument("--voltage-column")
+    parser.add_argument("--time-unit", choices=tuple(TIME_UNIT_SECONDS), default="s")
+    parser.add_argument(
+        "--current-unit", choices=tuple(CURRENT_UNIT_AMPS), default="mA"
+    )
+    parser.add_argument(
+        "--voltage-unit", choices=tuple(VOLTAGE_UNIT_VOLTS), default="V"
+    )
+    parser.add_argument("--supply-voltage", type=float)
+    parser.add_argument("--window-start-s", type=float, default=0.0)
+    parser.add_argument("--window-end-s", type=float)
+    parser.add_argument("--minimum-runs", type=int, default=3)
+    parser.add_argument("--output", type=Path)
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_argument_parser()
+    args = parser.parse_args(argv)
+    if args.minimum_runs < 1:
+        parser.error("--minimum-runs must be at least 1")
+    if len(args.traces) < args.minimum_runs:
+        parser.error(
+            f"expected at least {args.minimum_runs} trace files, "
+            f"received {len(args.traces)}"
+        )
+    if (args.voltage_column is None) == (args.supply_voltage is None):
+        parser.error(
+            "set exactly one of --voltage-column or --supply-voltage"
+        )
+
+    configuration = TraceConfiguration(
+        time_column=args.time_column,
+        current_column=args.current_column,
+        voltage_column=args.voltage_column,
+        time_unit=args.time_unit,
+        current_unit=args.current_unit,
+        voltage_unit=args.voltage_unit,
+        supply_voltage_v=args.supply_voltage,
+        window_start_s=args.window_start_s,
+        window_end_s=args.window_end_s,
+    )
+    try:
+        runs = [analyze_trace(path, configuration) for path in args.traces]
+        summary = summarize_campaign(
+            runs,
+            scenario=args.scenario,
+            target=args.target,
+            firmware_sha=args.firmware_sha,
+            configuration=configuration,
+        )
+    except (OSError, TraceFormatError, ValueError) as error:
+        parser.error(str(error))
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    if args.output is None:
+        print(rendered, end="")
+    else:
+        args.output.write_text(rendered, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esp32/tools/power_trace_summary.py
+++ b/esp32/tools/power_trace_summary.py
@@ -383,7 +383,10 @@ def analyze_trace(path: Path, configuration: TraceConfiguration) -> TraceSummary
     try:
         with path.open("rb") as handle:
             initial_identity = _stat_identity(os.fstat(handle.fileno()))
-            reader = csv.DictReader(_hashed_text_lines(handle, digest))
+            reader = csv.DictReader(
+                _hashed_text_lines(handle, digest),
+                strict=True,
+            )
             if reader.fieldnames is None:
                 raise TraceFormatError("trace is missing a CSV header")
             if len(reader.fieldnames) != len(set(reader.fieldnames)):

--- a/esp32/tools/tests/test_power_metrics_schema.cpp
+++ b/esp32/tools/tests/test_power_metrics_schema.cpp
@@ -1,0 +1,66 @@
+#include "../../lib/power_metrics/power_metrics_schema.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+  using namespace power_metrics;
+
+  static_assert(kSchemaVersion == 1);
+  IntervalAccumulator accumulator;
+
+  accumulator.noteLoop(100);
+  accumulator.noteLoop(107);
+  accumulator.noteLoop(111);
+  accumulator.noteLvgl(25);
+  accumulator.noteLvgl(75);
+  accumulator.noteDisplayFlush(10, 80, 100);
+  accumulator.noteDisplayFlush(20, 180, 225);
+  accumulator.noteMapRender(
+      true, 9'000, 2'000, 5'000, 1'000,
+      reasonMask(MapRenderReason::Gps) | reasonMask(MapRenderReason::Heading));
+  accumulator.noteMapRender(false, 1'500, 1'000, 0, 0, 0);
+  accumulator.noteBlePacket(BlePacketClass::Gps);
+  accumulator.noteBlePacket(BlePacketClass::Gps);
+  accumulator.noteBlePacket(BlePacketClass::Navigation);
+
+  const IntervalData first = accumulator.snapshotAndReset();
+  assert(first.loopWakeCount == 3);
+  assert(first.maxLoopGapMs == 7);
+  assert(first.lvgl.count == 2);
+  assert(first.lvgl.totalUs == 100);
+  assert(first.lvgl.maxUs == 75);
+  assert(first.displayFlush.count == 2);
+  assert(first.displayFlush.totalUs == 325);
+  assert(first.displayFlush.maxUs == 225);
+  assert(first.displayRotation.totalUs == 30);
+  assert(first.displayQspi.totalUs == 260);
+  assert(first.mapRenderCompleted == 1);
+  assert(first.mapRenderInterrupted == 1);
+  assert(first.mapRender.totalUs == 10'500);
+  assert(first.mapReasonCounts[0] == 1); // GPS
+  assert(first.mapReasonCounts[3] == 1); // heading
+  assert(first.mapReasonCounts[5] == 1); // missing reason becomes other
+  assert(first.blePacketCounts[static_cast<std::size_t>(
+             BlePacketClass::Gps)] == 2);
+  assert(first.blePacketCounts[static_cast<std::size_t>(
+             BlePacketClass::Navigation)] == 1);
+
+  // An interval reset preserves the prior loop timestamp so the boundary gap
+  // remains visible in the following report.
+  accumulator.noteLoop(125);
+  const IntervalData second = accumulator.snapshotAndReset();
+  assert(second.loopWakeCount == 1);
+  assert(second.maxLoopGapMs == 14);
+  assert(second.lvgl.count == 0);
+
+  // Unsigned subtraction intentionally handles millis() rollover.
+  accumulator.resetAll();
+  accumulator.noteLoop(std::numeric_limits<uint32_t>::max() - 2);
+  accumulator.noteLoop(3);
+  const IntervalData rollover = accumulator.snapshotAndReset();
+  assert(rollover.maxLoopGapMs == 6);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_power_metrics_schema.cpp
+++ b/esp32/tools/tests/test_power_metrics_schema.cpp
@@ -24,6 +24,7 @@ int main() {
   accumulator.noteBlePacket(BlePacketClass::Gps);
   accumulator.noteBlePacket(BlePacketClass::Gps);
   accumulator.noteBlePacket(BlePacketClass::Navigation);
+  accumulator.noteBlePacket(BlePacketClass::Transfer);
 
   const IntervalData first = accumulator.snapshotAndReset();
   assert(first.loopWakeCount == 3);
@@ -46,7 +47,8 @@ int main() {
              BlePacketClass::Gps)] == 2);
   assert(first.blePacketCounts[static_cast<std::size_t>(
              BlePacketClass::Navigation)] == 1);
-
+  assert(first.blePacketCounts[static_cast<std::size_t>(
+             BlePacketClass::Transfer)] == 1);
   // An interval reset preserves the prior loop timestamp so the boundary gap
   // remains visible in the following report.
   accumulator.noteLoop(125);

--- a/esp32/tools/tests/test_power_trace_summary.py
+++ b/esp32/tools/tests/test_power_trace_summary.py
@@ -170,6 +170,23 @@ class PowerTraceSummaryTests(unittest.TestCase):
                     TraceConfiguration(supply_voltage_v=4.0),
                 )
 
+    def test_unterminated_quoted_field_cannot_swallow_later_samples(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "unterminated.csv",
+                "time_s,current_mA,note\n"
+                "0,1,ok\n"
+                "1,2,ok\n"
+                '2,3,"unterminated\n'
+                "3,100,swallowed\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "invalid CSV"):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(supply_voltage_v=4.0),
+                )
+
     def test_percentile_handles_duplicates_and_linear_interpolation(self):
         self.assertEqual(sample_percentile(array("d", [2.0] * 100), 95), 2.0)
         values = array("d", [5.0, 1.0, 4.0, 2.0, 3.0])

--- a/esp32/tools/tests/test_power_trace_summary.py
+++ b/esp32/tools/tests/test_power_trace_summary.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import json
+import math
+import random
+import tempfile
+import unittest
+from array import array
+from pathlib import Path
+
+from power_trace_summary import (
+    TraceConfiguration,
+    TraceFormatError,
+    analyze_trace,
+    main,
+    sample_percentile,
+    summarize_campaign,
+)
+
+
+class PowerTraceSummaryTests(unittest.TestCase):
+    def write_trace(self, root: Path, name: str, contents: str) -> Path:
+        path = root / name
+        path.write_text(contents, encoding="utf-8")
+        return path
+
+    def test_constant_voltage_trace_uses_time_weighted_integration(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "run.csv",
+                "time_s,current_mA\n"
+                "0,1\n"
+                "1,2\n"
+                "2,3\n"
+                "3,4\n"
+                "4,5\n",
+            )
+            result = analyze_trace(
+                trace,
+                TraceConfiguration(supply_voltage_v=4.0),
+            )
+
+            self.assertEqual(result.total_samples, 5)
+            self.assertEqual(result.selected_samples, 5)
+            self.assertAlmostEqual(result.duration_s, 4.0)
+            self.assertAlmostEqual(result.effective_sample_rate_hz, 1.0)
+            self.assertAlmostEqual(result.average_current_mA, 3.0)
+            self.assertAlmostEqual(result.p95_current_mA, 4.8)
+            self.assertAlmostEqual(result.peak_current_mA, 5.0)
+            self.assertAlmostEqual(result.average_voltage_v, 4.0)
+            self.assertAlmostEqual(result.average_power_mW, 12.0)
+            self.assertAlmostEqual(result.energy_mWh, 12.0 * 4.0 / 3_600.0)
+            self.assertAlmostEqual(result.mWh_per_hour, 12.0)
+            self.assertRegex(result.raw_sha256, r"^[0-9a-f]{64}$")
+
+    def test_voltage_column_and_units_are_applied_before_integration(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "variable.csv",
+                "time_ms,current_A,voltage_mV\n"
+                "0,1,3000\n"
+                "1000,1,4000\n"
+                "2000,1,5000\n",
+            )
+            result = analyze_trace(
+                trace,
+                TraceConfiguration(
+                    time_column="time_ms",
+                    current_column="current_A",
+                    voltage_column="voltage_mV",
+                    time_unit="ms",
+                    current_unit="A",
+                    voltage_unit="mV",
+                ),
+            )
+
+            self.assertAlmostEqual(result.duration_s, 2.0)
+            self.assertAlmostEqual(result.average_current_mA, 1_000.0)
+            self.assertAlmostEqual(result.average_voltage_v, 4.0)
+            self.assertAlmostEqual(result.average_power_mW, 4_000.0)
+            self.assertAlmostEqual(result.energy_mWh, 4_000.0 * 2.0 / 3_600.0)
+            self.assertAlmostEqual(result.mWh_per_hour, 4_000.0)
+
+    def test_window_is_relative_to_first_trace_timestamp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "window.csv",
+                "time_s,current_mA\n"
+                "100,10\n"
+                "101,20\n"
+                "102,30\n"
+                "103,40\n"
+                "104,50\n",
+            )
+            result = analyze_trace(
+                trace,
+                TraceConfiguration(
+                    supply_voltage_v=4.0,
+                    window_start_s=1.0,
+                    window_end_s=3.0,
+                ),
+            )
+
+            self.assertEqual(result.total_samples, 5)
+            self.assertEqual(result.selected_samples, 3)
+            self.assertAlmostEqual(result.first_sample_elapsed_s, 1.0)
+            self.assertAlmostEqual(result.last_sample_elapsed_s, 3.0)
+            self.assertAlmostEqual(result.average_current_mA, 30.0)
+
+    def test_nonincreasing_timestamps_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "invalid.csv",
+                "time_s,current_mA\n0,1\n1,2\n1,3\n",
+            )
+            with self.assertRaisesRegex(
+                TraceFormatError, "timestamps must be strictly increasing"
+            ):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(supply_voltage_v=4.0),
+                )
+
+    def test_duplicate_csv_columns_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "duplicate.csv",
+                "time_s,current_mA,current_mA\n0,1,2\n1,2,3\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "duplicate columns"):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(supply_voltage_v=4.0),
+                )
+
+    def test_percentile_handles_duplicates_and_linear_interpolation(self):
+        self.assertEqual(sample_percentile(array("d", [2.0] * 100), 95), 2.0)
+        values = array("d", [5.0, 1.0, 4.0, 2.0, 3.0])
+        self.assertAlmostEqual(sample_percentile(values, 95), 4.8)
+
+    def test_percentile_matches_sorted_reference_across_sample_shapes(self):
+        random_source = random.Random(42)
+        for sample_count in (1, 2, 3, 10, 101):
+            for _ in range(20):
+                raw_values = [
+                    float(random_source.randrange(-5, 6))
+                    for _ in range(sample_count)
+                ]
+                ordered = sorted(raw_values)
+                position = (sample_count - 1) * 0.95
+                lower_rank = math.floor(position)
+                upper_rank = math.ceil(position)
+                fraction = position - lower_rank
+                expected = ordered[lower_rank] + (
+                    ordered[upper_rank] - ordered[lower_rank]
+                ) * fraction
+                actual = sample_percentile(array("d", raw_values), 95)
+                self.assertAlmostEqual(actual, expected)
+
+    def test_campaign_summary_reports_run_to_run_variance(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            traces = [
+                self.write_trace(
+                    root,
+                    f"run-{index}.csv",
+                    "time_s,current_mA,run_id\n"
+                    f"0,10,{index}\n"
+                    f"1,10,{index}\n",
+                )
+                for index in range(3)
+            ]
+            configuration = TraceConfiguration(supply_voltage_v=4.0)
+            runs = [analyze_trace(trace, configuration) for trace in traces]
+            summary = summarize_campaign(
+                runs,
+                scenario="static navigation",
+                target="1.75",
+                firmware_sha="a" * 40,
+                configuration=configuration,
+            )
+
+            average_stats = summary["run_statistics"]["average_current_mA"]
+            self.assertEqual(summary["run_count"], 3)
+            self.assertAlmostEqual(average_stats["mean"], 10.0)
+            self.assertAlmostEqual(average_stats["sample_stddev"], 0.0)
+            self.assertAlmostEqual(
+                average_stats["coefficient_of_variation_percent"], 0.0
+            )
+
+    def test_campaign_rejects_duplicate_raw_trace_evidence(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            traces = [
+                self.write_trace(
+                    root,
+                    f"duplicate-{index}.csv",
+                    "time_s,current_mA\n0,10\n1,10\n",
+                )
+                for index in range(3)
+            ]
+            configuration = TraceConfiguration(supply_voltage_v=4.0)
+            runs = [analyze_trace(trace, configuration) for trace in traces]
+            with self.assertRaisesRegex(ValueError, "duplicate raw trace"):
+                summarize_campaign(
+                    runs,
+                    scenario="static navigation",
+                    target="1.75",
+                    firmware_sha="a" * 40,
+                    configuration=configuration,
+                )
+
+    def test_cli_requires_and_writes_a_three_run_campaign(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            traces = [
+                self.write_trace(
+                    root,
+                    f"cli-{index}.csv",
+                    "time_s,current_mA,run_id\n"
+                    f"0,10,{index}\n"
+                    f"1,12,{index}\n",
+                )
+                for index in range(3)
+            ]
+            output = root / "summary.json"
+            exit_code = main(
+                [
+                    *(str(trace) for trace in traces),
+                    "--scenario",
+                    "deep sleep",
+                    "--target",
+                    "2.06",
+                    "--firmware-sha",
+                    "b" * 40,
+                    "--supply-voltage",
+                    "4.0",
+                    "--output",
+                    str(output),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+            rendered = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(rendered["analysis_schema_version"], 1)
+            self.assertEqual(rendered["run_count"], 3)
+            self.assertEqual(rendered["target"], "2.06")
+            self.assertEqual(rendered["firmware_sha"], "b" * 40)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/esp32/tools/tests/test_power_trace_summary.py
+++ b/esp32/tools/tests/test_power_trace_summary.py
@@ -1,12 +1,20 @@
 from __future__ import annotations
 
+import hashlib
+import io
 import json
 import math
+import os
 import random
 import tempfile
+import time
 import unittest
 from array import array
+from contextlib import redirect_stderr
 from pathlib import Path
+from unittest import mock
+
+import power_trace_summary
 
 from power_trace_summary import (
     TraceConfiguration,
@@ -23,6 +31,30 @@ class PowerTraceSummaryTests(unittest.TestCase):
         path = root / name
         path.write_text(contents, encoding="utf-8")
         return path
+
+    def cli_arguments(self, traces: list[Path]) -> list[str]:
+        return [
+            *(str(trace) for trace in traces),
+            "--scenario",
+            "test scenario",
+            "--target",
+            "1.75",
+            "--firmware-sha",
+            "a" * 40,
+            "--supply-voltage",
+            "4.0",
+            "--minimum-sample-rate-hz",
+            "1",
+            "--minimum-runs",
+            str(len(traces)),
+        ]
+
+    def assert_cli_error(self, arguments: list[str], message: str) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr), self.assertRaises(SystemExit) as raised:
+            main(arguments)
+        self.assertEqual(raised.exception.code, 2)
+        self.assertRegex(stderr.getvalue(), message)
 
     def test_constant_voltage_trace_uses_time_weighted_integration(self):
         with tempfile.TemporaryDirectory() as directory:
@@ -240,6 +272,8 @@ class PowerTraceSummaryTests(unittest.TestCase):
                     "b" * 40,
                     "--supply-voltage",
                     "4.0",
+                    "--minimum-sample-rate-hz",
+                    "1",
                     "--output",
                     str(output),
                 ]
@@ -251,6 +285,263 @@ class PowerTraceSummaryTests(unittest.TestCase):
             self.assertEqual(rendered["run_count"], 3)
             self.assertEqual(rendered["target"], "2.06")
             self.assertEqual(rendered["firmware_sha"], "b" * 40)
+            self.assertEqual(
+                list(root.glob(f".{output.name}.*.tmp")),
+                [],
+            )
+
+    def test_missing_required_column_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "missing.csv",
+                "time_s,amps\n0,1\n1,2\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "missing required column"):
+                analyze_trace(trace, TraceConfiguration(supply_voltage_v=4.0))
+
+    def test_nonfinite_samples_fail_closed(self):
+        for raw_value in ("nan", "inf", "-inf"):
+            with self.subTest(raw_value=raw_value), tempfile.TemporaryDirectory() as directory:
+                trace = self.write_trace(
+                    Path(directory),
+                    "nonfinite.csv",
+                    "time_s,current_mA\n"
+                    "0,1\n"
+                    f"1,{raw_value}\n",
+                )
+                with self.assertRaisesRegex(TraceFormatError, "non-finite"):
+                    analyze_trace(
+                        trace,
+                        TraceConfiguration(supply_voltage_v=4.0),
+                    )
+
+    def test_voltage_source_must_be_unambiguous(self):
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            TraceConfiguration().validate()
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            TraceConfiguration(
+                voltage_column="voltage_v",
+                supply_voltage_v=4.0,
+            ).validate()
+
+    def test_configured_column_names_must_be_distinct(self):
+        with self.assertRaisesRegex(ValueError, "must be distinct"):
+            TraceConfiguration(
+                time_column="value",
+                current_column="value",
+                supply_voltage_v=4.0,
+            ).validate()
+
+    def test_nonfinite_configuration_fails_closed_in_cli(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "valid.csv",
+                "time_s,current_mA\n0,1\n1,2\n",
+            )
+            base_arguments = self.cli_arguments([trace])
+            cases = (
+                ("--supply-voltage", "nan"),
+                ("--window-start-s", "inf"),
+                ("--minimum-sample-rate-hz", "nan"),
+                ("--maximum-gap-factor", "inf"),
+            )
+            for option, value in cases:
+                with self.subTest(option=option):
+                    self.assert_cli_error(
+                        [*base_arguments, option, value],
+                        "finite",
+                    )
+
+    def test_window_with_only_one_sample_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "one.csv",
+                "time_s,current_mA\n0,1\n1,2\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "at least two samples"):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(
+                        supply_voltage_v=4.0,
+                        window_start_s=1.0,
+                    ),
+                )
+
+    def test_explicit_window_end_must_be_covered(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "short.csv",
+                "time_s,current_mA\n0,1\n1,2\n2,3\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "requested window end"):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(
+                        supply_voltage_v=4.0,
+                        window_start_s=0.5,
+                        window_end_s=3.0,
+                    ),
+                )
+
+    def test_window_boundaries_are_interpolated_exactly(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "interpolate.csv",
+                "time_s,current_mA\n0,0\n1,10\n2,20\n3,30\n",
+            )
+            result = analyze_trace(
+                trace,
+                TraceConfiguration(
+                    supply_voltage_v=4.0,
+                    window_start_s=0.5,
+                    window_end_s=2.5,
+                ),
+            )
+
+            self.assertEqual(result.selected_samples, 2)
+            self.assertEqual(result.interpolated_boundary_samples, 2)
+            self.assertAlmostEqual(result.first_sample_elapsed_s, 0.5)
+            self.assertAlmostEqual(result.last_sample_elapsed_s, 2.5)
+            self.assertAlmostEqual(result.duration_s, 2.0)
+            self.assertAlmostEqual(result.average_current_mA, 15.0)
+            self.assertAlmostEqual(result.average_power_mW, 60.0)
+
+    def test_capture_rate_and_large_sample_gaps_are_enforced(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            slow_trace = self.write_trace(
+                root,
+                "slow.csv",
+                "time_s,current_mA\n0,1\n1,1\n2,1\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "below required"):
+                analyze_trace(
+                    slow_trace,
+                    TraceConfiguration(
+                        supply_voltage_v=4.0,
+                        minimum_sample_rate_hz=10.0,
+                    ),
+                )
+
+            dense_prefix = "".join(
+                f"{index / 10_000:.4f},1\n" for index in range(101)
+            )
+            gap_trace = self.write_trace(
+                root,
+                "gap.csv",
+                "time_s,current_mA\n" + dense_prefix + "0.1000,1\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "sample gap"):
+                analyze_trace(
+                    gap_trace,
+                    TraceConfiguration(
+                        supply_voltage_v=4.0,
+                        minimum_sample_rate_hz=1_000.0,
+                        maximum_gap_factor=2.0,
+                    ),
+                )
+
+    def test_raw_sha_is_for_the_exact_parsed_bytes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = Path(directory) / "bom.csv"
+            raw_bytes = (
+                b"\xef\xbb\xbftime_s,current_mA\r\n"
+                b"0,1\r\n"
+                b"1,2\r\n"
+            )
+            trace.write_bytes(raw_bytes)
+            result = analyze_trace(
+                trace,
+                TraceConfiguration(supply_voltage_v=4.0),
+            )
+            self.assertEqual(
+                result.raw_sha256,
+                hashlib.sha256(raw_bytes).hexdigest(),
+            )
+
+    def test_trace_mutation_during_analysis_fails_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "mutated.csv",
+                "time_s,current_mA\n0,1\n1,2\n",
+            )
+            initial_identity = (1, 2, 3, 4, 5)
+            changed_identity = (1, 2, 4, 4, 5)
+            with mock.patch.object(
+                power_trace_summary,
+                "_stat_identity",
+                side_effect=(
+                    initial_identity,
+                    changed_identity,
+                    initial_identity,
+                ),
+            ):
+                with self.assertRaisesRegex(TraceFormatError, "trace changed"):
+                    analyze_trace(
+                        trace,
+                        TraceConfiguration(supply_voltage_v=4.0),
+                    )
+
+    def test_output_cannot_alias_raw_evidence(self):
+        for alias_kind in ("same-path", "symlink", "hardlink"):
+            with self.subTest(alias_kind=alias_kind), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                trace = self.write_trace(
+                    root,
+                    "raw.csv",
+                    "time_s,current_mA\n0,1\n1,2\n",
+                )
+                original_bytes = trace.read_bytes()
+                if alias_kind == "same-path":
+                    output = trace
+                elif alias_kind == "symlink":
+                    output = root / "summary.json"
+                    output.symlink_to(trace)
+                else:
+                    output = root / "summary.json"
+                    os.link(trace, output)
+
+                self.assert_cli_error(
+                    [*self.cli_arguments([trace]), "--output", str(output)],
+                    "aliases raw trace input",
+                )
+                self.assertEqual(trace.read_bytes(), original_bytes)
+
+    def test_nonfinite_derived_results_fail_closed(self):
+        with tempfile.TemporaryDirectory() as directory:
+            trace = self.write_trace(
+                Path(directory),
+                "overflow.csv",
+                "time_s,current_A\n0,1e300\n1,1e300\n",
+            )
+            with self.assertRaisesRegex(TraceFormatError, "derived result"):
+                analyze_trace(
+                    trace,
+                    TraceConfiguration(
+                        current_column="current_A",
+                        current_unit="A",
+                        supply_voltage_v=1e300,
+                    ),
+                )
+
+    def test_percentile_stays_fast_for_large_monotonic_inputs(self):
+        sample_count = 200_000
+        started_at = time.monotonic()
+        for values in (
+            array("d", range(sample_count)),
+            array("d", reversed(range(sample_count))),
+        ):
+            self.assertAlmostEqual(
+                sample_percentile(values, 95.0),
+                (sample_count - 1) * 0.95,
+            )
+        self.assertLess(time.monotonic() - started_at, 8.0)
 
 
 if __name__ == "__main__":

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -629,6 +629,7 @@ class BLEManager: NSObject, ObservableObject {
         priorityMaxCount: 3
     )
     private var lastNavigationQueuePendingLogAt = Date.distantPast
+    private var lastNavigationQueueMetricsLogAt = Date.distantPast
     private var isConnecting: Bool = false
     private var isPairingMode: Bool = false
     private var pendingAuthNonce: String?
@@ -3909,6 +3910,27 @@ class BLEManager: NSObject, ObservableObject {
             log("Navigation write queue pending: \(navigationWriteQueue.count)")
             lastNavigationQueuePendingLogAt = Date()
         }
+        logNavigationQueueMetricsIfNeeded()
+    }
+
+    private func logNavigationQueueMetricsIfNeeded() {
+#if DEBUG
+        let now = Date()
+        guard now.timeIntervalSince(lastNavigationQueueMetricsLogAt) >= 10 else {
+            return
+        }
+        lastNavigationQueueMetricsLogAt = now
+        let metrics = navigationWriteQueue.metrics
+        log(
+            "PWRMET_IOS v=\(NavigationWriteQueueMetrics.schemaVersion) " +
+            "queue[depth=\(metrics.currentDepth) maxDepth=\(metrics.maxDepth) " +
+            "enqueued=\(metrics.enqueuedFrames) flushed=\(metrics.flushedFrames) " +
+            "dropped=\(metrics.droppedFrames) rejected=\(metrics.rejectedFrames) " +
+            "coalesced=\(metrics.coalescedFrames) cleared=\(metrics.clearedFrames) " +
+            "retries=\(metrics.retrySchedules) " +
+            "backpressure=\(metrics.backpressureStops)]"
+        )
+#endif
     }
 
     private func completeNavigationWrite(error: Error?) {
@@ -4001,6 +4023,8 @@ class BLEManager: NSObject, ObservableObject {
             self.flushPendingNavigationWrites(endpoint: endpoint)
             self.scheduleNavigationFlushRetryIfNeeded()
         }
+        navigationWriteQueue.noteRetryScheduled()
+        logNavigationQueueMetricsIfNeeded()
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -629,7 +629,9 @@ class BLEManager: NSObject, ObservableObject {
         priorityMaxCount: 3
     )
     private var lastNavigationQueuePendingLogAt = Date.distantPast
-    private var lastNavigationQueueMetricsLogAt = Date.distantPast
+#if DEBUG
+    private var navigationQueueMetricsTimer: Timer?
+#endif
     private var isConnecting: Bool = false
     private var isPairingMode: Bool = false
     private var pendingAuthNonce: String?
@@ -801,9 +803,22 @@ class BLEManager: NSObject, ObservableObject {
         )
 #endif
         log("BLE debug session started")
+#if DEBUG
+        let metricsTimer = Timer(
+            timeInterval: 10,
+            repeats: true
+        ) { [weak self] _ in
+            self?.logNavigationQueueMetricsInterval()
+        }
+        RunLoop.main.add(metricsTimer, forMode: .common)
+        navigationQueueMetricsTimer = metricsTimer
+#endif
     }
 
     deinit {
+#if DEBUG
+        navigationQueueMetricsTimer?.invalidate()
+#endif
 #if canImport(UIKit) && !HOST_TESTING
         NotificationCenter.default.removeObserver(
             self,
@@ -3910,19 +3925,14 @@ class BLEManager: NSObject, ObservableObject {
             log("Navigation write queue pending: \(navigationWriteQueue.count)")
             lastNavigationQueuePendingLogAt = Date()
         }
-        logNavigationQueueMetricsIfNeeded()
     }
 
-    private func logNavigationQueueMetricsIfNeeded() {
+    private func logNavigationQueueMetricsInterval() {
 #if DEBUG
-        let now = Date()
-        guard now.timeIntervalSince(lastNavigationQueueMetricsLogAt) >= 10 else {
-            return
-        }
-        lastNavigationQueueMetricsLogAt = now
-        let metrics = navigationWriteQueue.metrics
+        let metrics = navigationWriteQueue.snapshotMetricsAndReset()
         log(
             "PWRMET_IOS v=\(NavigationWriteQueueMetrics.schemaVersion) " +
+            "intervalMs=10000 " +
             "queue[depth=\(metrics.currentDepth) maxDepth=\(metrics.maxDepth) " +
             "enqueued=\(metrics.enqueuedFrames) flushed=\(metrics.flushedFrames) " +
             "dropped=\(metrics.droppedFrames) rejected=\(metrics.rejectedFrames) " +
@@ -4024,7 +4034,6 @@ class BLEManager: NSObject, ObservableObject {
             self.scheduleNavigationFlushRetryIfNeeded()
         }
         navigationWriteQueue.noteRetryScheduled()
-        logNavigationQueueMetricsIfNeeded()
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -631,6 +631,7 @@ class BLEManager: NSObject, ObservableObject {
     private var lastNavigationQueuePendingLogAt = Date.distantPast
 #if DEBUG
     private var navigationQueueMetricsTimer: Timer?
+    private var lastNavigationQueueMetricsUptime: TimeInterval = 0
 #endif
     private var isConnecting: Bool = false
     private var isPairingMode: Bool = false
@@ -804,6 +805,7 @@ class BLEManager: NSObject, ObservableObject {
 #endif
         log("BLE debug session started")
 #if DEBUG
+        lastNavigationQueueMetricsUptime = ProcessInfo.processInfo.systemUptime
         let metricsTimer = Timer(
             timeInterval: 10,
             repeats: true
@@ -3929,10 +3931,15 @@ class BLEManager: NSObject, ObservableObject {
 
     private func logNavigationQueueMetricsInterval() {
 #if DEBUG
+        let now = ProcessInfo.processInfo.systemUptime
+        let intervalMs = Int(
+            max(0, (now - lastNavigationQueueMetricsUptime) * 1_000).rounded()
+        )
+        lastNavigationQueueMetricsUptime = now
         let metrics = navigationWriteQueue.snapshotMetricsAndReset()
         log(
             "PWRMET_IOS v=\(NavigationWriteQueueMetrics.schemaVersion) " +
-            "intervalMs=10000 " +
+            "intervalMs=\(intervalMs) " +
             "queue[depth=\(metrics.currentDepth) maxDepth=\(metrics.maxDepth) " +
             "enqueued=\(metrics.enqueuedFrames) flushed=\(metrics.flushedFrames) " +
             "dropped=\(metrics.droppedFrames) rejected=\(metrics.rejectedFrames) " +

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
@@ -1,5 +1,20 @@
 import Foundation
 
+struct NavigationWriteQueueMetrics: Equatable {
+    static let schemaVersion = 1
+
+    var enqueuedFrames = 0
+    var flushedFrames = 0
+    var droppedFrames = 0
+    var rejectedFrames = 0
+    var coalescedFrames = 0
+    var clearedFrames = 0
+    var retrySchedules = 0
+    var backpressureStops = 0
+    var currentDepth = 0
+    var maxDepth = 0
+}
+
 struct NavigationWrite {
     let data: Data
     let label: String
@@ -66,6 +81,7 @@ struct NavigationWriteQueue {
     let priorityMaxCount: Int
     private var pendingWrites: [NavigationWrite] = []
     private var pendingPriorityWrites: [NavigationWrite] = []
+    private var diagnosticMetrics = NavigationWriteQueueMetrics()
 
     var count: Int {
         pendingPriorityWrites.count + pendingWrites.count
@@ -73,6 +89,12 @@ struct NavigationWriteQueue {
 
     var remainingCapacity: Int {
         max(maxCount - pendingWrites.count, 0)
+    }
+
+    var metrics: NavigationWriteQueueMetrics {
+        var snapshot = diagnosticMetrics
+        snapshot.currentDepth = count
+        return snapshot
     }
 
     init(maxCount: Int, priorityMaxCount: Int = 1) {
@@ -83,7 +105,11 @@ struct NavigationWriteQueue {
     @discardableResult
     mutating func enqueue(_ write: NavigationWrite) -> Bool {
         pendingWrites.append(write)
-        guard pendingWrites.count > maxCount else { return false }
+        recordEnqueuedFrames(1)
+        guard pendingWrites.count > maxCount else {
+            recordDepth()
+            return false
+        }
 
         // Never split a logical message that was accepted atomically. If the
         // queue consists only of protected chunks, the newly appended regular
@@ -92,6 +118,8 @@ struct NavigationWriteQueue {
             ?? pendingWrites.startIndex
         let droppedWrite = pendingWrites.remove(at: droppedIndex)
         droppedWrite.onDrop?()
+        recordDroppedFrames(1)
+        recordDepth()
         return true
     }
 
@@ -99,8 +127,13 @@ struct NavigationWriteQueue {
     /// or exposing only a prefix of the message to the transport.
     @discardableResult
     mutating func enqueueAtomically(_ writes: [NavigationWrite]) -> Bool {
-        guard writes.count <= remainingCapacity else { return false }
+        guard writes.count <= remainingCapacity else {
+            recordRejectedFrames(writes.count)
+            return false
+        }
         pendingWrites.append(contentsOf: writes.map { $0.protectingAtomicBatch() })
+        recordEnqueuedFrames(writes.count)
+        recordDepth()
         return true
     }
 
@@ -110,16 +143,20 @@ struct NavigationWriteQueue {
     @discardableResult
     mutating func enqueuePrioritizedAtomically(_ writes: [NavigationWrite]) -> Bool {
         guard !writes.isEmpty, writes.count <= priorityMaxCount else {
+            recordRejectedFrames(writes.count)
             return false
         }
 
         if pendingPriorityWrites.count + writes.count > priorityMaxCount {
+            recordDroppedFrames(pendingPriorityWrites.count)
             pendingPriorityWrites.forEach { $0.onDrop?() }
             pendingPriorityWrites.removeAll()
         }
         pendingPriorityWrites.append(contentsOf: writes.map {
             $0.protectingAtomicBatch()
         })
+        recordEnqueuedFrames(writes.count)
+        recordDepth()
         return true
     }
 
@@ -142,14 +179,21 @@ struct NavigationWriteQueue {
         removePendingWrites(withCoalescingKey: key)
         if prioritized {
             guard pendingPriorityWrites.count < priorityMaxCount else {
+                recordRejectedFrames(1)
                 return false
             }
             pendingPriorityWrites.append(write.protectingAtomicBatch())
+            recordEnqueuedFrames(1)
+            recordDepth()
             return true
         }
 
         pendingWrites.append(write)
-        guard pendingWrites.count > maxCount else { return true }
+        guard pendingWrites.count > maxCount else {
+            recordEnqueuedFrames(1)
+            recordDepth()
+            return true
+        }
         let droppedIndex = pendingWrites.firstIndex { !$0.protectedFromEviction }
             ?? pendingWrites.startIndex
         let rejectedNewWrite = droppedIndex == pendingWrites.index(before: pendingWrites.endIndex)
@@ -158,21 +202,29 @@ struct NavigationWriteQueue {
             // The caller receives `false` and owns retry scheduling. Invoking
             // onDrop here would schedule a second immediate retry and can spin
             // while a protected atomic batch keeps the queue full.
+            recordRejectedFrames(1)
+            recordDepth()
             return false
         }
         droppedWrite.onDrop?()
+        recordEnqueuedFrames(1)
+        recordDroppedFrames(1)
+        recordDepth()
         return true
     }
 
     mutating func removeAll() {
+        recordClearedFrames(count)
         pendingPriorityWrites.removeAll()
         pendingWrites.removeAll()
+        recordDepth()
     }
 
     mutating func removePendingWrites(withCoalescingKey key: String) {
         let priorityMatches = pendingPriorityWrites.indices.reversed().filter {
             pendingPriorityWrites[$0].coalescingKey == key
         }
+        recordCoalescedFrames(priorityMatches.count)
         for index in priorityMatches {
             pendingPriorityWrites.remove(at: index).onDrop?()
         }
@@ -180,9 +232,11 @@ struct NavigationWriteQueue {
         let regularMatches = pendingWrites.indices.reversed().filter {
             pendingWrites[$0].coalescingKey == key
         }
+        recordCoalescedFrames(regularMatches.count)
         for index in regularMatches {
             pendingWrites.remove(at: index).onDrop?()
         }
+        recordDepth()
     }
 
     mutating func flush(
@@ -205,12 +259,72 @@ struct NavigationWriteQueue {
         var writesRemaining = max(0, maxWrites)
         while writesRemaining > 0 && count > 0 {
             let nextWrite = pendingPriorityWrites.first ?? pendingWrites.first!
-            guard canSend(nextWrite) else { break }
+            guard canSend(nextWrite) else {
+                recordBackpressureStop()
+                break
+            }
             let dequeued = pendingPriorityWrites.isEmpty
                 ? pendingWrites.removeFirst()
                 : pendingPriorityWrites.removeFirst()
+            recordFlushedFrames(1)
+            recordDepth()
             write(dequeued)
             writesRemaining -= 1
         }
+    }
+
+    mutating func noteRetryScheduled() {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.retrySchedules += 1
+#endif
+    }
+
+    private mutating func recordEnqueuedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.enqueuedFrames += count
+#endif
+    }
+
+    private mutating func recordFlushedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.flushedFrames += count
+#endif
+    }
+
+    private mutating func recordDroppedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.droppedFrames += count
+#endif
+    }
+
+    private mutating func recordRejectedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.rejectedFrames += count
+#endif
+    }
+
+    private mutating func recordCoalescedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.coalescedFrames += count
+#endif
+    }
+
+    private mutating func recordClearedFrames(_ count: Int) {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.clearedFrames += count
+#endif
+    }
+
+    private mutating func recordBackpressureStop() {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.backpressureStops += 1
+#endif
+    }
+
+    private mutating func recordDepth() {
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics.currentDepth = count
+        diagnosticMetrics.maxDepth = max(diagnosticMetrics.maxDepth, count)
+#endif
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
@@ -97,6 +97,16 @@ struct NavigationWriteQueue {
         return snapshot
     }
 
+    mutating func snapshotMetricsAndReset() -> NavigationWriteQueueMetrics {
+        let snapshot = metrics
+#if DEBUG || HOST_TESTING
+        diagnosticMetrics = NavigationWriteQueueMetrics()
+        diagnosticMetrics.currentDepth = count
+        diagnosticMetrics.maxDepth = count
+#endif
+        return snapshot
+    }
+
     init(maxCount: Int, priorityMaxCount: Int = 1) {
         self.maxCount = max(1, maxCount)
         self.priorityMaxCount = max(1, priorityMaxCount)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8510,6 +8510,30 @@ struct NavigationProtocolTests {
                     "queue interval metrics reset after a snapshot")
         assertEqual(metricsQueue.metrics.maxDepth, 0,
                     "an empty queue starts the next interval at zero depth")
+
+        var boundaryQueue = NavigationWriteQueue(maxCount: 3)
+        boundaryQueue.enqueue(NavigationWrite(data: Data([6]), label: "pending-1"))
+        boundaryQueue.enqueue(NavigationWrite(data: Data([7]), label: "pending-2"))
+        let boundarySnapshot = boundaryQueue.snapshotMetricsAndReset()
+        assertEqual(boundarySnapshot.enqueuedFrames, 2,
+                    "the completed interval retains pre-boundary events")
+        assertEqual(boundarySnapshot.currentDepth, 2,
+                    "the completed interval reports pending queue depth")
+
+        let nextBoundarySnapshot = boundaryQueue.snapshotMetricsAndReset()
+        assertEqual(nextBoundarySnapshot.enqueuedFrames, 0,
+                    "the next interval starts with cleared event counters")
+        assertEqual(nextBoundarySnapshot.currentDepth, 2,
+                    "the next interval retains pending queue depth")
+        assertEqual(nextBoundarySnapshot.maxDepth, 2,
+                    "the next interval starts at the existing queue depth")
+
+        var boundaryWrites: [Data] = []
+        boundaryQueue.flush(canSend: { _ in true }) { write in
+            boundaryWrites.append(write.data)
+        }
+        assertEqual(boundaryWrites, [Data([6]), Data([7])],
+                    "metrics snapshots do not mutate pending writes")
     }
 
     static func testDeviceBLEProtocolConstants() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8487,7 +8487,7 @@ struct NavigationProtocolTests {
         metricsQueue.enqueue(NavigationWrite(data: Data([5]), label: "clear"))
         metricsQueue.removeAll()
 
-        let queueMetrics = metricsQueue.metrics
+        let queueMetrics = metricsQueue.snapshotMetricsAndReset()
         assertEqual(NavigationWriteQueueMetrics.schemaVersion, 1,
                     "queue metrics schema is explicitly versioned")
         assertEqual(queueMetrics.enqueuedFrames, 3,
@@ -8506,6 +8506,10 @@ struct NavigationProtocolTests {
                     "queue metrics count transport backpressure")
         assertEqual(queueMetrics.currentDepth, 0,
                     "queue metrics depth returns to zero")
+        assertEqual(metricsQueue.metrics.enqueuedFrames, 0,
+                    "queue interval metrics reset after a snapshot")
+        assertEqual(metricsQueue.metrics.maxDepth, 0,
+                    "an empty queue starts the next interval at zero depth")
     }
 
     static func testDeviceBLEProtocolConstants() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8250,6 +8250,16 @@ struct NavigationProtocolTests {
         assertEqual(sent, [Data([2]), Data([3])], "queue flushes remaining packet")
         assertEqual(labels, ["second", "third"], "queue flushes write metadata in order")
         assertEqual(queue.count, 0, "queue is empty after flush")
+        assertEqual(queue.metrics.enqueuedFrames, 3,
+                    "diagnostic metrics count accepted regular frames")
+        assertEqual(queue.metrics.flushedFrames, 2,
+                    "diagnostic metrics count flushed frames")
+        assertEqual(queue.metrics.droppedFrames, 1,
+                    "diagnostic metrics count capacity evictions")
+        assertEqual(queue.metrics.currentDepth, 0,
+                    "diagnostic metrics expose current queue depth")
+        assertEqual(queue.metrics.maxDepth, 2,
+                    "diagnostic metrics retain peak bounded depth")
 
         var pacedQueue = NavigationWriteQueue(maxCount: 3)
         pacedQueue.enqueue(NavigationWrite(data: Data([1]), label: "first"))
@@ -8453,6 +8463,49 @@ struct NavigationProtocolTests {
         }
         assert(catalogWriteFailureWasReported,
                "atomic batch protection preserves the transport failure callback")
+
+        var metricsQueue = NavigationWriteQueue(maxCount: 1)
+        assert(metricsQueue.enqueueCoalescing(NavigationWrite(
+            data: Data([1]),
+            label: "gps-1",
+            coalescingKey: "gps"
+        ), prioritized: false), "first replaceable state is accepted")
+        assert(metricsQueue.enqueueCoalescing(NavigationWrite(
+            data: Data([2]),
+            label: "gps-2",
+            coalescingKey: "gps"
+        ), prioritized: false), "new state replaces the stale state")
+        assert(!metricsQueue.enqueueAtomically([
+            NavigationWrite(data: Data([3]), label: "oversized-1"),
+            NavigationWrite(data: Data([4]), label: "oversized-2")
+        ]), "oversized atomic diagnostics fixture is rejected")
+        metricsQueue.flush(canSend: { false }) { _ in
+            assert(false, "backpressured queue must not write")
+        }
+        metricsQueue.noteRetryScheduled()
+        metricsQueue.flush(canSend: { true }) { _ in }
+        metricsQueue.enqueue(NavigationWrite(data: Data([5]), label: "clear"))
+        metricsQueue.removeAll()
+
+        let queueMetrics = metricsQueue.metrics
+        assertEqual(NavigationWriteQueueMetrics.schemaVersion, 1,
+                    "queue metrics schema is explicitly versioned")
+        assertEqual(queueMetrics.enqueuedFrames, 3,
+                    "queue metrics distinguish accepted frames")
+        assertEqual(queueMetrics.flushedFrames, 1,
+                    "queue metrics count transport writes")
+        assertEqual(queueMetrics.rejectedFrames, 2,
+                    "queue metrics count rejected atomic frames")
+        assertEqual(queueMetrics.coalescedFrames, 1,
+                    "queue metrics count superseded replaceable state")
+        assertEqual(queueMetrics.clearedFrames, 1,
+                    "queue metrics count disconnect-style clearing")
+        assertEqual(queueMetrics.retrySchedules, 1,
+                    "queue metrics count retry scheduling")
+        assertEqual(queueMetrics.backpressureStops, 1,
+                    "queue metrics count transport backpressure")
+        assertEqual(queueMetrics.currentDepth, 0,
+                    "queue metrics depth returns to zero")
     }
 
     static func testDeviceBLEProtocolConstants() {


### PR DESCRIPTION
## What changed

Implements Phase 0 of the [firmware battery-life plan](https://github.com/seichris/open-bike-computer/blob/agent/battery-life-implementation-plan/docs/firmware-battery-life-implementation-plan.md):

- adds compile-time-gated, versioned 10-second ESP32 power/performance metrics
- instruments loop/LVGL work, display rotation and QSPI flushes, map stages/reasons, logical BLE classes, display state, transfer state, CPU frequency, application-managed PM locks, and audio activity
- emits each long metrics record atomically through a metrics-only USB CDC queue, with explicit `PWRMET_ERROR` fail-closed reporting
- adds optional source-monitor correlation pulses
- adds Debug-only iOS navigation queue interval metrics using measured monotonic elapsed time
- builds both 1.75-inch and 2.06-inch metrics environments in CI
- adds a physical-validation protocol with truthful pending result tables for both boards
- adds a source-monitor campaign analyzer for time-weighted current, voltage, power, energy, exact sample p95/peak, and run-to-run variance
- protects raw evidence with same-stream SHA-256, source-mutation checks, strict CSV parsing, exact window boundaries, 10 kS/s cadence/gap gates, duplicate-trace rejection, and alias-safe atomic JSON output

## Why

Battery changes need attributable, repeatable measurements before runtime behavior changes. This establishes the counters, diagnostic builds, analysis tooling, and source-monitor procedure needed to capture the locked baseline.

Normal firmware keeps the instrumentation compiled out. No battery-saving behavior is introduced in this phase.

## Validation

- merged current GitHub `main` (`189d9cf4`) into the branch
- 26 Python analyzer/build-identity tests
- power-metrics schema host test with `-Wall -Wextra -Werror`
- full `ios-app/scripts/run-navigation-tests.sh` suite
- clean builds of both `WAVESHARE_AMOLED_175_POWER_METRICS` and `WAVESHARE_AMOLED_206_POWER_METRICS`
- exact clean head `f3f703ea582725c9f5e4920eacea82a4276d65fb` flashed to the connected 1.75-inch board on `/dev/cu.usbmodem101`
- uploaded 1.75 firmware SHA-256: `805dc163ce6caca067f207b6777e32337a2b31ff265241c638ad928a91d04cb9`
- post-flash capture: four complete 632-656 byte `PWRMET` records, zero `PWRMET_ERROR`, zero USB write timeouts, corrected `appPmLocks=0` contract in every record
- operator confirmed tap, map drag, and pinch-to-zoom on the flashed 1.75-inch board
- inline USB meter showed 5.1 W, unchanged from the previous firmware; recorded as non-baseline USB-path evidence only
- initial adversarial review fixed 8 findings; post-merge/hardware deep review fixed 2 additional findings (serial truncation and misleading system-wide PM-lock claim), with 0 active/deferred P0/P1/P2 findings
- `git diff --check`

Existing compiler and MapKit/CoreLocation deprecation warnings remain unchanged.

## Open Phase 0 gate

This PR remains intentionally draft. Only the 1.75-inch board is currently available. The connected inline USB-C meter is useful for coarse relative bring-up, but it is not a battery-terminal source monitor and cannot satisfy the electrical baseline contract.

Phase 0 still requires immutable source-monitor traces at the battery input with USB power disconnected, at least 10 kS/s, 5-10 minute steady windows, and at least three repetitions per scenario. The 2.06-inch target is compile-validated but its physical campaign is deferred until that board is available. No battery savings are claimed yet.
