### PR TITLE
Show favorites until navigation starts

### DIFF
--- a/esp32/lib/gui/src/batteryStatusScr.cpp
+++ b/esp32/lib/gui/src/batteryStatusScr.cpp
@@ -6,6 +6,7 @@
 #include "batteryStatusScr.hpp"
 
 #include "battery.hpp"
+#include "bikeIcon.hpp"
 #include "batteryStatusLayout.hpp"
 #include "ble_navigation.hpp"
 
@@ -30,10 +31,6 @@ struct BatteryGauge {
 BatteryGauge deviceGauge;
 BatteryGauge phoneGauge;
 
-// Lucide Bike's 24x24 geometry, scaled 3x. Source and license:
-// https://lucide.dev/icons/bike, LICENSES/Lucide-ISC.txt
-constexpr lv_point_precise_t LUCIDE_BIKE_PATH[] = {
-    {36, 53}, {36, 42}, {27, 33}, {39, 24}, {45, 33}, {51, 33}};
 constexpr lv_point_precise_t CHARGING_BOLT_PATH[] = {
     {14, 5}, {6, 16}, {13, 16}, {7, 31}};
 
@@ -79,43 +76,6 @@ void createIconLine(lv_obj_t *parent, const lv_point_precise_t *points,
   lv_obj_set_style_line_color(line, lv_color_hex(color), 0);
   lv_obj_set_style_line_rounded(line, true, 0);
   makePassive(line);
-}
-
-void createBikeWheel(lv_obj_t *parent, lv_coord_t x) {
-  lv_obj_t *wheel = lv_obj_create(parent);
-  lv_obj_remove_style_all(wheel);
-  lv_obj_set_size(wheel, 27, 27);
-  lv_obj_set_pos(wheel, x, 39);
-  lv_obj_set_style_bg_opa(wheel, LV_OPA_TRANSP, 0);
-  lv_obj_set_style_border_width(wheel, 6, 0);
-  lv_obj_set_style_border_color(wheel, lv_color_white(), 0);
-  lv_obj_set_style_radius(wheel, LV_RADIUS_CIRCLE, 0);
-  makePassive(wheel);
-}
-
-lv_obj_t *createBikeIcon(lv_obj_t *parent, lv_coord_t topOffset) {
-  lv_obj_t *bike = lv_obj_create(parent);
-  lv_obj_remove_style_all(bike);
-  lv_obj_set_size(bike, 72, 72);
-  lv_obj_align(bike, LV_ALIGN_TOP_MID, 0, topOffset);
-  makePassive(bike);
-
-  // Lucide circles: rear wheel (5.5,17.5,r3.5), front wheel
-  // (18.5,17.5,r3.5), and rider head (15,5,r1).
-  createBikeWheel(bike, 3);
-  createBikeWheel(bike, 42);
-  lv_obj_t *head = lv_obj_create(bike);
-  lv_obj_remove_style_all(head);
-  lv_obj_set_size(head, 12, 12);
-  lv_obj_set_pos(head, 39, 9);
-  lv_obj_set_style_bg_color(head, lv_color_white(), 0);
-  lv_obj_set_style_bg_opa(head, LV_OPA_COVER, 0);
-  lv_obj_set_style_radius(head, LV_RADIUS_CIRCLE, 0);
-  makePassive(head);
-  createIconLine(bike, LUCIDE_BIKE_PATH,
-                 sizeof(LUCIDE_BIKE_PATH) / sizeof(LUCIDE_BIKE_PATH[0]), 6,
-                 0xFFFFFF);
-  return bike;
 }
 
 lv_obj_t *createPhoneIcon(lv_obj_t *parent, lv_coord_t topOffset) {
@@ -199,7 +159,8 @@ BatteryGauge createGauge(lv_obj_t *parent, lv_coord_t diameter, lv_coord_t y,
   if (phoneIcon) {
     icon = createPhoneIcon(container, iconCenterY - 30);
   } else {
-    icon = createBikeIcon(container, iconCenterY - 36);
+    icon = bike_icon::create(container, 72, 0xFFFFFF);
+    lv_obj_align(icon, LV_ALIGN_TOP_MID, 0, iconCenterY - 36);
   }
   gauge.chargingBolt = createChargingBolt(icon, phoneIcon ? 0 : 3);
 

--- a/esp32/lib/gui/src/bikeIcon.cpp
+++ b/esp32/lib/gui/src/bikeIcon.cpp
@@ -1,0 +1,115 @@
+/**
+ * @file bikeIcon.cpp
+ * @brief Reusable Lucide-style bicycle icon for firmware screens.
+ */
+
+#include "bikeIcon.hpp"
+
+#include <algorithm>
+#include <cstddef>
+
+namespace bike_icon {
+namespace {
+
+// Lucide Bike's 24x24 geometry. Coordinates are doubled so the half-unit
+// wheel centers stay precise without floating point. Source and license:
+// https://lucide.dev/icons/bike, LICENSES/Lucide-ISC.txt
+constexpr lv_point_precise_t BIKE_PATH_X2[] = {
+    {24, 35}, {24, 28}, {18, 22}, {26, 16}, {30, 22}, {34, 22}};
+
+int32_t scaledCoordinate(int32_t origin, int32_t inset, int32_t usableSize,
+                         int32_t doubledCoordinate) {
+  return origin + inset +
+         (usableSize * doubledCoordinate + 24) / 48;
+}
+
+int32_t scaledLength(int32_t usableSize, int32_t doubledLength) {
+  return std::max<int32_t>(1, (usableSize * doubledLength + 24) / 48);
+}
+
+void drawBikeIcon(lv_event_t *event) {
+  if (lv_event_get_code(event) != LV_EVENT_DRAW_POST_END) {
+    return;
+  }
+
+  lv_obj_t *icon = static_cast<lv_obj_t *>(lv_event_get_target(event));
+  lv_layer_t *layer = lv_event_get_layer(event);
+  lv_area_t bounds{};
+  lv_obj_get_coords(icon, &bounds);
+  const int32_t size =
+      std::min(lv_area_get_width(&bounds), lv_area_get_height(&bounds));
+  const int32_t strokeWidth = std::max<int32_t>(2, size / 12);
+  const int32_t inset = strokeWidth / 2;
+  const int32_t usableSize = std::max<int32_t>(1, size - 2 * inset);
+  const lv_color_t color =
+      lv_obj_get_style_text_color(icon, LV_PART_MAIN);
+
+  lv_draw_arc_dsc_t wheel{};
+  lv_draw_arc_dsc_init(&wheel);
+  wheel.color = color;
+  wheel.width = strokeWidth;
+  wheel.start_angle = 0;
+  wheel.end_angle = 360;
+  wheel.rounded = true;
+  wheel.radius = static_cast<uint16_t>(scaledLength(usableSize, 7));
+  wheel.center.y = scaledCoordinate(bounds.y1, inset, usableSize, 35);
+  wheel.center.x = scaledCoordinate(bounds.x1, inset, usableSize, 11);
+  lv_draw_arc(layer, &wheel);
+  wheel.center.x = scaledCoordinate(bounds.x1, inset, usableSize, 37);
+  lv_draw_arc(layer, &wheel);
+
+  lv_draw_line_dsc_t line{};
+  lv_draw_line_dsc_init(&line);
+  line.color = color;
+  line.width = strokeWidth;
+  line.round_start = true;
+  line.round_end = true;
+  for (std::size_t index = 1;
+       index < sizeof(BIKE_PATH_X2) / sizeof(BIKE_PATH_X2[0]); ++index) {
+    const lv_point_precise_t &from = BIKE_PATH_X2[index - 1];
+    const lv_point_precise_t &to = BIKE_PATH_X2[index];
+    line.p1 = {
+        scaledCoordinate(bounds.x1, inset, usableSize, from.x),
+        scaledCoordinate(bounds.y1, inset, usableSize, from.y),
+    };
+    line.p2 = {
+        scaledCoordinate(bounds.x1, inset, usableSize, to.x),
+        scaledCoordinate(bounds.y1, inset, usableSize, to.y),
+    };
+    lv_draw_line(layer, &line);
+  }
+
+  const int32_t headRadius = scaledLength(usableSize, 4);
+  const int32_t headCenterX =
+      scaledCoordinate(bounds.x1, inset, usableSize, 30);
+  const int32_t headCenterY =
+      scaledCoordinate(bounds.y1, inset, usableSize, 10);
+  lv_draw_rect_dsc_t head{};
+  lv_draw_rect_dsc_init(&head);
+  head.bg_color = color;
+  head.bg_opa = LV_OPA_COVER;
+  head.radius = LV_RADIUS_CIRCLE;
+  lv_area_t headBounds = {
+      headCenterX - headRadius,
+      headCenterY - headRadius,
+      headCenterX + headRadius,
+      headCenterY + headRadius,
+  };
+  lv_draw_rect(layer, &head, &headBounds);
+}
+
+} // namespace
+
+lv_obj_t *create(lv_obj_t *parent, lv_coord_t size, uint32_t colorHex) {
+  lv_obj_t *icon = lv_obj_create(parent);
+  lv_obj_remove_style_all(icon);
+  lv_obj_set_size(icon, size, size);
+  lv_obj_set_style_text_color(icon, lv_color_hex(colorHex), 0);
+  lv_obj_add_event_cb(icon, drawBikeIcon, LV_EVENT_DRAW_POST_END, nullptr);
+  lv_obj_clear_flag(
+      icon, static_cast<lv_obj_flag_t>(LV_OBJ_FLAG_CLICKABLE |
+                                       LV_OBJ_FLAG_SCROLLABLE));
+  return icon;
+}
+
+} // namespace bike_icon

--- a/esp32/lib/gui/src/bikeIcon.hpp
+++ b/esp32/lib/gui/src/bikeIcon.hpp
@@ -1,0 +1,14 @@
+/**
+ * @file bikeIcon.hpp
+ * @brief Reusable Lucide-style bicycle icon for firmware screens.
+ */
+
+#pragma once
+
+#include "globalGuiDef.h"
+
+namespace bike_icon {
+
+lv_obj_t *create(lv_obj_t *parent, lv_coord_t size, uint32_t colorHex);
+
+} // namespace bike_icon

--- a/esp32/lib/gui/src/destinationPickerLayout.hpp
+++ b/esp32/lib/gui/src/destinationPickerLayout.hpp
@@ -8,6 +8,22 @@ constexpr int32_t kMinimumRowHeight = 88;
 constexpr int32_t kRowGap = 4;
 constexpr int32_t kTextVerticalPadding = 8;
 constexpr int32_t kBasePickerPadding = 4;
+constexpr int32_t kRectangularScreenInset = 16;
+
+constexpr bool usesRoundScreenSafeArea(int32_t screenWidth,
+                                       int32_t screenHeight) {
+  return screenWidth == screenHeight;
+}
+
+constexpr int32_t fullScreenInset(int32_t screenWidth,
+                                  int32_t screenHeight) {
+  // Move interactive content away from the clipped corners of the round
+  // 1.75-inch panel. The first row starts below the heading, where this inset
+  // keeps both its favorite star and wrapped address text visible.
+  return usesRoundScreenSafeArea(screenWidth, screenHeight)
+             ? (screenWidth + 8) / 9
+             : kRectangularScreenInset;
+}
 
 constexpr int32_t bottomPadding(int32_t screenWidth, int32_t screenHeight,
                                 uint8_t rowCount) {

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -12,6 +12,7 @@
 #include "destinationPickerLayout.hpp"
 #include "guiLayout.hpp"
 #include "mapTileTransition.hpp"
+#include "navigationContentMode.hpp"
 #include "../../utils/src/mapTapArbiter.hpp"
 #include <algorithm>
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
@@ -70,22 +71,26 @@ lv_obj_t *btnZoomOut;
 static lv_obj_t *mapGuidanceOverlay;
 static lv_obj_t *mapGuidanceArrow;
 static lv_obj_t *mapGuidanceDistance;
-static lv_obj_t *mapGuidanceDestinationPicker;
 static lv_obj_t *mapGuidanceCycleStrip;
 static map_tile_transition::State mapTileTransition;
-static uint32_t mapGuidanceCatalogRevision = UINT32_MAX;
-static uint32_t mapGuidanceStatusRevision = UINT32_MAX;
-static bool mapGuidancePickerExpanded = true;
-static bool mapGuidanceHadNavigationData = false;
 struct DestinationRowContext {
   uint32_t generation = 0;
   uint16_t token = 0;
 };
-static constexpr lv_point_precise_t MAP_GUIDANCE_STAR_POINTS[] = {
+struct DestinationPickerView {
+  lv_obj_t *container = nullptr;
+  uint32_t catalogRevision = UINT32_MAX;
+  uint32_t statusRevision = UINT32_MAX;
+  DestinationRowContext
+      rowContexts[destination_picker_protocol::MAX_ITEMS]{};
+};
+static DestinationPickerView mapGuidanceDestinationPicker;
+static DestinationPickerView navigationDestinationPicker;
+static constexpr lv_point_precise_t DESTINATION_STAR_POINTS[] = {
     {9, 0},  {11, 6}, {18, 7}, {13, 11}, {15, 18}, {9, 14},
     {3, 18}, {5, 11}, {0, 7},  {7, 6},   {9, 0}};
-static DestinationRowContext
-    mapGuidanceRowContexts[destination_picker_protocol::MAX_ITEMS];
+
+static void refreshDestinationPickersAsync(void *userData);
 
 Maps mapView;
 static map_tap_arbiter::Controller mapTapController;
@@ -248,7 +253,9 @@ bool shouldInterruptMapRenderForScreenCycle() {
     return true;
   }
   const bool pickerNeedsInput =
-      mapGuidancePickerExpanded && !hasCurrentNavigationData();
+      navigation_content_mode::forNavigationState(
+          hasCurrentNavigationData()) ==
+      navigation_content_mode::Mode::FavoriteDestinations;
   return (pickerNeedsInput || mapRenderSettings.tapToSwitchScreens) &&
          (touchPressed || digitalRead(TCH_I2C_INT) == LOW);
 #else
@@ -265,7 +272,6 @@ const ScreenMapRenderSettings &currentMapStyleSettings() {
 static void tapCycleScreenEvent(lv_event_t *event);
 static void mapGuidanceOverlayTapEvent(lv_event_t *event);
 static void updateMapGuidanceOverlay();
-static void refreshMapGuidanceOverlayAsync(void *userData);
 static void revealPendingMapTileIfReady();
 
 static int16_t mapInteractionAnchorX() {
@@ -472,27 +478,204 @@ static bool mapGuidanceTapIsOutsideOverlay(lv_event_t *event) {
          point.y < overlayArea.y1 || point.y > overlayArea.y2;
 }
 
+static lv_obj_t *createDestinationPickerContainer(lv_obj_t *parent) {
+  lv_obj_t *container = lv_obj_create(parent);
+  lv_obj_remove_style_all(container);
+  lv_obj_set_flex_flow(container, LV_FLEX_FLOW_COLUMN);
+  lv_obj_set_flex_align(container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START,
+                        LV_FLEX_ALIGN_START);
+  lv_obj_set_style_pad_all(container, 4, 0);
+  lv_obj_set_style_pad_row(container, 4, 0);
+  lv_obj_clear_flag(container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(container, LV_SCROLLBAR_MODE_OFF);
+  lv_obj_clear_flag(container, LV_OBJ_FLAG_EVENT_BUBBLE);
+  return container;
+}
+
+static void renderDestinationPicker(DestinationPickerView &picker) {
+  if (!picker.container) {
+    return;
+  }
+
+  const DestinationCatalogSnapshot catalog = getDestinationCatalogSnapshot();
+  const DestinationPickerStatusSnapshot status =
+      getDestinationPickerStatusSnapshot();
+  if (catalog.revision == picker.catalogRevision &&
+      status.revision == picker.statusRevision) {
+    return;
+  }
+
+  picker.catalogRevision = catalog.revision;
+  picker.statusRevision = status.revision;
+  lv_obj_clean(picker.container);
+  lv_obj_scroll_to_y(picker.container, 0, LV_ANIM_OFF);
+  lv_obj_clear_flag(picker.container, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_set_scrollbar_mode(picker.container, LV_SCROLLBAR_MODE_OFF);
+  lv_obj_set_style_pad_bottom(
+      picker.container, destination_picker_layout::kBasePickerPadding, 0);
+
+  uint8_t visibleFavoriteCount = 0;
+  for (uint8_t i = 0; i < catalog.count; i++) {
+    if (catalog.items[i].kind == DestinationKind::Favorite) {
+      visibleFavoriteCount++;
+    }
+  }
+
+  if (status.code != DestinationPickerStatusCode::Idle) {
+    lv_obj_t *statusContent = lv_obj_create(picker.container);
+    lv_obj_remove_style_all(statusContent);
+    lv_obj_set_size(statusContent, LV_PCT(100), LV_PCT(100));
+    lv_obj_clear_flag(statusContent, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_flex_flow(statusContent, LV_FLEX_FLOW_COLUMN);
+    lv_obj_set_flex_align(statusContent, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
+    lv_obj_set_style_pad_row(statusContent, 12, 0);
+
+    if (status.code == DestinationPickerStatusCode::Calculating) {
+      lv_obj_t *spinner = lv_spinner_create(statusContent);
+      lv_obj_set_size(spinner, 54, 54);
+      lv_spinner_set_anim_params(spinner, 900, 220);
+      lv_obj_set_style_arc_width(spinner, 5, LV_PART_MAIN);
+      lv_obj_set_style_arc_color(spinner, lv_color_hex(0x3A3A3A),
+                                 LV_PART_MAIN);
+      lv_obj_set_style_arc_width(spinner, 5, LV_PART_INDICATOR);
+      lv_obj_set_style_arc_color(spinner, lv_color_white(),
+                                 LV_PART_INDICATOR);
+    }
+
+    lv_obj_t *label = lv_label_create(statusContent);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(label, lv_color_white(), 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text(label, status.message[0] == '\0'
+                                 ? "Starting navigation..."
+                                 : status.message);
+    return;
+  }
+
+  if (visibleFavoriteCount == 0) {
+    lv_obj_t *label = lv_label_create(picker.container);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
+    lv_obj_set_style_text_color(label, lv_color_white(), 0);
+    lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text_static(label, "Add saved destinations in the app");
+    return;
+  }
+
+  lv_obj_set_style_pad_bottom(
+      picker.container,
+      destination_picker_layout::bottomPadding(TFT_WIDTH, TFT_HEIGHT,
+                                               visibleFavoriteCount),
+      0);
+  lv_obj_update_layout(picker.container);
+  const int32_t rowWidth = lv_obj_get_content_width(picker.container);
+  // Account for the row's horizontal padding and the label's left/right
+  // padding, which reserves room for the favorite star.
+  const int32_t labelTextWidth = rowWidth > 56 ? rowWidth - 56 : 1;
+  int32_t totalRowHeight = 0;
+  uint8_t createdRowCount = 0;
+  for (uint8_t i = 0; i < catalog.count; i++) {
+    const DeviceDestination &destination = catalog.items[i];
+    if (destination.kind != DestinationKind::Favorite) {
+      continue;
+    }
+
+    lv_point_t textSize{};
+    lv_text_get_size(&textSize, destination.label, &lv_font_montserrat_24, 0,
+                     0, labelTextWidth, LV_TEXT_FLAG_NONE);
+    const int32_t rowHeight =
+        destination_picker_layout::rowHeightForText(textSize.y);
+    totalRowHeight += rowHeight;
+    createdRowCount++;
+
+    lv_obj_t *row = lv_btn_create(picker.container);
+    lv_obj_remove_style_all(row);
+    lv_obj_set_size(row, LV_PCT(100), rowHeight);
+    lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_clear_flag(row, LV_OBJ_FLAG_EVENT_BUBBLE);
+    lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
+    lv_obj_add_flag(row, LV_OBJ_FLAG_PRESS_LOCK);
+    lv_obj_set_style_pad_hor(row, 8, 0);
+    lv_obj_set_style_pad_ver(row, 0, 0);
+    lv_obj_add_event_cb(
+        row,
+        [](lv_event_t *event) {
+          if (lv_event_get_code(event) != LV_EVENT_CLICKED) {
+            return;
+          }
+          lv_event_stop_bubbling(event);
+          const auto *context = static_cast<const DestinationRowContext *>(
+              lv_event_get_user_data(event));
+          if (context != nullptr) {
+            const bool accepted = requestDestinationRoute(context->generation,
+                                                          context->token);
+            log_i("UI: destination tapped generation=%lu token=%u accepted=%d",
+                  (unsigned long)context->generation, context->token,
+                  accepted ? 1 : 0);
+            (void)lv_async_call(refreshDestinationPickersAsync, nullptr);
+          }
+        },
+        LV_EVENT_CLICKED, &picker.rowContexts[i]);
+    picker.rowContexts[i].generation = catalog.generation;
+    picker.rowContexts[i].token = destination.token;
+
+    lv_obj_t *star = lv_line_create(row);
+    lv_obj_remove_style_all(star);
+    lv_line_set_points(star, DESTINATION_STAR_POINTS,
+                       sizeof(DESTINATION_STAR_POINTS) /
+                           sizeof(DESTINATION_STAR_POINTS[0]));
+    lv_obj_set_style_line_width(star, 2, 0);
+    lv_obj_set_style_line_color(star, lv_color_hex(0xFFD60A), 0);
+    lv_obj_set_style_line_rounded(star, true, 0);
+    lv_obj_align(star, LV_ALIGN_LEFT_MID, 5, 0);
+
+    lv_obj_t *label = lv_label_create(row);
+    lv_obj_set_width(label, LV_PCT(100));
+    lv_obj_set_style_pad_left(label, 36, 0);
+    lv_obj_set_style_pad_right(label, 4, 0);
+    lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(label, lv_color_white(), 0);
+    lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
+    lv_label_set_text(label, destination.label);
+    lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
+  }
+
+  if (destination_picker_layout::needsScrolling(
+          totalRowHeight, createdRowCount,
+          lv_obj_get_content_height(picker.container))) {
+    lv_obj_add_flag(picker.container, LV_OBJ_FLAG_SCROLLABLE);
+    lv_obj_set_scroll_dir(picker.container, LV_DIR_VER);
+    lv_obj_set_scrollbar_mode(picker.container, LV_SCROLLBAR_MODE_AUTO);
+  }
+}
+
 static void applyMapGuidanceOverlayLayout() {
-  if (!mapGuidanceOverlay || !mapGuidanceDestinationPicker ||
+  if (!mapGuidanceOverlay || !mapGuidanceDestinationPicker.container ||
       !mapGuidanceCycleStrip) {
     return;
   }
 
   const bool expanded =
-      mapGuidancePickerExpanded && !hasCurrentNavigationData();
+      navigation_content_mode::forNavigationState(
+          hasCurrentNavigationData()) ==
+      navigation_content_mode::Mode::FavoriteDestinations;
   const uint16_t overlayHeight = mapGuidanceOverlayHeight(expanded);
   lv_obj_set_size(mapGuidanceOverlay, TFT_WIDTH, overlayHeight);
   lv_obj_set_pos(mapGuidanceOverlay, 0, TFT_HEIGHT - overlayHeight);
 
   if (expanded) {
-    lv_obj_set_size(mapGuidanceDestinationPicker, TFT_WIDTH - 16,
+    lv_obj_set_size(mapGuidanceDestinationPicker.container, TFT_WIDTH - 16,
                     overlayHeight - 16);
-    lv_obj_align(mapGuidanceDestinationPicker, LV_ALIGN_CENTER, 0, 0);
+    lv_obj_align(mapGuidanceDestinationPicker.container, LV_ALIGN_CENTER, 0,
+                 0);
     lv_obj_add_flag(mapGuidanceCycleStrip, LV_OBJ_FLAG_HIDDEN);
   } else {
-    lv_obj_set_size(mapGuidanceDestinationPicker, TFT_WIDTH - 52,
+    lv_obj_set_size(mapGuidanceDestinationPicker.container, TFT_WIDTH - 52,
                     overlayHeight - 16);
-    lv_obj_align(mapGuidanceDestinationPicker, LV_ALIGN_LEFT_MID, 0, 0);
+    lv_obj_align(mapGuidanceDestinationPicker.container, LV_ALIGN_LEFT_MID, 0,
+                 0);
     lv_obj_set_size(mapGuidanceCycleStrip, 28, overlayHeight - 16);
     lv_obj_align(mapGuidanceCycleStrip, LV_ALIGN_RIGHT_MID, 0, 0);
     lv_obj_clear_flag(mapGuidanceCycleStrip, LV_OBJ_FLAG_HIDDEN);
@@ -501,195 +684,29 @@ static void applyMapGuidanceOverlayLayout() {
 
 static void updateMapGuidanceOverlay() {
   if (!mapGuidanceArrow || !mapGuidanceDistance ||
-      !mapGuidanceDestinationPicker) {
+      !mapGuidanceDestinationPicker.container) {
     return;
   }
 
   LV_IMG_DECLARE(navup);
   lv_img_set_src(mapGuidanceArrow, &navup);
 
-  const bool hasNavigationData = hasCurrentNavigationData();
-  if (hasNavigationData != mapGuidanceHadNavigationData) {
-    mapGuidanceHadNavigationData = hasNavigationData;
-    mapGuidancePickerExpanded = !hasNavigationData;
-  }
+  const navigation_content_mode::Mode contentMode =
+      navigation_content_mode::forNavigationState(hasCurrentNavigationData());
   applyMapGuidanceOverlayLayout();
 
-  if (!hasNavigationData) {
+  if (contentMode == navigation_content_mode::Mode::FavoriteDestinations) {
     lv_img_set_angle(mapGuidanceArrow, 0);
     lv_label_set_text_static(mapGuidanceDistance, "--");
-
-    if (!mapGuidancePickerExpanded) {
-      lv_obj_add_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(mapGuidanceArrow, LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(mapGuidanceDistance, LV_OBJ_FLAG_HIDDEN);
-      return;
-    }
-
     lv_obj_add_flag(mapGuidanceArrow, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(mapGuidanceDistance, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_HIDDEN);
-
-    const DestinationCatalogSnapshot catalog =
-        getDestinationCatalogSnapshot();
-    const DestinationPickerStatusSnapshot status =
-        getDestinationPickerStatusSnapshot();
-    uint8_t visibleFavoriteCount = 0;
-    for (uint8_t i = 0; i < catalog.count; i++) {
-      if (catalog.items[i].kind == DestinationKind::Favorite) {
-        visibleFavoriteCount++;
-      }
-    }
-    if (catalog.revision != mapGuidanceCatalogRevision ||
-        status.revision != mapGuidanceStatusRevision) {
-      mapGuidanceCatalogRevision = catalog.revision;
-      mapGuidanceStatusRevision = status.revision;
-      lv_obj_clean(mapGuidanceDestinationPicker);
-      lv_obj_scroll_to_y(mapGuidanceDestinationPicker, 0, LV_ANIM_OFF);
-      lv_obj_clear_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_SCROLLABLE);
-      lv_obj_set_scrollbar_mode(mapGuidanceDestinationPicker,
-                                LV_SCROLLBAR_MODE_OFF);
-      lv_obj_set_style_pad_bottom(
-          mapGuidanceDestinationPicker,
-          destination_picker_layout::kBasePickerPadding, 0);
-
-      if (status.code != DestinationPickerStatusCode::Idle) {
-        lv_obj_t *statusContent =
-            lv_obj_create(mapGuidanceDestinationPicker);
-        lv_obj_remove_style_all(statusContent);
-        lv_obj_set_size(statusContent, LV_PCT(100), LV_PCT(100));
-        lv_obj_clear_flag(statusContent, LV_OBJ_FLAG_SCROLLABLE);
-        lv_obj_set_flex_flow(statusContent, LV_FLEX_FLOW_COLUMN);
-        lv_obj_set_flex_align(statusContent, LV_FLEX_ALIGN_CENTER,
-                              LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
-        lv_obj_set_style_pad_row(statusContent, 12, 0);
-
-        if (status.code == DestinationPickerStatusCode::Calculating) {
-          lv_obj_t *spinner = lv_spinner_create(statusContent);
-          lv_obj_set_size(spinner, 54, 54);
-          lv_spinner_set_anim_params(spinner, 900, 220);
-          lv_obj_set_style_arc_width(spinner, 5, LV_PART_MAIN);
-          lv_obj_set_style_arc_color(spinner, lv_color_hex(0x3A3A3A),
-                                     LV_PART_MAIN);
-          lv_obj_set_style_arc_width(spinner, 5, LV_PART_INDICATOR);
-          lv_obj_set_style_arc_color(spinner, lv_color_white(),
-                                     LV_PART_INDICATOR);
-        }
-
-        lv_obj_t *label = lv_label_create(statusContent);
-        lv_obj_set_width(label, LV_PCT(100));
-        lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
-        lv_obj_set_style_text_color(label, lv_color_white(), 0);
-        lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
-        lv_label_set_text(label, status.message[0] == '\0'
-                                     ? "Starting navigation..."
-                                     : status.message);
-      } else if (visibleFavoriteCount == 0) {
-        lv_obj_t *label = lv_label_create(mapGuidanceDestinationPicker);
-        lv_obj_set_width(label, LV_PCT(100));
-        lv_obj_set_style_text_font(label, &lv_font_montserrat_18, 0);
-        lv_obj_set_style_text_color(label, lv_color_white(), 0);
-        lv_obj_set_style_text_align(label, LV_TEXT_ALIGN_CENTER, 0);
-        lv_label_set_text_static(label, "Add saved destinations in the app");
-      } else {
-        lv_obj_set_style_pad_bottom(
-            mapGuidanceDestinationPicker,
-            destination_picker_layout::bottomPadding(
-                TFT_WIDTH, TFT_HEIGHT, visibleFavoriteCount),
-            0);
-        lv_obj_update_layout(mapGuidanceDestinationPicker);
-        const int32_t rowWidth =
-            lv_obj_get_content_width(mapGuidanceDestinationPicker);
-        // Account for the row's horizontal padding and the label's left/right
-        // padding, which reserves room for the favorite star.
-        const int32_t labelTextWidth = rowWidth > 56 ? rowWidth - 56 : 1;
-        int32_t totalRowHeight = 0;
-        uint8_t createdRowCount = 0;
-        for (uint8_t i = 0; i < catalog.count; i++) {
-          const DeviceDestination &destination = catalog.items[i];
-          if (destination.kind != DestinationKind::Favorite) {
-            continue;
-          }
-
-          lv_point_t textSize{};
-          lv_text_get_size(&textSize, destination.label,
-                           &lv_font_montserrat_24, 0, 0, labelTextWidth,
-                           LV_TEXT_FLAG_NONE);
-          const int32_t rowHeight =
-              destination_picker_layout::rowHeightForText(textSize.y);
-          totalRowHeight += rowHeight;
-          createdRowCount++;
-
-          lv_obj_t *row = lv_btn_create(mapGuidanceDestinationPicker);
-          lv_obj_remove_style_all(row);
-          lv_obj_set_size(row, LV_PCT(100), rowHeight);
-          lv_obj_clear_flag(row, LV_OBJ_FLAG_SCROLLABLE);
-          lv_obj_clear_flag(row, LV_OBJ_FLAG_EVENT_BUBBLE);
-          lv_obj_add_flag(row, LV_OBJ_FLAG_CLICKABLE);
-          lv_obj_add_flag(row, LV_OBJ_FLAG_PRESS_LOCK);
-          lv_obj_set_style_pad_hor(row, 8, 0);
-          lv_obj_set_style_pad_ver(row, 0, 0);
-          lv_obj_add_event_cb(
-              row,
-              [](lv_event_t *event) {
-                if (lv_event_get_code(event) != LV_EVENT_CLICKED) {
-                  return;
-                }
-                lv_event_stop_bubbling(event);
-                const auto *context = static_cast<const DestinationRowContext *>(
-                    lv_event_get_user_data(event));
-                if (context != nullptr) {
-                  const bool accepted = requestDestinationRoute(
-                      context->generation, context->token);
-                  log_i("UI: destination tapped generation=%lu token=%u "
-                        "accepted=%d",
-                        (unsigned long)context->generation, context->token,
-                        accepted ? 1 : 0);
-                  (void)lv_async_call(refreshMapGuidanceOverlayAsync, nullptr);
-                }
-              },
-              LV_EVENT_CLICKED, &mapGuidanceRowContexts[i]);
-          mapGuidanceRowContexts[i].generation = catalog.generation;
-          mapGuidanceRowContexts[i].token = destination.token;
-
-          lv_obj_t *star = lv_line_create(row);
-          lv_obj_remove_style_all(star);
-          lv_line_set_points(
-              star, MAP_GUIDANCE_STAR_POINTS,
-              sizeof(MAP_GUIDANCE_STAR_POINTS) /
-                  sizeof(MAP_GUIDANCE_STAR_POINTS[0]));
-          lv_obj_set_style_line_width(star, 2, 0);
-          lv_obj_set_style_line_color(star, lv_color_hex(0xFFD60A), 0);
-          lv_obj_set_style_line_rounded(star, true, 0);
-          lv_obj_align(star, LV_ALIGN_LEFT_MID, 5, 0);
-
-          lv_obj_t *label = lv_label_create(row);
-          lv_obj_set_width(label, LV_PCT(100));
-          lv_obj_set_style_pad_left(label, 36, 0);
-          lv_obj_set_style_pad_right(label, 4, 0);
-          lv_obj_set_style_text_font(label, &lv_font_montserrat_24, 0);
-          lv_obj_set_style_text_color(label, lv_color_white(), 0);
-          lv_label_set_long_mode(label, LV_LABEL_LONG_WRAP);
-          lv_label_set_text(label, destination.label);
-          lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
-        }
-
-        if (destination_picker_layout::needsScrolling(
-                totalRowHeight, createdRowCount,
-                lv_obj_get_content_height(mapGuidanceDestinationPicker))) {
-          lv_obj_add_flag(mapGuidanceDestinationPicker,
-                          LV_OBJ_FLAG_SCROLLABLE);
-          lv_obj_set_scroll_dir(mapGuidanceDestinationPicker,
-                                LV_DIR_VER);
-          lv_obj_set_scrollbar_mode(mapGuidanceDestinationPicker,
-                                    LV_SCROLLBAR_MODE_AUTO);
-        }
-      }
-    }
+    lv_obj_clear_flag(mapGuidanceDestinationPicker.container,
+                      LV_OBJ_FLAG_HIDDEN);
+    renderDestinationPicker(mapGuidanceDestinationPicker);
     return;
   }
 
-  lv_obj_add_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(mapGuidanceDestinationPicker.container, LV_OBJ_FLAG_HIDDEN);
   lv_obj_clear_flag(mapGuidanceArrow, LV_OBJ_FLAG_HIDDEN);
   lv_obj_clear_flag(mapGuidanceDistance, LV_OBJ_FLAG_HIDDEN);
 
@@ -698,26 +715,19 @@ static void updateMapGuidanceOverlay() {
   setNavigationDistanceLabel(mapGuidanceDistance, navData.distance);
 }
 
-static void refreshMapGuidanceOverlayAsync(void *userData) {
+static void refreshDestinationPickersAsync(void *userData) {
   (void)userData;
-  if (!isMainScreen || mainScreen == nullptr || activeTile != MAP_GUIDANCE) {
+  if (!isMainScreen || mainScreen == nullptr) {
     return;
   }
-  updateMapGuidanceOverlay();
-  lv_obj_invalidate(mainScreen);
-}
-
-static bool dismissMapGuidanceDestinationPicker() {
-  if (activeTile != MAP_GUIDANCE || !mapGuidancePickerExpanded ||
-      hasCurrentNavigationData()) {
-    return false;
+  if (activeTile == MAP_GUIDANCE) {
+    updateMapGuidanceOverlay();
+  } else if (activeTile == NAV) {
+    updateNavEvent(nullptr);
+  } else {
+    return;
   }
-
-  mapGuidancePickerExpanded = false;
-  updateMapGuidanceOverlay();
   lv_obj_invalidate(mainScreen);
-  log_i("UI: dismissed destination picker");
-  return true;
 }
 
 /**
@@ -1114,12 +1124,14 @@ void scrollMapEvent(lv_event_t *event) {
   if (!canScrollMap) {
     if (activeTile == MAP_GUIDANCE &&
         lv_event_get_code(event) == LV_EVENT_CLICKED) {
-      if (mapGuidancePickerExpanded && !hasCurrentNavigationData()) {
-        // Only the exposed map above the two-thirds overlay dismisses it. This
-        // coordinate guard prevents a misdirected row touch from collapsing
-        // the picker instead of selecting its destination.
-        if (mapGuidanceTapIsOutsideOverlay(event)) {
-          (void)dismissMapGuidanceDestinationPicker();
+      if (!hasCurrentNavigationData()) {
+        // The inactive screen has one stable favorites state. A tap on the
+        // exposed map can still cycle screens, while this coordinate guard
+        // prevents a misdirected row touch from doing so.
+        if (mapRenderSettings.tapToSwitchScreens &&
+            mapGuidanceTapIsOutsideOverlay(event)) {
+          log_i("MAP GUIDANCE TAP: cycling main screen");
+          showNextMainScreen();
         }
         return;
       }
@@ -1462,19 +1474,33 @@ void zoomOutEvent(lv_event_t *event) {
  * @param event
  */
 void updateNavEvent(lv_event_t *event) {
-  if (!nameNav || !distNav || !arrowNav) {
+  (void)event;
+  if (!nameNav || !distNav || !arrowNav ||
+      !navigationDestinationPicker.container) {
     return;
   }
 
   LV_IMG_DECLARE(navup);
   lv_img_set_src(arrowNav, &navup);
 
-  if (!hasCurrentNavigationData()) {
-    lv_label_set_text_static(nameNav, "Waiting for instruction");
+  const navigation_content_mode::Mode contentMode =
+      navigation_content_mode::forNavigationState(hasCurrentNavigationData());
+  if (contentMode == navigation_content_mode::Mode::FavoriteDestinations) {
+    lv_obj_add_flag(nameNav, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(distNav, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(arrowNav, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(navigationDestinationPicker.container,
+                      LV_OBJ_FLAG_HIDDEN);
     lv_label_set_text_static(distNav, "--");
     lv_img_set_angle(arrowNav, 0);
+    renderDestinationPicker(navigationDestinationPicker);
     return;
   }
+
+  lv_obj_add_flag(navigationDestinationPicker.container, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(nameNav, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(distNav, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_clear_flag(arrowNav, LV_OBJ_FLAG_HIDDEN);
 
   NavigationData navData = getCurrentNavigationData();
   char formattedInstruction[160];
@@ -1501,23 +1527,12 @@ static void createMapGuidanceOverlay() {
   lv_obj_add_event_cb(mapGuidanceOverlay, mapGuidanceOverlayTapEvent,
                       LV_EVENT_CLICKED, NULL);
 
-  mapGuidanceDestinationPicker = lv_obj_create(mapGuidanceOverlay);
-  lv_obj_remove_style_all(mapGuidanceDestinationPicker);
-  lv_obj_set_size(mapGuidanceDestinationPicker, TFT_WIDTH - 52,
+  mapGuidanceDestinationPicker.container =
+      createDestinationPickerContainer(mapGuidanceOverlay);
+  lv_obj_set_size(mapGuidanceDestinationPicker.container, TFT_WIDTH - 52,
                   overlayHeight - 16);
-  lv_obj_align(mapGuidanceDestinationPicker, LV_ALIGN_LEFT_MID, 0, 0);
-  lv_obj_set_flex_flow(mapGuidanceDestinationPicker, LV_FLEX_FLOW_COLUMN);
-  lv_obj_set_flex_align(mapGuidanceDestinationPicker, LV_FLEX_ALIGN_START,
-                        LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_START);
-  lv_obj_set_style_pad_all(mapGuidanceDestinationPicker, 4, 0);
-  lv_obj_set_style_pad_row(mapGuidanceDestinationPicker, 4, 0);
-  // A favorites-only catalog always fits in the expanded overlay. Keeping this
-  // container scrollable can turn small touch jitter into a scroll gesture and
-  // suppress the destination row's selection event.
-  lv_obj_clear_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_SCROLLABLE);
-  lv_obj_set_scrollbar_mode(mapGuidanceDestinationPicker,
-                            LV_SCROLLBAR_MODE_OFF);
-  lv_obj_clear_flag(mapGuidanceDestinationPicker, LV_OBJ_FLAG_EVENT_BUBBLE);
+  lv_obj_align(mapGuidanceDestinationPicker.container, LV_ALIGN_LEFT_MID, 0,
+               0);
 
   mapGuidanceCycleStrip = lv_btn_create(mapGuidanceOverlay);
   lv_obj_set_size(mapGuidanceCycleStrip, 28, overlayHeight - 16);
@@ -1552,10 +1567,8 @@ static void createMapGuidanceOverlay() {
   lv_label_set_text_static(mapGuidanceDistance, "--");
   lv_obj_align(mapGuidanceDistance, LV_ALIGN_LEFT_MID, 212, 0);
 
-  mapGuidanceCatalogRevision = UINT32_MAX;
-  mapGuidanceStatusRevision = UINT32_MAX;
-  mapGuidanceHadNavigationData = hasCurrentNavigationData();
-  mapGuidancePickerExpanded = !mapGuidanceHadNavigationData;
+  mapGuidanceDestinationPicker.catalogRevision = UINT32_MAX;
+  mapGuidanceDestinationPicker.statusRevision = UINT32_MAX;
   updateMapGuidanceOverlay();
 
   lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
@@ -1599,8 +1612,6 @@ static void showMainTile(tileName tile) {
   case MAP_GUIDANCE:
     mapView.followGps = true;
     applyMapRotationForActiveTile();
-    mapGuidanceHadNavigationData = hasCurrentNavigationData();
-    mapGuidancePickerExpanded = !mapGuidanceHadNavigationData;
     updateMapGuidanceOverlay();
     mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
@@ -1681,7 +1692,7 @@ static void tapCycleScreenEvent(lv_event_t *event) {
 }
 
 static void mapGuidanceOverlayTapEvent(lv_event_t *event) {
-  if (mapGuidancePickerExpanded && !hasCurrentNavigationData()) {
+  if (!hasCurrentNavigationData()) {
     return;
   }
   tapCycleScreenEvent(event);
@@ -1693,9 +1704,6 @@ void toggleNavigationScreen() {
     return;
   }
 
-  if (dismissMapGuidanceDestinationPicker()) {
-    return;
-  }
   showNextMainScreen();
 }
 
@@ -1729,6 +1737,18 @@ void createMainScr() {
   lv_obj_clear_flag(navTile, LV_OBJ_FLAG_SCROLLABLE);
   lv_obj_add_flag(navTile, LV_OBJ_FLAG_CLICKABLE);
   navigationScr(navTile);
+  navigationDestinationPicker.container =
+      createDestinationPickerContainer(navTile);
+  lv_obj_set_size(navigationDestinationPicker.container, TFT_WIDTH,
+                  TFT_HEIGHT);
+  lv_obj_align(navigationDestinationPicker.container, LV_ALIGN_CENTER, 0, 0);
+  lv_obj_set_style_bg_color(navigationDestinationPicker.container,
+                            lv_color_black(), 0);
+  lv_obj_set_style_bg_opa(navigationDestinationPicker.container, LV_OPA_COVER,
+                          0);
+  lv_obj_set_style_pad_all(navigationDestinationPicker.container, 8, 0);
+  navigationDestinationPicker.catalogRevision = UINT32_MAX;
+  navigationDestinationPicker.statusRevision = UINT32_MAX;
   lv_obj_add_event_cb(navTile, updateNavEvent, LV_EVENT_VALUE_CHANGED, NULL);
   lv_obj_add_event_cb(navTile, tapCycleScreenEvent, LV_EVENT_CLICKED, NULL);
   lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -81,6 +81,7 @@ struct DestinationPickerView {
   lv_obj_t *container = nullptr;
   uint32_t catalogRevision = UINT32_MAX;
   uint32_t statusRevision = UINT32_MAX;
+  bool showsHeading = false;
   DestinationRowContext
       rowContexts[destination_picker_protocol::MAX_ITEMS]{};
 };
@@ -564,6 +565,18 @@ static void renderDestinationPicker(DestinationPickerView &picker) {
     return;
   }
 
+  int32_t headingHeight = 0;
+  if (picker.showsHeading) {
+    lv_obj_t *heading = lv_label_create(picker.container);
+    lv_obj_set_width(heading, LV_PCT(100));
+    lv_obj_set_height(heading, 34);
+    lv_obj_set_style_text_font(heading, &lv_font_montserrat_24, 0);
+    lv_obj_set_style_text_color(heading, lv_color_white(), 0);
+    lv_obj_set_style_text_align(heading, LV_TEXT_ALIGN_CENTER, 0);
+    lv_label_set_text_static(heading, "Choose Destination");
+    headingHeight = 34 + destination_picker_layout::kRowGap;
+  }
+
   lv_obj_set_style_pad_bottom(
       picker.container,
       destination_picker_layout::bottomPadding(TFT_WIDTH, TFT_HEIGHT,
@@ -643,7 +656,7 @@ static void renderDestinationPicker(DestinationPickerView &picker) {
   }
 
   if (destination_picker_layout::needsScrolling(
-          totalRowHeight, createdRowCount,
+          totalRowHeight + headingHeight, createdRowCount,
           lv_obj_get_content_height(picker.container))) {
     lv_obj_add_flag(picker.container, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_set_scroll_dir(picker.container, LV_DIR_VER);
@@ -1739,16 +1752,20 @@ void createMainScr() {
   navigationScr(navTile);
   navigationDestinationPicker.container =
       createDestinationPickerContainer(navTile);
-  lv_obj_set_size(navigationDestinationPicker.container, TFT_WIDTH,
-                  TFT_HEIGHT);
+  const int32_t navigationPickerInset =
+      destination_picker_layout::fullScreenInset(TFT_WIDTH, TFT_HEIGHT);
+  lv_obj_set_size(navigationDestinationPicker.container,
+                  TFT_WIDTH - 2 * navigationPickerInset,
+                  TFT_HEIGHT - 2 * navigationPickerInset);
   lv_obj_align(navigationDestinationPicker.container, LV_ALIGN_CENTER, 0, 0);
   lv_obj_set_style_bg_color(navigationDestinationPicker.container,
                             lv_color_black(), 0);
   lv_obj_set_style_bg_opa(navigationDestinationPicker.container, LV_OPA_COVER,
                           0);
-  lv_obj_set_style_pad_all(navigationDestinationPicker.container, 8, 0);
+  lv_obj_set_style_pad_all(navigationDestinationPicker.container, 4, 0);
   navigationDestinationPicker.catalogRevision = UINT32_MAX;
   navigationDestinationPicker.statusRevision = UINT32_MAX;
+  navigationDestinationPicker.showsHeading = true;
   lv_obj_add_event_cb(navTile, updateNavEvent, LV_EVENT_VALUE_CHANGED, NULL);
   lv_obj_add_event_cb(navTile, tapCycleScreenEvent, LV_EVENT_CLICKED, NULL);
   lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);

--- a/esp32/lib/gui/src/navScr.cpp
+++ b/esp32/lib/gui/src/navScr.cpp
@@ -61,7 +61,7 @@ void navigationScr(_lv_obj_t *screen) {
   lv_obj_set_style_text_align(nameNav, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(nameNav, LV_LABEL_LONG_WRAP);
   lv_obj_set_width(nameNav, TFT_WIDTH - 24);
-  lv_label_set_text_static(nameNav, "Waiting for instruction");
+  lv_label_set_text_static(nameNav, "");
   lv_obj_align(nameNav, LV_ALIGN_TOP_MID, 0, 72);
 
   latNav = lv_label_create(screen);

--- a/esp32/lib/gui/src/navigationContentMode.hpp
+++ b/esp32/lib/gui/src/navigationContentMode.hpp
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+
+namespace navigation_content_mode {
+
+enum class Mode : uint8_t {
+  FavoriteDestinations,
+  ActiveGuidance,
+};
+
+constexpr Mode forNavigationState(bool hasNavigationData) {
+  return hasNavigationData ? Mode::ActiveGuidance
+                           : Mode::FavoriteDestinations;
+}
+
+} // namespace navigation_content_mode

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -14,6 +14,13 @@ constexpr int32_t kMetricRowGap = 8;
 constexpr int32_t kStartWorkoutButtonGap = 16;
 constexpr int32_t kStartWorkoutButtonHeight = 52;
 constexpr int32_t kStartWorkoutButtonHorizontalInset = 42;
+constexpr int32_t kRoundStartWorkoutButtonHorizontalInset = 58;
+constexpr int32_t kRoundStartWorkoutButtonBottomInset = 88;
+
+constexpr bool usesRoundScreenSafeArea(int32_t screenWidth,
+                                       int32_t screenHeight) {
+  return screenWidth == screenHeight;
+}
 
 constexpr bool useLargeMetricValueFont(int32_t screenWidth) {
   // The 466 px display fits the compact 64 px values; the 410 px display
@@ -329,10 +336,24 @@ constexpr MetricPlacement makeMetricPlacement(const Layout &layout,
   placement.bottomRight = usesWorkout ? layout.metrics[5] : layout.metrics[3];
   const Rect &buttonPredecessor =
       hasNavigation ? placement.bottomLeft : placement.distance;
+  const int32_t minimumButtonY =
+      buttonPredecessor.bottom() + kStartWorkoutButtonGap;
+  const bool useRoundSafeArea =
+      usesRoundScreenSafeArea(layout.screenWidth, layout.screenHeight);
+  const int32_t roundSafeButtonY =
+      layout.screenHeight - kRoundStartWorkoutButtonBottomInset -
+      kStartWorkoutButtonHeight;
+  const int32_t buttonY =
+      useRoundSafeArea && roundSafeButtonY > minimumButtonY
+          ? roundSafeButtonY
+          : minimumButtonY;
+  const int32_t horizontalInset =
+      useRoundSafeArea ? kRoundStartWorkoutButtonHorizontalInset
+                       : kStartWorkoutButtonHorizontalInset;
   placement.startWorkoutButton = {
-      kStartWorkoutButtonHorizontalInset,
-      buttonPredecessor.bottom() + kStartWorkoutButtonGap,
-      layout.screenWidth - 2 * kStartWorkoutButtonHorizontalInset,
+      horizontalInset,
+      buttonY,
+      layout.screenWidth - 2 * horizontalInset,
       kStartWorkoutButtonHeight,
   };
   return placement;

--- a/esp32/lib/gui/src/rideTelemetryLayout.hpp
+++ b/esp32/lib/gui/src/rideTelemetryLayout.hpp
@@ -14,8 +14,10 @@ constexpr int32_t kMetricRowGap = 8;
 constexpr int32_t kStartWorkoutButtonGap = 16;
 constexpr int32_t kStartWorkoutButtonHeight = 52;
 constexpr int32_t kStartWorkoutButtonHorizontalInset = 42;
-constexpr int32_t kRoundStartWorkoutButtonHorizontalInset = 58;
-constexpr int32_t kRoundStartWorkoutButtonBottomInset = 88;
+constexpr int32_t kRoundStartWorkoutButtonHorizontalInset = 76;
+constexpr int32_t kRoundStartWorkoutButtonBottomInset = 104;
+constexpr int32_t kStartWorkoutIconSize = 28;
+constexpr int32_t kRoundStartWorkoutIconSize = 34;
 
 constexpr bool usesRoundScreenSafeArea(int32_t screenWidth,
                                        int32_t screenHeight) {

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -559,15 +559,28 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_obj_set_style_bg_opa(rideStartWorkoutButton, LV_OPA_COVER, 0);
   lv_obj_set_style_shadow_width(rideStartWorkoutButton, 0, 0);
   lv_obj_set_style_pad_all(rideStartWorkoutButton, 0, 0);
-  lv_obj_set_style_pad_column(rideStartWorkoutButton, 9, 0);
+  const bool useRoundStartWorkoutContent =
+      ride_telemetry_layout::usesRoundScreenSafeArea(
+          rideLayout.screenWidth, rideLayout.screenHeight);
+  lv_obj_set_style_pad_column(rideStartWorkoutButton,
+                              useRoundStartWorkoutContent ? 12 : 9, 0);
   lv_obj_set_flex_flow(rideStartWorkoutButton, LV_FLEX_FLOW_ROW);
   lv_obj_set_flex_align(rideStartWorkoutButton, LV_FLEX_ALIGN_CENTER,
                         LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_add_event_cb(rideStartWorkoutButton, startWorkoutEvent,
                       LV_EVENT_CLICKED, nullptr);
-  bike_icon::create(rideStartWorkoutButton, 28, 0x000000);
+  bike_icon::create(
+      rideStartWorkoutButton,
+      useRoundStartWorkoutContent
+          ? ride_telemetry_layout::kRoundStartWorkoutIconSize
+          : ride_telemetry_layout::kStartWorkoutIconSize,
+      0x000000);
   lv_obj_t *startWorkoutLabel = lv_label_create(rideStartWorkoutButton);
-  lv_obj_set_style_text_font(startWorkoutLabel, &lv_font_montserrat_18, 0);
+  lv_obj_set_style_text_font(
+      startWorkoutLabel,
+      useRoundStartWorkoutContent ? &lv_font_montserrat_24
+                                  : &lv_font_montserrat_18,
+      0);
   lv_obj_set_style_text_color(startWorkoutLabel, lv_color_black(), 0);
   lv_label_set_text_static(startWorkoutLabel, "Start Workout");
 

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -6,6 +6,7 @@
 #include "rideTelemetryScr.hpp"
 #include "../../ble_navigation/ble_navigation.hpp"
 #include "../../ble_navigation/workout_telemetry_runtime.hpp"
+#include "bikeIcon.hpp"
 #include "gps.hpp"
 #include "rideMetricFontSelection.hpp"
 #include "rideTelemetryLayout.hpp"
@@ -557,13 +558,18 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_obj_set_style_bg_color(rideStartWorkoutButton, lv_color_hex(0x66DD88), 0);
   lv_obj_set_style_bg_opa(rideStartWorkoutButton, LV_OPA_COVER, 0);
   lv_obj_set_style_shadow_width(rideStartWorkoutButton, 0, 0);
+  lv_obj_set_style_pad_all(rideStartWorkoutButton, 0, 0);
+  lv_obj_set_style_pad_column(rideStartWorkoutButton, 9, 0);
+  lv_obj_set_flex_flow(rideStartWorkoutButton, LV_FLEX_FLOW_ROW);
+  lv_obj_set_flex_align(rideStartWorkoutButton, LV_FLEX_ALIGN_CENTER,
+                        LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER);
   lv_obj_add_event_cb(rideStartWorkoutButton, startWorkoutEvent,
                       LV_EVENT_CLICKED, nullptr);
+  bike_icon::create(rideStartWorkoutButton, 28, 0x000000);
   lv_obj_t *startWorkoutLabel = lv_label_create(rideStartWorkoutButton);
   lv_obj_set_style_text_font(startWorkoutLabel, &lv_font_montserrat_18, 0);
   lv_obj_set_style_text_color(startWorkoutLabel, lv_color_black(), 0);
   lv_label_set_text_static(startWorkoutLabel, "Start Workout");
-  lv_obj_center(startWorkoutLabel);
 
   displayedMetricLayout = -1;
   updateRideTelemetryEvent(nullptr);

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -136,7 +136,7 @@ int main() {
                     idleMetrics.distance.bottom() ==
                 ride_telemetry_layout::kStartWorkoutButtonGap);
 #else
-  static_assert(idleMetrics.startWorkoutButton.y ==
+  static_assert(idleMetrics.startWorkoutButton.y <=
                 navigationMetrics.startWorkoutButton.y);
   static_assert(idleMetrics.startWorkoutButton.bottom() ==
                 rideLayout.screenHeight -
@@ -144,6 +144,9 @@ int main() {
   static_assert(idleMetrics.startWorkoutButton.x ==
                 ride_telemetry_layout::
                     kRoundStartWorkoutButtonHorizontalInset);
+  static_assert(idleMetrics.startWorkoutButton.width == 314);
+  static_assert(idleMetrics.startWorkoutButton.y == 310);
+  static_assert(ride_telemetry_layout::kRoundStartWorkoutIconSize == 34);
 #endif
   static_assert(ride_telemetry_layout::fits(
       navigationMetrics.startWorkoutButton, rideLayout.screenWidth,

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -2,6 +2,7 @@
 #include "../../lib/gui/src/destinationPickerLayout.hpp"
 #include "../../lib/gui/src/guiLayout.hpp"
 #include "../../lib/gui/src/mapTileTransition.hpp"
+#include "../../lib/gui/src/navigationContentMode.hpp"
 #include "../../lib/gui/src/rideMetricFontSelection.hpp"
 #include "../../lib/gui/src/rideTelemetryLayout.hpp"
 #include "../../lib/maps/src/mapLineStyle.hpp"
@@ -9,6 +10,11 @@
 #include <cassert>
 
 int main() {
+  static_assert(navigation_content_mode::forNavigationState(false) ==
+                navigation_content_mode::Mode::FavoriteDestinations);
+  static_assert(navigation_content_mode::forNavigationState(true) ==
+                navigation_content_mode::Mode::ActiveGuidance);
+
   map_tile_transition::State mapTransition;
   assert(!mapTransition.canReveal(false, false));
   mapTransition.begin();

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -61,6 +61,8 @@ int main() {
   static_assert(destination_picker_layout::bottomPadding(466, 466, 3) ==
                 186);
   static_assert(destination_picker_layout::bottomPadding(410, 502, 3) == 4);
+  static_assert(destination_picker_layout::fullScreenInset(466, 466) == 52);
+  static_assert(destination_picker_layout::fullScreenInset(410, 502) == 16);
   static_assert(!destination_picker_layout::needsScrolling(88 * 3, 3, 280));
   static_assert(destination_picker_layout::needsScrolling(116 * 3, 3, 280));
   static_assert(map_line_style::displayColor(1, 0xF567, 7, false) ==
@@ -116,7 +118,7 @@ int main() {
                     navigationMetrics.distance.bottom() ==
                 ride_telemetry_layout::kMetricRowGap);
   static_assert(navigationMetrics.startWorkoutButton.y -
-                    navigationMetrics.bottomLeft.bottom() ==
+                    navigationMetrics.bottomLeft.bottom() >=
                 ride_telemetry_layout::kStartWorkoutButtonGap);
   constexpr auto idleMetrics =
       ride_telemetry_layout::makeMetricPlacement(
@@ -127,8 +129,22 @@ int main() {
   static_assert(idleMetrics.distance.y == rideLayout.metrics[0].y);
   static_assert(idleMetrics.elapsed.y == rideLayout.metrics[1].y);
   static_assert(idleMetrics.startWorkoutButton.y -
+                    idleMetrics.distance.bottom() >=
+                ride_telemetry_layout::kStartWorkoutButtonGap);
+#if defined(WAVESHARE_AMOLED_206)
+  static_assert(idleMetrics.startWorkoutButton.y -
                     idleMetrics.distance.bottom() ==
                 ride_telemetry_layout::kStartWorkoutButtonGap);
+#else
+  static_assert(idleMetrics.startWorkoutButton.y ==
+                navigationMetrics.startWorkoutButton.y);
+  static_assert(idleMetrics.startWorkoutButton.bottom() ==
+                rideLayout.screenHeight -
+                    ride_telemetry_layout::kRoundStartWorkoutButtonBottomInset);
+  static_assert(idleMetrics.startWorkoutButton.x ==
+                ride_telemetry_layout::
+                    kRoundStartWorkoutButtonHorizontalInset);
+#endif
   static_assert(ride_telemetry_layout::fits(
       navigationMetrics.startWorkoutButton, rideLayout.screenWidth,
       rideLayout.screenHeight));


### PR DESCRIPTION
## What changed

- show the favorites picker full-screen on Navigation when guidance is inactive
- make Map + Navigation choose favorites or live guidance exclusively
- share the picker rendering while preserving destination request and loading behavior
- add a "Choose Destination" heading and round-screen-safe address insets
- lower the Start Workout button and add the shared rider/bike icon

## Why

Inactive navigation screens should offer useful destinations instead of placeholder guidance, and Map + Navigation should not expose duplicate inactive states. Controls and wrapped addresses should also remain comfortably inside the 1.75-inch round display.

## Validation

- `g++ -std=c++17 tools/tests/test_gui_layout.cpp` for Waveshare AMOLED 1.75 and 2.06 layouts
- `g++ -std=c++17 -Wall -Wextra -Werror tools/tests/test_destination_picker_protocol.cpp`
- `pio run -e WAVESHARE_AMOLED_175`

The latest UI-polish commit was flashed and boot-verified on the 1.75-inch device.
