### PR TITLE
Phase 1: add persistent display brightness control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,12 @@ jobs:
             tools/tests/test_power_metrics_schema.cpp \
             -o /tmp/test_power_metrics_schema
           /tmp/test_power_metrics_schema
+      - name: Display power and redraw policy host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_display_power_policy.cpp \
+            -o /tmp/test_display_power_policy
+          /tmp/test_display_power_policy
       - name: Two-finger Map zoom host tests
         run: |
           g++ -std=c++17 -Wall -Wextra -Werror \

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -459,7 +459,7 @@ Current setting IDs:
 | `9` | Map street width | Absolute rendered width is `1...24` px. The wire value remains `width - 4` (`-3...20`) so older apps that send a boost remain compatible. |
 | `10` | Map current-position marker scale | `1...5`; default is `2`, so the map position marker renders at twice its original size. The firmware shows a route-blue dot when no route is loaded and a route-blue arrow while navigating. Both shapes are rendered at their final display resolution. |
 | `11` | Tap to switch screens | `0` disabled, `1` enabled. When enabled, a short tap cycles the device through the enabled main screens. Map drags and long presses are ignored by this shortcut. |
-| `12` | Device brightness | `5...100` percent on supported hardware |
+| `12` | Device brightness | Whole-number percent. Firmware clamps the signed value to `5...100`, saves the normalized value in NVS, and applies it from the display task. First boot defaults to `100`; the saved value is restored across reboot and display sleep/wake. |
 | `13` | Enabled main screens mask | bit 0 Map, bit 1 Navigation, bit 2 Ride Stats, bit 3 Map + Navigation, bit 4 Battery Status. Invalid or empty masks fall back to all supported screens. Existing four-screen configurations enable Battery Status once during migration, after which it remains user-toggleable. |
 | `14` | Default main screen | `0` Map, `1` Navigation, `2` Ride Stats, `3` Map + Navigation, `4` Battery Status. Invalid or disabled defaults prefer Map + Navigation, then the first enabled fallback screen. |
 | `15` | Disconnected sleep timeout | seconds before deep sleep while not connected to the app: `60`, `120`, `300`, `600`; `0` disables automatic disconnected sleep. An unclaimed device waiting to be added applies a minimum 600-second registration grace period; `0` still disables automatic disconnected sleep. |
@@ -475,6 +475,12 @@ Current setting IDs:
 
 The settings list and the device's tap/PWR-button cycle use this screen order:
 Map + Navigation, Ride Stats, Map, Navigation, then Battery Status.
+
+Setting ID `12` has no application-level acknowledgement or readback packet.
+An acknowledged GATT write confirms transport delivery only, not persistence or
+panel application. The app retains the normalized value locally and sends it
+again after every authenticated reconnect. Brightness updates do not invalidate
+or rerender the map.
 
 Feature visibility toggles are authoritative for their classes. Detail level
 controls small-area density without overriding the visibility mask: high uses

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -1,7 +1,23 @@
 # Firmware battery-life hardware validation
 
-Status: **source-monitor baseline measurements pending**. Physical bring-up has
-passed on the available 1.75-inch target; 2.06-inch hardware is unavailable.
+Status: **implementation validation in progress; electrical measurements
+deferred**. Physical bring-up has passed on the available 1.75-inch target;
+2.06-inch hardware is unavailable.
+
+## Operator-approved validation scope
+
+On 2026-07-29, the operator chose not to block implementation on a source
+monitor or multimeter setup. The battery-life phases may continue with both
+firmware targets built and the available 1.75-inch device physically tested.
+The 2.06-inch target remains build-only until hardware is available.
+
+Practical battery use will be evaluated later by running controlled rides or
+bench scenarios from comparable battery starting states and observing battery
+depletion and elapsed runtime. Those observations can support practical runtime
+decisions, but coarse battery percentage must not be presented as a measured
+current curve or precise watt-hour saving. The source-monitor procedure below
+is retained as an optional higher-precision campaign, not an implementation
+gate.
 
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
@@ -276,10 +292,11 @@ Record values from the same run windows used for the electrical results.
 | AMOLED 1.75 | **No — pending** | Pending | No | No |
 | AMOLED 2.06 | **No — pending** | Pending | No | No |
 
-No later phase may claim measured savings until both targets have three
-repeatable baseline runs for the relevant comparison scenario and the observed
-difference exceeds measurement noise. Update this summary only after reviewing
-the raw traces and documenting exclusions.
+No phase may claim measured current or energy savings without trace-quality
+measurements whose observed difference exceeds measurement noise. Continuing
+implementation does not depend on that campaign. Later battery-depletion tests
+must report their starting state, elapsed runtime, scenario, and limitations
+without converting coarse percentages into precise electrical savings.
 
 ## Campaign review checklist
 

--- a/esp32/WAVESHARE_AMOLED_175_PORT.md
+++ b/esp32/WAVESHARE_AMOLED_175_PORT.md
@@ -70,7 +70,7 @@ Arduino_CO5300 *gfx = new Arduino_CO5300(bus, 39 /*RST*/, 0 /*rotation*/);
 ```
 
 **Key Functions:**
-- `setupDisplay()` – Initializes gfx, sets brightness to max
+- `setupDisplay()` – Initializes gfx and delegates saved-brightness restore to `DisplayPowerManager`
 - `setupLVGLforArduinoGFX()` – Creates LVGL 9 display, allocates PSRAM buffer (~43KB), registers flush callback
 - `my_disp_flush()` – Uses `gfx->draw16bitRGBBitmap()` for RGB565 output
 - `readTouch()` / `my_touchpad_read()` – CST9217 I2C touch driver (currently disabled via `DISABLE_TOUCH`)
@@ -162,7 +162,9 @@ Conditional compilation for Arduino_GFX:
 #endif
 ```
 
-Functions `tftOn()` / `tftOff()` now use `gfx->setBrightness()` and `gfx->displayOn()/Off()`.
+Functions `tftOn()` / `tftOff()` are compatibility adapters. On the AMOLED
+targets they delegate to `DisplayPowerManager`, which is the sole owner of
+CO5300 brightness and display on/off commands.
 
 #### [lib/tft/tft.hpp](file:///Users/chris/Documents/Workspace/esp32-bike-computer/IceNav-v3/lib/tft/tft.hpp)
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -11,6 +11,8 @@
 #include "ownership_button_policy.hpp"
 #include "device_screen_protocol.hpp"
 #include "gps_position_protocol.hpp"
+#include "map_setting_packet.hpp"
+#include "map_setting_redraw_policy.hpp"
 #include "map_profile_persistence.hpp"
 #include "transfer_control_dispatch.hpp"
 #include "workout_telemetry_protocol.hpp"
@@ -21,6 +23,9 @@
 #include "../gui/src/globalGuiDef.h"
 #include "../maps/src/maps.hpp"
 #include "../device_transfer/device_transfer_http.hpp"
+#ifdef USE_ARDUINO_GFX
+#include "../display_power/display_power.hpp"
+#endif
 #include "../firmware_metadata/firmware_metadata.hpp"
 #include "../firmware_update/firmware_update_http.hpp"
 #include "../map_transfer_http/map_transfer_http.hpp"
@@ -1999,6 +2004,21 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     Serial.printf("BLE Settings: tapToSwitchScreens = %d (saved)\n",
                   mapRenderSettings.tapToSwitchScreens);
     break;
+  case 12:
+#ifdef USE_ARDUINO_GFX
+    if (!displayPowerManager.requestUserBrightness(settingValue)) {
+      Serial.printf("BLE Settings: brightness persistence failed from %s\n",
+                    source == nullptr ? "unknown" : source);
+      return;
+    }
+#ifdef DISPLAY_POWER_DIAGNOSTICS
+    Serial.printf("BLE Settings: brightness = %u%% (saved, pending)\n",
+                  displayPowerManager.savedBrightnessPercent());
+#endif
+#else
+    Serial.println("BLE Settings: brightness unsupported on this target");
+#endif
+    return;
   case 13: {
     settingValue = device_screen_protocol::applyCompatibility(
         settingValue, mapRenderSettings.enabledScreensMask);
@@ -2045,7 +2065,7 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     Serial.println("BLE Settings: Reboot command received! Restarting...");
     delay(500);
     ESP.restart();
-    break;
+    return;
   case 6:
     mapRenderSettings.mapRotationMode =
         (uint8_t)std::min(std::max(settingValue, (int32_t)0), (int32_t)1);
@@ -2155,26 +2175,26 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
   default:
     Serial.printf("BLE Settings: Unknown setting ID %d from %s\n", settingId,
                   source == nullptr ? "unknown" : source);
-    break;
+    return;
   }
 
-  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
-  triggerMapRedraw();
+  if (map_setting_redraw_policy::invalidatesMap(settingId)) {
+    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
+    triggerMapRedraw();
+  }
 }
 
 static void handleMapSettingPayload(const uint8_t *data, size_t len,
                                     const char *source) {
   power_metrics::noteBlePacket(power_metrics::BlePacketClass::Settings);
-  if (data == nullptr || len < 5) {
-    Serial.printf("BLE: Rejected %s map setting: expected 5 bytes\n",
+  map_setting_packet::Packet packet;
+  if (!map_setting_packet::decode(data, len, packet)) {
+    Serial.printf("BLE: Rejected %s map setting: expected exactly 5 bytes\n",
                   source == nullptr ? "unknown" : source);
     return;
   }
 
-  uint8_t settingId = data[0];
-  int32_t settingValue;
-  memcpy(&settingValue, data + 1, sizeof(settingValue));
-  handleMapSetting(settingId, settingValue, source);
+  handleMapSetting(packet.settingId, packet.value, source);
 }
 
 static void processPendingMapInputs() {

--- a/esp32/lib/ble_navigation/map_setting_packet.hpp
+++ b/esp32/lib/ble_navigation/map_setting_packet.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace map_setting_packet {
+
+constexpr std::size_t kPacketSize = 5;
+
+struct Packet {
+  uint8_t settingId = 0;
+  int32_t value = 0;
+};
+
+inline bool decode(const uint8_t *data, std::size_t length, Packet &packet) {
+  if (data == nullptr || length != kPacketSize) {
+    return false;
+  }
+
+  packet.settingId = data[0];
+  const uint32_t rawValue = static_cast<uint32_t>(data[1]) |
+                            (static_cast<uint32_t>(data[2]) << 8) |
+                            (static_cast<uint32_t>(data[3]) << 16) |
+                            (static_cast<uint32_t>(data[4]) << 24);
+  static_assert(sizeof(rawValue) == sizeof(packet.value));
+  std::memcpy(&packet.value, &rawValue, sizeof(packet.value));
+  return true;
+}
+
+} // namespace map_setting_packet

--- a/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
+++ b/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+
+namespace map_setting_redraw_policy {
+
+constexpr bool invalidatesMap(uint8_t settingId) {
+  switch (settingId) {
+  case 1:
+  case 2:
+  case 3:
+  case 6:
+  case 7:
+  case 8:
+  case 9:
+  case 10:
+  case 16:
+  case 17:
+  case 18:
+  case 19:
+  case 20:
+  case 21:
+  case 22:
+    return true;
+  default:
+    return false;
+  }
+}
+
+} // namespace map_setting_redraw_policy

--- a/esp32/lib/display_power/display_power.cpp
+++ b/esp32/lib/display_power/display_power.cpp
@@ -1,0 +1,204 @@
+#include "display_power.hpp"
+
+#include "../panel/WAVESHARE_AMOLED_175.hpp"
+#include "../power_metrics/power_metrics.hpp"
+
+#include <Arduino.h>
+#include <Arduino_GFX_Library.h>
+#include <Preferences.h>
+
+namespace {
+
+constexpr char kPreferencesNamespace[] = "deviceSettings";
+constexpr char kBrightnessKey[] = "brightnessPct";
+
+} // namespace
+
+DisplayPowerManager displayPowerManager;
+
+bool DisplayPowerManager::lock() const {
+  return mutex_ != nullptr &&
+         xSemaphoreTake(mutex_, pdMS_TO_TICKS(250)) == pdTRUE;
+}
+
+void DisplayPowerManager::unlock() const { xSemaphoreGive(mutex_); }
+
+bool DisplayPowerManager::begin() {
+  if (initialized_) {
+    return true;
+  }
+
+  mutex_ = xSemaphoreCreateMutexStatic(&mutexStorage_);
+  if (mutex_ == nullptr) {
+    Serial.println("DisplayPower: failed to create state mutex");
+    return false;
+  }
+
+  Preferences preferences;
+  bool hasSavedValue = false;
+  uint8_t savedValue = display_power::kDefaultBrightnessPercent;
+  if (preferences.begin(kPreferencesNamespace, false)) {
+    hasSavedValue = preferences.isKey(kBrightnessKey);
+    if (hasSavedValue) {
+      savedValue = preferences.getUChar(
+          kBrightnessKey, display_power::kDefaultBrightnessPercent);
+    }
+    preferences.end();
+  } else {
+    Serial.println("DisplayPower: failed to open device settings NVS");
+  }
+
+  policy_.restoreSavedBrightness(hasSavedValue, savedValue);
+  savedBrightnessPersisted_ =
+      hasSavedValue && display_power::isBrightnessPercentInRange(savedValue);
+  initialized_ = true;
+  return true;
+}
+
+bool DisplayPowerManager::requestUserBrightness(int32_t requestedPercent) {
+  const uint8_t normalized =
+      display_power::clampBrightnessPercent(requestedPercent);
+  if (!initialized_ && !begin()) {
+    return false;
+  }
+  if (!lock()) {
+    return false;
+  }
+
+  if (savedBrightnessPersisted_ &&
+      policy_.savedBrightnessPercent() == normalized) {
+    unlock();
+    return true;
+  }
+
+  Preferences preferences;
+  const bool opened = preferences.begin(kPreferencesNamespace, false);
+  const bool persisted =
+      opened && preferences.putUChar(kBrightnessKey, normalized) == 1;
+  if (opened) {
+    preferences.end();
+  }
+  if (persisted) {
+    policy_.requestUserBrightness(normalized);
+    savedBrightnessPersisted_ = true;
+  }
+  unlock();
+
+  if (!persisted) {
+    Serial.println("DisplayPower: failed to persist brightness");
+  }
+  return persisted;
+}
+
+void DisplayPowerManager::requestState(display_power::State state) {
+  if (!initialized_ && !begin()) {
+    return;
+  }
+  if (!lock()) {
+    return;
+  }
+  policy_.requestState(state);
+  unlock();
+}
+
+display_power::State DisplayPowerManager::state() const {
+  if (!lock()) {
+    return display_power::State::Active;
+  }
+  const display_power::State value = policy_.state();
+  unlock();
+  return value;
+}
+
+uint8_t DisplayPowerManager::savedBrightnessPercent() const {
+  if (!lock()) {
+    return display_power::kDefaultBrightnessPercent;
+  }
+  const uint8_t value = policy_.savedBrightnessPercent();
+  unlock();
+  return value;
+}
+
+uint8_t DisplayPowerManager::effectiveBrightnessPercent() const {
+  if (!lock()) {
+    return display_power::kDefaultBrightnessPercent;
+  }
+  const uint8_t value = policy_.effectiveBrightnessPercent();
+  unlock();
+  return value;
+}
+
+bool DisplayPowerManager::initializePanel() {
+  if (gfx == nullptr) {
+    return false;
+  }
+
+  uint8_t requested = display_power::panelCommandForPercent(
+      display_power::kDefaultBrightnessPercent);
+  uint8_t effective = requested;
+  if (lock()) {
+    requested = display_power::panelCommandForPercent(
+        policy_.savedBrightnessPercent());
+    effective = policy_.effectivePanelCommand();
+    gfx->displayOn();
+    delay(50);
+    gfx->setBrightness(effective);
+    policy_.markPanelInitialized();
+    unlock();
+    power_metrics::noteDisplayState(power_metrics::DisplayState::On, requested,
+                                    effective);
+    return true;
+  }
+
+  // Keep the panel usable even if state tracking could not be initialized.
+  gfx->displayOn();
+  delay(50);
+  gfx->setBrightness(effective);
+  power_metrics::noteDisplayState(power_metrics::DisplayState::On, requested,
+                                  effective);
+  return false;
+}
+
+bool DisplayPowerManager::applyPendingPanelChange() {
+  if (gfx == nullptr || !lock()) {
+    return false;
+  }
+
+  display_power::PanelUpdate update;
+  const bool hasUpdate = policy_.takePendingPanelUpdate(update);
+  const uint8_t requested = display_power::panelCommandForPercent(
+      policy_.savedBrightnessPercent());
+  unlock();
+  if (!hasUpdate) {
+    return false;
+  }
+
+  if (update.turnDisplayOff) {
+    gfx->setBrightness(0);
+    gfx->displayOff();
+  } else {
+    if (update.turnDisplayOn) {
+      gfx->displayOn();
+      delay(50);
+    }
+    if (update.setBrightness) {
+      gfx->setBrightness(update.brightnessCommand);
+    }
+  }
+
+  power_metrics::noteDisplayState(
+      update.state == display_power::State::Off
+          ? power_metrics::DisplayState::Off
+          : power_metrics::DisplayState::On,
+      requested, update.brightnessCommand);
+  return true;
+}
+
+bool DisplayPowerManager::takeFullRefreshRequired() {
+  if (!lock()) {
+    return false;
+  }
+  const bool required = policy_.takeFullRefreshRequired();
+  unlock();
+  return required;
+}

--- a/esp32/lib/display_power/display_power.hpp
+++ b/esp32/lib/display_power/display_power.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "display_power_policy.hpp"
+
+#include <cstdint>
+#include <freertos/FreeRTOS.h>
+#include <freertos/semphr.h>
+
+class DisplayPowerManager {
+public:
+  bool begin();
+  bool requestUserBrightness(int32_t requestedPercent);
+  void requestState(display_power::State state);
+
+  display_power::State state() const;
+  uint8_t savedBrightnessPercent() const;
+  uint8_t effectiveBrightnessPercent() const;
+
+  bool initializePanel();
+  bool applyPendingPanelChange();
+  bool takeFullRefreshRequired();
+
+private:
+  bool lock() const;
+  void unlock() const;
+
+  mutable StaticSemaphore_t mutexStorage_{};
+  mutable SemaphoreHandle_t mutex_ = nullptr;
+  display_power::Policy policy_;
+  bool savedBrightnessPersisted_ = false;
+  bool initialized_ = false;
+};
+
+extern DisplayPowerManager displayPowerManager;

--- a/esp32/lib/display_power/display_power_policy.hpp
+++ b/esp32/lib/display_power/display_power_policy.hpp
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <cstdint>
+
+namespace display_power {
+
+constexpr uint8_t kMinimumBrightnessPercent = 5;
+constexpr uint8_t kMaximumBrightnessPercent = 100;
+constexpr uint8_t kDefaultBrightnessPercent = 100;
+constexpr uint8_t kDefaultDimmedBrightnessPercent = 20;
+
+constexpr bool isBrightnessPercentInRange(int32_t value) {
+  return value >= kMinimumBrightnessPercent &&
+         value <= kMaximumBrightnessPercent;
+}
+
+constexpr uint8_t clampBrightnessPercent(int32_t value) {
+  return value < kMinimumBrightnessPercent
+             ? kMinimumBrightnessPercent
+             : (value > kMaximumBrightnessPercent
+                    ? kMaximumBrightnessPercent
+                    : static_cast<uint8_t>(value));
+}
+
+constexpr uint8_t panelCommandForPercent(uint8_t percent) {
+  const uint16_t clamped = clampBrightnessPercent(percent);
+  return static_cast<uint8_t>((clamped * 255u + 50u) / 100u);
+}
+
+enum class State : uint8_t {
+  Active = 0,
+  Dimmed,
+  Off,
+};
+
+struct PanelUpdate {
+  State state = State::Active;
+  uint8_t brightnessCommand = 255;
+  bool turnDisplayOn = false;
+  bool turnDisplayOff = false;
+  bool setBrightness = false;
+};
+
+class Policy {
+public:
+  void restoreSavedBrightness(bool hasSavedValue, int32_t savedValue) {
+    savedBrightnessPercent_ =
+        hasSavedValue ? clampBrightnessPercent(savedValue)
+                      : kDefaultBrightnessPercent;
+    recomputePending();
+  }
+
+  void requestUserBrightness(int32_t requestedPercent) {
+    savedBrightnessPercent_ = clampBrightnessPercent(requestedPercent);
+    recomputePending();
+  }
+
+  void requestState(State state) {
+    requestedState_ = state;
+    recomputePending();
+  }
+
+  State state() const { return requestedState_; }
+  uint8_t savedBrightnessPercent() const { return savedBrightnessPercent_; }
+
+  uint8_t effectiveBrightnessPercent() const {
+    if (requestedState_ == State::Off) {
+      return 0;
+    }
+    if (requestedState_ == State::Dimmed &&
+        savedBrightnessPercent_ > kDefaultDimmedBrightnessPercent) {
+      return kDefaultDimmedBrightnessPercent;
+    }
+    return savedBrightnessPercent_;
+  }
+
+  uint8_t effectivePanelCommand() const {
+    const uint8_t percent = effectiveBrightnessPercent();
+    return percent == 0 ? 0 : panelCommandForPercent(percent);
+  }
+
+  void markPanelInitialized() {
+    panelInitialized_ = true;
+    appliedState_ = requestedState_;
+    appliedBrightnessCommand_ = effectivePanelCommand();
+    pendingPanelChange_ = false;
+    fullRefreshRequired_ = false;
+  }
+
+  bool takePendingPanelUpdate(PanelUpdate &update) {
+    if (!panelInitialized_ || !pendingPanelChange_) {
+      return false;
+    }
+
+    const uint8_t command = effectivePanelCommand();
+    update.state = requestedState_;
+    update.brightnessCommand = command;
+    update.turnDisplayOn =
+        appliedState_ == State::Off && requestedState_ != State::Off;
+    update.turnDisplayOff =
+        appliedState_ != State::Off && requestedState_ == State::Off;
+    update.setBrightness =
+        requestedState_ != State::Off &&
+        (update.turnDisplayOn || command != appliedBrightnessCommand_);
+
+    if (update.turnDisplayOn) {
+      fullRefreshRequired_ = true;
+    }
+
+    appliedState_ = requestedState_;
+    appliedBrightnessCommand_ = command;
+    pendingPanelChange_ = false;
+    return update.turnDisplayOn || update.turnDisplayOff ||
+           update.setBrightness;
+  }
+
+  bool takeFullRefreshRequired() {
+    const bool required = fullRefreshRequired_;
+    fullRefreshRequired_ = false;
+    return required;
+  }
+
+private:
+  void recomputePending() {
+    if (!panelInitialized_) {
+      pendingPanelChange_ = true;
+      return;
+    }
+    pendingPanelChange_ =
+        requestedState_ != appliedState_ ||
+        (requestedState_ != State::Off &&
+         effectivePanelCommand() != appliedBrightnessCommand_);
+  }
+
+  uint8_t savedBrightnessPercent_ = kDefaultBrightnessPercent;
+  State requestedState_ = State::Active;
+  State appliedState_ = State::Off;
+  uint8_t appliedBrightnessCommand_ = 0;
+  bool panelInitialized_ = false;
+  bool pendingPanelChange_ = true;
+  bool fullRefreshRequired_ = false;
+};
+
+} // namespace display_power

--- a/esp32/lib/gui/src/deviceSettingsScr.cpp
+++ b/esp32/lib/gui/src/deviceSettingsScr.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "deviceSettingsScr.hpp"
+#ifdef USE_ARDUINO_GFX
+#include "../../display_power/display_power.hpp"
+#endif
 
 lv_obj_t *deviceSettingsScreen; // Device Settings Screen
 
@@ -27,7 +30,9 @@ static void deviceSettingsEvent(lv_event_t *event) {
     saveGPSUpdateRate(gpsUpdate);
   }
   if (strcmp(option, "back") == 0) {
+#ifndef USE_ARDUINO_GFX
     cfg.saveUInt(PKEYS::KDEF_BRIGT, defBright);
+#endif
     lv_screen_load(settingsScreen);
   }
 }
@@ -39,8 +44,12 @@ static void deviceSettingsEvent(lv_event_t *event) {
  */
 static void brightnessEvent(lv_event_t *e) {
   lv_obj_t *obj = (lv_obj_t *)lv_event_get_target(e);
+#ifdef USE_ARDUINO_GFX
+  displayPowerManager.requestUserBrightness(lv_slider_get_value(obj));
+#else
   defBright = lv_slider_get_value(obj);
   tftOn(defBright);
+#endif
 }
 
 /**
@@ -182,8 +191,14 @@ void createDeviceSettingsScr() {
   lv_obj_add_event_cb(btn, upgradeEvent, LV_EVENT_CLICKED, NULL);
 
   // Brightness Slider
+#ifdef USE_ARDUINO_GFX
+  createBrightSlider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5,
+                     100, displayPowerManager.savedBrightnessPercent(),
+                     brightnessEvent, LV_EVENT_VALUE_CHANGED);
+#else
   createBrightSlider(deviceSettingsOptions, LV_SYMBOL_SETTINGS, "Brightness", 5,
                      255, defBright, brightnessEvent, LV_EVENT_VALUE_CHANGED);
+#endif
 
   // Back button
   btn = lv_btn_create(deviceSettingsScreen);

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -6,6 +6,7 @@
 
 #include "WAVESHARE_AMOLED_175.hpp"
 #ifdef USE_ARDUINO_GFX
+#include "../display_power/display_power.hpp"
 #include <Arduino_GFX_Library.h>
 #include <lvgl.h>
 #endif
@@ -983,12 +984,12 @@ void setupDisplay() {
   // 2.06-inch target remains native.
   applyCo5300Rotation(rotation);
 
-  // Turn on display and set brightness (CRITICAL for AMOLED!)
+  // DisplayPowerManager loads the saved percentage before panel init and owns
+  // every later brightness/off/restore transition.
   Serial.println("Turning on display and setting brightness...");
-  gfx->displayOn();
-  delay(50);
-  gfx->setBrightness(255); // Maximum brightness 0-255
-  power_metrics::noteDisplayState(power_metrics::DisplayState::On, 255, 255);
+  if (!displayPowerManager.initializePanel()) {
+    Serial.println("DisplayPower: panel state tracking unavailable");
+  }
   delay(50);
 
 #ifdef WAVESHARE_DISPLAY_TEST

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -7,6 +7,9 @@
  */
 
 #include "power.hpp"
+#ifdef USE_ARDUINO_GFX
+#include "../display_power/display_power.hpp"
+#endif
 #include "power_metrics.hpp"
 #ifdef USE_ARDUINO_GFX
 #include <Arduino_GFX_Library.h>
@@ -90,12 +93,8 @@ void Power::powerOffPeripherals() {
   tftOff();
   tft.fillScreen(TFT_BLACK);
 #else
-  // Arduino_GFX: turn off display
-  if (gfx) {
-    gfx->displayOff();
-    gfx->fillScreen(0x0000);
-    power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 0, 0);
-  }
+  displayPowerManager.requestState(display_power::State::Off);
+  displayPowerManager.applyPendingPanelChange();
 #endif
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(false);
@@ -117,12 +116,11 @@ void Power::deviceSuspend() {
   powerLightSleep();
   tftOn(brightness);
 #else
-  // Arduino_GFX: simplified suspend without brightness control
+  const display_power::State resumeState = displayPowerManager.state();
   lv_msgbox_close(powerMsg);
   lv_refr_now(display);
-  if (gfx)
-    gfx->displayOff();
-  power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 255, 0);
+  displayPowerManager.requestState(display_power::State::Off);
+  displayPowerManager.applyPendingPanelChange();
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   waveshare_board::axp2101::setDisplayPower(false);
 #endif
@@ -131,11 +129,8 @@ void Power::deviceSuspend() {
   waveshare_board::axp2101::setDisplayPower(true);
   delay(50);
 #endif
-  if (gfx) {
-    gfx->displayOn();
-    gfx->setBrightness(255);
-    power_metrics::noteDisplayState(power_metrics::DisplayState::On, 255, 255);
-  }
+  displayPowerManager.requestState(resumeState);
+  displayPowerManager.applyPendingPanelChange();
 #endif
   while (digitalRead(BOARD_BOOT_PIN) != 1) {
     delay(5);

--- a/esp32/lib/tft/tft.cpp
+++ b/esp32/lib/tft/tft.cpp
@@ -10,7 +10,7 @@
 #include "power_metrics.hpp"
 
 #ifdef USE_ARDUINO_GFX
-#include <Arduino_GFX_Library.h>
+#include "display_power.hpp"
 #endif
 
 #ifndef USE_ARDUINO_GFX
@@ -30,18 +30,21 @@ extern Storage storage;
 void tftOn(uint8_t brightness)
 {
 #ifdef USE_ARDUINO_GFX
-  // For CO5300 AMOLED - use Arduino_GFX methods
-  gfx->displayOn();
-  delay(50);
-  gfx->setBrightness(brightness);
+  // Compatibility adapter for legacy callers. DisplayPowerManager remains the
+  // only owner that issues CO5300 brightness and display-state commands.
+  const int32_t percent =
+      (static_cast<uint32_t>(brightness) * 100u + 127u) / 255u;
+  displayPowerManager.requestUserBrightness(percent);
+  displayPowerManager.requestState(display_power::State::Active);
+  displayPowerManager.applyPendingPanelChange();
 #else
   // For other displays (ILI9488, etc.) - use LovyanGFX
   tft.writecommand(0x11);  // Sleep Out
   delay(120);
   tft.setBrightness(brightness);
-#endif
   power_metrics::noteDisplayState(power_metrics::DisplayState::On, brightness,
                                   brightness);
+#endif
 }
 
 /**
@@ -51,15 +54,14 @@ void tftOn(uint8_t brightness)
 void tftOff()
 {
 #ifdef USE_ARDUINO_GFX
-  // For CO5300 AMOLED - use Arduino_GFX methods
-  gfx->setBrightness(0);
-  gfx->displayOff();
+  displayPowerManager.requestState(display_power::State::Off);
+  displayPowerManager.applyPendingPanelChange();
 #else
   // For other displays (ILI9488, etc.) - use LovyanGFX
   tft.setBrightness(0);
   tft.writecommand(0x10);  // Sleep In
-#endif
   power_metrics::noteDisplayState(power_metrics::DisplayState::Off, 0, 0);
+#endif
 }
 
 /**

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -68,6 +68,9 @@ extern xSemaphoreHandle gpsMutex;
 
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#include "display_power.hpp"
+#endif
 #include "disconnected_shutdown_policy.hpp"
 #include "ownership_button_policy.hpp"
 #include "power_metrics.hpp"
@@ -701,6 +704,9 @@ void setup() {
   }
 #endif
   power_metrics::begin();
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  displayPowerManager.begin();
+#endif
   delay(2000);              // Give time for USB CDC to attach
   log_i("Starting Setup...");
   Serial.printf("Reset reason: CPU0=%d CPU1=%d\n", esp_reset_reason(),
@@ -989,6 +995,13 @@ void loop() {
   // Sample the screen-cycle button before LVGL can start a synchronous vector
   // redraw. updateMainScreen() also defers while the raw input is active.
   processWaveshareBootButton();
+#endif
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  displayPowerManager.applyPendingPanelChange();
+  if (displayPowerManager.takeFullRefreshRequired()) {
+    lv_obj_invalidate(lv_screen_active());
+  }
 #endif
 
   if (!waitScreenRefresh) {

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -1,0 +1,101 @@
+#include "../../lib/display_power/display_power_policy.hpp"
+#include "../../lib/ble_navigation/map_setting_packet.hpp"
+#include "../../lib/ble_navigation/map_setting_redraw_policy.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <initializer_list>
+
+int main() {
+  using display_power::PanelUpdate;
+  using display_power::Policy;
+  using display_power::State;
+
+  static_assert(!display_power::isBrightnessPercentInRange(4));
+  static_assert(display_power::isBrightnessPercentInRange(5));
+  static_assert(display_power::isBrightnessPercentInRange(100));
+  static_assert(!display_power::isBrightnessPercentInRange(101));
+  static_assert(display_power::clampBrightnessPercent(-1) == 5);
+  static_assert(display_power::clampBrightnessPercent(5) == 5);
+  static_assert(display_power::clampBrightnessPercent(75) == 75);
+  static_assert(display_power::clampBrightnessPercent(101) == 100);
+  static_assert(display_power::clampBrightnessPercent(INT32_MIN) == 5);
+  static_assert(display_power::clampBrightnessPercent(INT32_MAX) == 100);
+  static_assert(display_power::panelCommandForPercent(5) == 13);
+  static_assert(display_power::panelCommandForPercent(25) == 64);
+  static_assert(display_power::panelCommandForPercent(50) == 128);
+  static_assert(display_power::panelCommandForPercent(75) == 191);
+  static_assert(display_power::panelCommandForPercent(100) == 255);
+
+  Policy firstBoot;
+  firstBoot.restoreSavedBrightness(false, 0);
+  assert(firstBoot.savedBrightnessPercent() == 100);
+  assert(firstBoot.effectivePanelCommand() == 255);
+
+  Policy restored;
+  restored.restoreSavedBrightness(true, 75);
+  assert(restored.savedBrightnessPercent() == 75);
+  assert(restored.effectivePanelCommand() == 191);
+  restored.markPanelInitialized();
+
+  restored.requestUserBrightness(50);
+  PanelUpdate update;
+  assert(restored.takePendingPanelUpdate(update));
+  assert(!update.turnDisplayOn);
+  assert(!update.turnDisplayOff);
+  assert(update.setBrightness);
+  assert(update.brightnessCommand == 128);
+
+  restored.requestState(State::Dimmed);
+  assert(restored.takePendingPanelUpdate(update));
+  assert(update.brightnessCommand == 51);
+
+  restored.requestUserBrightness(5);
+  assert(restored.takePendingPanelUpdate(update));
+  assert(update.brightnessCommand == 13);
+
+  restored.requestState(State::Off);
+  assert(restored.takePendingPanelUpdate(update));
+  assert(update.turnDisplayOff);
+  assert(update.brightnessCommand == 0);
+  restored.requestUserBrightness(90);
+  assert(!restored.takePendingPanelUpdate(update));
+
+  restored.requestState(State::Active);
+  assert(restored.takePendingPanelUpdate(update));
+  assert(update.turnDisplayOn);
+  assert(update.setBrightness);
+  assert(update.brightnessCommand == 230);
+  assert(restored.takeFullRefreshRequired());
+  assert(!restored.takeFullRefreshRequired());
+
+  for (uint8_t id : {uint8_t{1}, uint8_t{2}, uint8_t{3}, uint8_t{6},
+                     uint8_t{7}, uint8_t{8}, uint8_t{9}, uint8_t{10},
+                     uint8_t{16}, uint8_t{17}, uint8_t{18}, uint8_t{19},
+                     uint8_t{20}, uint8_t{21}, uint8_t{22}}) {
+    assert(map_setting_redraw_policy::invalidatesMap(id));
+  }
+  for (uint8_t id : {uint8_t{4}, uint8_t{5}, uint8_t{11}, uint8_t{12},
+                     uint8_t{13}, uint8_t{14}, uint8_t{15}, uint8_t{23},
+                     uint8_t{24}, uint8_t{255}}) {
+    assert(!map_setting_redraw_policy::invalidatesMap(id));
+  }
+
+  map_setting_packet::Packet packet;
+  const uint8_t positivePacket[] = {12, 75, 0, 0, 0};
+  assert(map_setting_packet::decode(positivePacket, sizeof(positivePacket),
+                                    packet));
+  assert(packet.settingId == 12);
+  assert(packet.value == 75);
+
+  const uint8_t negativePacket[] = {9, 0xFD, 0xFF, 0xFF, 0xFF};
+  assert(map_setting_packet::decode(negativePacket, sizeof(negativePacket),
+                                    packet));
+  assert(packet.settingId == 9);
+  assert(packet.value == -3);
+  assert(!map_setting_packet::decode(nullptr, 5, packet));
+  assert(!map_setting_packet::decode(positivePacket, 4, packet));
+  assert(!map_setting_packet::decode(positivePacket, 6, packet));
+
+  return 0;
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -177,6 +177,11 @@ enum DeviceBLEProtocol {
         min(max(width, 1), 24)
     }
 
+    static func normalizedBrightnessPercent(_ value: Double) -> Double {
+        guard value.isFinite else { return 100 }
+        return min(max(value.rounded(), 5), 100)
+    }
+
     static func legacyStreetWidthBoost(fromAbsoluteWidth width: Int32) -> Int32 {
         min(max(width, 1), 24) - defaultStreetWidth
     }
@@ -889,7 +894,9 @@ class BLEManager: NSObject, ObservableObject {
             defaults.set(defaultDeviceScreen.rawValue, forKey: SettingsKeys.defaultDeviceScreen)
             defaults.set(true, forKey: SettingsKeys.defaultDeviceScreenMigrated)
         }
-        deviceBrightnessPercent = defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
+        deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
+            defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
+        )
         disconnectedSleepTimeout = DisconnectedSleepTimeout.normalized(
             rawValue: defaults.object(forKey: SettingsKeys.disconnectedSleepTimeoutSeconds) as? Int ?? DisconnectedSleepTimeout.twoMinutes.rawValue
         )
@@ -1129,6 +1136,9 @@ class BLEManager: NSObject, ObservableObject {
         )
         defaults.set(enabledDeviceScreensMask, forKey: SettingsKeys.enabledDeviceScreensMask)
         defaults.set(defaultDeviceScreen.rawValue, forKey: SettingsKeys.defaultDeviceScreen)
+        deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
+            deviceBrightnessPercent
+        )
         defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
         defaults.set(disconnectedSleepTimeout.rawValue, forKey: SettingsKeys.disconnectedSleepTimeoutSeconds)
         defaults.set(Int(selectedDeviceSound.rawValue), forKey: SettingsKeys.selectedDeviceSound)
@@ -1990,6 +2000,11 @@ class BLEManager: NSObject, ObservableObject {
     /// Persist and send a runtime map setting to ESP32 when supported.
     func sendSetting(id: UInt8, value: Int32,
                      synchronizeLegacyProfile: Bool = true) {
+        if id == DeviceBLEProtocol.brightnessSettingID {
+            deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
+                Double(value)
+            )
+        }
         if hasReceivedDeviceCapabilities,
            !supportsIndependentMapProfiles,
            !isSendingNegotiatedMapProfiles,
@@ -2004,7 +2019,9 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
         let deviceValue: Int32
-        if id == 9 || id == DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID {
+        if id == DeviceBLEProtocol.brightnessSettingID {
+            deviceValue = Int32(deviceBrightnessPercent)
+        } else if id == 9 || id == DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID {
             deviceValue = DeviceBLEProtocol.legacyStreetWidthBoost(
                 fromAbsoluteWidth: value
             )
@@ -2966,6 +2983,10 @@ class BLEManager: NSObject, ObservableObject {
             priorityMaxCount: priorityMaxCount
         )
     }
+
+    func sendInitialDeviceSettingsAfterAuthenticationForTesting() {
+        sendInitialDeviceSettingsAfterAuthentication()
+    }
 #endif
 
     func installPowerButtonHonkRetryTiming(
@@ -3751,13 +3772,22 @@ class BLEManager: NSObject, ObservableObject {
         log("BLE peripheral authenticated")
         enqueueAuthMessage("GET_NAME")
         requestDeviceCapabilities()
-        sendSetting(id: 6, value: Int32(mapRotationMode))
-        sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
-        sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(deviceBrightnessPercent))
-        sendSetting(id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
-                    value: disconnectedSleepTimeout.settingValue)
+        sendInitialDeviceSettingsAfterAuthentication()
         requestDeviceTransferStatus()
         requestMapTransferStatus()
+    }
+
+    private func sendInitialDeviceSettingsAfterAuthentication() {
+        sendSetting(id: 6, value: Int32(mapRotationMode))
+        sendSetting(id: 11, value: tapToSwitchScreens ? 1 : 0)
+        sendSetting(
+            id: DeviceBLEProtocol.brightnessSettingID,
+            value: Int32(deviceBrightnessPercent)
+        )
+        sendSetting(
+            id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
+            value: disconnectedSleepTimeout.settingValue
+        )
     }
 
     private func enqueueNavigationWrite(

--- a/ios-app/BikeComputerTests/CyclingSensorTests.swift
+++ b/ios-app/BikeComputerTests/CyclingSensorTests.swift
@@ -521,7 +521,10 @@ private struct CyclingSensorTestSuite {
             "scheduled-expiry fixture starts with a candidate"
         )
 
-        try? await Task.sleep(nanoseconds: 100_000_000)
+        let expiryDeadline = Date().addingTimeInterval(1)
+        while !coordinator.candidates.isEmpty && Date() < expiryDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
         sensorAssert(
             coordinator.candidates.isEmpty,
             "candidate expires on wall-clock time without another presentation"

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -606,6 +606,7 @@ struct NavigationProtocolTests {
         testBLEManagerReassemblesChunkedMapTransferStatus()
         testBLEManagerParsesDeviceTransferStatus()
         testBLEManagerSendsBrightnessFallbackSetting()
+        testBLEManagerResendsBrightnessAfterAuthentication()
         testBLEManagerSendsDisconnectedSleepTimeoutSetting()
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
@@ -8595,6 +8596,10 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.legacyStreetWidthBoost(fromAbsoluteWidth: 1), -3, "one-pixel streets retain the legacy wire encoding")
         assertEqual(DeviceBLEProtocol.legacyStreetWidthBoost(fromAbsoluteWidth: 4), 0, "default street width uses a zero wire boost")
         assertEqual(DeviceBLEProtocol.brightnessSettingID, 12, "brightness uses firmware setting ID 12")
+        assertEqual(DeviceBLEProtocol.normalizedBrightnessPercent(-1), 5, "brightness clamps below the device range")
+        assertEqual(DeviceBLEProtocol.normalizedBrightnessPercent(65.4), 65, "brightness uses whole-number percent")
+        assertEqual(DeviceBLEProtocol.normalizedBrightnessPercent(101), 100, "brightness clamps above the device range")
+        assertEqual(DeviceBLEProtocol.normalizedBrightnessPercent(.nan), 100, "invalid stored brightness restores the compatibility default")
         assertEqual(DeviceBLEProtocol.enabledScreensSettingID, 13, "enabled screens use firmware setting ID 13")
         assertEqual(DeviceBLEProtocol.defaultScreenSettingID, 14, "default screen uses firmware setting ID 14")
         assertEqual(DeviceBLEProtocol.disconnectedSleepTimeoutSettingID, 15, "disconnected sleep timeout uses firmware setting ID 15")
@@ -11712,6 +11717,42 @@ struct NavigationProtocolTests {
 
         let reloaded = BLEManager()
         assertEqual(Int(reloaded.deviceBrightnessPercent), 65, "brightness setting persists for UI display")
+        defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+    }
+
+    static func testBLEManagerResendsBrightnessAfterAuthentication() {
+        let defaults = UserDefaults.standard
+        defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.deviceBrightnessPercent = 70
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendInitialDeviceSettingsAfterAuthenticationForTesting()
+
+        let brightnessPackets = sentPackets.filter {
+            $0.count == 9 &&
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.settingsFallbackPrefix &&
+            $0[4] == DeviceBLEProtocol.brightnessSettingID
+        }
+        assertEqual(brightnessPackets.count, 1,
+                    "authenticated reconnect sends brightness exactly once")
+        let valueBytes = Array(brightnessPackets[0][5..<9])
+        let value = Int32(valueBytes[0])
+            | (Int32(valueBytes[1]) << 8)
+            | (Int32(valueBytes[2]) << 16)
+            | (Int32(valueBytes[3]) << 24)
+        assertEqual(value, 70,
+                    "authenticated reconnect restores the saved brightness")
         defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
     }
 


### PR DESCRIPTION
## Summary

Implements Phase 1 of the battery-life plan by making display brightness a persistent 5-100% device setting and introducing one display-power owner for brightness, dim, off, and restore transitions.

The firmware now applies panel changes from the main/LVGL context, restores saved brightness across boot and wake, avoids redundant NVS writes on reconnect, and no longer rerenders the map for brightness or other non-visual settings. The iOS app normalizes brightness values and resends the saved value after authentication. Protocol and hardware-validation documentation are updated accordingly.

The branch also stabilizes an existing asynchronous cycling-sensor expiry test that repeatedly failed on GitHub runners despite passing locally: it now waits up to a bounded one-second deadline instead of assuming main-actor scheduling completes within exactly 100 ms. Production sensor behavior is unchanged.

This is a stacked draft based on `agent/battery-life-phase-0-instrumentation` / PR #152. Electrical measurements are intentionally deferred; later validation will use controlled battery-depletion/runtime observations without claiming precise current or energy savings.

## Validation

- `g++ -std=c++17 -Wall -Wextra -Werror esp32/tools/tests/test_display_power_policy.cpp` — passed
- `./ios-app/scripts/run-navigation-tests.sh` — passed
- `pio run -e WAVESHARE_AMOLED_175` — passed
- `pio run -e WAVESHARE_AMOLED_175_POWER_METRICS` — passed
- `pio run -e WAVESHARE_AMOLED_206` — passed
- `pio run -e WAVESHARE_AMOLED_206_POWER_METRICS` — passed
- `git diff --check` — passed
- Deep review converged with no unresolved P0/P1/P2 findings
- Physical 1.75-inch brightness sweep, reboot, suspend/wake, and deep-sleep/wake restore — pending USB reconnection
- Physical 2.06-inch validation — deferred until hardware is available

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
