### PR TITLE
Reduce static UI redraws and add production firmware profiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,10 @@ jobs:
         target:
           - WAVESHARE_AMOLED_175
           - WAVESHARE_AMOLED_175_POWER_METRICS
+          - WAVESHARE_AMOLED_175_PRODUCTION
           - WAVESHARE_AMOLED_206
           - WAVESHARE_AMOLED_206_POWER_METRICS
+          - WAVESHARE_AMOLED_206_PRODUCTION
     defaults:
       run:
         working-directory: esp32
@@ -118,6 +120,11 @@ jobs:
             tools/tests/test_display_power_policy.cpp \
             -o /tmp/test_display_power_policy
           /tmp/test_display_power_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_ui_update_policy.cpp \
+            -o /tmp/test_ui_update_policy
+          /tmp/test_ui_update_policy
+          python tools/tests/test_firmware_profile_config.py
       - name: Two-finger Map zoom host tests
         run: |
           g++ -std=c++17 -Wall -Wextra -Werror \

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -17,9 +17,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - WAVESHARE_AMOLED_175
-          - WAVESHARE_AMOLED_206
+        include:
+          - target: WAVESHARE_AMOLED_175
+            environment: WAVESHARE_AMOLED_175_PRODUCTION
+          - target: WAVESHARE_AMOLED_206
+            environment: WAVESHARE_AMOLED_206_PRODUCTION
     defaults:
       run:
         working-directory: esp32
@@ -31,11 +33,11 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
-        run: pio run -e "${{ matrix.target }}"
+        run: pio run -e "${{ matrix.environment }}"
       - name: Stage firmware image
         run: |
           mkdir -p dist
-          cp ".pio/build/${{ matrix.target }}/firmware.bin" "dist/${{ matrix.target }}.bin"
+          cp ".pio/build/${{ matrix.environment }}/firmware.bin" "dist/${{ matrix.target }}.bin"
           shasum -a 256 "dist/${{ matrix.target }}.bin"
       - uses: actions/upload-artifact@v4
         with:

--- a/docs/firmware-build-profiles.md
+++ b/docs/firmware-build-profiles.md
@@ -1,0 +1,28 @@
+# Firmware build profiles
+
+The Waveshare firmware has three intentional profile classes for each display
+target:
+
+- `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` are developer/diagnostic
+  builds. They keep USB CDC active, emit low-rate diagnostics, and pause for up
+  to two seconds during boot so a serial monitor can attach.
+- `*_POWER_METRICS` adds the structured `PWRMET` stream and optional timing
+  pulse to the corresponding diagnostic build.
+- `*_PRODUCTION` compiles with `CORE_DEBUG_LEVEL=0`, leaves `DEBUG` undefined,
+  and sets `FIRMWARE_DIAGNOSTICS=0`. It does not start USB CDC at application
+  boot and does not wait for a serial host. GitHub firmware releases use these
+  profiles.
+
+Production keeps native USB hardware support (`ARDUINO_USB_MODE=1`) but sets
+`ARDUINO_USB_CDC_ON_BOOT=0`. The application therefore avoids the steady USB
+CDC cost, while the ESP32-S3 ROM download mode remains available for recovery:
+hold BOOT (GPIO0) while reconnecting USB, then flash the correct board target.
+
+Each production profile keeps the canonical hardware target in firmware
+metadata (`WAVESHARE_AMOLED_175` or `WAVESHARE_AMOLED_206`). The profile suffix
+is intentionally not exposed over BLE, so released manifests and future OTA
+updates continue to match the installed device.
+
+Use a diagnostic or power-metrics build for serial capture. Do not compare its
+battery runtime directly with a production build because USB and logging state
+are deliberately different.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -6,6 +6,10 @@
  */
 
 #include "ble_navigation.hpp"
+
+#ifndef FIRMWARE_DIAGNOSTICS
+#define FIRMWARE_DIAGNOSTICS 1
+#endif
 #include "ble_connection_policy.hpp"
 #include "device_ownership.hpp"
 #include "ownership_button_policy.hpp"
@@ -112,6 +116,8 @@ static portMUX_TYPE ownershipUiMux = portMUX_INITIALIZER_UNLOCKED;
 static bool ownershipUiUpdatePending = false;
 static char ownershipUiName[device_ownership::MAX_DEVICE_NAME_BYTES + 1] = "";
 static bool ownershipUiClaimed = false;
+static bool ownershipUiConnected = false;
+static bool ownershipUiAuthenticated = false;
 static int32_t ownershipUiPairingCode = -1;
 static uint32_t ownershipUiPairingGeneration = 0;
 static ownership_button_policy::ComparisonRenderGate
@@ -143,6 +149,8 @@ static void queueOwnershipUiUpdate(int32_t pairingCode = -1,
   strncpy(ownershipUiName, name.c_str(), sizeof(ownershipUiName) - 1);
   ownershipUiName[sizeof(ownershipUiName) - 1] = '\0';
   ownershipUiClaimed = claimed;
+  ownershipUiConnected = bleNavServer.isConnected();
+  ownershipUiAuthenticated = bleSessionAuthenticated;
   ownershipUiPairingCode = pairingCode;
   ownershipUiPairingGeneration = pairingGeneration;
   ownershipUiUpdatePending = true;
@@ -152,6 +160,8 @@ static void queueOwnershipUiUpdate(int32_t pairingCode = -1,
 static void applyPendingOwnershipUiUpdate() {
   char name[sizeof(ownershipUiName)] = "";
   bool claimed = false;
+  bool connected = false;
+  bool authenticated = false;
   int32_t pairingCode = -1;
   uint32_t pairingGeneration = 0;
   portENTER_CRITICAL(&ownershipUiMux);
@@ -159,13 +169,16 @@ static void applyPendingOwnershipUiUpdate() {
   if (pending) {
     strncpy(name, ownershipUiName, sizeof(name) - 1);
     claimed = ownershipUiClaimed;
+    connected = ownershipUiConnected;
+    authenticated = ownershipUiAuthenticated;
     pairingCode = ownershipUiPairingCode;
     pairingGeneration = ownershipUiPairingGeneration;
     ownershipUiUpdatePending = false;
   }
   portEXIT_CRITICAL(&ownershipUiMux);
   if (pending) {
-    updateWaitingOwnershipStatus(name, claimed, pairingCode);
+    updateWaitingOwnershipStatus(name, claimed, connected, authenticated,
+                                 pairingCode);
     portENTER_CRITICAL(&ownershipUiMux);
     if (pairingCode >= 0) {
       ownershipComparisonRenderGate.request(pairingGeneration);
@@ -617,8 +630,10 @@ static void parseNavigationData(const std::string &data) {
 
   navDataUpdated = true;
 
+#if FIRMWARE_DIAGNOSTICS
   Serial.printf("BLE Nav: Icon=%d, Dist=%dm, Instr=%s\n", currentNavData.iconID,
                 currentNavData.distance, currentNavData.instruction);
+#endif
 }
 
 static bool requireAuthenticated(const char *payloadName) {
@@ -773,6 +788,7 @@ static void completeBleSessionAuthentication() {
   bleDebugStats.authenticated = true;
   bleDebugStats.authSuccessCount++;
   bleDebugStats.lastAuthSuccessMs = millis();
+  queueOwnershipUiUpdate();
 }
 
 static bool notifyAuthenticatedNavigation(NimBLECharacteristic *characteristic,
@@ -1876,6 +1892,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
   }
 #endif
 
+#if FIRMWARE_DIAGNOSTICS
   Serial.printf("BLE: %s GPS position received: heading=%u rtcSync=%d\n",
                 source == nullptr ? "unknown" : source,
                 (unsigned)gps.gpsData.heading,
@@ -1885,6 +1902,7 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
                 0
 #endif
   );
+#endif
   bleDebugStats.gpsPacketCount++;
   bleDebugStats.lastGpsPacketMs = millis();
 
@@ -2535,7 +2553,9 @@ public:
       return;
     }
 
+#if FIRMWARE_DIAGNOSTICS
     Serial.printf("BLE Nav received: %u bytes\n", (unsigned)value.length());
+#endif
     bleDebugStats.navPacketCount++;
     bleDebugStats.lastNavPacketMs = millis();
     parseNavigationData(value);
@@ -2972,6 +2992,7 @@ void BLENavigationServer::process() {
     }
   }
 
+#if FIRMWARE_DIAGNOSTICS
   if (millis() - lastLog > 5000) {
     lastLog = millis();
     bleDebugStats.initialized = initialized;
@@ -3005,6 +3026,9 @@ void BLENavigationServer::process() {
                   bleDebugStats.lastSettingsPacketMs,
                   bleDebugStats.lastRejectedUnauthenticatedMs);
   }
+#else
+  (void)lastLog;
+#endif
 }
 
 BLEDebugStats BLENavigationServer::getDebugStats() const {

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -14,8 +14,12 @@
 #include "guiLayout.hpp"
 #include "mapTileTransition.hpp"
 #include "navigationContentMode.hpp"
+#include "uiUpdatePolicy.hpp"
+#include "../../ble_navigation/workout_telemetry_runtime.hpp"
 #include "../../utils/src/mapTapArbiter.hpp"
 #include <algorithm>
+#include <cstring>
+#include <type_traits>
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "../../panel/WAVESHARE_AMOLED_175.hpp"
 #endif
@@ -38,6 +42,7 @@ extern uint32_t DOUBLE_TOUCH_EVENT;
 extern Compass compass;
 #endif
 extern Gps gps;
+extern Battery battery;
 extern wayPoint loadWpt;
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 extern bool touchPressed;
@@ -88,11 +93,233 @@ struct DestinationPickerView {
 };
 static DestinationPickerView mapGuidanceDestinationPicker;
 static DestinationPickerView navigationDestinationPicker;
+static ui_update_policy::ChangeTracker uiChangeTracker;
+static uint32_t lastRideStatsUpdateMs = 0;
 static constexpr lv_point_precise_t DESTINATION_STAR_POINTS[] = {
     {9, 0},  {11, 6}, {18, 7}, {13, 11}, {15, 18}, {9, 14},
     {3, 18}, {5, 11}, {0, 7},  {7, 6},   {9, 0}};
 
 static void refreshDestinationPickersAsync(void *userData);
+
+namespace {
+
+constexpr uint64_t FNV_OFFSET = 1469598103934665603ULL;
+constexpr uint64_t FNV_PRIME = 1099511628211ULL;
+
+template <typename T> void hashScalar(uint64_t &hash, const T &value) {
+  static_assert(std::is_trivially_copyable<T>::value,
+                "UI signatures only accept scalar values");
+  const auto *bytes = reinterpret_cast<const uint8_t *>(&value);
+  for (std::size_t index = 0; index < sizeof(T); ++index) {
+    hash ^= bytes[index];
+    hash *= FNV_PRIME;
+  }
+}
+
+void hashText(uint64_t &hash, const char *text, std::size_t maximumLength) {
+  if (text == nullptr) {
+    const uint8_t empty = 0;
+    hashScalar(hash, empty);
+    return;
+  }
+  const std::size_t length = strnlen(text, maximumLength);
+  for (std::size_t index = 0; index < length; ++index) {
+    hash ^= static_cast<uint8_t>(text[index]);
+    hash *= FNV_PRIME;
+  }
+  hashScalar(hash, length);
+}
+
+template <typename T>
+void hashOptionalMetric(uint64_t &hash,
+                        const workout_telemetry::OptionalMetric<T> &metric) {
+  hashScalar(hash, metric.available);
+  if (metric.available) {
+    hashScalar(hash, metric.value);
+  }
+}
+
+uint64_t navigationSignature() {
+  const NavigationData navigation = getCurrentNavigationData();
+  uint64_t hash = FNV_OFFSET;
+  hashScalar(hash, navigation.iconID);
+  hashScalar(hash, navigation.distance);
+  hashText(hash, navigation.instruction, sizeof(navigation.instruction));
+  if (activeTile == NAV || activeTile == MAP_GUIDANCE) {
+    const DestinationCatalogSnapshot catalog = getDestinationCatalogSnapshot();
+    const DestinationPickerStatusSnapshot status =
+        getDestinationPickerStatusSnapshot();
+    hashScalar(hash, catalog.revision);
+    hashScalar(hash, status.revision);
+  }
+  return hash;
+}
+
+uint64_t gpsSignature() {
+  uint64_t hash = FNV_OFFSET;
+  hashScalar(hash, gps.gpsData.satellites);
+  hashScalar(hash, gps.gpsData.fixMode);
+  hashScalar(hash, isGpsFixed);
+  hashScalar(hash, gps.gpsData.altitude);
+  hashScalar(hash, gps.gpsData.speed);
+  hashScalar(hash, gps.gpsData.distanceTraveled);
+  hashScalar(hash, gps.gpsData.elapsedSeconds);
+  hashScalar(hash, gps.gpsData.routeRemaining);
+  hashScalar(hash, gps.gpsData.hasRouteRemaining);
+  hashScalar(hash, gps.gpsData.latitude);
+  hashScalar(hash, gps.gpsData.longitude);
+  hashScalar(hash, gps.gpsData.heading);
+  hashScalar(hash, gps.gpsData.hdop);
+  hashScalar(hash, gps.gpsData.pdop);
+  hashScalar(hash, gps.gpsData.vdop);
+  hashScalar(hash, gps.gpsData.satInView);
+  if (activeTile == SATTRACK) {
+    const uint8_t count = std::min<uint8_t>(gps.gpsData.satInView,
+                                            MAX_SATELLLITES_IN_VIEW);
+    for (uint8_t index = 0; index < count; ++index) {
+      const auto &satellite = gps.satTracker[index];
+      hashScalar(hash, satellite.active);
+      hashScalar(hash, satellite.satNum);
+      hashScalar(hash, satellite.elev);
+      hashScalar(hash, satellite.azim);
+      hashScalar(hash, satellite.snr);
+      hashScalar(hash, satellite.posX);
+      hashScalar(hash, satellite.posY);
+      hashText(hash, satellite.talker_id, sizeof(satellite.talker_id));
+    }
+  }
+  return hash;
+}
+
+uint64_t workoutSignature(uint32_t nowMs) {
+  const workout_telemetry::Snapshot snapshot =
+      workout_telemetry_runtime::snapshot(nowMs);
+  const workout_telemetry::State &state = snapshot.state;
+  uint64_t hash = FNV_OFFSET;
+  hashScalar(hash, state.sessionState);
+  hashScalar(hash, state.sessionToken);
+  hashScalar(hash, state.lastCoreReceivedAtMs);
+  hashScalar(hash, state.lastExtendedReceivedAtMs);
+  hashScalar(hash, state.pendingUnavailableCoreReceivedAtMs);
+  hashScalar(hash, state.coreReceived);
+  hashScalar(hash, state.extendedReceived);
+  hashScalar(hash, state.transportUnavailable);
+  hashScalar(hash, state.pendingUnavailableCore);
+  hashOptionalMetric(hash, state.elapsedSeconds);
+  hashOptionalMetric(hash, state.distanceMeters);
+  hashOptionalMetric(hash, state.speedCentimetersPerSecond);
+  hashOptionalMetric(hash, state.currentHeartRateBpm);
+  hashScalar(hash, state.sourceFlags);
+  hashOptionalMetric(hash, state.averageHeartRateBpm);
+  hashOptionalMetric(hash, state.activeEnergyTenthsKilocalorie);
+  hashOptionalMetric(hash, state.cyclingPowerWatts);
+  hashOptionalMetric(hash, state.cyclingCadenceTenthsRpm);
+  hashOptionalMetric(hash, state.currentHeartRateZone);
+  hashOptionalMetric(hash, state.altitudeMeters);
+  hashOptionalMetric(hash, state.heartRateZoneCount);
+  hashScalar(hash, snapshot.stale);
+  return hash;
+}
+
+void hashScreenMapSettings(uint64_t &hash,
+                           const ScreenMapRenderSettings &settings) {
+  hashScalar(hash, settings.minPolygonSize);
+  hashScalar(hash, settings.detailLevel);
+  hashScalar(hash, settings.routeLineWidth);
+  hashScalar(hash, settings.streetLineWidth);
+  hashScalar(hash, settings.positionMarkerScale);
+  hashScalar(hash, settings.zoomLevel);
+  hashScalar(hash, settings.visibilityMask);
+}
+
+uint64_t settingsSignature() {
+  uint64_t hash = FNV_OFFSET;
+  hashScreenMapSettings(hash, mapRenderSettings.mapStyle);
+  hashScreenMapSettings(hash, mapRenderSettings.mapNavigationStyle);
+  hashScalar(hash, mapRenderSettings.mapRotationMode);
+  hashScalar(hash, mapRenderSettings.tapToSwitchScreens);
+  hashScalar(hash, mapRenderSettings.enabledScreensMask);
+  hashScalar(hash, mapRenderSettings.defaultScreen);
+  hashScalar(hash, mapRenderSettings.disconnectedSleepTimeoutSeconds);
+  hashScalar(hash, mapRenderSettings.navigationOverlayVisibilityMask);
+  hashScalar(hash, mapSet.showMapCompass);
+  hashScalar(hash, mapSet.compassRotation);
+  hashScalar(hash, mapSet.mapRotationComp);
+  hashScalar(hash, mapSet.mapFullScreen);
+  hashScalar(hash, mapSet.showMapSpeed);
+  hashScalar(hash, mapSet.vectorMap);
+  hashScalar(hash, mapSet.showMapScale);
+  hashScalar(hash, zoom);
+  return hash;
+}
+
+ui_update_policy::SourceSignatures captureSourceSignatures(uint32_t nowMs) {
+  static uint64_t cachedWorkoutSignature = FNV_OFFSET;
+  static uint64_t cachedDeviceBatterySignature = FNV_OFFSET;
+  static uint32_t lastWorkoutSampleMs = 0;
+  static uint32_t lastDeviceBatterySampleMs = 0;
+
+  if (ui_update_policy::cadenceDue(
+          nowMs, lastWorkoutSampleMs,
+          ui_update_policy::kRideStatsPeriodMs)) {
+    cachedWorkoutSignature = workoutSignature(nowMs);
+  }
+  if (ui_update_policy::cadenceDue(
+          nowMs, lastDeviceBatterySampleMs,
+          ui_update_policy::kDeviceBatteryPeriodMs)) {
+    uint8_t percentage = 0;
+    bool charging = false;
+    const bool available = battery.readBatteryStatus(percentage, charging);
+    cachedDeviceBatterySignature = FNV_OFFSET;
+    hashScalar(cachedDeviceBatterySignature, available);
+    if (available) {
+      hashScalar(cachedDeviceBatterySignature, percentage);
+      hashScalar(cachedDeviceBatterySignature, charging);
+    }
+  }
+
+  ui_update_policy::SourceSignatures signatures;
+  signatures[ui_update_policy::Source::Navigation] = navigationSignature();
+  signatures[ui_update_policy::Source::Gps] = gpsSignature();
+  signatures[ui_update_policy::Source::Route] = routeOverlay.revision();
+  signatures[ui_update_policy::Source::Workout] = cachedWorkoutSignature;
+  uint64_t phoneBattery = FNV_OFFSET;
+  const int16_t phoneLevel = getPhoneBatteryLevelPercent();
+  const bool phoneCharging = isPhoneBatteryCharging();
+  hashScalar(phoneBattery, phoneLevel);
+  hashScalar(phoneBattery, phoneCharging);
+  signatures[ui_update_policy::Source::PhoneBattery] = phoneBattery;
+  signatures[ui_update_policy::Source::Settings] = settingsSignature();
+  signatures[ui_update_policy::Source::DeviceBattery] =
+      cachedDeviceBatterySignature;
+  return signatures;
+}
+
+void setHiddenIfChanged(lv_obj_t *object, bool hidden) {
+  if (object == nullptr || lv_obj_has_flag(object, LV_OBJ_FLAG_HIDDEN) == hidden) {
+    return;
+  }
+  if (hidden) {
+    lv_obj_add_flag(object, LV_OBJ_FLAG_HIDDEN);
+  } else {
+    lv_obj_clear_flag(object, LV_OBJ_FLAG_HIDDEN);
+  }
+}
+
+void setLabelTextIfChanged(lv_obj_t *label, const char *text) {
+  if (label != nullptr && text != nullptr &&
+      strcmp(lv_label_get_text(label), text) != 0) {
+    lv_label_set_text(label, text);
+  }
+}
+
+void setImageAngleIfChanged(lv_obj_t *image, int16_t angle) {
+  if (image != nullptr && lv_img_get_angle(image) != angle) {
+    lv_img_set_angle(image, angle);
+  }
+}
+
+} // namespace
 
 Maps mapView;
 static map_tap_arbiter::Controller mapTapController;
@@ -412,13 +639,15 @@ static int16_t navigationArrowAngle(uint8_t iconID) {
 
 static void setNavigationDistanceLabel(lv_obj_t *label,
                                        uint16_t distanceMeters) {
+  char text[24];
   if (distanceMeters >= 1000) {
     const uint16_t deciKilometers = (distanceMeters + 50U) / 100U;
-    lv_label_set_text_fmt(label, "%u.%u km", deciKilometers / 10U,
-                          deciKilometers % 10U);
+    snprintf(text, sizeof(text), "%u.%u km", deciKilometers / 10U,
+             deciKilometers % 10U);
   } else {
-    lv_label_set_text_fmt(label, "%u m", distanceMeters);
+    snprintf(text, sizeof(text), "%u m", distanceMeters);
   }
+  setLabelTextIfChanged(label, text);
 }
 
 static void applyMapRotationForActiveTile() {
@@ -705,30 +934,32 @@ static void updateMapGuidanceOverlay() {
     return;
   }
 
-  LV_IMG_DECLARE(navup);
-  lv_img_set_src(mapGuidanceArrow, &navup);
-
   const navigation_content_mode::Mode contentMode =
       navigation_content_mode::forNavigationState(hasCurrentNavigationData());
-  applyMapGuidanceOverlayLayout();
+  static int8_t displayedContentMode = -1;
+  const int8_t nextContentMode = static_cast<int8_t>(contentMode);
+  if (displayedContentMode != nextContentMode) {
+    applyMapGuidanceOverlayLayout();
+    displayedContentMode = nextContentMode;
+  }
 
   if (contentMode == navigation_content_mode::Mode::FavoriteDestinations) {
-    lv_img_set_angle(mapGuidanceArrow, 0);
-    lv_label_set_text_static(mapGuidanceDistance, "--");
-    lv_obj_add_flag(mapGuidanceArrow, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(mapGuidanceDistance, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(mapGuidanceDestinationPicker.container,
-                      LV_OBJ_FLAG_HIDDEN);
+    setImageAngleIfChanged(mapGuidanceArrow, 0);
+    setLabelTextIfChanged(mapGuidanceDistance, "--");
+    setHiddenIfChanged(mapGuidanceArrow, true);
+    setHiddenIfChanged(mapGuidanceDistance, true);
+    setHiddenIfChanged(mapGuidanceDestinationPicker.container, false);
     renderDestinationPicker(mapGuidanceDestinationPicker);
     return;
   }
 
-  lv_obj_add_flag(mapGuidanceDestinationPicker.container, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_clear_flag(mapGuidanceArrow, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_clear_flag(mapGuidanceDistance, LV_OBJ_FLAG_HIDDEN);
+  setHiddenIfChanged(mapGuidanceDestinationPicker.container, true);
+  setHiddenIfChanged(mapGuidanceArrow, false);
+  setHiddenIfChanged(mapGuidanceDistance, false);
 
   NavigationData navData = getCurrentNavigationData();
-  lv_img_set_angle(mapGuidanceArrow, navigationArrowAngle(navData.iconID));
+  setImageAngleIfChanged(mapGuidanceArrow,
+                         navigationArrowAngle(navData.iconID));
   setNavigationDistanceLabel(mapGuidanceDistance, navData.distance);
 }
 
@@ -846,6 +1077,7 @@ void scrollTile(lv_event_t *event) {
  *
  */
 void updateMainScreen(lv_timer_t *t) {
+  (void)t;
   processMapPinchZoom();
   processDeferredMapTap();
 
@@ -855,6 +1087,17 @@ void updateMainScreen(lv_timer_t *t) {
   if (shouldInterruptMapRenderForScreenCycle()) {
     return;
   }
+
+  // The 30 ms timer remains the input path for touch responsiveness, but
+  // source acquisition is unnecessary while another screen is active.
+  if (!isMainScreen) {
+    serviceMapPinchZoomOutBackdrop();
+    return;
+  }
+
+  const uint32_t nowMs = millis();
+  (void)uiChangeTracker.observe(captureSourceSignatures(nowMs));
+  bool mapEventSent = false;
 
   // Handle BLE-triggered map updates OUTSIDE of isScrolled check
   // This ensures continuous updates even when user hasn't dragged
@@ -874,6 +1117,7 @@ void updateMainScreen(lv_timer_t *t) {
 
     // Trigger map regeneration and display
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
+    mapEventSent = true;
     if (shouldInterruptMapRenderForScreenCycle()) {
       return;
     }
@@ -889,9 +1133,16 @@ void updateMainScreen(lv_timer_t *t) {
         lv_obj_send_event(compassHeading, LV_EVENT_VALUE_CHANGED, NULL);
 #endif
 #ifndef ENABLE_COMPASS
-      heading = gps.gpsData.heading;
-      lv_obj_send_event(compassHeading, LV_EVENT_VALUE_CHANGED, NULL);
+      if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
+        heading = gps.gpsData.heading;
+        lv_obj_send_event(compassHeading, LV_EVENT_VALUE_CHANGED, NULL);
+        lv_obj_send_event(latitude, LV_EVENT_VALUE_CHANGED, NULL);
+        lv_obj_send_event(longitude, LV_EVENT_VALUE_CHANGED, NULL);
+        lv_obj_send_event(altitude, LV_EVENT_VALUE_CHANGED, NULL);
+        lv_obj_send_event(speedLabel, LV_EVENT_VALUE_CHANGED, NULL);
+      }
 #endif
+#ifdef ENABLE_COMPASS
       if (gps.hasLocationChange()) {
         lv_obj_send_event(latitude, LV_EVENT_VALUE_CHANGED, NULL);
         lv_obj_send_event(longitude, LV_EVENT_VALUE_CHANGED, NULL);
@@ -900,6 +1151,7 @@ void updateMainScreen(lv_timer_t *t) {
         lv_obj_send_event(altitude, LV_EVENT_VALUE_CHANGED, NULL);
       if (gps.isSpeedChanged())
         lv_obj_send_event(speedLabel, LV_EVENT_VALUE_CHANGED, NULL);
+#endif
       break;
 
     case MAP:
@@ -917,7 +1169,9 @@ void updateMainScreen(lv_timer_t *t) {
       applyMapRotationForActiveTile();
       if (activeTile == MAP_GUIDANCE) {
         mapView.followGps = true;
-        updateMapGuidanceOverlay();
+        if (uiChangeTracker.take(ui_update_policy::Source::Navigation)) {
+          updateMapGuidanceOverlay();
+        }
       }
 
       // Track last heading for Course-Up auto-rotation
@@ -970,30 +1224,62 @@ void updateMainScreen(lv_timer_t *t) {
         mapView.redrawMap = true;
       }
 
-      lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
+      if (!mapEventSent && (mapView.isPosMoved || mapView.redrawMap)) {
+        lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
+        mapEventSent = true;
+      }
+      (void)uiChangeTracker.take(ui_update_policy::Source::Gps);
       break;
     }
 
     case NAV:
-      lv_obj_send_event(navTile, LV_EVENT_VALUE_CHANGED, NULL);
+      if (uiChangeTracker.take(ui_update_policy::Source::Navigation)) {
+        lv_obj_send_event(navTile, LV_EVENT_VALUE_CHANGED, NULL);
+      }
       break;
 
-    case RIDESTATS:
-      lv_obj_send_event(rideStatsTile, LV_EVENT_VALUE_CHANGED, NULL);
+    case RIDESTATS: {
+      constexpr uint32_t rideSources =
+          ui_update_policy::sourceMask(ui_update_policy::Source::Gps) |
+          ui_update_policy::sourceMask(ui_update_policy::Source::Workout);
+      if ((uiChangeTracker.pending() & rideSources) != 0 &&
+          ui_update_policy::cadenceDue(
+              nowMs, lastRideStatsUpdateMs,
+              ui_update_policy::kRideStatsPeriodMs)) {
+        (void)uiChangeTracker.take(rideSources);
+        lv_obj_send_event(rideStatsTile, LV_EVENT_VALUE_CHANGED, NULL);
+      }
       break;
+    }
 
-    case BATTERY_STATUS:
-      lv_obj_send_event(batteryStatusTile, LV_EVENT_VALUE_CHANGED, NULL);
+    case BATTERY_STATUS: {
+      constexpr uint32_t batterySources =
+          ui_update_policy::sourceMask(
+              ui_update_policy::Source::PhoneBattery) |
+          ui_update_policy::sourceMask(
+              ui_update_policy::Source::DeviceBattery);
+      if (uiChangeTracker.take(batterySources) != 0) {
+        lv_obj_send_event(batteryStatusTile, LV_EVENT_VALUE_CHANGED, NULL);
+      }
       break;
+    }
 
     case SATTRACK:
-      lv_obj_send_event(satTrackTile, LV_EVENT_VALUE_CHANGED, NULL);
+      if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
+        lv_obj_send_event(satTrackTile, LV_EVENT_VALUE_CHANGED, NULL);
+      }
       break;
 
     default:
       break;
     }
   }
+
+  // Route and settings handlers already set the concrete map redraw flags or
+  // apply screen settings. Consuming their signatures prevents stale work from
+  // being mistaken for a later visible-widget change.
+  (void)uiChangeTracker.take(ui_update_policy::Source::Route);
+  (void)uiChangeTracker.take(ui_update_policy::Source::Settings);
 
   serviceMapPinchZoomOutBackdrop();
 }
@@ -1503,36 +1789,32 @@ void updateNavEvent(lv_event_t *event) {
     return;
   }
 
-  LV_IMG_DECLARE(navup);
-  lv_img_set_src(arrowNav, &navup);
-
   const navigation_content_mode::Mode contentMode =
       navigation_content_mode::forNavigationState(hasCurrentNavigationData());
   if (contentMode == navigation_content_mode::Mode::FavoriteDestinations) {
-    lv_obj_add_flag(nameNav, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(distNav, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(arrowNav, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_clear_flag(navigationDestinationPicker.container,
-                      LV_OBJ_FLAG_HIDDEN);
-    lv_label_set_text_static(distNav, "--");
-    lv_img_set_angle(arrowNav, 0);
+    setHiddenIfChanged(nameNav, true);
+    setHiddenIfChanged(distNav, true);
+    setHiddenIfChanged(arrowNav, true);
+    setHiddenIfChanged(navigationDestinationPicker.container, false);
+    setLabelTextIfChanged(distNav, "--");
+    setImageAngleIfChanged(arrowNav, 0);
     renderDestinationPicker(navigationDestinationPicker);
     return;
   }
 
-  lv_obj_add_flag(navigationDestinationPicker.container, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_clear_flag(nameNav, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_clear_flag(distNav, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_clear_flag(arrowNav, LV_OBJ_FLAG_HIDDEN);
+  setHiddenIfChanged(navigationDestinationPicker.container, true);
+  setHiddenIfChanged(nameNav, false);
+  setHiddenIfChanged(distNav, false);
+  setHiddenIfChanged(arrowNav, false);
 
   NavigationData navData = getCurrentNavigationData();
   char formattedInstruction[160];
   formatNavigationInstruction(navData.instruction, formattedInstruction,
                               sizeof(formattedInstruction));
-  lv_label_set_text(nameNav, formattedInstruction);
+  setLabelTextIfChanged(nameNav, formattedInstruction);
   setNavigationDistanceLabel(distNav, navData.distance);
 
-  lv_img_set_angle(arrowNav, navigationArrowAngle(navData.iconID));
+  setImageAngleIfChanged(arrowNav, navigationArrowAngle(navData.iconID));
 }
 
 static void createMapGuidanceOverlay() {
@@ -1633,26 +1915,43 @@ static void showMainTile(tileName tile) {
 
   switch (tile) {
   case MAP_GUIDANCE:
+    uiChangeTracker.mark(ui_update_policy::Source::Navigation);
     mapView.followGps = true;
     applyMapRotationForActiveTile();
     updateMapGuidanceOverlay();
+    (void)uiChangeTracker.take(ui_update_policy::Source::Navigation);
     mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to map guidance screen");
     break;
   case NAV:
+    uiChangeTracker.mark(ui_update_policy::Source::Navigation);
     lv_obj_clear_flag(navTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_send_event(navTile, LV_EVENT_VALUE_CHANGED, NULL);
+    (void)uiChangeTracker.take(ui_update_policy::Source::Navigation);
     log_i("UI: switched to navigation instruction screen");
     break;
   case RIDESTATS:
+    uiChangeTracker.mark(ui_update_policy::Source::Gps);
+    uiChangeTracker.mark(ui_update_policy::Source::Workout);
     lv_obj_clear_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_send_event(rideStatsTile, LV_EVENT_VALUE_CHANGED, NULL);
+    (void)uiChangeTracker.take(
+        ui_update_policy::sourceMask(ui_update_policy::Source::Gps) |
+        ui_update_policy::sourceMask(ui_update_policy::Source::Workout));
+    lastRideStatsUpdateMs = millis();
     log_i("UI: switched to ride telemetry screen");
     break;
   case BATTERY_STATUS:
+    uiChangeTracker.mark(ui_update_policy::Source::PhoneBattery);
+    uiChangeTracker.mark(ui_update_policy::Source::DeviceBattery);
     lv_obj_clear_flag(batteryStatusTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_send_event(batteryStatusTile, LV_EVENT_VALUE_CHANGED, NULL);
+    (void)uiChangeTracker.take(
+        ui_update_policy::sourceMask(
+            ui_update_policy::Source::PhoneBattery) |
+        ui_update_policy::sourceMask(
+            ui_update_policy::Source::DeviceBattery));
     log_i("UI: switched to battery status screen");
     break;
   case MAP:

--- a/esp32/lib/gui/src/notifyBar.cpp
+++ b/esp32/lib/gui/src/notifyBar.cpp
@@ -1,13 +1,13 @@
 /**
  * @file notifyBar.cpp
- * @author Jordi Gauchía (jgauchia@jgauchia.com)
- * @brief LVGL - Notify Bar Screen
- * @version 0.2.2
- * @date 2025-05
+ * @brief Change-driven LVGL notification bar.
  */
 
 #include "notifyBar.hpp"
+#include "uiUpdatePolicy.hpp"
+
 #include <WiFi.h>
+#include <cstring>
 
 lv_obj_t *mainScreen;
 lv_obj_t *notifyBarIcons;
@@ -17,117 +17,195 @@ Storage storage;
 Battery battery;
 extern Gps gps;
 
-/**
- * @brief Update notify bar event
- *
- * @param event
- */
-void updateNotifyBar(lv_event_t *event) {
-  lv_obj_t *obj = (lv_obj_t *)lv_event_get_target(event);
+namespace {
 
-  if (obj == gpsTime) {
-    struct tm local_tm;
-    time_t localTime = time(NULL);
-    struct tm *now = localtime_r(&localTime, &local_tm);
-
-    lv_label_set_text_fmt(obj, timeFormat, now->tm_hour, now->tm_min,
-                          now->tm_sec);
-  }
+lv_obj_t *gpsTime = nullptr;
+lv_obj_t *gpsCount = nullptr;
+lv_obj_t *gpsFix = nullptr;
+lv_obj_t *gpsFixMode = nullptr;
+lv_obj_t *battIcon = nullptr;
+lv_obj_t *sdCard = nullptr;
+lv_obj_t *temp = nullptr;
+lv_obj_t *wifi = nullptr;
+lv_timer_t *clockTimer = nullptr;
+lv_timer_t *statusTimer = nullptr;
+ui_update_policy::StatusSnapshot displayedStatus{};
+bool statusInitialized = false;
 
 #ifdef ENABLE_TEMP
-  if (obj == temp)
-    lv_label_set_text_fmt(obj, "%02d\xC2\xB0", tempValue);
+uint8_t displayedTemperature = UINT8_MAX;
 #endif
 
-  if (obj == gpsCount)
-    lv_label_set_text_fmt(obj, LV_SYMBOL_GPS "%2d", gps.gpsData.satellites);
-
-  if (obj == battIcon) {
-    if (battLevel <= 160 && battLevel > 140)
-      lv_label_set_text_static(obj, "  " LV_SYMBOL_CHARGE);
-    else if (battLevel <= 140 && battLevel > 80)
-      lv_label_set_text_static(obj, LV_SYMBOL_BATTERY_FULL);
-    else if (battLevel <= 80 && battLevel > 60)
-      lv_label_set_text_static(obj, LV_SYMBOL_BATTERY_3);
-    else if (battLevel <= 60 && battLevel > 40)
-      lv_label_set_text_static(obj, LV_SYMBOL_BATTERY_2);
-    else if (battLevel <= 40 && battLevel > 20)
-      lv_label_set_text_static(obj, LV_SYMBOL_BATTERY_1);
-    else if (battLevel <= 20)
-      lv_label_set_text(obj, LV_SYMBOL_BATTERY_EMPTY);
+void setLabelTextIfChanged(lv_obj_t *label, const char *text) {
+  if (label != nullptr && text != nullptr &&
+      strcmp(lv_label_get_text(label), text) != 0) {
+    lv_label_set_text(label, text);
   }
+}
 
-  if (obj == gpsFixMode) {
-    switch (gps.gpsData.fixMode) {
-    case gps_fix::STATUS_NONE:
-      lv_label_set_text_static(obj, "----");
-      break;
-    case gps_fix::STATUS_STD:
-      lv_label_set_text_static(obj, " 3D ");
-      break;
-    case gps_fix::STATUS_DGPS:
-      lv_label_set_text_static(obj, "DGPS");
-      break;
-    case gps_fix::STATUS_PPS:
-      lv_label_set_text_static(obj, "PPS");
-      break;
-    case gps_fix::STATUS_RTK_FLOAT:
-      lv_label_set_text_static(obj, "RTK");
-      break;
-    case gps_fix::STATUS_RTK_FIXED:
-      lv_label_set_text_static(obj, "RTK");
-      break;
-    case gps_fix::STATUS_TIME_ONLY:
-      lv_label_set_text_static(obj, "TIME");
-      break;
-    case gps_fix::STATUS_EST:
-      lv_label_set_text_static(obj, "EST");
-      break;
+const char *batterySymbol(const ui_update_policy::StatusSnapshot &status) {
+  if (!status.batteryAvailable) {
+    return LV_SYMBOL_BATTERY_EMPTY;
+  }
+  if (status.batteryCharging) {
+    return LV_SYMBOL_CHARGE;
+  }
+  if (status.batteryLevel >= 80) {
+    return LV_SYMBOL_BATTERY_FULL;
+  }
+  if (status.batteryLevel >= 60) {
+    return LV_SYMBOL_BATTERY_3;
+  }
+  if (status.batteryLevel >= 40) {
+    return LV_SYMBOL_BATTERY_2;
+  }
+  if (status.batteryLevel >= 20) {
+    return LV_SYMBOL_BATTERY_1;
+  }
+  return LV_SYMBOL_BATTERY_EMPTY;
+}
+
+const char *fixModeText(uint8_t fixMode) {
+  switch (fixMode) {
+  case gps_fix::STATUS_STD:
+    return " 3D ";
+  case gps_fix::STATUS_DGPS:
+    return "DGPS";
+  case gps_fix::STATUS_PPS:
+    return "PPS";
+  case gps_fix::STATUS_RTK_FLOAT:
+  case gps_fix::STATUS_RTK_FIXED:
+    return "RTK";
+  case gps_fix::STATUS_TIME_ONLY:
+    return "TIME";
+  case gps_fix::STATUS_EST:
+    return "EST";
+  case gps_fix::STATUS_NONE:
+  default:
+    return "----";
+  }
+}
+
+void refreshClock(lv_timer_t *) {
+  const time_t localTime = time(nullptr);
+  struct tm localTm{};
+  if (localtime_r(&localTime, &localTm) == nullptr) {
+    setLabelTextIfChanged(gpsTime, "--:--");
+  } else {
+    char text[8];
+    snprintf(text, sizeof(text), "%02d:%02d", localTm.tm_hour,
+             localTm.tm_min);
+    setLabelTextIfChanged(gpsTime, text);
+    if (clockTimer != nullptr) {
+      lv_timer_set_period(
+          clockTimer,
+          ui_update_policy::nextMinuteDelayMs(localTm.tm_sec));
+      lv_timer_reset(clockTimer);
     }
   }
-
-  if (obj == wifi) {
-    if (WiFi.status() == WL_CONNECTED)
-      lv_label_set_text_static(obj, LV_SYMBOL_WIFI);
-    else
-      lv_label_set_text_static(obj, " ");
-  }
 }
 
-/**
- * @brief Update notify bar info timer
- *
- */
-void updateNotifyBarTimer(lv_timer_t *t) {
-  lv_obj_send_event(gpsTime, LV_EVENT_VALUE_CHANGED, NULL);
-  lv_obj_send_event(gpsCount, LV_EVENT_VALUE_CHANGED, NULL);
-  lv_obj_send_event(gpsFixMode, LV_EVENT_VALUE_CHANGED, NULL);
-  lv_obj_send_event(wifi, LV_EVENT_VALUE_CHANGED, NULL);
+ui_update_policy::StatusSnapshot captureStatus(uint32_t nowMs) {
+  static bool batterySampled = false;
+  static uint32_t lastBatterySampleMs = 0;
+  static bool batteryAvailable = false;
+  static int16_t batteryLevel = -1;
+  static bool batteryCharging = false;
 
-  if (isGpsFixed)
-    lv_led_toggle(gpsFix);
-  else
-    lv_led_off(gpsFix);
+  ui_update_policy::StatusSnapshot status;
+  status.satellites = gps.gpsData.satellites;
+  status.fixMode = gps.gpsData.fixMode;
+  status.fixed = isGpsFixed;
+  status.wifiConnected = WiFi.status() == WL_CONNECTED;
+  status.sdLoaded = storage.getSdLoaded();
+  if (!batterySampled ||
+      static_cast<uint32_t>(nowMs - lastBatterySampleMs) >=
+          ui_update_policy::kDeviceBatteryPeriodMs) {
+    uint8_t percentage = 0;
+    bool charging = false;
+    batteryAvailable = battery.readBatteryStatus(percentage, charging);
+    batteryLevel =
+        batteryAvailable ? static_cast<int16_t>(percentage) : -1;
+    batteryCharging = batteryAvailable && charging;
+    batterySampled = true;
+    lastBatterySampleMs = nowMs;
+  }
+  status.batteryAvailable = batteryAvailable;
+  status.batteryLevel = batteryLevel;
+  status.batteryCharging = batteryCharging;
+  return status;
+}
+
+void refreshStatus(lv_timer_t *) {
+  const ui_update_policy::StatusSnapshot current = captureStatus(millis());
+  const uint8_t mutations =
+      statusInitialized
+          ? ui_update_policy::statusMutations(displayedStatus, current)
+          : static_cast<uint8_t>(ui_update_policy::StatusGpsCount |
+                                 ui_update_policy::StatusGpsFix |
+                                 ui_update_policy::StatusWifi |
+                                 ui_update_policy::StatusSd |
+                                 ui_update_policy::StatusBattery);
+
+  if ((mutations & ui_update_policy::StatusGpsCount) != 0) {
+    char text[16];
+    snprintf(text, sizeof(text), LV_SYMBOL_GPS "%2u", current.satellites);
+    setLabelTextIfChanged(gpsCount, text);
+  }
+  if ((mutations & ui_update_policy::StatusGpsFix) != 0) {
+    setLabelTextIfChanged(gpsFixMode, fixModeText(current.fixMode));
+    if (current.fixed) {
+      lv_led_on(gpsFix);
+    } else {
+      lv_led_off(gpsFix);
+    }
+  }
+  if ((mutations & ui_update_policy::StatusWifi) != 0) {
+    setLabelTextIfChanged(wifi,
+                          current.wifiConnected ? LV_SYMBOL_WIFI : " ");
+  }
+  if ((mutations & ui_update_policy::StatusSd) != 0) {
+    setLabelTextIfChanged(sdCard,
+                          current.sdLoaded ? LV_SYMBOL_SD_CARD : " ");
+  }
+  if ((mutations & ui_update_policy::StatusBattery) != 0) {
+    setLabelTextIfChanged(battIcon, batterySymbol(current));
+  }
 
 #ifdef ENABLE_TEMP
-  tempValue = (uint8_t)(bme.readTemperature() + tempOffset);
-  if (tempValue != tempOld) {
-    lv_obj_send_event(temp, LV_EVENT_VALUE_CHANGED, NULL);
-    tempOld = tempValue;
+  const uint8_t temperature =
+      static_cast<uint8_t>(bme.readTemperature() + tempOffset);
+  if (temperature != displayedTemperature) {
+    char text[12];
+    snprintf(text, sizeof(text), "%02u\xC2\xB0", temperature);
+    setLabelTextIfChanged(temp, text);
+    displayedTemperature = temperature;
   }
 #endif
 
-  battLevel = battery.readBattery();
-  if (battLevel != battLevelOld) {
-    lv_obj_send_event(battIcon, LV_EVENT_VALUE_CHANGED, NULL);
-    battLevelOld = battLevel;
+  displayedStatus = current;
+  statusInitialized = true;
+}
+
+void mainScreenTimerEvent(lv_event_t *event) {
+  if (clockTimer == nullptr || statusTimer == nullptr) {
+    return;
+  }
+  const lv_event_code_t code = lv_event_get_code(event);
+  if (code == LV_EVENT_SCREEN_LOADED) {
+    refreshClock(nullptr);
+    refreshStatus(nullptr);
+    lv_timer_resume(clockTimer);
+    lv_timer_resume(statusTimer);
+    lv_timer_reset(statusTimer);
+  } else if (code == LV_EVENT_SCREEN_UNLOADED) {
+    lv_timer_pause(clockTimer);
+    lv_timer_pause(statusTimer);
   }
 }
 
-/**
- * @brief Create a notify bar
- *
- */
+} // namespace
+
 void createNotifyBar() {
   notifyBarIcons = lv_obj_create(mainScreen);
   lv_obj_set_size(notifyBarIcons, (TFT_WIDTH / 3) * 2, 24);
@@ -155,27 +233,21 @@ void createNotifyBar() {
 
   gpsTime = lv_label_create(notifyBarHour);
   lv_obj_set_style_text_font(gpsTime, fontLarge, 0);
-  lv_label_set_text_fmt(gpsTime, timeFormat, 0, 0, 0);
-  lv_obj_add_event_cb(gpsTime, updateNotifyBar, LV_EVENT_VALUE_CHANGED, NULL);
+  lv_label_set_text_static(gpsTime, "--:--");
 
   wifi = lv_label_create(notifyBarIcons);
   lv_label_set_text_static(wifi, " ");
-  lv_obj_add_event_cb(wifi, updateNotifyBar, LV_EVENT_VALUE_CHANGED, NULL);
 
 #ifdef ENABLE_TEMP
   temp = lv_label_create(notifyBarIcons);
   lv_label_set_text_static(temp, "--\xC2\xB0");
-  lv_obj_add_event_cb(temp, updateNotifyBar, LV_EVENT_VALUE_CHANGED, NULL);
 #endif
 
-  if (storage.getSdLoaded()) {
-    sdCard = lv_label_create(notifyBarIcons);
-    lv_label_set_text_static(sdCard, LV_SYMBOL_SD_CARD);
-  }
+  sdCard = lv_label_create(notifyBarIcons);
+  lv_label_set_text_static(sdCard, " ");
 
   gpsCount = lv_label_create(notifyBarIcons);
-  lv_label_set_text_fmt(gpsCount, LV_SYMBOL_GPS "%2d", 0);
-  lv_obj_add_event_cb(gpsCount, updateNotifyBar, LV_EVENT_VALUE_CHANGED, NULL);
+  lv_label_set_text_static(gpsCount, LV_SYMBOL_GPS " 0");
 
   gpsFix = lv_led_create(notifyBarIcons);
   lv_led_set_color(gpsFix, lv_palette_main(LV_PALETTE_RED));
@@ -185,14 +257,14 @@ void createNotifyBar() {
   gpsFixMode = lv_label_create(notifyBarIcons);
   lv_obj_set_style_text_font(gpsFixMode, fontSmall, 0);
   lv_label_set_text_static(gpsFixMode, "----");
-  lv_obj_add_event_cb(gpsFixMode, updateNotifyBar, LV_EVENT_VALUE_CHANGED,
-                      NULL);
 
   battIcon = lv_label_create(notifyBarIcons);
   lv_label_set_text_static(battIcon, LV_SYMBOL_BATTERY_EMPTY);
-  lv_obj_add_event_cb(battIcon, updateNotifyBar, LV_EVENT_VALUE_CHANGED, NULL);
 
-  lv_timer_t *timerNotifyBar =
-      lv_timer_create(updateNotifyBarTimer, UPDATE_NOTIFY_PERIOD, NULL);
-  lv_timer_ready(timerNotifyBar);
+  clockTimer = lv_timer_create(refreshClock, 60000, nullptr);
+  statusTimer = lv_timer_create(refreshStatus,
+                                ui_update_policy::kStatusPollPeriodMs, nullptr);
+  lv_timer_pause(clockTimer);
+  lv_timer_pause(statusTimer);
+  lv_obj_add_event_cb(mainScreen, mainScreenTimerEvent, LV_EVENT_ALL, nullptr);
 }

--- a/esp32/lib/gui/src/notifyBar.hpp
+++ b/esp32/lib/gui/src/notifyBar.hpp
@@ -1,43 +1,14 @@
 /**
  * @file notifyBar.hpp
- * @author Jordi Gauchía (jgauchia@jgauchia.com)
- * @brief LVGL - Notify Bar Screen
- * @version 0.2.2
- * @date 2025-05
+ * @brief Change-driven LVGL notification bar.
  */
 
 #pragma once
 
-#include "globalGuiDef.h"
-#include "tasks.hpp"
-#include "storage.hpp"
 #include "battery.hpp"
+#include "globalGuiDef.h"
 #include "settings.hpp"
+#include "storage.hpp"
+#include "tasks.hpp"
 
-/**
- * @brief Notify Bar screen objects
- *
- */
-static lv_obj_t *gpsTime;    // Time
-static lv_obj_t *gpsCount;   // Satellite count
-static lv_obj_t *gpsFix;     // Satellite fix
-static lv_obj_t *gpsFixMode; // Satellite fix mode
-static lv_obj_t *battIcon;    // Battery level
-static lv_obj_t *sdCard;     // SD card icon
-static lv_obj_t *temp;       // Temperature
-static lv_obj_t *wifi;       // Wifi 
-
-static float battLevel = 0;
-static float battLevelOld = 0;
-
-#define UPDATE_NOTIFY_PERIOD 1000 // Notify Bar update time
-
-/**
- * @brief Temperature values
- *
- */
-static const char* timeFormat PROGMEM = "%02d:%02d:%02d";
-
-void updateNotifyBar(lv_event_t *event);
-void updateNotifyBarTimer(lv_timer_t *t);
 void createNotifyBar();

--- a/esp32/lib/gui/src/uiUpdatePolicy.hpp
+++ b/esp32/lib/gui/src/uiUpdatePolicy.hpp
@@ -1,0 +1,145 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+
+namespace ui_update_policy {
+
+constexpr uint32_t kRideStatsPeriodMs = 1000;
+constexpr uint32_t kStatusPollPeriodMs = 1000;
+constexpr uint32_t kDeviceBatteryPeriodMs = 5000;
+constexpr uint32_t kWaitingBatteryPeriodMs = 30000;
+
+enum class Source : uint8_t {
+  Navigation = 0,
+  Gps,
+  Route,
+  Workout,
+  PhoneBattery,
+  Settings,
+  DeviceBattery,
+  Count,
+};
+
+constexpr uint32_t sourceMask(Source source) {
+  return 1U << static_cast<uint8_t>(source);
+}
+
+constexpr uint32_t kAllSources =
+    (1U << static_cast<uint8_t>(Source::Count)) - 1U;
+
+struct SourceSignatures {
+  std::array<uint64_t, static_cast<std::size_t>(Source::Count)> values{};
+
+  uint64_t &operator[](Source source) {
+    return values[static_cast<std::size_t>(source)];
+  }
+
+  uint64_t operator[](Source source) const {
+    return values[static_cast<std::size_t>(source)];
+  }
+};
+
+class ChangeTracker {
+public:
+  uint32_t observe(const SourceSignatures &current) {
+    uint32_t changed = 0;
+    if (!initialized_) {
+      changed = kAllSources;
+      initialized_ = true;
+    } else {
+      for (uint8_t raw = 0; raw < static_cast<uint8_t>(Source::Count); ++raw) {
+        const Source source = static_cast<Source>(raw);
+        if (current[source] != previous_[source]) {
+          changed |= sourceMask(source);
+        }
+      }
+    }
+    previous_ = current;
+    pending_ |= changed;
+    return changed;
+  }
+
+  bool take(Source source) {
+    const uint32_t mask = sourceMask(source);
+    const bool wasPending = (pending_ & mask) != 0;
+    pending_ &= ~mask;
+    return wasPending;
+  }
+
+  uint32_t take(uint32_t mask) {
+    const uint32_t result = pending_ & mask;
+    pending_ &= ~mask;
+    return result;
+  }
+
+  void mark(Source source) { pending_ |= sourceMask(source); }
+  uint32_t pending() const { return pending_; }
+
+private:
+  bool initialized_ = false;
+  SourceSignatures previous_{};
+  uint32_t pending_ = 0;
+};
+
+inline bool cadenceDue(uint32_t nowMs, uint32_t &lastRunMs,
+                       uint32_t periodMs) {
+  if (lastRunMs != 0 && static_cast<uint32_t>(nowMs - lastRunMs) < periodMs) {
+    return false;
+  }
+  lastRunMs = nowMs == 0 ? 1 : nowMs;
+  return true;
+}
+
+constexpr uint32_t nextMinuteDelayMs(uint8_t second, uint16_t millisecond = 0) {
+  const uint32_t elapsedInMinute =
+      static_cast<uint32_t>(second % 60U) * 1000U +
+      static_cast<uint32_t>(millisecond % 1000U);
+  return elapsedInMinute == 0 ? 60000U : 60000U - elapsedInMinute;
+}
+
+enum StatusMutation : uint8_t {
+  StatusNone = 0,
+  StatusGpsCount = 1U << 0,
+  StatusGpsFix = 1U << 1,
+  StatusWifi = 1U << 2,
+  StatusSd = 1U << 3,
+  StatusBattery = 1U << 4,
+};
+
+struct StatusSnapshot {
+  uint8_t satellites = 0;
+  uint8_t fixMode = 0;
+  bool fixed = false;
+  bool wifiConnected = false;
+  bool sdLoaded = false;
+  int16_t batteryLevel = -1;
+  bool batteryCharging = false;
+  bool batteryAvailable = false;
+};
+
+constexpr uint8_t statusMutations(const StatusSnapshot &previous,
+                                  const StatusSnapshot &current) {
+  uint8_t mutations = StatusNone;
+  if (previous.satellites != current.satellites) {
+    mutations |= StatusGpsCount;
+  }
+  if (previous.fixMode != current.fixMode || previous.fixed != current.fixed) {
+    mutations |= StatusGpsFix;
+  }
+  if (previous.wifiConnected != current.wifiConnected) {
+    mutations |= StatusWifi;
+  }
+  if (previous.sdLoaded != current.sdLoaded) {
+    mutations |= StatusSd;
+  }
+  if (previous.batteryLevel != current.batteryLevel ||
+      previous.batteryCharging != current.batteryCharging ||
+      previous.batteryAvailable != current.batteryAvailable) {
+    mutations |= StatusBattery;
+  }
+  return mutations;
+}
+
+} // namespace ui_update_policy

--- a/esp32/lib/gui/src/waitingScr.cpp
+++ b/esp32/lib/gui/src/waitingScr.cpp
@@ -8,6 +8,10 @@
 #include "waitingScr.hpp"
 #include "battery.hpp"
 #include "mainScr.hpp"
+#include "uiUpdatePolicy.hpp"
+#include "waitingScreenLayout.hpp"
+
+#include <cstring>
 
 lv_obj_t *waitingScreen = nullptr;
 volatile bool gpsReceivedFromApp = false;
@@ -15,6 +19,8 @@ volatile bool pendingTransitionToMap = false;
 static lv_obj_t *waitingTitle = nullptr;
 static lv_obj_t *waitingMessage = nullptr;
 static lv_obj_t *waitingBattery = nullptr;
+static lv_obj_t *waitingState = nullptr;
+static lv_timer_t *waitingBatteryTimer = nullptr;
 
 extern Battery battery;
 
@@ -36,6 +42,23 @@ const char *batterySymbol(uint8_t percentage) {
   return LV_SYMBOL_BATTERY_EMPTY;
 }
 
+void setLabelTextIfChanged(lv_obj_t *label, const char *text) {
+  if (label != nullptr && text != nullptr &&
+      strcmp(lv_label_get_text(label), text) != 0) {
+    lv_label_set_text(label, text);
+  }
+}
+
+void setStateColorIfChanged(uint32_t rgb) {
+  static uint32_t displayedColor = UINT32_MAX;
+  if (waitingState != nullptr && displayedColor != rgb) {
+    const lv_color_t color = lv_color_hex(rgb);
+    lv_obj_set_style_text_color(waitingState, color, 0);
+    lv_obj_set_style_border_color(waitingState, color, 0);
+    displayedColor = rgb;
+  }
+}
+
 void refreshWaitingBatteryIndicator() {
   if (!waitingBattery) {
     return;
@@ -43,25 +66,40 @@ void refreshWaitingBatteryIndicator() {
 
   uint8_t percentage = 0;
   bool charging = false;
+  char text[48];
   if (!battery.readBatteryStatus(percentage, charging)) {
-    lv_label_set_text_static(waitingBattery,
-                             LV_SYMBOL_BATTERY_EMPTY " --%");
+    snprintf(text, sizeof(text), LV_SYMBOL_BATTERY_EMPTY " --%%");
+    setLabelTextIfChanged(waitingBattery, text);
     return;
   }
 
   if (charging) {
-    lv_label_set_text_fmt(waitingBattery, "%s %u%% %s",
-                          batterySymbol(percentage), percentage,
-                          LV_SYMBOL_CHARGE);
+    snprintf(text, sizeof(text), "%s %u%% %s", batterySymbol(percentage),
+             percentage, LV_SYMBOL_CHARGE);
   } else {
-    lv_label_set_text_fmt(waitingBattery, "%s %u%%", batterySymbol(percentage),
-                          percentage);
+    snprintf(text, sizeof(text), "%s %u%%", batterySymbol(percentage),
+             percentage);
   }
+  setLabelTextIfChanged(waitingBattery, text);
 }
 
 void updateWaitingBattery(lv_timer_t *) {
   if (waitingScreen && lv_scr_act() == waitingScreen) {
     refreshWaitingBatteryIndicator();
+  }
+}
+
+void waitingScreenEvent(lv_event_t *event) {
+  if (waitingBatteryTimer == nullptr) {
+    return;
+  }
+  const lv_event_code_t code = lv_event_get_code(event);
+  if (code == LV_EVENT_SCREEN_LOADED) {
+    refreshWaitingBatteryIndicator();
+    lv_timer_resume(waitingBatteryTimer);
+    lv_timer_reset(waitingBatteryTimer);
+  } else if (code == LV_EVENT_SCREEN_UNLOADED) {
+    lv_timer_pause(waitingBatteryTimer);
   }
 }
 
@@ -94,16 +132,21 @@ void createWaitingScr() {
 
   waitingScreen = lv_obj_create(NULL);
   lv_obj_set_style_bg_color(waitingScreen, lv_color_black(), 0);
+  lv_obj_add_event_cb(waitingScreen, waitingScreenEvent, LV_EVENT_ALL, nullptr);
+  const auto layout =
+      waiting_screen_layout::makeLayout(TFT_WIDTH, TFT_HEIGHT);
 
   waitingBattery = lv_label_create(waitingScreen);
   lv_obj_set_style_text_font(waitingBattery, &lv_font_montserrat_24, 0);
   lv_obj_set_style_text_color(waitingBattery, lv_color_white(), 0);
   lv_obj_set_style_text_align(waitingBattery, LV_TEXT_ALIGN_CENTER, 0);
-  lv_obj_set_width(waitingBattery, 210);
-  lv_obj_align(waitingBattery, LV_ALIGN_TOP_MID, 0, 45);
+  lv_obj_set_pos(waitingBattery, layout.battery.x, layout.battery.y);
+  lv_obj_set_size(waitingBattery, layout.battery.width,
+                  layout.battery.height);
   refreshWaitingBatteryIndicator();
-  lv_timer_t *batteryTimer = lv_timer_create(updateWaitingBattery, 1000, NULL);
-  lv_timer_ready(batteryTimer);
+  waitingBatteryTimer = lv_timer_create(
+      updateWaitingBattery, ui_update_policy::kWaitingBatteryPeriodMs, NULL);
+  lv_timer_pause(waitingBatteryTimer);
 
   // Title: "Bike Computer"
   waitingTitle = lv_label_create(waitingScreen);
@@ -111,16 +154,23 @@ void createWaitingScr() {
   lv_obj_set_style_text_color(waitingTitle, lv_color_white(), 0);
   lv_obj_set_style_text_align(waitingTitle, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_long_mode(waitingTitle, LV_LABEL_LONG_DOT);
-  lv_obj_set_width(waitingTitle, TFT_WIDTH - 24);
+  lv_obj_set_pos(waitingTitle, layout.title.x, layout.title.y);
+  lv_obj_set_size(waitingTitle, layout.title.width, layout.title.height);
   lv_label_set_text(waitingTitle, "Bike Computer");
-  lv_obj_set_align(waitingTitle, LV_ALIGN_CENTER);
-  lv_obj_set_y(waitingTitle, -105);
 
-  // Spinner (animated loading indicator)
-  lv_obj_t *spinner = lv_spinner_create(waitingScreen);
-  lv_obj_set_size(spinner, 100, 100);
-  lv_spinner_set_anim_params(spinner, 1500, 200);
-  lv_obj_center(spinner);
+  // A static state badge replaces the spinner. Animation on an AMOLED forces
+  // a full-screen flush even when all useful content is unchanged.
+  waitingState = lv_label_create(waitingScreen);
+  lv_obj_set_pos(waitingState, layout.state.x, layout.state.y);
+  lv_obj_set_size(waitingState, layout.state.width, layout.state.height);
+  lv_obj_set_style_text_font(waitingState, &lv_font_montserrat_24, 0);
+  lv_obj_set_style_text_align(waitingState, LV_TEXT_ALIGN_CENTER, 0);
+  lv_obj_set_style_pad_top(waitingState, 17, 0);
+  lv_obj_set_style_border_width(waitingState, 3, 0);
+  lv_obj_set_style_radius(waitingState, 18, 0);
+  lv_obj_set_style_bg_opa(waitingState, LV_OPA_TRANSP, 0);
+  lv_label_set_text_static(waitingState, "BLE");
+  setStateColorIfChanged(0x72A7FF);
 
   // Message: "Start the app to start navigation."
   waitingMessage = lv_label_create(waitingScreen);
@@ -128,29 +178,48 @@ void createWaitingScr() {
   lv_obj_set_style_text_color(waitingMessage, lv_color_hex(0xAAAAAA), 0);
   lv_obj_set_style_text_align(waitingMessage, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text(waitingMessage, "Start the app\nto start navigation.");
-  lv_obj_set_width(waitingMessage, TFT_WIDTH - 24);
-  lv_obj_set_align(waitingMessage, LV_ALIGN_CENTER);
-  lv_obj_set_y(waitingMessage, 125);
+  lv_obj_set_pos(waitingMessage, layout.message.x, layout.message.y);
+  lv_obj_set_size(waitingMessage, layout.message.width,
+                  layout.message.height);
 
   log_i("waitingScreen created at 0x%p", waitingScreen);
 }
 
 void updateWaitingOwnershipStatus(const char *deviceName, bool claimed,
+                                  bool connected, bool authenticated,
                                   int32_t pairingCode) {
-  if (waitingTitle == nullptr || waitingMessage == nullptr) {
+  if (waitingTitle == nullptr || waitingMessage == nullptr ||
+      waitingState == nullptr) {
     return;
   }
 
-  lv_label_set_text(waitingTitle,
-                    deviceName == nullptr || deviceName[0] == '\0'
-                        ? "Bike Computer"
-                        : deviceName);
+  setLabelTextIfChanged(waitingTitle,
+                        deviceName == nullptr || deviceName[0] == '\0'
+                            ? "Bike Computer"
+                            : deviceName);
   if (pairingCode >= 0) {
-    lv_label_set_text_fmt(waitingMessage, "Match %06ld\nthen press a button.",
-                          static_cast<long>(pairingCode));
+    char message[64];
+    snprintf(message, sizeof(message), "Match %06ld\nthen press a button.",
+             static_cast<long>(pairingCode));
+    setLabelTextIfChanged(waitingState, "PAIR");
+    setStateColorIfChanged(0xF6B73C);
+    setLabelTextIfChanged(waitingMessage, message);
+  } else if (authenticated) {
+    setLabelTextIfChanged(waitingState, "LINK");
+    setStateColorIfChanged(0x35D46F);
+    setLabelTextIfChanged(waitingMessage, "Connected to\nyour iPhone.");
+  } else if (connected) {
+    setLabelTextIfChanged(waitingState, "AUTH");
+    setStateColorIfChanged(0x72A7FF);
+    setLabelTextIfChanged(waitingMessage, "Securing\nyour iPhone link.");
   } else if (claimed) {
-    lv_label_set_text(waitingMessage, "Waiting for\nyour iPhone.");
+    setLabelTextIfChanged(waitingState, "BLE");
+    setStateColorIfChanged(0x8B93A1);
+    setLabelTextIfChanged(waitingMessage, "Waiting for\nyour iPhone.");
   } else {
-    lv_label_set_text(waitingMessage, "Open the app\nand add this device.");
+    setLabelTextIfChanged(waitingState, "ADD");
+    setStateColorIfChanged(0x72A7FF);
+    setLabelTextIfChanged(waitingMessage,
+                          "Open the app\nand add this device.");
   }
 }

--- a/esp32/lib/gui/src/waitingScr.hpp
+++ b/esp32/lib/gui/src/waitingScr.hpp
@@ -16,4 +16,5 @@ extern volatile bool pendingTransitionToMap; // Flag: Transition to map pending
 void createWaitingScr();
 void checkPendingMapTransition(); // Called from main loop
 void updateWaitingOwnershipStatus(const char *deviceName, bool claimed,
+                                  bool connected, bool authenticated,
                                   int32_t pairingCode = -1);

--- a/esp32/lib/gui/src/waitingScreenLayout.hpp
+++ b/esp32/lib/gui/src/waitingScreenLayout.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+
+namespace waiting_screen_layout {
+
+struct Rect {
+  int16_t x;
+  int16_t y;
+  int16_t width;
+  int16_t height;
+
+  constexpr int16_t right() const { return x + width; }
+  constexpr int16_t bottom() const { return y + height; }
+};
+
+struct Layout {
+  int16_t screenWidth;
+  int16_t screenHeight;
+  Rect battery;
+  Rect title;
+  Rect state;
+  Rect message;
+};
+
+constexpr Layout makeLayout(int16_t width, int16_t height) {
+  const int16_t margin = 16;
+  const int16_t contentWidth = width - margin * 2;
+  return {width,
+          height,
+          {margin, 34, contentWidth, 34},
+          {margin, 88, contentWidth, 58},
+          {static_cast<int16_t>((width - 112) / 2),
+           static_cast<int16_t>((height - 72) / 2 - 8), 112, 72},
+          {margin, static_cast<int16_t>(height - 130), contentWidth, 98}};
+}
+
+constexpr bool fits(const Rect &rect, int16_t width, int16_t height) {
+  return rect.x >= 0 && rect.y >= 0 && rect.right() <= width &&
+         rect.bottom() <= height;
+}
+
+constexpr bool isValid(const Layout &layout) {
+  return fits(layout.battery, layout.screenWidth, layout.screenHeight) &&
+         fits(layout.title, layout.screenWidth, layout.screenHeight) &&
+         fits(layout.state, layout.screenWidth, layout.screenHeight) &&
+         fits(layout.message, layout.screenWidth, layout.screenHeight) &&
+         layout.battery.bottom() <= layout.title.y &&
+         layout.title.bottom() <= layout.state.y &&
+         layout.state.bottom() <= layout.message.y;
+}
+
+} // namespace waiting_screen_layout

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -15,6 +15,11 @@
 #include "../../gui/src/guiLayout.hpp"
 #include "../../power_metrics/power_metrics.hpp"
 #include "../../utils/src/line_rasterizer.hpp"
+
+#ifndef FIRMWARE_DIAGNOSTICS
+#define FIRMWARE_DIAGNOSTICS 1
+#endif
+
 // #include "../../compass/compass.hpp"
 extern Gps gps;
 extern Storage storage;
@@ -1931,8 +1936,10 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
           }
         }
       }
+#if FIRMWARE_DIAGNOSTICS
       Serial.printf("[Maps] Block polygons: Total=%d, Checked=%d, Drawn=%d\n",
                     poly_total, poly_checked, poly_drawn);
+#endif
       const uint32_t polygonMs = millis() - polygonStartMs;
       log_i("Block polygons done %i ms", polygonMs);
       const uint32_t lineStartMs = millis();

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -7,6 +7,10 @@
  */
 
 #include "route_overlay.hpp"
+
+#ifndef FIRMWARE_DIAGNOSTICS
+#define FIRMWARE_DIAGNOSTICS 1
+#endif
 #include "../ble_navigation/ble_navigation.hpp"
 #include "../maps/src/mapTransform.hpp"
 #include "../utils/src/line_rasterizer.hpp"
@@ -183,8 +187,10 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
     return; // Need at least 2 points to draw a line
   }
 
+#if FIRMWARE_DIAGNOSTICS
   Serial.printf("RouteOverlay::drawRoute: zoom=%d points=%d rot=%.2frad\n",
                 zoom, points.size(), rotationRad);
+#endif
 
   // Get canvas buffer
   lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
@@ -205,8 +211,10 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
     anchorY = bufH / 2;
   }
 
+#if FIRMWARE_DIAGNOSTICS
   Serial.printf("RouteOverlay: Canvas buffer W=%d H=%d stride=%d\n", bufW, bufH,
                 stride);
+#endif
 
   // Pre-calculate rotation values
   double cosA = cos(rotationRad);

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -240,9 +240,10 @@ build_flags =
   ; -DDISABLE_TOUCH=1
   -DDISABLE_ADVANCED_GUI=1  ; Disable advanced GUI features (depends on TFT_eSprite)
   -D LV_CONF_PATH="${PROJECT_DIR}/lib/lvgl/lv_conf.h"
-  -D CORE_DEBUG_LEVEL=2
+  -DCORE_DEBUG_LEVEL=2
   -D BAUDRATE=115200
-  -D DEBUG=1
+  -DDEBUG=1
+  -DFIRMWARE_DIAGNOSTICS=1
   ; Arduino's sdkconfig.h defines NimBLE's connection limit after command-line
   ; macros. Preinclude our override so every locally built NimBLE source agrees
   ; that the ownership protocol permits exactly one central.
@@ -268,6 +269,20 @@ build_flags =
   -DPOWER_METRICS=1
   ; Set to a verified spare output pin when correlating source-monitor traces.
   ; -DPOWER_METRICS_PULSE_GPIO=XX
+
+[env:WAVESHARE_AMOLED_175_PRODUCTION]
+extends = env:WAVESHARE_AMOLED_175
+custom_firmware_target = WAVESHARE_AMOLED_175
+build_unflags =
+  -DCORE_DEBUG_LEVEL=2
+  -DDEBUG=1
+  -DFIRMWARE_DIAGNOSTICS=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+  ${env:WAVESHARE_AMOLED_175.build_flags}
+  -DCORE_DEBUG_LEVEL=0
+  -DFIRMWARE_DIAGNOSTICS=0
+  -DARDUINO_USB_CDC_ON_BOOT=0
 
 [env:WAVESHARE_AMOLED_175_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_175
@@ -311,6 +326,20 @@ build_flags =
   -DPOWER_METRICS=1
   ; Set to a verified spare output pin when correlating source-monitor traces.
   ; -DPOWER_METRICS_PULSE_GPIO=XX
+
+[env:WAVESHARE_AMOLED_206_PRODUCTION]
+extends = env:WAVESHARE_AMOLED_206
+custom_firmware_target = WAVESHARE_AMOLED_206
+build_unflags =
+  -DCORE_DEBUG_LEVEL=2
+  -DDEBUG=1
+  -DFIRMWARE_DIAGNOSTICS=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+build_flags =
+  ${env:WAVESHARE_AMOLED_206.build_flags}
+  -DCORE_DEBUG_LEVEL=0
+  -DFIRMWARE_DIAGNOSTICS=0
+  -DARDUINO_USB_CDC_ON_BOOT=0
 
 [env:WAVESHARE_AMOLED_206_DISPLAY_TEST]
 extends = env:WAVESHARE_AMOLED_206

--- a/esp32/prebuild.py
+++ b/esp32/prebuild.py
@@ -29,6 +29,7 @@ config.read("platformio.ini")
 # get platformio source path
 srcdir = env.get("PROJECTSRC_DIR")
 flavor = env.get("PIOENV")
+firmware_target = env.GetProjectOption("custom_firmware_target", flavor)
 revision = config.get("common","revision")
 version = config.get("common", "version")
 build_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -44,7 +45,7 @@ dfl_lon = os.environ.get('ICENAV3_LON')
 env.Append(BUILD_FLAGS=[
     u'-DREVISION=' + revision + '',
     u'-DVERSION=\\"' + version + '\\"',
-    u'-DFLAVOR=\\"' + flavor + '\\"',
+    u'-DFLAVOR=\\"' + firmware_target + '\\"',
     u'-DGIT_SHA=\\"' + git_sha + '\\"',
     u'-DBUILD_TIMESTAMP=\\"' + build_timestamp + '\\"',
     u'-D'+ flavor + '=1'

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -7,6 +7,10 @@
  */
 
 #include <Arduino.h>
+
+#ifndef FIRMWARE_DIAGNOSTICS
+#define FIRMWARE_DIAGNOSTICS 1
+#endif
 #include <SPI.h>
 #include <WiFi.h>
 #include <Wire.h>
@@ -386,6 +390,9 @@ static const char *debugTileName(uint8_t tile) {
 }
 
 static void logSystemDebugHeartbeat() {
+#if !FIRMWARE_DIAGNOSTICS
+  return;
+#else
   static uint32_t lastLogMs = 0;
   uint32_t now = millis();
   if (now - lastLogMs < 5000) {
@@ -505,6 +512,7 @@ static void logSystemDebugHeartbeat() {
                 (unsigned long)bleStats.routePacketCount,
                 (unsigned long)bleStats.gpsPacketCount,
                 (unsigned long)bleStats.settingsPacketCount);
+#endif
 #endif
 }
 
@@ -681,8 +689,12 @@ void setup() {
 #ifdef HAS_HARDWARE_GPS
   gpsMutex = xSemaphoreCreateMutex();
 #endif
+#if FIRMWARE_DIAGNOSTICS
   esp_log_level_set("*", ESP_LOG_DEBUG);
   esp_log_level_set("storage", ESP_LOG_DEBUG);
+#else
+  esp_log_level_set("*", ESP_LOG_NONE);
+#endif
 
   // Initialize Serial for debug. A complete PWRMET report is larger than the
   // default 256-byte HWCDC queue, so metrics builds reserve enough space for
@@ -692,10 +704,12 @@ void setup() {
   const size_t configuredSerialTxBufferSize =
       Serial.setTxBufferSize(kPowerMetricsSerialTxBufferSize);
 #endif
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
   Serial.begin(115200);
   // HWCDC uses this value as both a timeout and a retry counter. Zero
   // underflows that counter when the USB host stops reading and stalls the UI.
   Serial.setTxTimeoutMs(1);
+#endif
 #if POWER_METRICS
   if (configuredSerialTxBufferSize != kPowerMetricsSerialTxBufferSize) {
     Serial.printf("PWRMET_ERROR txBuffer=%u/%u\n",
@@ -707,7 +721,9 @@ void setup() {
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   displayPowerManager.begin();
 #endif
-  delay(2000);              // Give time for USB CDC to attach
+#if FIRMWARE_DIAGNOSTICS
+  delay(2000); // Give a diagnostic USB CDC monitor time to attach.
+#endif
   log_i("Starting Setup...");
   Serial.printf("Reset reason: CPU0=%d CPU1=%d\n", esp_reset_reason(),
                 esp_reset_reason());

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+import configparser
+from pathlib import Path
+
+
+project_dir = Path(__file__).resolve().parents[2]
+repo_root = project_dir.parent
+config = configparser.ConfigParser(interpolation=None)
+config.read(project_dir / "platformio.ini")
+
+expected_targets = {
+    "env:WAVESHARE_AMOLED_175_PRODUCTION": "WAVESHARE_AMOLED_175",
+    "env:WAVESHARE_AMOLED_206_PRODUCTION": "WAVESHARE_AMOLED_206",
+}
+
+for environment, target in expected_targets.items():
+    assert config.get(environment, "custom_firmware_target") == target
+    flags = config.get(environment, "build_flags")
+    unflags = config.get(environment, "build_unflags")
+    assert "-DCORE_DEBUG_LEVEL=0" in flags
+    assert "-DFIRMWARE_DIAGNOSTICS=0" in flags
+    assert "-DARDUINO_USB_CDC_ON_BOOT=0" in flags
+    assert "-DDEBUG=0" not in flags
+    assert "-DDEBUG=1" in unflags
+
+release_workflow = (repo_root / ".github/workflows/firmware-release.yml").read_text()
+for environment, target in expected_targets.items():
+    profile = environment.removeprefix("env:")
+    mapping = f"target: {target}\n            environment: {profile}"
+    assert mapping in release_workflow
+
+print("firmware production profile contracts passed")

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -5,6 +5,7 @@
 #include "../../lib/gui/src/navigationContentMode.hpp"
 #include "../../lib/gui/src/rideMetricFontSelection.hpp"
 #include "../../lib/gui/src/rideTelemetryLayout.hpp"
+#include "../../lib/gui/src/waitingScreenLayout.hpp"
 #include "../../lib/maps/src/mapLineStyle.hpp"
 
 #include <cassert>
@@ -36,6 +37,7 @@ int main() {
   assert(gui_layout::mapScreenAnchorY(502, 502) == 251);
   constexpr auto rideLayout = ride_telemetry_layout::makeLayout(410, 502);
   constexpr auto batteryLayout = battery_status_layout::makeLayout(410, 502);
+  constexpr auto waitingLayout = waiting_screen_layout::makeLayout(410, 502);
   static_assert(!ride_telemetry_layout::useLargeMetricValueFont(
       rideLayout.screenWidth));
 #else
@@ -46,9 +48,12 @@ int main() {
   assert(gui_layout::mapScreenAnchorY(466, 466) == 233);
   constexpr auto rideLayout = ride_telemetry_layout::makeLayout(466, 466);
   constexpr auto batteryLayout = battery_status_layout::makeLayout(466, 466);
+  constexpr auto waitingLayout = waiting_screen_layout::makeLayout(466, 466);
   static_assert(ride_telemetry_layout::useLargeMetricValueFont(
       rideLayout.screenWidth));
 #endif
+  static_assert(waiting_screen_layout::isValid(waitingLayout));
+  static_assert(waitingLayout.state.width == 112);
   static_assert(batteryLayout.topMargin == batteryLayout.bottomMargin);
   assert(batteryLayout.deviceY == batteryLayout.topMargin);
   assert(batteryLayout.phoneY + batteryLayout.diameter +

--- a/esp32/tools/tests/test_ui_update_policy.cpp
+++ b/esp32/tools/tests/test_ui_update_policy.cpp
@@ -1,0 +1,59 @@
+#include "../../lib/gui/src/uiUpdatePolicy.hpp"
+
+#include <cassert>
+#include <cstdint>
+
+using namespace ui_update_policy;
+
+int main() {
+  SourceSignatures signatures;
+  ChangeTracker tracker;
+  assert(tracker.observe(signatures) == kAllSources);
+  assert(tracker.take(kAllSources) == kAllSources);
+
+  // A static screen must not request any more widget mutations or flushes.
+  uint32_t widgetMutationRequests = 0;
+  uint32_t displayFlushRequests = 0;
+  for (uint32_t tick = 0; tick < 10000; ++tick) {
+    const uint32_t changed = tracker.observe(signatures);
+    if (changed != 0) {
+      ++widgetMutationRequests;
+      ++displayFlushRequests;
+    }
+  }
+  assert(widgetMutationRequests == 0);
+  assert(displayFlushRequests == 0);
+  assert(tracker.pending() == 0);
+
+  signatures[Source::Navigation] = 1;
+  assert(tracker.observe(signatures) == sourceMask(Source::Navigation));
+  signatures[Source::Gps] = 2;
+  assert(tracker.observe(signatures) == sourceMask(Source::Gps));
+  assert(tracker.take(Source::Navigation));
+  assert(!tracker.take(Source::Navigation));
+  assert(tracker.take(Source::Gps));
+
+  tracker.mark(Source::Workout);
+  assert(tracker.take(Source::Workout));
+
+  uint32_t lastRunMs = 0;
+  assert(cadenceDue(100, lastRunMs, kRideStatsPeriodMs));
+  assert(!cadenceDue(1099, lastRunMs, kRideStatsPeriodMs));
+  assert(cadenceDue(1100, lastRunMs, kRideStatsPeriodMs));
+  lastRunMs = UINT32_MAX - 100;
+  assert(cadenceDue(1000, lastRunMs, kRideStatsPeriodMs));
+
+  static_assert(nextMinuteDelayMs(0) == 60000);
+  static_assert(nextMinuteDelayMs(1) == 59000);
+  static_assert(nextMinuteDelayMs(59, 999) == 1);
+
+  constexpr StatusSnapshot initial{};
+  static_assert(statusMutations(initial, initial) == StatusNone);
+  StatusSnapshot changed = initial;
+  changed.satellites = 7;
+  changed.fixed = true;
+  changed.sdLoaded = true;
+  assert(statusMutations(initial, changed) ==
+         (StatusGpsCount | StatusGpsFix | StatusSd));
+  return 0;
+}


### PR DESCRIPTION
## What changed

- convert the waiting, notification, and main UI paths from unconditional redraws to change-driven updates with explicit cadences
- keep tap, drag, and pinch input responsive while pausing screen-specific work when a screen is hidden
- replace the animated waiting spinner and blinking GPS indicator with static, honest connection states
- add diagnostic and production firmware profiles for both 1.75-inch and 2.06-inch boards
- strip high-rate diagnostics and USB CDC startup from production builds while preserving canonical OTA target metadata
- build all six firmware profiles in CI and add host contract/regression tests for update policy, layouts, and release profile mapping

## Why

Static screens were still triggering frequent widget mutations, redraw requests, status sampling, and diagnostic output. Those activities keep the ESP32 and display pipeline busier than necessary. This phase makes the UI event/change driven and creates production profiles that remove development-only logging overhead.

## Validation

- built `WAVESHARE_AMOLED_175`
- built `WAVESHARE_AMOLED_175_PRODUCTION`
- built `WAVESHARE_AMOLED_175_POWER_METRICS`
- built `WAVESHARE_AMOLED_206`
- built `WAVESHARE_AMOLED_206_PRODUCTION`
- built `WAVESHARE_AMOLED_206_POWER_METRICS`
- passed UI no-change policy and both-board GUI layout host tests
- passed firmware profile, build identity, power trace schema, and display power policy tests
- verified production compiler flags and ELF strings omit high-rate diagnostics while retaining canonical OTA targets
- parsed both edited GitHub workflows and passed `git diff --check`
- completed a deep review loop with no remaining P0, P1, or P2 findings

## Outstanding physical gates

- the 1.75-inch board is currently unavailable over USB, so this phase has not been flashed yet
- re-check tap, map drag, pinch-to-zoom, screen transitions, and BLE states after the board reconnects
- the 2.06-inch variant is compile-only by agreement because that board is not available
- battery impact will be evaluated later by controlled battery runtime/depletion rather than the existing USB power meter or multimeter

This is a stacked draft PR. Its base is Phase 1 (`agent/battery-life-phase-1-brightness`).
