### PR TITLE
Bound GPS-driven vector map renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,10 @@ jobs:
             tools/tests/test_ui_update_policy.cpp \
             -o /tmp/test_ui_update_policy
           /tmp/test_ui_update_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_map_render_policy.cpp \
+            -o /tmp/test_map_render_policy
+          /tmp/test_map_render_policy
           python tools/tests/test_firmware_profile_config.py
       - name: Two-finger Map zoom host tests
         run: |

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -26,11 +26,11 @@ tables below only from saved source-monitor traces taken at the battery input.
 
 ## Instrumentation contract
 
-Power-metrics firmware uses schema version `1` and emits one aggregate line
+Power-metrics firmware uses schema version `2` and emits one aggregate line
 every ten seconds:
 
 ```text
-PWRMET v=1 intervalMs=... screen=... tile=... display=... brightness[...] loop[...] lvgl[...] flush[...] map[...] ble[...] system[...]
+PWRMET v=2 intervalMs=... screen=... tile=... display=... brightness[...] loop[...] lvgl[...] flush[...] map[...] ble[...] system[...]
 ```
 
 The report contains:
@@ -39,7 +39,8 @@ The report contains:
 - main-loop wakes and maximum loop gap;
 - LVGL call count plus total/maximum handler time;
 - display flush count plus rotation, QSPI, and total time;
-- completed/interrupted map renders, stage timing, and render-reason counts;
+- completed/interrupted map renders, stage timing, and position, route, style,
+  heading, zoom, screen, recovery, and other render-reason counts;
 - logically classified BLE packets after authenticated transport framing is
   unwrapped, including packets later rejected by session authentication or
   application-payload validation;
@@ -53,6 +54,10 @@ The accumulator schema is defined in
 `esp32/lib/power_metrics/power_metrics_schema.hpp` and has a host test in
 `esp32/tools/tests/test_power_metrics_schema.cpp`. Metrics builds are separate
 from normal firmware builds:
+
+Phase 0 traces remain valid schema-version-1 records. Always keep the raw
+version field with a trace rather than interpreting an older reason vector as
+version 2.
 
 ```sh
 cd esp32

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -1,0 +1,46 @@
+# Firmware map-render scheduler
+
+The firmware retains every accepted GPS fix for telemetry and the current
+position marker, but it no longer treats each fix as a request to read map data
+and regenerate the vector-map background.
+
+## Default policy
+
+An ordinary follow-mode GPS update regenerates the base map only when both of
+these conditions are true:
+
+- at least 750 ms has passed since the last completed base-map render; and
+- position moved at least 8 m, or course-up heading changed at least 12 degrees.
+
+North-up ignores heading-only changes. A manually panned map continues to move
+its position marker without recentering or regenerating its base map. Course-up
+rotation remains eligible while panned because it affects the whole visible
+map.
+
+Route, style, zoom, screen, and recovery requests bypass the GPS cadence and
+threshold gates. A failed/interrupted render retains its original pending
+reason and adds `recovery` for the next attempt.
+
+## Separation of work
+
+The LVGL owner performs four independent operations:
+
+1. ingest the latest GPS model (outside LVGL);
+2. apply lightweight telemetry and marker updates;
+3. apply navigation/maneuver overlay changes immediately; and
+4. ask the pure `map_render_policy::Scheduler` whether the vector background
+   is due.
+
+Only a completed base-map generation advances the scheduler baseline. This
+prevents a blocked or interrupted render from dropping pending work.
+
+## Diagnostics and validation
+
+`PWRMET` schema version 2 reports map-render reasons separately as `position`,
+`route`, `style`, `heading`, `zoom`, `screen`, `recovery`, and `other`.
+
+The host policy test covers movement, cadence, heading wraparound, stationary
+course noise, forced changes, retry retention, `millis()` rollover, and a
+deterministic 60-second 4 Hz GPS replay. Physical GPX replay, visible-position
+latency, gesture behavior, and both-board display validation remain required
+before the stacked battery work leaves draft status.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -25,6 +25,7 @@
 #include "../gps/gps.hpp"
 #include "../gui/src/waitingScr.hpp"
 #include "../gui/src/globalGuiDef.h"
+#include "../gui/src/mapRenderPolicy.hpp"
 #include "../maps/src/maps.hpp"
 #include "../device_transfer/device_transfer_http.hpp"
 #ifdef USE_ARDUINO_GFX
@@ -68,8 +69,8 @@ extern Storage storage;
 // Global instance
 BLENavigationServer bleNavServer;
 
-// Forward declaration of map redraw trigger
-extern void triggerMapRedraw();
+// Forward declaration of the LVGL-owner map scheduler entry point.
+extern void requestMapRender(map_render_policy::Reason reason);
 extern void applyDeviceScreenSettings();
 extern bool isMapScreenActive();
 extern bool isMapGuidanceScreenActive();
@@ -1818,8 +1819,7 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
     bleDebugStats.lastRoutePacketMs = millis();
     routeOverlay.clear();
     clearCurrentNavigationData();
-    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Route);
-    triggerMapRedraw();
+    requestMapRender(map_render_policy::Reason::Route);
     return;
   }
 
@@ -1860,8 +1860,7 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
   }
 
   routeOverlay.parseRouteData(data, len);
-  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Route);
-  triggerMapRedraw();
+  requestMapRender(map_render_policy::Reason::Route);
 }
 
 static void handleGpsPayload(const uint8_t *data, size_t len,
@@ -1912,8 +1911,9 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
     Serial.println("BLE GPS: First position received, transitioning to map...");
   }
 
-  power_metrics::noteMapRequest(power_metrics::MapRenderReason::Gps);
-  triggerMapRedraw();
+  // Retain every accepted fix. The LVGL owner updates lightweight telemetry and
+  // the position marker immediately, then independently decides whether the
+  // vector-map background crossed its time/movement/heading thresholds.
 }
 
 static void handleWorkoutTelemetryPayload(const uint8_t *data, size_t len,
@@ -2197,8 +2197,9 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
   }
 
   if (map_setting_redraw_policy::invalidatesMap(settingId)) {
-    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
-    triggerMapRedraw();
+    requestMapRender(map_setting_redraw_policy::changesZoom(settingId)
+                         ? map_render_policy::Reason::Zoom
+                         : map_render_policy::Reason::Style);
   }
 }
 
@@ -3138,9 +3139,10 @@ bool BLENavigationServer::confirmOwnershipPairing() {
 // Map Redraw Trigger (weak symbol - can be overridden by main app)
 // ============================================================================
 
-__attribute__((weak)) void triggerMapRedraw() {
+__attribute__((weak)) void requestMapRender(map_render_policy::Reason reason) {
+  (void)reason;
   // Default implementation - will be overridden by mainScr.cpp
-  Serial.println("BLE: triggerMapRedraw called (default - no map linked)");
+  Serial.println("BLE: requestMapRender called (default - no map linked)");
 }
 
 __attribute__((weak)) void applyDeviceScreenSettings() {

--- a/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
+++ b/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
@@ -27,4 +27,8 @@ constexpr bool invalidatesMap(uint8_t settingId) {
   }
 }
 
+constexpr bool changesZoom(uint8_t settingId) {
+  return settingId == 7 || settingId == 19;
+}
+
 } // namespace map_setting_redraw_policy

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -12,6 +12,7 @@
 #include "../../route_overlay/route_overlay.hpp"
 #include "destinationPickerLayout.hpp"
 #include "guiLayout.hpp"
+#include "mapRenderPolicy.hpp"
 #include "mapTileTransition.hpp"
 #include "navigationContentMode.hpp"
 #include "uiUpdatePolicy.hpp"
@@ -94,6 +95,7 @@ struct DestinationPickerView {
 static DestinationPickerView mapGuidanceDestinationPicker;
 static DestinationPickerView navigationDestinationPicker;
 static ui_update_policy::ChangeTracker uiChangeTracker;
+static map_render_policy::Scheduler mapRenderScheduler;
 static uint32_t lastRideStatsUpdateMs = 0;
 static constexpr lv_point_precise_t DESTINATION_STAR_POINTS[] = {
     {9, 0},  {11, 6}, {18, 7}, {13, 11}, {15, 18}, {9, 14},
@@ -323,6 +325,43 @@ void setImageAngleIfChanged(lv_obj_t *image, int16_t angle) {
 
 Maps mapView;
 static map_tap_arbiter::Controller mapTapController;
+static uint16_t currentCourseUpHeading();
+
+static map_render_policy::Fix currentMapFix() {
+  return {gps.gpsData.latitude, gps.gpsData.longitude,
+          currentCourseUpHeading()};
+}
+
+static void noteMapRenderReasons(uint32_t reasons) {
+  using PolicyReason = map_render_policy::Reason;
+  using MetricsReason = power_metrics::MapRenderReason;
+  struct Mapping {
+    PolicyReason policy;
+    MetricsReason metrics;
+  };
+  static constexpr Mapping mappings[] = {
+      {PolicyReason::Position, MetricsReason::Position},
+      {PolicyReason::Heading, MetricsReason::Heading},
+      {PolicyReason::Route, MetricsReason::Route},
+      {PolicyReason::Style, MetricsReason::Style},
+      {PolicyReason::Zoom, MetricsReason::Zoom},
+      {PolicyReason::Screen, MetricsReason::Screen},
+      {PolicyReason::Recovery, MetricsReason::Recovery},
+      {PolicyReason::Other, MetricsReason::Other},
+  };
+  for (const Mapping &mapping : mappings) {
+    if ((reasons & map_render_policy::reasonMask(mapping.policy)) != 0) {
+      power_metrics::noteMapRequest(mapping.metrics);
+    }
+  }
+}
+
+void requestMapRender(map_render_policy::Reason reason) {
+  mapRenderScheduler.request(reason);
+  noteMapRenderReasons(map_render_policy::reasonMask(reason));
+  mapView.isPosMoved = true;
+  mapView.redrawMap = true;
+}
 
 #if defined(WAVESHARE_AMOLED_175)
 static map_pinch_zoom::Controller mapPinchController;
@@ -377,6 +416,7 @@ static void processMapPinchZoom() {
     zoom = decision.targetZoom;
     mapView.commitPinchZoom(zoom, decision.previewRatio, decision.midpointX,
                             decision.midpointY);
+    requestMapRender(map_render_policy::Reason::Zoom);
     break;
   case map_pinch_zoom::Action::Cancel:
     mapView.cancelPinchPreview();
@@ -660,8 +700,7 @@ static void applyMapRotationForActiveTile() {
         mapView.rotationRad = 0;
       }
       mapView.updateArrowColor();
-      mapView.isPosMoved = true;
-      power_metrics::noteMapRequest(power_metrics::MapRenderReason::Heading);
+      requestMapRender(map_render_policy::Reason::Heading);
       log_i("Map guidance: rotation switched to %s",
             desiredMode == Maps::ROT_COURSE_UP ? "Course Up" : "North Up");
     }
@@ -676,16 +715,14 @@ static void applyMapRotationForActiveTile() {
       mapView.rotationMode != Maps::ROT_COURSE_UP) {
     mapView.rotationMode = Maps::ROT_COURSE_UP;
     mapView.updateArrowColor();
-    mapView.isPosMoved = true;
-    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
+    requestMapRender(map_render_policy::Reason::Style);
     log_i("Creating Map: Syncing rotation to Course Up (from settings)");
   } else if (mapRenderSettings.mapRotationMode == 0 &&
              mapView.rotationMode != Maps::ROT_NORTH_UP) {
     mapView.rotationMode = Maps::ROT_NORTH_UP;
     mapView.rotationRad = 0;
     mapView.updateArrowColor();
-    mapView.isPosMoved = true;
-    power_metrics::noteMapRequest(power_metrics::MapRenderReason::Settings);
+    requestMapRender(map_render_policy::Reason::Style);
     log_i("Creating Map: Syncing rotation to North Up (from settings)");
   }
 }
@@ -979,14 +1016,6 @@ static void refreshDestinationPickersAsync(void *userData) {
 }
 
 /**
- * @brief Trigger map redraw (called by BLE when route geometry is received)
- */
-void triggerMapRedraw() {
-  mapView.isPosMoved = true;
-  mapView.redrawMap = true;
-}
-
-/**
  * @brief Update compass screen event
  *
  * @param event
@@ -1072,6 +1101,62 @@ void scrollTile(lv_event_t *event) {
   mapView.deleteMapScrSprites();
 }
 
+static bool prepareVisibleMapUpdate(uint32_t nowMs) {
+  if (!isMapBackedTile(activeTile) || !mapView.hasMapCanvas()) {
+    return false;
+  }
+
+#ifdef ENABLE_COMPASS
+  heading = compass.getHeading();
+#endif
+  applyMapRotationForActiveTile();
+
+  bool navigationOverlayChanged = false;
+  if (activeTile == MAP_GUIDANCE) {
+    mapView.followGps = true;
+    navigationOverlayChanged =
+        uiChangeTracker.take(ui_update_policy::Source::Navigation);
+    if (navigationOverlayChanged) {
+      // Apply the maneuver model before considering synchronous base-map work.
+      // The caller gives LVGL one cycle to present this overlay first.
+      updateMapGuidanceOverlay();
+    }
+  }
+
+  if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
+    // Keep the lightweight marker current for every accepted fix. The vector
+    // background has a separate, bounded regeneration policy.
+    mapView.updatePositionOverlay();
+    mapRenderScheduler.observe(currentMapFix());
+  }
+
+  if (mapRenderScheduler.hasPendingWork()) {
+    const bool followPosition =
+        mapView.followGps || activeTile == MAP_GUIDANCE;
+    const bool courseUp = mapView.rotationMode == Maps::ROT_COURSE_UP;
+    const map_render_policy::Decision decision =
+        mapRenderScheduler.evaluate(nowMs, followPosition, courseUp);
+    if (decision.render) {
+      mapRenderScheduler.commit(decision);
+      noteMapRenderReasons(decision.reasons);
+      if (followPosition) {
+        mapView.followGps = true;
+        mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
+      } else {
+        mapView.isPosMoved = true;
+      }
+      mapView.redrawMap = true;
+      log_i("Map scheduler: render reasons=0x%02lx distance=%.1fm "
+            "heading=%u",
+            static_cast<unsigned long>(decision.reasons),
+            decision.distanceMeters,
+            static_cast<unsigned>(decision.headingDeltaDegrees));
+    }
+  }
+
+  return navigationOverlayChanged;
+}
+
 /**
  * @brief Update Main Screen
  *
@@ -1097,31 +1182,7 @@ void updateMainScreen(lv_timer_t *t) {
 
   const uint32_t nowMs = millis();
   (void)uiChangeTracker.observe(captureSourceSignatures(nowMs));
-  bool mapEventSent = false;
-
-  // Handle BLE-triggered map updates OUTSIDE of isScrolled check
-  // This ensures continuous updates even when user hasn't dragged
-  if (isMainScreen && isMapBackedTile(activeTile) &&
-      (mapView.isPosMoved || mapView.redrawMap)) {
-
-    applyMapRotationForActiveTile();
-
-    log_i("BLE map update: isPosMoved=%d redrawMap=%d followGps=%d",
-          mapView.isPosMoved, mapView.redrawMap, mapView.followGps);
-
-    // Re-center on GPS if in follow mode
-    if (mapView.followGps || activeTile == MAP_GUIDANCE) {
-      mapView.followGps = true;
-      mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
-    }
-
-    // Trigger map regeneration and display
-    lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
-    mapEventSent = true;
-    if (shouldInterruptMapRenderForScreenCycle()) {
-      return;
-    }
-  }
+  const bool navigationOverlayChanged = prepareVisibleMapUpdate(nowMs);
 
   if (isScrolled && isMainScreen) {
     switch (activeTile) {
@@ -1155,82 +1216,8 @@ void updateMainScreen(lv_timer_t *t) {
       break;
 
     case MAP:
-    case MAP_GUIDANCE: {
-      if (shouldInterruptMapRenderForScreenCycle()) {
-        return;
-      }
-
-      // SIMULATE GPS MOVEMENT - TEST MODE
-      // Removed legacy simulation code - controlled via BLE now
-
-#ifdef ENABLE_COMPASS
-      heading = compass.getHeading();
-#endif
-      applyMapRotationForActiveTile();
-      if (activeTile == MAP_GUIDANCE) {
-        mapView.followGps = true;
-        if (uiChangeTracker.take(ui_update_policy::Source::Navigation)) {
-          updateMapGuidanceOverlay();
-        }
-      }
-
-      // Track last heading for Course-Up auto-rotation
-      static uint16_t lastHeading = 0;
-      uint16_t currentHeading = currentCourseUpHeading();
-
-      // In Course-Up mode, redraw map when heading changes significantly (> 5
-      // degrees)
-      if (mapView.rotationMode == Maps::ROT_COURSE_UP) {
-        int headingDiff = abs((int)currentHeading - (int)lastHeading);
-        // Handle wrap-around (e.g., 355 to 5 = 10 degrees, not 350)
-        if (headingDiff > 180)
-          headingDiff = 360 - headingDiff;
-
-        if (headingDiff > 5) {
-          log_i("Course-Up: Heading changed from %d to %d (diff=%d), "
-                "triggering redraw",
-                lastHeading, currentHeading, headingDiff);
-          mapView.isPosMoved = true; // Force map regeneration with new rotation
-          power_metrics::noteMapRequest(
-              power_metrics::MapRenderReason::Heading);
-          lastHeading = currentHeading;
-        }
-      } else {
-        lastHeading = currentHeading; // Track heading even in North-Up for
-                                      // smooth transition
-      }
-
-      // Handle BLE simulated GPS: triggerMapRedraw() sets isPosMoved/redrawMap
-      // ALWAYS regenerate map when these flags are set, regardless of followGps
-      // This ensures continuous updates for GPS position and route overlay
-      if (mapView.isPosMoved || mapView.redrawMap) {
-        log_i(
-            "MAP case: Flags detected! isPosMoved=%d redrawMap=%d followGps=%d",
-            mapView.isPosMoved, mapView.redrawMap, mapView.followGps);
-        // Only re-center on GPS if in follow mode
-        if (mapView.followGps || activeTile == MAP_GUIDANCE) {
-          mapView.followGps = true;
-          mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
-        }
-        mapView.redrawMap = true;
-      }
-
-      // Also handle hardware GPS location changes (when in follow mode)
-      if (gps.hasLocationChange() &&
-          (mapView.followGps || activeTile == MAP_GUIDANCE)) {
-        power_metrics::noteMapRequest(power_metrics::MapRenderReason::Gps);
-        mapView.followGps = true;
-        mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
-        mapView.redrawMap = true;
-      }
-
-      if (!mapEventSent && (mapView.isPosMoved || mapView.redrawMap)) {
-        lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
-        mapEventSent = true;
-      }
-      (void)uiChangeTracker.take(ui_update_policy::Source::Gps);
+    case MAP_GUIDANCE:
       break;
-    }
 
     case NAV:
       if (uiChangeTracker.take(ui_update_policy::Source::Navigation)) {
@@ -1280,6 +1267,18 @@ void updateMainScreen(lv_timer_t *t) {
   // being mistaken for a later visible-widget change.
   (void)uiChangeTracker.take(ui_update_policy::Source::Route);
   (void)uiChangeTracker.take(ui_update_policy::Source::Settings);
+
+  // Synchronous vector-map generation can be long. When a new maneuver and a
+  // base-map request arrive together, return to LVGL once so the lightweight
+  // overlay can be presented before the expensive background regeneration.
+  if (!navigationOverlayChanged && isMapBackedTile(activeTile) &&
+      mapView.hasMapCanvas() &&
+      (mapView.isPosMoved || mapView.redrawMap)) {
+    if (shouldInterruptMapRenderForScreenCycle()) {
+      return;
+    }
+    lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
+  }
 
   serviceMapPinchZoomOutBackdrop();
 }
@@ -1343,18 +1342,19 @@ void updateMap(lv_event_t *event) {
       // Keep both flags set so the map is regenerated cleanly if the user
       // remains on this screen. Do not display the partially rendered canvas.
       mapView.redrawMap = true;
-      power_metrics::noteMapRequest(power_metrics::MapRenderReason::Retry);
+      mapRenderScheduler.markInterrupted();
+      noteMapRenderReasons(mapRenderScheduler.pendingForcedReasons());
       return;
     }
     // Clear flag AFTER generation complete (not inside generateVectorMap)
     // This ensures BLE updates during generation will queue another cycle
     mapView.isPosMoved = false;
+    mapRenderScheduler.markRendered(millis(), currentMapFix());
     if (mapView.takeDeferredVectorRedraw()) {
       // Course-up heading changed while a pinch was in flight. First present
       // the focal-stable settlement frame, then render the latest heading on
       // the following LVGL cycle.
-      mapView.isPosMoved = true;
-      mapView.redrawMap = true;
+      requestMapRender(map_render_policy::Reason::Heading);
     }
   }
 
@@ -1557,7 +1557,7 @@ void scrollMapEvent(lv_event_t *event) {
             log_i("LONG PRESS DETECTED: Re-enabling GPS following");
             mapView.followGps = true;
             mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
-            mapView.redrawMap = true;
+            requestMapRender(map_render_policy::Reason::Other);
             longPressTriggered = true;
             // Don't process as a scroll
             break;
@@ -1661,6 +1661,7 @@ void scrollMapEvent(lv_event_t *event) {
             if (distX < 120 && distY < 120) {
               log_i("SHORT TAP ON GPS DOT: Toggling rotation mode");
               mapView.toggleRotationMode();
+              requestMapRender(map_render_policy::Reason::Style);
 
               // Sync back to mapRenderSettings so it persists if we save or app
               // queries it (though app push is one-way usually)
@@ -1720,7 +1721,7 @@ void fullScreenEvent(lv_event_t *event) {
   mapView.deleteMapScrSprites();
   mapView.createMapScrSprites();
 
-  mapView.redrawMap = true;
+  requestMapRender(map_render_policy::Reason::Style);
 
   lv_obj_invalidate(tilesScreen);
   lv_obj_send_event(mapTile, LV_EVENT_REFRESH, NULL);
@@ -1739,8 +1740,7 @@ static bool requestVectorRuntimeZoom(int8_t levelDelta) {
     return false;
   }
   zoom = target;
-  mapView.isPosMoved = true;
-  mapView.redrawMap = true;
+  requestMapRender(map_render_policy::Reason::Zoom);
   return true;
 }
 
@@ -1904,7 +1904,7 @@ static void showMainTile(tileName tile) {
     }
     mapTileTransition.begin();
     zoom = currentMapStyleSettings().zoomLevel;
-    mapView.isPosMoved = true;
+    requestMapRender(map_render_policy::Reason::Screen);
   } else {
     mapTileTransition.cancel();
     lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
@@ -1920,7 +1920,6 @@ static void showMainTile(tileName tile) {
     applyMapRotationForActiveTile();
     updateMapGuidanceOverlay();
     (void)uiChangeTracker.take(ui_update_policy::Source::Navigation);
-    mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to map guidance screen");
     break;
@@ -1956,7 +1955,6 @@ static void showMainTile(tileName tile) {
     break;
   case MAP:
   default:
-    mapView.redrawMap = true;
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
     log_i("UI: switched to map screen");
     break;

--- a/esp32/lib/gui/src/mainScr.hpp
+++ b/esp32/lib/gui/src/mainScr.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "maps.hpp"
+#include "mapRenderPolicy.hpp"
 
 #include "buttonBar.hpp"
 #include "batteryStatusScr.hpp"
@@ -75,6 +76,7 @@ void updateMainScreen(lv_timer_t *t);
 void gestureEvent(lv_event_t *event);
 
 void updateMap(lv_event_t *event);
+void requestMapRender(map_render_policy::Reason reason);
 void updateSatTrack(lv_event_t *event);
 void mapToolBarEvent(lv_event_t *event);
 void scrollMapEvent(lv_event_t *event);

--- a/esp32/lib/gui/src/mapRenderPolicy.hpp
+++ b/esp32/lib/gui/src/mapRenderPolicy.hpp
@@ -1,0 +1,167 @@
+#pragma once
+
+#include <cmath>
+#include <cstdint>
+
+namespace map_render_policy {
+
+constexpr uint32_t kMinimumRenderIntervalMs = 750;
+constexpr double kMovementThresholdMeters = 8.0;
+constexpr uint16_t kHeadingThresholdDegrees = 12;
+
+enum class Reason : uint32_t {
+  Position = 1u << 0,
+  Heading = 1u << 1,
+  Route = 1u << 2,
+  Style = 1u << 3,
+  Zoom = 1u << 4,
+  Screen = 1u << 5,
+  Recovery = 1u << 6,
+  Other = 1u << 7,
+};
+
+constexpr uint32_t reasonMask(Reason reason) {
+  return static_cast<uint32_t>(reason);
+}
+
+struct Fix {
+  double latitude = 0.0;
+  double longitude = 0.0;
+  uint16_t headingDegrees = 0;
+};
+
+struct Decision {
+  bool render = false;
+  bool deferredByCadence = false;
+  uint32_t reasons = 0;
+  double distanceMeters = 0.0;
+  uint16_t headingDeltaDegrees = 0;
+};
+
+inline uint16_t headingDelta(uint16_t first, uint16_t second) {
+  const uint16_t normalizedFirst = first % 360U;
+  const uint16_t normalizedSecond = second % 360U;
+  const uint16_t direct = normalizedFirst > normalizedSecond
+                              ? normalizedFirst - normalizedSecond
+                              : normalizedSecond - normalizedFirst;
+  return direct > 180U ? 360U - direct : direct;
+}
+
+inline double distanceMeters(const Fix &first, const Fix &second) {
+  constexpr double kRadiansPerDegree =
+      3.14159265358979323846 / 180.0;
+  constexpr double kEarthRadiusMeters = 6371000.0;
+  const double firstLatitude = first.latitude * kRadiansPerDegree;
+  const double secondLatitude = second.latitude * kRadiansPerDegree;
+  const double latitudeDelta =
+      (second.latitude - first.latitude) * kRadiansPerDegree;
+  const double longitudeDelta =
+      (second.longitude - first.longitude) * kRadiansPerDegree;
+  const double sinLatitude = std::sin(latitudeDelta / 2.0);
+  const double sinLongitude = std::sin(longitudeDelta / 2.0);
+  const double a = sinLatitude * sinLatitude +
+                   std::cos(firstLatitude) * std::cos(secondLatitude) *
+                       sinLongitude * sinLongitude;
+  const double clamped = a > 1.0 ? 1.0 : (a < 0.0 ? 0.0 : a);
+  return 2.0 * kEarthRadiusMeters *
+         std::atan2(std::sqrt(clamped), std::sqrt(1.0 - clamped));
+}
+
+class Scheduler {
+public:
+  void request(Reason reason) { pendingForcedReasons_ |= reasonMask(reason); }
+
+  void observe(const Fix &fix) {
+    observedFix_ = fix;
+    hasObservation_ = true;
+  }
+
+  Decision evaluate(uint32_t nowMs, bool allowPosition, bool courseUp) {
+    Decision decision;
+    decision.reasons = pendingForcedReasons_;
+
+    if (!hasRenderedFix_) {
+      if (hasObservation_) {
+        decision.reasons |= reasonMask(Reason::Position);
+      }
+      decision.render = decision.reasons != 0;
+      return decision;
+    }
+
+    if (hasObservation_) {
+      decision.distanceMeters =
+          map_render_policy::distanceMeters(renderedFix_, observedFix_);
+      decision.headingDeltaDegrees = map_render_policy::headingDelta(
+          renderedFix_.headingDegrees, observedFix_.headingDegrees);
+    }
+
+    if (decision.reasons != 0) {
+      decision.render = true;
+      return decision;
+    }
+
+    if (!hasObservation_) {
+      return decision;
+    }
+
+    const bool moved =
+        allowPosition && decision.distanceMeters >= kMovementThresholdMeters;
+    const bool turned = courseUp &&
+                        decision.headingDeltaDegrees >=
+                            kHeadingThresholdDegrees;
+    if (!moved && !turned) {
+      hasObservation_ = false;
+      return decision;
+    }
+
+    if (static_cast<uint32_t>(nowMs - lastRenderMs_) <
+        kMinimumRenderIntervalMs) {
+      decision.deferredByCadence = true;
+      return decision;
+    }
+
+    if (moved) {
+      decision.reasons |= reasonMask(Reason::Position);
+    }
+    if (turned) {
+      decision.reasons |= reasonMask(Reason::Heading);
+    }
+    decision.render = true;
+    return decision;
+  }
+
+  void commit(const Decision &decision) {
+    if (decision.render) {
+      pendingForcedReasons_ |= decision.reasons;
+    }
+  }
+
+  void markRendered(uint32_t nowMs, const Fix &renderedFix) {
+    renderedFix_ = renderedFix;
+    observedFix_ = renderedFix;
+    hasRenderedFix_ = true;
+    hasObservation_ = false;
+    pendingForcedReasons_ = 0;
+    lastRenderMs_ = nowMs;
+  }
+
+  void markInterrupted() { request(Reason::Recovery); }
+
+  void discardObservation() { hasObservation_ = false; }
+
+  bool hasPendingWork() const {
+    return pendingForcedReasons_ != 0 || hasObservation_;
+  }
+
+  uint32_t pendingForcedReasons() const { return pendingForcedReasons_; }
+
+private:
+  Fix renderedFix_{};
+  Fix observedFix_{};
+  uint32_t lastRenderMs_ = 0;
+  uint32_t pendingForcedReasons_ = 0;
+  bool hasRenderedFix_ = false;
+  bool hasObservation_ = false;
+};
+
+} // namespace map_render_policy

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -4025,10 +4025,13 @@ void Maps::generateRenderMap(uint8_t zoom) {
  * @brief Display Map (Stub for Vector Maps/Arduino_GFX)
  */
 void Maps::displayMap() {
-  const uint32_t displayStartMs = MAPIO_TIME_MS();
   if (Maps::canvasMap)
     lv_obj_invalidate(Maps::canvasMap);
+  updatePositionOverlay();
+}
 
+void Maps::updatePositionOverlay() {
+  const uint32_t displayStartMs = MAPIO_TIME_MS();
   // Update Arrow Position
   if (Maps::canvasArrow) {
     if (!Maps::isMapFound || !isCurrentPositionVisible(mapRenderSettings)) {

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -323,7 +323,9 @@ public:
   void createMapScrSprites();
   void generateRenderMap(uint8_t zoom);
   bool generateVectorMap(uint8_t zoom);
+  bool hasMapCanvas() const { return canvasMap != nullptr; }
   void displayMap();
+  void updatePositionOverlay();
   void setWaypoint(double wptLat, double wptLon);
   void updateMap();
   void panMap(int8_t dx, int8_t dy);

--- a/esp32/lib/power_metrics/power_metrics_schema.hpp
+++ b/esp32/lib/power_metrics/power_metrics_schema.hpp
@@ -6,25 +6,28 @@
 
 namespace power_metrics {
 
-constexpr uint8_t kSchemaVersion = 1;
+constexpr uint8_t kSchemaVersion = 2;
 
 enum class MapRenderReason : uint32_t {
-  Gps = 1u << 0,
+  Position = 1u << 0,
   Route = 1u << 1,
-  Settings = 1u << 2,
+  Style = 1u << 2,
   Heading = 1u << 3,
-  Retry = 1u << 4,
-  Other = 1u << 5,
+  Zoom = 1u << 4,
+  Screen = 1u << 5,
+  Recovery = 1u << 6,
+  Other = 1u << 7,
 };
 
 constexpr uint32_t reasonMask(MapRenderReason reason) {
   return static_cast<uint32_t>(reason);
 }
 
-constexpr std::array<MapRenderReason, 6> kMapRenderReasons = {
-    MapRenderReason::Gps,     MapRenderReason::Route,
-    MapRenderReason::Settings, MapRenderReason::Heading,
-    MapRenderReason::Retry,   MapRenderReason::Other,
+constexpr std::array<MapRenderReason, 8> kMapRenderReasons = {
+    MapRenderReason::Position, MapRenderReason::Route,
+    MapRenderReason::Style,    MapRenderReason::Heading,
+    MapRenderReason::Zoom,     MapRenderReason::Screen,
+    MapRenderReason::Recovery, MapRenderReason::Other,
 };
 
 enum class BlePacketClass : uint8_t {

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -575,7 +575,8 @@ static void logPowerMetricsReport() {
       "totalUs=%llu/%lu] "
       "map[count=%lu completed=%lu interrupted=%lu totalUs=%llu/%lu "
       "blocksUs=%llu/%lu drawUs=%llu/%lu routeUs=%llu/%lu "
-      "reasons=gps:%lu,route:%lu,settings:%lu,heading:%lu,retry:%lu,other:%lu] "
+      "reasons=position:%lu,route:%lu,style:%lu,heading:%lu,zoom:%lu,"
+      "screen:%lu,recovery:%lu,other:%lu] "
       "ble[connected=%d authenticated=%d "
       "logical=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
@@ -614,6 +615,8 @@ static void logPowerMetricsReport() {
       (unsigned long)metrics.mapReasonCounts[3],
       (unsigned long)metrics.mapReasonCounts[4],
       (unsigned long)metrics.mapReasonCounts[5],
+      (unsigned long)metrics.mapReasonCounts[6],
+      (unsigned long)metrics.mapReasonCounts[7],
       bleStats.connected, bleStats.authenticated,
       (unsigned long)bleCount(power_metrics::BlePacketClass::Navigation),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Route),

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -80,6 +80,10 @@ int main() {
                      uint8_t{24}, uint8_t{255}}) {
     assert(!map_setting_redraw_policy::invalidatesMap(id));
   }
+  assert(map_setting_redraw_policy::changesZoom(7));
+  assert(map_setting_redraw_policy::changesZoom(19));
+  assert(!map_setting_redraw_policy::changesZoom(3));
+  assert(!map_setting_redraw_policy::changesZoom(20));
 
   map_setting_packet::Packet packet;
   const uint8_t positivePacket[] = {12, 75, 0, 0, 0};

--- a/esp32/tools/tests/test_map_render_policy.cpp
+++ b/esp32/tools/tests/test_map_render_policy.cpp
@@ -1,0 +1,147 @@
+#include "../../lib/gui/src/mapRenderPolicy.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+
+namespace {
+
+map_render_policy::Fix northOf(const map_render_policy::Fix &origin,
+                               double meters) {
+  map_render_policy::Fix result = origin;
+  result.latitude += meters / 111195.0;
+  return result;
+}
+
+} // namespace
+
+int main() {
+  using namespace map_render_policy;
+
+  assert(headingDelta(355, 5) == 10);
+  assert(headingDelta(5, 355) == 10);
+  assert(headingDelta(20, 200) == 180);
+
+  const Fix origin{51.5007, -0.1246, 359};
+  assert(std::fabs(distanceMeters(origin, northOf(origin, 10.0)) - 10.0) <
+         0.1);
+
+  Scheduler scheduler;
+  scheduler.observe(origin);
+  Decision first = scheduler.evaluate(100, true, false);
+  assert(first.render);
+  assert((first.reasons & reasonMask(Reason::Position)) != 0);
+  scheduler.commit(first);
+  scheduler.markRendered(100, origin);
+
+  // Sub-threshold movement never schedules a render, even after the cadence.
+  scheduler.observe(northOf(origin, 7.9));
+  Decision smallMove = scheduler.evaluate(2000, true, false);
+  assert(!smallMove.render);
+  assert(!smallMove.deferredByCadence);
+
+  // Meaningful movement is retained until the minimum interval expires.
+  const Fix moved = northOf(origin, 9.0);
+  scheduler.observe(moved);
+  Decision earlyMove = scheduler.evaluate(600, true, false);
+  assert(!earlyMove.render);
+  assert(earlyMove.deferredByCadence);
+  Decision dueMove = scheduler.evaluate(850, true, false);
+  assert(dueMove.render);
+  assert((dueMove.reasons & reasonMask(Reason::Position)) != 0);
+  scheduler.commit(dueMove);
+  scheduler.markRendered(850, moved);
+
+  // Stationary course noise stays below the heading threshold, including wrap.
+  Fix noisy = moved;
+  noisy.headingDegrees = 5;
+  scheduler.observe(noisy);
+  Decision noisyHeading = scheduler.evaluate(2000, true, true);
+  assert(!noisyHeading.render);
+  noisy.headingDegrees = 12;
+  scheduler.observe(noisy);
+  Decision thresholdHeading = scheduler.evaluate(2000, true, true);
+  assert(thresholdHeading.render);
+  assert((thresholdHeading.reasons & reasonMask(Reason::Heading)) != 0);
+  scheduler.commit(thresholdHeading);
+  scheduler.markRendered(2000, noisy);
+
+  // North-up ignores heading-only changes.
+  noisy.headingDegrees = 90;
+  scheduler.observe(noisy);
+  assert(!scheduler.evaluate(3000, true, false).render);
+
+  // A panned map can keep its lightweight position marker fresh without
+  // moving the base map; course-up rotation remains independently eligible.
+  Fix pannedMovement = northOf(noisy, 100.0);
+  scheduler.observe(pannedMovement);
+  assert(!scheduler.evaluate(3000, false, false).render);
+
+  // Forced semantic changes bypass movement and cadence gates and accumulate.
+  scheduler.request(Reason::Route);
+  scheduler.request(Reason::Style);
+  Decision forced = scheduler.evaluate(3001, false, false);
+  assert(forced.render);
+  assert((forced.reasons & reasonMask(Reason::Route)) != 0);
+  assert((forced.reasons & reasonMask(Reason::Style)) != 0);
+  scheduler.commit(forced);
+  scheduler.markRendered(3001, pannedMovement);
+
+  scheduler.request(Reason::Zoom);
+  assert(scheduler.evaluate(3002, true, true).render);
+  scheduler.markInterrupted();
+  Decision recovery = scheduler.evaluate(3003, true, true);
+  assert(recovery.render);
+  assert((recovery.reasons & reasonMask(Reason::Zoom)) != 0);
+  assert((recovery.reasons & reasonMask(Reason::Recovery)) != 0);
+
+  // A GPS-driven render that is interrupted also retains its semantic reason
+  // so the retry is not reported as recovery-only.
+  Scheduler interruptedPosition;
+  interruptedPosition.observe(origin);
+  interruptedPosition.markRendered(0, origin);
+  interruptedPosition.observe(northOf(origin, 9.0));
+  Decision attemptedPosition =
+      interruptedPosition.evaluate(kMinimumRenderIntervalMs, true, false);
+  assert(attemptedPosition.render);
+  interruptedPosition.commit(attemptedPosition);
+  interruptedPosition.markInterrupted();
+  Decision retriedPosition = interruptedPosition.evaluate(
+      kMinimumRenderIntervalMs + 1, true, false);
+  assert(retriedPosition.render);
+  assert((retriedPosition.reasons & reasonMask(Reason::Position)) != 0);
+  assert((retriedPosition.reasons & reasonMask(Reason::Recovery)) != 0);
+
+  // Unsigned elapsed-time arithmetic stays correct across millis rollover.
+  Scheduler rollover;
+  rollover.observe(origin);
+  rollover.request(Reason::Screen);
+  rollover.markRendered(std::numeric_limits<uint32_t>::max() - 400, origin);
+  rollover.observe(northOf(origin, 10.0));
+  assert(!rollover.evaluate(100, true, false).render);
+  assert(rollover.evaluate(400, true, false).render);
+
+  // A deterministic 60-second, 4 Hz straight-line replay keeps every fix but
+  // regenerates the base map only when the cumulative 8 m threshold is met.
+  Scheduler replay;
+  uint32_t replayRenders = 0;
+  for (uint32_t sample = 0; sample <= 240; ++sample) {
+    Fix fix = northOf(origin, static_cast<double>(sample) * 0.5);
+    // Representative wraparound noise must not add course-up renders.
+    fix.headingDegrees = sample % 2 == 0 ? 358 : 2;
+    replay.observe(fix);
+    const uint32_t nowMs = sample * 250;
+    const Decision decision = replay.evaluate(nowMs, true, true);
+    if (decision.render) {
+      replay.commit(decision);
+      replay.markRendered(nowMs, fix);
+      replayRenders++;
+    }
+  }
+  assert(replayRenders >= 14);
+  assert(replayRenders <= 16);
+  assert(replayRenders < 241);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_power_metrics_schema.cpp
+++ b/esp32/tools/tests/test_power_metrics_schema.cpp
@@ -7,7 +7,7 @@
 int main() {
   using namespace power_metrics;
 
-  static_assert(kSchemaVersion == 1);
+  static_assert(kSchemaVersion == 2);
   IntervalAccumulator accumulator;
 
   accumulator.noteLoop(100);
@@ -19,7 +19,8 @@ int main() {
   accumulator.noteDisplayFlush(20, 180, 225);
   accumulator.noteMapRender(
       true, 9'000, 2'000, 5'000, 1'000,
-      reasonMask(MapRenderReason::Gps) | reasonMask(MapRenderReason::Heading));
+      reasonMask(MapRenderReason::Position) |
+          reasonMask(MapRenderReason::Heading));
   accumulator.noteMapRender(false, 1'500, 1'000, 0, 0, 0);
   accumulator.noteBlePacket(BlePacketClass::Gps);
   accumulator.noteBlePacket(BlePacketClass::Gps);
@@ -40,9 +41,9 @@ int main() {
   assert(first.mapRenderCompleted == 1);
   assert(first.mapRenderInterrupted == 1);
   assert(first.mapRender.totalUs == 10'500);
-  assert(first.mapReasonCounts[0] == 1); // GPS
+  assert(first.mapReasonCounts[0] == 1); // position
   assert(first.mapReasonCounts[3] == 1); // heading
-  assert(first.mapReasonCounts[5] == 1); // missing reason becomes other
+  assert(first.mapReasonCounts[7] == 1); // missing reason becomes other
   assert(first.blePacketCounts[static_cast<std::size_t>(
              BlePacketClass::Gps)] == 2);
   assert(first.blePacketCounts[static_cast<std::size_t>(


### PR DESCRIPTION
## Summary

- retain every accepted GPS fix while separating lightweight marker and maneuver updates from vector-map regeneration
- add a pure map-render scheduler with a 750 ms minimum interval, 8 m movement threshold, and 12 degree course-up heading threshold
- force immediate renders for route, style, zoom, screen, and recovery changes
- prioritize maneuver-overlay presentation ahead of synchronous base-map work
- extend power metrics schema v2 with position, route, style, heading, zoom, screen, recovery, and other render reasons
- add scheduler documentation, host coverage, and CI enforcement

## Why

GPS packets previously mapped one-to-one to full vector-map regeneration and SD-backed rendering. This keeps model and overlay freshness while bounding expensive background work.

This is a stacked draft PR based on `agent/battery-life-phase-2-static-ui` (PR #162). Review Phase 3 as the single commit `49079d56`; its exact baseline is `a7655f10860e03c257508962cabbdea70f2fb464`.

## Deep review

The phase review resolved five findings before publication:

- maneuver overlays could be delayed behind a synchronous base-map render
- zoom settings were attributed as generic style work
- interrupted GPS renders could be reported as recovery-only
- a legacy transition path could render without a live canvas
- the initial readiness guard violated renderer encapsulation

No verified code findings remain open.

## Validation

- all six PlatformIO profiles build:
  - `WAVESHARE_AMOLED_175`
  - `WAVESHARE_AMOLED_175_PRODUCTION`
  - `WAVESHARE_AMOLED_175_POWER_METRICS`
  - `WAVESHARE_AMOLED_206`
  - `WAVESHARE_AMOLED_206_PRODUCTION`
  - `WAVESHARE_AMOLED_206_POWER_METRICS`
- map-render policy, display/redraw policy, power-metrics schema, and UI update host tests pass
- 1.75-inch and 2.06-inch layout tests pass
- CST9217 touch-frame and pinch-zoom host tests pass
- firmware production-profile contract passes
- `git diff --check` passes

## Physical validation

Not run in this phase: the 1.75-inch board is currently disconnected, and no 2.06-inch board is available. No firmware was flashed. The PR remains draft until the existing tap, map drag, pinch-to-zoom, GPS replay, maneuver freshness, and map-visual scenario gates can be rerun on the 1.75-inch device. Battery impact will be compared later with controlled battery-depletion/runtime observations rather than the USB power meter or multimeter.

## Rollback

Revert commit `49079d56` to restore the Phase 2 behavior and metrics schema.
