### PR TITLE
Coalesce replaceable BLE navigation state

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -283,6 +283,18 @@ the original 8-byte lat/lon payload, the 10-byte lat/lon/heading payload, the
 14-byte payload with Unix time, and the extended 30-byte telemetry payload. The
 Waveshare firmware uses the optional Unix time to sync the onboard PCF85063 RTC.
 
+The iOS sender treats GPS as replaceable state, not an ordered history. At most
+one unsent native or `GPSP` position is retained; a newer position replaces only
+that pending position and never route, settings, transfer, destination, auth, or
+workout traffic. A complete maneuver snapshot uses the bounded priority lane so
+it is delivered ahead of a GPS backlog. Native `2A72` prefers
+write-without-response only when the characteristic advertises it and the
+protected payload fits CoreBluetooth's current maximum. CoreBluetooth
+backpressure pauses dequeue without discarding the latest position. If the
+unacknowledged maximum is too small, iOS uses acknowledged native `2A72`; if no
+native write fits, it uses the authenticated navigation fallback. Route and
+catalog batches remain atomic and ordered.
+
 ## Watch Workout Telemetry (`9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003`)
 
 Workout telemetry is iOS-to-device, RAM-only, and accepted only after the

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -48,7 +48,12 @@ The report contains:
   number of application-managed power-management locks (`appPmLocks`,
   currently zero because this firmware creates none); and
 - `appQueue=ios-diagnostic`, which identifies the separate
-  `PWRMET_IOS v=1` ten-second interval report produced by a Debug iOS build.
+  `PWRMET_IOS v=2` ten-second interval report produced by a Debug iOS build.
+
+The iOS queue report includes current/maximum depth, oldest pending and active
+retry age, total admissions/flushes/drops/rejections/coalesces, and packet-class
+drop/coalescing counters. Queue schema-version-1 traces remain usable but do not
+contain the age or packet-class fields; retain the raw version with every trace.
 
 The accumulator schema is defined in
 `esp32/lib/power_metrics/power_metrics_schema.hpp` and has a host test in

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -50,6 +50,34 @@ struct WorkoutTelemetryWriteEndpoint {
     }
 }
 
+enum GPSPositionWriteRoute: Equatable {
+    case nativeWithoutResponse
+    case nativeWithResponse
+    case navigationFallback
+}
+
+enum GPSPositionWriteRouting {
+    static func route(
+        hasNativeWriteWithResponse: Bool,
+        hasNativeWriteWithoutResponse: Bool,
+        payloadLength: Int,
+        protectionOverhead: Int,
+        withResponseMaximum: Int,
+        withoutResponseMaximum: Int
+    ) -> GPSPositionWriteRoute {
+        let protectedLength = payloadLength + protectionOverhead
+        if hasNativeWriteWithoutResponse,
+           protectedLength <= withoutResponseMaximum {
+            return .nativeWithoutResponse
+        }
+        if hasNativeWriteWithResponse,
+           protectedLength <= withResponseMaximum {
+            return .nativeWithResponse
+        }
+        return .navigationFallback
+    }
+}
+
 enum WorkoutTelemetryWriteRoute: Equatable {
     case nativeWithResponse
     case navigationFallback
@@ -121,6 +149,8 @@ enum DeviceBLEProtocol {
     static let workoutTelemetryCoreCoalescingKey = "workout-telemetry-core"
     static let workoutTelemetryExtendedCoalescingKey =
         "workout-telemetry-extended"
+    static let navigationSnapshotCoalescingKey = "navigation-snapshot"
+    static let gpsPositionCoalescingKey = "gps-position"
     // Large enough for the worst schema-v1 three-favorite catalog at the
     // minimum BLE write length, without retaining a long stale GPS backlog.
     static let fallbackWriteQueueCapacity = 64
@@ -630,9 +660,9 @@ class BLEManager: NSObject, ObservableObject {
     private var navigationWriteEndpoint: NavigationWriteEndpoint?
     private var navigationWriteQueue = NavigationWriteQueue(
         maxCount: DeviceBLEProtocol.fallbackWriteQueueCapacity,
-        // One complete workout pair plus the latest destination status must be
-        // able to coexist while an acknowledged write is in flight.
-        priorityMaxCount: 3
+        // One complete workout pair plus the latest destination status and
+        // maneuver snapshot must coexist while an acknowledged write is in flight.
+        priorityMaxCount: 4
     )
     private var lastNavigationQueuePendingLogAt = Date.distantPast
 #if DEBUG
@@ -1673,7 +1703,17 @@ class BLEManager: NSObject, ObservableObject {
             return false
         }
         
-        enqueueNavigationWrite(dataToSend, endpoint: endpoint, label: "navigation")
+        guard enqueueNavigationWrite(
+            dataToSend,
+            endpoint: endpoint,
+            label: "navigation",
+            writeClass: .navigationSnapshot,
+            coalescingKey: DeviceBLEProtocol.navigationSnapshotCoalescingKey,
+            prioritized: true
+        ) else {
+            log("Navigation snapshot not queued: priority lane unavailable")
+            return false
+        }
         log("Queued navigation packet: \(dataToSend.count) bytes")
         return true
     }
@@ -1700,6 +1740,8 @@ class BLEManager: NSObject, ObservableObject {
                 data,
                 endpoint: endpoint,
                 label: "native route geometry",
+                writeClass: .route,
+                atomically: true,
                 transportWrite: { [weak self, weak peripheral, weak characteristic] payload in
                     guard let self, let peripheral, let characteristic else { return }
                     self.writeDeviceData(payload, to: characteristic, on: peripheral)
@@ -1716,7 +1758,12 @@ class BLEManager: NSObject, ObservableObject {
             return
         }
 
-        sendFallbackMapPacket(fallback, label: "route geometry")
+        sendFallbackMapPacket(
+            fallback,
+            label: "route geometry",
+            writeClass: .route,
+            atomically: true
+        )
     }
 
     /// Clear route geometry on ESP32.
@@ -1736,8 +1783,8 @@ class BLEManager: NSObject, ObservableObject {
         elapsedSeconds: TimeInterval? = nil,
         routeRemainingMeters: Double? = nil
     ) {
-        guard let peripheral = connectedPeripheral,
-              isConnected,
+        guard isConnected,
+              let endpoint = navigationWriteEndpoint,
               isNavigationReady else {
             log("Cannot send GPS position: BLE not ready")
             return
@@ -1754,28 +1801,78 @@ class BLEManager: NSObject, ObservableObject {
             routeRemainingMeters: routeRemainingMeters
         )
 
-        if let characteristic = gpsPositionCharacteristic,
-           let endpoint = navigationWriteEndpoint {
-            enqueueNavigationWrite(
-                data,
-                endpoint: endpoint,
-                label: "native GPS position",
-                transportWrite: { [weak self, weak peripheral, weak characteristic] payload in
-                    guard let self, let peripheral, let characteristic else { return }
-                    self.writeDeviceData(payload, to: characteristic, on: peripheral)
-                }
+        if let peripheral = connectedPeripheral,
+           let characteristic = gpsPositionCharacteristic {
+            let route = GPSPositionWriteRouting.route(
+                hasNativeWriteWithResponse:
+                    characteristic.properties.contains(.write),
+                hasNativeWriteWithoutResponse:
+                    characteristic.properties.contains(.writeWithoutResponse),
+                payloadLength: data.count,
+                protectionOverhead: authenticatedWriteSession == nil
+                    ? 0
+                    : AuthenticatedBLEWriteSession.frameOverhead,
+                withResponseMaximum: peripheral.maximumWriteValueLength(
+                    for: .withResponse
+                ),
+                withoutResponseMaximum: peripheral.maximumWriteValueLength(
+                    for: .withoutResponse
+                )
             )
-            log(String(format: "Queued native GPS position: heading=%.0f", heading))
-            return
+            let writeType: CBCharacteristicWriteType?
+            switch route {
+            case .nativeWithoutResponse:
+                writeType = CBCharacteristicWriteType.withoutResponse
+            case .nativeWithResponse:
+                writeType = CBCharacteristicWriteType.withResponse
+            case .navigationFallback:
+                writeType = nil
+            }
+            if let writeType {
+                let expectsWriteResponse = writeType == .withResponse
+                guard enqueueNavigationWrite(
+                    data,
+                    endpoint: endpoint,
+                    label: "native GPS position",
+                    writeClass: .gpsPosition,
+                    coalescingKey: DeviceBLEProtocol.gpsPositionCoalescingKey,
+                    transportWrite: { [weak self, weak peripheral, weak characteristic] payload in
+                        guard let self, let peripheral, let characteristic else { return }
+                        self.writeDeviceData(
+                            payload,
+                            to: characteristic,
+                            on: peripheral,
+                            type: writeType
+                        )
+                    },
+                    transportCanSend: { [weak self, weak peripheral] in
+                        if expectsWriteResponse {
+                            return self?.writeWithResponseInFlight == false
+                        }
+                        return peripheral?.canSendWriteWithoutResponse ?? false
+                    },
+                    transportExpectsWriteResponse: expectsWriteResponse
+                ) else {
+                    log("GPS position not queued: write queue unavailable")
+                    return
+                }
+                log(String(format: "Queued native GPS position: heading=%.0f", heading))
+                return
+            }
         }
 
         var fallback = Data(DeviceBLEProtocol.gpsPositionFallbackPrefix.utf8)
         fallback.append(data)
-        guard fallback.count <= peripheral.maximumWriteValueLength(for: .withoutResponse) else {
+        guard fallback.count <= endpoint.maximumWriteLength else {
             log("Cannot send GPS position fallback: write limit exceeded")
             return
         }
-        sendFallbackMapPacket(fallback, label: "GPS position")
+        sendFallbackMapPacket(
+            fallback,
+            label: "GPS position",
+            writeClass: .gpsPosition,
+            coalescingKey: DeviceBLEProtocol.gpsPositionCoalescingKey
+        )
     }
 
     /// Relays one fixed workout frame only after authentication and explicit
@@ -1993,6 +2090,7 @@ class BLEManager: NSObject, ObservableObject {
             onWriteFailure: onWriteFailure,
             transportCanSend: transportCanSend,
             transportExpectsWriteResponse: transportExpectsWriteResponse,
+            writeClass: .workoutTelemetry,
             coalescingKey: coalescingKey
         )
     }
@@ -2508,16 +2606,32 @@ class BLEManager: NSObject, ObservableObject {
         var packet = Data(DeviceBLEProtocol.mapTransferControlPrefix.utf8)
         packet.append(Data((enabled ? "enter" : "exit").utf8))
         let label = enabled ? "map transfer enter" : "map transfer exit"
-        let sentNative = sendNativeMapTransferPacket(packet, label: label)
-        let sentFallback = sendFallbackMapPacket(packet, label: label)
+        let sentNative = sendNativeMapTransferPacket(
+            packet,
+            label: label,
+            writeClass: .transfer
+        )
+        let sentFallback = sendFallbackMapPacket(
+            packet,
+            label: label,
+            writeClass: .transfer
+        )
         return sentNative || sentFallback
     }
 
     @discardableResult
     func requestMapTransferStatus() -> Bool {
         let packet = Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8)
-        let sentNative = sendNativeMapTransferPacket(packet, label: "map transfer status")
-        let sentFallback = sendFallbackMapPacket(packet, label: "map transfer status")
+        let sentNative = sendNativeMapTransferPacket(
+            packet,
+            label: "map transfer status",
+            writeClass: .transfer
+        )
+        let sentFallback = sendFallbackMapPacket(
+            packet,
+            label: "map transfer status",
+            writeClass: .transfer
+        )
         return sentNative || sentFallback
     }
 
@@ -2536,8 +2650,16 @@ class BLEManager: NSObject, ObservableObject {
     func requestDeviceTransferMode(_ mode: DeviceTransferSession.Mode) -> Bool {
         var packet = Data(DeviceBLEProtocol.deviceTransferControlPrefix.utf8)
         packet.append(Data("enter|\(mode.rawValue)".utf8))
-        let sentNative = sendNativeMapTransferPacket(packet, label: "\(mode.rawValue) transfer enter")
-        let sentFallback = sendFallbackMapPacket(packet, label: "\(mode.rawValue) transfer enter")
+        let sentNative = sendNativeMapTransferPacket(
+            packet,
+            label: "\(mode.rawValue) transfer enter",
+            writeClass: .transfer
+        )
+        let sentFallback = sendFallbackMapPacket(
+            packet,
+            label: "\(mode.rawValue) transfer enter",
+            writeClass: .transfer
+        )
         return sentNative || sentFallback
     }
 
@@ -2545,16 +2667,32 @@ class BLEManager: NSObject, ObservableObject {
     func requestDeviceTransferExit() -> Bool {
         var packet = Data(DeviceBLEProtocol.deviceTransferControlPrefix.utf8)
         packet.append(Data("exit".utf8))
-        let sentNative = sendNativeMapTransferPacket(packet, label: "device transfer exit")
-        let sentFallback = sendFallbackMapPacket(packet, label: "device transfer exit")
+        let sentNative = sendNativeMapTransferPacket(
+            packet,
+            label: "device transfer exit",
+            writeClass: .transfer
+        )
+        let sentFallback = sendFallbackMapPacket(
+            packet,
+            label: "device transfer exit",
+            writeClass: .transfer
+        )
         return sentNative || sentFallback
     }
 
     @discardableResult
     func requestDeviceTransferStatus() -> Bool {
         let packet = Data(DeviceBLEProtocol.deviceTransferStatusPrefix.utf8)
-        let sentNative = sendNativeMapTransferPacket(packet, label: "device transfer status")
-        let sentFallback = sendFallbackMapPacket(packet, label: "device transfer status")
+        let sentNative = sendNativeMapTransferPacket(
+            packet,
+            label: "device transfer status",
+            writeClass: .transfer
+        )
+        let sentFallback = sendFallbackMapPacket(
+            packet,
+            label: "device transfer status",
+            writeClass: .transfer
+        )
         return sentNative || sentFallback
     }
 
@@ -2976,7 +3114,7 @@ class BLEManager: NSObject, ObservableObject {
 
     func installNavigationWriteQueueForTesting(
         maxCount: Int,
-        priorityMaxCount: Int = 3
+        priorityMaxCount: Int = 4
     ) {
         navigationWriteQueue = NavigationWriteQueue(
             maxCount: maxCount,
@@ -3790,28 +3928,57 @@ class BLEManager: NSObject, ObservableObject {
         )
     }
 
+    @discardableResult
     private func enqueueNavigationWrite(
         _ data: Data,
         endpoint: NavigationWriteEndpoint,
         label: String,
+        writeClass: NavigationWriteClass = .other,
+        coalescingKey: String? = nil,
+        prioritized: Bool = false,
+        atomically: Bool = false,
         transportWrite: ((Data) -> Void)? = nil,
+        transportCanSend: (() -> Bool)? = nil,
+        transportExpectsWriteResponse: Bool? = nil,
         onWrite: (() -> Void)? = nil,
         onDrop: (() -> Void)? = nil,
         onWriteFailure: (() -> Void)? = nil
-    ) {
-        if navigationWriteQueue.enqueue(NavigationWrite(
+    ) -> Bool {
+        let write = NavigationWrite(
             data: data,
             label: label,
             transportWrite: transportWrite,
             onWrite: onWrite,
             onDrop: onDrop,
-            onWriteFailure: onWriteFailure
-        )) {
-            log("Navigation write queue full; dropped oldest packet")
+            onWriteFailure: onWriteFailure,
+            transportCanSend: transportCanSend,
+            transportExpectsWriteResponse: transportExpectsWriteResponse,
+            writeClass: writeClass,
+            coalescingKey: coalescingKey
+        )
+        let didEnqueue: Bool
+        if coalescingKey != nil {
+            didEnqueue = navigationWriteQueue.enqueueCoalescing(
+                write,
+                prioritized: prioritized
+            )
+        } else if prioritized {
+            didEnqueue = navigationWriteQueue.enqueuePrioritizedAtomically([write])
+        } else if atomically {
+            didEnqueue = navigationWriteQueue.enqueueAtomically([write])
+        } else {
+            if navigationWriteQueue.enqueue(write) {
+                log("Navigation write queue full; dropped oldest packet")
+            }
+            didEnqueue = true
+        }
+        guard didEnqueue else {
+            return false
         }
 
         flushPendingNavigationWrites(endpoint: endpoint)
         scheduleNavigationFlushRetryIfNeeded()
+        return true
     }
 
     @discardableResult
@@ -3819,6 +3986,7 @@ class BLEManager: NSObject, ObservableObject {
         _ frames: [Data],
         endpoint: NavigationWriteEndpoint,
         label: String,
+        writeClass: NavigationWriteClass = .transfer,
         prioritized: Bool = false,
         coalescingKey: String? = nil,
         onWriteFailure: (() -> Void)? = nil
@@ -3839,6 +4007,7 @@ class BLEManager: NSObject, ObservableObject {
                     self.writeDeviceData(payload, to: characteristic, on: peripheral)
                 },
                 onWriteFailure: onWriteFailure,
+                writeClass: writeClass,
                 coalescingKey: coalescingKey
             )
         }
@@ -3867,6 +4036,10 @@ class BLEManager: NSObject, ObservableObject {
     private func sendFallbackMapPacket(
         _ data: Data,
         label: String,
+        writeClass: NavigationWriteClass = .settingsControl,
+        coalescingKey: String? = nil,
+        prioritized: Bool = false,
+        atomically: Bool = false,
         onWrite: (() -> Void)? = nil,
         onDrop: (() -> Void)? = nil
     ) -> Bool {
@@ -3877,19 +4050,30 @@ class BLEManager: NSObject, ObservableObject {
             return false
         }
 
-        enqueueNavigationWrite(
+        guard enqueueNavigationWrite(
             data,
             endpoint: endpoint,
             label: "fallback \(label)",
+            writeClass: writeClass,
+            coalescingKey: coalescingKey,
+            prioritized: prioritized,
+            atomically: atomically,
             onWrite: onWrite,
             onDrop: onDrop
-        )
+        ) else {
+            log("Fallback \(label) not queued: write queue unavailable")
+            return false
+        }
         log("Queued fallback \(label): \(data.count) bytes")
         return true
     }
 
     @discardableResult
-    private func sendNativeMapTransferPacket(_ data: Data, label: String) -> Bool {
+    private func sendNativeMapTransferPacket(
+        _ data: Data,
+        label: String,
+        writeClass: NavigationWriteClass = .settingsControl
+    ) -> Bool {
         guard isConnected,
               isNavigationReady,
               let peripheral = connectedPeripheral,
@@ -3899,15 +4083,16 @@ class BLEManager: NSObject, ObservableObject {
             return false
         }
 
-        enqueueNavigationWrite(
+        guard enqueueNavigationWrite(
             data,
             endpoint: endpoint,
             label: "native \(label)",
+            writeClass: writeClass,
             transportWrite: { [weak self, weak peripheral, weak characteristic] payload in
                 guard let self, let peripheral, let characteristic else { return }
                 self.writeDeviceData(payload, to: characteristic, on: peripheral)
             }
-        )
+        ) else { return false }
         log("Queued native \(label): \(data.count) bytes")
         return true
     }
@@ -3973,11 +4158,22 @@ class BLEManager: NSObject, ObservableObject {
             "PWRMET_IOS v=\(NavigationWriteQueueMetrics.schemaVersion) " +
             "intervalMs=\(intervalMs) " +
             "queue[depth=\(metrics.currentDepth) maxDepth=\(metrics.maxDepth) " +
+            "oldestMs=\(metrics.oldestPendingAgeMs) retryAgeMs=\(metrics.retryAgeMs) " +
             "enqueued=\(metrics.enqueuedFrames) flushed=\(metrics.flushedFrames) " +
             "dropped=\(metrics.droppedFrames) rejected=\(metrics.rejectedFrames) " +
             "coalesced=\(metrics.coalescedFrames) cleared=\(metrics.clearedFrames) " +
             "retries=\(metrics.retrySchedules) " +
-            "backpressure=\(metrics.backpressureStops)]"
+            "backpressure=\(metrics.backpressureStops) " +
+            "class[gpsDrop=\(metrics.droppedFrames(for: .gpsPosition)) " +
+            "gpsCoalesce=\(metrics.coalescedFrames(for: .gpsPosition)) " +
+            "navDrop=\(metrics.droppedFrames(for: .navigationSnapshot)) " +
+            "navCoalesce=\(metrics.coalescedFrames(for: .navigationSnapshot)) " +
+            "routeDrop=\(metrics.droppedFrames(for: .route)) " +
+            "settingsDrop=\(metrics.droppedFrames(for: .settingsControl)) " +
+            "transferDrop=\(metrics.droppedFrames(for: .transfer)) " +
+            "workoutDrop=\(metrics.droppedFrames(for: .workoutTelemetry)) " +
+            "workoutCoalesce=\(metrics.coalescedFrames(for: .workoutTelemetry)) " +
+            "otherDrop=\(metrics.droppedFrames(for: .other))]]"
         )
 #endif
     }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationWriteQueue.swift
@@ -1,7 +1,17 @@
 import Foundation
 
+enum NavigationWriteClass: String, CaseIterable, Equatable {
+    case navigationSnapshot = "navigation"
+    case gpsPosition = "gps"
+    case route
+    case settingsControl = "settings"
+    case transfer
+    case workoutTelemetry = "workout"
+    case other
+}
+
 struct NavigationWriteQueueMetrics: Equatable {
-    static let schemaVersion = 1
+    static let schemaVersion = 2
 
     var enqueuedFrames = 0
     var flushedFrames = 0
@@ -13,6 +23,18 @@ struct NavigationWriteQueueMetrics: Equatable {
     var backpressureStops = 0
     var currentDepth = 0
     var maxDepth = 0
+    var oldestPendingAgeMs = 0
+    var retryAgeMs = 0
+    var droppedFramesByClass: [NavigationWriteClass: Int] = [:]
+    var coalescedFramesByClass: [NavigationWriteClass: Int] = [:]
+
+    func droppedFrames(for writeClass: NavigationWriteClass) -> Int {
+        droppedFramesByClass[writeClass, default: 0]
+    }
+
+    func coalescedFrames(for writeClass: NavigationWriteClass) -> Int {
+        coalescedFramesByClass[writeClass, default: 0]
+    }
 }
 
 struct NavigationWrite {
@@ -24,8 +46,10 @@ struct NavigationWrite {
     let onWriteFailure: (() -> Void)?
     let transportCanSend: (() -> Bool)?
     let transportExpectsWriteResponse: Bool?
+    let writeClass: NavigationWriteClass
     fileprivate let coalescingKey: String?
     fileprivate let protectedFromEviction: Bool
+    fileprivate let enqueuedAtUptime: TimeInterval?
 
     init(
         data: Data,
@@ -36,8 +60,10 @@ struct NavigationWrite {
         onWriteFailure: (() -> Void)? = nil,
         transportCanSend: (() -> Bool)? = nil,
         transportExpectsWriteResponse: Bool? = nil,
+        writeClass: NavigationWriteClass = .other,
         coalescingKey: String? = nil,
-        protectedFromEviction: Bool = false
+        protectedFromEviction: Bool = false,
+        enqueuedAtUptime: TimeInterval? = nil
     ) {
         self.data = data
         self.label = label
@@ -47,8 +73,10 @@ struct NavigationWrite {
         self.onWriteFailure = onWriteFailure
         self.transportCanSend = transportCanSend
         self.transportExpectsWriteResponse = transportExpectsWriteResponse
+        self.writeClass = writeClass
         self.coalescingKey = coalescingKey
         self.protectedFromEviction = protectedFromEviction
+        self.enqueuedAtUptime = enqueuedAtUptime
     }
 
     func perform(using fallbackWrite: (Data) -> Void) {
@@ -70,8 +98,27 @@ struct NavigationWrite {
             onWriteFailure: onWriteFailure,
             transportCanSend: transportCanSend,
             transportExpectsWriteResponse: transportExpectsWriteResponse,
+            writeClass: writeClass,
             coalescingKey: coalescingKey,
-            protectedFromEviction: true
+            protectedFromEviction: true,
+            enqueuedAtUptime: enqueuedAtUptime
+        )
+    }
+
+    fileprivate func enqueued(at uptime: TimeInterval) -> NavigationWrite {
+        NavigationWrite(
+            data: data,
+            label: label,
+            transportWrite: transportWrite,
+            onWrite: onWrite,
+            onDrop: onDrop,
+            onWriteFailure: onWriteFailure,
+            transportCanSend: transportCanSend,
+            transportExpectsWriteResponse: transportExpectsWriteResponse,
+            writeClass: writeClass,
+            coalescingKey: coalescingKey,
+            protectedFromEviction: protectedFromEviction,
+            enqueuedAtUptime: uptime
         )
     }
 }
@@ -82,6 +129,8 @@ struct NavigationWriteQueue {
     private var pendingWrites: [NavigationWrite] = []
     private var pendingPriorityWrites: [NavigationWrite] = []
     private var diagnosticMetrics = NavigationWriteQueueMetrics()
+    private var retryStartedAtUptime: TimeInterval?
+    private let now: () -> TimeInterval
 
     var count: Int {
         pendingPriorityWrites.count + pendingWrites.count
@@ -94,6 +143,18 @@ struct NavigationWriteQueue {
     var metrics: NavigationWriteQueueMetrics {
         var snapshot = diagnosticMetrics
         snapshot.currentDepth = count
+        let currentUptime = now()
+        let oldestEnqueueUptime = (pendingPriorityWrites + pendingWrites)
+            .compactMap(\.enqueuedAtUptime)
+            .min()
+        snapshot.oldestPendingAgeMs = ageMilliseconds(
+            since: oldestEnqueueUptime,
+            at: currentUptime
+        )
+        snapshot.retryAgeMs = ageMilliseconds(
+            since: retryStartedAtUptime,
+            at: currentUptime
+        )
         return snapshot
     }
 
@@ -107,14 +168,22 @@ struct NavigationWriteQueue {
         return snapshot
     }
 
-    init(maxCount: Int, priorityMaxCount: Int = 1) {
+    init(
+        maxCount: Int,
+        priorityMaxCount: Int = 1,
+        now: @escaping () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        }
+    ) {
         self.maxCount = max(1, maxCount)
         self.priorityMaxCount = max(1, priorityMaxCount)
+        self.now = now
     }
 
     @discardableResult
     mutating func enqueue(_ write: NavigationWrite) -> Bool {
-        pendingWrites.append(write)
+        beginEnqueueIfEmpty()
+        pendingWrites.append(write.enqueued(at: now()))
         recordEnqueuedFrames(1)
         guard pendingWrites.count > maxCount else {
             recordDepth()
@@ -128,7 +197,7 @@ struct NavigationWriteQueue {
             ?? pendingWrites.startIndex
         let droppedWrite = pendingWrites.remove(at: droppedIndex)
         droppedWrite.onDrop?()
-        recordDroppedFrames(1)
+        recordDropped(write: droppedWrite)
         recordDepth()
         return true
     }
@@ -141,7 +210,11 @@ struct NavigationWriteQueue {
             recordRejectedFrames(writes.count)
             return false
         }
-        pendingWrites.append(contentsOf: writes.map { $0.protectingAtomicBatch() })
+        beginEnqueueIfEmpty()
+        let enqueuedAt = now()
+        pendingWrites.append(contentsOf: writes.map {
+            $0.enqueued(at: enqueuedAt).protectingAtomicBatch()
+        })
         recordEnqueuedFrames(writes.count)
         recordDepth()
         return true
@@ -157,13 +230,38 @@ struct NavigationWriteQueue {
             return false
         }
 
+        let replacementKeys = Set(writes.compactMap(\.coalescingKey))
+        if !replacementKeys.isEmpty {
+            let replacementIndices = pendingPriorityWrites.indices.reversed().filter {
+                guard let key = pendingPriorityWrites[$0].coalescingKey else {
+                    return false
+                }
+                return replacementKeys.contains(key)
+            }
+            let retainedCount = pendingPriorityWrites.count - replacementIndices.count
+            guard retainedCount + writes.count <= priorityMaxCount else {
+                recordRejectedFrames(writes.count)
+                return false
+            }
+            for index in replacementIndices {
+                let removed = pendingPriorityWrites.remove(at: index)
+                recordCoalesced(write: removed)
+                removed.onDrop?()
+            }
+        }
+
         if pendingPriorityWrites.count + writes.count > priorityMaxCount {
-            recordDroppedFrames(pendingPriorityWrites.count)
-            pendingPriorityWrites.forEach { $0.onDrop?() }
+            let supersededWrites = pendingPriorityWrites
+            for supersededWrite in supersededWrites {
+                recordDropped(write: supersededWrite)
+                supersededWrite.onDrop?()
+            }
             pendingPriorityWrites.removeAll()
         }
+        beginEnqueueIfEmpty()
+        let enqueuedAt = now()
         pendingPriorityWrites.append(contentsOf: writes.map {
-            $0.protectingAtomicBatch()
+            $0.enqueued(at: enqueuedAt).protectingAtomicBatch()
         })
         recordEnqueuedFrames(writes.count)
         recordDepth()
@@ -186,19 +284,24 @@ struct NavigationWriteQueue {
             return true
         }
 
-        removePendingWrites(withCoalescingKey: key)
+        removePendingWrites(
+            withCoalescingKey: key,
+            resetRetryWhenEmpty: false
+        )
         if prioritized {
             guard pendingPriorityWrites.count < priorityMaxCount else {
                 recordRejectedFrames(1)
                 return false
             }
-            pendingPriorityWrites.append(write.protectingAtomicBatch())
+            pendingPriorityWrites.append(
+                write.enqueued(at: now()).protectingAtomicBatch()
+            )
             recordEnqueuedFrames(1)
             recordDepth()
             return true
         }
 
-        pendingWrites.append(write)
+        pendingWrites.append(write.enqueued(at: now()))
         guard pendingWrites.count > maxCount else {
             recordEnqueuedFrames(1)
             recordDepth()
@@ -218,7 +321,7 @@ struct NavigationWriteQueue {
         }
         droppedWrite.onDrop?()
         recordEnqueuedFrames(1)
-        recordDroppedFrames(1)
+        recordDropped(write: droppedWrite)
         recordDepth()
         return true
     }
@@ -227,24 +330,40 @@ struct NavigationWriteQueue {
         recordClearedFrames(count)
         pendingPriorityWrites.removeAll()
         pendingWrites.removeAll()
+        retryStartedAtUptime = nil
         recordDepth()
     }
 
     mutating func removePendingWrites(withCoalescingKey key: String) {
+        removePendingWrites(
+            withCoalescingKey: key,
+            resetRetryWhenEmpty: true
+        )
+    }
+
+    private mutating func removePendingWrites(
+        withCoalescingKey key: String,
+        resetRetryWhenEmpty: Bool
+    ) {
         let priorityMatches = pendingPriorityWrites.indices.reversed().filter {
             pendingPriorityWrites[$0].coalescingKey == key
         }
-        recordCoalescedFrames(priorityMatches.count)
         for index in priorityMatches {
-            pendingPriorityWrites.remove(at: index).onDrop?()
+            let removed = pendingPriorityWrites.remove(at: index)
+            recordCoalesced(write: removed)
+            removed.onDrop?()
         }
 
         let regularMatches = pendingWrites.indices.reversed().filter {
             pendingWrites[$0].coalescingKey == key
         }
-        recordCoalescedFrames(regularMatches.count)
         for index in regularMatches {
-            pendingWrites.remove(at: index).onDrop?()
+            let removed = pendingWrites.remove(at: index)
+            recordCoalesced(write: removed)
+            removed.onDrop?()
+        }
+        if resetRetryWhenEmpty, count == 0 {
+            retryStartedAtUptime = nil
         }
         recordDepth()
     }
@@ -281,11 +400,17 @@ struct NavigationWriteQueue {
             write(dequeued)
             writesRemaining -= 1
         }
+        if count == 0 {
+            retryStartedAtUptime = nil
+        }
     }
 
     mutating func noteRetryScheduled() {
 #if DEBUG || HOST_TESTING
         diagnosticMetrics.retrySchedules += 1
+        if retryStartedAtUptime == nil, count > 0 {
+            retryStartedAtUptime = now()
+        }
 #endif
     }
 
@@ -301,9 +426,10 @@ struct NavigationWriteQueue {
 #endif
     }
 
-    private mutating func recordDroppedFrames(_ count: Int) {
+    private mutating func recordDropped(write: NavigationWrite) {
 #if DEBUG || HOST_TESTING
-        diagnosticMetrics.droppedFrames += count
+        diagnosticMetrics.droppedFrames += 1
+        diagnosticMetrics.droppedFramesByClass[write.writeClass, default: 0] += 1
 #endif
     }
 
@@ -313,9 +439,10 @@ struct NavigationWriteQueue {
 #endif
     }
 
-    private mutating func recordCoalescedFrames(_ count: Int) {
+    private mutating func recordCoalesced(write: NavigationWrite) {
 #if DEBUG || HOST_TESTING
-        diagnosticMetrics.coalescedFrames += count
+        diagnosticMetrics.coalescedFrames += 1
+        diagnosticMetrics.coalescedFramesByClass[write.writeClass, default: 0] += 1
 #endif
     }
 
@@ -336,5 +463,19 @@ struct NavigationWriteQueue {
         diagnosticMetrics.currentDepth = count
         diagnosticMetrics.maxDepth = max(diagnosticMetrics.maxDepth, count)
 #endif
+    }
+
+    private mutating func beginEnqueueIfEmpty() {
+        if count == 0 {
+            retryStartedAtUptime = nil
+        }
+    }
+
+    private func ageMilliseconds(
+        since startUptime: TimeInterval?,
+        at currentUptime: TimeInterval
+    ) -> Int {
+        guard let startUptime else { return 0 }
+        return Int(max(0, (currentUptime - startUptime) * 1_000).rounded())
     }
 }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -573,6 +573,7 @@ struct NavigationProtocolTests {
         testDeviceGPSPacketBuilder()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
+        testGPSQueuePolicy()
         testDeviceBLEProtocolConstants()
         testWorkoutDeviceFrameVectors()
         testWorkoutDeviceFrameSentinelsAndSaturation()
@@ -8486,11 +8487,13 @@ struct NavigationProtocolTests {
         assert(metricsQueue.enqueueCoalescing(NavigationWrite(
             data: Data([1]),
             label: "gps-1",
+            writeClass: .gpsPosition,
             coalescingKey: "gps"
         ), prioritized: false), "first replaceable state is accepted")
         assert(metricsQueue.enqueueCoalescing(NavigationWrite(
             data: Data([2]),
             label: "gps-2",
+            writeClass: .gpsPosition,
             coalescingKey: "gps"
         ), prioritized: false), "new state replaces the stale state")
         assert(!metricsQueue.enqueueAtomically([
@@ -8506,7 +8509,7 @@ struct NavigationProtocolTests {
         metricsQueue.removeAll()
 
         let queueMetrics = metricsQueue.snapshotMetricsAndReset()
-        assertEqual(NavigationWriteQueueMetrics.schemaVersion, 1,
+        assertEqual(NavigationWriteQueueMetrics.schemaVersion, 2,
                     "queue metrics schema is explicitly versioned")
         assertEqual(queueMetrics.enqueuedFrames, 3,
                     "queue metrics distinguish accepted frames")
@@ -8516,6 +8519,8 @@ struct NavigationProtocolTests {
                     "queue metrics count rejected atomic frames")
         assertEqual(queueMetrics.coalescedFrames, 1,
                     "queue metrics count superseded replaceable state")
+        assertEqual(queueMetrics.coalescedFrames(for: .gpsPosition), 1,
+                    "queue metrics attribute coalescing to GPS state")
         assertEqual(queueMetrics.clearedFrames, 1,
                     "queue metrics count disconnect-style clearing")
         assertEqual(queueMetrics.retrySchedules, 1,
@@ -8552,6 +8557,247 @@ struct NavigationProtocolTests {
         }
         assertEqual(boundaryWrites, [Data([6]), Data([7])],
                     "metrics snapshots do not mutate pending writes")
+    }
+
+    static func testGPSQueuePolicy() {
+        assertEqual(GPSPositionWriteRouting.route(
+            hasNativeWriteWithResponse: true,
+            hasNativeWriteWithoutResponse: true,
+            payloadLength: 30,
+            protectionOverhead: 22,
+            withResponseMaximum: 512,
+            withoutResponseMaximum: 512
+        ), .nativeWithoutResponse,
+                    "replaceable native GPS prefers write-without-response")
+        assertEqual(GPSPositionWriteRouting.route(
+            hasNativeWriteWithResponse: true,
+            hasNativeWriteWithoutResponse: false,
+            payloadLength: 30,
+            protectionOverhead: 22,
+            withResponseMaximum: 512,
+            withoutResponseMaximum: 512
+        ), .nativeWithResponse,
+                    "GPS remains acknowledged when that is the only native transport")
+        assertEqual(GPSPositionWriteRouting.route(
+            hasNativeWriteWithResponse: false,
+            hasNativeWriteWithoutResponse: false,
+            payloadLength: 30,
+            protectionOverhead: 22,
+            withResponseMaximum: 512,
+            withoutResponseMaximum: 512
+        ), .navigationFallback,
+                    "missing native GPS uses the reliable navigation endpoint")
+        assertEqual(GPSPositionWriteRouting.route(
+            hasNativeWriteWithResponse: true,
+            hasNativeWriteWithoutResponse: true,
+            payloadLength: 30,
+            protectionOverhead: 22,
+            withResponseMaximum: 512,
+            withoutResponseMaximum: 20
+        ), .nativeWithResponse,
+                    "insufficient unacknowledged MTU falls back to acknowledged native GPS")
+        assertEqual(GPSPositionWriteRouting.route(
+            hasNativeWriteWithResponse: true,
+            hasNativeWriteWithoutResponse: true,
+            payloadLength: 30,
+            protectionOverhead: 22,
+            withResponseMaximum: 20,
+            withoutResponseMaximum: 20
+        ), .navigationFallback,
+                    "insufficient native MTU falls back without dropping current GPS")
+
+        let channelManager = BLEManager()
+        let writeSession = AuthenticatedBLEWriteSession(
+            ownerKey: Data((0..<32).map(UInt8.init)),
+            deviceID: "00112233445566778899aabbccddeeff",
+            clientNonce: "102132435465768798a9babbdcddedef",
+            serverNonce: "ffeeddccbbaa99887766554433221100"
+        )
+        let gpsPayload = DeviceGPSPacketBuilder.data(
+            lat: 1.3,
+            lon: 103.8,
+            heading: 45
+        )
+        let protectedGPS = channelManager.devicePayloadForTesting(
+            gpsPayload,
+            for: DeviceBLEProtocol.gpsPositionCharacteristicUUID,
+            authenticatedWriteSession: writeSession
+        )
+        let protectedNavigation = channelManager.devicePayloadForTesting(
+            gpsPayload,
+            for: DeviceBLEProtocol.navigationCharacteristicUUID,
+            authenticatedWriteSession: writeSession
+        )
+        assertEqual(
+            protectedGPS?.count,
+            gpsPayload.count + AuthenticatedBLEWriteSession.frameOverhead,
+            "native GPS capacity accounts for authenticated framing overhead"
+        )
+        assert(protectedGPS != protectedNavigation,
+               "native GPS uses its characteristic-bound authenticated channel")
+
+        var transportReady = false
+        var queue = NavigationWriteQueue(maxCount: 4, priorityMaxCount: 2)
+        func gpsWrite(_ value: UInt8) -> NavigationWrite {
+            NavigationWrite(
+                data: Data([value]),
+                label: "gps-\(value)",
+                transportCanSend: { transportReady },
+                transportExpectsWriteResponse: false,
+                writeClass: .gpsPosition,
+                coalescingKey: DeviceBLEProtocol.gpsPositionCoalescingKey
+            )
+        }
+
+        assert(queue.enqueueCoalescing(gpsWrite(1), prioritized: false),
+               "first GPS state enters the regular lane")
+        assert(queue.enqueueCoalescing(gpsWrite(2), prioritized: false),
+               "second GPS state replaces the first pending state")
+        assert(queue.enqueueAtomically([
+            NavigationWrite(
+                data: Data([40]),
+                label: "route-1",
+                writeClass: .route
+            ),
+            NavigationWrite(
+                data: Data([41]),
+                label: "route-2",
+                writeClass: .route
+            )
+        ]), "protected route chunks are admitted atomically")
+        assert(queue.enqueueCoalescing(NavigationWrite(
+            data: Data([9]),
+            label: "maneuver",
+            transportCanSend: { true },
+            transportExpectsWriteResponse: true,
+            writeClass: .navigationSnapshot,
+            coalescingKey: DeviceBLEProtocol.navigationSnapshotCoalescingKey
+        ), prioritized: true), "complete maneuver state enters the priority lane")
+
+        var sent: [Data] = []
+        queue.flush(canSend: { write in
+            write.transportCanSend?() ?? true
+        }, maxWrites: 1) { sent.append($0.data) }
+        assertEqual(sent, [Data([9])],
+                    "maneuver state is delivered ahead of stalled GPS and route traffic")
+
+        queue.flush(canSend: { write in
+            write.transportCanSend?() ?? true
+        }) { _ in
+            assert(false, "write-without-response backpressure must stop GPS dequeue")
+        }
+        assert(queue.enqueueCoalescing(gpsWrite(3), prioritized: false),
+               "latest GPS replaces the stalled pending value")
+        assert(queue.enqueueCoalescing(gpsWrite(4), prioritized: false),
+               "another GPS update still leaves only one pending position")
+
+        transportReady = true
+        queue.flush(canSend: { write in
+            write.transportCanSend?() ?? true
+        }) { sent.append($0.data) }
+        assertEqual(sent, [Data([9]), Data([40]), Data([41]), Data([4])],
+                    "recovery preserves the atomic route and sends only latest GPS state")
+        assertEqual(queue.metrics.coalescedFrames(for: .gpsPosition), 3,
+                    "GPS replacements are attributed separately in diagnostics")
+
+        var priorityCapacityQueue = NavigationWriteQueue(
+            maxCount: 1,
+            priorityMaxCount: 4
+        )
+        assert(priorityCapacityQueue.enqueuePrioritizedAtomically([
+            NavigationWrite(
+                data: Data([20]),
+                label: "workout-core",
+                writeClass: .workoutTelemetry,
+                coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryCoreCoalescingKey
+            ),
+            NavigationWrite(
+                data: Data([21]),
+                label: "workout-extended",
+                writeClass: .workoutTelemetry,
+                coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryExtendedCoalescingKey
+            )
+        ]), "complete workout pair retains its existing priority transaction")
+        assert(priorityCapacityQueue.enqueueCoalescing(NavigationWrite(
+            data: Data([22]),
+            label: "destination-status",
+            writeClass: .transfer,
+            coalescingKey: "destination-status"
+        ), prioritized: true), "destination status retains its priority slot")
+        assert(priorityCapacityQueue.enqueueCoalescing(NavigationWrite(
+            data: Data([23]),
+            label: "maneuver",
+            writeClass: .navigationSnapshot,
+            coalescingKey: DeviceBLEProtocol.navigationSnapshotCoalescingKey
+        ), prioritized: true), "maneuver has a dedicated fourth priority slot")
+        assertEqual(priorityCapacityQueue.count, 4,
+                    "workout, destination, and maneuver priority traffic coexist")
+        assert(priorityCapacityQueue.enqueuePrioritizedAtomically([
+            NavigationWrite(
+                data: Data([24]),
+                label: "new-workout-core",
+                writeClass: .workoutTelemetry,
+                coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryCoreCoalescingKey
+            ),
+            NavigationWrite(
+                data: Data([25]),
+                label: "new-workout-extended",
+                writeClass: .workoutTelemetry,
+                coalescingKey:
+                    DeviceBLEProtocol.workoutTelemetryExtendedCoalescingKey
+            )
+        ]), "new workout pair replaces only its prior complete pair")
+        var priorityCapacityWrites: [Data] = []
+        priorityCapacityQueue.flush(canSend: { true }) {
+            priorityCapacityWrites.append($0.data)
+        }
+        assertEqual(
+            priorityCapacityWrites,
+            [Data([22]), Data([23]), Data([24]), Data([25])],
+            "workout replacement preserves destination and maneuver priority state"
+        )
+        assertEqual(
+            priorityCapacityQueue.metrics.coalescedFrames(
+                for: .workoutTelemetry
+            ),
+            2,
+            "atomic workout replacement is recorded as class coalescing"
+        )
+
+        var dropMetricsQueue = NavigationWriteQueue(maxCount: 1)
+        dropMetricsQueue.enqueue(NavigationWrite(
+            data: Data([30]),
+            label: "old-gps",
+            writeClass: .gpsPosition
+        ))
+        assert(dropMetricsQueue.enqueue(NavigationWrite(
+            data: Data([31]),
+            label: "new-setting",
+            writeClass: .settingsControl
+        )), "ordinary overflow evicts the oldest packet")
+        assertEqual(dropMetricsQueue.metrics.droppedFrames(for: .gpsPosition), 1,
+                    "drop metrics attribute capacity eviction to packet class")
+
+        var uptime: TimeInterval = 10
+        var ageQueue = NavigationWriteQueue(
+            maxCount: 1,
+            now: { uptime }
+        )
+        assert(ageQueue.enqueueCoalescing(gpsWrite(5), prioritized: false),
+               "age fixture admits one pending GPS state")
+        uptime = 10.25
+        ageQueue.noteRetryScheduled()
+        uptime = 10.5
+        assert(ageQueue.enqueueCoalescing(gpsWrite(6), prioritized: false),
+               "coalescing retains the active transport retry interval")
+        uptime = 11
+        assertEqual(ageQueue.metrics.oldestPendingAgeMs, 500,
+                    "oldest age follows the newest pending GPS replacement")
+        assertEqual(ageQueue.metrics.retryAgeMs, 750,
+                    "retry age survives replacement while backpressure remains active")
     }
 
     static func testDeviceBLEProtocolConstants() {
@@ -11095,6 +11341,34 @@ struct NavigationProtocolTests {
         manager.isNavigationReady = true
         assert(manager.sendNavigationData("2|120|Turn left"), "BLEManager should write after navigation characteristic readiness")
         assertEqual(sentPackets, ["2|120|Turn left"], "BLEManager writes encoded navigation packet")
+
+        let stalledManager = BLEManager()
+        stalledManager.installNavigationWriteQueueForTesting(
+            maxCount: 2,
+            priorityMaxCount: 2
+        )
+        var transportReady = false
+        var recoveredPackets: [String] = []
+        stalledManager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: NavigationPacketBuilder.protocolMaxBytes,
+            expectsWriteResponse: true,
+            canSend: { transportReady },
+            write: { data in
+                recoveredPackets.append(String(data: data, encoding: .utf8) ?? "")
+            }
+        ))
+        stalledManager.isConnected = true
+        stalledManager.isNavigationReady = true
+        assert(stalledManager.sendNavigationData("2|120|Turn left"),
+               "first stalled maneuver snapshot is queued")
+        assert(stalledManager.sendNavigationData("3|80|Turn right"),
+               "new stalled maneuver snapshot replaces its predecessor")
+        assertEqual(recoveredPackets, [],
+                    "stalled transport sends no premature maneuver state")
+        transportReady = true
+        stalledManager.completeNavigationWriteForTesting(error: nil)
+        assertEqual(recoveredPackets, ["3|80|Turn right"],
+                    "transport recovery sends only the newest complete maneuver snapshot")
     }
 
     static func testBLEManagerSendsFallbackMapSettings() {


### PR DESCRIPTION
## Summary

- make complete maneuver snapshots priority-lane state whose newest unsent value replaces its predecessor
- coalesce native and fallback GPS to one latest pending position
- prefer native GPS write-without-response only when the protected frame fits, with acknowledged native and navigation fallbacks
- preserve atomic route, catalog, destination, transfer, and workout traffic under queue pressure
- add schema-v2 queue ages and packet-class drop/coalescing diagnostics

## Queue policy

- auth, ownership, settings, and commands remain ordered and acknowledged
- route geometry and existing multi-frame batches use atomic admission and cannot be split or evicted after acceptance
- maneuver, destination status, and prioritized workout state have separate keyed replacement semantics and four bounded priority slots
- GPS alone uses latest-pending-wins; native `2A72` honors CoreBluetooth write-without-response backpressure
- authenticated framing overhead is included before selecting the native write type

## Deep review

The phase review resolved six findings: native MTU fallback, maneuver priority capacity, unrelated priority eviction during workout replacement, retry-age continuity during GPS coalescing, stale metrics documentation, and evictable route geometry. No reviewed code findings remain open.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- `ios-app/scripts/run-workout-contract-tests.sh`
- Release iOS/watch app-container build with code signing disabled
- `git diff --check`

## Deferred physical gates

- deliberately stall and recover authenticated BLE on the 1.75-inch board and confirm only the latest GPS is delivered
- repeat under degraded RF and confirm maneuver latency plus protected traffic integrity
- no physical flash was attempted because the board is currently disconnected

Stacked on Phase 3 / PR #163 (`agent/battery-life-phase-3-map-scheduler`).
