### PR TITLE
Add connected display power states

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,10 @@ jobs:
             -o /tmp/test_display_power_policy
           /tmp/test_display_power_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_display_inactivity_policy.cpp \
+            -o /tmp/test_display_inactivity_policy
+          /tmp/test_display_inactivity_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_ui_update_policy.cpp \
             -o /tmp/test_ui_update_policy
           /tmp/test_ui_update_policy

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -565,6 +565,16 @@ bit `2`. ACK-capable firmware uses a tracked frame:
 Firmware persists the complete configuration and queues the configured sound
 after an AXP2101 short-press event, so the button works without an active app
 connection. The AXP2101's six-second hardware power-off behavior is unchanged.
+
+Independently of hard power-off, connected firmware dims after 15 seconds and
+turns the panel off after 45 seconds without meaningful activity when no
+navigation is active. GPS and workout telemetry alone do not keep the panel
+awake. A
+changed maneuver instruction/icon, a closer maneuver-distance threshold,
+route, screen/input event, connection/authentication event, ownership
+comparison, active sound, or transfer wakes or holds it as appropriate. BLE
+advertising/connection processing continues with the panel off, and wake
+restores the saved brightness with one synchronized full-screen refresh.
 Firmware echoes the request ID when acknowledging tracked requests on the
 navigation notification characteristic:
 

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -19,6 +19,36 @@ current curve or precise watt-hour saving. The source-monitor procedure below
 is retained as an optional higher-precision campaign, not an implementation
 gate.
 
+## Connected display-power policy
+
+The firmware now uses four connected operating modes:
+
+- `active`: saved user brightness and the normal LVGL cadence;
+- `dimmed`: at most 20% brightness after 15 seconds without meaningful input,
+  with the main UI timer reduced from 30 ms to 250 ms and LVGL serviced at most
+  every 100 ms;
+- `off`: after 45 seconds idle, the panel is turned off, the main UI timer is
+  paused, LVGL servicing stops, and any already-queued flush is acknowledged
+  without QSPI traffic; and
+- `transfer`: the panel remains active while the map/firmware transfer service
+  or map activation is active. An enabled transfer service exits after five
+  minutes without an authenticated request, unless an authenticated request or
+  map activation is still in progress.
+
+Active navigation guidance or a loaded route, an ownership comparison, and
+active audio hold the display active. Touch, BOOT/PWR input, screen changes,
+BLE connection or authentication, changed maneuver instructions/icons, closer
+maneuver-distance thresholds, route changes, transfer progress, and new
+actionable transfer errors restart the idle interval. Repeated GPS, workout,
+and unchanged maneuver-distance samples intentionally do not. Waking restores
+the saved brightness and forces one full-screen refresh before normal rendering
+resumes.
+
+Host tests cover time wraparound, inactivity boundaries, navigation/transfer/
+attention holds, transfer timeouts, and 10,000 display-off/wake transitions.
+Physical wake, touch, reconnect, and battery-depletion checks remain pending
+until the 1.75-inch device is connected again.
+
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
 percentage, or USB-powered observation is not a power baseline. Fill in the
@@ -263,10 +293,10 @@ battery Wh.
 | 10 | Ride-statistics screen | 2.06 | Pending | — | — | — | — | Pending |
 | 11 | Battery/status screen | 1.75 | Pending | — | — | — | — | Pending |
 | 11 | Battery/status screen | 2.06 | Pending | — | — | — | — | Pending |
-| 12 | Connected dimmed state | 1.75 | Not implemented | — | — | — | — | Measure after state exists |
-| 12 | Connected dimmed state | 2.06 | Not implemented | — | — | — | — | Measure after state exists |
-| 13 | Connected display-off state | 1.75 | Not implemented | — | — | — | — | Measure after state exists |
-| 13 | Connected display-off state | 2.06 | Not implemented | — | — | — | — | Measure after state exists |
+| 12 | Connected dimmed state | 1.75 | Implemented; hardware pending | — | — | — | — | Compare battery depletion later |
+| 12 | Connected dimmed state | 2.06 | Build-only; hardware unavailable | — | — | — | — | Hardware deferred |
+| 13 | Connected display-off state | 1.75 | Implemented; hardware pending | — | — | — | — | Verify touch/BOOT/PWR wake later |
+| 13 | Connected display-off state | 2.06 | Build-only; hardware unavailable | — | — | — | — | Hardware deferred |
 | 14 | Transfer AP enabled, idle | 1.75 | Pending | — | — | — | — | Pending |
 | 14 | Transfer AP enabled, idle | 2.06 | Pending | — | — | — | — | Pending |
 | 15 | Map upload in progress | 1.75 | Pending | — | — | — | — | Pending |

--- a/esp32/lib/device_transfer/device_transfer_http.cpp
+++ b/esp32/lib/device_transfer/device_transfer_http.cpp
@@ -231,6 +231,7 @@ bool HttpTransferServer::setEnabled(bool enabled, std::string mode) {
     }
     if (transferBoundary) {
       transferGeneration_ = nextHttpTransferGeneration(transferGeneration_);
+      lastUsefulTrafficMs_ = millis();
     }
     unlockState();
   }
@@ -287,8 +288,19 @@ void HttpTransferServer::runWorker() {
     }
     WiFiClient client = server_.accept();
     if (client) {
+      lockState();
+      requestInProgress_ = true;
+      currentRequestAuthorized_ = false;
+      unlockState();
       handleClient(client);
       client.stop();
+      lockState();
+      if (currentRequestAuthorized_) {
+        lastUsefulTrafficMs_ = millis();
+      }
+      requestInProgress_ = false;
+      currentRequestAuthorized_ = false;
+      unlockState();
     } else {
       vTaskDelay(pdMS_TO_TICKS(2));
     }
@@ -313,6 +325,12 @@ HttpTransferStatus HttpTransferServer::status() const {
   const std::string sessionToken = sessionToken_;
   const std::string lastErrorCode = lastErrorCode_;
   const std::string lastErrorMessage = lastErrorMessage_;
+  const uint32_t errorSequence = errorSequence_;
+  const uint32_t lastUsefulTrafficMs = lastUsefulTrafficMs_;
+  // Only authenticated work may extend the transfer lifetime. A client that
+  // stalls before authorization must not keep the AP awake indefinitely.
+  const bool authorizedRequestInProgress =
+      requestInProgress_ && currentRequestAuthorized_;
   unlockState();
 
   std::string baseUrl;
@@ -326,23 +344,36 @@ HttpTransferStatus HttpTransferServer::status() const {
                 std::to_string(port);
     }
   }
-  return {configured,       enabled, port,     mode,
-          baseUrl,          startedAp ? apSsid : "",
-          sessionToken,     lastErrorCode,
-          lastErrorMessage};
+  return {configured,
+          enabled,
+          port,
+          mode,
+          baseUrl,
+          startedAp ? apSsid : "",
+          sessionToken,
+          lastErrorCode,
+          lastErrorMessage,
+          errorSequence,
+          lastUsefulTrafficMs,
+          authorizedRequestInProgress};
 }
 
 bool HttpTransferServer::isRequestAuthorized(
-    const HttpRequest &request) const {
+    const HttpRequest &request) {
   lockState();
   const bool enabled = enabled_;
   const std::string sessionToken = sessionToken_;
   const uint32_t transferGeneration = transferGeneration_;
+  const bool authorized =
+      isHttpTransferGenerationCurrent(enabled, transferGeneration,
+                                      request.transferGeneration) &&
+      !sessionToken.empty() && request.transferToken == sessionToken;
+  if (authorized) {
+    lastUsefulTrafficMs_ = millis();
+    currentRequestAuthorized_ = true;
+  }
   unlockState();
-  return isHttpTransferGenerationCurrent(enabled, transferGeneration,
-                                         request.transferGeneration) &&
-         !sessionToken.empty() &&
-         request.transferToken == sessionToken;
+  return authorized;
 }
 
 bool HttpTransferServer::waitUntilStopped(uint32_t timeoutMs) {
@@ -487,6 +518,7 @@ void HttpTransferServer::rememberError(const std::string &code,
                                        const std::string &message) {
   lastErrorCode_ = code;
   lastErrorMessage_ = message;
+  errorSequence_ = nextHttpTransferGeneration(errorSequence_);
 }
 
 void HttpTransferServer::lockState() const {

--- a/esp32/lib/device_transfer/device_transfer_http.hpp
+++ b/esp32/lib/device_transfer/device_transfer_http.hpp
@@ -21,6 +21,9 @@ struct HttpTransferStatus {
   std::string sessionToken;
   std::string lastErrorCode;
   std::string lastErrorMessage;
+  uint32_t errorSequence = 0;
+  uint32_t lastUsefulTrafficMs = 0;
+  bool authorizedRequestInProgress = false;
 };
 
 struct HttpRequest {
@@ -52,7 +55,7 @@ public:
   void setLastError(const std::string &code, const std::string &message);
   void process();
   HttpTransferStatus status() const;
-  bool isRequestAuthorized(const HttpRequest &request) const;
+  bool isRequestAuthorized(const HttpRequest &request);
   bool waitUntilStopped(uint32_t timeoutMs);
 
 private:
@@ -67,6 +70,10 @@ private:
   mutable SemaphoreHandle_t stateMutex_ = nullptr;
   std::string lastErrorCode_;
   std::string lastErrorMessage_;
+  uint32_t errorSequence_ = 0;
+  uint32_t lastUsefulTrafficMs_ = 0;
+  bool requestInProgress_ = false;
+  bool currentRequestAuthorized_ = false;
   uint32_t transferGeneration_ = 0;
   struct HandlerRegistration {
     std::string pathPrefix;

--- a/esp32/lib/display_power/display_inactivity_policy.hpp
+++ b/esp32/lib/display_power/display_inactivity_policy.hpp
@@ -1,0 +1,143 @@
+#pragma once
+
+#include <cstdint>
+
+namespace display_inactivity {
+
+constexpr uint32_t kDimAfterMs = 15'000;
+constexpr uint32_t kDisplayOffAfterMs = 45'000;
+constexpr uint32_t kTransferInactivityTimeoutMs = 300'000;
+
+enum class Mode : uint8_t {
+  Active = 0,
+  Dimmed,
+  DisplayOff,
+  Transfer,
+};
+
+struct Context {
+  bool navigating = false;
+  bool transferActive = false;
+  bool attentionActive = false;
+};
+
+struct Update {
+  Mode previous = Mode::Active;
+  Mode current = Mode::Active;
+  bool changed = false;
+  bool displayWakeRequired = false;
+};
+
+constexpr uint32_t elapsedMs(uint32_t nowMs, uint32_t sinceMs) {
+  return nowMs - sinceMs;
+}
+
+constexpr bool transferInactivityElapsed(uint32_t nowMs,
+                                         uint32_t lastUsefulTrafficMs,
+                                         uint32_t timeoutMs,
+                                         bool authorizedRequestInProgress) {
+  return timeoutMs > 0 && !authorizedRequestInProgress &&
+         elapsedMs(nowMs, lastUsefulTrafficMs) >= timeoutMs;
+}
+
+constexpr bool maneuverDataBecameActive(uint16_t previousDistanceMeters,
+                                        bool previousHasInstruction,
+                                        uint16_t currentDistanceMeters,
+                                        bool currentHasInstruction) {
+  return previousDistanceMeters == 0 && !previousHasInstruction &&
+         (currentDistanceMeters > 0 || currentHasInstruction);
+}
+
+constexpr uint8_t maneuverDistanceBucket(uint16_t distanceMeters) {
+  if (distanceMeters == 0)
+    return 0;
+  if (distanceMeters <= 25)
+    return 1;
+  if (distanceMeters <= 50)
+    return 2;
+  if (distanceMeters <= 100)
+    return 3;
+  if (distanceMeters <= 200)
+    return 4;
+  if (distanceMeters <= 500)
+    return 5;
+  if (distanceMeters <= 1'000)
+    return 6;
+  return 7;
+}
+
+constexpr bool crossedCloserManeuverDistanceThreshold(
+    uint16_t previousDistanceMeters, uint16_t currentDistanceMeters) {
+  return previousDistanceMeters > 0 &&
+         maneuverDistanceBucket(currentDistanceMeters) <
+             maneuverDistanceBucket(previousDistanceMeters);
+}
+
+class Policy {
+public:
+  void begin(uint32_t nowMs) {
+    initialized_ = true;
+    lastMeaningfulActivityMs_ = nowMs;
+    heldAwake_ = false;
+    mode_ = Mode::Active;
+  }
+
+  void noteMeaningfulActivity(uint32_t nowMs) {
+    if (!initialized_) {
+      begin(nowMs);
+      return;
+    }
+    lastMeaningfulActivityMs_ = nowMs;
+  }
+
+  Update update(uint32_t nowMs, const Context &context) {
+    if (!initialized_) {
+      begin(nowMs);
+    }
+
+    const bool heldAwake = context.navigating || context.transferActive ||
+                           context.attentionActive;
+    if (heldAwake_ && !heldAwake) {
+      // Leaving navigation, transfer, pairing, or audio should start a fresh
+      // idle interval instead of immediately inheriting the time spent held.
+      lastMeaningfulActivityMs_ = nowMs;
+    }
+    heldAwake_ = heldAwake;
+
+    Mode requested = Mode::Active;
+    if (context.transferActive) {
+      requested = Mode::Transfer;
+    } else if (context.navigating || context.attentionActive) {
+      requested = Mode::Active;
+    } else {
+      const uint32_t idleMs = elapsedMs(nowMs, lastMeaningfulActivityMs_);
+      if (idleMs >= kDisplayOffAfterMs) {
+        requested = Mode::DisplayOff;
+      } else if (idleMs >= kDimAfterMs) {
+        requested = Mode::Dimmed;
+      }
+    }
+
+    Update result;
+    result.previous = mode_;
+    result.current = requested;
+    result.changed = requested != mode_;
+    result.displayWakeRequired =
+        mode_ == Mode::DisplayOff && requested != Mode::DisplayOff;
+    mode_ = requested;
+    return result;
+  }
+
+  Mode mode() const { return mode_; }
+  uint32_t lastMeaningfulActivityMs() const {
+    return lastMeaningfulActivityMs_;
+  }
+
+private:
+  bool initialized_ = false;
+  bool heldAwake_ = false;
+  uint32_t lastMeaningfulActivityMs_ = 0;
+  Mode mode_ = Mode::Active;
+};
+
+} // namespace display_inactivity

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -159,6 +159,14 @@ static void drawDisplayTestPatterns(uint8_t appliedRotation) {
 // ============================================================================
 
 void my_disp_flush(lv_display_t *disp, const lv_area_t *area, uint8_t *px_map) {
+  // LVGL may have queued a refresh just before the inactivity transition. The
+  // logical frame remains dirty for the synchronized full refresh on wake, but
+  // no QSPI traffic should reach a panel that is intentionally off.
+  if (displayPowerManager.state() == display_power::State::Off) {
+    lv_display_flush_ready(disp);
+    return;
+  }
+
   uint32_t startUs = micros();
 #if POWER_METRICS
   power_metrics::pulseBegin(power_metrics::Pulse::DisplayFlush);

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -22,11 +22,9 @@
 extern const uint8_t BOARD_BOOT_PIN;
 #endif
 
-/**
- * @brief Power Class constructor
- *
- */
-Power::Power() {
+void Power::begin() {
+  // Radio shutdown touches Arduino/IDF subsystems and must not run from the
+  // global Power object's constructor before framework initialization.
 #ifdef DISABLE_RADIO
   WiFi.disconnect(true);
   WiFi.mode(WIFI_OFF);
@@ -72,7 +70,6 @@ void Power::powerDeepSleep() {
  */
 void Power::powerLightSleepTimer(int millis) {
   esp_sleep_enable_timer_wakeup(millis * 1000);
-  esp_err_t rtc_gpio_hold_en(gpio_num_t GPIO_NUM_5);
   esp_light_sleep_start();
 }
 

--- a/esp32/lib/power/power.hpp
+++ b/esp32/lib/power/power.hpp
@@ -31,7 +31,9 @@ private:
   void powerOffPeripherals();
 
 public:
-  Power();
+  Power() = default;
+
+  void begin();
 
   void deviceSuspend();
   void deviceShutdown();

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -22,12 +22,7 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 #include <math.h>
-#ifndef POWER_METRICS
-#define POWER_METRICS 0
-#endif
-#if POWER_METRICS
 #include <atomic>
-#endif
 #include <string.h>
 
 namespace waveshare_board::speaker {
@@ -87,9 +82,7 @@ esp_codec_dev_handle_t speakerDevice = nullptr;
 QueueHandle_t soundQueue = nullptr;
 SemaphoreHandle_t powerButtonConfigMutex = nullptr;
 bool initialized = false;
-#if POWER_METRICS
 std::atomic<bool> playbackActive{false};
-#endif
 bool powerButtonHonkAvailable = false;
 bool powerButtonMonitoringConfigured = false;
 float codecHardwareGainDb = 0.0f;
@@ -537,16 +530,12 @@ void speakerTask(void *) {
 
     Sound sound = static_cast<Sound>(request.sound);
     if (!initializeCodec()) {
-#if POWER_METRICS
       playbackActive.store(false, std::memory_order_relaxed);
-#endif
       Serial.println("Speaker: playback skipped because initialization failed");
       continue;
     }
 
-#if POWER_METRICS
     playbackActive.store(true, std::memory_order_relaxed);
-#endif
     if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
         ESP_CODEC_DEV_OK) {
       Serial.printf("Speaker: failed to set volume to %u%%\n",
@@ -562,9 +551,7 @@ void speakerTask(void *) {
         Serial.printf("Speaker: sound %u playback failed\n", request.sound);
       }
     }
-#if POWER_METRICS
     playbackActive.store(false, std::memory_order_relaxed);
-#endif
 
     if (uxQueueMessagesWaiting(soundQueue) == 0) {
       releaseCodecResources();
@@ -630,11 +617,7 @@ bool begin() {
 bool isAvailable() { return soundQueue != nullptr; }
 
 bool isPlaying() {
-#if POWER_METRICS
   return playbackActive.load(std::memory_order_relaxed);
-#else
-  return false;
-#endif
 }
 
 bool requestPlay(Sound sound, uint8_t volumePercent) {

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -73,6 +73,7 @@ extern xSemaphoreHandle gpsMutex;
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#include "display_inactivity_policy.hpp"
 #include "display_power.hpp"
 #endif
 #include "disconnected_shutdown_policy.hpp"
@@ -194,20 +195,21 @@ static bool takeWaveshareBootScreenCycle() {
   return pending;
 }
 
-static void processWaveshareBootButton() {
+static bool processWaveshareBootButton() {
   constexpr uint32_t DEBOUNCE_MS = 50;
 
   const uint32_t now = millis();
   const bool pressed = digitalRead(BOARD_BOOT_PIN) == LOW;
   const bool latchedPress = takeWaveshareBootScreenCycle();
+  const bool hadInput = latchedPress || pressed;
 
   if (waveshareBootPairingGate.blocksInput(pressed, now, DEBOUNCE_MS)) {
-    return;
+    return hadInput;
   }
 
   if (!waveshareBootWaitingForRelease) {
     if (!latchedPress && !pressed) {
-      return;
+      return false;
     }
 
     waveshareBootWaitingForRelease = true;
@@ -229,21 +231,21 @@ static void processWaveshareBootButton() {
     } else {
       log_i("Waveshare BOOT pressed; handling forward action");
     }
-    return;
+    return true;
   }
 
   if (pressed) {
     waveshareBootReleaseStartMs = 0;
-    return;
+    return true;
   }
 
   if (waveshareBootReleaseStartMs == 0) {
     waveshareBootReleaseStartMs = now;
-    return;
+    return false;
   }
 
   if (now - waveshareBootReleaseStartMs < DEBOUNCE_MS) {
-    return;
+    return false;
   }
 
   waveshareBootWaitingForRelease = false;
@@ -258,22 +260,25 @@ static void processWaveshareBootButton() {
       log_i("Waveshare BOOT long press: no registered iPhone to clear");
     }
   }
+  return false;
 }
 
-static void processWavesharePowerButton() {
+static bool processWavesharePowerButton() {
   constexpr uint32_t POLL_INTERVAL_MS = 100;
   static uint32_t lastPollMs = 0;
 
   const uint32_t now = millis();
   if (now - lastPollMs < POLL_INTERVAL_MS) {
-    return;
+    return false;
   }
   lastPollMs = now;
 
   waveshare_board::axp2101::PowerButtonEvents events;
   if (!waveshare_board::axp2101::readAndClearPowerButtonEvents(events)) {
-    return;
+    return false;
   }
+  const bool hadInput =
+      events.negativeEdge || events.positiveEdge || events.shortPress;
 
   if (bleNavServer.hasOwnershipPairingCode()) {
     if (wavesharePowerPairingGate.acceptEvents(
@@ -284,7 +289,7 @@ static void processWavesharePowerButton() {
     }
     // Never honk while a pairing comparison is active, including before the
     // screen has flushed and the fresh-edge gate has been armed.
-    return;
+    return hadInput;
   }
 
   wavesharePowerPairingGate.cancel();
@@ -292,6 +297,7 @@ static void processWavesharePowerButton() {
   if (events.shortPress) {
     waveshare_board::speaker::handlePowerButtonHonkPress();
   }
+  return hadInput;
 }
 
 static void armOwnershipPairingAfterRenderedComparison() {
@@ -344,6 +350,11 @@ static uint32_t lvglHandlerCount = 0;
 static uint32_t lastLvglHandlerMs = 0;
 static uint32_t lastLvglHandlerDurationUs = 0;
 static uint32_t maxLvglHandlerDurationUs = 0;
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+static display_inactivity::Policy displayInactivityPolicy;
+static display_inactivity::Mode currentDisplayMode =
+    display_inactivity::Mode::Active;
+#endif
 #include "lvglSetup.hpp"
 #include "settings.hpp"
 #include "tasks.hpp"
@@ -388,6 +399,238 @@ static const char *debugTileName(uint8_t tile) {
     return "UNKNOWN";
   }
 }
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+static const char *displayInactivityModeName(display_inactivity::Mode mode) {
+  switch (mode) {
+  case display_inactivity::Mode::Active:
+    return "active";
+  case display_inactivity::Mode::Dimmed:
+    return "dimmed";
+  case display_inactivity::Mode::DisplayOff:
+    return "off";
+  case display_inactivity::Mode::Transfer:
+    return "transfer";
+  }
+  return "unknown";
+}
+
+static bool processTransferInactivityTimeout(uint32_t nowMs) {
+  static uint32_t lastCheckMs = 0;
+  constexpr uint32_t kCheckPeriodMs = 1'000;
+  if (lastCheckMs != 0 && nowMs - lastCheckMs < kCheckPeriodMs) {
+    return false;
+  }
+  lastCheckMs = nowMs;
+
+  const device_transfer::HttpTransferStatus transferStatus =
+      deviceTransferHttp.status();
+  if (!transferStatus.enabled ||
+      !display_inactivity::transferInactivityElapsed(
+          nowMs, transferStatus.lastUsefulTrafficMs,
+          display_inactivity::kTransferInactivityTimeoutMs,
+          transferStatus.authorizedRequestInProgress)) {
+    return false;
+  }
+
+  // Map activation continues after its initiating HTTP request. Do not revoke
+  // the AP while that transactional install is still using it.
+  if (mapTransferHttp.activationSnapshot().running) {
+    return false;
+  }
+
+  bool disabled = false;
+  if (transferStatus.mode == "map") {
+    disabled = mapTransferHttp.setEnabled(false);
+  } else if (transferStatus.mode == "firmware") {
+    disabled = firmwareUpdateHttp.setEnabled(false);
+  } else {
+    disabled = deviceTransferHttp.setEnabled(false);
+  }
+  Serial.printf(
+      "DEVICE_TRANSFER_HTTP: inactivity timeout mode=%s disabled=%d\n",
+      transferStatus.mode.empty() ? "unknown" : transferStatus.mode.c_str(),
+      disabled);
+  return disabled;
+}
+
+static display_inactivity::Update updateDisplayInactivityPolicy(
+    uint32_t nowMs) {
+  struct Signals {
+    bool initialized = false;
+    lv_obj_t *screen = nullptr;
+    uint8_t tile = 0;
+    uint32_t connectCount = 0;
+    uint32_t authSuccessCount = 0;
+    uint32_t navPacketCount = 0;
+    uint32_t routeRevision = 0;
+    uint8_t maneuverIcon = 0;
+    uint16_t maneuverDistance = 0;
+    std::string maneuverInstruction;
+    bool pairing = false;
+    uint32_t lastPairingPollMs = 0;
+    bool transferEnabled = false;
+    std::string transferMode;
+    uint32_t transferErrorSequence = 0;
+    uint32_t activationSequence = 0;
+    uint8_t activationProgress = 0;
+    bool activationRunning = false;
+    uint32_t lastTransferPollMs = 0;
+    bool audioActive = false;
+    bool touchPending = false;
+  };
+  static Signals signals;
+
+  const BLEDebugStats bleStats = bleNavServer.getDebugStats();
+  const bool audioActive = waveshare_board::speaker::isPlaying();
+  const bool touchPending = hasUnattemptedTouchInterrupt();
+  lv_obj_t *const activeScreen = lv_screen_active();
+  const uint32_t routeRevision = routeOverlay.revision();
+
+  bool meaningfulActivity = false;
+  if (!signals.initialized) {
+    signals.initialized = true;
+    signals.screen = activeScreen;
+    signals.tile = activeTile;
+    signals.connectCount = bleStats.connectCount;
+    signals.authSuccessCount = bleStats.authSuccessCount;
+    signals.navPacketCount = bleStats.navPacketCount;
+    signals.routeRevision = routeRevision;
+    const NavigationData maneuver = getCurrentNavigationData();
+    signals.maneuverIcon = maneuver.iconID;
+    signals.maneuverDistance = maneuver.distance;
+    signals.maneuverInstruction = maneuver.instruction;
+    signals.pairing = bleNavServer.hasOwnershipPairingCode();
+    signals.lastPairingPollMs = nowMs;
+    const device_transfer::HttpTransferStatus transferStatus =
+        deviceTransferHttp.status();
+    signals.transferEnabled = transferStatus.enabled;
+    signals.transferMode = transferStatus.mode;
+    signals.transferErrorSequence = transferStatus.errorSequence;
+    const map_transfer::MapActivationSnapshot activation =
+        mapTransferHttp.activationSnapshot();
+    signals.activationSequence = activation.sequence;
+    signals.activationProgress = activation.progress;
+    signals.activationRunning = activation.running;
+    signals.lastTransferPollMs = nowMs;
+    signals.audioActive = audioActive;
+    signals.touchPending = touchPending;
+  } else {
+    meaningfulActivity =
+        activeScreen != signals.screen || activeTile != signals.tile ||
+        bleStats.connectCount != signals.connectCount ||
+        bleStats.authSuccessCount != signals.authSuccessCount ||
+        routeRevision != signals.routeRevision ||
+        audioActive != signals.audioActive ||
+        (touchPending && !signals.touchPending);
+    signals.screen = activeScreen;
+    signals.tile = activeTile;
+    signals.connectCount = bleStats.connectCount;
+    signals.authSuccessCount = bleStats.authSuccessCount;
+    signals.routeRevision = routeRevision;
+    signals.audioActive = audioActive;
+    signals.touchPending = touchPending;
+
+    if (bleStats.navPacketCount != signals.navPacketCount) {
+      signals.navPacketCount = bleStats.navPacketCount;
+      const NavigationData maneuver = getCurrentNavigationData();
+      const std::string instruction = maneuver.instruction;
+      meaningfulActivity =
+          meaningfulActivity || maneuver.iconID != signals.maneuverIcon ||
+          instruction != signals.maneuverInstruction ||
+          display_inactivity::maneuverDataBecameActive(
+              signals.maneuverDistance,
+              !signals.maneuverInstruction.empty(), maneuver.distance,
+              !instruction.empty()) ||
+          display_inactivity::crossedCloserManeuverDistanceThreshold(
+              signals.maneuverDistance, maneuver.distance);
+      signals.maneuverIcon = maneuver.iconID;
+      signals.maneuverDistance = maneuver.distance;
+      signals.maneuverInstruction = instruction;
+    }
+
+    constexpr uint32_t kPairingPollPeriodMs = 100;
+    if (nowMs - signals.lastPairingPollMs >= kPairingPollPeriodMs) {
+      signals.lastPairingPollMs = nowMs;
+      const bool pairing = bleNavServer.hasOwnershipPairingCode();
+      meaningfulActivity = meaningfulActivity || pairing != signals.pairing;
+      signals.pairing = pairing;
+    }
+
+    constexpr uint32_t kTransferPollPeriodMs = 250;
+    if (nowMs - signals.lastTransferPollMs >= kTransferPollPeriodMs) {
+      signals.lastTransferPollMs = nowMs;
+      const device_transfer::HttpTransferStatus transferStatus =
+          deviceTransferHttp.status();
+      const map_transfer::MapActivationSnapshot activation =
+          mapTransferHttp.activationSnapshot();
+      meaningfulActivity =
+          meaningfulActivity ||
+          transferStatus.enabled != signals.transferEnabled ||
+          transferStatus.mode != signals.transferMode ||
+          (!transferStatus.lastErrorCode.empty() &&
+           transferStatus.errorSequence != signals.transferErrorSequence) ||
+          activation.sequence != signals.activationSequence ||
+          (activation.running &&
+           (activation.progress != signals.activationProgress ||
+            !signals.activationRunning));
+      signals.transferEnabled = transferStatus.enabled;
+      signals.transferMode = transferStatus.mode;
+      signals.transferErrorSequence = transferStatus.errorSequence;
+      signals.activationSequence = activation.sequence;
+      signals.activationProgress = activation.progress;
+      signals.activationRunning = activation.running;
+    }
+  }
+
+  if (meaningfulActivity) {
+    displayInactivityPolicy.noteMeaningfulActivity(nowMs);
+  }
+
+  display_inactivity::Context context;
+  context.navigating =
+      bleStats.connected && bleStats.authenticated &&
+      (routeOverlay.hasRoute() || hasCurrentNavigationData());
+  context.transferActive =
+      signals.transferEnabled || signals.activationRunning;
+  context.attentionActive = signals.pairing || audioActive;
+  const display_inactivity::Update update =
+      displayInactivityPolicy.update(nowMs, context);
+  currentDisplayMode = update.current;
+  if (!update.changed) {
+    return update;
+  }
+
+  const bool displayOff =
+      update.current == display_inactivity::Mode::DisplayOff;
+  const bool dimmed = update.current == display_inactivity::Mode::Dimmed;
+  displayPowerManager.requestState(
+      displayOff ? display_power::State::Off
+                 : (dimmed ? display_power::State::Dimmed
+                            : display_power::State::Active));
+
+  if (mainTimer != nullptr) {
+    if (displayOff) {
+      lv_timer_pause(mainTimer);
+    } else if (isMainScreen) {
+      lv_timer_set_period(mainTimer,
+                          dimmed ? 250 : UPDATE_MAINSCR_PERIOD);
+      lv_timer_resume(mainTimer);
+      if (update.displayWakeRequired) {
+        lv_timer_ready(mainTimer);
+      }
+    }
+  }
+
+  Serial.printf("DisplayPower: mode %s -> %s idleMs=%lu\n",
+                displayInactivityModeName(update.previous),
+                displayInactivityModeName(update.current),
+                static_cast<unsigned long>(display_inactivity::elapsedMs(
+                    nowMs,
+                    displayInactivityPolicy.lastMeaningfulActivityMs())));
+  return update;
+}
+#endif
 
 static void logSystemDebugHeartbeat() {
 #if !FIRMWARE_DIAGNOSTICS
@@ -443,6 +686,7 @@ static void logSystemDebugHeartbeat() {
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   Serial.printf("SYS: up=%lus heap=%lu psram=%lu screen=%s tile=%s "
+                "displayMode=%s "
                 "waitRefresh=%d gpsFromApp=%d pendingMap=%d "
                 "gps[fix=%u heading=%u] routePts=%u mapFound=%d mapBlocks=%u "
                 "mapFlags[pos=%d redraw=%d follow=%d vector=%d zoom=%u] "
@@ -454,7 +698,9 @@ static void logSystemDebugHeartbeat() {
                 (unsigned long)(now / 1000),
                 (unsigned long)ESP.getFreeHeap(),
                 (unsigned long)ESP.getFreePsram(), screenName,
-                debugTileName(activeTile), waitScreenRefresh,
+                debugTileName(activeTile),
+                displayInactivityModeName(currentDisplayMode),
+                waitScreenRefresh,
                 gpsReceivedFromApp, pendingTransitionToMap,
                 (unsigned)gps.gpsData.fixMode,
                 (unsigned)gps.gpsData.heading,
@@ -558,6 +804,11 @@ static void logPowerMetricsReport() {
 
   bool audioActive = false;
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  const char *powerMode = displayInactivityModeName(currentDisplayMode);
+#else
+  const char *powerMode = "unsupported";
+#endif
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   audioActive = waveshare_board::speaker::isPlaying();
 #endif
 
@@ -581,7 +832,8 @@ static void logPowerMetricsReport() {
       "logical=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
       "appQueue=ios-diagnostic] "
-      "system[wifiMode=%d transfer=%d transferMode=%s audio=%d cpuMHz=%u "
+      "system[powerMode=%s wifiMode=%d transfer=%d transferMode=%s "
+      "audio=%d cpuMHz=%u "
       "appPmLocks=0]\n",
       power_metrics::kSchemaVersion, (unsigned long)intervalMs, screenName,
       debugTileName(activeTile),
@@ -627,7 +879,7 @@ static void logPowerMetricsReport() {
       (unsigned long)bleCount(power_metrics::BlePacketClass::Audio),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Control),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Auth),
-      static_cast<int>(WiFi.getMode()), transferStatus.enabled,
+      powerMode, static_cast<int>(WiFi.getMode()), transferStatus.enabled,
       transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
       audioActive, getCpuFrequencyMhz());
   if (reportLength < 0 ||
@@ -721,6 +973,7 @@ void setup() {
   }
 #endif
   power_metrics::begin();
+  power.begin();
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   displayPowerManager.begin();
 #endif
@@ -970,6 +1223,9 @@ void setup() {
   // Show waiting screen - will transition to map when GPS is received via BLE
   log_i("Loading Waiting Screen...");
   lv_screen_load(waitingScreen);
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  displayInactivityPolicy.begin(millis());
+#endif
 
   log_i("Setup Complete");
   firmwareUpdateHttp.markRunningAppValid();
@@ -1004,6 +1260,9 @@ void loop() {
     Serial.printf("MAP_TRANSFER_HTTP: automatic exit applied disabled=%d\n",
                   disabled);
   }
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  processTransferInactivityTimeout(now);
+#endif
 
   // Process app-provided GPS transitions before any periodic work that can
   // briefly block on display, sensor, BLE, or debug output.
@@ -1013,17 +1272,30 @@ void loop() {
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   // Sample the screen-cycle button before LVGL can start a synchronous vector
   // redraw. updateMainScreen() also defers while the raw input is active.
-  processWaveshareBootButton();
+  if (processWaveshareBootButton()) {
+    displayInactivityPolicy.noteMeaningfulActivity(now);
+  }
 #endif
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  updateDisplayInactivityPolicy(now);
   displayPowerManager.applyPendingPanelChange();
   if (displayPowerManager.takeFullRefreshRequired()) {
     lv_obj_invalidate(lv_screen_active());
   }
 #endif
 
-  if (!waitScreenRefresh) {
+  bool runLvglHandler = !waitScreenRefresh;
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  constexpr uint32_t kDimmedLvglCadenceMs = 100;
+  if (currentDisplayMode == display_inactivity::Mode::DisplayOff) {
+    runLvglHandler = false;
+  } else if (currentDisplayMode == display_inactivity::Mode::Dimmed &&
+             now - lastLvglHandlerMs < kDimmedLvglCadenceMs) {
+    runLvglHandler = false;
+  }
+#endif
+  if (runLvglHandler) {
     uint32_t startUs = micros();
     lv_timer_handler();
     lastLvglHandlerDurationUs = micros() - startUs;
@@ -1033,11 +1305,22 @@ void loop() {
     }
     lvglHandlerCount++;
     lastLvglHandlerMs = millis();
-    vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
     armOwnershipPairingAfterRenderedComparison();
 #endif
   }
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  const uint32_t loopDelayMs =
+      currentDisplayMode == display_inactivity::Mode::DisplayOff
+          ? 20
+          : TASK_SLEEP_PERIOD_MS;
+  vTaskDelay(pdMS_TO_TICKS(loopDelayMs));
+#else
+  if (runLvglHandler) {
+    vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
+  }
+#endif
 
   // Process BLE events
   bleNavServer.process();
@@ -1048,7 +1331,9 @@ void loop() {
   waveshare_board::imu::process();
 #endif
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  processWavesharePowerButton();
+  if (processWavesharePowerButton()) {
+    displayInactivityPolicy.noteMeaningfulActivity(millis());
+  }
 #endif
 
   logSystemDebugHeartbeat();

--- a/esp32/tools/tests/test_display_inactivity_policy.cpp
+++ b/esp32/tools/tests/test_display_inactivity_policy.cpp
@@ -1,0 +1,198 @@
+#include "../../lib/display_power/display_inactivity_policy.hpp"
+
+#include <array>
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+  using display_inactivity::Context;
+  using display_inactivity::Mode;
+  using display_inactivity::Policy;
+
+  Policy idle;
+  idle.begin(1'000);
+  assert(idle.update(15'999, {}).current == Mode::Active);
+  assert(idle.update(16'000, {}).current == Mode::Dimmed);
+  assert(idle.update(45'999, {}).current == Mode::Dimmed);
+  assert(idle.update(46'000, {}).current == Mode::DisplayOff);
+
+  // Connection state and replaceable GPS/workout samples are intentionally not
+  // policy inputs, so repeated updates alone cannot postpone idle states.
+  Policy gpsOnly;
+  gpsOnly.begin(0);
+  for (uint32_t now = 1'000; now <= 50'000; now += 1'000) {
+    gpsOnly.update(now, {});
+  }
+  assert(gpsOnly.mode() == Mode::DisplayOff);
+
+  gpsOnly.noteMeaningfulActivity(50'001);
+  auto wake = gpsOnly.update(50'001, {});
+  assert(wake.current == Mode::Active);
+  assert(wake.displayWakeRequired);
+  assert(!gpsOnly.update(50'002, {}).displayWakeRequired);
+
+  Policy routeWake;
+  routeWake.begin(0);
+  assert(routeWake.update(45'000, {}).current == Mode::DisplayOff);
+  Context routeContext;
+  routeContext.navigating = true;
+  wake = routeWake.update(45'001, routeContext);
+  assert(wake.current == Mode::Active);
+  assert(wake.displayWakeRequired);
+
+  Policy transferWake;
+  transferWake.begin(0);
+  assert(transferWake.update(45'000, {}).current == Mode::DisplayOff);
+  Context transferContext;
+  transferContext.transferActive = true;
+  wake = transferWake.update(45'001, transferContext);
+  assert(wake.current == Mode::Transfer);
+  assert(wake.displayWakeRequired);
+
+  Policy attentionWake;
+  attentionWake.begin(0);
+  assert(attentionWake.update(45'000, {}).current == Mode::DisplayOff);
+  Context attentionContext;
+  attentionContext.attentionActive = true;
+  wake = attentionWake.update(45'001, attentionContext);
+  assert(wake.current == Mode::Active);
+  assert(wake.displayWakeRequired);
+
+  Policy eventWake;
+  eventWake.begin(0);
+  assert(eventWake.update(45'000, {}).current == Mode::DisplayOff);
+  eventWake.noteMeaningfulActivity(45'001);
+  wake = eventWake.update(45'001, {});
+  assert(wake.current == Mode::Active);
+  assert(wake.displayWakeRequired);
+
+  Policy navigation;
+  navigation.begin(0);
+  Context navigating;
+  navigating.navigating = true;
+  assert(navigation.update(100'000, navigating).current == Mode::Active);
+  assert(navigation.update(200'000, {}).current == Mode::Active);
+  assert(navigation.update(215'000, {}).current == Mode::Dimmed);
+
+  Policy transfer;
+  transfer.begin(0);
+  Context transferring;
+  transferring.transferActive = true;
+  assert(transfer.update(100'000, transferring).current == Mode::Transfer);
+  assert(transfer.update(200'000, {}).current == Mode::Active);
+  assert(transfer.update(245'000, {}).current == Mode::DisplayOff);
+
+  Policy attention;
+  attention.begin(0);
+  Context pairingOrAudio;
+  pairingOrAudio.attentionActive = true;
+  assert(attention.update(100'000, pairingOrAudio).current == Mode::Active);
+  assert(attention.update(145'000, pairingOrAudio).current == Mode::Active);
+  assert(attention.update(145'001, {}).current == Mode::Active);
+
+  const auto policyAtMode = [](Mode mode) {
+    Policy policy;
+    policy.begin(0);
+    if (mode == Mode::Dimmed) {
+      policy.update(display_inactivity::kDimAfterMs, {});
+    } else if (mode == Mode::DisplayOff) {
+      policy.update(display_inactivity::kDisplayOffAfterMs, {});
+    } else if (mode == Mode::Transfer) {
+      Context context;
+      context.transferActive = true;
+      policy.update(1, context);
+    }
+    assert(policy.mode() == mode);
+    return policy;
+  };
+  constexpr std::array<Mode, 4> allModes = {
+      Mode::Active, Mode::Dimmed, Mode::DisplayOff, Mode::Transfer};
+  for (const Mode previous : allModes) {
+    // BOOT/touch/screen/error events all enter through the meaningful-activity
+    // path and therefore recover Active from every display state.
+    Policy event = policyAtMode(previous);
+    event.noteMeaningfulActivity(100'000);
+    const auto eventUpdate = event.update(100'000, {});
+    assert(eventUpdate.current == Mode::Active);
+    assert(eventUpdate.displayWakeRequired ==
+           (previous == Mode::DisplayOff));
+
+    // Route/navigation start, pairing/ownership, audio, and transfer entry are
+    // policy holds and must work from every prior state as well.
+    Policy route = policyAtMode(previous);
+    Context routeStarted;
+    routeStarted.navigating = true;
+    assert(route.update(100'000, routeStarted).current == Mode::Active);
+
+    Policy pairing = policyAtMode(previous);
+    Context pairingStarted;
+    pairingStarted.attentionActive = true;
+    assert(pairing.update(100'000, pairingStarted).current == Mode::Active);
+
+    Policy audio = policyAtMode(previous);
+    Context audioStarted;
+    audioStarted.attentionActive = true;
+    assert(audio.update(100'000, audioStarted).current == Mode::Active);
+
+    Policy transferEntry = policyAtMode(previous);
+    Context transferStarted;
+    transferStarted.transferActive = true;
+    assert(transferEntry.update(100'000, transferStarted).current ==
+           Mode::Transfer);
+  }
+
+  Policy wrapped;
+  constexpr uint32_t nearWrap = std::numeric_limits<uint32_t>::max() - 10'000;
+  wrapped.begin(nearWrap);
+  assert(wrapped.update(nearWrap + 14'999, {}).current == Mode::Active);
+  assert(wrapped.update(nearWrap + 15'000, {}).current == Mode::Dimmed);
+  assert(wrapped.update(nearWrap + 45'000, {}).current == Mode::DisplayOff);
+
+  assert(!display_inactivity::transferInactivityElapsed(
+      299'999, 0, display_inactivity::kTransferInactivityTimeoutMs, false));
+  assert(display_inactivity::transferInactivityElapsed(
+      300'000, 0, display_inactivity::kTransferInactivityTimeoutMs, false));
+  assert(!display_inactivity::transferInactivityElapsed(
+      600'000, 0, display_inactivity::kTransferInactivityTimeoutMs, true));
+  assert(!display_inactivity::transferInactivityElapsed(600'000, 0, 0,
+                                                        false));
+
+  assert(display_inactivity::maneuverDataBecameActive(0, false, 100, false));
+  assert(display_inactivity::maneuverDataBecameActive(0, false, 0, true));
+  assert(!display_inactivity::maneuverDataBecameActive(25, true, 20, true));
+  assert(!display_inactivity::maneuverDataBecameActive(0, true, 100, true));
+  assert(!display_inactivity::maneuverDataBecameActive(0, false, 0, false));
+
+  static_assert(display_inactivity::maneuverDistanceBucket(1'001) == 7);
+  static_assert(display_inactivity::maneuverDistanceBucket(1'000) == 6);
+  static_assert(display_inactivity::maneuverDistanceBucket(500) == 5);
+  static_assert(display_inactivity::maneuverDistanceBucket(200) == 4);
+  static_assert(display_inactivity::maneuverDistanceBucket(100) == 3);
+  static_assert(display_inactivity::maneuverDistanceBucket(50) == 2);
+  static_assert(display_inactivity::maneuverDistanceBucket(25) == 1);
+  static_assert(display_inactivity::maneuverDistanceBucket(0) == 0);
+  assert(display_inactivity::crossedCloserManeuverDistanceThreshold(1'001,
+                                                                    1'000));
+  assert(display_inactivity::crossedCloserManeuverDistanceThreshold(26, 25));
+  assert(display_inactivity::crossedCloserManeuverDistanceThreshold(1, 0));
+  assert(!display_inactivity::crossedCloserManeuverDistanceThreshold(1'000,
+                                                                     999));
+  assert(!display_inactivity::crossedCloserManeuverDistanceThreshold(0, 25));
+  assert(!display_inactivity::crossedCloserManeuverDistanceThreshold(25, 26));
+
+  // Long-run transition stability: each off-to-active transition requests one
+  // wake, and the immediately following update requests none.
+  Policy cycles;
+  cycles.begin(0);
+  uint32_t now = 0;
+  for (int i = 0; i < 10'000; ++i) {
+    now += display_inactivity::kDisplayOffAfterMs;
+    assert(cycles.update(now, {}).current == Mode::DisplayOff);
+    cycles.noteMeaningfulActivity(++now);
+    assert(cycles.update(now, {}).displayWakeRequired);
+    assert(!cycles.update(now, {}).displayWakeRequired);
+  }
+
+  return 0;
+}

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -69,6 +69,17 @@ int main() {
   assert(restored.takeFullRefreshRequired());
   assert(!restored.takeFullRefreshRequired());
 
+  for (int cycle = 0; cycle < 10'000; ++cycle) {
+    restored.requestState(State::Off);
+    assert(restored.takePendingPanelUpdate(update));
+    assert(update.turnDisplayOff);
+    restored.requestState(State::Active);
+    assert(restored.takePendingPanelUpdate(update));
+    assert(update.turnDisplayOn);
+    assert(restored.takeFullRefreshRequired());
+    assert(!restored.takeFullRefreshRequired());
+  }
+
   for (uint8_t id : {uint8_t{1}, uint8_t{2}, uint8_t{3}, uint8_t{6},
                      uint8_t{7}, uint8_t{8}, uint8_t{9}, uint8_t{10},
                      uint8_t{16}, uint8_t{17}, uint8_t{18}, uint8_t{19},


### PR DESCRIPTION
## Summary

- add ACTIVE, DIMMED, DISPLAY_OFF, and TRANSFER display modes with meaningful-activity wake rules
- stop LVGL and panel QSPI work while the display is off, then restore saved brightness with one full refresh
- add a five-minute authenticated-transfer inactivity timeout and production-safe audio activity tracking
- move radio shutdown out of the global `Power` constructor and expand power-state diagnostics and host tests

## Deep review

The phase review converged after resolving 12 findings, including instruction-only navigation, first-maneuver wake, production audio state, stale-route behavior, long authorized uploads, and unauthenticated clients suppressing transfer timeout. No code findings remain open.

## Verification

- display inactivity/power host tests, including 10,000 off/wake cycles
- device-transfer limit host tests
- 25 power-trace unit tests and power-metrics schema test
- `WAVESHARE_AMOLED_175` compile
- `WAVESHARE_AMOLED_175_POWER_METRICS` compile
- `WAVESHARE_AMOLED_206` compile
- `WAVESHARE_AMOLED_206_POWER_METRICS` compile
- `git diff --check`

All firmware validation above was compile-only. No device was flashed. Physical touch/BOOT/PWR wake, BLE reconnect, interaction, and controlled battery-depletion validation remain deferred until the 1.75-inch board is connected. The 2.06-inch target remains build-only.

## Stack

This draft is stacked on Phase 4 (`agent/battery-life-phase-4-ble-queue`, PR #164).
