### PR TITLE
Add event-driven UI scheduling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,10 @@ jobs:
             -o /tmp/test_display_inactivity_policy
           /tmp/test_display_inactivity_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_ui_scheduler_policy.cpp \
+            -o /tmp/test_ui_scheduler_policy
+          /tmp/test_ui_scheduler_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_ui_update_policy.cpp \
             -o /tmp/test_ui_update_policy
           /tmp/test_ui_update_policy

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -575,6 +575,9 @@ route, screen/input event, connection/authentication event, ownership
 comparison, active sound, or transfer wakes or holds it as appropriate. BLE
 advertising/connection processing continues with the panel off, and wake
 restores the saved brightness with one synchronized full-screen refresh.
+Incoming BLE callbacks publish their latest state and notify the firmware's UI
+owner task. The UI task applies those mailboxes and LVGL changes immediately;
+callbacks do not mutate LVGL objects directly.
 Firmware echoes the request ID when acknowledging tracked requests on the
 navigation notification characteristic:
 

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -49,6 +49,29 @@ attention holds, transfer timeouts, and 10,000 display-off/wake transitions.
 Physical wake, touch, reconnect, and battery-depletion checks remain pending
 until the 1.75-inch device is connected again.
 
+## Event-driven UI scheduling
+
+LVGL now reads the monotonic ESP timer directly instead of waking a periodic
+5 ms timer only to advance its tick. The Arduino UI-owner task uses the delay
+returned by `lv_timer_handler()` together with explicit housekeeping deadlines,
+then blocks on a FreeRTOS task notification. Live navigation has a conservative
+50 ms maximum wait; connected-idle, disconnected, and display-off states have a
+250 ms maximum wait. An actual LVGL or housekeeping deadline can always shorten
+those waits.
+
+BLE state publication, touch and BOOT interrupts, display changes, audio state,
+and transfer completion notify the UI owner immediately. BLE callbacks continue
+to publish mailbox/state changes and never mutate LVGL objects directly. BLE
+ownership/timeout processing, disconnected shutdown, transfer completion, and
+PMU button polling now have explicit deadlines instead of running on every loop.
+The existing `PWRMET` `loop[count=...]` and `lvgl[count=...]` fields provide the
+software wakeup counters for later before/after battery-depletion runs.
+
+Host tests cover deadline selection, immediate deadlines, event-bit
+coalescing, wraparound, and the 50/250 ms maximum-wait policy. Physical maneuver,
+touch, reconnect, and long-running transfer latency remain pending until the
+1.75-inch device is connected again.
+
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
 percentage, or USB-powered observation is not a power baseline. Fill in the

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -38,6 +38,7 @@
 #include "../power_metrics/power_metrics.hpp"
 #include "../route_overlay/route_overlay.hpp"
 #include "../speaker/speaker.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "../waveshare_board/pcf85063.hpp"
 #endif
@@ -156,6 +157,7 @@ static void queueOwnershipUiUpdate(int32_t pairingCode = -1,
   ownershipUiPairingGeneration = pairingGeneration;
   ownershipUiUpdatePending = true;
   portEXIT_CRITICAL(&ownershipUiMux);
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
 }
 
 static void applyPendingOwnershipUiUpdate() {
@@ -244,6 +246,7 @@ static void setDestinationPickerStatus(DestinationPickerStatusCode code,
       '\0';
   destinationStatusUpdatedMs = nowMs;
   portEXIT_CRITICAL(&destinationPickerMux);
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
 }
 
 static bool beginDestinationRequest(uint32_t nowMs) {
@@ -279,6 +282,9 @@ static bool applyDestinationResponseIfPending(
     }
   }
   portEXIT_CRITICAL(&destinationPickerMux);
+  if (matches) {
+    ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
+  }
   return matches;
 }
 
@@ -429,6 +435,7 @@ static uint32_t normalizedDisconnectedSleepTimeoutSeconds(int64_t rawSeconds) {
 static void clearCurrentNavigationData() {
   currentNavData = {0, 0, ""};
   navDataUpdated = true;
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
 }
 
 // Route geometry debouncing - skip redundant parses
@@ -510,6 +517,7 @@ static bool queueMapInput(PendingMapInputType type, const uint8_t *data,
   // Latest-state mailboxes make periodic GPS and repeated route/settings
   // updates bounded without ever dropping the newest authoritative value.
   free(replaced.data);
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
   return true;
 }
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
@@ -635,6 +643,7 @@ static void parseNavigationData(const std::string &data) {
   Serial.printf("BLE Nav: Icon=%d, Dist=%dm, Instr=%s\n", currentNavData.iconID,
                 currentNavData.distance, currentNavData.instruction);
 #endif
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
 }
 
 static bool requireAuthenticated(const char *payloadName) {
@@ -1386,6 +1395,7 @@ static void notifyGenericTransferStatus(NimBLECharacteristic *pChar) {
 static void queueTransferControl(ble_transfer::Action action,
                                  uint8_t notifications) {
   pendingTransferControl.merge(action, notifications);
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
 }
 
 static void processPendingTransferControl() {
@@ -1651,6 +1661,7 @@ static bool commitDestinationCatalog(const std::string &json) {
   candidate.revision = destinationCatalog.revision + 1;
   destinationCatalog = candidate;
   portEXIT_CRITICAL(&destinationPickerMux);
+  ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
   Serial.printf("BLE Destination: committed generation=%lu items=%u\n",
                 (unsigned long)candidate.generation, candidate.count);
   return true;
@@ -1928,6 +1939,7 @@ static void handleWorkoutTelemetryPayload(const uint8_t *data, size_t len,
   case workout_telemetry::ApplyResult::Applied:
   case workout_telemetry::ApplyResult::Cleared:
     // Health metrics remain RAM-only and are intentionally absent from logs.
+    ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
     return;
   default:
     Serial.printf("BLE Workout: rejected %s frame (%s)\n",
@@ -2371,6 +2383,7 @@ public:
       xSemaphoreGive(destinationCatalogReassemblerMutex);
     }
     Serial.println("BLE: iOS client connected!");
+    ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
     // Stop advertising when connected
     NimBLEDevice::stopAdvertising();
   }
@@ -2408,6 +2421,7 @@ public:
     ownershipDisconnectPending = false;
     bleDebugStats.connected = false;
     bleDebugStats.authenticated = false;
+    ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
     bleDebugStats.disconnectCount++;
     bleDebugStats.lastDisconnectMs = millis();
     pendingAuthNonce[0] = '\0';
@@ -2721,6 +2735,7 @@ public:
     if (!value.empty()) {
       power_metrics::noteBlePacket(power_metrics::BlePacketClass::Auth);
       handleAuthPayload(value);
+      ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
     }
   }
 };

--- a/esp32/lib/device_transfer/device_transfer_http.cpp
+++ b/esp32/lib/device_transfer/device_transfer_http.cpp
@@ -1,4 +1,5 @@
 #include "device_transfer_http.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 #include "device_transfer_http_limits.hpp"
 
 #include <algorithm>
@@ -301,6 +302,7 @@ void HttpTransferServer::runWorker() {
       requestInProgress_ = false;
       currentRequestAuthorized_ = false;
       unlockState();
+      ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
     } else {
       vTaskDelay(pdMS_TO_TICKS(2));
     }

--- a/esp32/lib/display_power/display_power.cpp
+++ b/esp32/lib/display_power/display_power.cpp
@@ -2,6 +2,7 @@
 
 #include "../panel/WAVESHARE_AMOLED_175.hpp"
 #include "../power_metrics/power_metrics.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 
 #include <Arduino.h>
 #include <Arduino_GFX_Library.h>
@@ -86,6 +87,8 @@ bool DisplayPowerManager::requestUserBrightness(int32_t requestedPercent) {
 
   if (!persisted) {
     Serial.println("DisplayPower: failed to persist brightness");
+  } else {
+    ui_scheduler::notify(ui_scheduler::WakeReason::Display);
   }
   return persisted;
 }
@@ -97,8 +100,12 @@ void DisplayPowerManager::requestState(display_power::State state) {
   if (!lock()) {
     return;
   }
+  const bool changed = policy_.state() != state;
   policy_.requestState(state);
   unlock();
+  if (changed) {
+    ui_scheduler::notify(ui_scheduler::WakeReason::Display);
+  }
 }
 
 display_power::State DisplayPowerManager::state() const {

--- a/esp32/lib/lvgl/src/lvglSetup.cpp
+++ b/esp32/lib/lvgl/src/lvglSetup.cpp
@@ -9,6 +9,8 @@
 #include "lvglSetup.hpp"
 #include "../../power/power.hpp"
 
+#include <esp_timer.h>
+
 lv_display_t *display;
 
 lv_obj_t *searchSatScreen; // Search Satellite Screen
@@ -306,14 +308,8 @@ void modifyTheme() {
   lv_disp_set_theme(NULL, &th_new);
 }
 
-/**
- * @brief Setting up tick task for lvgl
- *
- * @param arg
- */
-void lv_tick_task(void *arg) {
-  (void)arg;
-  lv_tick_inc(LV_TICK_PERIOD_MS);
+static uint32_t lvMonotonicTickMs() {
+  return static_cast<uint32_t>(esp_timer_get_time() / 1000);
 }
 
 /**
@@ -398,6 +394,10 @@ void initLVGL() {
 
 #endif
 
+  // LVGL reads the monotonic ESP timer on demand. This removes the 5 ms
+  // periodic esp_timer wakeup previously used only to call lv_tick_inc().
+  lv_tick_set_cb(lvMonotonicTickMs);
+
   //  Create Main Timer
   mainTimer = lv_timer_create(updateMainScreen, UPDATE_MAINSCR_PERIOD, NULL);
   lv_timer_ready(mainTimer);
@@ -417,13 +417,6 @@ void initLVGL() {
   createGpxDetailScreen();
   createGpxListScreen();
 
-  // Create and start a periodic timer interrupt to call lv_tick_inc
-  const esp_timer_create_args_t periodic_timer_args = {
-      .callback = &lv_tick_task, .name = "periodic_gui"};
-  esp_timer_handle_t periodic_timer;
-  ESP_ERROR_CHECK(esp_timer_create(&periodic_timer_args, &periodic_timer));
-  ESP_ERROR_CHECK(
-      esp_timer_start_periodic(periodic_timer, LV_TICK_PERIOD_MS * 1000));
 }
 
 /**

--- a/esp32/lib/lvgl/src/lvglSetup.hpp
+++ b/esp32/lib/lvgl/src/lvglSetup.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#define LV_TICK_PERIOD_MS 5
-
 #include "globalGpxDef.h"
 #include "lvgl_private.h"
 #include "tasks.hpp"
@@ -51,6 +49,5 @@ uint8_t gpioGetBut();
 #endif
 void applyModifyTheme(lv_theme_t *th, lv_obj_t *obj);
 void modifyTheme();
-void lv_tick_task(void *arg);
 void initLVGL();
 void loadMainScreen();

--- a/esp32/lib/map_transfer_http/map_transfer_http.cpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.cpp
@@ -3,6 +3,7 @@
 #include "../firmware_metadata/firmware_metadata.hpp"
 #include "../maps/src/mapBlockFormat.hpp"
 #include "map_stream_compiled_trust.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 
 #include <algorithm>
 #include <cerrno>
@@ -1157,6 +1158,7 @@ void MapTransferHttpServer::requestAutomaticExit() {
   lockState();
   pendingAutomaticExit_ = true;
   unlockState();
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
 }
 
 void MapTransferHttpServer::finishActivation(const std::string &status,
@@ -1169,6 +1171,7 @@ void MapTransferHttpServer::finishActivation(const std::string &status,
   if (!errorCode.empty()) {
     transferServer_->setLastError(errorCode, errorMessage);
   }
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
 }
 
 void MapTransferHttpServer::updateActivationProgress(
@@ -1176,6 +1179,7 @@ void MapTransferHttpServer::updateActivationProgress(
   lockState();
   activationState_.updateProgress(progress);
   unlockState();
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
 }
 
 bool MapTransferHttpServer::startActivationTask(const std::string &sessionId,
@@ -1228,6 +1232,7 @@ bool MapTransferHttpServer::runStreamActivationTask(
   pendingRendererStreamProtocol_ = true;
   activationState_.updateProgress({3, 3, 2, 3});
   unlockState();
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
   return true;
 }
 
@@ -1302,6 +1307,7 @@ bool MapTransferHttpServer::runActivationTask(const std::string &sessionId,
   pendingRendererStreamProtocol_ = false;
   activationState_.updateProgress({5, 5, 4, 5});
   unlockState();
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
   return true;
 }
 

--- a/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
+++ b/esp32/lib/panel/WAVESHARE_AMOLED_175.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "WAVESHARE_AMOLED_175.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 #ifdef USE_ARDUINO_GFX
 #include "../display_power/display_power.hpp"
 #include <Arduino_GFX_Library.h>
@@ -261,6 +262,7 @@ static uint32_t attemptedTouchInterruptGeneration = 0;
 
 static void IRAM_ATTR latchTouchInterrupt() {
   touchInterruptGeneration = touchInterruptGeneration + 1;
+  ui_scheduler::notifyFromIsr(ui_scheduler::WakeReason::Touch);
 }
 
 waveshare_board::touch::TouchFrame getTouchFrameSnapshot() {

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -1,4 +1,5 @@
 #include "speaker.hpp"
+#include "../ui_scheduler/ui_scheduler.hpp"
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
@@ -536,6 +537,7 @@ void speakerTask(void *) {
     }
 
     playbackActive.store(true, std::memory_order_relaxed);
+    ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
     if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
         ESP_CODEC_DEV_OK) {
       Serial.printf("Speaker: failed to set volume to %u%%\n",
@@ -552,6 +554,7 @@ void speakerTask(void *) {
       }
     }
     playbackActive.store(false, std::memory_order_relaxed);
+    ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
 
     if (uxQueueMessagesWaiting(soundQueue) == 0) {
       releaseCodecResources();

--- a/esp32/lib/tasks/tasks.cpp
+++ b/esp32/lib/tasks/tasks.cpp
@@ -8,7 +8,6 @@
 
 #include "tasks.hpp"
 
-TaskHandle_t LVGLTaskHandler;
 #ifdef HAS_HARDWARE_GPS
 xSemaphoreHandle gpsMutex;
 extern Gps gps;
@@ -88,4 +87,3 @@ void cliTask(void *param)
 void initCLITask() { xTaskCreatePinnedToCore(cliTask, "cliTask ", 20000, NULL, 1, NULL, 1); }
 
 #endif
-

--- a/esp32/lib/tasks/tasks.hpp
+++ b/esp32/lib/tasks/tasks.hpp
@@ -26,8 +26,6 @@
 #include "globalGpxDef.h"
 #include "lvglFuncs.hpp"
 
-#define TASK_SLEEP_PERIOD_MS 5
-
 #ifdef HAS_HARDWARE_GPS
 void gpsTask(void *pvParameters);
 void initGpsTask();

--- a/esp32/lib/ui_scheduler/ui_scheduler.cpp
+++ b/esp32/lib/ui_scheduler/ui_scheduler.cpp
@@ -1,0 +1,45 @@
+#include "ui_scheduler.hpp"
+
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
+
+namespace ui_scheduler {
+namespace {
+
+TaskHandle_t uiTask = nullptr;
+
+} // namespace
+
+void bindCurrentTask() { uiTask = xTaskGetCurrentTaskHandle(); }
+
+void notify(WakeReason reason) {
+  if (uiTask == nullptr || reason == WakeReason::None) {
+    return;
+  }
+  xTaskNotify(uiTask, reasonBits(reason), eSetBits);
+}
+
+void notifyFromIsr(WakeReason reason) {
+  if (uiTask == nullptr || reason == WakeReason::None) {
+    return;
+  }
+  BaseType_t higherPriorityTaskWoken = pdFALSE;
+  xTaskNotifyFromISR(uiTask, reasonBits(reason), eSetBits,
+                     &higherPriorityTaskWoken);
+  if (higherPriorityTaskWoken == pdTRUE) {
+    portYIELD_FROM_ISR();
+  }
+}
+
+uint32_t wait(uint32_t timeoutMs) {
+  uint32_t reasons = 0;
+  TickType_t timeoutTicks = timeoutMs == 0 ? 0 : pdMS_TO_TICKS(timeoutMs);
+  if (timeoutMs > 0 && timeoutTicks == 0) {
+    timeoutTicks = 1;
+  }
+  xTaskNotifyWait(0, std::numeric_limits<uint32_t>::max(), &reasons,
+                  timeoutTicks);
+  return reasons;
+}
+
+} // namespace ui_scheduler

--- a/esp32/lib/ui_scheduler/ui_scheduler.hpp
+++ b/esp32/lib/ui_scheduler/ui_scheduler.hpp
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "ui_scheduler_policy.hpp"
+
+#include <cstdint>
+#include <esp_attr.h>
+
+namespace ui_scheduler {
+
+void bindCurrentTask();
+void notify(WakeReason reason);
+void IRAM_ATTR notifyFromIsr(WakeReason reason);
+uint32_t wait(uint32_t timeoutMs);
+
+} // namespace ui_scheduler

--- a/esp32/lib/ui_scheduler/ui_scheduler_policy.hpp
+++ b/esp32/lib/ui_scheduler/ui_scheduler_policy.hpp
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <limits>
+
+namespace ui_scheduler {
+
+constexpr uint32_t kConnectedNavigationMaximumWaitMs = 50;
+constexpr uint32_t kStaticMaximumWaitMs = 250;
+constexpr uint32_t kNoDeadline = std::numeric_limits<uint32_t>::max();
+
+enum class WakeReason : uint32_t {
+  None = 0,
+  Ble = 1u << 0,
+  Touch = 1u << 1,
+  Boot = 1u << 2,
+  Display = 1u << 3,
+  Transfer = 1u << 4,
+  Audio = 1u << 5,
+};
+
+constexpr uint32_t reasonBits(WakeReason reason) {
+  return static_cast<uint32_t>(reason);
+}
+
+constexpr bool hasReason(uint32_t reasons, WakeReason reason) {
+  return (reasons & reasonBits(reason)) != 0;
+}
+
+struct DeadlineContext {
+  uint32_t lvglDelayMs = kNoDeadline;
+  uint32_t housekeepingDelayMs = kNoDeadline;
+  bool connectedNavigation = false;
+  bool lvglBlocked = false;
+  bool displayOff = false;
+};
+
+constexpr uint32_t elapsedMs(uint32_t nowMs, uint32_t sinceMs) {
+  return nowMs - sinceMs;
+}
+
+constexpr uint32_t remainingUntil(uint32_t nowMs, uint32_t lastRunMs,
+                                  uint32_t periodMs) {
+  const uint32_t elapsed = elapsedMs(nowMs, lastRunMs);
+  return elapsed >= periodMs ? 0 : periodMs - elapsed;
+}
+
+constexpr bool isDue(uint32_t nowMs, uint32_t lastRunMs, uint32_t periodMs) {
+  return remainingUntil(nowMs, lastRunMs, periodMs) == 0;
+}
+
+constexpr bool shouldRunForReason(uint32_t reasons, WakeReason reason,
+                                  uint32_t nowMs, uint32_t lastRunMs,
+                                  uint32_t periodMs) {
+  return hasReason(reasons, reason) ||
+         isDue(nowMs, lastRunMs, periodMs);
+}
+
+constexpr uint32_t nextWaitMs(const DeadlineContext &context) {
+  uint32_t waitMs = context.connectedNavigation
+                        ? kConnectedNavigationMaximumWaitMs
+                        : kStaticMaximumWaitMs;
+  if (!context.displayOff && !context.lvglBlocked) {
+    waitMs = std::min(waitMs, context.lvglDelayMs);
+  }
+  waitMs = std::min(waitMs, context.housekeepingDelayMs);
+  return waitMs;
+}
+
+} // namespace ui_scheduler

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -8,6 +8,8 @@
 
 #include <Arduino.h>
 
+#include <algorithm>
+
 #ifndef FIRMWARE_DIAGNOSTICS
 #define FIRMWARE_DIAGNOSTICS 1
 #endif
@@ -82,6 +84,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "guiLayout.hpp"
 #include "mainScr.hpp"
 #include "route_overlay.hpp"
+#include "ui_scheduler.hpp"
 #include "waitingScr.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "WAVESHARE_AMOLED_175.hpp"
@@ -185,6 +188,7 @@ static void IRAM_ATTR latchWaveshareBootScreenCycle() {
   portENTER_CRITICAL_ISR(&waveshareBootButtonMux);
   waveshareBootScreenCyclePending = true;
   portEXIT_CRITICAL_ISR(&waveshareBootButtonMux);
+  ui_scheduler::notifyFromIsr(ui_scheduler::WakeReason::Boot);
 }
 
 static bool takeWaveshareBootScreenCycle() {
@@ -264,15 +268,6 @@ static bool processWaveshareBootButton() {
 }
 
 static bool processWavesharePowerButton() {
-  constexpr uint32_t POLL_INTERVAL_MS = 100;
-  static uint32_t lastPollMs = 0;
-
-  const uint32_t now = millis();
-  if (now - lastPollMs < POLL_INTERVAL_MS) {
-    return false;
-  }
-  lastPollMs = now;
-
   waveshare_board::axp2101::PowerButtonEvents events;
   if (!waveshare_board::axp2101::readAndClearPowerButtonEvents(events)) {
     return false;
@@ -350,10 +345,16 @@ static uint32_t lvglHandlerCount = 0;
 static uint32_t lastLvglHandlerMs = 0;
 static uint32_t lastLvglHandlerDurationUs = 0;
 static uint32_t maxLvglHandlerDurationUs = 0;
+static uint32_t nextLvglDelayMs = 0;
+static uint32_t pendingUiWakeReasons = 0;
+static uint32_t lastBleHousekeepingMs = 0;
+static uint32_t lastShutdownHousekeepingMs = 0;
+static uint32_t lastTransferHousekeepingMs = 0;
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 static display_inactivity::Policy displayInactivityPolicy;
 static display_inactivity::Mode currentDisplayMode =
     display_inactivity::Mode::Active;
+static uint32_t lastPowerButtonHousekeepingMs = 0;
 #endif
 #include "lvglSetup.hpp"
 #include "settings.hpp"
@@ -974,6 +975,9 @@ void setup() {
 #endif
   power_metrics::begin();
   power.begin();
+  // Arduino setup() and loop() share the same FreeRTOS task. Bind it before
+  // enabling BLE, touch, BOOT, audio, or transfer publishers.
+  ui_scheduler::bindCurrentTask();
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   displayPowerManager.begin();
 #endif
@@ -1238,6 +1242,9 @@ void setup() {
  */
 void loop() {
   uint32_t now = millis();
+  const uint32_t wakeReasons =
+      pendingUiWakeReasons | ui_scheduler::wait(0);
+  pendingUiWakeReasons = 0;
   power_metrics::noteLoop(now);
   if (lastLoopMs != 0) {
     uint32_t gap = now - lastLoopMs;
@@ -1248,32 +1255,71 @@ void loop() {
   lastLoopMs = now;
   loopCount++;
 
-  std::string activatedMapRoot;
-  if (mapTransferHttp.takeActivatedMapRoot(activatedMapRoot)) {
-    const std::string rendererRoot = std::string("/sdcard") + activatedMapRoot;
-    const bool loaded = mapView.probeVectorMapFolder(rendererRoot) &&
-                        mapView.setVectorMapFolder(rendererRoot);
-    mapTransferHttp.acknowledgeActivatedMapRoot(activatedMapRoot, loaded);
-  }
-  if (mapTransferHttp.takeAutomaticExitRequest()) {
-    const bool disabled = mapTransferHttp.setEnabled(false);
-    Serial.printf("MAP_TRANSFER_HTTP: automatic exit applied disabled=%d\n",
-                  disabled);
-  }
+  constexpr uint32_t kStaticHousekeepingPeriodMs =
+      ui_scheduler::kStaticMaximumWaitMs;
+  const bool transferHousekeepingDue =
+      ui_scheduler::shouldRunForReason(
+          wakeReasons, ui_scheduler::WakeReason::Transfer, now,
+          lastTransferHousekeepingMs, kStaticHousekeepingPeriodMs);
+  if (transferHousekeepingDue) {
+    lastTransferHousekeepingMs = now;
+    std::string activatedMapRoot;
+    if (mapTransferHttp.takeActivatedMapRoot(activatedMapRoot)) {
+      const std::string rendererRoot =
+          std::string("/sdcard") + activatedMapRoot;
+      const bool loaded = mapView.probeVectorMapFolder(rendererRoot) &&
+                          mapView.setVectorMapFolder(rendererRoot);
+      mapTransferHttp.acknowledgeActivatedMapRoot(activatedMapRoot, loaded);
+    }
+    if (mapTransferHttp.takeAutomaticExitRequest()) {
+      const bool disabled = mapTransferHttp.setEnabled(false);
+      Serial.printf("MAP_TRANSFER_HTTP: automatic exit applied disabled=%d\n",
+                    disabled);
+    }
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  processTransferInactivityTimeout(now);
+    processTransferInactivityTimeout(now);
 #endif
+    updateMapActivationProgressOverlay();
+    deviceTransferHttp.process();
+  }
+
+  const BLEDebugStats bleStatsBeforeWork = bleNavServer.getDebugStats();
+  const bool navigatingBeforeBleWork =
+      bleStatsBeforeWork.connected && bleStatsBeforeWork.authenticated &&
+      (routeOverlay.hasRoute() || hasCurrentNavigationData());
+  const uint32_t bleHousekeepingPeriodMs =
+      navigatingBeforeBleWork
+          ? ui_scheduler::kConnectedNavigationMaximumWaitMs
+          : ui_scheduler::kStaticMaximumWaitMs;
+  if (ui_scheduler::shouldRunForReason(
+          wakeReasons, ui_scheduler::WakeReason::Ble, now,
+          lastBleHousekeepingMs, bleHousekeepingPeriodMs)) {
+    lastBleHousekeepingMs = now;
+    bleNavServer.process();
+  }
+
+  if (ui_scheduler::isDue(now, lastShutdownHousekeepingMs,
+                          kStaticHousekeepingPeriodMs)) {
+    lastShutdownHousekeepingMs = now;
+    processDisconnectedShutdown();
+  }
 
   // Process app-provided GPS transitions before any periodic work that can
   // briefly block on display, sensor, BLE, or debug output.
   checkPendingMapTransition();
-  updateMapActivationProgressOverlay();
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   // Sample the screen-cycle button before LVGL can start a synchronous vector
   // redraw. updateMainScreen() also defers while the raw input is active.
   if (processWaveshareBootButton()) {
     displayInactivityPolicy.noteMeaningfulActivity(now);
+  }
+  if (ui_scheduler::isDue(now, lastPowerButtonHousekeepingMs,
+                          kStaticHousekeepingPeriodMs)) {
+    lastPowerButtonHousekeepingMs = now;
+    if (processWavesharePowerButton()) {
+      displayInactivityPolicy.noteMeaningfulActivity(now);
+    }
   }
 #endif
 
@@ -1297,7 +1343,7 @@ void loop() {
 #endif
   if (runLvglHandler) {
     uint32_t startUs = micros();
-    lv_timer_handler();
+    nextLvglDelayMs = lv_timer_handler();
     lastLvglHandlerDurationUs = micros() - startUs;
     power_metrics::noteLvgl(lastLvglHandlerDurationUs);
     if (lastLvglHandlerDurationUs > maxLvglHandlerDurationUs) {
@@ -1310,30 +1356,9 @@ void loop() {
 #endif
   }
 
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  const uint32_t loopDelayMs =
-      currentDisplayMode == display_inactivity::Mode::DisplayOff
-          ? 20
-          : TASK_SLEEP_PERIOD_MS;
-  vTaskDelay(pdMS_TO_TICKS(loopDelayMs));
-#else
-  if (runLvglHandler) {
-    vTaskDelay(pdMS_TO_TICKS(TASK_SLEEP_PERIOD_MS));
-  }
-#endif
-
-  // Process BLE events
-  bleNavServer.process();
-  processDisconnectedShutdown();
-
 #if (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)) &&       \
     defined(WAVESHARE_IMU_DIAGNOSTICS)
   waveshare_board::imu::process();
-#endif
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  if (processWavesharePowerButton()) {
-    displayInactivityPolicy.noteMeaningfulActivity(millis());
-  }
 #endif
 
   logSystemDebugHeartbeat();
@@ -1351,5 +1376,51 @@ void loop() {
   }
 #endif
 
-  deviceTransferHttp.process();
+  const uint32_t schedulerNow = millis();
+  const BLEDebugStats schedulerBleStats = bleNavServer.getDebugStats();
+  const bool connectedNavigation =
+      schedulerBleStats.connected && schedulerBleStats.authenticated &&
+      (routeOverlay.hasRoute() || hasCurrentNavigationData());
+  const uint32_t nextBleHousekeepingMs = ui_scheduler::remainingUntil(
+      schedulerNow, lastBleHousekeepingMs,
+      connectedNavigation
+          ? ui_scheduler::kConnectedNavigationMaximumWaitMs
+          : ui_scheduler::kStaticMaximumWaitMs);
+  uint32_t nextHousekeepingMs = std::min(
+      ui_scheduler::remainingUntil(schedulerNow,
+                                   lastTransferHousekeepingMs,
+                                   kStaticHousekeepingPeriodMs),
+      ui_scheduler::remainingUntil(schedulerNow,
+                                   lastShutdownHousekeepingMs,
+                                   kStaticHousekeepingPeriodMs));
+  nextHousekeepingMs = std::min(nextHousekeepingMs, nextBleHousekeepingMs);
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  nextHousekeepingMs = std::min(
+      nextHousekeepingMs,
+      ui_scheduler::remainingUntil(schedulerNow,
+                                   lastPowerButtonHousekeepingMs,
+                                   kStaticHousekeepingPeriodMs));
+#endif
+
+  uint32_t effectiveLvglDelayMs = ui_scheduler::remainingUntil(
+      schedulerNow, lastLvglHandlerMs, nextLvglDelayMs);
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  if (currentDisplayMode == display_inactivity::Mode::Dimmed) {
+    effectiveLvglDelayMs =
+        std::max(effectiveLvglDelayMs,
+                 ui_scheduler::remainingUntil(schedulerNow,
+                                              lastLvglHandlerMs, 100));
+  }
+#endif
+  ui_scheduler::DeadlineContext deadline;
+  deadline.lvglDelayMs = effectiveLvglDelayMs;
+  deadline.housekeepingDelayMs = nextHousekeepingMs;
+  deadline.connectedNavigation = connectedNavigation;
+  deadline.lvglBlocked = waitScreenRefresh;
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  deadline.displayOff =
+      currentDisplayMode == display_inactivity::Mode::DisplayOff;
+#endif
+  pendingUiWakeReasons =
+      ui_scheduler::wait(ui_scheduler::nextWaitMs(deadline));
 }

--- a/esp32/tools/tests/test_ui_scheduler_policy.cpp
+++ b/esp32/tools/tests/test_ui_scheduler_policy.cpp
@@ -1,0 +1,76 @@
+#include "../../lib/ui_scheduler/ui_scheduler_policy.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+  using ui_scheduler::DeadlineContext;
+
+  DeadlineContext context;
+  assert(ui_scheduler::nextWaitMs(context) == 250);
+
+  context.connectedNavigation = true;
+  assert(ui_scheduler::nextWaitMs(context) == 50);
+
+  context.lvglDelayMs = 12;
+  assert(ui_scheduler::nextWaitMs(context) == 12);
+
+  context.housekeepingDelayMs = 7;
+  assert(ui_scheduler::nextWaitMs(context) == 7);
+
+  context.displayOff = true;
+  context.connectedNavigation = false;
+  context.housekeepingDelayMs = ui_scheduler::kNoDeadline;
+  assert(ui_scheduler::nextWaitMs(context) == 250);
+
+  context.displayOff = false;
+  context.lvglBlocked = true;
+  context.lvglDelayMs = 0;
+  assert(ui_scheduler::nextWaitMs(context) == 250);
+
+  context.lvglBlocked = false;
+  assert(ui_scheduler::nextWaitMs(context) == 0);
+
+  assert(ui_scheduler::remainingUntil(1'000, 900, 250) == 150);
+  assert(ui_scheduler::remainingUntil(1'150, 900, 250) == 0);
+  assert(ui_scheduler::isDue(1'150, 900, 250));
+  assert(!ui_scheduler::isDue(1'149, 900, 250));
+
+  // A maneuver published one millisecond after BLE housekeeping bypasses the
+  // remaining 249 ms cadence immediately, while an unrelated wake does not.
+  const uint32_t maneuverWake =
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Ble);
+  assert(ui_scheduler::shouldRunForReason(
+      maneuverWake, ui_scheduler::WakeReason::Ble, 1'001, 1'000, 250));
+  assert(!ui_scheduler::shouldRunForReason(
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Touch),
+      ui_scheduler::WakeReason::Ble, 1'001, 1'000, 250));
+
+  // Work performed after LVGL returns consumes part of its next delay rather
+  // than being added on top of that deadline.
+  context = {};
+  context.lvglDelayMs = ui_scheduler::remainingUntil(1'005, 1'000, 30);
+  assert(ui_scheduler::nextWaitMs(context) == 25);
+
+  constexpr uint32_t nearWrap = std::numeric_limits<uint32_t>::max() - 100;
+  assert(ui_scheduler::remainingUntil(nearWrap + 150, nearWrap, 250) == 100);
+  assert(ui_scheduler::remainingUntil(nearWrap + 250, nearWrap, 250) == 0);
+
+  const uint32_t allReasons =
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Ble) |
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Touch) |
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Boot) |
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Display) |
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Transfer) |
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Audio);
+  assert(ui_scheduler::hasReason(allReasons,
+                                 ui_scheduler::WakeReason::Ble));
+  assert(ui_scheduler::hasReason(allReasons,
+                                 ui_scheduler::WakeReason::Transfer));
+  assert(!ui_scheduler::hasReason(
+      ui_scheduler::reasonBits(ui_scheduler::WakeReason::Boot),
+      ui_scheduler::WakeReason::Touch));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary
- replace the fixed-delay LVGL loop with monotonic LVGL ticks and notification-driven scheduling
- wake only after BLE/touch/display/transfer/audio state is published and enforce explicit 50 ms live-navigation / 250 ms static deadlines
- gate transfer, BLE, shutdown, and PMU housekeeping behind notifications or deadlines
- document the scheduler contract and add host coverage for deadlines, wake reasons, wraparound, and a maneuver arriving immediately after blocking

## Deep review
Converged after fixing 9 findings: two P1 publication/deadline bugs, six P2 cadence/notification issues, and one P3 dead-code issue.

## Validation
- host policy, display, map-render, metrics, and firmware-profile tests pass
- `pio run -e WAVESHARE_AMOLED_175 -e WAVESHARE_AMOLED_206` passes
- compile/build only; no firmware was flashed
- physical latency, interaction, and battery validation remain deferred until the 1.75-inch board is connected

## Stack
- depends on #165