### PR TITLE
Enable dynamic frequency scaling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,12 @@ jobs:
             -o /tmp/test_ui_scheduler_policy
           /tmp/test_ui_scheduler_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_power_management_policy.cpp \
+            -o /tmp/test_power_management_policy
+          /tmp/test_power_management_policy
+          PYTHONPATH=tools python -m unittest \
+            tools.tests.test_pioarduino_custom_core
+          g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_ui_update_policy.cpp \
             -o /tmp/test_ui_update_policy
           /tmp/test_ui_update_policy

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -72,6 +72,24 @@ coalescing, wraparound, and the 50/250 ms maximum-wait policy. Physical maneuver
 touch, reconnect, and long-running transfer latency remain pending until the
 1.75-inch device is connected again.
 
+## Dynamic frequency scaling
+
+All Waveshare firmware profiles now compile ESP-IDF power-management support
+and explicitly request 80-240 MHz dynamic frequency scaling during setup.
+Automatic light sleep and FreeRTOS tickless idle remain disabled. The firmware
+reads the effective configuration back from ESP-IDF and exposes its enabled,
+error, minimum, maximum, and light-sleep fields in the ten-second `PWRMET`
+report. A rejected configuration request leaves the prior framework setting
+intact. Readback failure or an unexpected effective configuration is reported
+instead of making assumptions about the active frequency range.
+
+This is Phase 7 Step A only. The minimum frequency must remain at 80 MHz until
+physical map-render, display-flush, BLE, touch, transfer, audio, and overnight
+connected-navigation checks pass. Do not enable 40 MHz or automatic light
+sleep from build configuration alone. Step B requires explicit locks around
+every timing-sensitive display, map, SD, transfer, audio, and tested I2C path,
+then separate physical validation on the 1.75-inch board.
+
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
 percentage, or USB-powered observation is not a power baseline. Fill in the
@@ -97,9 +115,11 @@ The report contains:
 - logically classified BLE packets after authenticated transport framing is
   unwrapped, including packets later rejected by session authentication or
   application-payload validation;
-- Wi-Fi mode, transfer state/mode, audio activity, CPU frequency, and the
-  number of application-managed power-management locks (`appPmLocks`,
-  currently zero because this firmware creates none); and
+- Wi-Fi mode, transfer state/mode, audio activity, current CPU frequency,
+  effective DFS range, power-management error code, automatic-light-sleep
+  state, and the number of
+  application-managed power-management locks (`appPmLocks`, currently zero
+  because Step A creates none); and
 - `appQueue=ios-diagnostic`, which identifies the separate
   `PWRMET_IOS v=2` ten-second interval report produced by a Debug iOS build.
 

--- a/esp32/lib/power_management/power_management.cpp
+++ b/esp32/lib/power_management/power_management.cpp
@@ -1,0 +1,88 @@
+#include "power_management.hpp"
+
+#include <Arduino.h>
+#include <esp_err.h>
+#include <esp_pm.h>
+
+#if !CONFIG_PM_ENABLE
+#error "Waveshare DFS requires CONFIG_PM_ENABLE=y"
+#endif
+
+#if CONFIG_FREERTOS_USE_TICKLESS_IDLE
+#error "Automatic light sleep must remain disabled during Phase 7A"
+#endif
+
+namespace power_management {
+namespace {
+
+RuntimeStatus runtimeStatus;
+bool attempted = false;
+
+Configuration fromEspIdf(const esp_pm_config_t &configuration) {
+  return {
+      static_cast<uint16_t>(configuration.max_freq_mhz),
+      static_cast<uint16_t>(configuration.min_freq_mhz),
+      configuration.light_sleep_enable,
+  };
+}
+
+} // namespace
+
+bool begin() {
+  if (attempted) {
+    return runtimeStatus.enabled;
+  }
+  attempted = true;
+  runtimeStatus.requested = kDfsConfiguration;
+
+  const esp_pm_config_t requested{
+      kDfsConfiguration.maximumCpuMhz,
+      kDfsConfiguration.minimumCpuMhz,
+      kDfsConfiguration.automaticLightSleep,
+  };
+  const esp_err_t configureResult = esp_pm_configure(&requested);
+  runtimeStatus.errorCode = configureResult;
+  if (configureResult != ESP_OK) {
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
+    Serial.printf("Power management: DFS configuration failed: %s (%d)\n",
+                  esp_err_to_name(configureResult), configureResult);
+#endif
+    return false;
+  }
+
+  esp_pm_config_t effective{};
+  const esp_err_t readResult = esp_pm_get_configuration(&effective);
+  if (readResult != ESP_OK) {
+    runtimeStatus.errorCode = readResult;
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
+    Serial.printf("Power management: DFS readback failed: %s (%d)\n",
+                  esp_err_to_name(readResult), readResult);
+#endif
+    return false;
+  }
+
+  runtimeStatus.effective = fromEspIdf(effective);
+  runtimeStatus.enabled =
+      runtimeStatus.effective.maximumCpuMhz ==
+          runtimeStatus.requested.maximumCpuMhz &&
+      runtimeStatus.effective.minimumCpuMhz ==
+          runtimeStatus.requested.minimumCpuMhz &&
+      runtimeStatus.effective.automaticLightSleep ==
+          runtimeStatus.requested.automaticLightSleep;
+  if (!runtimeStatus.enabled) {
+    runtimeStatus.errorCode = ESP_ERR_INVALID_STATE;
+  }
+
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
+  Serial.printf(
+      "Power management: DFS enabled=%d min=%uMHz max=%uMHz lightSleep=%d\n",
+      runtimeStatus.enabled, runtimeStatus.effective.minimumCpuMhz,
+      runtimeStatus.effective.maximumCpuMhz,
+      runtimeStatus.effective.automaticLightSleep);
+#endif
+  return runtimeStatus.enabled;
+}
+
+RuntimeStatus status() { return runtimeStatus; }
+
+} // namespace power_management

--- a/esp32/lib/power_management/power_management.hpp
+++ b/esp32/lib/power_management/power_management.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "power_management_policy.hpp"
+
+namespace power_management {
+
+struct RuntimeStatus {
+  bool enabled = false;
+  Configuration requested = kDfsConfiguration;
+  Configuration effective{};
+  int errorCode = 0;
+};
+
+// Configure ESP-IDF dynamic frequency scaling once framework initialization is
+// complete. A rejected request leaves the prior configuration intact. Any
+// configuration or readback failure is exposed through status().
+bool begin();
+RuntimeStatus status();
+
+} // namespace power_management

--- a/esp32/lib/power_management/power_management_policy.hpp
+++ b/esp32/lib/power_management/power_management_policy.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <cstdint>
+
+namespace power_management {
+
+struct Configuration {
+  uint16_t maximumCpuMhz;
+  uint16_t minimumCpuMhz;
+  bool automaticLightSleep;
+};
+
+constexpr Configuration kDfsConfiguration{
+    240,
+    80,
+    false,
+};
+
+constexpr bool isValid(const Configuration &configuration) {
+  return configuration.minimumCpuMhz > 0 &&
+         configuration.minimumCpuMhz <= configuration.maximumCpuMhz;
+}
+
+static_assert(isValid(kDfsConfiguration));
+static_assert(!kDfsConfiguration.automaticLightSleep,
+              "Phase 7A must not enable automatic light sleep");
+
+} // namespace power_management

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -171,6 +171,15 @@ build_flags =
 board = esp32-s3-devkitc-1
 lib_ldf_mode = deep
 board_build.mcu = esp32s3
+; Build ESP-IDF power-management support into every Waveshare profile. Runtime
+; code enables 80-240 MHz dynamic frequency scaling explicitly. Tickless idle
+; stays disabled until the separate automatic-light-sleep phase has passed its
+; physical lock/soak gates.
+custom_sdkconfig =
+  CONFIG_PM_ENABLE=y
+  CONFIG_PM_DFS_INIT_AUTO=n
+  CONFIG_PM_PROFILING=n
+  CONFIG_FREERTOS_USE_TICKLESS_IDLE=n
 ; This board uses 8MB/16MB Flash and OPI PSRAM
 board_build.arduino.memory_type = qio_opi
 board_build.partitions = partitions.csv
@@ -179,6 +188,12 @@ board_build.filesystem = fatfs
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
 extra_scripts = pre:prebuild.py
+; pioarduino's custom SDK build drops its private CONFIG_LIB_BUILDER_COMPILE
+; symbol, so ESP-Diagnostics does not provide the log_printf wrapper that the
+; stock link flags request. This firmware does not use ESP Insights; link
+; Arduino logging directly instead of depending on that absent wrapper.
+build_unflags =
+  -Wl,--wrap=log_printf
 
 ; Use pioarduino platform for Arduino Core 3.x (required for Arduino_GFX 1.4.7+).
 ; Pin the release archive so GitHub release firmware matches locally tested builds.
@@ -242,7 +257,8 @@ build_flags =
   -D LV_CONF_PATH="${PROJECT_DIR}/lib/lvgl/lv_conf.h"
   -DCORE_DEBUG_LEVEL=2
   -D BAUDRATE=115200
-  -DDEBUG=1
+  ; Do not define the generic DEBUG macro. Custom ESP-IDF core builds inherit
+  ; application flags, and DEBUG collides with IDF/NimBLE log-level tokens.
   -DFIRMWARE_DIAGNOSTICS=1
   ; Arduino's sdkconfig.h defines NimBLE's connection limit after command-line
   ; macros. Preinclude our override so every locally built NimBLE source agrees
@@ -274,8 +290,8 @@ build_flags =
 extends = env:WAVESHARE_AMOLED_175
 custom_firmware_target = WAVESHARE_AMOLED_175
 build_unflags =
+  ${waveshare_amoled_common.build_unflags}
   -DCORE_DEBUG_LEVEL=2
-  -DDEBUG=1
   -DFIRMWARE_DIAGNOSTICS=1
   -DARDUINO_USB_CDC_ON_BOOT=1
 build_flags =
@@ -331,8 +347,8 @@ build_flags =
 extends = env:WAVESHARE_AMOLED_206
 custom_firmware_target = WAVESHARE_AMOLED_206
 build_unflags =
+  ${waveshare_amoled_common.build_unflags}
   -DCORE_DEBUG_LEVEL=2
-  -DDEBUG=1
   -DFIRMWARE_DIAGNOSTICS=1
   -DARDUINO_USB_CDC_ON_BOOT=1
 build_flags =

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -224,7 +224,6 @@ build_flags =
   -DUSE_ARDUINO_GFX  ; Use Arduino_GFX instead of LovyanGFX for CO5300
   -DBOARD_HAS_PSRAM
   -DARDUINO_USB_MODE=1
-  -DARDUINO_USB_CDC_ON_BOOT=1
   ; Dev-only BLE pairing recovery: bypasses the persisted random static BLE
   ; identity and makes iOS see a fresh peripheral after each firmware boot.
   ; Keep disabled for normal reconnect behavior.
@@ -255,11 +254,13 @@ build_flags =
   ; -DDISABLE_TOUCH=1
   -DDISABLE_ADVANCED_GUI=1  ; Disable advanced GUI features (depends on TFT_eSprite)
   -D LV_CONF_PATH="${PROJECT_DIR}/lib/lvgl/lv_conf.h"
-  -DCORE_DEBUG_LEVEL=2
   -D BAUDRATE=115200
   ; Do not define the generic DEBUG macro. Custom ESP-IDF core builds inherit
   ; application flags, and DEBUG collides with IDF/NimBLE log-level tokens.
-  -DFIRMWARE_DIAGNOSTICS=1
+  ; Keep debug, diagnostics, and USB CDC values in concrete profiles. The
+  ; pioarduino custom-core path expands inherited flags before PlatformIO
+  ; applies build_unflags, so shared values would collide with production
+  ; overrides inside ESP-IDF components compiled with -Werror.
   ; Arduino's sdkconfig.h defines NimBLE's connection limit after command-line
   ; macros. Preinclude our override so every locally built NimBLE source agrees
   ; that the ownership protocol permits exactly one central.
@@ -268,7 +269,7 @@ build_flags =
   ; but we define a default here just in case.
   -DTFT_BL=-1
 
-[env:WAVESHARE_AMOLED_175]
+[waveshare_amoled_175_base]
 extends = waveshare_amoled_common
 board_build.embed_files =
   lib/speaker/assets/real_bike_horn.pcm
@@ -277,6 +278,14 @@ board_build.embed_files =
 build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_175
+
+[env:WAVESHARE_AMOLED_175]
+extends = waveshare_amoled_175_base
+build_flags =
+  ${waveshare_amoled_175_base.build_flags}
+  -DCORE_DEBUG_LEVEL=2
+  -DFIRMWARE_DIAGNOSTICS=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
 
 [env:WAVESHARE_AMOLED_175_POWER_METRICS]
 extends = env:WAVESHARE_AMOLED_175
@@ -287,15 +296,12 @@ build_flags =
   ; -DPOWER_METRICS_PULSE_GPIO=XX
 
 [env:WAVESHARE_AMOLED_175_PRODUCTION]
-extends = env:WAVESHARE_AMOLED_175
+extends = waveshare_amoled_175_base
 custom_firmware_target = WAVESHARE_AMOLED_175
 build_unflags =
   ${waveshare_amoled_common.build_unflags}
-  -DCORE_DEBUG_LEVEL=2
-  -DFIRMWARE_DIAGNOSTICS=1
-  -DARDUINO_USB_CDC_ON_BOOT=1
 build_flags =
-  ${env:WAVESHARE_AMOLED_175.build_flags}
+  ${waveshare_amoled_175_base.build_flags}
   -DCORE_DEBUG_LEVEL=0
   -DFIRMWARE_DIAGNOSTICS=0
   -DARDUINO_USB_CDC_ON_BOOT=0
@@ -324,7 +330,7 @@ build_src_filter =
   -<*>
   +<../speaker_honk_test.cpp>
 
-[env:WAVESHARE_AMOLED_206]
+[waveshare_amoled_206_base]
 extends = waveshare_amoled_common
 board_build.embed_files =
   lib/speaker/assets/real_bike_horn.pcm
@@ -335,6 +341,14 @@ build_flags =
   -DWAVESHARE_AMOLED_206
   -DWAVESHARE_206_FORCE_AXP_DISPLAY=1
 
+[env:WAVESHARE_AMOLED_206]
+extends = waveshare_amoled_206_base
+build_flags =
+  ${waveshare_amoled_206_base.build_flags}
+  -DCORE_DEBUG_LEVEL=2
+  -DFIRMWARE_DIAGNOSTICS=1
+  -DARDUINO_USB_CDC_ON_BOOT=1
+
 [env:WAVESHARE_AMOLED_206_POWER_METRICS]
 extends = env:WAVESHARE_AMOLED_206
 build_flags =
@@ -344,15 +358,12 @@ build_flags =
   ; -DPOWER_METRICS_PULSE_GPIO=XX
 
 [env:WAVESHARE_AMOLED_206_PRODUCTION]
-extends = env:WAVESHARE_AMOLED_206
+extends = waveshare_amoled_206_base
 custom_firmware_target = WAVESHARE_AMOLED_206
 build_unflags =
   ${waveshare_amoled_common.build_unflags}
-  -DCORE_DEBUG_LEVEL=2
-  -DFIRMWARE_DIAGNOSTICS=1
-  -DARDUINO_USB_CDC_ON_BOOT=1
 build_flags =
-  ${env:WAVESHARE_AMOLED_206.build_flags}
+  ${waveshare_amoled_206_base.build_flags}
   -DCORE_DEBUG_LEVEL=0
   -DFIRMWARE_DIAGNOSTICS=0
   -DARDUINO_USB_CDC_ON_BOOT=0

--- a/esp32/prebuild.py
+++ b/esp32/prebuild.py
@@ -16,6 +16,96 @@ if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
 from firmware_build_identity import firmware_git_identity
+from pioarduino_custom_core import correct_sections_text
+
+
+def ensure_custom_core_generated_source_alias():
+    """Work around pioarduino custom-core generated-source path nesting.
+
+    The pinned platform passes some CMake-generated assembly sources back to
+    SCons as project-relative paths. SCons then resolves those paths relative
+    to the environment build directory a second time. A build-local alias
+    makes the doubled path resolve to the actual generated source without
+    patching the installed PlatformIO package.
+    """
+    custom_sdkconfig = env.GetProjectOption("custom_sdkconfig", "").strip()
+    if not custom_sdkconfig:
+        return
+
+    project_pio_dir = Path(env.get("PROJECT_DIR")).resolve() / ".pio"
+    environment_build_dir = Path(env.subst("$BUILD_DIR")).resolve()
+    generated_source_alias = environment_build_dir / ".pio"
+    environment_build_dir.mkdir(parents=True, exist_ok=True)
+
+    if generated_source_alias.is_symlink():
+        if generated_source_alias.resolve() != project_pio_dir:
+            generated_source_alias.unlink()
+    elif generated_source_alias.exists():
+        raise RuntimeError(
+            "custom-core generated-source alias collides with an existing path: "
+            f"{generated_source_alias}"
+        )
+
+    if not generated_source_alias.exists():
+        generated_source_alias.symlink_to(project_pio_dir, target_is_directory=True)
+
+    # These sources belong to optional Arduino registry components that are not
+    # linked by this firmware. CMake owns their final contents, but pioarduino
+    # asks SCons to resolve the source nodes before CMake's generators run. The
+    # placeholders keep graph construction deterministic; CMake may replace
+    # them with the real embedded-certificate assembly later in the build.
+    for generated_name in (
+        "https_server.crt.S",
+        "rmaker_mqtt_server.crt.S",
+        "rmaker_claim_service_server.crt.S",
+        "rmaker_ota_server.crt.S",
+    ):
+        generated_source = environment_build_dir / generated_name
+        if not generated_source.exists():
+            generated_source.write_text(
+                "/* pioarduino custom-core generated-source placeholder */\n",
+                encoding="utf-8",
+            )
+
+    # pioarduino copies custom-compiled archives and memory.ld back into its
+    # framework package, but it does not copy the matching sections.ld. With
+    # CONFIG_PM_ENABLE the generated script adds the esp_pm_configure literal;
+    # without it, sufficiently large variants can fail with an Xtensa
+    # "literal placed after use" relocation. Keep the installed package
+    # immutable and put a corrected script in the environment build directory,
+    # which is first on the linker's script search path.
+    framework_libs_package = env.PioPlatform().get_package_dir(
+        "framework-arduinoespressif32-libs"
+    )
+    if not framework_libs_package:
+        raise RuntimeError("pioarduino framework-libs package is unavailable")
+    framework_libs_dir = Path(framework_libs_package)
+    board = env.BoardConfig()
+    mcu = board.get("build.mcu", "esp32")
+    memory_type = board.get(
+        "build.arduino.memory_type",
+        f"{board.get('build.flash_mode', 'dio')}_qspi",
+    )
+    installed_sections = framework_libs_dir / mcu / memory_type / "sections.ld"
+    if not installed_sections.is_file():
+        raise RuntimeError(
+            "pioarduino custom-core linker script is missing: "
+            f"{installed_sections}"
+        )
+
+    sections_text = installed_sections.read_text(encoding="utf-8")
+    try:
+        sections_text = correct_sections_text(sections_text)
+    except ValueError as error:
+        raise RuntimeError(str(error)) from error
+
+    (environment_build_dir / "sections.ld").write_text(
+        sections_text,
+        encoding="utf-8",
+    )
+
+
+ensure_custom_core_generated_source_alias()
 
 try:
     import configparser

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -83,6 +83,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "power_metrics.hpp"
 #include "guiLayout.hpp"
 #include "mainScr.hpp"
+#include "power_management.hpp"
 #include "route_overlay.hpp"
 #include "ui_scheduler.hpp"
 #include "waitingScr.hpp"
@@ -794,6 +795,8 @@ static void logPowerMetricsReport() {
   const BLEDebugStats bleStats = bleNavServer.getDebugStats();
   const device_transfer::HttpTransferStatus transferStatus =
       deviceTransferHttp.status();
+  const power_management::RuntimeStatus powerManagementStatus =
+      power_management::status();
 
   const char *screenName = "unknown";
   const lv_obj_t *activeScreen = lv_scr_act();
@@ -834,7 +837,8 @@ static void logPowerMetricsReport() {
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
       "appQueue=ios-diagnostic] "
       "system[powerMode=%s wifiMode=%d transfer=%d transferMode=%s "
-      "audio=%d cpuMHz=%u "
+      "audio=%d cpuMHz=%u dfs=%d pmError=%d minCpuMHz=%u maxCpuMHz=%u "
+      "lightSleep=%d "
       "appPmLocks=0]\n",
       power_metrics::kSchemaVersion, (unsigned long)intervalMs, screenName,
       debugTileName(activeTile),
@@ -882,7 +886,11 @@ static void logPowerMetricsReport() {
       (unsigned long)bleCount(power_metrics::BlePacketClass::Auth),
       powerMode, static_cast<int>(WiFi.getMode()), transferStatus.enabled,
       transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
-      audioActive, getCpuFrequencyMhz());
+      audioActive, getCpuFrequencyMhz(), powerManagementStatus.enabled,
+      powerManagementStatus.errorCode,
+      powerManagementStatus.effective.minimumCpuMhz,
+      powerManagementStatus.effective.maximumCpuMhz,
+      powerManagementStatus.effective.automaticLightSleep);
   if (reportLength < 0 ||
       static_cast<size_t>(reportLength) >= sizeof(report)) {
     Serial.printf("PWRMET_ERROR formatLength=%d capacity=%u\n", reportLength,
@@ -975,6 +983,7 @@ void setup() {
 #endif
   power_metrics::begin();
   power.begin();
+  power_management::begin();
   // Arduino setup() and loop() share the same FreeRTOS task. Bind it before
   // enabling BLE, touch, BOOT, audio, or transfer publishers.
   ui_scheduler::bindCurrentTask();

--- a/esp32/tools/pioarduino_custom_core.py
+++ b/esp32/tools/pioarduino_custom_core.py
@@ -1,0 +1,29 @@
+"""Pure helpers for pioarduino custom-core build workarounds."""
+
+
+STALE_PM_LITERAL_MAPPING = (
+    "*libesp_pm.a:pm_impl.*(.literal.esp_pm_get_configuration"
+)
+CORRECTED_PM_LITERAL_MAPPING = (
+    "*libesp_pm.a:pm_impl.*(.literal.esp_pm_configure "
+    ".literal.esp_pm_get_configuration"
+)
+
+
+def correct_sections_text(sections_text: str) -> str:
+    """Add the CONFIG_PM_ENABLE linker mapping missing from pinned pioarduino.
+
+    The operation is idempotent, while an unexpected installed linker-script
+    shape fails closed so a platform update cannot silently apply a bad patch.
+    """
+    corrected_count = sections_text.count(CORRECTED_PM_LITERAL_MAPPING)
+    stale_count = sections_text.count(STALE_PM_LITERAL_MAPPING)
+    if corrected_count == 1 and stale_count == 0:
+        return sections_text
+    if corrected_count != 0 or stale_count != 1:
+        raise ValueError("pioarduino esp_pm linker mapping has an unexpected format")
+    return sections_text.replace(
+        STALE_PM_LITERAL_MAPPING,
+        CORRECTED_PM_LITERAL_MAPPING,
+        1,
+    )

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -18,6 +18,29 @@ waveshare_unflags = config.get("waveshare_amoled_common", "build_unflags")
 assert "-Wl,--wrap=log_printf" in waveshare_unflags
 waveshare_flags = config.get("waveshare_amoled_common", "build_flags")
 assert "-DDEBUG=1" not in waveshare_flags
+assert "-DCORE_DEBUG_LEVEL=" not in waveshare_flags
+assert "-DFIRMWARE_DIAGNOSTICS=" not in waveshare_flags
+assert "-DARDUINO_USB_CDC_ON_BOOT=" not in waveshare_flags
+
+diagnostic_profiles = {
+    "env:WAVESHARE_AMOLED_175": (
+        "waveshare_amoled_175_base",
+        "WAVESHARE_AMOLED_175",
+    ),
+    "env:WAVESHARE_AMOLED_206": (
+        "waveshare_amoled_206_base",
+        "WAVESHARE_AMOLED_206",
+    ),
+}
+for environment, (base, board_define) in diagnostic_profiles.items():
+    assert config.get(environment, "extends") == base
+    base_flags = config.get(base, "build_flags")
+    assert f"-D{board_define}" in base_flags
+    flags = config.get(environment, "build_flags")
+    assert f"${{{base}.build_flags}}" in flags
+    assert "-DCORE_DEBUG_LEVEL=2" in flags
+    assert "-DFIRMWARE_DIAGNOSTICS=1" in flags
+    assert "-DARDUINO_USB_CDC_ON_BOOT=1" in flags
 
 expected_targets = {
     "env:WAVESHARE_AMOLED_175_PRODUCTION": "WAVESHARE_AMOLED_175",
@@ -26,11 +49,17 @@ expected_targets = {
 
 for environment, target in expected_targets.items():
     assert config.get(environment, "custom_firmware_target") == target
+    base = diagnostic_profiles[environment.replace("_PRODUCTION", "")][0]
+    assert config.get(environment, "extends") == base
     flags = config.get(environment, "build_flags")
+    assert f"${{{base}.build_flags}}" in flags
     assert "-DCORE_DEBUG_LEVEL=0" in flags
     assert "-DFIRMWARE_DIAGNOSTICS=0" in flags
     assert "-DARDUINO_USB_CDC_ON_BOOT=0" in flags
     assert "-DDEBUG=0" not in flags
+    assert "-DCORE_DEBUG_LEVEL=2" not in flags
+    assert "-DFIRMWARE_DIAGNOSTICS=1" not in flags
+    assert "-DARDUINO_USB_CDC_ON_BOOT=1" not in flags
     unflags = config.get(environment, "build_unflags")
     assert "${waveshare_amoled_common.build_unflags}" in unflags
     assert "-DDEBUG=1" not in unflags

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -9,6 +9,16 @@ repo_root = project_dir.parent
 config = configparser.ConfigParser(interpolation=None)
 config.read(project_dir / "platformio.ini")
 
+waveshare_sdkconfig = config.get("waveshare_amoled_common", "custom_sdkconfig")
+assert "CONFIG_PM_ENABLE=y" in waveshare_sdkconfig
+assert "CONFIG_PM_DFS_INIT_AUTO=n" in waveshare_sdkconfig
+assert "CONFIG_PM_PROFILING=n" in waveshare_sdkconfig
+assert "CONFIG_FREERTOS_USE_TICKLESS_IDLE=n" in waveshare_sdkconfig
+waveshare_unflags = config.get("waveshare_amoled_common", "build_unflags")
+assert "-Wl,--wrap=log_printf" in waveshare_unflags
+waveshare_flags = config.get("waveshare_amoled_common", "build_flags")
+assert "-DDEBUG=1" not in waveshare_flags
+
 expected_targets = {
     "env:WAVESHARE_AMOLED_175_PRODUCTION": "WAVESHARE_AMOLED_175",
     "env:WAVESHARE_AMOLED_206_PRODUCTION": "WAVESHARE_AMOLED_206",
@@ -17,12 +27,13 @@ expected_targets = {
 for environment, target in expected_targets.items():
     assert config.get(environment, "custom_firmware_target") == target
     flags = config.get(environment, "build_flags")
-    unflags = config.get(environment, "build_unflags")
     assert "-DCORE_DEBUG_LEVEL=0" in flags
     assert "-DFIRMWARE_DIAGNOSTICS=0" in flags
     assert "-DARDUINO_USB_CDC_ON_BOOT=0" in flags
     assert "-DDEBUG=0" not in flags
-    assert "-DDEBUG=1" in unflags
+    unflags = config.get(environment, "build_unflags")
+    assert "${waveshare_amoled_common.build_unflags}" in unflags
+    assert "-DDEBUG=1" not in unflags
 
 release_workflow = (repo_root / ".github/workflows/firmware-release.yml").read_text()
 for environment, target in expected_targets.items():

--- a/esp32/tools/tests/test_pioarduino_custom_core.py
+++ b/esp32/tools/tests/test_pioarduino_custom_core.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+
+import unittest
+
+from pioarduino_custom_core import (
+    CORRECTED_PM_LITERAL_MAPPING,
+    STALE_PM_LITERAL_MAPPING,
+    correct_sections_text,
+)
+
+
+class CorrectSectionsTextTests(unittest.TestCase):
+    def test_adds_missing_esp_pm_configure_literal(self):
+        source = f"before\n{STALE_PM_LITERAL_MAPPING} trailing\nafter\n"
+
+        corrected = correct_sections_text(source)
+
+        self.assertIn(CORRECTED_PM_LITERAL_MAPPING, corrected)
+        self.assertNotIn(
+            f"{STALE_PM_LITERAL_MAPPING} trailing",
+            corrected,
+        )
+
+    def test_is_idempotent_when_installed_script_is_already_corrected(self):
+        source = f"before\n{CORRECTED_PM_LITERAL_MAPPING} trailing\nafter\n"
+
+        self.assertEqual(correct_sections_text(source), source)
+
+    def test_rejects_an_unknown_linker_script_shape(self):
+        with self.assertRaisesRegex(ValueError, "unexpected format"):
+            correct_sections_text("no esp_pm mapping")
+
+    def test_rejects_multiple_stale_mappings(self):
+        source = f"{STALE_PM_LITERAL_MAPPING}\n{STALE_PM_LITERAL_MAPPING}\n"
+
+        with self.assertRaisesRegex(ValueError, "unexpected format"):
+            correct_sections_text(source)
+
+    def test_rejects_mixed_corrected_and_stale_mappings(self):
+        source = f"{CORRECTED_PM_LITERAL_MAPPING}\n{STALE_PM_LITERAL_MAPPING}\n"
+
+        with self.assertRaisesRegex(ValueError, "unexpected format"):
+            correct_sections_text(source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/esp32/tools/tests/test_power_management_policy.cpp
+++ b/esp32/tools/tests/test_power_management_policy.cpp
@@ -1,0 +1,17 @@
+#include "../../lib/power_management/power_management_policy.hpp"
+
+#include <cassert>
+
+int main() {
+  using namespace power_management;
+
+  static_assert(kDfsConfiguration.maximumCpuMhz == 240);
+  static_assert(kDfsConfiguration.minimumCpuMhz == 80);
+  static_assert(!kDfsConfiguration.automaticLightSleep);
+
+  assert(isValid(kDfsConfiguration));
+  assert(isValid(Configuration{80, 80, false}));
+  assert(!isValid(Configuration{80, 240, false}));
+  assert(!isValid(Configuration{240, 0, false}));
+  return 0;
+}


### PR DESCRIPTION
## Summary

- compile ESP-IDF power-management support into every Waveshare firmware profile
- enable verified 80-240 MHz dynamic frequency scaling while keeping tickless idle and automatic light sleep disabled
- expose effective DFS state and failures through diagnostics and power metrics
- keep pinned pioarduino custom-core builds reproducible without modifying installed packages
- add host coverage for the DFS policy, firmware profiles, and linker-script correction

## Validation

- deep review converged with seven findings resolved
- 30 relevant host tests passed
- `WAVESHARE_AMOLED_175` build passed (52.2% RAM, 90.6% flash)
- `WAVESHARE_AMOLED_206` build passed (52.1% RAM, 90.4% flash)
- generated sdkconfig verified PM enabled at 80-240 MHz with tickless idle disabled
- ELF verified `esp_pm_configure` and readback are linked without the unavailable log wrapper

## Physical gate

This is Phase 7 Step A only. No device was connected or flashed. Automatic light sleep, PM locks, a 40 MHz minimum, and Phase 7B remain deferred until the 1.75-inch board passes map/display, BLE, touch, transfer, audio, soak, and controlled battery-depletion validation.

Stacked on #166.
