### PR TITLE
Add battery characterization harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,27 @@ jobs:
             tools/tests/test_power_management_policy.cpp \
             -o /tmp/test_power_management_policy
           /tmp/test_power_management_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_ble_radio_policy.cpp \
+            -o /tmp/test_ble_radio_policy
+          /tmp/test_ble_radio_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            -DBLE_RADIO_CHARACTERIZATION=1 -DBLE_TX_POWER_DBM=3 \
+            tools/tests/test_ble_radio_policy.cpp \
+            -o /tmp/test_ble_radio_policy_p3
+          /tmp/test_ble_radio_policy_p3
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            -DBLE_RADIO_CHARACTERIZATION=1 -DBLE_TX_POWER_DBM=0 \
+            tools/tests/test_ble_radio_policy.cpp \
+            -o /tmp/test_ble_radio_policy_p0
+          /tmp/test_ble_radio_policy_p0
+          if g++ -std=c++17 -Wall -Wextra -Werror \
+            -DBLE_TX_POWER_DBM=3 \
+            tools/tests/test_ble_radio_policy.cpp \
+            -o /tmp/test_ble_radio_policy_unsafe; then
+            echo "Non-default TX power compiled without characterization"
+            exit 1
+          fi
           PYTHONPATH=tools python -m unittest \
             tools.tests.test_pioarduino_custom_core
           g++ -std=c++17 -Wall -Wextra -Werror \

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -90,6 +90,56 @@ sleep from build configuration alone. Step B requires explicit locks around
 every timing-sensitive display, map, SD, transfer, audio, and tested I2C path,
 then separate physical validation on the 1.75-inch board.
 
+## BLE, PMU, and SD characterization harness
+
+Production defaults remain unchanged: BLE TX power is P9, NimBLE owns its
+default advertising and connection policy, the SD bus remains at 4 MHz, PMU
+rails retain their known-good masks, and the AXP2101 button status remains on
+the 250 ms housekeeping deadline. No lower-power radio, rail, or SD setting is
+selected without physical evidence.
+
+Power-metrics and diagnostic builds now record the connected interval in
+1.25 ms units, slave latency, supervision timeout in 10 ms units, sample count,
+configured TX power, advertising mode, and requested experimental profile.
+The initial connection descriptor is captured immediately and the effective
+parameters are resampled every five seconds because iOS may negotiate values
+different from the firmware request.
+
+An explicitly opt-in build enables the Phase 8 radio matrix without changing
+ordinary firmware:
+
+```sh
+cd esp32
+PLATFORMIO_BUILD_FLAGS="-DBLE_RADIO_CHARACTERIZATION=1 -DBLE_TX_POWER_DBM=9" \
+  pio run -e WAVESHARE_AMOLED_175_POWER_METRICS
+```
+
+Repeat with `BLE_TX_POWER_DBM=3` and `0`. The experimental policy uses
+100-200 ms advertising for 30 seconds after boot, disconnect, or physical
+touch/BOOT wake, then 900-1100 ms advertising. It requests 30-50 ms with zero
+latency during navigation and 60-100 ms with latency four while connected-idle.
+These are requests only; the recorded effective values are authoritative.
+
+For the SD matrix, keep the card image and scenario fixed and repeat both
+targets at 4, 8, 12, and 16 MHz:
+
+```sh
+PLATFORMIO_BUILD_FLAGS="-DWAVESHARE_SD_SPI_FREQ_HZ=8000000 -DWAVESHARE_MAPIO_TIMING_LOG=1" \
+  pio run -e WAVESHARE_AMOLED_175_POWER_METRICS
+```
+
+The checked-in schematics close the PMU-interrupt routing question for current
+board revisions. On 1.75, AXP2101 `IRQ` reaches TCA9554 P5 (`EXIO5`), while the
+expander's `INT` output is not routed to the ESP32. On 2.06, `EXIO5` has no
+populated receiver or ESP32 connection. Neither board exposes a direct usable
+PMU IRQ GPIO, so replacing deadline-based polling would add I2C work rather
+than create an interrupt-driven path.
+
+Audio-rail toggling and all PMU rail changes remain prohibited until the
+1.75-inch schematic mapping is verified against physical codec, display,
+touch, RTC, battery, SD, reboot, and wake tests. The 2.06 safe path continues
+to preserve PMU state.
+
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery
 percentage, or USB-powered observation is not a power baseline. Fill in the
@@ -114,7 +164,8 @@ The report contains:
   heading, zoom, screen, recovery, and other render-reason counts;
 - logically classified BLE packets after authenticated transport framing is
   unwrapped, including packets later rejected by session authentication or
-  application-payload validation;
+  application-payload validation, plus configured radio power/advertising mode
+  and the latest effective connection interval, latency, and timeout;
 - Wi-Fi mode, transfer state/mode, audio activity, current CPU frequency,
   effective DFS range, power-management error code, automatic-light-sleep
   state, and the number of

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -103,6 +103,31 @@ static_assert(BLE_HS_CONN_HANDLE_NONE == ble_connection_policy::noConnection,
               "single-connection policy must match NimBLE's empty handle");
 static uint16_t activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
 static bool unauthTimeoutDisconnectRequested = false;
+#if BLE_RADIO_CHARACTERIZATION
+static std::atomic<bool> radioNavigationActive{false};
+static std::atomic<bool> radioUserWakePending{false};
+static std::atomic<uint8_t> radioAdvertisingMode{
+    static_cast<uint8_t>(ble_radio_policy::AdvertisingMode::Default)};
+static std::atomic<uint32_t> radioAdvertisingModeStartedMs{0};
+static std::atomic<uint8_t> radioRequestedConnectionProfile{
+    static_cast<uint8_t>(ble_radio_policy::ConnectionProfile::Unset)};
+#endif
+static std::atomic<uint16_t> radioConnectionHandle{BLE_HS_CONN_HANDLE_NONE};
+static std::atomic<uint32_t> lastConnectionParameterSampleMs{0};
+struct RadioDebugSnapshot {
+  bool connectionParametersValid = false;
+  uint16_t connectionIntervalUnits = 0;
+  uint16_t connectionLatency = 0;
+  uint16_t supervisionTimeoutUnits = 0;
+  uint32_t connectionParameterSampleCount = 0;
+  uint32_t lastConnectionParameterSampleMs = 0;
+  ble_radio_policy::AdvertisingMode advertisingMode =
+      ble_radio_policy::AdvertisingMode::Default;
+  ble_radio_policy::ConnectionProfile requestedConnectionProfile =
+      ble_radio_policy::ConnectionProfile::Unset;
+};
+static RadioDebugSnapshot radioDebugSnapshot;
+static portMUX_TYPE radioDebugMux = portMUX_INITIALIZER_UNLOCKED;
 static device_ownership::DeviceOwnership deviceOwnership;
 static bool deviceOwnershipReady = false;
 static bool ownershipPairingActiveSnapshot = false;
@@ -137,6 +162,160 @@ static uint32_t destinationStatusUpdatedMs = 0;
 
 static bool notifyAuthenticatedNavigation(NimBLECharacteristic *characteristic,
                                           const uint8_t *data, size_t length);
+
+#if BLE_RADIO_CHARACTERIZATION
+static const char *advertisingModeName(
+    ble_radio_policy::AdvertisingMode mode) {
+  switch (mode) {
+  case ble_radio_policy::AdvertisingMode::Fast:
+    return "fast";
+  case ble_radio_policy::AdvertisingMode::Slow:
+    return "slow";
+  case ble_radio_policy::AdvertisingMode::Default:
+  default:
+    return "default";
+  }
+}
+
+static const char *connectionProfileName(
+    ble_radio_policy::ConnectionProfile profile) {
+  switch (profile) {
+  case ble_radio_policy::ConnectionProfile::Navigation:
+    return "navigation";
+  case ble_radio_policy::ConnectionProfile::Idle:
+    return "idle";
+  case ble_radio_policy::ConnectionProfile::Unset:
+  default:
+    return "unset";
+  }
+}
+#endif
+
+static esp_power_level_t configuredTxPowerLevel() {
+  switch (ble_radio_policy::kConfiguration.txPowerDbm) {
+  case 0:
+    return ESP_PWR_LVL_N0;
+  case 3:
+    return ESP_PWR_LVL_P3;
+  case 9:
+  default:
+    return ESP_PWR_LVL_P9;
+  }
+}
+
+static void recordConnectionParameters(const ble_gap_conn_desc &description,
+                                       uint32_t nowMs) {
+  portENTER_CRITICAL(&radioDebugMux);
+  const bool changed = !radioDebugSnapshot.connectionParametersValid ||
+                       radioDebugSnapshot.connectionIntervalUnits !=
+                           description.conn_itvl ||
+                       radioDebugSnapshot.connectionLatency !=
+                           description.conn_latency ||
+                       radioDebugSnapshot.supervisionTimeoutUnits !=
+                           description.supervision_timeout;
+  radioDebugSnapshot.connectionParametersValid = true;
+  radioDebugSnapshot.connectionIntervalUnits = description.conn_itvl;
+  radioDebugSnapshot.connectionLatency = description.conn_latency;
+  radioDebugSnapshot.supervisionTimeoutUnits = description.supervision_timeout;
+  radioDebugSnapshot.connectionParameterSampleCount++;
+  radioDebugSnapshot.lastConnectionParameterSampleMs = nowMs;
+  portEXIT_CRITICAL(&radioDebugMux);
+  lastConnectionParameterSampleMs.store(nowMs, std::memory_order_release);
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
+  if (changed) {
+    Serial.printf(
+        "BLE Radio: effective intervalUnits=%u latency=%u timeoutUnits=%u\n",
+        description.conn_itvl, description.conn_latency,
+        description.supervision_timeout);
+  }
+#else
+  (void)changed;
+#endif
+}
+
+#if BLE_RADIO_CHARACTERIZATION
+static void applyCharacterizationAdvertisingMode(
+    ble_radio_policy::AdvertisingMode mode, bool restartAdvertising) {
+  NimBLEAdvertising *advertising = NimBLEDevice::getAdvertising();
+  if (advertising == nullptr) {
+    return;
+  }
+  if (restartAdvertising) {
+    if (!advertising->isAdvertising() ||
+        !NimBLEDevice::stopAdvertising()) {
+      return;
+    }
+  }
+  const ble_radio_policy::IntervalRange &range =
+      mode == ble_radio_policy::AdvertisingMode::Slow
+          ? ble_radio_policy::kConfiguration.slowAdvertising
+          : ble_radio_policy::kConfiguration.fastAdvertising;
+  advertising->setMinInterval(range.minimumUnits);
+  advertising->setMaxInterval(range.maximumUnits);
+  const uint32_t nowMs = millis();
+  radioAdvertisingMode.store(static_cast<uint8_t>(mode),
+                             std::memory_order_release);
+  radioAdvertisingModeStartedMs.store(nowMs, std::memory_order_release);
+  portENTER_CRITICAL(&radioDebugMux);
+  radioDebugSnapshot.advertisingMode = mode;
+  portEXIT_CRITICAL(&radioDebugMux);
+  Serial.printf("BLE Radio: advertising mode=%s minUnits=%u maxUnits=%u\n",
+                advertisingModeName(mode), range.minimumUnits,
+                range.maximumUnits);
+  if (restartAdvertising &&
+      radioConnectionHandle.load(std::memory_order_acquire) ==
+          BLE_HS_CONN_HANDLE_NONE &&
+      !NimBLEDevice::startAdvertising()) {
+    Serial.println("BLE Radio: failed to restart advertising");
+  }
+}
+
+static void processRadioCharacterization(uint32_t nowMs,
+                                         NimBLEServer *server) {
+  const uint16_t connectionHandle =
+      radioConnectionHandle.load(std::memory_order_acquire);
+  if (connectionHandle == BLE_HS_CONN_HANDLE_NONE) {
+    const bool wakeRequested =
+        radioUserWakePending.exchange(false, std::memory_order_acq_rel);
+    const auto currentMode = static_cast<ble_radio_policy::AdvertisingMode>(
+        radioAdvertisingMode.load(std::memory_order_acquire));
+    const uint32_t modeStartedMs =
+        radioAdvertisingModeStartedMs.load(std::memory_order_acquire);
+    const auto desiredMode = ble_radio_policy::nextAdvertisingMode(
+        currentMode, nowMs - modeStartedMs, wakeRequested);
+    if (desiredMode != currentMode || wakeRequested) {
+      applyCharacterizationAdvertisingMode(desiredMode, true);
+    }
+    return;
+  }
+
+  radioUserWakePending.store(false, std::memory_order_release);
+  const auto desiredProfile = ble_radio_policy::connectionProfile(
+      radioNavigationActive.load(std::memory_order_acquire));
+  const auto appliedProfile =
+      static_cast<ble_radio_policy::ConnectionProfile>(
+          radioRequestedConnectionProfile.load(std::memory_order_acquire));
+  if (server != nullptr && desiredProfile != appliedProfile) {
+    const ble_radio_policy::ConnectionParameters &parameters =
+        ble_radio_policy::connectionParameters(desiredProfile);
+    server->updateConnParams(
+        connectionHandle, parameters.minimumIntervalUnits,
+        parameters.maximumIntervalUnits, parameters.latency,
+        parameters.supervisionTimeoutUnits);
+    radioRequestedConnectionProfile.store(
+        static_cast<uint8_t>(desiredProfile), std::memory_order_release);
+    portENTER_CRITICAL(&radioDebugMux);
+    radioDebugSnapshot.requestedConnectionProfile = desiredProfile;
+    portEXIT_CRITICAL(&radioDebugMux);
+    Serial.printf(
+        "BLE Radio: requested profile=%s intervalUnits=%u-%u latency=%u "
+        "timeoutUnits=%u\n",
+        connectionProfileName(desiredProfile),
+        parameters.minimumIntervalUnits, parameters.maximumIntervalUnits,
+        parameters.latency, parameters.supervisionTimeoutUnits);
+  }
+}
+#endif
 
 static void queueOwnershipUiUpdate(int32_t pairingCode = -1,
                                    uint32_t pairingGeneration = 0) {
@@ -2357,6 +2536,17 @@ public:
       pServer->disconnect(desc->conn_handle);
       return;
     }
+    radioConnectionHandle.store(desc->conn_handle, std::memory_order_release);
+#if BLE_RADIO_CHARACTERIZATION
+    radioRequestedConnectionProfile.store(
+        static_cast<uint8_t>(ble_radio_policy::ConnectionProfile::Unset),
+        std::memory_order_release);
+    portENTER_CRITICAL(&radioDebugMux);
+    radioDebugSnapshot.requestedConnectionProfile =
+        ble_radio_policy::ConnectionProfile::Unset;
+    portEXIT_CRITICAL(&radioDebugMux);
+#endif
+    recordConnectionParameters(*desc, millis());
     acceptConnection();
   }
 
@@ -2398,6 +2588,11 @@ public:
                                     : desc->conn_handle);
       return;
     }
+    radioConnectionHandle.store(BLE_HS_CONN_HANDLE_NONE,
+                                std::memory_order_release);
+    portENTER_CRITICAL(&radioDebugMux);
+    radioDebugSnapshot.connectionParametersValid = false;
+    portEXIT_CRITICAL(&radioDebugMux);
     disconnectActive();
   }
 
@@ -2441,6 +2636,17 @@ public:
     Serial.println("BLE: iOS client disconnected");
     // Restart advertising
     Serial.println("BLE: Restarting advertising...");
+#if BLE_RADIO_CHARACTERIZATION
+    radioRequestedConnectionProfile.store(
+        static_cast<uint8_t>(ble_radio_policy::ConnectionProfile::Unset),
+        std::memory_order_release);
+    portENTER_CRITICAL(&radioDebugMux);
+    radioDebugSnapshot.requestedConnectionProfile =
+        ble_radio_policy::ConnectionProfile::Unset;
+    portEXIT_CRITICAL(&radioDebugMux);
+    applyCharacterizationAdvertisingMode(
+        ble_radio_policy::AdvertisingMode::Fast, false);
+#endif
     NimBLEDevice::startAdvertising();
   }
 };
@@ -2856,8 +3062,8 @@ void BLENavigationServer::init(const char *deviceName) {
   }
 
   initBleIdentityAndSecurity(effectiveDeviceName.c_str());
-  NimBLEDevice::setPower(ESP_PWR_LVL_P9); // Maximum power
-  NimBLEDevice::setMTU(512);              // Increase MTU for route geometry
+  NimBLEDevice::setPower(configuredTxPowerLevel());
+  NimBLEDevice::setMTU(512); // Increase MTU for route geometry
 
   // Create server
   pServer = NimBLEDevice::createServer();
@@ -2923,6 +3129,10 @@ void BLENavigationServer::init(const char *deviceName) {
     pAdvertising->setManufacturerData(manufacturerData);
   }
   pAdvertising->setScanResponse(true);
+#if BLE_RADIO_CHARACTERIZATION
+  applyCharacterizationAdvertisingMode(
+      ble_radio_policy::AdvertisingMode::Fast, false);
+#endif
   pAdvertising->start();
 
   initialized = true;
@@ -2961,6 +3171,25 @@ void BLENavigationServer::process() {
   }
   processPendingTransferControl();
   const uint32_t nowMs = millis();
+#if BLE_RADIO_CHARACTERIZATION
+  processRadioCharacterization(nowMs, pServer);
+#endif
+#if FIRMWARE_DIAGNOSTICS || POWER_METRICS
+  constexpr uint32_t kConnectionParameterSamplePeriodMs = 5000;
+  const uint32_t lastSampleMs =
+      lastConnectionParameterSampleMs.load(std::memory_order_acquire);
+  const uint16_t connectionHandle =
+      radioConnectionHandle.load(std::memory_order_acquire);
+  if (connectionHandle != BLE_HS_CONN_HANDLE_NONE &&
+      nowMs - lastSampleMs >= kConnectionParameterSamplePeriodMs) {
+    ble_gap_conn_desc description{};
+    if (ble_gap_conn_find(connectionHandle, &description) == 0) {
+      recordConnectionParameters(description, nowMs);
+    } else {
+      lastConnectionParameterSampleMs.store(nowMs, std::memory_order_release);
+    }
+  }
+#endif
   if (destinationCatalogReassemblerMutex != nullptr &&
       xSemaphoreTake(destinationCatalogReassemblerMutex, 0) == pdTRUE) {
     const bool expired = destinationCatalogReassembler.expire(nowMs);
@@ -3047,11 +3276,40 @@ void BLENavigationServer::process() {
 #endif
 }
 
+void BLENavigationServer::noteUserWake() {
+#if BLE_RADIO_CHARACTERIZATION
+  radioUserWakePending.store(true, std::memory_order_release);
+#endif
+}
+
+void BLENavigationServer::setNavigationActivity(bool active) {
+#if BLE_RADIO_CHARACTERIZATION
+  radioNavigationActive.store(active, std::memory_order_release);
+#else
+  (void)active;
+#endif
+}
+
 BLEDebugStats BLENavigationServer::getDebugStats() const {
   BLEDebugStats stats = bleDebugStats;
   stats.initialized = initialized;
   stats.connected = connected;
   stats.authenticated = bleSessionAuthenticated;
+  portENTER_CRITICAL(&radioDebugMux);
+  stats.connectionParametersValid =
+      radioDebugSnapshot.connectionParametersValid;
+  stats.connectionIntervalUnits = radioDebugSnapshot.connectionIntervalUnits;
+  stats.connectionLatency = radioDebugSnapshot.connectionLatency;
+  stats.supervisionTimeoutUnits =
+      radioDebugSnapshot.supervisionTimeoutUnits;
+  stats.connectionParameterSampleCount =
+      radioDebugSnapshot.connectionParameterSampleCount;
+  stats.lastConnectionParameterSampleMs =
+      radioDebugSnapshot.lastConnectionParameterSampleMs;
+  stats.advertisingMode = radioDebugSnapshot.advertisingMode;
+  stats.requestedConnectionProfile =
+      radioDebugSnapshot.requestedConnectionProfile;
+  portEXIT_CRITICAL(&radioDebugMux);
   return stats;
 }
 

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -14,6 +14,7 @@
  */
 
 #include <Arduino.h>
+#include "ble_radio_policy.hpp"
 #include "destination_picker_protocol.hpp"
 #include "map_profile_protocol.hpp"
 
@@ -192,6 +193,17 @@ struct BLEDebugStats {
   uint32_t lastGpsPacketMs = 0;
   uint32_t lastSettingsPacketMs = 0;
   uint32_t lastRejectedUnauthenticatedMs = 0;
+  bool connectionParametersValid = false;
+  uint16_t connectionIntervalUnits = 0;
+  uint16_t connectionLatency = 0;
+  uint16_t supervisionTimeoutUnits = 0;
+  uint32_t connectionParameterSampleCount = 0;
+  uint32_t lastConnectionParameterSampleMs = 0;
+  int8_t txPowerDbm = ble_radio_policy::kConfiguration.txPowerDbm;
+  ble_radio_policy::AdvertisingMode advertisingMode =
+      ble_radio_policy::AdvertisingMode::Default;
+  ble_radio_policy::ConnectionProfile requestedConnectionProfile =
+      ble_radio_policy::ConnectionProfile::Unset;
 };
 
 class BLENavigationServer {
@@ -213,6 +225,12 @@ public:
    * @brief Process any pending BLE events (call from main loop)
    */
   void process();
+
+  /** Record physical input that should reopen the fast-advertising window. */
+  void noteUserWake();
+
+  /** Publish current navigation activity for opt-in radio experiments. */
+  void setNavigationActivity(bool active);
 
   /**
    * @brief Clear the registered iPhone owner after physical recovery input.

--- a/esp32/lib/ble_navigation/ble_radio_policy.hpp
+++ b/esp32/lib/ble_navigation/ble_radio_policy.hpp
@@ -1,0 +1,126 @@
+#pragma once
+
+#include <cstdint>
+
+#ifndef BLE_RADIO_CHARACTERIZATION
+#define BLE_RADIO_CHARACTERIZATION 0
+#endif
+
+#ifndef BLE_TX_POWER_DBM
+#define BLE_TX_POWER_DBM 9
+#endif
+
+namespace ble_radio_policy {
+
+enum class AdvertisingMode : uint8_t {
+  Default = 0,
+  Fast = 1,
+  Slow = 2,
+};
+
+enum class ConnectionProfile : uint8_t {
+  Unset = 0,
+  Navigation = 1,
+  Idle = 2,
+};
+
+struct IntervalRange {
+  uint16_t minimumUnits;
+  uint16_t maximumUnits;
+};
+
+struct ConnectionParameters {
+  uint16_t minimumIntervalUnits;
+  uint16_t maximumIntervalUnits;
+  uint16_t latency;
+  uint16_t supervisionTimeoutUnits;
+};
+
+struct Configuration {
+  bool characterizationEnabled;
+  int8_t txPowerDbm;
+  uint32_t fastAdvertisingWindowMs;
+  IntervalRange fastAdvertising;
+  IntervalRange slowAdvertising;
+  ConnectionParameters navigation;
+  ConnectionParameters idle;
+};
+
+constexpr Configuration kConfiguration{
+    BLE_RADIO_CHARACTERIZATION != 0,
+    BLE_TX_POWER_DBM,
+    30000,
+    {160, 320},   // 100-200 ms in 0.625 ms units.
+    {1440, 1760}, // 900-1100 ms in 0.625 ms units.
+    {24, 40, 0, 400}, // 30-50 ms, zero latency, four-second timeout.
+    {48, 80, 4, 600}, // 60-100 ms, latency four, six-second timeout.
+};
+
+constexpr bool isSupportedTxPowerDbm(int txPowerDbm) {
+  return txPowerDbm == 9 || txPowerDbm == 3 || txPowerDbm == 0;
+}
+
+constexpr bool isValid(const IntervalRange &range) {
+  return range.minimumUnits >= 0x20 &&
+         range.minimumUnits <= range.maximumUnits &&
+         range.maximumUnits <= 0x4000;
+}
+
+constexpr bool isValid(const ConnectionParameters &parameters) {
+  return parameters.minimumIntervalUnits >= 0x06 &&
+         parameters.minimumIntervalUnits <= parameters.maximumIntervalUnits &&
+         parameters.maximumIntervalUnits <= 0x0C80 &&
+         parameters.latency <= 499 &&
+         parameters.supervisionTimeoutUnits >= 10 &&
+         parameters.supervisionTimeoutUnits <= 3200 &&
+         static_cast<uint32_t>(parameters.supervisionTimeoutUnits) * 8 >
+             static_cast<uint32_t>(parameters.latency + 1) * 2 *
+                 parameters.maximumIntervalUnits;
+}
+
+constexpr bool isValid(const Configuration &configuration) {
+  return isSupportedTxPowerDbm(configuration.txPowerDbm) &&
+         configuration.fastAdvertisingWindowMs > 0 &&
+         isValid(configuration.fastAdvertising) &&
+         isValid(configuration.slowAdvertising) &&
+         isValid(configuration.navigation) && isValid(configuration.idle);
+}
+
+constexpr AdvertisingMode advertisingModeForElapsed(uint32_t elapsedMs) {
+  return elapsedMs < kConfiguration.fastAdvertisingWindowMs
+             ? AdvertisingMode::Fast
+             : AdvertisingMode::Slow;
+}
+
+constexpr AdvertisingMode nextAdvertisingMode(AdvertisingMode currentMode,
+                                               uint32_t elapsedMs,
+                                               bool userWakeRequested) {
+  if (userWakeRequested) {
+    return AdvertisingMode::Fast;
+  }
+  if (currentMode == AdvertisingMode::Default) {
+    return AdvertisingMode::Fast;
+  }
+  if (currentMode == AdvertisingMode::Slow) {
+    return AdvertisingMode::Slow;
+  }
+  return advertisingModeForElapsed(elapsedMs);
+}
+
+constexpr ConnectionProfile connectionProfile(bool navigationActive) {
+  return navigationActive ? ConnectionProfile::Navigation
+                          : ConnectionProfile::Idle;
+}
+
+constexpr const ConnectionParameters &
+connectionParameters(ConnectionProfile profile) {
+  return profile == ConnectionProfile::Navigation ? kConfiguration.navigation
+                                                   : kConfiguration.idle;
+}
+
+static_assert(isValid(kConfiguration));
+static_assert(kConfiguration.characterizationEnabled ||
+                  kConfiguration.txPowerDbm == 9,
+              "non-default BLE TX power is characterization-only");
+
+} // namespace ble_radio_policy

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -835,7 +835,9 @@ static void logPowerMetricsReport() {
       "ble[connected=%d authenticated=%d "
       "logical=nav:%lu,route:%lu,gps:%lu,settings:%lu,workout:%lu,"
       "transfer:%lu,audio:%lu,control:%lu,auth:%lu "
-      "appQueue=ios-diagnostic] "
+      "appQueue=ios-diagnostic "
+      "radio=txDbm:%d,advMode:%u,requestedProfile:%u,valid:%d,"
+      "intervalUnits:%u,latency:%u,timeoutUnits:%u,samples:%lu] "
       "system[powerMode=%s wifiMode=%d transfer=%d transferMode=%s "
       "audio=%d cpuMHz=%u dfs=%d pmError=%d minCpuMHz=%u maxCpuMHz=%u "
       "lightSleep=%d "
@@ -884,6 +886,12 @@ static void logPowerMetricsReport() {
       (unsigned long)bleCount(power_metrics::BlePacketClass::Audio),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Control),
       (unsigned long)bleCount(power_metrics::BlePacketClass::Auth),
+      static_cast<int>(bleStats.txPowerDbm),
+      static_cast<unsigned>(bleStats.advertisingMode),
+      static_cast<unsigned>(bleStats.requestedConnectionProfile),
+      bleStats.connectionParametersValid, bleStats.connectionIntervalUnits,
+      bleStats.connectionLatency, bleStats.supervisionTimeoutUnits,
+      (unsigned long)bleStats.connectionParameterSampleCount,
       powerMode, static_cast<int>(WiFi.getMode()), transferStatus.enabled,
       transferStatus.mode.empty() ? "none" : transferStatus.mode.c_str(),
       audioActive, getCpuFrequencyMhz(), powerManagementStatus.enabled,
@@ -1254,6 +1262,13 @@ void loop() {
   const uint32_t wakeReasons =
       pendingUiWakeReasons | ui_scheduler::wait(0);
   pendingUiWakeReasons = 0;
+#if BLE_RADIO_CHARACTERIZATION
+  if (ui_scheduler::hasReason(wakeReasons,
+                              ui_scheduler::WakeReason::Touch) ||
+      ui_scheduler::hasReason(wakeReasons, ui_scheduler::WakeReason::Boot)) {
+    bleNavServer.noteUserWake();
+  }
+#endif
   power_metrics::noteLoop(now);
   if (lastLoopMs != 0) {
     uint32_t gap = now - lastLoopMs;
@@ -1300,6 +1315,9 @@ void loop() {
       navigatingBeforeBleWork
           ? ui_scheduler::kConnectedNavigationMaximumWaitMs
           : ui_scheduler::kStaticMaximumWaitMs;
+#if BLE_RADIO_CHARACTERIZATION
+  bleNavServer.setNavigationActivity(navigatingBeforeBleWork);
+#endif
   if (ui_scheduler::shouldRunForReason(
           wakeReasons, ui_scheduler::WakeReason::Ble, now,
           lastBleHousekeepingMs, bleHousekeepingPeriodMs)) {

--- a/esp32/tools/tests/test_ble_radio_policy.cpp
+++ b/esp32/tools/tests/test_ble_radio_policy.cpp
@@ -1,0 +1,47 @@
+#include "../../lib/ble_navigation/ble_radio_policy.hpp"
+
+#include <cassert>
+#include <cstdint>
+
+int main() {
+  using namespace ble_radio_policy;
+
+  static_assert(kConfiguration.characterizationEnabled ==
+                (BLE_RADIO_CHARACTERIZATION != 0));
+  static_assert(kConfiguration.txPowerDbm == BLE_TX_POWER_DBM);
+  static_assert(isValid(kConfiguration));
+  static_assert(isSupportedTxPowerDbm(9));
+  static_assert(isSupportedTxPowerDbm(3));
+  static_assert(isSupportedTxPowerDbm(0));
+  static_assert(!isSupportedTxPowerDbm(6));
+
+  assert(advertisingModeForElapsed(0) == AdvertisingMode::Fast);
+  assert(advertisingModeForElapsed(29999) == AdvertisingMode::Fast);
+  assert(advertisingModeForElapsed(30000) == AdvertisingMode::Slow);
+  assert(advertisingModeForElapsed(UINT32_MAX) == AdvertisingMode::Slow);
+  assert(nextAdvertisingMode(AdvertisingMode::Default, 0, false) ==
+         AdvertisingMode::Fast);
+  assert(nextAdvertisingMode(AdvertisingMode::Fast, 29999, false) ==
+         AdvertisingMode::Fast);
+  assert(nextAdvertisingMode(AdvertisingMode::Fast, 30000, false) ==
+         AdvertisingMode::Slow);
+  assert(nextAdvertisingMode(AdvertisingMode::Slow, 0, false) ==
+         AdvertisingMode::Slow);
+  assert(nextAdvertisingMode(AdvertisingMode::Slow, UINT32_MAX, false) ==
+         AdvertisingMode::Slow);
+  assert(nextAdvertisingMode(AdvertisingMode::Slow, 0, true) ==
+         AdvertisingMode::Fast);
+
+  assert(connectionProfile(true) == ConnectionProfile::Navigation);
+  assert(connectionProfile(false) == ConnectionProfile::Idle);
+  assert(connectionParameters(ConnectionProfile::Navigation).latency == 0);
+  assert(connectionParameters(ConnectionProfile::Idle).latency == 4);
+
+  assert(isValid(IntervalRange{160, 320}));
+  assert(!isValid(IntervalRange{31, 320}));
+  assert(!isValid(IntervalRange{320, 160}));
+  assert(isValid(ConnectionParameters{24, 40, 0, 400}));
+  assert(!isValid(ConnectionParameters{40, 24, 0, 400}));
+  assert(!isValid(ConnectionParameters{48, 80, 499, 10}));
+  return 0;
+}

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -21,6 +21,8 @@ assert "-DDEBUG=1" not in waveshare_flags
 assert "-DCORE_DEBUG_LEVEL=" not in waveshare_flags
 assert "-DFIRMWARE_DIAGNOSTICS=" not in waveshare_flags
 assert "-DARDUINO_USB_CDC_ON_BOOT=" not in waveshare_flags
+assert "-DBLE_RADIO_CHARACTERIZATION=1" not in waveshare_flags
+assert "-DBLE_TX_POWER_DBM=" not in waveshare_flags
 
 diagnostic_profiles = {
     "env:WAVESHARE_AMOLED_175": (

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -280,6 +280,10 @@ capability discovery also returns the persisted honk configuration, so
 reconnecting from a fresh app does not overwrite device state with app
 defaults.
 
+The local 2.06 schematic labels the AXP2101 IRQ net `EXIO5`, but does not route
+that net to an ESP32 GPIO or a populated I/O expander. It therefore cannot wake
+firmware through a direct GPIO interrupt on this board revision.
+
 ### Buttons, External Pads, And Power
 
 | Function | GPIO / Net | Notes |
@@ -550,6 +554,11 @@ Verified firmware behavior:
   Temporary test builds with `POWER_SAVE` reproduced Bluetooth/IPC instability,
   and BOOT-button short/long presses did not produce reliable sleep/shutdown
   transitions on the waiting screen.
+- The 1.75 schematic routes AXP2101 `IRQ` to TCA9554 P5 (`EXIO5`). The
+  TCA9554's own `INT` pin is not routed to the ESP32, so this is readable only
+  through another I2C transaction and is not a firmware wake GPIO. Keep the
+  deadline-based AXP2101 status polling unless a later board revision exposes
+  a direct interrupt.
 
 ### 3. Touch Coordinate Mirroring
 


### PR DESCRIPTION
## Summary

- add an opt-in BLE characterization harness for advertising cadence, connection parameters, and P9/P3/P0 TX-power trials
- record effective iOS-negotiated BLE parameters in diagnostics and power-metrics output
- document SD-clock and PMU/audio-rail characterization gates, including the schematic-confirmed lack of a direct PMU IRQ GPIO
- preserve ordinary and production firmware defaults: P9 TX power, NimBLE default radio policy, 4 MHz SD, existing PMU rails, and deadline-based button polling

## Safety

- experimental radio behavior requires `BLE_RADIO_CHARACTERIZATION=1`
- P3/P0 without that gate fails at compile time and in CI
- ordinary and production ELFs contain no characterization strings or control symbols
- no board was connected and no firmware was flashed

## Validation

- 31 firmware Python tests
- relevant power/display/scheduler/map/radio host policy suites
- default P9, opt-in P3, and opt-in P0 radio-policy builds
- 1.75 ordinary, P3 power-metrics, and production firmware builds
- 2.06 ordinary compatibility build
- 1.75 production: 52.1% RAM, 88.6% flash

## Physical gates still open

The 1.75-inch board must be reconnected before any experimental radio, SD, PMU, or automatic-light-sleep setting can become a default. The remaining matrix includes BLE reconnect/range/transfer tests, effective iOS connection parameters, SD cards at 4/8/12/16 MHz, audio and rail checks, map/display/touch behavior, soak testing, and controlled battery-depletion comparisons.

Stacked on #167.
