### PR TITLE
Refine privacy policy links

### DIFF
--- a/docs/app-store-privacy-disclosures.md
+++ b/docs/app-store-privacy-disclosures.md
@@ -70,8 +70,8 @@ other identifier as linked even when the app has no account or real-world name.
 - Confirm each infrastructure provider processing app data is bound to use it
   only on our instructions and provide the same or equivalent protection stated
   in the public policy.
-- Open the privacy-policy link from both iPhone Settings and the Watch start
-  screen, and confirm the same URL is entered in App Store Connect metadata.
+- Open the privacy-policy link from both iPhone Settings and Watch Settings,
+  and confirm the same URL is entered in App Store Connect metadata.
 - Review the App Store product-page preview before selecting **Publish**.
 
 ## Bundled privacy manifests

--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -44,7 +44,7 @@ To test:
    directly without a second confirmation.
 
 The privacy policy is available from **Settings > Privacy Policy** on iPhone and
-from **Privacy Policy** on the Watch start screen.
+from **Settings > Privacy Policy** on Apple Watch.
 
 Watch and iPhone starts proceed directly after their setup checks. Public APIs
 cannot detect another app's workout, so any resulting displacement is reported

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -145,8 +145,7 @@ struct SettingsView: View {
                     Link(destination: AppPrivacyPolicy.url) {
                         Label("Privacy Policy", systemImage: "hand.raised")
                     }
-                } footer: {
-                    Text("Opens the Bike Computer 2.0 privacy policy in your browser.")
+                    .listRowBackground(Color.clear)
                 }
             }
             .navigationTitle("Settings")

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchSettingsView.swift
@@ -6,6 +6,11 @@ struct WatchSettingsView: View {
             Section("About") {
                 LabeledContent("Version", value: versionDescription)
             }
+
+            Link(destination: AppPrivacyPolicy.url) {
+                Label("Privacy Policy", systemImage: "hand.raised")
+            }
+            .listRowBackground(Color.clear)
         }
         .navigationTitle("Settings")
     }

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -116,6 +116,11 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
 
         self.assertIn(PRIVACY_POLICY_URL, shared_policy)
         self.assertIn("AppPrivacyPolicy.url", ios_settings)
+        self.assertIn(".listRowBackground(Color.clear)", ios_settings)
+        self.assertNotIn(
+            "Opens the Bike Computer 2.0 privacy policy in your browser.",
+            ios_settings,
+        )
         self.assertIn("same or equivalent privacy protection", normalized_policy)
         self.assertIn("30 days after a map job becomes ready", normalized_policy)
         self.assertIn("renaming or downloading a map does not extend", normalized_policy)
@@ -123,7 +128,7 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
         self.assertIn("until you request its deletion", normalized_policy)
         self.assertIn(PRIVACY_POLICY_URL, disclosures)
 
-    def test_watch_settings_exposes_the_installed_app_version(self):
+    def test_watch_settings_exposes_version_and_privacy_policy(self):
         watch_root = (
             IOS_PROJECT
             / "BikeComputerWatch"
@@ -148,6 +153,8 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
         self.assertIn('Image(systemName: "gearshape")', watch_start)
         self.assertIn('accessibilityLabel("Settings")', watch_start)
         self.assertNotIn("AppPrivacyPolicy.url", watch_start)
+        self.assertIn("AppPrivacyPolicy.url", watch_settings)
+        self.assertIn(".listRowBackground(Color.clear)", watch_settings)
         self.assertIn('LabeledContent("Version"', watch_settings)
         self.assertIn('"CFBundleShortVersionString"', watch_settings)
         self.assertIn('"CFBundleVersion"', watch_settings)


### PR DESCRIPTION
## Summary

- make the iPhone Privacy Policy row transparent so it reads as a lower-level settings link
- remove the redundant “Opens the Bike Computer 2.0 privacy policy in your browser” footer
- add the same subordinate Privacy Policy link to Apple Watch Settings
- align release documentation and regression coverage with both settings locations

## Why

The privacy policy should remain easy to reach without carrying the same visual weight as primary settings controls. The independently runnable Watch companion should expose the same policy from its Settings screen.

## Validation

- `python3 ios-app/scripts/tests/test_workout_release_assets.py` — 9 tests passed
- `xcodebuild` BikeComputer scheme for generic iOS Simulator — passed
- `xcodebuild` BikeComputerWatch scheme for generic watchOS Simulator — passed
- public privacy-policy URL returned HTTP 200
- `git diff --check` — passed
