### PR TITLE
Preserve Waveshare PMIC rail configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,13 +17,11 @@ jobs:
           - WAVESHARE_AMOLED_175_POWER_METRICS
           - WAVESHARE_AMOLED_175_LIGHT_SLEEP
           - WAVESHARE_AMOLED_175_PRODUCTION
-          - WAVESHARE_AMOLED_175_SPEAKER_HONK
           - WAVESHARE_AMOLED_206
           - WAVESHARE_AMOLED_206_DISPLAY_TEST
           - WAVESHARE_AMOLED_206_POWER_METRICS
           - WAVESHARE_AMOLED_206_LIGHT_SLEEP
           - WAVESHARE_AMOLED_206_PRODUCTION
-          - WAVESHARE_AMOLED_206_SPEAKER_HONK
     defaults:
       run:
         working-directory: esp32
@@ -35,7 +33,7 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
-        run: pio run -e "${{ matrix.target }}"
+        run: python tools/build_firmware.py "${{ matrix.target }}"
 
   ios:
     name: iOS
@@ -102,6 +100,7 @@ jobs:
       - name: GUI layout host tests
         run: |
           PYTHONPATH=tools python -m unittest \
+            tools.tests.test_build_firmware \
             tools.tests.test_firmware_build_identity \
             tools.tests.test_capture_boot
           g++ -std=c++17 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y libmbedtls-dev
       - name: GUI layout host tests
         run: |
-          PYTHONPATH=tools python -m unittest tools.tests.test_firmware_build_identity
+          PYTHONPATH=tools python -m unittest \
+            tools.tests.test_firmware_build_identity \
+            tools.tests.test_capture_boot
           g++ -std=c++17 \
             tools/tests/test_gui_layout.cpp \
             -o /tmp/test_gui_layout_175
@@ -138,6 +140,10 @@ jobs:
             tools/tests/test_axp2101_register_policy.cpp \
             -o /tmp/test_axp2101_register_policy
           /tmp/test_axp2101_register_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_boot_diagnostics_policy.cpp \
+            -o /tmp/test_boot_diagnostics_policy
+          /tmp/test_boot_diagnostics_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
             -DAUTOMATIC_LIGHT_SLEEP_EXPERIMENT=1 \
             tools/tests/test_power_management_policy.cpp \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
           - WAVESHARE_AMOLED_175_POWER_METRICS
           - WAVESHARE_AMOLED_175_LIGHT_SLEEP
           - WAVESHARE_AMOLED_175_PRODUCTION
+          - WAVESHARE_AMOLED_175_SPEAKER_HONK
           - WAVESHARE_AMOLED_206
+          - WAVESHARE_AMOLED_206_DISPLAY_TEST
           - WAVESHARE_AMOLED_206_POWER_METRICS
           - WAVESHARE_AMOLED_206_LIGHT_SLEEP
           - WAVESHARE_AMOLED_206_PRODUCTION
+          - WAVESHARE_AMOLED_206_SPEAKER_HONK
     defaults:
       run:
         working-directory: esp32
@@ -144,6 +147,10 @@ jobs:
             tools/tests/test_boot_diagnostics_policy.cpp \
             -o /tmp/test_boot_diagnostics_policy
           /tmp/test_boot_diagnostics_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_speaker_playback_policy.cpp \
+            -o /tmp/test_speaker_playback_policy
+          /tmp/test_speaker_playback_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
             -DAUTOMATIC_LIGHT_SLEEP_EXPERIMENT=1 \
             tools/tests/test_power_management_policy.cpp \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,10 @@ jobs:
             -o /tmp/test_power_management_policy
           /tmp/test_power_management_policy
           g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_axp2101_register_policy.cpp \
+            -o /tmp/test_axp2101_register_policy
+          /tmp/test_axp2101_register_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
             -DAUTOMATIC_LIGHT_SLEEP_EXPERIMENT=1 \
             tools/tests/test_power_management_policy.cpp \
             -o /tmp/test_power_management_policy_light_sleep

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
-        run: pio run -e "${{ matrix.environment }}"
+        run: python tools/build_firmware.py "${{ matrix.environment }}"
       - name: Stage firmware image
         run: |
           mkdir -p dist

--- a/.github/workflows/speaker-firmware.yml
+++ b/.github/workflows/speaker-firmware.yml
@@ -1,0 +1,27 @@
+name: Speaker firmware builds
+
+on:
+  workflow_dispatch:
+
+jobs:
+  esp32-speaker:
+    name: ESP32 Speaker (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - WAVESHARE_AMOLED_175_SPEAKER_HONK
+          - WAVESHARE_AMOLED_206_SPEAKER_HONK
+    defaults:
+      run:
+        working-directory: esp32
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install PlatformIO
+        run: python -m pip install --upgrade platformio
+      - name: Build speaker firmware
+        run: python tools/build_firmware.py "${{ matrix.target }}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,12 +31,18 @@ device is connected. Do not assume 1.75 versus 2.06.
 
 ```sh
 cd esp32
-pio run -e WAVESHARE_AMOLED_175
-pio run -e WAVESHARE_AMOLED_206
+python3 tools/build_firmware.py WAVESHARE_AMOLED_175
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206
 pio device list
 pio run -e WAVESHARE_AMOLED_175 -t upload --upload-port /dev/cu.usbmodemXXXX
 pio device monitor -b 115200
 ```
+
+Use `tools/build_firmware.py` for build-only checks and CI. A clean pioarduino
+installation can spend its first PlatformIO invocation compiling a custom core
+against a generated `.dummy` sketch; the helper detects that bootstrap pass,
+rebuilds the requested source, and requires the target `firmware.elf`. Direct
+`pio run -e ... -t upload` remains the upload command.
 
 Use the matching `WAVESHARE_AMOLED_206` environment for a 2.06-inch board. If
 upload fails, hold BOOT (`GPIO0`) while reconnecting USB and retry.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,21 +48,34 @@ hold the ESP32-S3 in reset:
 
 ```sh
 cd esp32
-python tools/capture_boot.py \
+python3 tools/capture_boot.py \
   --port '/dev/cu.usbmodem*' \
   --duration 40 \
   --expected-target WAVESHARE_AMOLED_175 \
+  --expected-profile WAVESHARE_AMOLED_175 \
   --expected-git "$(git rev-parse HEAD)" \
+  --expected-reset power_on \
   --require-pmic-read-only \
   --require-ready
 ```
 
-Arm that command before reconnecting the device for a true cold-start test.
-Use `--reset` only when an intentional warm reset is wanted. Treat `BOOT_META`
-as the running-image source of truth, use `BOOT_PREVIOUS`/`BOOT_FAILURE` to
-locate an interrupted setup stage, and require a final `BOOT_STAGE ...
-event=ready`. Any `AXP_WRITE_BLOCKED` or `BOOT_DIAGNOSTICS_ERROR` makes the
-capture helper fail validation.
+Arm that command before reconnecting a fully unpowered device for a true
+cold-start test. Disconnect both USB and battery first so the PMIC reloads its
+power-on baseline; preserving rails cannot prove that a still-powered PMIC is
+in factory state. Use `--reset` only when an intentional warm reset is wanted,
+and change or omit `--expected-reset` accordingly. Treat `BOOT_META` as the
+running-image source of truth: target identifies OTA compatibility, while
+profile distinguishes ordinary, production, metrics, light-sleep, and other
+builds from the same Git SHA. Use `BOOT_PREVIOUS`/`BOOT_FAILURE` to locate an
+interrupted setup stage; their fingerprint and failure-reset fields identify
+the failed image and how it ended after rescue firmware is flashed. Require a
+final `BOOT_STAGE ... event=ready` from the same boot sequence.
+`--require-pmic-read-only` also requires a successful PMIC probe plus status and
+LDO-state reads and is the 1.75-inch safety gate. For a 2.06-inch capture, use
+`--require-pmic-display-enable-only`; it additionally requires the dedicated
+one-way display recovery and verified display-enable bit. Any
+`AXP_WRITE_BLOCKED` or `BOOT_DIAGNOSTICS_ERROR` makes the capture helper fail
+validation.
 
 ### iOS app
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,29 @@ pio device monitor -b 115200
 Use the matching `WAVESHARE_AMOLED_206` environment for a 2.06-inch board. If
 upload fails, hold BOOT (`GPIO0`) while reconnecting USB and retry.
 
+For a reproducible post-flash or cold-start capture, prefer the repository
+helper over an interactive PlatformIO monitor. It waits for a disconnected
+board to reappear and leaves RTS/DTR deasserted so the serial reader does not
+hold the ESP32-S3 in reset:
+
+```sh
+cd esp32
+python tools/capture_boot.py \
+  --port '/dev/cu.usbmodem*' \
+  --duration 40 \
+  --expected-target WAVESHARE_AMOLED_175 \
+  --expected-git "$(git rev-parse HEAD)" \
+  --require-pmic-read-only \
+  --require-ready
+```
+
+Arm that command before reconnecting the device for a true cold-start test.
+Use `--reset` only when an intentional warm reset is wanted. Treat `BOOT_META`
+as the running-image source of truth, use `BOOT_PREVIOUS`/`BOOT_FAILURE` to
+locate an interrupted setup stage, and require a final `BOOT_STAGE ...
+event=ready`. Any `AXP_WRITE_BLOCKED` or `BOOT_DIAGNOSTICS_ERROR` makes the
+capture helper fail validation.
+
 ### iOS app
 
 Open `ios-app/BikeComputer/BikeComputer.xcodeproj`. Run the portable Swift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,8 +90,9 @@ Definitive Waveshare pinouts and known quirks live in
 - The 1.75 and 2.06 Waveshare boards both use CO5300 AMOLED displays, but they
   do not share the same display, touch, or SD pinout. Keep
   `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` changes separate.
-- Waveshare 1.75 display power is controlled through AXP2101, touch reset is
-  via TCA9554 P0, and SD uses `CS=41, MOSI=1, MISO=3, SCK=2`.
+- Waveshare 1.75 display power is supplied through AXP2101, but firmware must
+  preserve its current output-rail state; touch reset is via TCA9554 P0, and SD
+  uses `CS=41, MOSI=1, MISO=3, SCK=2`.
 - Waveshare 2.06 uses direct FT3168 touch reset on `GPIO9`, display clock on
   `GPIO11`, display reset on `GPIO8`, and SD `CS=17`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,14 +38,14 @@ Build the default Waveshare ESP32-S3 1.75 firmware:
 
 ```sh
 cd esp32
-pio run -e WAVESHARE_AMOLED_175
+python3 tools/build_firmware.py WAVESHARE_AMOLED_175
 ```
 
 Build the Waveshare ESP32-S3 2.06 firmware:
 
 ```sh
 cd esp32
-pio run -e WAVESHARE_AMOLED_206
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206
 ```
 
 Upload ESP32 firmware:

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -292,10 +292,11 @@ automatic light sleep can be considered for production enablement.
 ## BLE, PMU, and SD characterization harness
 
 Production defaults remain unchanged: BLE TX power is P9, NimBLE owns its
-default advertising and connection policy, the SD bus remains at 4 MHz, PMU
-rails retain their factory/eFuse state, and the AXP2101 button status remains on
-the 250 ms housekeeping deadline. No lower-power radio, rail, or SD setting is
-selected without physical evidence.
+default advertising and connection policy, the SD bus remains at 4 MHz,
+runtime power paths do not switch PMU outputs, and the AXP2101 button status
+remains on the 250 ms housekeeping deadline. No lower-power radio, rail, or SD
+setting is selected without physical evidence. The 2.06-inch boot-only
+display-enable compatibility operation is not a power-saving setting.
 
 Power-metrics and diagnostic builds now record the connected interval in
 1.25 ms units, slave latency, supervision timeout in 10 ms units, sample count,
@@ -334,10 +335,12 @@ populated receiver or ESP32 connection. Neither board exposes a direct usable
 PMU IRQ GPIO, so replacing deadline-based polling would add I2C work rather
 than create an interrupt-driven path.
 
-Audio-rail toggling and all PMU rail changes remain prohibited until the
-1.75-inch schematic mapping is verified against physical codec, display,
-touch, RTC, battery, SD, reboot, and wake tests. The 2.06 safe path continues
-to preserve PMU state.
+On 1.75-inch hardware, audio-rail toggling and every PMU output-rail change
+remain prohibited until the schematic mapping is verified against physical
+codec, display, touch, RTC, battery, SD, reboot, and wake tests. The 2.06-inch
+runtime and sleep paths likewise do not switch PMU outputs; its sole exception
+is the one-way boot compatibility operation that may set register `0x90` bit
+`0x80` while preserving all other bits.
 
 This document is the source of truth for physical power measurements made
 during the battery-life program. A firmware build, simulator result, PMU battery

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -293,7 +293,7 @@ automatic light sleep can be considered for production enablement.
 
 Production defaults remain unchanged: BLE TX power is P9, NimBLE owns its
 default advertising and connection policy, the SD bus remains at 4 MHz, PMU
-rails retain their known-good masks, and the AXP2101 button status remains on
+rails retain their factory/eFuse state, and the AXP2101 button status remains on
 the 250 ms housekeeping deadline. No lower-power radio, rail, or SD setting is
 selected without physical evidence.
 

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -45,7 +45,7 @@ peripheral transaction part of the correctness boundary.
 | Connected, display off | 45 seconds without meaningful activity | BLE remains connected; the display and ordinary LVGL timer work are stopped; touch wake detection remains available | Touch, BLE/UI activity, or another wake reason restores the display and forces one full refresh |
 | Transfer or attention hold | Device transfer, activation, pairing, or audio needs immediate feedback | Display stays awake and required PM locks protect the operation | Hold ends when the operation ends |
 | Disconnected countdown | BLE is disconnected and the configured timeout is nonzero | Firmware remains available for reconnection | Reconnection cancels the countdown; expiry enters deep sleep |
-| Deep sleep | Disconnected timeout expires | RTC wake configuration only; panel and peripheral rails, buses, and radio are shut down | BOOT/PWR button on GPIO0 |
+| Deep sleep | Disconnected timeout expires | Panel is commanded off; buses and radio stop; unvalidated AXP2101 rails remain at their factory/eFuse state | BOOT/PWR button on GPIO0 |
 
 Display-off while connected is not deep sleep. The BLE connection is retained,
 and touch can wake the UI without requiring a reboot or reconnection.
@@ -57,10 +57,10 @@ The disconnected sleep timeout is BLE setting `15`. Supported values are 60,
 default is 120 seconds. An unclaimed device receives a minimum 600-second
 registration grace period unless the feature is disabled.
 
-Before deep sleep, firmware turns off the panel and peripheral rails, stops the
-SPI and I2C buses, and shuts down the radio. This existing deep-sleep path
-provides the lowest-power state and is independent of the connected light-sleep
-experiment.
+Before deep sleep, firmware commands the panel off, stops the SPI and I2C buses,
+and shuts down the radio. It does not rewrite AXP2101 output-enable or voltage
+registers because the populated rail map has not been electrically validated.
+This path is independent of the connected light-sleep experiment.
 
 ## Display inactivity policy
 

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -45,7 +45,7 @@ peripheral transaction part of the correctness boundary.
 | Connected, display off | 45 seconds without meaningful activity | BLE remains connected; the display and ordinary LVGL timer work are stopped; touch wake detection remains available | Touch, BLE/UI activity, or another wake reason restores the display and forces one full refresh |
 | Transfer or attention hold | Device transfer, activation, pairing, or audio needs immediate feedback | Display stays awake and required PM locks protect the operation | Hold ends when the operation ends |
 | Disconnected countdown | BLE is disconnected and the configured timeout is nonzero | Firmware remains available for reconnection | Reconnection cancels the countdown; expiry enters deep sleep |
-| Deep sleep | Disconnected timeout expires | Panel is commanded off; buses and radio stop; unvalidated AXP2101 rails remain at their factory/eFuse state | BOOT/PWR button on GPIO0 |
+| Deep sleep | Disconnected timeout expires | Panel is commanded off; buses and radio stop; firmware does not turn off or rewrite AXP2101 output rails | BOOT/PWR button on GPIO0 |
 
 Display-off while connected is not deep sleep. The BLE connection is retained,
 and touch can wake the UI without requiring a reboot or reconnection.
@@ -60,6 +60,13 @@ registration grace period unless the feature is disabled.
 Before deep sleep, firmware commands the panel off, stops the SPI and I2C buses,
 and shuts down the radio. It does not rewrite AXP2101 output-enable or voltage
 registers because the populated rail map has not been electrically validated.
+That preserves the PMIC's current state; it does not prove factory defaults are
+loaded unless USB and battery were both removed before the boot.
+The 2.06-inch boot path has one one-way compatibility exception outside the
+sleep path: it may set established display-enable bit `0x80` in register `0x90`
+after older firmware left that bit clear. It preserves every other bit, verifies
+readback, and never clears the bit. The 1.75-inch boot path remains read-only
+for every output-rail register.
 This path is independent of the connected light-sleep experiment.
 
 ## Display inactivity policy

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -22,9 +22,14 @@ Install [PlatformIO](https://platformio.org/), then build the profile matching
 your device:
 
 ```sh
-pio run -e WAVESHARE_AMOLED_175
-pio run -e WAVESHARE_AMOLED_206
+python3 tools/build_firmware.py WAVESHARE_AMOLED_175
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206
 ```
+
+The helper handles pioarduino's one-time custom-core bootstrap and confirms
+that PlatformIO produced the requested firmware rather than its generated
+bootstrap sketch. The speaker test profiles remain available through the
+manual **Speaker firmware builds** GitHub Actions workflow.
 
 The available production, diagnostics, and test profiles are defined in
 [`platformio.ini`](platformio.ini).

--- a/esp32/WAVESHARE_AMOLED_175_PORT.md
+++ b/esp32/WAVESHARE_AMOLED_175_PORT.md
@@ -1,5 +1,10 @@
 # IceNav-v3: Waveshare ESP32-S3 AMOLED 1.75" Port
 
+> **Historical snapshot:** This document records the original porting work and
+> contains superseded pin and power assumptions. Do not use it as a bring-up
+> recipe. [../hardware/README.md](../hardware/README.md) is authoritative for
+> current hardware behavior, especially AXP2101 safety.
+
 **Target Board:** [Waveshare ESP32-S3 Touch AMOLED 1.75"](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm)
 
 **Goal:** Get the vector map view working on this 466×466 round AMOLED display with CO5300 driver.
@@ -273,20 +278,14 @@ Added `#include <SD.h>` and `#include <FFat.h>` conditionally.
 
 #### [src/main.cpp](file:///Users/chris/Documents/Workspace/esp32-bike-computer/IceNav-v3/src/main.cpp)
 
-**AXP2101 Power Management** (lines 150-212):
-```cpp
-// Enable DLDO1 (3.3V for display)
-Wire.beginTransmission(0x34);
-Wire.write(0x90); Wire.write(0x9C);  // Enable + 3.3V
-Wire.endTransmission();
+**AXP2101 Power Management (superseded):**
 
-// Power cycle all LDOs for SD card stability
-for (uint8_t reg : {0x92, 0x93, 0x94, 0x95, 0x96, 0x97}) {
-  // Disable then re-enable each LDO
-}
-
-Wire.end();  // Release I2C pins for SD (GPIO 14/15 shared)
-```
+The original port forced an assumed display-enable mask and rewrote every
+ALDO/BLDO voltage register. Those writes were not based on a validated populated
+rail map and are now prohibited. Current firmware preserves the PMIC's live
+output state and permits writes only to the two PWR-button interrupt registers.
+Do not copy the historical rail sequence into application or diagnostic code;
+follow [../hardware/README.md](../hardware/README.md#2-pmic-rail-safety-axp2101).
 
 **GPS Bypass** (lines 278-289):
 ```cpp

--- a/esp32/lib/boot_diagnostics/boot_diagnostics.cpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics.cpp
@@ -1,0 +1,225 @@
+#include "boot_diagnostics.hpp"
+
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+
+#include <Arduino.h>
+#include <esp_attr.h>
+#include <esp_system.h>
+
+#include "../firmware_metadata/firmware_metadata.hpp"
+
+#ifndef FIRMWARE_DIAGNOSTICS
+#define FIRMWARE_DIAGNOSTICS 0
+#endif
+
+#ifndef POWER_METRICS
+#define POWER_METRICS 0
+#endif
+
+namespace boot_diagnostics {
+namespace {
+
+RTC_NOINIT_ATTR policy::PersistentState persistentState;
+bool initialized = false;
+bool runtimeSafeMode = false;
+uint32_t bootStartedAtMs = 0;
+
+constexpr bool kLogEnabled = FIRMWARE_DIAGNOSTICS || POWER_METRICS;
+
+uint32_t mixString(uint32_t hash, const char *value) {
+  if (value != nullptr) {
+    while (*value != '\0') {
+      hash = policy::mixByte(hash, static_cast<uint8_t>(*value));
+      ++value;
+    }
+  }
+  return policy::mixByte(hash, 0);
+}
+
+uint32_t firmwareFingerprint() {
+  uint32_t hash = 2166136261U;
+  hash = mixString(hash, firmware_metadata::target());
+  hash = mixString(hash, firmware_metadata::version());
+  hash = policy::mixU32(hash, firmware_metadata::build());
+  hash = mixString(hash, firmware_metadata::gitSha());
+  hash = mixString(hash, firmware_metadata::buildTimestamp());
+  return hash == 0 ? 1 : hash;
+}
+
+const char *resetReasonName(uint32_t reason) {
+  // Stable numeric values from esp_reset_reason_t. Keeping the switch numeric
+  // also lets the diagnostics build across Arduino/IDF versions that expose a
+  // different subset of the newer enum labels.
+  switch (reason) {
+  case 1:
+    return "power_on";
+  case 2:
+    return "external_pin";
+  case 3:
+    return "software";
+  case 4:
+    return "panic";
+  case 5:
+    return "interrupt_watchdog";
+  case 6:
+    return "task_watchdog";
+  case 7:
+    return "watchdog";
+  case 8:
+    return "deep_sleep";
+  case 9:
+    return "brownout";
+  case 10:
+    return "sdio";
+  case 11:
+    return "usb";
+  case 12:
+    return "jtag";
+  case 13:
+    return "efuse";
+  case 14:
+    return "power_glitch";
+  case 15:
+    return "cpu_lockup";
+  default:
+    return "unknown";
+  }
+}
+
+const char *historyStatus(const policy::BeginResult &result) {
+  if (!result.previousValid) {
+    return "empty_or_invalid";
+  }
+  if (result.coldStart) {
+    return "cold_power_reset";
+  }
+  if (!result.previousSameFirmware) {
+    return "firmware_changed";
+  }
+  return "retained";
+}
+
+void logStage(const char *event, Stage stage) {
+  if (!kLogEnabled) {
+    return;
+  }
+  Serial.printf("BOOT_STAGE schema=1 sequence=%lu event=%s id=%u name=%s "
+                "uptimeMs=%lu\n",
+                static_cast<unsigned long>(persistentState.bootSequence), event,
+                static_cast<unsigned>(stage), policy::stageName(stage),
+                static_cast<unsigned long>(millis() - bootStartedAtMs));
+}
+
+} // namespace
+
+void begin() {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+  bootStartedAtMs = millis();
+
+  const uint32_t resetReason = static_cast<uint32_t>(esp_reset_reason());
+  const uint32_t fingerprint = firmwareFingerprint();
+  const policy::BeginResult result = policy::beginBoot(
+      persistentState, fingerprint, resetReason, resetReason == 1);
+  runtimeSafeMode = result.safeMode;
+
+  if (kLogEnabled) {
+    Serial.printf("BOOT_META schema=1 sequence=%lu target=%s version=%s "
+                  "build=%lu git=%s built=%s fingerprint=%08lX reset=%s "
+                  "resetCode=%lu\n",
+                  static_cast<unsigned long>(persistentState.bootSequence),
+                  firmware_metadata::target(), firmware_metadata::version(),
+                  static_cast<unsigned long>(firmware_metadata::build()),
+                  firmware_metadata::gitSha(),
+                  firmware_metadata::buildTimestamp(),
+                  static_cast<unsigned long>(fingerprint),
+                  resetReasonName(resetReason),
+                  static_cast<unsigned long>(resetReason));
+
+    const policy::PersistentState &previous = result.previous;
+    Serial.printf("BOOT_PREVIOUS schema=1 history=%s valid=%d sameFirmware=%d "
+                  "sequence=%lu ready=%d safeMode=%d reset=%s resetCode=%lu "
+                  "active=%s completed=%s\n",
+                  historyStatus(result), result.previousValid ? 1 : 0,
+                  result.previousSameFirmware ? 1 : 0,
+                  static_cast<unsigned long>(result.previousValid
+                                                 ? previous.bootSequence
+                                                 : 0),
+                  result.previousValid && policy::isReady(previous) ? 1 : 0,
+                  result.previousValid && policy::isSafeMode(previous) ? 1 : 0,
+                  resetReasonName(result.previousValid ? previous.resetReason
+                                                       : 0),
+                  static_cast<unsigned long>(result.previousValid
+                                                 ? previous.resetReason
+                                                 : 0),
+                  policy::stageName(static_cast<Stage>(
+                      result.previousValid ? previous.activeStage : 0)),
+                  policy::stageName(static_cast<Stage>(
+                      result.previousValid ? previous.completedStage : 0)));
+
+    Serial.printf("BOOT_FAILURE schema=1 recorded=%d count=%u threshold=%u "
+                  "stage=%s after=%s safeMode=%d\n",
+                  result.failureRecorded ? 1 : 0,
+                  static_cast<unsigned>(
+                      persistentState.consecutiveEarlyFailures),
+                  static_cast<unsigned>(policy::kSafeModeFailureThreshold),
+                  policy::stageName(static_cast<Stage>(
+                      persistentState.lastFailureStage)),
+                  policy::stageName(static_cast<Stage>(
+                      persistentState.lastFailureCompletedStage)),
+                  runtimeSafeMode ? 1 : 0);
+
+    if (runtimeSafeMode) {
+      Serial.println(
+          "BOOT_SAFE_MODE schema=1 active=1 peripherals=skipped "
+          "recovery=flash-new-build-or-remove-all-power");
+    }
+  }
+
+  logStage(runtimeSafeMode ? "hold" : "enter",
+           runtimeSafeMode ? Stage::SafeMode : Stage::Startup);
+}
+
+bool safeModeActive() { return runtimeSafeMode; }
+
+void enterStage(Stage stage) {
+  if (!initialized || runtimeSafeMode) {
+    return;
+  }
+  if (policy::enterStage(persistentState, stage)) {
+    logStage("enter", stage);
+  } else if (kLogEnabled) {
+    Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 operation=enter stage=%s\n",
+                  policy::stageName(stage));
+  }
+}
+
+void completeStage(Stage stage) {
+  if (!initialized || runtimeSafeMode) {
+    return;
+  }
+  if (policy::completeStage(persistentState, stage)) {
+    logStage("complete", stage);
+  } else if (kLogEnabled) {
+    Serial.printf(
+        "BOOT_DIAGNOSTICS_ERROR schema=1 operation=complete stage=%s\n",
+        policy::stageName(stage));
+  }
+}
+
+void markReady() {
+  if (!initialized || runtimeSafeMode) {
+    return;
+  }
+  if (policy::markReady(persistentState)) {
+    logStage("ready", Stage::Ready);
+  } else if (kLogEnabled) {
+    Serial.println("BOOT_DIAGNOSTICS_ERROR schema=1 operation=ready");
+  }
+}
+
+} // namespace boot_diagnostics
+
+#endif // WAVESHARE_AMOLED_175 || WAVESHARE_AMOLED_206

--- a/esp32/lib/boot_diagnostics/boot_diagnostics.cpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics.cpp
@@ -39,6 +39,7 @@ uint32_t mixString(uint32_t hash, const char *value) {
 uint32_t firmwareFingerprint() {
   uint32_t hash = 2166136261U;
   hash = mixString(hash, firmware_metadata::target());
+  hash = mixString(hash, firmware_metadata::buildProfile());
   hash = mixString(hash, firmware_metadata::version());
   hash = policy::mixU32(hash, firmware_metadata::build());
   hash = mixString(hash, firmware_metadata::gitSha());
@@ -126,11 +127,13 @@ void begin() {
   runtimeSafeMode = result.safeMode;
 
   if (kLogEnabled) {
-    Serial.printf("BOOT_META schema=1 sequence=%lu target=%s version=%s "
+    Serial.printf("BOOT_META schema=1 sequence=%lu target=%s profile=%s version=%s "
                   "build=%lu git=%s built=%s fingerprint=%08lX reset=%s "
                   "resetCode=%lu\n",
                   static_cast<unsigned long>(persistentState.bootSequence),
-                  firmware_metadata::target(), firmware_metadata::version(),
+                  firmware_metadata::target(),
+                  firmware_metadata::buildProfile(),
+                  firmware_metadata::version(),
                   static_cast<unsigned long>(firmware_metadata::build()),
                   firmware_metadata::gitSha(),
                   firmware_metadata::buildTimestamp(),
@@ -140,15 +143,24 @@ void begin() {
 
     const policy::PersistentState &previous = result.previous;
     Serial.printf("BOOT_PREVIOUS schema=1 history=%s valid=%d sameFirmware=%d "
-                  "sequence=%lu ready=%d safeMode=%d reset=%s resetCode=%lu "
-                  "active=%s completed=%s\n",
+                  "sequence=%lu fingerprint=%08lX ready=%d safeMode=%d "
+                  "diagnosticHold=%d "
+                  "reset=%s resetCode=%lu active=%s completed=%s "
+                  "failureCount=%u failureStage=%s failureAfter=%s "
+                  "failureReset=%s failureResetCode=%lu\n",
                   historyStatus(result), result.previousValid ? 1 : 0,
                   result.previousSameFirmware ? 1 : 0,
                   static_cast<unsigned long>(result.previousValid
                                                  ? previous.bootSequence
                                                  : 0),
+                  static_cast<unsigned long>(result.previousValid
+                                                 ? previous.firmwareFingerprint
+                                                 : 0),
                   result.previousValid && policy::isReady(previous) ? 1 : 0,
                   result.previousValid && policy::isSafeMode(previous) ? 1 : 0,
+                  result.previousValid && policy::isDiagnosticHold(previous)
+                      ? 1
+                      : 0,
                   resetReasonName(result.previousValid ? previous.resetReason
                                                        : 0),
                   static_cast<unsigned long>(result.previousValid
@@ -157,10 +169,25 @@ void begin() {
                   policy::stageName(static_cast<Stage>(
                       result.previousValid ? previous.activeStage : 0)),
                   policy::stageName(static_cast<Stage>(
-                      result.previousValid ? previous.completedStage : 0)));
+                      result.previousValid ? previous.completedStage : 0)),
+                  static_cast<unsigned>(
+                      result.previousValid ? previous.consecutiveEarlyFailures
+                                           : 0),
+                  policy::stageName(static_cast<Stage>(
+                      result.previousValid ? previous.lastFailureStage : 0)),
+                  policy::stageName(static_cast<Stage>(
+                      result.previousValid
+                          ? previous.lastFailureCompletedStage
+                          : 0)),
+                  resetReasonName(result.previousValid
+                                      ? previous.lastFailureResetReason
+                                      : 0),
+                  static_cast<unsigned long>(
+                      result.previousValid ? previous.lastFailureResetReason
+                                           : 0));
 
     Serial.printf("BOOT_FAILURE schema=1 recorded=%d count=%u threshold=%u "
-                  "stage=%s after=%s safeMode=%d\n",
+                  "stage=%s after=%s reset=%s resetCode=%lu safeMode=%d\n",
                   result.failureRecorded ? 1 : 0,
                   static_cast<unsigned>(
                       persistentState.consecutiveEarlyFailures),
@@ -169,6 +196,9 @@ void begin() {
                       persistentState.lastFailureStage)),
                   policy::stageName(static_cast<Stage>(
                       persistentState.lastFailureCompletedStage)),
+                  resetReasonName(persistentState.lastFailureResetReason),
+                  static_cast<unsigned long>(
+                      persistentState.lastFailureResetReason),
                   runtimeSafeMode ? 1 : 0);
 
     if (runtimeSafeMode) {
@@ -217,6 +247,18 @@ void markReady() {
     logStage("ready", Stage::Ready);
   } else if (kLogEnabled) {
     Serial.println("BOOT_DIAGNOSTICS_ERROR schema=1 operation=ready");
+  }
+}
+
+void markDiagnosticHold() {
+  if (!initialized || runtimeSafeMode) {
+    return;
+  }
+  if (policy::markDiagnosticHold(persistentState)) {
+    logStage("hold", Stage::DiagnosticHold);
+  } else if (kLogEnabled) {
+    Serial.println(
+        "BOOT_DIAGNOSTICS_ERROR schema=1 operation=diagnostic_hold");
   }
 }
 

--- a/esp32/lib/boot_diagnostics/boot_diagnostics.hpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "boot_diagnostics_policy.hpp"
+
+namespace boot_diagnostics {
+
+using Stage = policy::Stage;
+
+// Call once, before initializing board peripherals. This records the new boot
+// in RTC no-init memory and reports the previous unfinished stage.
+void begin();
+
+bool safeModeActive();
+void enterStage(Stage stage);
+void completeStage(Stage stage);
+void markReady();
+
+} // namespace boot_diagnostics

--- a/esp32/lib/boot_diagnostics/boot_diagnostics.hpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics.hpp
@@ -5,6 +5,8 @@
 namespace boot_diagnostics {
 
 using Stage = policy::Stage;
+constexpr std::size_t kStructuredSerialTxBufferSize =
+    policy::kStructuredSerialTxBufferSize;
 
 // Call once, before initializing board peripherals. This records the new boot
 // in RTC no-init memory and reports the previous unfinished stage.
@@ -14,5 +16,6 @@ bool safeModeActive();
 void enterStage(Stage stage);
 void completeStage(Stage stage);
 void markReady();
+void markDiagnosticHold();
 
 } // namespace boot_diagnostics

--- a/esp32/lib/boot_diagnostics/boot_diagnostics_policy.hpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics_policy.hpp
@@ -1,0 +1,282 @@
+#pragma once
+
+#include <cstdint>
+
+namespace boot_diagnostics::policy {
+
+constexpr uint32_t kStateMagic = 0x424F4F54; // "BOOT"
+constexpr uint16_t kStateSchema = 1;
+constexpr uint8_t kSafeModeFailureThreshold = 3;
+
+enum class Stage : uint8_t {
+  None = 0,
+  Startup = 1,
+  CoreServices = 2,
+  WakeConfiguration = 3,
+  I2cBus = 4,
+  PmicInspection = 5,
+  ClockAndSensors = 6,
+  Display = 7,
+  Storage = 8,
+  MapRecovery = 9,
+  ApplicationServices = 10,
+  UserInterface = 11,
+  Speaker = 12,
+  Ble = 13,
+  Finalization = 14,
+  Ready = 15,
+  SafeMode = 16,
+};
+
+constexpr const char *stageName(Stage stage) {
+  switch (stage) {
+  case Stage::None:
+    return "none";
+  case Stage::Startup:
+    return "startup";
+  case Stage::CoreServices:
+    return "core_services";
+  case Stage::WakeConfiguration:
+    return "wake_configuration";
+  case Stage::I2cBus:
+    return "i2c_bus";
+  case Stage::PmicInspection:
+    return "pmic_inspection";
+  case Stage::ClockAndSensors:
+    return "clock_and_sensors";
+  case Stage::Display:
+    return "display";
+  case Stage::Storage:
+    return "storage";
+  case Stage::MapRecovery:
+    return "map_recovery";
+  case Stage::ApplicationServices:
+    return "application_services";
+  case Stage::UserInterface:
+    return "user_interface";
+  case Stage::Speaker:
+    return "speaker";
+  case Stage::Ble:
+    return "ble";
+  case Stage::Finalization:
+    return "finalization";
+  case Stage::Ready:
+    return "ready";
+  case Stage::SafeMode:
+    return "safe_mode";
+  }
+  return "invalid";
+}
+
+constexpr bool isKnownStage(uint8_t stage) {
+  return stage <= static_cast<uint8_t>(Stage::SafeMode);
+}
+
+constexpr uint8_t kFlagReady = 1U << 0;
+constexpr uint8_t kFlagSafeMode = 1U << 1;
+constexpr uint8_t kKnownFlags = kFlagReady | kFlagSafeMode;
+
+// RTC no-init memory preserves this state across software, watchdog, panic,
+// brownout, and USB resets. A magic/version/size/checksum envelope makes
+// uninitialized cold-boot memory fail closed as an empty history.
+struct PersistentState {
+  uint32_t magic;
+  uint16_t schema;
+  uint16_t size;
+  uint32_t firmwareFingerprint;
+  uint32_t bootSequence;
+  uint32_t resetReason;
+  uint8_t activeStage;
+  uint8_t completedStage;
+  uint8_t lastFailureStage;
+  uint8_t lastFailureCompletedStage;
+  uint8_t consecutiveEarlyFailures;
+  uint8_t flags;
+  uint16_t reserved;
+  uint32_t checksum;
+};
+
+static_assert(sizeof(PersistentState) == 32,
+              "boot state layout is part of the RTC-memory schema");
+
+struct BeginResult {
+  PersistentState previous;
+  bool previousValid;
+  bool previousSameFirmware;
+  bool coldStart;
+  bool failureRecorded;
+  bool safeMode;
+};
+
+constexpr uint32_t mixByte(uint32_t hash, uint8_t value) {
+  return (hash ^ value) * 16777619U;
+}
+
+constexpr uint32_t mixU16(uint32_t hash, uint16_t value) {
+  hash = mixByte(hash, static_cast<uint8_t>(value));
+  return mixByte(hash, static_cast<uint8_t>(value >> 8));
+}
+
+constexpr uint32_t mixU32(uint32_t hash, uint32_t value) {
+  hash = mixU16(hash, static_cast<uint16_t>(value));
+  return mixU16(hash, static_cast<uint16_t>(value >> 16));
+}
+
+constexpr uint32_t checksum(const PersistentState &state) {
+  uint32_t hash = 2166136261U;
+  hash = mixU32(hash, state.magic);
+  hash = mixU16(hash, state.schema);
+  hash = mixU16(hash, state.size);
+  hash = mixU32(hash, state.firmwareFingerprint);
+  hash = mixU32(hash, state.bootSequence);
+  hash = mixU32(hash, state.resetReason);
+  hash = mixByte(hash, state.activeStage);
+  hash = mixByte(hash, state.completedStage);
+  hash = mixByte(hash, state.lastFailureStage);
+  hash = mixByte(hash, state.lastFailureCompletedStage);
+  hash = mixByte(hash, state.consecutiveEarlyFailures);
+  hash = mixByte(hash, state.flags);
+  return mixU16(hash, state.reserved);
+}
+
+inline void seal(PersistentState &state) { state.checksum = checksum(state); }
+
+constexpr bool isValid(const PersistentState &state) {
+  if (state.magic != kStateMagic || state.schema != kStateSchema ||
+      state.size != sizeof(PersistentState) || state.reserved != 0 ||
+      (state.flags & ~kKnownFlags) != 0 ||
+      !isKnownStage(state.activeStage) ||
+      !isKnownStage(state.completedStage) ||
+      !isKnownStage(state.lastFailureStage) ||
+      !isKnownStage(state.lastFailureCompletedStage) ||
+      state.checksum != checksum(state)) {
+    return false;
+  }
+
+  const bool ready = (state.flags & kFlagReady) != 0;
+  const bool safeMode = (state.flags & kFlagSafeMode) != 0;
+  if (ready &&
+      (state.activeStage != static_cast<uint8_t>(Stage::Ready) ||
+       state.completedStage != static_cast<uint8_t>(Stage::Ready))) {
+    return false;
+  }
+  if (safeMode &&
+      state.activeStage != static_cast<uint8_t>(Stage::SafeMode)) {
+    return false;
+  }
+  return !(ready && safeMode);
+}
+
+constexpr bool isReady(const PersistentState &state) {
+  return (state.flags & kFlagReady) != 0;
+}
+
+constexpr bool isSafeMode(const PersistentState &state) {
+  return (state.flags & kFlagSafeMode) != 0;
+}
+
+constexpr uint8_t incrementSaturating(uint8_t value) {
+  return value == UINT8_MAX ? value : static_cast<uint8_t>(value + 1);
+}
+
+inline BeginResult beginBoot(PersistentState &state,
+                             uint32_t firmwareFingerprint,
+                             uint32_t resetReason, bool coldStart) {
+  const PersistentState previous = state;
+  const bool previousValid = isValid(previous);
+  const bool sameFirmware =
+      previousValid &&
+      previous.firmwareFingerprint == firmwareFingerprint;
+  const bool retainHistory = previousValid && sameFirmware && !coldStart;
+
+  uint32_t sequence = 1;
+  uint8_t failures = 0;
+  uint8_t lastFailure = static_cast<uint8_t>(Stage::None);
+  uint8_t lastFailureCompleted = static_cast<uint8_t>(Stage::None);
+  bool failureRecorded = false;
+
+  if (retainHistory) {
+    sequence = previous.bootSequence + 1;
+    if (sequence == 0) {
+      sequence = 1;
+    }
+    lastFailure = previous.lastFailureStage;
+    lastFailureCompleted = previous.lastFailureCompletedStage;
+
+    if (isReady(previous)) {
+      failures = 0;
+      lastFailure = static_cast<uint8_t>(Stage::None);
+      lastFailureCompleted = static_cast<uint8_t>(Stage::None);
+    } else if (isSafeMode(previous)) {
+      // Safe mode is a deliberate hold, not another failed initialization.
+      failures = previous.consecutiveEarlyFailures;
+    } else {
+      failures = incrementSaturating(previous.consecutiveEarlyFailures);
+      lastFailure = previous.activeStage;
+      lastFailureCompleted = previous.completedStage;
+      failureRecorded = true;
+    }
+  }
+
+  const bool safeMode = failures >= kSafeModeFailureThreshold;
+  state = {
+      kStateMagic,
+      kStateSchema,
+      static_cast<uint16_t>(sizeof(PersistentState)),
+      firmwareFingerprint,
+      sequence,
+      resetReason,
+      static_cast<uint8_t>(safeMode ? Stage::SafeMode : Stage::Startup),
+      static_cast<uint8_t>(Stage::None),
+      lastFailure,
+      lastFailureCompleted,
+      failures,
+      static_cast<uint8_t>(safeMode ? kFlagSafeMode : 0),
+      0,
+      0,
+  };
+  seal(state);
+
+  return {previous, previousValid, sameFirmware, coldStart, failureRecorded,
+          safeMode};
+}
+
+inline bool enterStage(PersistentState &state, Stage stage) {
+  if (!isValid(state) || isReady(state) || isSafeMode(state) ||
+      stage == Stage::None || stage == Stage::Ready ||
+      stage == Stage::SafeMode) {
+    return false;
+  }
+  state.activeStage = static_cast<uint8_t>(stage);
+  seal(state);
+  return true;
+}
+
+inline bool completeStage(PersistentState &state, Stage stage) {
+  if (!isValid(state) || isReady(state) || isSafeMode(state) ||
+      state.activeStage != static_cast<uint8_t>(stage) ||
+      stage == Stage::None || stage == Stage::Ready ||
+      stage == Stage::SafeMode) {
+    return false;
+  }
+  state.completedStage = static_cast<uint8_t>(stage);
+  state.activeStage = static_cast<uint8_t>(Stage::None);
+  seal(state);
+  return true;
+}
+
+inline bool markReady(PersistentState &state) {
+  if (!isValid(state) || isSafeMode(state)) {
+    return false;
+  }
+  state.activeStage = static_cast<uint8_t>(Stage::Ready);
+  state.completedStage = static_cast<uint8_t>(Stage::Ready);
+  state.lastFailureStage = static_cast<uint8_t>(Stage::None);
+  state.lastFailureCompletedStage = static_cast<uint8_t>(Stage::None);
+  state.consecutiveEarlyFailures = 0;
+  state.flags = kFlagReady;
+  seal(state);
+  return true;
+}
+
+} // namespace boot_diagnostics::policy

--- a/esp32/lib/boot_diagnostics/boot_diagnostics_policy.hpp
+++ b/esp32/lib/boot_diagnostics/boot_diagnostics_policy.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace boot_diagnostics::policy {
@@ -7,6 +8,10 @@ namespace boot_diagnostics::policy {
 constexpr uint32_t kStateMagic = 0x424F4F54; // "BOOT"
 constexpr uint16_t kStateSchema = 1;
 constexpr uint8_t kSafeModeFailureThreshold = 3;
+// BOOT_PREVIOUS is intentionally a single structured record. Keep enough USB
+// CDC buffering for that record, power-metrics reports, and future fields to
+// survive the host-attach window without truncating the diagnostic tail.
+constexpr std::size_t kStructuredSerialTxBufferSize = 4096;
 
 enum class Stage : uint8_t {
   None = 0,
@@ -26,6 +31,7 @@ enum class Stage : uint8_t {
   Finalization = 14,
   Ready = 15,
   SafeMode = 16,
+  DiagnosticHold = 17,
 };
 
 constexpr const char *stageName(Stage stage) {
@@ -64,17 +70,21 @@ constexpr const char *stageName(Stage stage) {
     return "ready";
   case Stage::SafeMode:
     return "safe_mode";
+  case Stage::DiagnosticHold:
+    return "diagnostic_hold";
   }
   return "invalid";
 }
 
 constexpr bool isKnownStage(uint8_t stage) {
-  return stage <= static_cast<uint8_t>(Stage::SafeMode);
+  return stage <= static_cast<uint8_t>(Stage::DiagnosticHold);
 }
 
 constexpr uint8_t kFlagReady = 1U << 0;
 constexpr uint8_t kFlagSafeMode = 1U << 1;
-constexpr uint8_t kKnownFlags = kFlagReady | kFlagSafeMode;
+constexpr uint8_t kFlagDiagnosticHold = 1U << 2;
+constexpr uint8_t kKnownFlags =
+    kFlagReady | kFlagSafeMode | kFlagDiagnosticHold;
 
 // RTC no-init memory preserves this state across software, watchdog, panic,
 // brownout, and USB resets. A magic/version/size/checksum envelope makes
@@ -92,7 +102,8 @@ struct PersistentState {
   uint8_t lastFailureCompletedStage;
   uint8_t consecutiveEarlyFailures;
   uint8_t flags;
-  uint16_t reserved;
+  uint8_t lastFailureResetReason;
+  uint8_t reserved;
   uint32_t checksum;
 };
 
@@ -136,7 +147,8 @@ constexpr uint32_t checksum(const PersistentState &state) {
   hash = mixByte(hash, state.lastFailureCompletedStage);
   hash = mixByte(hash, state.consecutiveEarlyFailures);
   hash = mixByte(hash, state.flags);
-  return mixU16(hash, state.reserved);
+  hash = mixByte(hash, state.lastFailureResetReason);
+  return mixByte(hash, state.reserved);
 }
 
 inline void seal(PersistentState &state) { state.checksum = checksum(state); }
@@ -155,6 +167,7 @@ constexpr bool isValid(const PersistentState &state) {
 
   const bool ready = (state.flags & kFlagReady) != 0;
   const bool safeMode = (state.flags & kFlagSafeMode) != 0;
+  const bool diagnosticHold = (state.flags & kFlagDiagnosticHold) != 0;
   if (ready &&
       (state.activeStage != static_cast<uint8_t>(Stage::Ready) ||
        state.completedStage != static_cast<uint8_t>(Stage::Ready))) {
@@ -164,7 +177,13 @@ constexpr bool isValid(const PersistentState &state) {
       state.activeStage != static_cast<uint8_t>(Stage::SafeMode)) {
     return false;
   }
-  return !(ready && safeMode);
+  if (diagnosticHold &&
+      state.activeStage != static_cast<uint8_t>(Stage::DiagnosticHold)) {
+    return false;
+  }
+  return static_cast<unsigned>(ready) + static_cast<unsigned>(safeMode) +
+             static_cast<unsigned>(diagnosticHold) <=
+         1;
 }
 
 constexpr bool isReady(const PersistentState &state) {
@@ -173,6 +192,10 @@ constexpr bool isReady(const PersistentState &state) {
 
 constexpr bool isSafeMode(const PersistentState &state) {
   return (state.flags & kFlagSafeMode) != 0;
+}
+
+constexpr bool isDiagnosticHold(const PersistentState &state) {
+  return (state.flags & kFlagDiagnosticHold) != 0;
 }
 
 constexpr uint8_t incrementSaturating(uint8_t value) {
@@ -193,6 +216,7 @@ inline BeginResult beginBoot(PersistentState &state,
   uint8_t failures = 0;
   uint8_t lastFailure = static_cast<uint8_t>(Stage::None);
   uint8_t lastFailureCompleted = static_cast<uint8_t>(Stage::None);
+  uint8_t lastFailureResetReason = 0;
   bool failureRecorded = false;
 
   if (retainHistory) {
@@ -202,11 +226,13 @@ inline BeginResult beginBoot(PersistentState &state,
     }
     lastFailure = previous.lastFailureStage;
     lastFailureCompleted = previous.lastFailureCompletedStage;
+    lastFailureResetReason = previous.lastFailureResetReason;
 
-    if (isReady(previous)) {
+    if (isReady(previous) || isDiagnosticHold(previous)) {
       failures = 0;
       lastFailure = static_cast<uint8_t>(Stage::None);
       lastFailureCompleted = static_cast<uint8_t>(Stage::None);
+      lastFailureResetReason = 0;
     } else if (isSafeMode(previous)) {
       // Safe mode is a deliberate hold, not another failed initialization.
       failures = previous.consecutiveEarlyFailures;
@@ -214,6 +240,10 @@ inline BeginResult beginBoot(PersistentState &state,
       failures = incrementSaturating(previous.consecutiveEarlyFailures);
       lastFailure = previous.activeStage;
       lastFailureCompleted = previous.completedStage;
+      // esp_reset_reason() on this boot describes how the unfinished previous
+      // boot ended. Preserve that final cause across subsequent safe-mode
+      // resets and diagnostic rescue flashes.
+      lastFailureResetReason = static_cast<uint8_t>(resetReason);
       failureRecorded = true;
     }
   }
@@ -232,6 +262,7 @@ inline BeginResult beginBoot(PersistentState &state,
       lastFailureCompleted,
       failures,
       static_cast<uint8_t>(safeMode ? kFlagSafeMode : 0),
+      lastFailureResetReason,
       0,
       0,
   };
@@ -243,8 +274,9 @@ inline BeginResult beginBoot(PersistentState &state,
 
 inline bool enterStage(PersistentState &state, Stage stage) {
   if (!isValid(state) || isReady(state) || isSafeMode(state) ||
+      isDiagnosticHold(state) ||
       stage == Stage::None || stage == Stage::Ready ||
-      stage == Stage::SafeMode) {
+      stage == Stage::SafeMode || stage == Stage::DiagnosticHold) {
     return false;
   }
   state.activeStage = static_cast<uint8_t>(stage);
@@ -254,9 +286,10 @@ inline bool enterStage(PersistentState &state, Stage stage) {
 
 inline bool completeStage(PersistentState &state, Stage stage) {
   if (!isValid(state) || isReady(state) || isSafeMode(state) ||
+      isDiagnosticHold(state) ||
       state.activeStage != static_cast<uint8_t>(stage) ||
       stage == Stage::None || stage == Stage::Ready ||
-      stage == Stage::SafeMode) {
+      stage == Stage::SafeMode || stage == Stage::DiagnosticHold) {
     return false;
   }
   state.completedStage = static_cast<uint8_t>(stage);
@@ -266,7 +299,7 @@ inline bool completeStage(PersistentState &state, Stage stage) {
 }
 
 inline bool markReady(PersistentState &state) {
-  if (!isValid(state) || isSafeMode(state)) {
+  if (!isValid(state) || isSafeMode(state) || isDiagnosticHold(state)) {
     return false;
   }
   state.activeStage = static_cast<uint8_t>(Stage::Ready);
@@ -275,6 +308,27 @@ inline bool markReady(PersistentState &state) {
   state.lastFailureCompletedStage = static_cast<uint8_t>(Stage::None);
   state.consecutiveEarlyFailures = 0;
   state.flags = kFlagReady;
+  state.lastFailureResetReason = 0;
+  seal(state);
+  return true;
+}
+
+// Diagnostic images can intentionally stop after a partial bring-up. Record
+// that terminal state separately from full application readiness so repeated
+// probe resets neither count as crashes nor satisfy a normal ready gate.
+inline bool markDiagnosticHold(PersistentState &state) {
+  if (!isValid(state) || isReady(state) || isSafeMode(state) ||
+      isDiagnosticHold(state) ||
+      state.activeStage != static_cast<uint8_t>(Stage::None) ||
+      state.completedStage == static_cast<uint8_t>(Stage::None)) {
+    return false;
+  }
+  state.activeStage = static_cast<uint8_t>(Stage::DiagnosticHold);
+  state.lastFailureStage = static_cast<uint8_t>(Stage::None);
+  state.lastFailureCompletedStage = static_cast<uint8_t>(Stage::None);
+  state.consecutiveEarlyFailures = 0;
+  state.flags = kFlagDiagnosticHold;
+  state.lastFailureResetReason = 0;
   seal(state);
   return true;
 }

--- a/esp32/lib/firmware_metadata/firmware_metadata.cpp
+++ b/esp32/lib/firmware_metadata/firmware_metadata.cpp
@@ -12,6 +12,10 @@
 #define FLAVOR "unknown"
 #endif
 
+#ifndef BUILD_PROFILE
+#define BUILD_PROFILE "unknown"
+#endif
+
 #ifndef GIT_SHA
 #define GIT_SHA "unknown"
 #endif
@@ -44,6 +48,8 @@ static std::string jsonEscape(const std::string &value) {
 } // namespace
 
 const char *target() { return FLAVOR; }
+
+const char *buildProfile() { return BUILD_PROFILE; }
 
 const char *version() { return VERSION; }
 

--- a/esp32/lib/firmware_metadata/firmware_metadata.hpp
+++ b/esp32/lib/firmware_metadata/firmware_metadata.hpp
@@ -8,6 +8,7 @@ namespace firmware_metadata {
 static constexpr uint32_t kUpdaterProtocolVersion = 1;
 
 const char *target();
+const char *buildProfile();
 const char *version();
 uint32_t build();
 const char *gitSha();

--- a/esp32/lib/power/power.cpp
+++ b/esp32/lib/power/power.cpp
@@ -16,7 +16,6 @@
 #endif
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-#include "axp2101.hpp"
 #include "hal.hpp"
 #else
 extern const uint8_t BOARD_BOOT_PIN;
@@ -93,10 +92,6 @@ void Power::powerOffPeripherals() {
   displayPowerManager.requestState(display_power::State::Off);
   displayPowerManager.applyPendingPanelChange();
 #endif
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  waveshare_board::axp2101::setDisplayPower(false);
-  waveshare_board::axp2101::setPeripheralPower(false);
-#endif
   SPI.end();
   Wire.end();
 }
@@ -118,14 +113,7 @@ void Power::deviceSuspend() {
   lv_refr_now(display);
   displayPowerManager.requestState(display_power::State::Off);
   displayPowerManager.applyPendingPanelChange();
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  waveshare_board::axp2101::setDisplayPower(false);
-#endif
   powerLightSleep();
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  waveshare_board::axp2101::setDisplayPower(true);
-  delay(50);
-#endif
   displayPowerManager.requestState(resumeState);
   displayPowerManager.applyPendingPanelChange();
 #endif

--- a/esp32/lib/speaker/speaker.cpp
+++ b/esp32/lib/speaker/speaker.cpp
@@ -85,6 +85,8 @@ QueueHandle_t soundQueue = nullptr;
 SemaphoreHandle_t powerButtonConfigMutex = nullptr;
 bool initialized = false;
 std::atomic<bool> playbackActive{false};
+std::atomic<uint32_t> nextPlaybackRequestId{1U};
+std::atomic<uint32_t> latestPlaybackCompletionToken{0U};
 bool powerButtonHonkAvailable = false;
 bool powerButtonMonitoringConfigured = false;
 float codecHardwareGainDb = 0.0f;
@@ -103,9 +105,28 @@ constexpr char POWER_BUTTON_SOUND_KEY[] = "pwrSound";
 constexpr char POWER_BUTTON_VOLUME_KEY[] = "pwrVolume";
 
 struct QueuedPlaybackRequest {
+  uint32_t requestId;
   uint8_t sound;
   uint8_t volumePercent;
 };
+
+uint32_t allocatePlaybackRequestId() {
+  uint32_t requestId = nextPlaybackRequestId.fetch_add(
+                           1U, std::memory_order_relaxed) &
+                       kPlaybackRequestIdMask;
+  if (requestId == 0U) {
+    requestId = nextPlaybackRequestId.fetch_add(
+                    1U, std::memory_order_relaxed) &
+                kPlaybackRequestIdMask;
+  }
+  return requestId;
+}
+
+void recordPlaybackCompletion(uint32_t requestId, bool succeeded) {
+  latestPlaybackCompletionToken.store(
+      encodePlaybackCompletion(requestId, succeeded),
+      std::memory_order_release);
+}
 
 class PowerButtonConfigLock {
 public:
@@ -533,35 +554,39 @@ void speakerTask(void *) {
     power_management::ScopedLock powerLock(
         power_management::LockDomain::Audio);
     Sound sound = static_cast<Sound>(request.sound);
+    bool playbackSucceeded = false;
     if (!initializeCodec()) {
       playbackActive.store(false, std::memory_order_relaxed);
       Serial.println("Speaker: playback skipped because initialization failed");
-      continue;
-    }
-
-    playbackActive.store(true, std::memory_order_relaxed);
-    ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
-    if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
-        ESP_CODEC_DEV_OK) {
-      Serial.printf("Speaker: failed to set volume to %u%%\n",
-                    request.volumePercent);
     } else {
-      currentDacGainDb = speaker_dac_gain_db(
-          request.volumePercent, codecHardwareGainDb,
-          VOLUME_DB_AT_70_PERCENT, MAX_DAC_GAIN_DB);
-      speaker_configure_limiter(&playbackLimiter, currentDacGainDb);
-      Serial.printf("Speaker: playing sound %u at %u%% volume\n", request.sound,
-                    request.volumePercent);
-      if (!playNow(sound)) {
-        Serial.printf("Speaker: sound %u playback failed\n", request.sound);
+      playbackActive.store(true, std::memory_order_relaxed);
+      ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
+      if (esp_codec_dev_set_out_vol(speakerDevice, request.volumePercent) !=
+          ESP_CODEC_DEV_OK) {
+        Serial.printf("Speaker: failed to set volume to %u%%\n",
+                      request.volumePercent);
+      } else {
+        currentDacGainDb = speaker_dac_gain_db(
+            request.volumePercent, codecHardwareGainDb,
+            VOLUME_DB_AT_70_PERCENT, MAX_DAC_GAIN_DB);
+        speaker_configure_limiter(&playbackLimiter, currentDacGainDb);
+        Serial.printf("Speaker: playing sound %u at %u%% volume\n",
+                      request.sound, request.volumePercent);
+        playbackSucceeded = playNow(sound);
+        if (!playbackSucceeded) {
+          Serial.printf("Speaker: sound %u playback failed\n", request.sound);
+        }
       }
+      playbackActive.store(false, std::memory_order_relaxed);
+      ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
     }
-    playbackActive.store(false, std::memory_order_relaxed);
-    ui_scheduler::notify(ui_scheduler::WakeReason::Audio);
-
-    if (uxQueueMessagesWaiting(soundQueue) == 0) {
-      releaseCodecResources();
-    }
+    const bool cleanupRequired = uxQueueMessagesWaiting(soundQueue) == 0;
+    const bool cleanupSucceeded =
+        !cleanupRequired || releaseCodecResources();
+    recordPlaybackCompletion(
+        request.requestId,
+        playbackRequestLifecycleSucceeded(
+            playbackSucceeded, cleanupRequired, cleanupSucceeded));
   }
 }
 
@@ -627,12 +652,30 @@ bool isPlaying() {
 }
 
 bool requestPlay(Sound sound, uint8_t volumePercent) {
+  uint32_t requestId = 0U;
+  return requestPlayTracked(sound, volumePercent, requestId);
+}
+
+bool requestPlayTracked(Sound sound, uint8_t volumePercent,
+                        uint32_t &requestId) {
+  requestId = 0U;
   if (!isSupported(sound) || volumePercent > 100 || soundQueue == nullptr) {
     return false;
   }
 
-  QueuedPlaybackRequest request{static_cast<uint8_t>(sound), volumePercent};
-  return xQueueSend(soundQueue, &request, 0) == pdTRUE;
+  const uint32_t candidateRequestId = allocatePlaybackRequestId();
+  QueuedPlaybackRequest request{candidateRequestId,
+                                static_cast<uint8_t>(sound), volumePercent};
+  if (xQueueSend(soundQueue, &request, 0) != pdTRUE) {
+    return false;
+  }
+  requestId = candidateRequestId;
+  return true;
+}
+
+PlaybackCompletion latestPlaybackCompletion() {
+  return decodePlaybackCompletion(
+      latestPlaybackCompletionToken.load(std::memory_order_acquire));
 }
 
 bool isPowerButtonHonkAvailable() {
@@ -733,6 +776,11 @@ bool begin() { return false; }
 bool isAvailable() { return false; }
 bool isPlaying() { return false; }
 bool requestPlay(Sound, uint8_t) { return false; }
+bool requestPlayTracked(Sound, uint8_t, uint32_t &requestId) {
+  requestId = 0U;
+  return false;
+}
+PlaybackCompletion latestPlaybackCompletion() { return {0U, false}; }
 bool isSupported(Sound) { return false; }
 bool isPowerButtonHonkAvailable() { return false; }
 bool getPowerButtonHonkConfig(PowerButtonHonkConfig &) { return false; }

--- a/esp32/lib/speaker/speaker.hpp
+++ b/esp32/lib/speaker/speaker.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "speaker_playback_policy.hpp"
 #include "sound_protocol.hpp"
 
 #include <Arduino.h>
@@ -11,6 +12,9 @@ bool isAvailable();
 bool isPlaying();
 bool requestPlay(Sound sound,
                  uint8_t volumePercent = DEFAULT_VOLUME_PERCENT);
+bool requestPlayTracked(Sound sound, uint8_t volumePercent,
+                        uint32_t &requestId);
+PlaybackCompletion latestPlaybackCompletion();
 bool isSupported(Sound sound);
 bool isPowerButtonHonkAvailable();
 bool getPowerButtonHonkConfig(PowerButtonHonkConfig &config);

--- a/esp32/lib/speaker/speaker_playback_policy.hpp
+++ b/esp32/lib/speaker/speaker_playback_policy.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <cstdint>
+
+namespace waveshare_board::speaker {
+
+constexpr uint32_t kPlaybackRequestIdMask = 0x7FFFFFFFU;
+
+struct PlaybackCompletion {
+  uint32_t requestId;
+  bool succeeded;
+};
+
+enum class TrackedPlaybackResult : uint8_t {
+  Pending,
+  Succeeded,
+  Failed,
+  Superseded,
+};
+
+constexpr uint32_t encodePlaybackCompletion(uint32_t requestId,
+                                            bool succeeded) {
+  return ((requestId & kPlaybackRequestIdMask) << 1U) |
+         (succeeded ? 1U : 0U);
+}
+
+constexpr PlaybackCompletion decodePlaybackCompletion(uint32_t token) {
+  return {token >> 1U, (token & 1U) != 0U};
+}
+
+constexpr bool playbackRequestIdAfter(uint32_t candidate,
+                                      uint32_t reference) {
+  const uint32_t distance =
+      (candidate - reference) & kPlaybackRequestIdMask;
+  return distance != 0U && distance < (1U << 30U);
+}
+
+constexpr TrackedPlaybackResult classifyPlaybackCompletion(
+    uint32_t expectedRequestId, PlaybackCompletion completion) {
+  if (expectedRequestId == 0U || completion.requestId == 0U ||
+      playbackRequestIdAfter(expectedRequestId, completion.requestId)) {
+    return TrackedPlaybackResult::Pending;
+  }
+  if (completion.requestId != expectedRequestId) {
+    return TrackedPlaybackResult::Superseded;
+  }
+  return completion.succeeded ? TrackedPlaybackResult::Succeeded
+                              : TrackedPlaybackResult::Failed;
+}
+
+constexpr bool playbackRequestLifecycleSucceeded(bool playbackSucceeded,
+                                                 bool cleanupRequired,
+                                                 bool cleanupSucceeded) {
+  return playbackSucceeded && (!cleanupRequired || cleanupSucceeded);
+}
+
+} // namespace waveshare_board::speaker

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -27,8 +27,6 @@ constexpr uint8_t AXP2101_BATTERY_CURRENT_DIRECTION_MASK = 0x03;
 constexpr uint8_t AXP2101_SYSTEM_ON_MASK = 0x10;
 constexpr uint8_t AXP2101_VINDPM_ACTIVE_MASK = 0x08;
 constexpr uint8_t AXP2101_CHARGING_STATUS_MASK = 0x07;
-constexpr uint8_t AXP2101_INTERRUPT_ENABLE_1_REG = 0x41;
-constexpr uint8_t AXP2101_INTERRUPT_STATUS_1_REG = 0x49;
 constexpr uint8_t AXP2101_LDO_ENABLE_REG = 0x90;
 constexpr uint8_t AXP2101_POWER_BUTTON_SHORT_PRESS_MASK = 0x08;
 constexpr uint8_t AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK = 0x02;
@@ -40,8 +38,8 @@ constexpr uint8_t AXP2101_POWER_BUTTON_EVENT_MASK =
 
 bool writeRegister(uint8_t reg, uint8_t value) {
   if (!register_policy::isWriteAllowed(reg)) {
-    Serial.printf("AXP2101: blocked unvalidated power-rail write "
-                  "reg=0x%02X value=0x%02X\n",
+    Serial.printf("AXP_WRITE_BLOCKED schema=1 reg=0x%02X value=0x%02X "
+                  "policy=interrupt-only\n",
                   reg, value);
     return false;
   }
@@ -115,7 +113,7 @@ bool setPowerButtonEventMonitoring(bool enabled) {
   }
 
   uint8_t interruptEnable = 0;
-  if (!readRegister(AXP2101_INTERRUPT_ENABLE_1_REG, interruptEnable)) {
+  if (!readRegister(register_policy::INTERRUPT_ENABLE_1, interruptEnable)) {
     return false;
   }
 
@@ -123,14 +121,14 @@ bool setPowerButtonEventMonitoring(bool enabled) {
       enabled ? interruptEnable | AXP2101_POWER_BUTTON_EVENT_MASK
               : interruptEnable & ~AXP2101_POWER_BUTTON_EVENT_MASK;
   if (updatedInterruptEnable != interruptEnable &&
-      !writeRegister(AXP2101_INTERRUPT_ENABLE_1_REG,
+      !writeRegister(register_policy::INTERRUPT_ENABLE_1,
                      updatedInterruptEnable)) {
     return false;
   }
 
   // AXP2101 interrupt status is write-one-to-clear. Remove any stale press so
   // enabling the feature cannot immediately trigger playback.
-  return writeRegister(AXP2101_INTERRUPT_STATUS_1_REG,
+  return writeRegister(register_policy::INTERRUPT_STATUS_1,
                        AXP2101_POWER_BUTTON_EVENT_MASK);
 }
 
@@ -141,7 +139,7 @@ bool readAndClearPowerButtonEvents(PowerButtonEvents &events) {
   }
 
   uint8_t interruptStatus = 0;
-  if (!readRegister(AXP2101_INTERRUPT_STATUS_1_REG, interruptStatus)) {
+  if (!readRegister(register_policy::INTERRUPT_STATUS_1, interruptStatus)) {
     return false;
   }
   const uint8_t pendingEvents =
@@ -149,7 +147,7 @@ bool readAndClearPowerButtonEvents(PowerButtonEvents &events) {
   if (pendingEvents == 0) {
     return true;
   }
-  if (!writeRegister(AXP2101_INTERRUPT_STATUS_1_REG, pendingEvents)) {
+  if (!writeRegister(register_policy::INTERRUPT_STATUS_1, pendingEvents)) {
     return false;
   }
 
@@ -166,6 +164,7 @@ bool initializePowerState() {
   Serial.println("Probing AXP2101 without changing power rails...");
   if (!begin()) {
     Serial.println("AXP2101 not found");
+    Serial.println("BOOT_PMIC schema=1 mode=read-only available=0");
     return false;
   }
 
@@ -181,10 +180,21 @@ bool initializePowerState() {
                   status.batteryPresent ? "present" : "absent",
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoEnable, ldoReadOk ? 1 : 0);
+    Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+                  "statusRead=1 status1=0x%02X status2=0x%02X vbus=%d "
+                  "battery=%d currentDirection=%u charging=%u ldoRead=%d "
+                  "ldo=0x%02X\n",
+                  status.status1, status.status2, status.vbusGood ? 1 : 0,
+                  status.batteryPresent ? 1 : 0,
+                  status.batteryCurrentDirection, status.chargingStatus,
+                  ldoReadOk ? 1 : 0, ldoEnable);
   } else {
     Serial.printf("AXP2101: preserving factory rails; status read failed "
                   "ldo=0x%02X ldoRead=%d\n",
                   ldoEnable, ldoReadOk ? 1 : 0);
+    Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+                  "statusRead=0 ldoRead=%d ldo=0x%02X\n",
+                  ldoReadOk ? 1 : 0, ldoEnable);
   }
   return true;
 }

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -8,6 +8,7 @@
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
 #include "i2c_bus.hpp"
+#include "axp2101_register_policy.hpp"
 #include "waveshare_board.hpp"
 
 namespace waveshare_board::axp2101 {
@@ -28,6 +29,7 @@ constexpr uint8_t AXP2101_VINDPM_ACTIVE_MASK = 0x08;
 constexpr uint8_t AXP2101_CHARGING_STATUS_MASK = 0x07;
 constexpr uint8_t AXP2101_INTERRUPT_ENABLE_1_REG = 0x41;
 constexpr uint8_t AXP2101_INTERRUPT_STATUS_1_REG = 0x49;
+constexpr uint8_t AXP2101_LDO_ENABLE_REG = 0x90;
 constexpr uint8_t AXP2101_POWER_BUTTON_SHORT_PRESS_MASK = 0x08;
 constexpr uint8_t AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK = 0x02;
 constexpr uint8_t AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK = 0x01;
@@ -36,44 +38,14 @@ constexpr uint8_t AXP2101_POWER_BUTTON_EVENT_MASK =
     AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK |
     AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK;
 
-constexpr uint8_t peripheralRailRegs[] = {
-    AXP2101_ALDO1_VOLTAGE_REG, AXP2101_ALDO2_VOLTAGE_REG,
-    AXP2101_ALDO3_VOLTAGE_REG, AXP2101_ALDO4_VOLTAGE_REG,
-    AXP2101_BLDO1_VOLTAGE_REG, AXP2101_BLDO2_VOLTAGE_REG};
-
-bool writeRegisterChecked(const char *label, uint8_t reg, uint8_t value,
-                          uint8_t readbackMask = 0xFF) {
-  uint8_t readback = 0;
-  for (uint8_t attempt = 0; attempt < 2; attempt++) {
-    if (!writeRegister(reg, value)) {
-      Serial.printf("AXP2101: %s write failed reg=0x%02X value=0x%02X\n",
-                    label, reg, value);
-      return false;
-    }
-
-    delay(5);
-    if (!readRegister(reg, readback)) {
-      Serial.printf("AXP2101: %s readback failed reg=0x%02X expected=0x%02X\n",
-                    label, reg, value);
-      continue;
-    }
-
-    bool ok = (readback & readbackMask) == (value & readbackMask);
-    Serial.printf("AXP2101: %s reg=0x%02X value=0x%02X read=0x%02X mask=0x%02X %s\n",
-                  label, reg, value, readback, readbackMask,
-                  ok ? "ok" : "mismatch");
-    if (ok) {
-      return true;
-    }
+bool writeRegister(uint8_t reg, uint8_t value) {
+  if (!register_policy::isWriteAllowed(reg)) {
+    Serial.printf("AXP2101: blocked unvalidated power-rail write "
+                  "reg=0x%02X value=0x%02X\n",
+                  reg, value);
+    return false;
   }
-
-  return false;
-}
-
-uint8_t currentLdoEnableValue(uint8_t fallback) {
-  uint8_t value = fallback;
-  readRegister(AXP2101_LDO_ENABLE_REG, value);
-  return value;
+  return i2c::writeRegister8(AXP2101_ADDR, reg, value, "AXP2101");
 }
 
 } // namespace
@@ -87,10 +59,6 @@ bool isAvailable() { return pmuAvailable; }
 
 bool readRegister(uint8_t reg, uint8_t &value) {
   return i2c::readRegister8(AXP2101_ADDR, reg, value, "AXP2101");
-}
-
-bool writeRegister(uint8_t reg, uint8_t value) {
-  return i2c::writeRegister8(AXP2101_ADDR, reg, value, "AXP2101");
 }
 
 bool readPowerStatus(PowerStatus &status) {
@@ -194,70 +162,18 @@ bool readAndClearPowerButtonEvents(PowerButtonEvents &events) {
   return true;
 }
 
-bool setDisplayPower(bool enabled) {
-  uint8_t value = currentLdoEnableValue(AXP2101_KNOWN_GOOD_LDO_ENABLES);
-  Serial.printf("AXP2101: display power request enabled=%d currentLdo=0x%02X "
-                "mask=0x%02X\n",
-                enabled ? 1 : 0, value, AXP2101_DISPLAY_ENABLE_MASK);
-  if (enabled) {
-    value |= AXP2101_DISPLAY_ENABLE_MASK;
-  } else {
-    value &= ~AXP2101_DISPLAY_ENABLE_MASK;
-  }
-  return writeRegisterChecked(enabled ? "display on" : "display off",
-                              AXP2101_LDO_ENABLE_REG, value);
-}
-
-bool enableDisplayRails() { return setDisplayPower(true); }
-
-bool setPeripheralPower(bool enabled) {
-  uint8_t value = currentLdoEnableValue(
-      enabled ? AXP2101_KNOWN_GOOD_LDO_ENABLES
-              : AXP2101_MANAGED_LDO_ENABLE_MASK);
-  if (enabled) {
-    value |= AXP2101_MANAGED_LDO_ENABLE_MASK;
-  } else {
-    value &= ~AXP2101_MANAGED_LDO_ENABLE_MASK;
-  }
-  return writeRegisterChecked(enabled ? "peripheral on" : "peripheral off",
-                              AXP2101_LDO_ENABLE_REG, value);
-}
-
-bool enablePeripheralRails() {
-  bool voltageOk = true;
-  for (uint8_t reg : peripheralRailRegs) {
-    voltageOk = writeRegisterChecked("peripheral 3v3", reg,
-                                     AXP2101_LDO_VOLTAGE_3V3,
-                                     AXP2101_LDO_VOLTAGE_MASK) &&
-                voltageOk;
-  }
-
-  if (!voltageOk) {
-    Serial.println("AXP2101: peripheral voltage readback warning");
-  }
-
-  return writeRegisterChecked("peripheral on", AXP2101_LDO_ENABLE_REG,
-                              AXP2101_KNOWN_GOOD_LDO_ENABLES);
-}
-
-bool restoreDefaultRails() {
-  Serial.println("Enabling display power via AXP2101...");
+bool initializePowerState() {
+  Serial.println("Probing AXP2101 without changing power rails...");
   if (!begin()) {
-    Serial.println("AXP2101 not found - display may not work!");
+    Serial.println("AXP2101 not found");
     return false;
   }
 
-  Serial.println("AXP2101 found!");
-
-#ifdef WAVESHARE_AMOLED_206
-  // Waveshare's 2.06 Arduino display examples do not program AXP2101 rails
-  // before gfx->begin(). Preserve the PMU state during bring-up instead of
-  // reusing the 1.75 board's known-good LDO mask and voltage sequence.
   PowerStatus status;
+  uint8_t ldoEnable = 0;
+  const bool ldoReadOk = readRegister(AXP2101_LDO_ENABLE_REG, ldoEnable);
   if (readPowerStatus(status)) {
-    uint8_t ldoEnable = 0;
-    bool ldoReadOk = readRegister(AXP2101_LDO_ENABLE_REG, ldoEnable);
-    Serial.printf("AXP2101: 2.06 safe mode preserving rails; status1=0x%02X "
+    Serial.printf("AXP2101: preserving factory rails; status1=0x%02X "
                   "status2=0x%02X vbus=%s battery=%s currentDir=%u "
                   "charge=%u ldo=0x%02X ldoRead=%d\n",
                   status.status1, status.status2,
@@ -266,45 +182,11 @@ bool restoreDefaultRails() {
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoEnable, ldoReadOk ? 1 : 0);
   } else {
-    Serial.println("AXP2101: 2.06 safe mode status read failed");
+    Serial.printf("AXP2101: preserving factory rails; status read failed "
+                  "ldo=0x%02X ldoRead=%d\n",
+                  ldoEnable, ldoReadOk ? 1 : 0);
   }
-
-#ifdef WAVESHARE_206_FORCE_AXP_DISPLAY
-  Serial.println("AXP2101: 2.06 forcing display rail by explicit build flag");
-  return enableDisplayRails();
-#else
   return true;
-#endif
-#else
-  bool ok = writeRegisterChecked("ldo baseline reset", AXP2101_LDO_ENABLE_REG,
-                                 AXP2101_KNOWN_GOOD_LDO_RESET);
-  ok = writeRegisterChecked("ldo baseline on", AXP2101_LDO_ENABLE_REG,
-                            AXP2101_KNOWN_GOOD_LDO_ENABLES) &&
-       ok;
-
-  PowerStatus status;
-  if (readPowerStatus(status)) {
-    Serial.printf("AXP2101: status1=0x%02X status2=0x%02X vbus=%s battery=%s "
-                  "currentDir=%u charge=%u\n",
-                  status.status1, status.status2,
-                  status.vbusGood ? "good" : "not-good",
-                  status.batteryPresent ? "present" : "absent",
-                  status.batteryCurrentDirection, status.chargingStatus);
-  } else {
-    Serial.println("AXP2101: status read failed");
-  }
-
-  Serial.println("Configuring Peripheral Power...");
-  ok = enablePeripheralRails() && ok;
-
-  delay(500);
-  if (ok) {
-    Serial.println("AXP2101 display power enabled");
-  } else {
-    Serial.println("! AXP2101 rail setup completed with readback errors");
-  }
-  return ok;
-#endif
 }
 
 } // namespace waveshare_board::axp2101

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -161,18 +161,63 @@ bool readAndClearPowerButtonEvents(PowerButtonEvents &events) {
 }
 
 bool initializePowerState() {
-  Serial.println("Probing AXP2101 without changing power rails...");
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+  Serial.println("Probing AXP2101 with 2.06 display-enable-only recovery...");
+#else
+  Serial.println("Probing AXP2101 without changing output rails...");
+#endif
   if (!begin()) {
     Serial.println("AXP2101 not found");
-    Serial.println("BOOT_PMIC schema=1 mode=read-only available=0");
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+    Serial.println("BOOT_PMIC schema=1 mode=display-enable-only available=0 "
+                   "railState=unknown displayRecovery=0");
+#else
+    Serial.println("BOOT_PMIC schema=1 mode=read-only available=0 "
+                   "railState=unknown");
+#endif
     return false;
   }
 
   PowerStatus status;
   uint8_t ldoEnable = 0;
-  const bool ldoReadOk = readRegister(AXP2101_LDO_ENABLE_REG, ldoEnable);
-  if (readPowerStatus(status)) {
-    Serial.printf("AXP2101: preserving factory rails; status1=0x%02X "
+  bool ldoReadOk = readRegister(AXP2101_LDO_ENABLE_REG, ldoEnable);
+  const bool statusReadOk = readPowerStatus(status);
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+  i2c::Axp2101DisplayEnableResult displayEnable;
+  const bool displayRecoveryOk =
+      i2c::ensureAxp2101DisplayEnabled(displayEnable);
+  if (displayRecoveryOk) {
+    ldoEnable = displayEnable.after;
+    ldoReadOk = true;
+  }
+  Serial.printf("AXP2101: 2.06 display-enable-only recovery ok=%d changed=%d "
+                "before=0x%02X after=0x%02X\n",
+                displayRecoveryOk ? 1 : 0, displayEnable.changed ? 1 : 0,
+                displayEnable.before, displayEnable.after);
+#endif
+  if (statusReadOk) {
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+    Serial.printf("AXP2101: preserving every non-display PMIC rail bit; "
+                  "status1=0x%02X status2=0x%02X vbus=%s battery=%s "
+                  "currentDir=%u charge=%u ldo=0x%02X ldoRead=%d\n",
+                  status.status1, status.status2,
+                  status.vbusGood ? "good" : "not-good",
+                  status.batteryPresent ? "present" : "absent",
+                  status.batteryCurrentDirection, status.chargingStatus,
+                  ldoEnable, ldoReadOk ? 1 : 0);
+    Serial.printf("BOOT_PMIC schema=1 mode=display-enable-only available=1 "
+                  "railState=%s statusRead=1 status1=0x%02X status2=0x%02X "
+                  "vbus=%d battery=%d currentDirection=%u charging=%u "
+                  "ldoRead=%d ldo=0x%02X displayRecovery=%d "
+                  "displayChanged=%d\n",
+                  displayRecoveryOk ? "display-enabled" : "unknown",
+                  status.status1, status.status2, status.vbusGood ? 1 : 0,
+                  status.batteryPresent ? 1 : 0,
+                  status.batteryCurrentDirection, status.chargingStatus,
+                  ldoReadOk ? 1 : 0, ldoEnable, displayRecoveryOk ? 1 : 0,
+                  displayEnable.changed ? 1 : 0);
+#else
+    Serial.printf("AXP2101: preserving current PMIC rail state; status1=0x%02X "
                   "status2=0x%02X vbus=%s battery=%s currentDir=%u "
                   "charge=%u ldo=0x%02X ldoRead=%d\n",
                   status.status1, status.status2,
@@ -181,6 +226,7 @@ bool initializePowerState() {
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoEnable, ldoReadOk ? 1 : 0);
     Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+                  "railState=current-preserved "
                   "statusRead=1 status1=0x%02X status2=0x%02X vbus=%d "
                   "battery=%d currentDirection=%u charging=%u ldoRead=%d "
                   "ldo=0x%02X\n",
@@ -188,15 +234,34 @@ bool initializePowerState() {
                   status.batteryPresent ? 1 : 0,
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoReadOk ? 1 : 0, ldoEnable);
+#endif
   } else {
-    Serial.printf("AXP2101: preserving factory rails; status read failed "
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+    Serial.printf("AXP2101: preserving every non-display PMIC rail bit; "
+                  "status read failed ldo=0x%02X ldoRead=%d\n",
+                  ldoEnable, ldoReadOk ? 1 : 0);
+    Serial.printf("BOOT_PMIC schema=1 mode=display-enable-only available=1 "
+                  "railState=%s statusRead=0 ldoRead=%d ldo=0x%02X "
+                  "displayRecovery=%d displayChanged=%d\n",
+                  displayRecoveryOk ? "display-enabled" : "unknown",
+                  ldoReadOk ? 1 : 0, ldoEnable,
+                  displayRecoveryOk ? 1 : 0,
+                  displayEnable.changed ? 1 : 0);
+#else
+    Serial.printf("AXP2101: preserving current PMIC rail state; status read failed "
                   "ldo=0x%02X ldoRead=%d\n",
                   ldoEnable, ldoReadOk ? 1 : 0);
     Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+                  "railState=current-preserved "
                   "statusRead=0 ldoRead=%d ldo=0x%02X\n",
                   ldoReadOk ? 1 : 0, ldoEnable);
+#endif
   }
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+  return displayRecoveryOk;
+#else
   return true;
+#endif
 }
 
 } // namespace waveshare_board::axp2101

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -31,18 +31,15 @@ struct PowerButtonEvents {
 bool begin();
 bool isAvailable();
 bool readRegister(uint8_t reg, uint8_t &value);
-bool writeRegister(uint8_t reg, uint8_t value);
 bool readPowerStatus(PowerStatus &status);
 bool readBatteryStatus(uint8_t &percentage, bool &charging);
 bool readBatteryPercentage(uint8_t &percentage);
 bool setPowerButtonEventMonitoring(bool enabled);
 bool readAndClearPowerButtonEvents(PowerButtonEvents &events);
-
-bool enableDisplayRails();
-bool enablePeripheralRails();
-bool setDisplayPower(bool enabled);
-bool setPeripheralPower(bool enabled);
-bool restoreDefaultRails();
+// Probe and report the PMIC state without changing any power-rail register.
+// The board-specific rail map has not been electrically validated, so the
+// vendor/factory configuration remains authoritative.
+bool initializePowerState();
 
 } // namespace waveshare_board::axp2101
 

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -36,9 +36,11 @@ bool readBatteryStatus(uint8_t &percentage, bool &charging);
 bool readBatteryPercentage(uint8_t &percentage);
 bool setPowerButtonEventMonitoring(bool enabled);
 bool readAndClearPowerButtonEvents(PowerButtonEvents &events);
-// Probe and report the PMIC state without changing any power-rail register.
-// The board-specific rail map has not been electrically validated, so the
-// vendor/factory configuration remains authoritative.
+// Probe and report the PMIC state. The 1.75-inch target leaves every output
+// rail unchanged. The 2.06-inch target has one boot-only compatibility
+// exception: it may set the established display-enable bit while preserving
+// every other bit in that register. No target rewrites rail voltages or turns
+// an output off.
 bool initializePowerState();
 
 } // namespace waveshare_board::axp2101

--- a/esp32/lib/waveshare_board/axp2101_register_policy.hpp
+++ b/esp32/lib/waveshare_board/axp2101_register_policy.hpp
@@ -1,16 +1,25 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 
 namespace waveshare_board::axp2101::register_policy {
 
-// AXP2101 writes are fail-closed. The only validated writes are the two
-// registers needed to monitor and acknowledge PWR-button interrupts. Charger,
-// input-current, BATFET, DCDC, LDO, and every other register remain read-only
-// until a board-specific electrical validation deliberately expands this
-// allowlist.
+// Generic AXP2101 writes are fail-closed. The only validated generic writes
+// are the two registers needed to monitor and acknowledge PWR-button
+// interrupts. Charger, input-current, BATFET, DCDC, LDO, and every other
+// register remain read-only through the shared helpers. The 2.06-inch target's
+// dedicated one-way display recovery below is deliberately not part of this
+// generic allowlist.
+constexpr uint8_t DEVICE_ADDRESS = 0x34;
 constexpr uint8_t INTERRUPT_ENABLE_1 = 0x41;
 constexpr uint8_t INTERRUPT_STATUS_1 = 0x49;
+// The 2.06-inch target historically disabled this display bit before sleep and
+// relies on boot-time recovery after OTA rollback. The generic write helpers
+// still reject this register; only the dedicated one-way read/modify/write
+// operation in i2c_bus.cpp may set this bit while preserving every other bit.
+constexpr uint8_t DISPLAY_ENABLE_REGISTER_206 = 0x90;
+constexpr uint8_t DISPLAY_ENABLE_MASK_206 = 0x80;
 
 // These ranges remain named so tests and documentation can explicitly cover
 // the output-rail blocks that prompted the policy. They are not the boundary
@@ -27,6 +36,31 @@ constexpr bool isPowerRailControlRegister(uint8_t reg) {
 
 constexpr bool isWriteAllowed(uint8_t reg) {
   return reg == INTERRUPT_ENABLE_1 || reg == INTERRUPT_STATUS_1;
+}
+
+constexpr uint8_t withDisplayEnabled206(uint8_t current) {
+  return current | DISPLAY_ENABLE_MASK_206;
+}
+
+constexpr bool isDisplayEnableOnlyTransition206(uint8_t current,
+                                                uint8_t updated) {
+  return updated == withDisplayEnabled206(current) &&
+         ((current ^ updated) & ~DISPLAY_ENABLE_MASK_206) == 0;
+}
+
+// Enforce the device policy at the shared I2C boundary, not only inside the
+// AXP2101 wrapper. Other devices remain unrestricted. AXP2101 writes must use
+// one 8-bit register address and one payload byte so block/16-bit helpers cannot
+// step into adjacent, non-allowlisted registers.
+constexpr bool isTransactionWriteAllowed(uint8_t deviceAddress,
+                                         uint16_t reg,
+                                         std::size_t registerAddressBytes,
+                                         std::size_t payloadBytes) {
+  if (deviceAddress != DEVICE_ADDRESS) {
+    return true;
+  }
+  return registerAddressBytes == 1 && payloadBytes == 1 && reg <= 0xFF &&
+         isWriteAllowed(static_cast<uint8_t>(reg));
 }
 
 } // namespace waveshare_board::axp2101::register_policy

--- a/esp32/lib/waveshare_board/axp2101_register_policy.hpp
+++ b/esp32/lib/waveshare_board/axp2101_register_policy.hpp
@@ -4,11 +4,17 @@
 
 namespace waveshare_board::axp2101::register_policy {
 
-// The board schematics do not identify every populated load behind the
-// AXP2101 outputs, and the vendor display/audio examples rely on the PMIC's
-// factory/eFuse configuration. Treat every output-enable and output-voltage
-// register as read-only until a board-specific rail map is electrically
-// validated.
+// AXP2101 writes are fail-closed. The only validated writes are the two
+// registers needed to monitor and acknowledge PWR-button interrupts. Charger,
+// input-current, BATFET, DCDC, LDO, and every other register remain read-only
+// until a board-specific electrical validation deliberately expands this
+// allowlist.
+constexpr uint8_t INTERRUPT_ENABLE_1 = 0x41;
+constexpr uint8_t INTERRUPT_STATUS_1 = 0x49;
+
+// These ranges remain named so tests and documentation can explicitly cover
+// the output-rail blocks that prompted the policy. They are not the boundary
+// of the protection: all non-allowlisted addresses are blocked.
 constexpr uint8_t DCDC_CONTROL_FIRST = 0x80;
 constexpr uint8_t DCDC_CONTROL_LAST = 0x86;
 constexpr uint8_t LDO_CONTROL_FIRST = 0x90;
@@ -20,7 +26,7 @@ constexpr bool isPowerRailControlRegister(uint8_t reg) {
 }
 
 constexpr bool isWriteAllowed(uint8_t reg) {
-  return !isPowerRailControlRegister(reg);
+  return reg == INTERRUPT_ENABLE_1 || reg == INTERRUPT_STATUS_1;
 }
 
 } // namespace waveshare_board::axp2101::register_policy

--- a/esp32/lib/waveshare_board/axp2101_register_policy.hpp
+++ b/esp32/lib/waveshare_board/axp2101_register_policy.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstdint>
+
+namespace waveshare_board::axp2101::register_policy {
+
+// The board schematics do not identify every populated load behind the
+// AXP2101 outputs, and the vendor display/audio examples rely on the PMIC's
+// factory/eFuse configuration. Treat every output-enable and output-voltage
+// register as read-only until a board-specific rail map is electrically
+// validated.
+constexpr uint8_t DCDC_CONTROL_FIRST = 0x80;
+constexpr uint8_t DCDC_CONTROL_LAST = 0x86;
+constexpr uint8_t LDO_CONTROL_FIRST = 0x90;
+constexpr uint8_t LDO_CONTROL_LAST = 0x9A;
+
+constexpr bool isPowerRailControlRegister(uint8_t reg) {
+  return (reg >= DCDC_CONTROL_FIRST && reg <= DCDC_CONTROL_LAST) ||
+         (reg >= LDO_CONTROL_FIRST && reg <= LDO_CONTROL_LAST);
+}
+
+constexpr bool isWriteAllowed(uint8_t reg) {
+  return !isPowerRailControlRegister(reg);
+}
+
+} // namespace waveshare_board::axp2101::register_policy

--- a/esp32/lib/waveshare_board/i2c_bus.cpp
+++ b/esp32/lib/waveshare_board/i2c_bus.cpp
@@ -7,6 +7,7 @@
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 
+#include "axp2101_register_policy.hpp"
 #include "waveshare_board.hpp"
 #include "../power_management/power_management.hpp"
 #include <Wire.h>
@@ -18,11 +19,32 @@ namespace waveshare_board::i2c {
 
 namespace {
 
+namespace axp_policy = waveshare_board::axp2101::register_policy;
+
+static_assert(axp_policy::DEVICE_ADDRESS == AXP2101_ADDR,
+              "AXP2101 address must match the write policy");
+
 Stats i2cStats;
 bool busConfigured = false;
 uint32_t activeClockHz = DEFAULT_CLOCK_HZ;
 uint32_t lastFailureLogMs = 0;
 SemaphoreHandle_t busMutex = nullptr;
+
+bool writeAllowed(uint8_t address, uint16_t reg,
+                  std::size_t registerAddressBytes,
+                  std::size_t payloadBytes, const char *shape) {
+  if (axp_policy::isTransactionWriteAllowed(
+          address, reg, registerAddressBytes, payloadBytes)) {
+    return true;
+  }
+
+  Serial.printf("AXP_WRITE_BLOCKED schema=1 reg=0x%04X shape=%s "
+                "registerBytes=%u payloadBytes=%u policy=interrupt-only\n",
+                static_cast<unsigned>(reg), shape,
+                static_cast<unsigned>(registerAddressBytes),
+                static_cast<unsigned>(payloadBytes));
+  return false;
+}
 
 void ensureMutex() {
   if (busMutex == nullptr) {
@@ -211,6 +233,9 @@ bool probe(uint8_t address, const char *label, uint8_t attempts) {
 
 bool writeRegister8(uint8_t address, uint8_t reg, uint8_t value,
                     const char *label, uint8_t attempts) {
+  if (!writeAllowed(address, reg, 1, 1, "write8")) {
+    return false;
+  }
   return withRetries(address, label, "write8", attempts,
                      [address, reg, value]() {
                        Wire.beginTransmission(address);
@@ -223,6 +248,9 @@ bool writeRegister8(uint8_t address, uint8_t reg, uint8_t value,
 bool writeRegisterBlock8(uint8_t address, uint8_t reg, const uint8_t *data,
                          uint8_t len, const char *label, uint8_t attempts) {
   if (data == nullptr || len == 0) {
+    return false;
+  }
+  if (!writeAllowed(address, reg, 1, len, "writeBlock8")) {
     return false;
   }
 
@@ -239,6 +267,9 @@ bool writeRegisterBlock8(uint8_t address, uint8_t reg, const uint8_t *data,
 
 bool writeRegister16(uint8_t address, uint16_t reg, uint8_t value,
                      const char *label, uint8_t attempts) {
+  if (!writeAllowed(address, reg, 2, 1, "write16")) {
+    return false;
+  }
   return withRetries(address, label, "write16", attempts,
                      [address, reg, value]() {
                        Wire.beginTransmission(address);
@@ -248,6 +279,78 @@ bool writeRegister16(uint8_t address, uint16_t reg, uint8_t value,
                        return Wire.endTransmission() == 0;
                      });
 }
+
+#ifdef WAVESHARE_AMOLED_206
+bool ensureAxp2101DisplayEnabled(Axp2101DisplayEnableResult &result,
+                                uint8_t attempts) {
+  result = {};
+  bool observedInitialValue = false;
+  return withRetries(
+      axp_policy::DEVICE_ADDRESS, "AXP2101", "display-enable-only", attempts,
+      [&result, &observedInitialValue]() {
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::DISPLAY_ENABLE_REGISTER_206);
+        if (Wire.endTransmission() != 0 ||
+            Wire.requestFrom(axp_policy::DEVICE_ADDRESS,
+                             static_cast<uint8_t>(1)) != 1) {
+          return false;
+        }
+
+        const uint8_t current = Wire.read();
+        if (!observedInitialValue) {
+          result.before = current;
+          observedInitialValue = true;
+        }
+        const uint8_t updated = axp_policy::withDisplayEnabled206(current);
+        if (current == updated) {
+          result.after = current;
+          const bool valid =
+              axp_policy::isDisplayEnableOnlyTransition206(result.before,
+                                                            current);
+          if (valid) {
+            result.changed = result.before != current;
+          }
+          return valid;
+        }
+
+        if (!axp_policy::isDisplayEnableOnlyTransition206(current, updated) ||
+            !axp_policy::isDisplayEnableOnlyTransition206(result.before,
+                                                           updated)) {
+          Serial.printf("AXP_WRITE_BLOCKED schema=1 reg=0x%02X value=0x%02X "
+                        "policy=206-display-enable-only\n",
+                        axp_policy::DISPLAY_ENABLE_REGISTER_206, updated);
+          return false;
+        }
+
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::DISPLAY_ENABLE_REGISTER_206);
+        Wire.write(updated);
+        if (Wire.endTransmission() != 0) {
+          return false;
+        }
+
+        delay(5);
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::DISPLAY_ENABLE_REGISTER_206);
+        if (Wire.endTransmission() != 0 ||
+            Wire.requestFrom(axp_policy::DEVICE_ADDRESS,
+                             static_cast<uint8_t>(1)) != 1) {
+          return false;
+        }
+
+        const uint8_t readback = Wire.read();
+        result.after = readback;
+        const bool valid =
+            readback == updated &&
+            axp_policy::isDisplayEnableOnlyTransition206(result.before,
+                                                          readback);
+        if (valid) {
+          result.changed = result.before != readback;
+        }
+        return valid;
+      });
+}
+#endif
 
 bool readRegister8(uint8_t address, uint8_t reg, uint8_t &value,
                    const char *label, uint8_t attempts) {

--- a/esp32/lib/waveshare_board/i2c_bus.hpp
+++ b/esp32/lib/waveshare_board/i2c_bus.hpp
@@ -35,6 +35,20 @@ bool writeRegisterBlock8(uint8_t address, uint8_t reg, const uint8_t *data,
                          uint8_t attempts = 2);
 bool writeRegister16(uint8_t address, uint16_t reg, uint8_t value,
                      const char *label = nullptr, uint8_t attempts = 2);
+#ifdef WAVESHARE_AMOLED_206
+struct Axp2101DisplayEnableResult {
+  uint8_t before = 0;
+  uint8_t after = 0;
+  bool changed = false;
+};
+
+// One-way compatibility recovery for the 2.06-inch display. This reads the
+// current AXP2101 enable register, sets only the previously validated display
+// bit, preserves every other bit, and verifies readback. Generic AXP2101 writes
+// to this register remain blocked.
+bool ensureAxp2101DisplayEnabled(Axp2101DisplayEnableResult &result,
+                                uint8_t attempts = 3);
+#endif
 bool readRegister8(uint8_t address, uint8_t reg, uint8_t &value,
                    const char *label = nullptr, uint8_t attempts = 3);
 bool readRegisterBlock8(uint8_t address, uint8_t reg, uint8_t *data,

--- a/esp32/lib/waveshare_board/waveshare_board.cpp
+++ b/esp32/lib/waveshare_board/waveshare_board.cpp
@@ -44,8 +44,8 @@ void recoverI2CBus() {
   log_i("I2C bus recovery done (%d clocks)", clockCount);
 }
 
-void enablePowerRails() {
-  axp2101::restoreDefaultRails();
+void initializePowerManagement() {
+  axp2101::initializePowerState();
 }
 
 } // namespace waveshare_board

--- a/esp32/lib/waveshare_board/waveshare_board.hpp
+++ b/esp32/lib/waveshare_board/waveshare_board.hpp
@@ -19,32 +19,8 @@ constexpr uint8_t PCF85063_ADDR = 0x51;
 constexpr uint8_t QMI8658_ADDR_PRIMARY = 0x6B;
 constexpr uint8_t QMI8658_ADDR_FALLBACK = 0x6A;
 
-constexpr uint8_t AXP2101_LDO_ENABLE_REG = 0x90;
-constexpr uint8_t AXP2101_ALDO1_VOLTAGE_REG = 0x92;
-constexpr uint8_t AXP2101_ALDO2_VOLTAGE_REG = 0x93;
-constexpr uint8_t AXP2101_ALDO3_VOLTAGE_REG = 0x94;
-constexpr uint8_t AXP2101_ALDO4_VOLTAGE_REG = 0x95;
-constexpr uint8_t AXP2101_BLDO1_VOLTAGE_REG = 0x96;
-constexpr uint8_t AXP2101_BLDO2_VOLTAGE_REG = 0x97;
-constexpr uint8_t AXP2101_LDO_VOLTAGE_3V3 = 0x1C;
-constexpr uint8_t AXP2101_LDO_VOLTAGE_MASK = 0x1F;
-constexpr uint8_t AXP2101_DISPLAY_ENABLE_MASK = 0x80;
-constexpr uint8_t AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK = 0x1C;
-#ifdef WAVESHARE_AMOLED_175
-constexpr uint8_t AXP2101_AUDIO_ENABLE_MASK = 0x01;
-constexpr uint8_t AXP2101_MANAGED_LDO_ENABLE_MASK =
-    AXP2101_AUDIO_ENABLE_MASK | AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK;
-constexpr uint8_t AXP2101_KNOWN_GOOD_LDO_ENABLES =
-    AXP2101_DISPLAY_ENABLE_MASK | AXP2101_MANAGED_LDO_ENABLE_MASK;
-#else
-constexpr uint8_t AXP2101_MANAGED_LDO_ENABLE_MASK =
-    AXP2101_MANAGED_PERIPHERAL_ENABLE_MASK;
-constexpr uint8_t AXP2101_KNOWN_GOOD_LDO_ENABLES = 0x9C;
-#endif
-constexpr uint8_t AXP2101_KNOWN_GOOD_LDO_RESET = 0x1C;
-
 void recoverI2CBus();
-void enablePowerRails();
+void initializePowerManagement();
 
 } // namespace waveshare_board
 

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -355,7 +355,6 @@ board_build.embed_files =
 build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_206
-  -DWAVESHARE_206_FORCE_AXP_DISPLAY=1
 
 [env:WAVESHARE_AMOLED_206]
 extends = waveshare_amoled_206_base

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -271,6 +271,7 @@ build_flags =
 
 [waveshare_amoled_175_base]
 extends = waveshare_amoled_common
+custom_firmware_target = WAVESHARE_AMOLED_175
 board_build.embed_files =
   lib/speaker/assets/real_bike_horn.pcm
   lib/speaker/assets/rotating_bike_bell.pcm
@@ -300,7 +301,6 @@ build_flags =
 ; passes the physical BLE/display/touch/storage/audio/transfer soak gates.
 [env:WAVESHARE_AMOLED_175_LIGHT_SLEEP]
 extends = env:WAVESHARE_AMOLED_175_POWER_METRICS
-custom_firmware_target = WAVESHARE_AMOLED_175
 custom_sdkconfig =
   CONFIG_PM_ENABLE=y
   CONFIG_PM_DFS_INIT_AUTO=n
@@ -313,7 +313,6 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_175_PRODUCTION]
 extends = waveshare_amoled_175_base
-custom_firmware_target = WAVESHARE_AMOLED_175
 build_unflags =
   ${waveshare_amoled_common.build_unflags}
 build_flags =
@@ -348,6 +347,7 @@ build_src_filter =
 
 [waveshare_amoled_206_base]
 extends = waveshare_amoled_common
+custom_firmware_target = WAVESHARE_AMOLED_206
 board_build.embed_files =
   lib/speaker/assets/real_bike_horn.pcm
   lib/speaker/assets/rotating_bike_bell.pcm
@@ -355,6 +355,10 @@ board_build.embed_files =
 build_flags =
   ${waveshare_amoled_common.build_flags}
   -DWAVESHARE_AMOLED_206
+  ; One-way boot compatibility recovery for images that inherit the display
+  ; enable bit cleared by older 2.06 firmware. The implementation may only set
+  ; register 0x90 bit 0x80 and must preserve every other PMIC bit.
+  -DWAVESHARE_206_FORCE_AXP_DISPLAY=1
 
 [env:WAVESHARE_AMOLED_206]
 extends = waveshare_amoled_206_base
@@ -374,7 +378,6 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_206_LIGHT_SLEEP]
 extends = env:WAVESHARE_AMOLED_206_POWER_METRICS
-custom_firmware_target = WAVESHARE_AMOLED_206
 custom_sdkconfig =
   CONFIG_PM_ENABLE=y
   CONFIG_PM_DFS_INIT_AUTO=n
@@ -388,7 +391,6 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_206_PRODUCTION]
 extends = waveshare_amoled_206_base
-custom_firmware_target = WAVESHARE_AMOLED_206
 build_unflags =
   ${waveshare_amoled_common.build_unflags}
 build_flags =
@@ -412,6 +414,7 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_206_VENDOR_HELLO]
 extends = waveshare_amoled_common
+custom_firmware_target = WAVESHARE_AMOLED_206
 lib_deps =
   moononournation/GFX Library for Arduino @ ^1.6.0
 build_src_filter =

--- a/esp32/prebuild.py
+++ b/esp32/prebuild.py
@@ -136,6 +136,7 @@ env.Append(BUILD_FLAGS=[
     u'-DREVISION=' + revision + '',
     u'-DVERSION=\\"' + version + '\\"',
     u'-DFLAVOR=\\"' + firmware_target + '\\"',
+    u'-DBUILD_PROFILE=\\"' + flavor + '\\"',
     u'-DGIT_SHA=\\"' + git_sha + '\\"',
     u'-DBUILD_TIMESTAMP=\\"' + build_timestamp + '\\"',
     u'-D'+ flavor + '=1'

--- a/esp32/speaker_honk_test.cpp
+++ b/esp32/speaker_honk_test.cpp
@@ -1,5 +1,6 @@
 #include <Arduino.h>
 
+#include "boot_diagnostics.hpp"
 #include "i2c_bus.hpp"
 #include "speaker.hpp"
 #include "waveshare_board.hpp"
@@ -10,6 +11,8 @@ using waveshare_board::speaker::Sound;
 
 constexpr uint8_t TEST_VOLUME_PERCENT = 60;
 constexpr uint32_t PLAYBACK_INTERVAL_MS = 5000;
+constexpr uint32_t STARTUP_PLAYBACK_START_TIMEOUT_MS = 5000;
+constexpr uint32_t STARTUP_PLAYBACK_FINISH_TIMEOUT_MS = 15000;
 constexpr Sound TEST_SOUNDS[] = {
     Sound::BellDing,
     Sound::PlasticBicycleHorn,
@@ -18,20 +21,47 @@ constexpr Sound TEST_SOUNDS[] = {
 };
 
 size_t nextSoundIndex = 0;
+size_t startupSoundsCompleted = 0;
 uint32_t lastPlaybackMs = 0;
+uint32_t playbackRequestedMs = 0;
+uint8_t currentSoundId = 0;
+bool testInitialized = false;
+bool testReady = false;
+bool awaitingPlayback = false;
+bool observedPlaybackActive = false;
+uint32_t currentPlaybackRequestId = 0;
 
 } // namespace
 
 void setup() {
+  const size_t configuredSerialTxBufferSize =
+      Serial.setTxBufferSize(boot_diagnostics::kStructuredSerialTxBufferSize);
   Serial.begin(115200);
   Serial.setTxTimeoutMs(1);
   delay(1500);
+  if (configuredSerialTxBufferSize !=
+      boot_diagnostics::kStructuredSerialTxBufferSize) {
+    Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 operation=serial_buffer "
+                  "configured=%u required=%u\n",
+                  static_cast<unsigned>(configuredSerialTxBufferSize),
+                  static_cast<unsigned>(
+                      boot_diagnostics::kStructuredSerialTxBufferSize));
+  }
+
+  boot_diagnostics::begin();
+  if (boot_diagnostics::safeModeActive()) {
+    return;
+  }
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Startup);
   Serial.println("Waveshare AMOLED production speaker smoke test");
 
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::I2cBus);
   waveshare_board::i2c::configureBus();
-#ifdef WAVESHARE_AMOLED_175
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::I2cBus);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::PmicInspection);
   waveshare_board::initializePowerManagement();
-#endif
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::PmicInspection);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Speaker);
   if (!waveshare_board::speaker::begin()) {
     Serial.println("Speaker test: initialization failed");
     return;
@@ -39,11 +69,91 @@ void setup() {
 
   Serial.printf("Speaker test: cycling sound IDs 1, 2, 3, 5 at %u%% volume\n",
                 TEST_VOLUME_PERCENT);
+  Serial.println(
+      "Speaker test: first complete cycle must finish before boot readiness");
   lastPlaybackMs = millis() - PLAYBACK_INTERVAL_MS;
+  testInitialized = true;
 }
 
 void loop() {
+  if (!testInitialized) {
+    delay(1000);
+    return;
+  }
+
   const uint32_t now = millis();
+
+  if (!testReady && awaitingPlayback) {
+    if (waveshare_board::speaker::isPlaying()) {
+      observedPlaybackActive = true;
+    }
+
+    const waveshare_board::speaker::TrackedPlaybackResult playbackResult =
+        waveshare_board::speaker::classifyPlaybackCompletion(
+            currentPlaybackRequestId,
+            waveshare_board::speaker::latestPlaybackCompletion());
+    if (playbackResult ==
+        waveshare_board::speaker::TrackedPlaybackResult::Succeeded) {
+      awaitingPlayback = false;
+      startupSoundsCompleted++;
+      Serial.printf("Speaker test: startup playback %u/%u completed\n",
+                    static_cast<unsigned>(startupSoundsCompleted),
+                    static_cast<unsigned>(sizeof(TEST_SOUNDS) /
+                                          sizeof(TEST_SOUNDS[0])));
+      if (startupSoundsCompleted ==
+          sizeof(TEST_SOUNDS) / sizeof(TEST_SOUNDS[0])) {
+        boot_diagnostics::completeStage(boot_diagnostics::Stage::Speaker);
+        boot_diagnostics::enterStage(boot_diagnostics::Stage::Finalization);
+        boot_diagnostics::completeStage(
+            boot_diagnostics::Stage::Finalization);
+        boot_diagnostics::markReady();
+        testReady = true;
+        lastPlaybackMs = now;
+        Serial.println("Speaker test: guarded startup cycle complete");
+      }
+    } else if (playbackResult ==
+                   waveshare_board::speaker::TrackedPlaybackResult::Failed ||
+               playbackResult == waveshare_board::speaker::
+                                     TrackedPlaybackResult::Superseded) {
+      Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 "
+                    "operation=speaker_startup_playback phase=result "
+                    "sound=%u request=%lu result=%s\n",
+                    currentSoundId,
+                    static_cast<unsigned long>(currentPlaybackRequestId),
+                    playbackResult == waveshare_board::speaker::
+                                          TrackedPlaybackResult::Failed
+                        ? "failed"
+                        : "superseded");
+      awaitingPlayback = false;
+      testInitialized = false;
+    } else if (!observedPlaybackActive &&
+               now - playbackRequestedMs >=
+                   STARTUP_PLAYBACK_START_TIMEOUT_MS) {
+      Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 "
+                    "operation=speaker_startup_playback phase=start "
+                    "sound=%u timeoutMs=%lu\n",
+                    currentSoundId,
+                    static_cast<unsigned long>(
+                        STARTUP_PLAYBACK_START_TIMEOUT_MS));
+      awaitingPlayback = false;
+      testInitialized = false;
+    }
+
+    if (!testReady && awaitingPlayback && observedPlaybackActive &&
+        now - playbackRequestedMs >= STARTUP_PLAYBACK_FINISH_TIMEOUT_MS) {
+      Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 "
+                    "operation=speaker_startup_playback phase=finish "
+                    "sound=%u timeoutMs=%lu\n",
+                    currentSoundId,
+                    static_cast<unsigned long>(
+                        STARTUP_PLAYBACK_FINISH_TIMEOUT_MS));
+      awaitingPlayback = false;
+      testInitialized = false;
+    }
+    delay(20);
+    return;
+  }
+
   if (now - lastPlaybackMs < PLAYBACK_INTERVAL_MS) {
     delay(20);
     return;
@@ -51,10 +161,30 @@ void loop() {
 
   const Sound sound = TEST_SOUNDS[nextSoundIndex];
   const uint8_t soundId = static_cast<uint8_t>(sound);
-  if (waveshare_board::speaker::requestPlay(sound, TEST_VOLUME_PERCENT)) {
+  uint32_t requestId = 0;
+  const bool queued = !testReady
+                          ? waveshare_board::speaker::requestPlayTracked(
+                                sound, TEST_VOLUME_PERCENT, requestId)
+                          : waveshare_board::speaker::requestPlay(
+                                sound, TEST_VOLUME_PERCENT);
+  if (queued) {
     Serial.printf("Speaker test: queued sound ID %u\n", soundId);
+    if (!testReady) {
+      awaitingPlayback = true;
+      observedPlaybackActive = false;
+      playbackRequestedMs = now;
+      currentSoundId = soundId;
+      currentPlaybackRequestId = requestId;
+    }
   } else {
     Serial.printf("Speaker test: failed to queue sound ID %u\n", soundId);
+    if (!testReady) {
+      Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 "
+                    "operation=speaker_startup_playback phase=queue "
+                    "sound=%u\n",
+                    soundId);
+      testInitialized = false;
+    }
   }
 
   nextSoundIndex = (nextSoundIndex + 1) %

--- a/esp32/speaker_honk_test.cpp
+++ b/esp32/speaker_honk_test.cpp
@@ -30,7 +30,7 @@ void setup() {
 
   waveshare_board::i2c::configureBus();
 #ifdef WAVESHARE_AMOLED_175
-  waveshare_board::enablePowerRails();
+  waveshare_board::initializePowerManagement();
 #endif
   if (!waveshare_board::speaker::begin()) {
     Serial.println("Speaker test: initialization failed");

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -75,6 +75,7 @@ extern xSemaphoreHandle gpsMutex;
 // BLE Navigation for iOS route overlay
 #include "ble_navigation.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+#include "boot_diagnostics.hpp"
 #include "display_inactivity_policy.hpp"
 #include "display_power.hpp"
 #endif
@@ -1030,12 +1031,31 @@ void setup() {
                   static_cast<unsigned>(kPowerMetricsSerialTxBufferSize));
   }
 #endif
+#if FIRMWARE_DIAGNOSTICS
+  // Delay before the first structured marker so a post-flash USB CDC monitor
+  // can attach without missing firmware identity or the first boot stage.
+  delay(2000);
+#endif
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::begin();
+  if (boot_diagnostics::safeModeActive()) {
+    // setup() returns into a deliberately inert loop. No I2C, PMIC, display,
+    // storage, speaker, radio, or charging-control initialization is attempted.
+    return;
+  }
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Startup);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::CoreServices);
+#endif
   power_metrics::begin();
   power.begin();
   power_management::begin();
   // Arduino setup() and loop() share the same FreeRTOS task. Bind it before
   // enabling BLE, touch, BOOT, audio, or transfer publishers.
   ui_scheduler::bindCurrentTask();
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::CoreServices);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::WakeConfiguration);
+#endif
 #if AUTOMATIC_LIGHT_SLEEP_EXPERIMENT &&                                      \
     (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206))
   power_management::setGpioWakeNotifier(notifyAutomaticLightSleepGpioWake);
@@ -1043,12 +1063,7 @@ void setup() {
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
   displayPowerManager.begin();
 #endif
-#if FIRMWARE_DIAGNOSTICS
-  delay(2000); // Give a diagnostic USB CDC monitor time to attach.
-#endif
   log_i("Starting Setup...");
-  Serial.printf("Reset reason: CPU0=%d CPU1=%d\n", esp_reset_reason(),
-                esp_reset_reason());
 
 #ifdef WAVESHARE_AMOLED_175
   // Configure Wire directly below; do not preemptively bit-bang the shared bus.
@@ -1074,6 +1089,10 @@ void setup() {
   gpio_deep_sleep_hold_dis();
 #endif
 #endif
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(
+      boot_diagnostics::Stage::WakeConfiguration);
+#endif
 
 #ifdef TDECK_ESP32S3
   pinMode(BOARD_POWERON, OUTPUT);
@@ -1097,10 +1116,16 @@ void setup() {
 #ifdef WAVESHARE_AMOLED_206
   // Recover the shared bus before PMIC inspection on the 2.06-inch board.
   // Power-output registers remain at their factory/eFuse configuration.
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::I2cBus);
   waveshare_board::recoverI2CBus();
   waveshare_board::i2c::configureBus();
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::I2cBus);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::PmicInspection);
   waveshare_board::initializePowerManagement();
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::PmicInspection);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Display);
   initTFT();
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Display);
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare 2.06 display probe complete; holding before I2C/PMU/SD/LVGL/BLE/touch init");
   while (true) {
@@ -1110,17 +1135,22 @@ void setup() {
 #endif
 
 #if defined(WAVESHARE_AMOLED_175)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::I2cBus);
   waveshare_board::i2c::configureBus();
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::I2cBus);
 #elif !defined(WAVESHARE_AMOLED_206)
   Wire.setPins(I2C_SDA_PIN, I2C_SCL_PIN);
   Wire.begin();
 #endif
 
 #if defined(WAVESHARE_AMOLED_175)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::PmicInspection);
   waveshare_board::initializePowerManagement();
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::PmicInspection);
 #endif
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::ClockAndSensors);
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare display probe: skipping RTC and IMU init");
 #else
@@ -1146,13 +1176,23 @@ void setup() {
 #endif
 
   battery.initADC();
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(
+      boot_diagnostics::Stage::ClockAndSensors);
+#endif
 
   // IMPORTANT: Initialize TFT BEFORE SD card!
   // The QSPI display init can disrupt SPI bus settings.
   // By initializing display first, the SPI buses are settled
   // before we configure the SD card.
 #ifndef WAVESHARE_AMOLED_206
+#if defined(WAVESHARE_AMOLED_175)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Display);
+#endif
   initTFT();
+#if defined(WAVESHARE_AMOLED_175)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Display);
+#endif
 
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare display probe complete; holding before SD/LVGL/BLE/touch init");
@@ -1163,12 +1203,19 @@ void setup() {
 #endif
 
   // Now initialize SD card after display is fully configured
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Storage);
+#endif
   esp_err_t sdResult = storage.initSD();
   if (sdResult != ESP_OK) {
     // SD card failed - fall back to internal FFat storage
     Serial.println("SD Card failed, falling back to FFat...");
     storage.initSPIFFS();
   }
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Storage);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::MapRecovery);
+#endif
 
   {
     map_transfer::MapTransferInstaller mapInstaller("/sdcard");
@@ -1214,6 +1261,11 @@ void setup() {
                     activeStatus.code.c_str(), activeStatus.message.c_str());
     }
   }
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::MapRecovery);
+  boot_diagnostics::enterStage(
+      boot_diagnostics::Stage::ApplicationServices);
+#endif
   deviceTransferHttp.configure(8080, "BikeComputer-Transfer");
   mapTransferHttp.configure("/sdcard", 8080, &deviceTransferHttp);
   mapTransferHttp.setStreamStorageProbe(
@@ -1230,6 +1282,11 @@ void setup() {
   loadPreferences();
 #ifdef HAS_HARDWARE_GPS
   gps.init();
+#endif
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(
+      boot_diagnostics::Stage::ApplicationServices);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::UserInterface);
 #endif
   initLVGL();
   log_i("Checkpoint A: LVGL Init Done");
@@ -1272,16 +1329,28 @@ void setup() {
 
   log_i("Loading Splash Screen...");
   splashScreen();
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::UserInterface);
+#endif
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Speaker);
   waveshare_board::speaker::begin();
   if (!waveshare_board::axp2101::setPowerButtonEventMonitoring(true)) {
     Serial.println("AXP2101: PWR button-event monitoring unavailable");
   }
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Speaker);
 #endif
 
   // Initialize BLE early so device is discoverable while showing waiting screen
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Ble);
+#endif
   bleNavServer.init("BikeComputer");
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Ble);
+  boot_diagnostics::enterStage(boot_diagnostics::Stage::Finalization);
+#endif
 
   // Set default coordinates as fallback (will be overwritten by BLE GPS)
 #if defined(DEFAULT_LAT) && defined(DEFAULT_LON)
@@ -1303,6 +1372,10 @@ void setup() {
   firmwareUpdateHttp.markRunningAppValid();
   mapTransferHttp.resumePendingActivations();
   power_management::completeStartup();
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  boot_diagnostics::completeStage(boot_diagnostics::Stage::Finalization);
+  boot_diagnostics::markReady();
+#endif
 }
 
 /**
@@ -1310,6 +1383,12 @@ void setup() {
  *
  */
 void loop() {
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  if (boot_diagnostics::safeModeActive()) {
+    delay(1000);
+    return;
+  }
+#endif
   uint32_t now = millis();
   const uint32_t wakeReasons =
       pendingUiWakeReasons | ui_scheduler::wait(0);

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -1010,13 +1010,20 @@ void setup() {
   esp_log_level_set("*", ESP_LOG_NONE);
 #endif
 
-  // Initialize Serial for debug. A complete PWRMET report is larger than the
-  // default 256-byte HWCDC queue, so metrics builds reserve enough space for
-  // one atomic report while keeping the normal firmware footprint unchanged.
-#if POWER_METRICS
-  constexpr size_t kPowerMetricsSerialTxBufferSize = 4096;
+  // Initialize Serial for debug. BOOT_PREVIOUS and complete PWRMET reports are
+  // larger than the default 256-byte HWCDC queue. Reserve enough room before
+  // opening USB CDC so the host-attach window cannot truncate their tails.
+#if POWER_METRICS ||                                                         \
+    (FIRMWARE_DIAGNOSTICS &&                                                \
+     (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)))
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
+  constexpr size_t kSerialTxBufferSize =
+      boot_diagnostics::kStructuredSerialTxBufferSize;
+#else
+  constexpr size_t kSerialTxBufferSize = 4096;
+#endif
   const size_t configuredSerialTxBufferSize =
-      Serial.setTxBufferSize(kPowerMetricsSerialTxBufferSize);
+      Serial.setTxBufferSize(kSerialTxBufferSize);
 #endif
 #if FIRMWARE_DIAGNOSTICS || POWER_METRICS
   Serial.begin(115200);
@@ -1025,10 +1032,18 @@ void setup() {
   Serial.setTxTimeoutMs(1);
 #endif
 #if POWER_METRICS
-  if (configuredSerialTxBufferSize != kPowerMetricsSerialTxBufferSize) {
+  if (configuredSerialTxBufferSize != kSerialTxBufferSize) {
     Serial.printf("PWRMET_ERROR txBuffer=%u/%u\n",
                   static_cast<unsigned>(configuredSerialTxBufferSize),
-                  static_cast<unsigned>(kPowerMetricsSerialTxBufferSize));
+                  static_cast<unsigned>(kSerialTxBufferSize));
+  }
+#elif FIRMWARE_DIAGNOSTICS &&                                               \
+    (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206))
+  if (configuredSerialTxBufferSize != kSerialTxBufferSize) {
+    Serial.printf("BOOT_DIAGNOSTICS_ERROR schema=1 operation=serial_buffer "
+                  "configured=%u required=%u\n",
+                  static_cast<unsigned>(configuredSerialTxBufferSize),
+                  static_cast<unsigned>(kSerialTxBufferSize));
   }
 #endif
 #if FIRMWARE_DIAGNOSTICS
@@ -1115,7 +1130,8 @@ void setup() {
 
 #ifdef WAVESHARE_AMOLED_206
   // Recover the shared bus before PMIC inspection on the 2.06-inch board.
-  // Power-output registers remain at their factory/eFuse configuration.
+  // PMIC inspection may set only the established display-enable bit for
+  // compatibility with older images; every other output bit remains intact.
   boot_diagnostics::enterStage(boot_diagnostics::Stage::I2cBus);
   waveshare_board::recoverI2CBus();
   waveshare_board::i2c::configureBus();
@@ -1127,7 +1143,8 @@ void setup() {
   initTFT();
   boot_diagnostics::completeStage(boot_diagnostics::Stage::Display);
 #ifdef WAVESHARE_DISPLAY_PROBE
-  Serial.println("Waveshare 2.06 display probe complete; holding before I2C/PMU/SD/LVGL/BLE/touch init");
+  boot_diagnostics::markDiagnosticHold();
+  Serial.println("Waveshare 2.06 display probe complete; holding before RTC/IMU/SD/LVGL/BLE/touch init");
   while (true) {
     delay(1000);
   }
@@ -1195,6 +1212,7 @@ void setup() {
 #endif
 
 #ifdef WAVESHARE_DISPLAY_PROBE
+  boot_diagnostics::markDiagnosticHold();
   Serial.println("Waveshare display probe complete; holding before SD/LVGL/BLE/touch init");
   while (true) {
     delay(1000);

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -1095,11 +1095,11 @@ void setup() {
 #endif
 
 #ifdef WAVESHARE_AMOLED_206
-  // OTA rollback/recovery can leave the PMU display rail off. Bring the rail
-  // up before CO5300 init so the panel does not stay black after a bad image.
+  // Recover the shared bus before PMIC inspection on the 2.06-inch board.
+  // Power-output registers remain at their factory/eFuse configuration.
   waveshare_board::recoverI2CBus();
   waveshare_board::i2c::configureBus();
-  waveshare_board::enablePowerRails();
+  waveshare_board::initializePowerManagement();
   initTFT();
 #ifdef WAVESHARE_DISPLAY_PROBE
   Serial.println("Waveshare 2.06 display probe complete; holding before I2C/PMU/SD/LVGL/BLE/touch init");
@@ -1117,7 +1117,7 @@ void setup() {
 #endif
 
 #if defined(WAVESHARE_AMOLED_175)
-  waveshare_board::enablePowerRails();
+  waveshare_board::initializePowerManagement();
 #endif
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Build a real PlatformIO firmware target across pioarduino bootstrap passes."""
+
+from __future__ import annotations
+
+import argparse
+import configparser
+import os
+import re
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Callable, Sequence
+
+
+ENVIRONMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+PIOARDUINO_DUMMY_SIGNATURES = {
+    "CMakeLists.txt": (
+        'idf_component_register(SRCS "sketch.cpp" "arduino-lib-builder-gcc.c" '
+        '"arduino-lib-builder-cpp.cpp" "arduino-lib-builder-as.S" '
+        'INCLUDE_DIRS ".")'
+    ),
+    "sketch.cpp": "void setup()",
+}
+PIOARDUINO_DUMMY_REQUIRED_FILES = {
+    "CMakeLists.txt",
+    "idf_component.yml",
+    "sketch.cpp",
+    "arduino-lib-builder-gcc.c",
+    "arduino-lib-builder-cpp.cpp",
+    "arduino-lib-builder-as.S",
+}
+
+
+class BuildError(RuntimeError):
+    """Raised when a deterministic real-target build cannot be confirmed."""
+
+
+def _validate_environment(project_dir: Path, environment: str) -> None:
+    if not ENVIRONMENT_PATTERN.fullmatch(environment):
+        raise BuildError(f"invalid PlatformIO environment: {environment!r}")
+
+    config_path = project_dir / "platformio.ini"
+    if not config_path.is_file():
+        raise BuildError(f"PlatformIO project file is missing: {config_path}")
+
+    config = configparser.ConfigParser(interpolation=None)
+    config.read(config_path)
+    if not config.has_section(f"env:{environment}"):
+        raise BuildError(f"unknown PlatformIO environment: {environment}")
+
+
+def _is_pioarduino_dummy(dummy_dir: Path) -> bool:
+    if dummy_dir.is_symlink() or not dummy_dir.is_dir():
+        return False
+    if not all(
+        (dummy_dir / name).is_file()
+        for name in PIOARDUINO_DUMMY_REQUIRED_FILES
+    ):
+        return False
+    for name, signature in PIOARDUINO_DUMMY_SIGNATURES.items():
+        if signature not in (dummy_dir / name).read_text(encoding="utf-8"):
+            return False
+    return True
+
+
+def _remove_pioarduino_dummy(project_dir: Path) -> bool:
+    dummy_dir = project_dir / ".dummy"
+    if not os.path.lexists(dummy_dir):
+        return False
+    if not _is_pioarduino_dummy(dummy_dir):
+        raise BuildError(
+            f"refusing to remove unrecognized project artifact: {dummy_dir}"
+        )
+    shutil.rmtree(dummy_dir)
+    return True
+
+
+def _remove_environment_build(project_dir: Path, environment: str) -> None:
+    pio_dir = project_dir / ".pio"
+    build_root = pio_dir / "build"
+    target_dir = build_root / environment
+    for parent in (pio_dir, build_root):
+        if parent.is_symlink():
+            raise BuildError(f"refusing to clean through symlink: {parent}")
+    if not os.path.lexists(target_dir):
+        return
+    if target_dir.is_symlink() or not target_dir.is_dir():
+        raise BuildError(f"refusing to remove unexpected build artifact: {target_dir}")
+    shutil.rmtree(target_dir)
+
+
+def build_firmware(
+    project_dir: Path,
+    environment: str,
+    *,
+    pio_command: str = "pio",
+    max_passes: int = 3,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> Path:
+    """Build ``environment`` and return its verified firmware ELF path.
+
+    pioarduino may use the first PlatformIO invocation to compile a custom
+    Arduino core. During that invocation it replaces the project source with a
+    generated ``.dummy`` sketch. PlatformIO can either return success for that
+    sketch or fail later when an external source filter also defines Arduino's
+    entry points. In both cases a clean second invocation is required.
+    """
+
+    project_dir = project_dir.resolve()
+    if max_passes < 1:
+        raise BuildError("max_passes must be at least 1")
+    _validate_environment(project_dir, environment)
+    _remove_pioarduino_dummy(project_dir)
+    _remove_environment_build(project_dir, environment)
+
+    command: Sequence[str] = (pio_command, "run", "-e", environment)
+    firmware_elf = project_dir / ".pio" / "build" / environment / "firmware.elf"
+
+    for pass_number in range(1, max_passes + 1):
+        print(
+            f"=== PlatformIO real-target build: {environment} "
+            f"(pass {pass_number}/{max_passes}) ===",
+            flush=True,
+        )
+        try:
+            result = runner(command, cwd=project_dir)
+        except OSError as error:
+            raise BuildError(f"could not run {pio_command!r}: {error}") from error
+
+        if os.path.lexists(project_dir / ".dummy"):
+            _remove_pioarduino_dummy(project_dir)
+            _remove_environment_build(project_dir, environment)
+            if pass_number == max_passes:
+                raise BuildError(
+                    "pioarduino custom-core bootstrap did not converge after "
+                    f"{max_passes} passes"
+                )
+            print(
+                "Detected pioarduino custom-core bootstrap; rebuilding the real "
+                "firmware target.",
+                flush=True,
+            )
+            continue
+
+        if result.returncode != 0:
+            raise BuildError(
+                f"PlatformIO exited with status {result.returncode} while building "
+                f"{environment}"
+            )
+        if not firmware_elf.is_file():
+            raise BuildError(
+                "PlatformIO returned success without the expected real-target "
+                f"artifact: {firmware_elf}"
+            )
+
+        print(f"Verified real firmware artifact: {firmware_elf}", flush=True)
+        return firmware_elf
+
+    raise AssertionError("unreachable")
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("environment", help="PlatformIO environment to build")
+    parser.add_argument(
+        "--project-dir",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="PlatformIO project directory (default: esp32/)",
+    )
+    parser.add_argument(
+        "--pio",
+        default=os.environ.get("PLATFORMIO_CMD", "pio"),
+        help="PlatformIO executable (default: pio or PLATFORMIO_CMD)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        build_firmware(args.project_dir, args.environment, pio_command=args.pio)
+    except BuildError as error:
+        print(f"Firmware build failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esp32/tools/capture_boot.py
+++ b/esp32/tools/capture_boot.py
@@ -11,8 +11,16 @@ import time
 from dataclasses import dataclass
 
 
+_POST_READY_BOOT_RECORD_MARKERS = (
+    "BOOT_PREVIOUS",
+    "BOOT_FAILURE",
+    "BOOT_PMIC",
+    "BOOT_SAFE_MODE",
+)
+
+
 def _fields(line: str, marker: str) -> dict[str, str] | None:
-    if not line.startswith(f"{marker} "):
+    if line != marker and not line.startswith(f"{marker} "):
         return None
     parsed: dict[str, str] = {}
     for token in line.split()[1:]:
@@ -38,6 +46,8 @@ class BootSummary:
     failure: dict[str, str]
     pmic: dict[str, str]
     ready: bool
+    sequence_mismatches: int
+    boot_discontinuities: int
     blocked_writes: int
     diagnostic_errors: int
 
@@ -50,23 +60,57 @@ def summarize(capture: str) -> BootSummary:
             latest_boot_index = index
     latest_boot = "\n".join(lines[latest_boot_index:])
 
+    meta = _latest(latest_boot, "BOOT_META")
+    expected_sequence = meta.get("sequence")
     ready = False
+    sequence_mismatches = 0
+    boot_discontinuities = 0
+    saw_ready = False
     for line in latest_boot.splitlines():
-        stage = _fields(line.strip(), "BOOT_STAGE")
-        if stage and stage.get("event") == "ready" and stage.get("name") == "ready":
+        stripped = line.strip()
+        stage = _fields(stripped, "BOOT_STAGE")
+        if stage is None:
+            if saw_ready and any(
+                _fields(stripped, marker) is not None
+                for marker in _POST_READY_BOOT_RECORD_MARKERS
+            ):
+                # These records are emitted before readiness during setup. If
+                # one appears after ready, capture has crossed into a later
+                # boot whose BOOT_META/BOOT_STAGE output may have been lost
+                # while USB serial re-enumerated.
+                boot_discontinuities += 1
+                ready = False
+            continue
+        if not expected_sequence or stage.get("sequence") != expected_sequence:
+            sequence_mismatches += 1
+            ready = False
+            continue
+        if saw_ready:
+            # Ready is terminal for one boot. A later stage means a new or
+            # corrupted boot stream even if RTC history reused the same numeric
+            # sequence and its BOOT_META line was lost during USB enumeration.
+            boot_discontinuities += 1
+            ready = False
+            continue
+        if stage.get("event") == "ready" and stage.get("name") == "ready":
             ready = True
+            saw_ready = True
 
     return BootSummary(
-        meta=_latest(latest_boot, "BOOT_META"),
+        meta=meta,
         previous=_latest(latest_boot, "BOOT_PREVIOUS"),
         failure=_latest(latest_boot, "BOOT_FAILURE"),
         pmic=_latest(latest_boot, "BOOT_PMIC"),
         ready=ready,
+        sequence_mismatches=sequence_mismatches,
+        boot_discontinuities=boot_discontinuities,
         blocked_writes=sum(
-            line.strip().startswith("AXP_WRITE_BLOCKED ") for line in lines
+            _fields(line.strip(), "AXP_WRITE_BLOCKED") is not None
+            for line in lines
         ),
         diagnostic_errors=sum(
-            line.strip().startswith("BOOT_DIAGNOSTICS_ERROR ") for line in lines
+            _fields(line.strip(), "BOOT_DIAGNOSTICS_ERROR") is not None
+            for line in lines
         ),
     )
 
@@ -78,16 +122,29 @@ def format_summary(summary: BootSummary) -> str:
     return (
         "BOOT_CAPTURE_SUMMARY schema=1 "
         f"target={value(summary.meta, 'target')} "
+        f"profile={value(summary.meta, 'profile')} "
         f"git={value(summary.meta, 'git')} "
+        f"sequence={value(summary.meta, 'sequence')} "
         f"reset={value(summary.meta, 'reset')} "
+        f"previousFingerprint={value(summary.previous, 'fingerprint')} "
         f"previousActive={value(summary.previous, 'active')} "
+        f"previousFailures={value(summary.previous, 'failureCount')} "
+        f"previousFailureStage={value(summary.previous, 'failureStage')} "
+        f"previousFailureAfter={value(summary.previous, 'failureAfter')} "
+        f"previousFailureReset={value(summary.previous, 'failureReset')} "
         f"failures={value(summary.failure, 'count')} "
+        f"failureReset={value(summary.failure, 'reset')} "
         f"safeMode={value(summary.failure, 'safeMode')} "
         f"pmicMode={value(summary.pmic, 'mode')} "
+        f"pmicRailState={value(summary.pmic, 'railState')} "
+        f"pmicDisplayRecovery={value(summary.pmic, 'displayRecovery')} "
+        f"pmicDisplayChanged={value(summary.pmic, 'displayChanged')} "
         f"vbus={value(summary.pmic, 'vbus')} "
         f"battery={value(summary.pmic, 'battery')} "
         f"ldo={value(summary.pmic, 'ldo')} "
         f"ready={1 if summary.ready else 0} "
+        f"sequenceMismatches={summary.sequence_mismatches} "
+        f"bootDiscontinuities={summary.boot_discontinuities} "
         f"blockedWrites={summary.blocked_writes} "
         f"diagnosticErrors={summary.diagnostic_errors}"
     )
@@ -97,26 +154,93 @@ def validation_errors(
     summary: BootSummary,
     *,
     expected_target: str | None = None,
+    expected_profile: str | None = None,
     expected_git: str | None = None,
+    expected_reset: str | None = None,
     require_ready: bool = False,
     require_pmic_read_only: bool = False,
+    require_pmic_display_enable_only: bool = False,
 ) -> list[str]:
     errors: list[str] = []
+    if summary.sequence_mismatches:
+        errors.append(
+            "boot sequence mismatch observed: "
+            f"{summary.sequence_mismatches} stage marker(s) do not match "
+            f"BOOT_META sequence {summary.meta.get('sequence', 'missing')}"
+        )
+    if summary.boot_discontinuities:
+        errors.append(
+            "boot stream continued after ready marker: "
+            f"{summary.boot_discontinuities} later boot marker(s) observed"
+        )
     if expected_target and summary.meta.get("target") != expected_target:
         errors.append(
             f"target expected {expected_target}, got {summary.meta.get('target', 'missing')}"
+        )
+    if expected_profile and summary.meta.get("profile") != expected_profile:
+        errors.append(
+            "profile expected "
+            f"{expected_profile}, got {summary.meta.get('profile', 'missing')}"
         )
     if expected_git and summary.meta.get("git") != expected_git:
         errors.append(
             f"git expected {expected_git}, got {summary.meta.get('git', 'missing')}"
         )
+    if expected_reset and summary.meta.get("reset") != expected_reset:
+        errors.append(
+            f"reset expected {expected_reset}, got {summary.meta.get('reset', 'missing')}"
+        )
     if require_ready and not summary.ready:
         errors.append("ready marker missing")
-    if require_pmic_read_only and summary.pmic.get("mode") != "read-only":
-        errors.append(
-            "PMIC read-only marker missing "
-            f"(got {summary.pmic.get('mode', 'missing')})"
-        )
+    if require_pmic_read_only:
+        if summary.pmic.get("mode") != "read-only":
+            errors.append(
+                "PMIC read-only marker missing "
+                f"(got {summary.pmic.get('mode', 'missing')})"
+            )
+        for field, label in (
+            ("available", "PMIC probe"),
+            ("statusRead", "PMIC status read"),
+            ("ldoRead", "PMIC LDO-state read"),
+        ):
+            if summary.pmic.get(field) != "1":
+                errors.append(
+                    f"{label} required (got {summary.pmic.get(field, 'missing')})"
+                )
+    if require_pmic_display_enable_only:
+        if summary.pmic.get("mode") != "display-enable-only":
+            errors.append(
+                "PMIC display-enable-only marker missing "
+                f"(got {summary.pmic.get('mode', 'missing')})"
+            )
+        for field, label in (
+            ("available", "PMIC probe"),
+            ("statusRead", "PMIC status read"),
+            ("ldoRead", "PMIC LDO-state read"),
+            ("displayRecovery", "PMIC display recovery"),
+        ):
+            if summary.pmic.get(field) != "1":
+                errors.append(
+                    f"{label} required (got {summary.pmic.get(field, 'missing')})"
+                )
+        if summary.pmic.get("railState") != "display-enabled":
+            errors.append(
+                "PMIC display-enabled rail state required "
+                f"(got {summary.pmic.get('railState', 'missing')})"
+            )
+        try:
+            ldo_value = int(summary.pmic.get("ldo", ""), 0)
+        except ValueError:
+            errors.append(
+                "PMIC LDO-state value required "
+                f"(got {summary.pmic.get('ldo', 'missing')})"
+            )
+        else:
+            if (ldo_value & 0x80) == 0:
+                errors.append(
+                    "PMIC 2.06 display-enable bit required "
+                    f"(got {summary.pmic.get('ldo', 'missing')})"
+                )
     if summary.blocked_writes:
         errors.append(f"blocked AXP2101 writes observed: {summary.blocked_writes}")
     if summary.diagnostic_errors:
@@ -141,6 +265,18 @@ def _resolve_port(requested: str | None, wait_seconds: float) -> str:
         time.sleep(0.2)
 
 
+def _open_serial(serial_module, port: str, baud: int):
+    # Construct the pyserial object closed. Serial(port, ...) opens immediately
+    # with pyserial's default asserted DTR/RTS state, which can reset or hold an
+    # ESP32-S3 before callers get a chance to deassert those lines.
+    device = serial_module.Serial(port=None, baudrate=baud, timeout=0.05)
+    device.dtr = False
+    device.rts = False
+    device.port = port
+    device.open()
+    return device
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--port", help="serial device or glob; auto-detects one modem")
@@ -151,9 +287,15 @@ def main(argv: list[str] | None = None) -> int:
         "--reset", action="store_true", help="pulse RTS once after opening the port"
     )
     parser.add_argument("--expected-target")
+    parser.add_argument("--expected-profile")
     parser.add_argument("--expected-git")
+    parser.add_argument("--expected-reset")
     parser.add_argument("--require-ready", action="store_true")
-    parser.add_argument("--require-pmic-read-only", action="store_true")
+    pmic_gate = parser.add_mutually_exclusive_group()
+    pmic_gate.add_argument("--require-pmic-read-only", action="store_true")
+    pmic_gate.add_argument(
+        "--require-pmic-display-enable-only", action="store_true"
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -171,12 +313,9 @@ def main(argv: list[str] | None = None) -> int:
     print(f"BOOT_CAPTURE port={port} baud={args.baud} duration={args.duration:g}")
     decoder = codecs.getincrementaldecoder("utf-8")("replace")
     chunks: list[str] = []
+    device = None
     try:
-        device = serial.Serial(port, args.baud, timeout=0.05)
-        # Never leave control lines asserted: that can reset or hold the S3's
-        # USB CDC/JTAG serial path and make a healthy boot look silent.
-        device.dtr = False
-        device.rts = False
+        device = _open_serial(serial, port, args.baud)
         if args.reset:
             device.rts = True
             time.sleep(0.25)
@@ -194,19 +333,24 @@ def main(argv: list[str] | None = None) -> int:
         if tail:
             chunks.append(tail)
             print(tail, end="", flush=True)
-        device.close()
     except serial.SerialException as error:
         print(f"\nBOOT_CAPTURE_ERROR serial={error}", file=sys.stderr)
         return 2
+    finally:
+        if device is not None and device.is_open:
+            device.close()
 
     summary = summarize("".join(chunks))
     print("\n" + format_summary(summary))
     errors = validation_errors(
         summary,
         expected_target=args.expected_target,
+        expected_profile=args.expected_profile,
         expected_git=args.expected_git,
+        expected_reset=args.expected_reset,
         require_ready=args.require_ready,
         require_pmic_read_only=args.require_pmic_read_only,
+        require_pmic_display_enable_only=args.require_pmic_display_enable_only,
     )
     for error in errors:
         print(f"BOOT_CAPTURE_VALIDATION_ERROR {error}", file=sys.stderr)

--- a/esp32/tools/capture_boot.py
+++ b/esp32/tools/capture_boot.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Capture ESP32 USB serial and summarize the structured boot contract."""
+
+from __future__ import annotations
+
+import argparse
+import codecs
+import glob
+import sys
+import time
+from dataclasses import dataclass
+
+
+def _fields(line: str, marker: str) -> dict[str, str] | None:
+    if not line.startswith(f"{marker} "):
+        return None
+    parsed: dict[str, str] = {}
+    for token in line.split()[1:]:
+        key, separator, value = token.partition("=")
+        if separator:
+            parsed[key] = value
+    return parsed
+
+
+def _latest(capture: str, marker: str) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line in capture.splitlines():
+        parsed = _fields(line.strip(), marker)
+        if parsed is not None:
+            result = parsed
+    return result
+
+
+@dataclass(frozen=True)
+class BootSummary:
+    meta: dict[str, str]
+    previous: dict[str, str]
+    failure: dict[str, str]
+    pmic: dict[str, str]
+    ready: bool
+    blocked_writes: int
+    diagnostic_errors: int
+
+
+def summarize(capture: str) -> BootSummary:
+    lines = capture.splitlines()
+    latest_boot_index = 0
+    for index, line in enumerate(lines):
+        if _fields(line.strip(), "BOOT_META") is not None:
+            latest_boot_index = index
+    latest_boot = "\n".join(lines[latest_boot_index:])
+
+    ready = False
+    for line in latest_boot.splitlines():
+        stage = _fields(line.strip(), "BOOT_STAGE")
+        if stage and stage.get("event") == "ready" and stage.get("name") == "ready":
+            ready = True
+
+    return BootSummary(
+        meta=_latest(latest_boot, "BOOT_META"),
+        previous=_latest(latest_boot, "BOOT_PREVIOUS"),
+        failure=_latest(latest_boot, "BOOT_FAILURE"),
+        pmic=_latest(latest_boot, "BOOT_PMIC"),
+        ready=ready,
+        blocked_writes=sum(
+            line.strip().startswith("AXP_WRITE_BLOCKED ") for line in lines
+        ),
+        diagnostic_errors=sum(
+            line.strip().startswith("BOOT_DIAGNOSTICS_ERROR ") for line in lines
+        ),
+    )
+
+
+def format_summary(summary: BootSummary) -> str:
+    def value(fields: dict[str, str], key: str) -> str:
+        return fields.get(key, "missing")
+
+    return (
+        "BOOT_CAPTURE_SUMMARY schema=1 "
+        f"target={value(summary.meta, 'target')} "
+        f"git={value(summary.meta, 'git')} "
+        f"reset={value(summary.meta, 'reset')} "
+        f"previousActive={value(summary.previous, 'active')} "
+        f"failures={value(summary.failure, 'count')} "
+        f"safeMode={value(summary.failure, 'safeMode')} "
+        f"pmicMode={value(summary.pmic, 'mode')} "
+        f"vbus={value(summary.pmic, 'vbus')} "
+        f"battery={value(summary.pmic, 'battery')} "
+        f"ldo={value(summary.pmic, 'ldo')} "
+        f"ready={1 if summary.ready else 0} "
+        f"blockedWrites={summary.blocked_writes} "
+        f"diagnosticErrors={summary.diagnostic_errors}"
+    )
+
+
+def validation_errors(
+    summary: BootSummary,
+    *,
+    expected_target: str | None = None,
+    expected_git: str | None = None,
+    require_ready: bool = False,
+    require_pmic_read_only: bool = False,
+) -> list[str]:
+    errors: list[str] = []
+    if expected_target and summary.meta.get("target") != expected_target:
+        errors.append(
+            f"target expected {expected_target}, got {summary.meta.get('target', 'missing')}"
+        )
+    if expected_git and summary.meta.get("git") != expected_git:
+        errors.append(
+            f"git expected {expected_git}, got {summary.meta.get('git', 'missing')}"
+        )
+    if require_ready and not summary.ready:
+        errors.append("ready marker missing")
+    if require_pmic_read_only and summary.pmic.get("mode") != "read-only":
+        errors.append(
+            "PMIC read-only marker missing "
+            f"(got {summary.pmic.get('mode', 'missing')})"
+        )
+    if summary.blocked_writes:
+        errors.append(f"blocked AXP2101 writes observed: {summary.blocked_writes}")
+    if summary.diagnostic_errors:
+        errors.append(f"boot diagnostic errors observed: {summary.diagnostic_errors}")
+    return errors
+
+
+def _resolve_port(requested: str | None, wait_seconds: float) -> str:
+    deadline = time.monotonic() + wait_seconds
+    while True:
+        matches = sorted(glob.glob(requested or "/dev/cu.usbmodem*"))
+        if len(matches) == 1:
+            return matches[0]
+        if len(matches) > 1:
+            raise RuntimeError(
+                "multiple USB modem ports found; pass --port explicitly: "
+                + ", ".join(matches)
+            )
+        if time.monotonic() >= deadline:
+            target = requested or "/dev/cu.usbmodem*"
+            raise RuntimeError(f"timed out waiting for {target}")
+        time.sleep(0.2)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", help="serial device or glob; auto-detects one modem")
+    parser.add_argument("--baud", type=int, default=115200)
+    parser.add_argument("--duration", type=float, default=35.0)
+    parser.add_argument("--wait-seconds", type=float, default=30.0)
+    parser.add_argument(
+        "--reset", action="store_true", help="pulse RTS once after opening the port"
+    )
+    parser.add_argument("--expected-target")
+    parser.add_argument("--expected-git")
+    parser.add_argument("--require-ready", action="store_true")
+    parser.add_argument("--require-pmic-read-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    try:
+        import serial
+    except ImportError:
+        print("capture_boot.py requires pyserial", file=sys.stderr)
+        return 2
+
+    try:
+        port = _resolve_port(args.port, args.wait_seconds)
+    except RuntimeError as error:
+        print(f"BOOT_CAPTURE_ERROR {error}", file=sys.stderr)
+        return 2
+
+    print(f"BOOT_CAPTURE port={port} baud={args.baud} duration={args.duration:g}")
+    decoder = codecs.getincrementaldecoder("utf-8")("replace")
+    chunks: list[str] = []
+    try:
+        device = serial.Serial(port, args.baud, timeout=0.05)
+        # Never leave control lines asserted: that can reset or hold the S3's
+        # USB CDC/JTAG serial path and make a healthy boot look silent.
+        device.dtr = False
+        device.rts = False
+        if args.reset:
+            device.rts = True
+            time.sleep(0.25)
+            device.rts = False
+
+        deadline = time.monotonic() + args.duration
+        while time.monotonic() < deadline:
+            data = device.read(8192)
+            if not data:
+                continue
+            text = decoder.decode(data)
+            chunks.append(text)
+            print(text, end="", flush=True)
+        tail = decoder.decode(b"", final=True)
+        if tail:
+            chunks.append(tail)
+            print(tail, end="", flush=True)
+        device.close()
+    except serial.SerialException as error:
+        print(f"\nBOOT_CAPTURE_ERROR serial={error}", file=sys.stderr)
+        return 2
+
+    summary = summarize("".join(chunks))
+    print("\n" + format_summary(summary))
+    errors = validation_errors(
+        summary,
+        expected_target=args.expected_target,
+        expected_git=args.expected_git,
+        require_ready=args.require_ready,
+        require_pmic_read_only=args.require_pmic_read_only,
+    )
+    for error in errors:
+        print(f"BOOT_CAPTURE_VALIDATION_ERROR {error}", file=sys.stderr)
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esp32/tools/tests/test_axp2101_register_policy.cpp
+++ b/esp32/tools/tests/test_axp2101_register_policy.cpp
@@ -1,6 +1,7 @@
 #include "../../lib/waveshare_board/axp2101_register_policy.hpp"
 
 #include <cassert>
+#include <cstddef>
 
 int main() {
   using namespace waveshare_board::axp2101::register_policy;
@@ -14,11 +15,20 @@ int main() {
   static_assert(isPowerRailControlRegister(0x9A));
   static_assert(!isPowerRailControlRegister(0x9B));
 
-  assert(isWriteAllowed(0x41));
-  assert(isWriteAllowed(0x49));
-  assert(!isWriteAllowed(0x80));
-  assert(!isWriteAllowed(0x90));
-  assert(!isWriteAllowed(0x92));
-  assert(!isWriteAllowed(0x9A));
+  static_assert(isWriteAllowed(INTERRUPT_ENABLE_1));
+  static_assert(isWriteAllowed(INTERRUPT_STATUS_1));
+
+  std::size_t allowedCount = 0;
+  for (unsigned int address = 0; address <= 0xFF; ++address) {
+    const bool expected = address == INTERRUPT_ENABLE_1 ||
+                          address == INTERRUPT_STATUS_1;
+    const bool allowed = isWriteAllowed(static_cast<uint8_t>(address));
+    assert(allowed == expected);
+    allowedCount += allowed ? 1 : 0;
+  }
+
+  // The exhaustive loop makes any future permission an intentional test
+  // change instead of an accidental hole around the known rail registers.
+  assert(allowedCount == 2);
   return 0;
 }

--- a/esp32/tools/tests/test_axp2101_register_policy.cpp
+++ b/esp32/tools/tests/test_axp2101_register_policy.cpp
@@ -1,0 +1,24 @@
+#include "../../lib/waveshare_board/axp2101_register_policy.hpp"
+
+#include <cassert>
+
+int main() {
+  using namespace waveshare_board::axp2101::register_policy;
+
+  static_assert(!isPowerRailControlRegister(0x7F));
+  static_assert(isPowerRailControlRegister(0x80));
+  static_assert(isPowerRailControlRegister(0x86));
+  static_assert(!isPowerRailControlRegister(0x87));
+  static_assert(!isPowerRailControlRegister(0x8F));
+  static_assert(isPowerRailControlRegister(0x90));
+  static_assert(isPowerRailControlRegister(0x9A));
+  static_assert(!isPowerRailControlRegister(0x9B));
+
+  assert(isWriteAllowed(0x41));
+  assert(isWriteAllowed(0x49));
+  assert(!isWriteAllowed(0x80));
+  assert(!isWriteAllowed(0x90));
+  assert(!isWriteAllowed(0x92));
+  assert(!isWriteAllowed(0x9A));
+  return 0;
+}

--- a/esp32/tools/tests/test_axp2101_register_policy.cpp
+++ b/esp32/tools/tests/test_axp2101_register_policy.cpp
@@ -24,11 +24,41 @@ int main() {
                           address == INTERRUPT_STATUS_1;
     const bool allowed = isWriteAllowed(static_cast<uint8_t>(address));
     assert(allowed == expected);
+    assert(isTransactionWriteAllowed(DEVICE_ADDRESS, address, 1, 1) ==
+           expected);
     allowedCount += allowed ? 1 : 0;
   }
 
   // The exhaustive loop makes any future permission an intentional test
   // change instead of an accidental hole around the known rail registers.
   assert(allowedCount == 2);
+
+  // The shared-bus block and 16-bit helpers must not provide alternate paths
+  // into the AXP2101, even when the starting register itself is allowlisted.
+  assert(!isTransactionWriteAllowed(DEVICE_ADDRESS, INTERRUPT_ENABLE_1, 1, 2));
+  assert(!isTransactionWriteAllowed(DEVICE_ADDRESS, INTERRUPT_STATUS_1, 2, 1));
+  assert(!isTransactionWriteAllowed(DEVICE_ADDRESS,
+                                    DISPLAY_ENABLE_REGISTER_206, 1, 1));
+
+  // The 2.06-inch compatibility operation is intentionally narrower than a
+  // generic permission for register 0x90. Exhaust every possible starting
+  // value to prove that it can only set bit 0x80 and preserves all seven other
+  // bits exactly.
+  for (unsigned int value = 0; value <= 0xFF; ++value) {
+    const uint8_t current = static_cast<uint8_t>(value);
+    const uint8_t updated = withDisplayEnabled206(current);
+    assert((updated & DISPLAY_ENABLE_MASK_206) != 0);
+    assert((updated & ~DISPLAY_ENABLE_MASK_206) ==
+           (current & ~DISPLAY_ENABLE_MASK_206));
+    assert(isDisplayEnableOnlyTransition206(current, updated));
+
+    const uint8_t malicious = updated ^ 0x01;
+    assert(!isDisplayEnableOnlyTransition206(current, malicious));
+  }
+
+  // This device policy must not interfere with normal writes to other I2C
+  // peripherals on the shared bus.
+  assert(isTransactionWriteAllowed(0x20, 0x03, 1, 2));
+  assert(isTransactionWriteAllowed(0x51, 0x0000, 2, 1));
   return 0;
 }

--- a/esp32/tools/tests/test_boot_diagnostics_policy.cpp
+++ b/esp32/tools/tests/test_boot_diagnostics_policy.cpp
@@ -21,6 +21,7 @@ int main() {
   using namespace boot_diagnostics::policy;
 
   static_assert(kSafeModeFailureThreshold == 3);
+  static_assert(kStructuredSerialTxBufferSize >= 512);
   assert(std::strcmp(stageName(Stage::PmicInspection),
                      "pmic_inspection") == 0);
 
@@ -46,6 +47,7 @@ int main() {
   assert(!afterReady.failureRecorded);
   assert(state.bootSequence == 2);
   assert(state.consecutiveEarlyFailures == 0);
+  assert(state.lastFailureResetReason == 0);
 
   // Three unfinished boots of the same exact image trigger the fourth boot's
   // minimal safe mode and retain the actual failing stage.
@@ -55,12 +57,14 @@ int main() {
   assert(!secondAttempt.safeMode);
   assert(state.consecutiveEarlyFailures == 1);
   assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+  assert(state.lastFailureResetReason == 4);
 
   enterAndCrash(state, Stage::Display);
   BeginResult thirdAttempt = beginBoot(state, kFirmwareA, 6, false);
   assert(thirdAttempt.failureRecorded);
   assert(!thirdAttempt.safeMode);
   assert(state.consecutiveEarlyFailures == 2);
+  assert(state.lastFailureResetReason == 6);
 
   enterAndCrash(state, Stage::Display);
   BeginResult safeAttempt = beginBoot(state, kFirmwareA, 9, false);
@@ -69,6 +73,7 @@ int main() {
   assert(isSafeMode(state));
   assert(state.consecutiveEarlyFailures == 3);
   assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+  assert(state.lastFailureResetReason == 9);
   assert(!enterStage(state, Stage::I2cBus));
   assert(!markReady(state));
 
@@ -79,12 +84,14 @@ int main() {
   assert(heldAgain.safeMode);
   assert(state.consecutiveEarlyFailures == 3);
   assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+  assert(state.lastFailureResetReason == 9);
 
   // A newly built firmware is allowed to try again without requiring a power
   // cycle, while a true cold power-on also clears retained failure history.
   BeginResult newFirmware = beginBoot(state, kFirmwareB, 11, false);
   assert(newFirmware.previousValid);
   assert(!newFirmware.previousSameFirmware);
+  assert(newFirmware.previous.lastFailureResetReason == 9);
   assert(!newFirmware.safeMode);
   assert(state.bootSequence == 1);
   assert(state.consecutiveEarlyFailures == 0);
@@ -105,6 +112,27 @@ int main() {
   assert(!recovered.previousValid);
   assert(isValid(corrupt));
   assert(corrupt.bootSequence == 1);
+
+  // An intentional partial bring-up is neither a full application-ready boot
+  // nor a failure. Repeatedly resetting a display-probe image must continue to
+  // reach the display instead of entering safe mode on the fourth attempt.
+  PersistentState probe{};
+  for (unsigned attempt = 0; attempt < 5; ++attempt) {
+    BeginResult probeBoot = beginBoot(probe, kFirmwareA,
+                                      attempt == 0 ? 1 : 3,
+                                      attempt == 0);
+    assert(!probeBoot.failureRecorded);
+    assert(!probeBoot.safeMode);
+    assert(completeStage(probe, Stage::Startup));
+    assert(enterStage(probe, Stage::Display));
+    assert(completeStage(probe, Stage::Display));
+    assert(markDiagnosticHold(probe));
+    assert(isDiagnosticHold(probe));
+    assert(!isReady(probe));
+    assert(probe.consecutiveEarlyFailures == 0);
+    assert(probe.lastFailureStage == static_cast<uint8_t>(Stage::None));
+    assert(probe.lastFailureResetReason == 0);
+  }
 
   return 0;
 }

--- a/esp32/tools/tests/test_boot_diagnostics_policy.cpp
+++ b/esp32/tools/tests/test_boot_diagnostics_policy.cpp
@@ -1,0 +1,110 @@
+#include "../../lib/boot_diagnostics/boot_diagnostics_policy.hpp"
+
+#include <cassert>
+#include <cstring>
+
+namespace {
+
+using boot_diagnostics::policy::PersistentState;
+using boot_diagnostics::policy::Stage;
+
+constexpr uint32_t kFirmwareA = 0x11223344;
+constexpr uint32_t kFirmwareB = 0x55667788;
+
+void enterAndCrash(PersistentState &state, Stage stage) {
+  assert(boot_diagnostics::policy::enterStage(state, stage));
+}
+
+} // namespace
+
+int main() {
+  using namespace boot_diagnostics::policy;
+
+  static_assert(kSafeModeFailureThreshold == 3);
+  assert(std::strcmp(stageName(Stage::PmicInspection),
+                     "pmic_inspection") == 0);
+
+  PersistentState state{};
+  BeginResult first = beginBoot(state, kFirmwareA, 1, true);
+  assert(!first.previousValid);
+  assert(!first.safeMode);
+  assert(isValid(state));
+  assert(state.bootSequence == 1);
+  assert(state.activeStage == static_cast<uint8_t>(Stage::Startup));
+
+  assert(completeStage(state, Stage::Startup));
+  assert(enterStage(state, Stage::CoreServices));
+  assert(completeStage(state, Stage::CoreServices));
+  assert(state.activeStage == static_cast<uint8_t>(Stage::None));
+  assert(state.completedStage == static_cast<uint8_t>(Stage::CoreServices));
+  assert(markReady(state));
+  assert(isReady(state));
+
+  BeginResult afterReady = beginBoot(state, kFirmwareA, 11, false);
+  assert(afterReady.previousValid);
+  assert(afterReady.previousSameFirmware);
+  assert(!afterReady.failureRecorded);
+  assert(state.bootSequence == 2);
+  assert(state.consecutiveEarlyFailures == 0);
+
+  // Three unfinished boots of the same exact image trigger the fourth boot's
+  // minimal safe mode and retain the actual failing stage.
+  enterAndCrash(state, Stage::Display);
+  BeginResult secondAttempt = beginBoot(state, kFirmwareA, 4, false);
+  assert(secondAttempt.failureRecorded);
+  assert(!secondAttempt.safeMode);
+  assert(state.consecutiveEarlyFailures == 1);
+  assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+
+  enterAndCrash(state, Stage::Display);
+  BeginResult thirdAttempt = beginBoot(state, kFirmwareA, 6, false);
+  assert(thirdAttempt.failureRecorded);
+  assert(!thirdAttempt.safeMode);
+  assert(state.consecutiveEarlyFailures == 2);
+
+  enterAndCrash(state, Stage::Display);
+  BeginResult safeAttempt = beginBoot(state, kFirmwareA, 9, false);
+  assert(safeAttempt.failureRecorded);
+  assert(safeAttempt.safeMode);
+  assert(isSafeMode(state));
+  assert(state.consecutiveEarlyFailures == 3);
+  assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+  assert(!enterStage(state, Stage::I2cBus));
+  assert(!markReady(state));
+
+  // Rebooting the deliberate hold does not count it as another failed
+  // peripheral initialization or erase the original failing stage.
+  BeginResult heldAgain = beginBoot(state, kFirmwareA, 3, false);
+  assert(!heldAgain.failureRecorded);
+  assert(heldAgain.safeMode);
+  assert(state.consecutiveEarlyFailures == 3);
+  assert(state.lastFailureStage == static_cast<uint8_t>(Stage::Display));
+
+  // A newly built firmware is allowed to try again without requiring a power
+  // cycle, while a true cold power-on also clears retained failure history.
+  BeginResult newFirmware = beginBoot(state, kFirmwareB, 11, false);
+  assert(newFirmware.previousValid);
+  assert(!newFirmware.previousSameFirmware);
+  assert(!newFirmware.safeMode);
+  assert(state.bootSequence == 1);
+  assert(state.consecutiveEarlyFailures == 0);
+
+  enterAndCrash(state, Stage::PmicInspection);
+  BeginResult coldBoot = beginBoot(state, kFirmwareB, 1, true);
+  assert(coldBoot.previousValid);
+  assert(coldBoot.coldStart);
+  assert(!coldBoot.failureRecorded);
+  assert(!coldBoot.safeMode);
+  assert(state.bootSequence == 1);
+  assert(state.consecutiveEarlyFailures == 0);
+
+  PersistentState corrupt = state;
+  corrupt.activeStage = 0xFF;
+  assert(!isValid(corrupt));
+  BeginResult recovered = beginBoot(corrupt, kFirmwareB, 3, false);
+  assert(!recovered.previousValid);
+  assert(isValid(corrupt));
+  assert(corrupt.bootSequence == 1);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from build_firmware import BuildError, build_firmware
+
+
+DUMMY_FILES = {
+    "CMakeLists.txt": (
+        'idf_component_register(SRCS "sketch.cpp" "arduino-lib-builder-gcc.c" '
+        '"arduino-lib-builder-cpp.cpp" "arduino-lib-builder-as.S" '
+        'INCLUDE_DIRS ".")\n'
+    ),
+    "idf_component.yml": "dependencies:\n  idf: \">=5.1\"\n",
+    "sketch.cpp": "#include \"Arduino.h\"\nvoid setup() {}\nvoid loop() {}\n",
+    "arduino-lib-builder-gcc.c": "",
+    "arduino-lib-builder-cpp.cpp": "",
+    "arduino-lib-builder-as.S": "",
+}
+
+
+class FirmwareBuildTests(unittest.TestCase):
+    environment = "WAVESHARE_AMOLED_175"
+
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.project_dir = Path(self.temp_dir.name)
+        (self.project_dir / "platformio.ini").write_text(
+            f"[env:{self.environment}]\nplatform = test\n", encoding="utf-8"
+        )
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def write_dummy(self):
+        dummy_dir = self.project_dir / ".dummy"
+        dummy_dir.mkdir()
+        for name, contents in DUMMY_FILES.items():
+            (dummy_dir / name).write_text(contents, encoding="utf-8")
+
+    def write_firmware(self):
+        firmware = (
+            self.project_dir
+            / ".pio"
+            / "build"
+            / self.environment
+            / "firmware.elf"
+        )
+        firmware.parent.mkdir(parents=True, exist_ok=True)
+        firmware.write_bytes(b"real firmware")
+
+    def test_rebuilds_after_successful_custom_core_dummy_bootstrap(self):
+        return_codes = iter((0, 0))
+        calls = []
+
+        def runner(command, cwd):
+            calls.append((tuple(command), cwd))
+            if len(calls) == 1:
+                self.write_dummy()
+            else:
+                self.write_firmware()
+            return subprocess.CompletedProcess(command, next(return_codes))
+
+        firmware = build_firmware(self.project_dir, self.environment, runner=runner)
+
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(firmware.is_file())
+        self.assertFalse((self.project_dir / ".dummy").exists())
+
+    def test_rebuilds_after_failed_speaker_profile_dummy_bootstrap(self):
+        return_codes = iter((1, 0))
+        calls = []
+
+        def runner(command, cwd):
+            calls.append((tuple(command), cwd))
+            if len(calls) == 1:
+                self.write_dummy()
+            else:
+                self.write_firmware()
+            return subprocess.CompletedProcess(command, next(return_codes))
+
+        build_firmware(self.project_dir, self.environment, runner=runner)
+
+        self.assertEqual(len(calls), 2)
+
+    def test_propagates_a_real_build_failure_without_dummy_source(self):
+        def runner(command, cwd):
+            return subprocess.CompletedProcess(command, 2)
+
+        with self.assertRaisesRegex(BuildError, "status 2"):
+            build_firmware(self.project_dir, self.environment, runner=runner)
+
+    def test_rejects_success_without_firmware_elf(self):
+        def runner(command, cwd):
+            return subprocess.CompletedProcess(command, 0)
+
+        with self.assertRaisesRegex(BuildError, "without the expected"):
+            build_firmware(self.project_dir, self.environment, runner=runner)
+
+    def test_removes_a_stale_target_artifact_before_building(self):
+        self.write_firmware()
+        stale_firmware = (
+            self.project_dir
+            / ".pio"
+            / "build"
+            / self.environment
+            / "firmware.elf"
+        )
+
+        def runner(command, cwd):
+            self.assertFalse(stale_firmware.exists())
+            self.write_firmware()
+            return subprocess.CompletedProcess(command, 0)
+
+        build_firmware(self.project_dir, self.environment, runner=runner)
+
+    def test_stops_when_custom_core_bootstrap_does_not_converge(self):
+        calls = []
+
+        def runner(command, cwd):
+            calls.append(tuple(command))
+            self.write_dummy()
+            return subprocess.CompletedProcess(command, 0)
+
+        with self.assertRaisesRegex(BuildError, "did not converge"):
+            build_firmware(
+                self.project_dir,
+                self.environment,
+                max_passes=2,
+                runner=runner,
+            )
+
+        self.assertEqual(len(calls), 2)
+
+    def test_refuses_to_remove_an_unrecognized_dummy_directory(self):
+        dummy_dir = self.project_dir / ".dummy"
+        dummy_dir.mkdir()
+        (dummy_dir / "important.txt").write_text("keep me", encoding="utf-8")
+
+        with self.assertRaisesRegex(BuildError, "refusing to remove"):
+            build_firmware(
+                self.project_dir,
+                self.environment,
+                runner=lambda command, cwd: self.fail("runner must not be called"),
+            )
+
+        self.assertEqual(
+            (dummy_dir / "important.txt").read_text(encoding="utf-8"), "keep me"
+        )
+
+    def test_rejects_unknown_or_unsafe_environment_names(self):
+        with self.assertRaisesRegex(BuildError, "invalid PlatformIO environment"):
+            build_firmware(
+                self.project_dir,
+                "../outside",
+                runner=lambda command, cwd: self.fail("runner must not be called"),
+            )
+        with self.assertRaisesRegex(BuildError, "unknown PlatformIO environment"):
+            build_firmware(
+                self.project_dir,
+                "UNKNOWN",
+                runner=lambda command, cwd: self.fail("runner must not be called"),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/esp32/tools/tests/test_capture_boot.py
+++ b/esp32/tools/tests/test_capture_boot.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import unittest
+
+from capture_boot import format_summary, summarize, validation_errors
+
+
+HEALTHY_CAPTURE = """
+BOOT_META schema=1 sequence=2 target=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=usb resetCode=11
+BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=1 ready=1 safeMode=0 reset=power_on resetCode=1 active=ready completed=ready
+BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none safeMode=0
+BOOT_PMIC schema=1 mode=read-only available=1 statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF
+BOOT_STAGE schema=1 sequence=2 event=ready id=15 name=ready uptimeMs=1042
+"""
+
+
+class CaptureBootTests(unittest.TestCase):
+    def test_healthy_capture(self) -> None:
+        summary = summarize(HEALTHY_CAPTURE)
+        self.assertTrue(summary.ready)
+        self.assertEqual(summary.meta["target"], "WAVESHARE_AMOLED_175")
+        self.assertEqual(summary.previous["active"], "ready")
+        self.assertEqual(summary.pmic["ldo"], "0xFF")
+        self.assertEqual(summary.blocked_writes, 0)
+        self.assertEqual(
+            validation_errors(
+                summary,
+                expected_target="WAVESHARE_AMOLED_175",
+                expected_git="0123456789012345678901234567890123456789",
+                require_ready=True,
+                require_pmic_read_only=True,
+            ),
+            [],
+        )
+        rendered = format_summary(summary)
+        self.assertIn("ready=1", rendered)
+        self.assertIn("pmicMode=read-only", rendered)
+
+    def test_hazard_and_incomplete_boot_fail_validation(self) -> None:
+        capture = HEALTHY_CAPTURE.replace(
+            "BOOT_STAGE schema=1 sequence=2 event=ready id=15 name=ready uptimeMs=1042\n",
+            "AXP_WRITE_BLOCKED schema=1 reg=0x90 value=0x9D policy=interrupt-only\n",
+        )
+        summary = summarize(capture)
+        errors = validation_errors(summary, require_ready=True)
+        self.assertIn("ready marker missing", errors)
+        self.assertIn("blocked AXP2101 writes observed: 1", errors)
+
+    def test_only_latest_boot_can_satisfy_ready_gate(self) -> None:
+        interrupted_boot = """
+BOOT_META schema=1 sequence=3 target=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=panic resetCode=4
+BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=2 ready=1 safeMode=0 reset=usb resetCode=11 active=ready completed=ready
+BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none safeMode=0
+BOOT_STAGE schema=1 sequence=3 event=enter id=1 name=startup uptimeMs=0
+"""
+        summary = summarize(HEALTHY_CAPTURE + interrupted_boot)
+        self.assertFalse(summary.ready)
+        self.assertEqual(summary.meta["sequence"], "3")
+        self.assertEqual(summary.meta["reset"], "panic")
+        self.assertEqual(summary.pmic, {})
+        self.assertIn(
+            "ready marker missing",
+            validation_errors(
+                summary,
+                require_ready=True,
+                require_pmic_read_only=True,
+            ),
+        )
+        self.assertIn(
+            "PMIC read-only marker missing (got missing)",
+            validation_errors(summary, require_pmic_read_only=True),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/esp32/tools/tests/test_capture_boot.py
+++ b/esp32/tools/tests/test_capture_boot.py
@@ -2,16 +2,24 @@ from __future__ import annotations
 
 import unittest
 
-from capture_boot import format_summary, summarize, validation_errors
+from capture_boot import _open_serial, format_summary, summarize, validation_errors
 
 
 HEALTHY_CAPTURE = """
-BOOT_META schema=1 sequence=2 target=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=usb resetCode=11
-BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=1 ready=1 safeMode=0 reset=power_on resetCode=1 active=ready completed=ready
-BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none safeMode=0
-BOOT_PMIC schema=1 mode=read-only available=1 statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF
+BOOT_META schema=1 sequence=2 target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=usb resetCode=11
+BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=1 fingerprint=12345678 ready=1 safeMode=0 diagnosticHold=0 reset=power_on resetCode=1 active=ready completed=ready failureCount=0 failureStage=none failureAfter=none failureReset=unknown failureResetCode=0
+BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none reset=unknown resetCode=0 safeMode=0
+BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF
 BOOT_STAGE schema=1 sequence=2 event=ready id=15 name=ready uptimeMs=1042
 """
+
+DISPLAY_RECOVERY_CAPTURE = HEALTHY_CAPTURE.replace(
+    "target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175",
+    "target=WAVESHARE_AMOLED_206 profile=WAVESHARE_AMOLED_206",
+).replace(
+    "BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF",
+    "BOOT_PMIC schema=1 mode=display-enable-only available=1 railState=display-enabled statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0x80 displayRecovery=1 displayChanged=1",
+)
 
 
 class CaptureBootTests(unittest.TestCase):
@@ -20,13 +28,18 @@ class CaptureBootTests(unittest.TestCase):
         self.assertTrue(summary.ready)
         self.assertEqual(summary.meta["target"], "WAVESHARE_AMOLED_175")
         self.assertEqual(summary.previous["active"], "ready")
+        self.assertEqual(summary.previous["fingerprint"], "12345678")
         self.assertEqual(summary.pmic["ldo"], "0xFF")
+        self.assertEqual(summary.sequence_mismatches, 0)
+        self.assertEqual(summary.boot_discontinuities, 0)
         self.assertEqual(summary.blocked_writes, 0)
         self.assertEqual(
             validation_errors(
                 summary,
                 expected_target="WAVESHARE_AMOLED_175",
+                expected_profile="WAVESHARE_AMOLED_175",
                 expected_git="0123456789012345678901234567890123456789",
+                expected_reset="usb",
                 require_ready=True,
                 require_pmic_read_only=True,
             ),
@@ -35,6 +48,27 @@ class CaptureBootTests(unittest.TestCase):
         rendered = format_summary(summary)
         self.assertIn("ready=1", rendered)
         self.assertIn("pmicMode=read-only", rendered)
+        self.assertIn("pmicRailState=current-preserved", rendered)
+        self.assertIn("profile=WAVESHARE_AMOLED_175", rendered)
+        self.assertIn("previousFingerprint=12345678", rendered)
+        self.assertIn("sequenceMismatches=0", rendered)
+        self.assertIn("bootDiscontinuities=0", rendered)
+
+        previous_line = next(
+            line for line in HEALTHY_CAPTURE.splitlines() if line.startswith("BOOT_PREVIOUS ")
+        )
+        self.assertGreater(len(previous_line.encode()), 256)
+
+        identity_errors = validation_errors(
+            summary,
+            expected_profile="WAVESHARE_AMOLED_175_LIGHT_SLEEP",
+            expected_reset="power_on",
+        )
+        self.assertIn(
+            "profile expected WAVESHARE_AMOLED_175_LIGHT_SLEEP, got WAVESHARE_AMOLED_175",
+            identity_errors,
+        )
+        self.assertIn("reset expected power_on, got usb", identity_errors)
 
     def test_hazard_and_incomplete_boot_fail_validation(self) -> None:
         capture = HEALTHY_CAPTURE.replace(
@@ -48,9 +82,9 @@ class CaptureBootTests(unittest.TestCase):
 
     def test_only_latest_boot_can_satisfy_ready_gate(self) -> None:
         interrupted_boot = """
-BOOT_META schema=1 sequence=3 target=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=panic resetCode=4
-BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=2 ready=1 safeMode=0 reset=usb resetCode=11 active=ready completed=ready
-BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none safeMode=0
+BOOT_META schema=1 sequence=3 target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=panic resetCode=4
+BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=2 fingerprint=12345678 ready=1 safeMode=0 diagnosticHold=0 reset=usb resetCode=11 active=ready completed=ready failureCount=0 failureStage=none failureAfter=none failureReset=unknown failureResetCode=0
+BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none reset=unknown resetCode=0 safeMode=0
 BOOT_STAGE schema=1 sequence=3 event=enter id=1 name=startup uptimeMs=0
 """
         summary = summarize(HEALTHY_CAPTURE + interrupted_boot)
@@ -70,6 +104,247 @@ BOOT_STAGE schema=1 sequence=3 event=enter id=1 name=startup uptimeMs=0
             "PMIC read-only marker missing (got missing)",
             validation_errors(summary, require_pmic_read_only=True),
         )
+
+    def test_newer_stage_without_meta_cannot_reuse_older_ready_gate(self) -> None:
+        missing_meta_reboot = (
+            HEALTHY_CAPTURE
+            + "\nBOOT_STAGE schema=1 sequence=3 event=enter id=1 "
+            "name=startup uptimeMs=0\n"
+        )
+        summary = summarize(missing_meta_reboot)
+        self.assertFalse(summary.ready)
+        self.assertEqual(summary.meta["sequence"], "2")
+        self.assertEqual(summary.sequence_mismatches, 1)
+        errors = validation_errors(
+            summary,
+            expected_target="WAVESHARE_AMOLED_175",
+            expected_git="0123456789012345678901234567890123456789",
+            expected_reset="usb",
+            require_ready=True,
+            require_pmic_read_only=True,
+        )
+        self.assertIn("ready marker missing", errors)
+        self.assertTrue(
+            any(error.startswith("boot sequence mismatch observed:") for error in errors)
+        )
+
+    def test_truncated_stage_without_meta_cannot_reuse_older_ready_gate(self) -> None:
+        summary = summarize(HEALTHY_CAPTURE + "\nBOOT_STAGE truncated\n")
+        self.assertFalse(summary.ready)
+        self.assertEqual(summary.meta["sequence"], "2")
+        self.assertEqual(summary.sequence_mismatches, 1)
+        errors = validation_errors(summary, require_ready=True)
+        self.assertIn("ready marker missing", errors)
+        self.assertTrue(
+            any(error.startswith("boot sequence mismatch observed:") for error in errors)
+        )
+
+    def test_exact_truncated_boot_marker_cannot_reuse_older_ready(self) -> None:
+        for marker in (
+            "BOOT_META",
+            "BOOT_STAGE",
+            "BOOT_PREVIOUS",
+            "BOOT_FAILURE",
+            "BOOT_PMIC",
+            "BOOT_SAFE_MODE",
+        ):
+            with self.subTest(marker=marker):
+                summary = summarize(HEALTHY_CAPTURE + "\n" + marker)
+                self.assertFalse(summary.ready)
+                self.assertIn(
+                    "ready marker missing",
+                    validation_errors(summary, require_ready=True),
+                )
+
+    def test_exact_truncated_hazard_markers_fail_validation(self) -> None:
+        summary = summarize(
+            HEALTHY_CAPTURE + "\nAXP_WRITE_BLOCKED\nBOOT_DIAGNOSTICS_ERROR"
+        )
+        self.assertEqual(summary.blocked_writes, 1)
+        self.assertEqual(summary.diagnostic_errors, 1)
+        errors = validation_errors(summary)
+        self.assertIn("blocked AXP2101 writes observed: 1", errors)
+        self.assertIn("boot diagnostic errors observed: 1", errors)
+
+    def test_same_sequence_restart_after_ready_cannot_false_green(self) -> None:
+        reused_sequence = (
+            HEALTHY_CAPTURE
+            + "\nBOOT_STAGE schema=1 sequence=2 event=enter id=1 "
+            "name=startup uptimeMs=0\n"
+        )
+        summary = summarize(reused_sequence)
+        self.assertFalse(summary.ready)
+        self.assertEqual(summary.sequence_mismatches, 0)
+        self.assertEqual(summary.boot_discontinuities, 1)
+        errors = validation_errors(
+            summary,
+            require_ready=True,
+            require_pmic_read_only=True,
+        )
+        self.assertIn("ready marker missing", errors)
+        self.assertIn(
+            "boot stream continued after ready marker: 1 later boot marker(s) observed",
+            errors,
+        )
+
+    def test_setup_record_without_meta_or_stage_cannot_reuse_older_ready(self) -> None:
+        later_boot_records = (
+            "BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 "
+            "sequence=2 fingerprint=12345678 ready=1 safeMode=0 "
+            "diagnosticHold=0 reset=usb resetCode=11 active=ready "
+            "completed=ready failureCount=0 failureStage=none "
+            "failureAfter=none failureReset=unknown failureResetCode=0",
+            "BOOT_FAILURE schema=1 recorded=1 count=1 threshold=3 "
+            "stage=startup after=none reset=panic resetCode=4 safeMode=0",
+            "BOOT_PMIC schema=1 mode=read-only available=1 "
+            "railState=current-preserved statusRead=1 status1=0x20 "
+            "status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 "
+            "ldoRead=1 ldo=0xFF",
+            "BOOT_SAFE_MODE schema=1 active=1 peripherals=skipped "
+            "failureCount=3 threshold=3",
+        )
+
+        for record in later_boot_records:
+            with self.subTest(marker=record.split()[0]):
+                summary = summarize(HEALTHY_CAPTURE + "\n" + record + "\n")
+                self.assertFalse(summary.ready)
+                self.assertEqual(summary.meta["sequence"], "2")
+                self.assertEqual(summary.boot_discontinuities, 1)
+                errors = validation_errors(
+                    summary,
+                    require_ready=True,
+                    require_pmic_read_only=True,
+                )
+                self.assertIn("ready marker missing", errors)
+                self.assertIn(
+                    "boot stream continued after ready marker: "
+                    "1 later boot marker(s) observed",
+                    errors,
+                )
+
+    def test_pmic_gate_requires_probe_and_both_reads(self) -> None:
+        unavailable = HEALTHY_CAPTURE.replace(
+            "BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF",
+            "BOOT_PMIC schema=1 mode=read-only available=0 railState=unknown",
+        )
+        errors = validation_errors(
+            summarize(unavailable), require_pmic_read_only=True
+        )
+        self.assertIn("PMIC probe required (got 0)", errors)
+        self.assertIn("PMIC status read required (got missing)", errors)
+        self.assertIn("PMIC LDO-state read required (got missing)", errors)
+
+        unreadable = HEALTHY_CAPTURE.replace(
+            "available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF",
+            "available=1 railState=current-preserved statusRead=0 ldoRead=0 ldo=0x00",
+        )
+        errors = validation_errors(
+            summarize(unreadable), require_pmic_read_only=True
+        )
+        self.assertNotIn("PMIC probe required (got 0)", errors)
+        self.assertIn("PMIC status read required (got 0)", errors)
+        self.assertIn("PMIC LDO-state read required (got 0)", errors)
+
+    def test_206_pmic_gate_requires_verified_display_enable_only_recovery(self) -> None:
+        summary = summarize(DISPLAY_RECOVERY_CAPTURE)
+        self.assertEqual(
+            validation_errors(
+                summary,
+                expected_target="WAVESHARE_AMOLED_206",
+                require_ready=True,
+                require_pmic_display_enable_only=True,
+            ),
+            [],
+        )
+        rendered = format_summary(summary)
+        self.assertIn("pmicMode=display-enable-only", rendered)
+        self.assertIn("pmicDisplayRecovery=1", rendered)
+        self.assertIn("pmicDisplayChanged=1", rendered)
+
+        for old, new, expected_error in (
+            ("displayRecovery=1", "displayRecovery=0", "PMIC display recovery required (got 0)"),
+            ("railState=display-enabled", "railState=unknown", "PMIC display-enabled rail state required (got unknown)"),
+            ("ldo=0x80", "ldo=0x00", "PMIC 2.06 display-enable bit required (got 0x00)"),
+        ):
+            errors = validation_errors(
+                summarize(DISPLAY_RECOVERY_CAPTURE.replace(old, new)),
+                require_pmic_display_enable_only=True,
+            )
+            self.assertIn(expected_error, errors)
+
+        read_only_errors = validation_errors(
+            summarize(HEALTHY_CAPTURE),
+            require_pmic_display_enable_only=True,
+        )
+        self.assertIn(
+            "PMIC display-enable-only marker missing (got read-only)",
+            read_only_errors,
+        )
+
+    def test_previous_safe_mode_failure_survives_firmware_change_log(self) -> None:
+        recovery = HEALTHY_CAPTURE.replace(
+            "history=retained valid=1 sameFirmware=1 sequence=1 fingerprint=12345678 ready=1 safeMode=0 diagnosticHold=0 reset=power_on resetCode=1 active=ready completed=ready failureCount=0 failureStage=none failureAfter=none failureReset=unknown failureResetCode=0",
+            "history=firmware_changed valid=1 sameFirmware=0 sequence=8 fingerprint=DEADBEEF ready=0 safeMode=1 diagnosticHold=0 reset=panic resetCode=4 active=safe_mode completed=none failureCount=3 failureStage=display failureAfter=clock_and_sensors failureReset=brownout failureResetCode=9",
+        )
+        summary = summarize(recovery)
+        self.assertEqual(summary.previous["fingerprint"], "DEADBEEF")
+        self.assertEqual(summary.previous["failureCount"], "3")
+        self.assertEqual(summary.previous["failureStage"], "display")
+        self.assertEqual(summary.previous["failureReset"], "brownout")
+        self.assertIn("previousFailureStage=display", format_summary(summary))
+        self.assertIn("previousFingerprint=DEADBEEF", format_summary(summary))
+        self.assertIn("previousFailureReset=brownout", format_summary(summary))
+
+    def test_serial_control_lines_are_deasserted_before_open(self) -> None:
+        events: list[tuple[str, object]] = []
+
+        class FakeDevice:
+            def __init__(self, *, port, baudrate, timeout):
+                events.append(("construct_port", port))
+                events.append(("baudrate", baudrate))
+                events.append(("timeout", timeout))
+                self._dtr = True
+                self._rts = True
+                self.port = port
+                self.is_open = False
+
+            @property
+            def dtr(self):
+                return self._dtr
+
+            @dtr.setter
+            def dtr(self, value):
+                self._dtr = value
+                events.append(("dtr", value))
+
+            @property
+            def rts(self):
+                return self._rts
+
+            @rts.setter
+            def rts(self, value):
+                self._rts = value
+                events.append(("rts", value))
+
+            def open(self):
+                events.append(("open_dtr", self.dtr))
+                events.append(("open_rts", self.rts))
+                events.append(("open_port", self.port))
+                self.is_open = True
+
+        class FakeSerialModule:
+            Serial = FakeDevice
+
+        device = _open_serial(FakeSerialModule, "/dev/cu.test", 115200)
+        self.assertTrue(device.is_open)
+        self.assertEqual(events[0], ("construct_port", None))
+        self.assertLess(
+            events.index(("dtr", False)), events.index(("open_dtr", False))
+        )
+        self.assertLess(
+            events.index(("rts", False)), events.index(("open_rts", False))
+        )
+        self.assertIn(("open_port", "/dev/cu.test"), events)
 
 
 if __name__ == "__main__":

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import configparser
+import re
 from pathlib import Path
 
 
@@ -8,6 +9,23 @@ project_dir = Path(__file__).resolve().parents[2]
 repo_root = project_dir.parent
 config = configparser.ConfigParser(interpolation=None)
 config.read(project_dir / "platformio.ini")
+
+
+def inherited_option(section: str, option: str) -> str:
+    """Resolve the single-parent PlatformIO inheritance used by this file."""
+    visited: set[str] = set()
+    current = section
+    while current:
+        assert current not in visited, f"cyclic PlatformIO inheritance at {current}"
+        visited.add(current)
+        if config.has_option(current, option):
+            return config.get(current, option)
+        current = config.get(current, "extends", fallback="").strip()
+    raise AssertionError(f"{section} does not resolve {option}")
+
+
+prebuild_source = (project_dir / "prebuild.py").read_text()
+assert "-DBUILD_PROFILE=" in prebuild_source
 
 waveshare_sdkconfig = config.get("waveshare_amoled_common", "custom_sdkconfig")
 assert "CONFIG_PM_ENABLE=y" in waveshare_sdkconfig
@@ -37,6 +55,7 @@ diagnostic_profiles = {
 }
 for environment, (base, board_define) in diagnostic_profiles.items():
     assert config.get(environment, "extends") == base
+    assert inherited_option(environment, "custom_firmware_target") == board_define
     base_flags = config.get(base, "build_flags")
     assert f"-D{board_define}" in base_flags
     flags = config.get(environment, "build_flags")
@@ -45,13 +64,20 @@ for environment, (base, board_define) in diagnostic_profiles.items():
     assert "-DFIRMWARE_DIAGNOSTICS=1" in flags
     assert "-DARDUINO_USB_CDC_ON_BOOT=1" in flags
 
+assert "-DWAVESHARE_206_FORCE_AXP_DISPLAY=1" in config.get(
+    "waveshare_amoled_206_base", "build_flags"
+)
+assert "-DWAVESHARE_206_FORCE_AXP_DISPLAY" not in config.get(
+    "waveshare_amoled_175_base", "build_flags"
+)
+
 expected_targets = {
     "env:WAVESHARE_AMOLED_175_PRODUCTION": "WAVESHARE_AMOLED_175",
     "env:WAVESHARE_AMOLED_206_PRODUCTION": "WAVESHARE_AMOLED_206",
 }
 
 for environment, target in expected_targets.items():
-    assert config.get(environment, "custom_firmware_target") == target
+    assert inherited_option(environment, "custom_firmware_target") == target
     base = diagnostic_profiles[environment.replace("_PRODUCTION", "")][0]
     assert config.get(environment, "extends") == base
     flags = config.get(environment, "build_flags")
@@ -79,7 +105,7 @@ light_sleep_profiles = {
 }
 for environment, (base, target) in light_sleep_profiles.items():
     assert config.get(environment, "extends") == base
-    assert config.get(environment, "custom_firmware_target") == target
+    assert inherited_option(environment, "custom_firmware_target") == target
     sdkconfig = config.get(environment, "custom_sdkconfig")
     assert "CONFIG_PM_ENABLE=y" in sdkconfig
     assert "CONFIG_FREERTOS_USE_TICKLESS_IDLE=y" in sdkconfig
@@ -96,9 +122,96 @@ assert "CONFIG_GPIO_CTRL_FUNC_IN_IRAM=y" in config.get(
     "env:WAVESHARE_AMOLED_206_LIGHT_SLEEP", "custom_sdkconfig"
 )
 
+# Every board-named firmware profile reports the stable hardware/OTA target;
+# BUILD_PROFILE remains the distinct PIO environment identity in boot logs.
+for section in config.sections():
+    profile = section.removeprefix("env:")
+    if profile.startswith("WAVESHARE_AMOLED_175"):
+        assert (
+            inherited_option(section, "custom_firmware_target")
+            == "WAVESHARE_AMOLED_175"
+        )
+    elif profile.startswith("WAVESHARE_AMOLED_206"):
+        assert (
+            inherited_option(section, "custom_firmware_target")
+            == "WAVESHARE_AMOLED_206"
+        )
+
 ci_workflow = (repo_root / ".github/workflows/ci.yml").read_text()
 for environment in light_sleep_profiles:
     assert environment.removeprefix("env:") in ci_workflow
+
+display_probe_profile = "env:WAVESHARE_AMOLED_206_DISPLAY_TEST"
+assert config.get(display_probe_profile, "extends") == "env:WAVESHARE_AMOLED_206"
+display_probe_flags = config.get(display_probe_profile, "build_flags")
+assert "-DWAVESHARE_DISPLAY_PROBE=1" in display_probe_flags
+assert display_probe_profile.removeprefix("env:") in ci_workflow
+
+speaker_source = (project_dir / "speaker_honk_test.cpp").read_text()
+speaker_implementation = (project_dir / "lib/speaker/speaker.cpp").read_text()
+for board in ("175", "206"):
+    profile = f"env:WAVESHARE_AMOLED_{board}_SPEAKER_HONK"
+    assert config.get(profile, "extends") == f"env:WAVESHARE_AMOLED_{board}"
+    assert "+<../speaker_honk_test.cpp>" in config.get(profile, "build_src_filter")
+    assert profile.removeprefix("env:") in ci_workflow
+assert speaker_source.index("boot_diagnostics::begin()") < speaker_source.index(
+    "waveshare_board::i2c::configureBus()"
+)
+assert speaker_source.index(
+    "waveshare_board::i2c::configureBus()"
+) < speaker_source.index("waveshare_board::initializePowerManagement()")
+assert "boot_diagnostics::safeModeActive()" in speaker_source
+assert "boot_diagnostics::markReady()" in speaker_source
+assert "waveshare_board::speaker::requestPlayTracked" in speaker_source
+assert "waveshare_board::speaker::latestPlaybackCompletion" in speaker_source
+assert "TrackedPlaybackResult::Succeeded" in speaker_source
+assert "TrackedPlaybackResult::Failed" in speaker_source
+assert "playbackSucceeded = playNow(sound)" in speaker_implementation
+cleanup_call = speaker_implementation.index(
+    "!cleanupRequired || releaseCodecResources();"
+)
+completion_publish = speaker_implementation.index(
+    "recordPlaybackCompletion(\n        request.requestId"
+)
+assert cleanup_call < completion_publish
+assert "playbackRequestLifecycleSucceeded(" in speaker_implementation[
+    completion_publish:
+]
+startup_ready_guard = speaker_source.index("if (startupSoundsCompleted ==")
+assert startup_ready_guard < speaker_source.index("boot_diagnostics::markReady()")
+assert startup_ready_guard < speaker_source.index(
+    "boot_diagnostics::completeStage(boot_diagnostics::Stage::Speaker)"
+)
+assert "startupSoundsCompleted" in speaker_source
+assert "if (!testInitialized)" in speaker_source
+
+boot_policy_source = (
+    project_dir / "lib/boot_diagnostics/boot_diagnostics_policy.hpp"
+).read_text()
+assert "kStructuredSerialTxBufferSize = 4096" in boot_policy_source
+main_source = (project_dir / "src/main.cpp").read_text()
+for source in (main_source, speaker_source):
+    assert "Serial.setTxBufferSize(" in source
+    assert "boot_diagnostics::kStructuredSerialTxBufferSize" in source
+
+# Keep every raw I2C write transaction behind i2c_bus.cpp, where the AXP2101
+# allowlist is enforced. Direct requestFrom() reads remain permitted.
+i2c_boundary = (project_dir / "lib/waveshare_board/i2c_bus.cpp").resolve()
+raw_write_pattern = re.compile(r"\bWire\s*\.\s*beginTransmission\s*\(")
+raw_write_offenders: list[str] = []
+source_paths = set(project_dir.glob("*.cpp")) | set(project_dir.glob("*.ino"))
+for source_root in (project_dir / "src", project_dir / "lib"):
+    for suffix in ("*.cpp", "*.hpp", "*.h", "*.ino"):
+        source_paths.update(source_root.rglob(suffix))
+for source_path in sorted(source_paths):
+    if source_path.resolve() == i2c_boundary:
+        continue
+    if raw_write_pattern.search(source_path.read_text(errors="ignore")):
+        raw_write_offenders.append(str(source_path.relative_to(project_dir)))
+assert not raw_write_offenders, (
+    "raw Wire.beginTransmission() bypasses the AXP2101 policy boundary: "
+    + ", ".join(raw_write_offenders)
+)
 
 release_workflow = (repo_root / ".github/workflows/firmware-release.yml").read_text()
 for environment, target in expected_targets.items():

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -138,6 +138,14 @@ for section in config.sections():
         )
 
 ci_workflow = (repo_root / ".github/workflows/ci.yml").read_text()
+speaker_workflow = (
+    repo_root / ".github/workflows/speaker-firmware.yml"
+).read_text()
+assert "python tools/build_firmware.py" in ci_workflow
+assert "workflow_dispatch:" in speaker_workflow
+assert "push:" not in speaker_workflow
+assert "pull_request:" not in speaker_workflow
+assert "python tools/build_firmware.py" in speaker_workflow
 for environment in light_sleep_profiles:
     assert environment.removeprefix("env:") in ci_workflow
 
@@ -153,7 +161,8 @@ for board in ("175", "206"):
     profile = f"env:WAVESHARE_AMOLED_{board}_SPEAKER_HONK"
     assert config.get(profile, "extends") == f"env:WAVESHARE_AMOLED_{board}"
     assert "+<../speaker_honk_test.cpp>" in config.get(profile, "build_src_filter")
-    assert profile.removeprefix("env:") in ci_workflow
+    assert profile.removeprefix("env:") not in ci_workflow
+    assert profile.removeprefix("env:") in speaker_workflow
 assert speaker_source.index("boot_diagnostics::begin()") < speaker_source.index(
     "waveshare_board::i2c::configureBus()"
 )
@@ -214,6 +223,7 @@ assert not raw_write_offenders, (
 )
 
 release_workflow = (repo_root / ".github/workflows/firmware-release.yml").read_text()
+assert "python tools/build_firmware.py" in release_workflow
 for environment, target in expected_targets.items():
     profile = environment.removeprefix("env:")
     mapping = f"target: {target}\n            environment: {profile}"

--- a/esp32/tools/tests/test_speaker_playback_policy.cpp
+++ b/esp32/tools/tests/test_speaker_playback_policy.cpp
@@ -1,0 +1,51 @@
+#include "../../lib/speaker/speaker_playback_policy.hpp"
+
+#include <cassert>
+#include <cstdint>
+
+using waveshare_board::speaker::PlaybackCompletion;
+using waveshare_board::speaker::TrackedPlaybackResult;
+using waveshare_board::speaker::classifyPlaybackCompletion;
+using waveshare_board::speaker::decodePlaybackCompletion;
+using waveshare_board::speaker::encodePlaybackCompletion;
+using waveshare_board::speaker::kPlaybackRequestIdMask;
+using waveshare_board::speaker::playbackRequestLifecycleSucceeded;
+
+int main() {
+  const PlaybackCompletion success =
+      decodePlaybackCompletion(encodePlaybackCompletion(42U, true));
+  assert(success.requestId == 42U);
+  assert(success.succeeded);
+  assert(classifyPlaybackCompletion(42U, success) ==
+         TrackedPlaybackResult::Succeeded);
+
+  const PlaybackCompletion failure =
+      decodePlaybackCompletion(encodePlaybackCompletion(43U, false));
+  assert(failure.requestId == 43U);
+  assert(!failure.succeeded);
+  assert(classifyPlaybackCompletion(43U, failure) ==
+         TrackedPlaybackResult::Failed);
+
+  assert(classifyPlaybackCompletion(44U, failure) ==
+         TrackedPlaybackResult::Pending);
+  assert(classifyPlaybackCompletion(42U, failure) ==
+         TrackedPlaybackResult::Superseded);
+  assert(classifyPlaybackCompletion(1U, {0U, false}) ==
+         TrackedPlaybackResult::Pending);
+  assert(classifyPlaybackCompletion(0U, success) ==
+         TrackedPlaybackResult::Pending);
+
+  const PlaybackCompletion beforeWrap{kPlaybackRequestIdMask, true};
+  const PlaybackCompletion afterWrap{1U, true};
+  assert(classifyPlaybackCompletion(1U, beforeWrap) ==
+         TrackedPlaybackResult::Pending);
+  assert(classifyPlaybackCompletion(kPlaybackRequestIdMask, afterWrap) ==
+         TrackedPlaybackResult::Superseded);
+
+  assert(playbackRequestLifecycleSucceeded(true, false, false));
+  assert(playbackRequestLifecycleSucceeded(true, true, true));
+  assert(!playbackRequestLifecycleSucceeded(true, true, false));
+  assert(!playbackRequestLifecycleSucceeded(false, false, true));
+
+  return 0;
+}

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -533,9 +533,10 @@ the PMIC's factory/eFuse rail configuration.
 
 Safety rules:
 - Probe AXP2101 at `0x34` and read status for diagnostics only.
-- Do not write DCDC control/voltage registers `0x80`-`0x86` or LDO
-  control/voltage registers `0x90`-`0x9A` during boot, display inactivity,
-  light sleep, or deep sleep.
+- The firmware write allowlist contains exactly two addresses: interrupt-enable
+  register `0x41` and write-one-to-clear interrupt-status register `0x49`, both
+  used only for PWR-button events. Charger current/voltage, input limits,
+  BATFET, DCDC, LDO, and every other AXP2101 register are read-only.
 - Turn the AMOLED panel off with its controller command. Do not assume an
   AXP2101 enable bit belongs exclusively to the display or another peripheral.
 - A black screen is not sufficient evidence that an AXP rail should be forced;
@@ -546,8 +547,8 @@ Safety rules:
 Verified firmware behavior:
 - AXP2101 is found at `0x34`, and status plus the current LDO-enable value are
   logged without modifying them.
-- A register-policy guard rejects future writes to the AXP2101 DCDC/LDO output
-  control blocks.
+- A register-policy guard rejects writes to all 254 non-allowlisted AXP2101
+  addresses, with an exhaustive host test covering the complete address space.
 - Deep and light sleep preserve PMIC output state; the panel, buses, and radio
   are managed independently.
 - On USB, observed PMU status reports VBUS present and `battery=absent`.
@@ -560,6 +561,38 @@ Verified firmware behavior:
   through another I2C transaction and is not a firmware wake GPIO. Keep the
   deadline-based AXP2101 status polling unless a later board revision exposes
   a direct interrupt.
+
+### Boot Failure Telemetry and Safe Mode
+
+Waveshare firmware records the active and last-completed setup stage in RTC
+no-init memory before touching each major subsystem. The state survives panic,
+watchdog, brownout, software, and USB resets. It is discarded after full power
+removal, checksum/schema failure, or when a newly built firmware image is
+flashed.
+
+Diagnostic builds emit stable, machine-readable lines:
+
+```text
+BOOT_META schema=1 ... target=... git=... built=... reset=... resetCode=...
+BOOT_PREVIOUS schema=1 ... active=... completed=...
+BOOT_FAILURE schema=1 ... count=... stage=... after=... safeMode=...
+BOOT_STAGE schema=1 ... event=enter|complete|ready name=...
+BOOT_PMIC schema=1 mode=read-only ... vbus=... battery=... ldo=...
+```
+
+`BOOT_META` is the source of truth for the image actually running; do not infer
+it only from the local checkout or the upload command. An entered stage without
+its matching completion marker identifies the first setup group to audit on
+the next boot. `BOOT_PMIC mode=read-only` confirms that the startup path only
+inspected the PMIC; any `AXP_WRITE_BLOCKED` line is a failed safety gate and
+must be investigated.
+
+After three unfinished early boots from the same exact build, the fourth boot
+enters minimal safe mode before I2C, PMIC, display, storage, speaker, or BLE
+initialization. Safe mode retains the original failing stage and can be cleared
+by flashing a newly built image or removing all USB and battery power. A safe
+mode decision is software containment evidence, not proof that a physical
+short was software-caused.
 
 ### 3. Touch Coordinate Mirroring
 

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -95,7 +95,7 @@ Temporary reference clone used during bring-up:
 | MCU | ESP32-S3R8 | internal | Dual-core LX7 up to 240 MHz; 8 MB PSRAM; external 32 MB flash |
 | Display Driver | CO5300 | QSPI | 2.06" AMOLED, 410x502, 16.7M colors |
 | Touch Controller | FT3168 | I2C | Vendor `FT3168_DEVICE_ADDRESS` is `0x38`; docs describe 10 kHz-400 kHz I2C support |
-| Power Management | AXP2101 | I2C | PMU, charging, battery management, multiple output rails |
+| Power Management | AXP2101 | I2C | PMU, charging, battery management; output-rail ownership is not yet electrically validated |
 | RTC | PCF85063ATL | I2C | Address `0x51`; RTC rail is powered through AXP2101/battery path |
 | IMU | QMI8658C | I2C | Schematic ties SDO/SAO low, so expected address is `0x6B` |
 | Audio Codec | ES8311 | I2C/I2S | Audio codec used by vendor `08_ES8311` demo |
@@ -335,7 +335,7 @@ card, and factory firmware.
 | RTC | Partially verified | PCF85063 found at `0x51`; retention behavior still needs battery-backed power-removal validation |
 | IMU | Partially verified | QMI8658 found at `0x6B` and reports motion; axis/sign tests still need validation on 2.06 |
 | Audio | Verified / implemented | ES8311 speaker plays generated and embedded 16 kHz PCM; app selects the sound and `0...100%` playback volume, defaulting to 70% |
-| Power / Battery | Partially verified | AXP2101 status readable; current app preserves rails during boot; deeper sleep/rail shutdown still needs testing |
+| Power / Battery | Partially verified | AXP2101 status readable; current app preserves factory/eFuse rail state during boot and sleep; firmware rail control is intentionally disabled pending an electrically validated rail map |
 
 ## 2.06 Bring-up Rules
 
@@ -365,7 +365,7 @@ card, and factory firmware.
 
 | Component | IC | Bus | Address / Notes |
 |---|---|---|---|
-| Power Management | AXP2101 | I2C | 0x34; controls display/peripheral/RTC rails |
+| Power Management | AXP2101 | I2C | 0x34; provides board power and charging; firmware treats output-rail registers as read-only |
 | Touch Controller | CST9217 | I2C | 0x5A; interrupt on GPIO21 is a hint, not sole trigger |
 | I/O Expander | TCA9554 | I2C | 0x20; controls CST9217 reset on P0 |
 | RTC | PCF85063 | I2C | 0x51; on AXP2101 RTC rail, but no full power-removal retention on the tested board |
@@ -523,32 +523,33 @@ changing the amplifier or gain assumptions.
 
 **Verified:** This approach successfully initializes the CST9217 touch controller.
 
-### 2. Power Sequencing (AXP2101)
+### 2. PMIC Rail Safety (AXP2101)
 
-The display, touch peripherals, and ES8311 codec analog supply are powered by
-the AXP2101 PMU. You **must** initialize the AXP2101 via I2C and enable the
-relevant ALDO/DLDO voltage rails before these devices will respond.
+The AXP2101 provides board power and charging, but the populated load behind
+every programmable output has not been electrically validated. Waveshare's
+standard 1.75-inch display and ES8311 examples initialize those peripherals
+without programming AXP2101 output registers. Firmware must therefore preserve
+the PMIC's factory/eFuse rail configuration.
 
-**Initialization sequence:**
-```cpp
-Wire.beginTransmission(0x34);
-Wire.write(0x90); Wire.write(0x9D); // Enable ALDO1 plus display/peripheral rails
-Wire.endTransmission();
-// Enable ALDO1-4, BLDO1-2 similarly on registers 0x92-0x97
-```
-
-If the screen is black, it is likely an AXP2101 configuration issue, not a pinout error.
+Safety rules:
+- Probe AXP2101 at `0x34` and read status for diagnostics only.
+- Do not write DCDC control/voltage registers `0x80`-`0x86` or LDO
+  control/voltage registers `0x90`-`0x9A` during boot, display inactivity,
+  light sleep, or deep sleep.
+- Turn the AMOLED panel off with its controller command. Do not assume an
+  AXP2101 enable bit belongs exclusively to the display or another peripheral.
+- A black screen is not sufficient evidence that an AXP rail should be forced;
+  check the reset log, QSPI pins, build target, and panel initialization first.
+- If an older firmware image already changed persistent PMIC state, fully
+  remove USB and battery power before validating the safe firmware.
 
 Verified firmware behavior:
-- AXP2101 is found at `0x34`.
-- Enable register `0x90` should read back `0x9D` after display, peripheral, and
-  codec analog rails are enabled. Bit 0 (ALDO1) supplies the ES8311 `AVDD`;
-  leaving it clear makes speaker playback silent after a cold boot.
-- The normal peripheral shutdown path clears ALDO1 together with the other
-  managed 1.75 rails before deep sleep; it is enabled again during boot.
-- Voltage register readback can be noisy on this shared I2C bus; treat final
-  enable-register readback and successful peripheral initialization as the
-  stronger boot signal.
+- AXP2101 is found at `0x34`, and status plus the current LDO-enable value are
+  logged without modifying them.
+- A register-policy guard rejects future writes to the AXP2101 DCDC/LDO output
+  control blocks.
+- Deep and light sleep preserve PMIC output state; the panel, buses, and radio
+  are managed independently.
 - On USB, observed PMU status reports VBUS present and `battery=absent`.
 - `POWER_SAVE` is intentionally not enabled for `WAVESHARE_AMOLED_175`.
   Temporary test builds with `POWER_SAVE` reproduced Bluetooth/IPC instability,

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -335,7 +335,7 @@ card, and factory firmware.
 | RTC | Partially verified | PCF85063 found at `0x51`; retention behavior still needs battery-backed power-removal validation |
 | IMU | Partially verified | QMI8658 found at `0x6B` and reports motion; axis/sign tests still need validation on 2.06 |
 | Audio | Verified / implemented | ES8311 speaker plays generated and embedded 16 kHz PCM; app selects the sound and `0...100%` playback volume, defaulting to 70% |
-| Power / Battery | Partially verified | AXP2101 status readable; current app preserves factory/eFuse rail state during boot and sleep; firmware rail control is intentionally disabled pending an electrically validated rail map |
+| Power / Battery | Partially verified | AXP2101 status readable; runtime and sleep paths never switch PMIC outputs. At boot, one compatibility operation may set only register `0x90` bit `0x80` to recover the established display supply after older firmware left it off; all other bits and voltage registers remain unchanged |
 
 ## 2.06 Bring-up Rules
 
@@ -355,6 +355,10 @@ card, and factory firmware.
   its first pixel through a 1x1 window to present the completed frame.
 - USB CDC logging uses a 1 ms TX timeout so display rendering remains
   independent of whether a serial reader is attached.
+- New firmware never turns the AXP2101 display-enable bit off. At boot it may
+  set only register `0x90` bit `0x80`, preserving every other bit, so an OTA or
+  rollback can recover from the state left by older 2.06 firmware. Generic PMIC
+  writes to `0x90` remain blocked.
 - A full USB and battery power removal can matter after failed experiments; the
   verified standalone display test became visible after power removal and
   USB-only replug.
@@ -529,7 +533,8 @@ The AXP2101 provides board power and charging, but the populated load behind
 every programmable output has not been electrically validated. Waveshare's
 standard 1.75-inch display and ES8311 examples initialize those peripherals
 without programming AXP2101 output registers. Firmware must therefore preserve
-the PMIC's factory/eFuse rail configuration.
+the PMIC's current output-rail configuration. That is not evidence of factory
+state when an older image may have programmed a still-powered PMIC.
 
 Safety rules:
 - Probe AXP2101 at `0x34` and read status for diagnostics only.
@@ -541,14 +546,18 @@ Safety rules:
   AXP2101 enable bit belongs exclusively to the display or another peripheral.
 - A black screen is not sufficient evidence that an AXP rail should be forced;
   check the reset log, QSPI pins, build target, and panel initialization first.
-- If an older firmware image already changed persistent PMIC state, fully
-  remove USB and battery power before validating the safe firmware.
+- Before validating a migration from older firmware, disconnect both USB and
+  battery. Reconnect only after all power is removed so the PMIC reloads its
+  power-on baseline; otherwise the safe image preserves the older live state.
 
 Verified firmware behavior:
 - AXP2101 is found at `0x34`, and status plus the current LDO-enable value are
-  logged without modifying them.
+  logged without modifying them. The log labels that value as preserved current
+  state, not verified factory state.
 - A register-policy guard rejects writes to all 254 non-allowlisted AXP2101
   addresses, with an exhaustive host test covering the complete address space.
+  A source-policy test also rejects raw `Wire.beginTransmission()` calls
+  outside the guarded shared-I2C implementation.
 - Deep and light sleep preserve PMIC output state; the panel, buses, and radio
   are managed independently.
 - On USB, observed PMU status reports VBUS present and `battery=absent`.
@@ -562,30 +571,53 @@ Verified firmware behavior:
   deadline-based AXP2101 status polling unless a later board revision exposes
   a direct interrupt.
 
+These rules are intentionally strict for the 1.75-inch board implicated in the
+short investigation. The 2.06-inch board has one separate, established
+compatibility exception: during boot only, firmware reads register `0x90`, sets
+bit `0x80` if needed, and verifies the result while preserving every other bit.
+That one-way operation recovers a display supply that older 2.06 firmware could
+leave disabled; it cannot turn any output off or change a voltage. Generic
+AXP2101 writes remain limited to interrupt registers `0x41` and `0x49` on both
+targets.
+
 ### Boot Failure Telemetry and Safe Mode
 
-Waveshare firmware records the active and last-completed setup stage in RTC
-no-init memory before touching each major subsystem. The state survives panic,
-watchdog, brownout, software, and USB resets. It is discarded after full power
-removal, checksum/schema failure, or when a newly built firmware image is
-flashed.
+Waveshare main-application and speaker-smoke firmware record the active and
+last-completed setup stage in RTC no-init memory before touching each major
+subsystem. The vendor-hello sketch remains an isolated upstream bring-up image
+and does not implement this contract. The state survives panic, watchdog,
+brownout, software, and USB resets. A new firmware fingerprint first emits the
+prior valid record in `BOOT_PREVIOUS`, then starts fresh same-build failure
+history. Full power removal or a checksum/schema failure makes the prior record
+unavailable.
 
 Diagnostic builds emit stable, machine-readable lines:
 
 ```text
-BOOT_META schema=1 ... target=... git=... built=... reset=... resetCode=...
-BOOT_PREVIOUS schema=1 ... active=... completed=...
-BOOT_FAILURE schema=1 ... count=... stage=... after=... safeMode=...
-BOOT_STAGE schema=1 ... event=enter|complete|ready name=...
-BOOT_PMIC schema=1 mode=read-only ... vbus=... battery=... ldo=...
+BOOT_META schema=1 ... target=... profile=... git=... built=... reset=... resetCode=...
+BOOT_PREVIOUS schema=1 ... fingerprint=... active=... completed=... failureCount=... failureStage=... failureAfter=... failureReset=...
+BOOT_FAILURE schema=1 ... count=... stage=... after=... reset=... safeMode=...
+BOOT_STAGE schema=1 ... event=enter|complete|ready|hold name=...
+BOOT_PMIC schema=1 mode=read-only railState=current-preserved ... vbus=... battery=... ldo=...
+BOOT_PMIC schema=1 mode=display-enable-only railState=display-enabled ... displayRecovery=1 displayChanged=...
 ```
 
 `BOOT_META` is the source of truth for the image actually running; do not infer
-it only from the local checkout or the upload command. An entered stage without
-its matching completion marker identifies the first setup group to audit on
-the next boot. `BOOT_PMIC mode=read-only` confirms that the startup path only
-inspected the PMIC; any `AXP_WRITE_BLOCKED` line is a failed safety gate and
-must be investigated.
+it only from the local checkout or the upload command. `target` is the canonical
+hardware/OTA identity, while `profile` distinguishes experimental and
+production variants built from the same commit. An entered stage without its
+matching completion marker identifies the first setup group to audit on the
+next boot. `BOOT_PREVIOUS` retains the failed image fingerprint, original
+failure fields, and the reset cause that ended it even when a new diagnostic
+build clears the current history. On 1.75-inch firmware,
+`BOOT_PMIC mode=read-only` means startup did not request an output-rail change;
+the matching capture gate separately requires a successful PMIC probe and
+status/LDO reads. On 2.06-inch firmware,
+`BOOT_PMIC mode=display-enable-only` means the dedicated one-way compatibility
+operation verified bit `0x80` enabled without changing other register bits;
+its capture gate additionally requires `displayRecovery=1`. A preserved 1.75
+`railState` remains unverified unless the PMIC was fully power-cycled. Any
+`AXP_WRITE_BLOCKED` line is a failed safety gate and must be investigated.
 
 After three unfinished early boots from the same exact build, the fourth boot
 enters minimal safe mode before I2C, PMIC, display, storage, speaker, or BLE
@@ -593,6 +625,10 @@ initialization. Safe mode retains the original failing stage and can be cleared
 by flashing a newly built image or removing all USB and battery power. A safe
 mode decision is software containment evidence, not proof that a physical
 short was software-caused.
+
+Display-probe builds end in a distinct `diagnostic_hold` state after their
+intended partial bring-up. That state does not satisfy full-app readiness and
+does not count as a failed boot on the next reset.
 
 ### 3. Touch Coordinate Mirroring
 


### PR DESCRIPTION
## What changed

- Remove boot-time programming of AXP2101 DCDC/LDO voltage values and broad
  output-enable masks.
- Keep the Waveshare 1.75-inch PMIC output rails strictly read-only. Generic
  AXP2101 writes fail closed; only interrupt-enable register `0x41` and
  write-one-to-clear interrupt-status register `0x49` are allowlisted.
- Preserve the established Waveshare 2.06-inch display boot behavior with one
  narrow compatibility operation: read register `0x90`, set only display bit
  `0x80`, preserve every other bit, and verify readback. Generic writes to
  `0x90` remain blocked.
- Remove AXP2101 output-rail toggles from runtime, light-sleep, and deep-sleep
  paths.
- Record boot identity, reset reason, active/completed stage, and retained
  failure history in checksummed RTC no-init state. After three unfinished
  early boots from the same firmware, the next boot enters a minimal safe mode
  before peripheral initialization.
- Distinguish the canonical hardware target from derived build profiles so
  captures can identify normal, production, power, sleep, display, and speaker
  images precisely.
- Harden `tools/capture_boot.py`: open USB serial with DTR/RTS deasserted,
  validate target/profile/Git/reset/PMIC policy, select only the latest boot,
  and fail closed on mismatched, restarted, malformed, or truncated structured
  records.
- Route both speaker smoke profiles through the safe boot sequence and publish
  readiness only after every startup sound completes successfully, including
  codec/I2S cleanup where required.
- Add `tools/build_firmware.py` to handle pioarduino's generated `.dummy`
  custom-core bootstrap safely, rebuild from the requested source, and require
  the target `firmware.elf` before CI or a release can pass.
- Keep the two speaker firmware builds available in a manual-only **Speaker
  firmware builds** workflow; they no longer run for pushes or pull requests.
- Expand host tests, firmware-profile contract checks, CI build coverage, and
  hardware-validation documentation.

## Why

The previous startup path wrote a 3.3 V configuration value across ALDO1-4 and
BLDO1-2 and rewrote their enable state even though the published 1.75-inch
schematic assigns mixed nominal voltages. Two 1.75-inch boards later developed
a persistent low-resistance VBUS-to-GND fault after failures observed during
boot.

That firmware behavior was an avoidable electrical risk. It is a plausible
contributor, but this PR does **not** claim it proves the historical root cause
after the boards were damaged. The new policy removes the unsafe writes and
makes any future boot failure attributable to an exact image, reset, stage, and
PMIC policy.

The failed speaker CI builds exposed a separate pioarduino clean-runner edge:
its custom-core pass compiles a generated sketch that also defines `setup()`
and `loop()`. The speaker profile's external source filter compiled both entry
points during that pass. The build helper now recognizes that generated pass,
cleans only validated generated artifacts, and requires a clean real-target
build.

## Impact

- 1.75-inch firmware observes the current PMIC rail state without changing it.
- 2.06-inch firmware may only set its established display-enable bit during
  boot; it cannot clear that bit or change any other rail bit or voltage.
- Safe mode skips I2C, PMIC, display, storage, speaker, and BLE initialization
  after the repeated-early-failure threshold.
- Diagnostic captures reject stale readiness from an older boot and withhold a
  green result on blocked PMIC writes or diagnostic errors.
- Ordinary firmware CI covers nine normal/diagnostic/production profiles.
  Speaker smoke firmware remains opt-in through `workflow_dispatch`.
- CI and tag releases reject unknown targets, unsafe generated-artifact paths,
  repeated custom-core bootstrap passes, nonzero real builds, and successful
  PlatformIO exits that did not produce the requested ELF.

## Validation

- Final committed tree `6c2044c1fa7c23b58dd3db80ceb3e6f410a44131`:
  - 55 Python tests passed, including firmware identity/profile contracts,
    boot-capture false-green regressions, and eight deterministic-build tests.
  - AXP2101 register-policy, retained boot-state, and speaker playback-policy
    C++ host tests passed with `-Wall -Wextra -Werror`.
  - All three GitHub Actions workflow files parsed as valid YAML.
  - `git diff --check` and Python byte-compilation passed.
- GitHub Actions passed on the exact final head for both push and pull-request
  events: all 18 ordinary firmware jobs (nine profiles twice), both ESP32 host
  test jobs, both iOS jobs, map backend, and OSM pipeline. No speaker firmware
  job was scheduled automatically.
- The full 11-profile firmware matrix passed during the review:
  - `WAVESHARE_AMOLED_175`
  - `WAVESHARE_AMOLED_175_POWER_METRICS`
  - `WAVESHARE_AMOLED_175_LIGHT_SLEEP`
  - `WAVESHARE_AMOLED_175_PRODUCTION`
  - `WAVESHARE_AMOLED_175_SPEAKER_HONK`
  - `WAVESHARE_AMOLED_206`
  - `WAVESHARE_AMOLED_206_POWER_METRICS`
  - `WAVESHARE_AMOLED_206_LIGHT_SLEEP`
  - `WAVESHARE_AMOLED_206_PRODUCTION`
  - `WAVESHARE_AMOLED_206_DISPLAY_TEST`
  - `WAVESHARE_AMOLED_206_SPEAKER_HONK`
- The new deterministic helper reproduced the pioarduino clean bootstrap
  locally, then built and verified the ordinary 1.75-inch target and both
  1.75/2.06 speaker targets.
- Both speaker ELFs retain the boot state as exactly 32 bytes in RTC slow
  no-init memory and contain the expected target, profile, and PMIC-policy
  identities.
- A deep P0/P1/P2 review/fix loop converged with no remaining code findings.

The exact `6c2044c1` firmware has not yet been flashed or physically validated.
There is no 2.06-inch hardware result for the display recovery or speaker path.
The earlier `365b045b` 1.75-inch image operated normally for several minutes on
USB with no observed heating.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
