### PR TITLE
Keep display awake during active workouts

### DIFF
--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -40,7 +40,7 @@ peripheral transaction part of the correctness boundary.
 
 | State | Entry policy | What remains active | Exit |
 | --- | --- | --- | --- |
-| Connected, active display | Default connected state, meaningful activity, navigation, transfer, pairing, or audio attention | Display at saved brightness, BLE, UI scheduler, required peripherals | Inactivity can dim the display |
+| Connected, active display | Default connected state, meaningful activity, navigation, workout, transfer, pairing, or audio attention | Display at saved brightness, BLE, UI scheduler, required peripherals | Inactivity can dim the display |
 | Connected, dimmed display | 15 seconds without meaningful activity | BLE and touch remain available; display brightness is capped at 20%; UI work is throttled | Meaningful activity restores the saved brightness; continued inactivity turns the display off |
 | Connected, display off | 45 seconds without meaningful activity | BLE remains connected; the display and ordinary LVGL timer work are stopped; touch wake detection remains available | Touch, BLE/UI activity, or another wake reason restores the display and forces one full refresh |
 | Transfer or attention hold | Device transfer, activation, pairing, or audio needs immediate feedback | Display stays awake and required PM locks protect the operation | Hold ends when the operation ends |
@@ -82,10 +82,13 @@ The user's active brightness is stored in NVS under namespace
 `deviceSettings`, key `brightnessPct`. It is clamped to 5–100%, restored after
 reboot and display wake, and capped at 20% while dimmed.
 
-Navigation, transfer, and attention states deliberately hold the display awake:
+Navigation, workout, transfer, and attention states deliberately hold the
+display awake:
 
 - navigation requires an authenticated BLE connection plus a route or active
   maneuver;
+- workout requires an authenticated BLE connection plus a live Starting,
+  Running, Paused, or Ending workout state;
 - transfer includes the transfer service and device-activation work; and
 - attention includes pairing and audio.
 
@@ -93,7 +96,8 @@ Meaningful activity includes touch, screen or tile changes, BLE
 connect/authentication, route revisions, audio transitions, pairing and
 transfer state changes, new transfer progress/errors, and materially changed
 maneuver information. Repeated GPS fixes, routine workout samples, and an
-unchanged maneuver-distance update do not keep the panel awake by themselves.
+unchanged maneuver-distance update are not treated as activity events; the live
+workout state itself holds the panel awake instead.
 
 When the display is dimmed, the legacy UI timer runs at 250 ms and LVGL work is
 bounded to at most once per 100 ms. When the display is off, the main LVGL timer

--- a/esp32/lib/ble_navigation/workout_telemetry_runtime.cpp
+++ b/esp32/lib/ble_navigation/workout_telemetry_runtime.cpp
@@ -30,6 +30,14 @@ workout_telemetry::Snapshot snapshot(uint32_t nowMs) {
   return workout_telemetry::makeSnapshot(state, nowMs);
 }
 
+bool isWorkoutActive() {
+  portENTER_CRITICAL(&workoutTelemetryMux);
+  const bool active =
+      workout_telemetry::isActiveWorkout(workoutTelemetryReducer.state());
+  portEXIT_CRITICAL(&workoutTelemetryMux);
+  return active;
+}
+
 void beginAuthenticatedResynchronization() {
   portENTER_CRITICAL(&workoutTelemetryMux);
   workoutTelemetryReducer.beginResynchronization();

--- a/esp32/lib/ble_navigation/workout_telemetry_runtime.hpp
+++ b/esp32/lib/ble_navigation/workout_telemetry_runtime.hpp
@@ -14,6 +14,8 @@ workout_telemetry::ApplyResult ingestFrame(const uint8_t *bytes,
 
 workout_telemetry::Snapshot snapshot(uint32_t nowMs);
 
+bool isWorkoutActive();
+
 void beginAuthenticatedResynchronization();
 
 void reset();

--- a/esp32/lib/ble_navigation/workout_telemetry_state.hpp
+++ b/esp32/lib/ble_navigation/workout_telemetry_state.hpp
@@ -111,6 +111,10 @@ inline bool isLiveSessionState(
          state == SessionState::Paused || state == SessionState::Ending;
 }
 
+inline bool isActiveWorkout(const State &state) {
+  return state.coreReceived && isLiveSessionState(state.sessionState);
+}
+
 inline bool isValidSessionState(uint8_t raw) {
   return raw <= static_cast<uint8_t>(
                     workout_telemetry_protocol::SessionState::Failed);

--- a/esp32/lib/display_power/display_inactivity_policy.hpp
+++ b/esp32/lib/display_power/display_inactivity_policy.hpp
@@ -37,6 +37,7 @@ constexpr bool shouldPollTouchWhileDisplayInactive(Mode currentMode,
 
 struct Context {
   bool navigating = false;
+  bool workoutActive = false;
   bool transferActive = false;
   bool attentionActive = false;
 };
@@ -115,11 +116,13 @@ public:
       begin(nowMs);
     }
 
-    const bool heldAwake = context.navigating || context.transferActive ||
-                           context.attentionActive;
+    const bool heldAwake =
+        context.navigating || context.workoutActive || context.transferActive ||
+        context.attentionActive;
     if (heldAwake_ && !heldAwake) {
-      // Leaving navigation, transfer, pairing, or audio should start a fresh
-      // idle interval instead of immediately inheriting the time spent held.
+      // Leaving navigation, workout, transfer, pairing, or audio should start
+      // a fresh idle interval instead of immediately inheriting the time spent
+      // held.
       lastMeaningfulActivityMs_ = nowMs;
     }
     heldAwake_ = heldAwake;
@@ -127,7 +130,8 @@ public:
     Mode requested = Mode::Active;
     if (context.transferActive) {
       requested = Mode::Transfer;
-    } else if (context.navigating || context.attentionActive) {
+    } else if (context.navigating || context.workoutActive ||
+               context.attentionActive) {
       requested = Mode::Active;
     } else {
       const uint32_t idleMs = elapsedMs(nowMs, lastMeaningfulActivityMs_);

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -88,6 +88,7 @@ extern xSemaphoreHandle gpsMutex;
 #include "route_overlay.hpp"
 #include "ui_scheduler.hpp"
 #include "waitingScr.hpp"
+#include "workout_telemetry_runtime.hpp"
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 #include "WAVESHARE_AMOLED_175.hpp"
 #include "axp2101.hpp"
@@ -619,6 +620,9 @@ static display_inactivity::Update updateDisplayInactivityPolicy(
   context.navigating =
       bleStats.connected && bleStats.authenticated &&
       (routeOverlay.hasRoute() || hasCurrentNavigationData());
+  context.workoutActive =
+      bleStats.connected && bleStats.authenticated &&
+      workout_telemetry_runtime::isWorkoutActive();
   context.transferActive =
       signals.transferEnabled || signals.activationRunning;
   context.attentionActive = signals.pairing || audioActive;

--- a/esp32/tools/tests/test_display_inactivity_policy.cpp
+++ b/esp32/tools/tests/test_display_inactivity_policy.cpp
@@ -42,7 +42,8 @@ int main() {
   assert(idle.update(46'000, {}).current == Mode::DisplayOff);
 
   // Connection state and replaceable GPS/workout samples are intentionally not
-  // policy inputs, so repeated updates alone cannot postpone idle states.
+  // meaningful-activity inputs, so repeated updates alone cannot postpone idle
+  // states without an explicit navigation or workout hold.
   Policy gpsOnly;
   gpsOnly.begin(0);
   for (uint32_t now = 1'000; now <= 50'000; now += 1'000) {
@@ -99,6 +100,16 @@ int main() {
   assert(navigation.update(200'000, {}).current == Mode::Active);
   assert(navigation.update(215'000, {}).current == Mode::Dimmed);
 
+  Policy workout;
+  workout.begin(0);
+  Context workingOut;
+  workingOut.workoutActive = true;
+  assert(workout.update(100'000, workingOut).current == Mode::Active);
+  assert(workout.update(200'000, workingOut).current == Mode::Active);
+  assert(workout.update(300'000, {}).current == Mode::Active);
+  assert(workout.update(315'000, {}).current == Mode::Dimmed);
+  assert(workout.update(345'000, {}).current == Mode::DisplayOff);
+
   Policy transfer;
   transfer.begin(0);
   Context transferring;
@@ -142,12 +153,21 @@ int main() {
     assert(eventUpdate.displayWakeRequired ==
            (previous == Mode::DisplayOff));
 
-    // Route/navigation start, pairing/ownership, audio, and transfer entry are
-    // policy holds and must work from every prior state as well.
+    // Route/navigation start, workout start, pairing/ownership, audio, and
+    // transfer entry are policy holds and must work from every prior state as
+    // well.
     Policy route = policyAtMode(previous);
     Context routeStarted;
     routeStarted.navigating = true;
     assert(route.update(100'000, routeStarted).current == Mode::Active);
+
+    Policy workout = policyAtMode(previous);
+    Context workoutStarted;
+    workoutStarted.workoutActive = true;
+    const auto workoutUpdate = workout.update(100'000, workoutStarted);
+    assert(workoutUpdate.current == Mode::Active);
+    assert(workoutUpdate.displayWakeRequired ==
+           (previous == Mode::DisplayOff));
 
     Policy pairing = policyAtMode(previous);
     Context pairingStarted;

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -85,6 +85,31 @@ void assertResultPreservesState(Reducer &reducer, const uint8_t *bytes,
 } // namespace
 
 int main() {
+  State activityState;
+  const SessionState liveStates[] = {
+      SessionState::Starting,
+      SessionState::Running,
+      SessionState::Paused,
+      SessionState::Ending,
+  };
+  for (const SessionState state : liveStates) {
+    activityState.sessionState = state;
+    activityState.coreReceived = false;
+    assert(!workout_telemetry::isActiveWorkout(activityState));
+    activityState.coreReceived = true;
+    assert(workout_telemetry::isActiveWorkout(activityState));
+  }
+  const SessionState inactiveStates[] = {
+      SessionState::Idle,
+      SessionState::Ended,
+      SessionState::Failed,
+  };
+  for (const SessionState state : inactiveStates) {
+    activityState.sessionState = state;
+    activityState.coreReceived = true;
+    assert(!workout_telemetry::isActiveWorkout(activityState));
+  }
+
   const uint8_t core[workout_telemetry_protocol::FRAME_SIZE] = {
       0x01, 0x02, 0x34, 0x12, 0x4D, 0x0E, 0x00, 0x00,
       0x39, 0x30, 0x00, 0x00, 0xD2, 0x04, 0x9D, 0x00,


### PR DESCRIPTION
## What changed

- hold the connected device display awake while a workout is Starting, Running, Paused, or Ending
- wake the display if a workout begins while it is dimmed or off
- restart the normal inactivity timer when the workout finishes
- document the updated display policy

## Why

Workout telemetry updates were intentionally excluded from meaningful-activity events, but the workout session itself was not represented as a display-awake hold. As a result, workout-only rides dimmed after 15 seconds and turned the panel off after 45 seconds.

## Validation

- display inactivity policy host tests
- workout telemetry state and presentation host tests
- display power policy host tests
- UI scheduler policy host tests
- power-management policy host tests
- workout telemetry protocol host tests
- `git diff --check`

The full firmware build matrix will run in GitHub Actions.
