### PR TITLE
Add adjustable bird's-eye Map + Navigation view

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,12 @@ jobs:
             tools/tests/test_map_pinch_zoom.cpp \
             -o /tmp/test_map_pinch_zoom
           /tmp/test_map_pinch_zoom
+      - name: Map projection host tests
+        run: |
+          g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_map_projection.cpp \
+            -o /tmp/test_map_projection
+          /tmp/test_map_projection
       - name: Map profile protocol host tests
         run: |
           g++ -std=c++17 \

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -485,7 +485,7 @@ Current setting IDs:
 | `23` | Connected phone battery level | transient whole-number percentage `0...100`; iOS sends it after authentication and whenever the phone battery level changes. Firmware clears it on disconnect. |
 | `24` | Connected phone charging state | transient `0` not charging, `1` charging; iOS sends it after authentication and whenever the public battery state changes. Firmware clears it on disconnect. |
 | `25` | Map + Navigation bird's-eye view | `0` disabled, `1` enabled; defaults to enabled and is persisted as `navBirdEye`. The projection is effective only while Map + Navigation has an active route. |
-| `26` | Map + Navigation bird's-eye perspective | `0` Gentle, `1` Standard, `2` Strong; defaults to Standard and is persisted as `navBirdTilt`. This changes the shared projection strength for the map, route, and position marker. |
+| `26` | Map + Navigation bird's-eye perspective | `0` Gentle, `1` Standard, `2` Strong, `3` Very Strong, `4` Maximum; defaults to Standard and is persisted as `navBirdTilt`. This changes the shared projection strength for the map, route, and position marker. At extreme zoom/viewport combinations, firmware eases the requested strength only as much as needed to stay within the four-block renderer budget. |
 
 The settings list and the device's tap/PWR-button cycle use this screen order:
 Map + Navigation, Ride Stats, Map, Navigation, then Battery Status.
@@ -634,10 +634,13 @@ Extended flag bit `0` reports support for the Map + Navigation bird's-eye
 projection and setting ID `25`. iOS keeps the switch disabled and never sends
 ID `25` when this bit is absent. Version `8` additionally requests bit `1`,
 which reports support for the Gentle, Standard, and Strong perspective presets
-and setting ID `26`. iOS hides the perspective picker and never sends ID `26`
-when bit `1` is absent. Version `7` clients receive only bit `0`; firmware only
-appends the extended byte for version `7` or newer requests, so older clients
-continue receiving the exact legacy five- or eight-byte response.
+and setting ID `26`. Version `9` additionally requests bit `2`, which reports
+support for the Very Strong and Maximum values. iOS hides the perspective
+picker when bit `1` is absent and limits it to the first three presets when bit
+`2` is absent. Values `3` and `4` are clamped to Strong before being sent to
+older perspective-capable firmware. Version `7` clients receive only bit `0`;
+firmware only appends the extended byte for version `7` or newer requests, so
+older clients continue receiving the exact legacy five- or eight-byte response.
 
 Receiving a `CAPS` request alone does not switch the firmware's
 setting semantics: a session switches to independent profiles only after the

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -484,6 +484,7 @@ Current setting IDs:
 | `22` | Map + Navigation current-position marker scale | `1...5` |
 | `23` | Connected phone battery level | transient whole-number percentage `0...100`; iOS sends it after authentication and whenever the phone battery level changes. Firmware clears it on disconnect. |
 | `24` | Connected phone charging state | transient `0` not charging, `1` charging; iOS sends it after authentication and whenever the public battery state changes. Firmware clears it on disconnect. |
+| `25` | Map + Navigation bird's-eye view | `0` disabled, `1` enabled; defaults to enabled and is persisted as `navBirdEye`. The projection is effective only while Map + Navigation has an active route. |
 
 The settings list and the device's tap/PWR-button cycle use this screen order:
 Map + Navigation, Ride Stats, Map, Navigation, then Battery Status.
@@ -504,6 +505,12 @@ Navigation profile. On firmware upgrade, missing Map + Navigation values inherit
 the persisted Map values. Map rotation mode remains Map-only; Map + Navigation
 automatically uses course-up while navigating. Route and current-position
 overlay visibility remains shared by both profiles.
+
+Setting ID `25` is separately capability-gated and does not change the
+`16...22` independent-profile range. The ordinary Map screen and Map +
+Navigation without an active route remain flat. During active navigation the
+bird's-eye renderer uses one projection snapshot for vector features, route
+geometry, and the current-position marker so all three layers stay aligned.
 
 Fresh Map profiles default to high detail, zoom level `3`, a `4` px route line,
 `4` px streets, and a `2x` position marker. Fresh Map + Navigation profiles
@@ -613,8 +620,22 @@ screen settings so the device can distinguish a current screen mask from one
 sent by an older four-screen app; older app masks preserve the device's
 existing Battery Status preference. Version `5` advertises destination-catalog
 and device-originated route-request support. Version `6` advertises that the
-client understands the dedicated Watch-workout telemetry contract. Receiving a `CAPS` request alone does not
-switch the firmware's
+client understands the dedicated Watch-workout telemetry contract. Version `7`
+asks firmware to append an extended capability byte after the optional
+PWR-button configuration:
+
+```text
+"CAPS" | Flags: UInt8 | ExtendedFlags: UInt8
+"CAPS" | Flags: UInt8 | Enabled: UInt8 | SoundID: UInt8 | VolumePercent: UInt8 | ExtendedFlags: UInt8
+```
+
+Extended flag bit `0` reports support for the Map + Navigation bird's-eye
+projection and setting ID `25`. iOS keeps the switch disabled and never sends
+ID `25` when this bit is absent. Firmware only appends this byte for version
+`7` or newer requests, so older clients continue receiving the exact legacy
+five- or eight-byte response.
+
+Receiving a `CAPS` request alone does not switch the firmware's
 setting semantics: a session switches to independent profiles only after the
 first setting ID in `16...22` is received. This keeps legacy IDs shared when a
 capability response is dropped.

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -485,6 +485,7 @@ Current setting IDs:
 | `23` | Connected phone battery level | transient whole-number percentage `0...100`; iOS sends it after authentication and whenever the phone battery level changes. Firmware clears it on disconnect. |
 | `24` | Connected phone charging state | transient `0` not charging, `1` charging; iOS sends it after authentication and whenever the public battery state changes. Firmware clears it on disconnect. |
 | `25` | Map + Navigation bird's-eye view | `0` disabled, `1` enabled; defaults to enabled and is persisted as `navBirdEye`. The projection is effective only while Map + Navigation has an active route. |
+| `26` | Map + Navigation bird's-eye perspective | `0` Gentle, `1` Standard, `2` Strong; defaults to Standard and is persisted as `navBirdTilt`. This changes the shared projection strength for the map, route, and position marker. |
 
 The settings list and the device's tap/PWR-button cycle use this screen order:
 Map + Navigation, Ride Stats, Map, Navigation, then Battery Status.
@@ -631,9 +632,12 @@ PWR-button configuration:
 
 Extended flag bit `0` reports support for the Map + Navigation bird's-eye
 projection and setting ID `25`. iOS keeps the switch disabled and never sends
-ID `25` when this bit is absent. Firmware only appends this byte for version
-`7` or newer requests, so older clients continue receiving the exact legacy
-five- or eight-byte response.
+ID `25` when this bit is absent. Version `8` additionally requests bit `1`,
+which reports support for the Gentle, Standard, and Strong perspective presets
+and setting ID `26`. iOS hides the perspective picker and never sends ID `26`
+when bit `1` is absent. Version `7` clients receive only bit `0`; firmware only
+appends the extended byte for version `7` or newer requests, so older clients
+continue receiving the exact legacy five- or eight-byte response.
 
 Receiving a `CAPS` request alone does not switch the firmware's
 setting semantics: a session switches to independent profiles only after the

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1666,7 +1666,7 @@ static void processPendingTransferControl() {
 
 static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
                                      bool includePowerButtonConfig,
-                                     bool includeExtendedCapabilities) {
+                                     uint8_t clientVersion) {
   if (pChar == nullptr) {
     pChar = mapTransferStatusCharacteristic;
   }
@@ -1701,18 +1701,19 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
     }
     responseSize += waveshare_board::speaker::POWER_BUTTON_HONK_PAYLOAD_SIZE;
   }
-  if (includeExtendedCapabilities) {
-    response[responseSize++] =
-        map_profile_protocol::BIRDS_EYE_EXTENDED_CAPABILITY_MASK;
+  const uint8_t extendedCapabilityFlags =
+      map_profile_protocol::extendedCapabilityFlagsForClient(clientVersion);
+  if (extendedCapabilityFlags != 0) {
+    response[responseSize++] = extendedCapabilityFlags;
   }
   if (!notifyAuthenticatedNavigation(pChar, response, responseSize)) {
     Serial.println("BLE Capabilities: protected notification failed");
     return;
   }
   Serial.printf(
-      "BLE Capabilities: notified flags=0x%02X config=%d extended=%d\n",
+      "BLE Capabilities: notified flags=0x%02X config=%d extended=0x%02X\n",
       response[4], includePowerButtonConfig && powerButtonHonkAvailable ? 1 : 0,
-      includeExtendedCapabilities ? 1 : 0);
+      extendedCapabilityFlags);
 }
 
 static void notifyPowerButtonHonkStatus(
@@ -1752,9 +1753,7 @@ static bool handleDeviceCapabilitiesCommand(const std::string &value,
         value.length() == 5 ? static_cast<uint8_t>(value[4]) : 0;
     const bool includePowerButtonConfig =
         clientVersion >= 1;
-    notifyDeviceCapabilities(
-        pChar, includePowerButtonConfig,
-        map_profile_protocol::clientSupportsBirdsEyeProjection(clientVersion));
+    notifyDeviceCapabilities(pChar, includePowerButtonConfig, clientVersion);
   }
   return true;
 }
@@ -2401,6 +2400,18 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
                   mapRenderSettings.mapNavigationBirdsEyeEnabled ? "on"
                                                                   : "off");
     break;
+  case map_profile_protocol::MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID:
+    mapRenderSettings.mapNavigationBirdsEyePerspective =
+        static_cast<uint8_t>(
+            map_profile_protocol::clampValue(settingId, settingValue));
+    settingsPrefs.begin("mapSettings", false);
+    map_profile_persistence::persistBirdsEyePerspective(
+        settingsPrefs, mapRenderSettings.mapNavigationBirdsEyePerspective);
+    settingsPrefs.end();
+    Serial.printf("BLE Settings: mapNavigationBirdsEyePerspective = %u "
+                  "(saved)\n",
+                  mapRenderSettings.mapNavigationBirdsEyePerspective);
+    break;
   default:
     Serial.printf("BLE Settings: Unknown setting ID %d from %s\n", settingId,
                   source == nullptr ? "unknown" : source);
@@ -2981,6 +2992,8 @@ static void loadSettingsFromNVS() {
                                 mapRenderSettings.mapNavigationStyle);
   mapRenderSettings.mapNavigationBirdsEyeEnabled =
       map_profile_persistence::loadBirdsEyeEnabled(prefs);
+  mapRenderSettings.mapNavigationBirdsEyePerspective =
+      map_profile_persistence::loadBirdsEyePerspective(prefs);
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
   mapRenderSettings.tapToSwitchScreens = prefs.getUChar("tapSwitch", 0);
   uint8_t storedScreenMask =
@@ -3006,7 +3019,7 @@ static void loadSettingsFromNVS() {
 
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
                 "detailLevel=%d, routeWidth=%d, streetWidth=%d, "
-                "markerScale=%d, navBirdEye=%d, tapSwitch=%d, "
+                "markerScale=%d, navBirdEye=%d, navBirdTilt=%d, tapSwitch=%d, "
                 "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
                 mapRenderSettings.mapStyle.minPolygonSize,
                 mapRenderSettings.mapStyle.detailLevel,
@@ -3014,6 +3027,7 @@ static void loadSettingsFromNVS() {
                 mapRenderSettings.mapStyle.streetLineWidth,
                 mapRenderSettings.mapStyle.positionMarkerScale,
                 mapRenderSettings.mapNavigationBirdsEyeEnabled ? 1 : 0,
+                mapRenderSettings.mapNavigationBirdsEyePerspective,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,
                 mapRenderSettings.defaultScreen,

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1665,7 +1665,8 @@ static void processPendingTransferControl() {
 }
 
 static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
-                                     bool includePowerButtonConfig) {
+                                     bool includePowerButtonConfig,
+                                     bool includeExtendedCapabilities) {
   if (pChar == nullptr) {
     pChar = mapTransferStatusCharacteristic;
   }
@@ -1676,7 +1677,7 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
   const bool speakerAvailable = waveshare_board::speaker::isAvailable();
   const bool powerButtonHonkAvailable =
       waveshare_board::speaker::isPowerButtonHonkAvailable();
-  uint8_t response[8] = {
+  uint8_t response[9] = {
       'C', 'A', 'P', 'S',
       static_cast<uint8_t>(
           waveshare_board::speaker::capabilityFlags(
@@ -1700,12 +1701,18 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
     }
     responseSize += waveshare_board::speaker::POWER_BUTTON_HONK_PAYLOAD_SIZE;
   }
+  if (includeExtendedCapabilities) {
+    response[responseSize++] =
+        map_profile_protocol::BIRDS_EYE_EXTENDED_CAPABILITY_MASK;
+  }
   if (!notifyAuthenticatedNavigation(pChar, response, responseSize)) {
     Serial.println("BLE Capabilities: protected notification failed");
     return;
   }
-  Serial.printf("BLE Capabilities: notified flags=0x%02X config=%d\n",
-                response[4], responseSize > 5 ? 1 : 0);
+  Serial.printf(
+      "BLE Capabilities: notified flags=0x%02X config=%d extended=%d\n",
+      response[4], includePowerButtonConfig && powerButtonHonkAvailable ? 1 : 0,
+      includeExtendedCapabilities ? 1 : 0);
 }
 
 static void notifyPowerButtonHonkStatus(
@@ -1745,7 +1752,9 @@ static bool handleDeviceCapabilitiesCommand(const std::string &value,
         value.length() == 5 ? static_cast<uint8_t>(value[4]) : 0;
     const bool includePowerButtonConfig =
         clientVersion >= 1;
-    notifyDeviceCapabilities(pChar, includePowerButtonConfig);
+    notifyDeviceCapabilities(
+        pChar, includePowerButtonConfig,
+        map_profile_protocol::clientSupportsBirdsEyeProjection(clientVersion));
   }
   return true;
 }
@@ -2381,6 +2390,17 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
     Serial.printf("BLE Settings: phoneBatteryCharging = %s\n",
                   phoneBatteryCharging ? "yes" : "no");
     return;
+  case map_profile_protocol::MAP_NAVIGATION_BIRDS_EYE_SETTING_ID:
+    mapRenderSettings.mapNavigationBirdsEyeEnabled =
+        map_profile_protocol::clampValue(settingId, settingValue) != 0;
+    settingsPrefs.begin("mapSettings", false);
+    map_profile_persistence::persistBirdsEyeEnabled(
+        settingsPrefs, mapRenderSettings.mapNavigationBirdsEyeEnabled);
+    settingsPrefs.end();
+    Serial.printf("BLE Settings: mapNavigationBirdsEye = %s (saved)\n",
+                  mapRenderSettings.mapNavigationBirdsEyeEnabled ? "on"
+                                                                  : "off");
+    break;
   default:
     Serial.printf("BLE Settings: Unknown setting ID %d from %s\n", settingId,
                   source == nullptr ? "unknown" : source);
@@ -2959,6 +2979,8 @@ static void loadSettingsFromNVS() {
 
   map_profile_persistence::load(prefs, mapRenderSettings.mapStyle,
                                 mapRenderSettings.mapNavigationStyle);
+  mapRenderSettings.mapNavigationBirdsEyeEnabled =
+      map_profile_persistence::loadBirdsEyeEnabled(prefs);
   mapRenderSettings.mapRotationMode = prefs.getUChar("mapRotMode", 0);
   mapRenderSettings.tapToSwitchScreens = prefs.getUChar("tapSwitch", 0);
   uint8_t storedScreenMask =
@@ -2984,13 +3006,14 @@ static void loadSettingsFromNVS() {
 
   Serial.printf("BLE: Loaded settings from NVS - minPolySize=%d, "
                 "detailLevel=%d, routeWidth=%d, streetWidth=%d, "
-                "markerScale=%d, tapSwitch=%d, "
+                "markerScale=%d, navBirdEye=%d, tapSwitch=%d, "
                 "screenMask=0x%02X, defaultScreen=%d, discSleepSec=%lu\n",
                 mapRenderSettings.mapStyle.minPolygonSize,
                 mapRenderSettings.mapStyle.detailLevel,
                 mapRenderSettings.mapStyle.routeLineWidth,
                 mapRenderSettings.mapStyle.streetLineWidth,
                 mapRenderSettings.mapStyle.positionMarkerScale,
+                mapRenderSettings.mapNavigationBirdsEyeEnabled ? 1 : 0,
                 mapRenderSettings.tapToSwitchScreens,
                 mapRenderSettings.enabledScreensMask,
                 mapRenderSettings.defaultScreen,

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -37,8 +37,8 @@ struct NavigationData {
  * IDs 1,2,3,7,8,9,10 configure the Map screen. IDs 16-22 configure
  * Map + Navigation. IDs 6,11-15 configure shared/device behavior, and IDs
  * 23-24 carry the connected phone's transient battery percentage and charging
- * state. Legacy ID 4 is ignored because display rotation is selected by the
- * hardware target.
+ * state. ID 25 controls the Map + Navigation bird's-eye projection. Legacy ID
+ * 4 is ignored because display rotation is selected by the hardware target.
  */
 enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
@@ -113,6 +113,7 @@ struct MapRenderSettings {
         map_profile_protocol::MAP_NAVIGATION_DEFAULT_VISIBILITY_MASK;
     return settings;
   }();
+  bool mapNavigationBirdsEyeEnabled = true;
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
   uint8_t enabledScreensMask =

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -37,8 +37,9 @@ struct NavigationData {
  * IDs 1,2,3,7,8,9,10 configure the Map screen. IDs 16-22 configure
  * Map + Navigation. IDs 6,11-15 configure shared/device behavior, and IDs
  * 23-24 carry the connected phone's transient battery percentage and charging
- * state. ID 25 controls the Map + Navigation bird's-eye projection. Legacy ID
- * 4 is ignored because display rotation is selected by the hardware target.
+ * state. IDs 25-26 control the Map + Navigation bird's-eye projection and
+ * perspective. Legacy ID 4 is ignored because display rotation is selected by
+ * the hardware target.
  */
 enum DeviceScreenSetting : uint8_t {
   DEVICE_SCREEN_MAP = 0,
@@ -114,6 +115,8 @@ struct MapRenderSettings {
     return settings;
   }();
   bool mapNavigationBirdsEyeEnabled = true;
+  uint8_t mapNavigationBirdsEyePerspective =
+      map_profile_protocol::MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE;
   uint8_t mapRotationMode = 0; // 0=North Up, 1=Course Up
   uint8_t tapToSwitchScreens = 0; // 0=off, 1=short tap cycles main screens
   uint8_t enabledScreensMask =

--- a/esp32/lib/ble_navigation/map_profile_persistence.hpp
+++ b/esp32/lib/ble_navigation/map_profile_persistence.hpp
@@ -6,6 +6,16 @@
 
 namespace map_profile_persistence {
 
+template <typename Store>
+inline bool loadBirdsEyeEnabled(Store &store) {
+  return store.getBool("navBirdEye", true);
+}
+
+template <typename Store>
+inline void persistBirdsEyeEnabled(Store &store, bool enabled) {
+  store.putBool("navBirdEye", enabled);
+}
+
 template <typename Store, typename Profile>
 inline void load(Store &store, Profile &mapStyle,
                  Profile &mapNavigationStyle) {

--- a/esp32/lib/ble_navigation/map_profile_persistence.hpp
+++ b/esp32/lib/ble_navigation/map_profile_persistence.hpp
@@ -16,6 +16,24 @@ inline void persistBirdsEyeEnabled(Store &store, bool enabled) {
   store.putBool("navBirdEye", enabled);
 }
 
+template <typename Store>
+inline uint8_t loadBirdsEyePerspective(Store &store) {
+  return static_cast<uint8_t>(map_profile_protocol::clampValue(
+      map_profile_protocol::MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID,
+      store.getUChar(
+          "navBirdTilt",
+          map_profile_protocol::MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE)));
+}
+
+template <typename Store>
+inline void persistBirdsEyePerspective(Store &store, uint8_t perspective) {
+  store.putUChar(
+      "navBirdTilt",
+      static_cast<uint8_t>(map_profile_protocol::clampValue(
+          map_profile_protocol::MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID,
+          perspective)));
+}
+
 template <typename Store, typename Profile>
 inline void load(Store &store, Profile &mapStyle,
                  Profile &mapNavigationStyle) {

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -10,7 +10,11 @@ constexpr uint8_t EXTENDED_VISIBILITY_CAPABILITY_MASK = 1 << 4;
 constexpr uint8_t EXTENDED_VISIBILITY_CLIENT_VERSION = 3;
 constexpr uint8_t BIRDS_EYE_EXTENDED_CAPABILITY_MASK = 1 << 0;
 constexpr uint8_t BIRDS_EYE_CLIENT_VERSION = 7;
+constexpr uint8_t BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK = 1 << 1;
+constexpr uint8_t BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION = 8;
 constexpr uint8_t MAP_NAVIGATION_BIRDS_EYE_SETTING_ID = 25;
+constexpr uint8_t MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID = 26;
+constexpr uint8_t MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE = 1;
 constexpr uint8_t DEFAULT_STREET_WIDTH = 4;
 constexpr uint8_t MAP_DEFAULT_DETAIL_LEVEL = 2;
 constexpr uint8_t MAP_DEFAULT_ROUTE_LINE_WIDTH = 4;
@@ -51,6 +55,19 @@ inline bool clientSupportsExtendedVisibility(uint8_t clientVersion) {
 
 inline bool clientSupportsBirdsEyeProjection(uint8_t clientVersion) {
   return clientVersion >= BIRDS_EYE_CLIENT_VERSION;
+}
+
+inline bool clientSupportsBirdsEyePerspective(uint8_t clientVersion) {
+  return clientVersion >= BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION;
+}
+
+inline uint8_t extendedCapabilityFlagsForClient(uint8_t clientVersion) {
+  uint8_t flags = 0;
+  if (clientSupportsBirdsEyeProjection(clientVersion))
+    flags |= BIRDS_EYE_EXTENDED_CAPABILITY_MASK;
+  if (clientSupportsBirdsEyePerspective(clientVersion))
+    flags |= BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK;
+  return flags;
 }
 
 inline uint32_t normalizedFeatureVisibilityMask(uint32_t mask) {
@@ -150,6 +167,9 @@ inline int32_t clampValue(uint8_t settingId, int32_t value) {
     break;
   case MAP_NAVIGATION_BIRDS_EYE_SETTING_ID:
     maximum = 1;
+    break;
+  case MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID:
+    maximum = 2;
     break;
   default:
     return value;

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -8,6 +8,9 @@ constexpr uint8_t CAPABILITY_MASK = 1 << 3;
 constexpr uint8_t CLIENT_VERSION = 2;
 constexpr uint8_t EXTENDED_VISIBILITY_CAPABILITY_MASK = 1 << 4;
 constexpr uint8_t EXTENDED_VISIBILITY_CLIENT_VERSION = 3;
+constexpr uint8_t BIRDS_EYE_EXTENDED_CAPABILITY_MASK = 1 << 0;
+constexpr uint8_t BIRDS_EYE_CLIENT_VERSION = 7;
+constexpr uint8_t MAP_NAVIGATION_BIRDS_EYE_SETTING_ID = 25;
 constexpr uint8_t DEFAULT_STREET_WIDTH = 4;
 constexpr uint8_t MAP_DEFAULT_DETAIL_LEVEL = 2;
 constexpr uint8_t MAP_DEFAULT_ROUTE_LINE_WIDTH = 4;
@@ -44,6 +47,10 @@ inline bool clientSupportsIndependentProfiles(uint8_t clientVersion) {
 
 inline bool clientSupportsExtendedVisibility(uint8_t clientVersion) {
   return clientVersion >= EXTENDED_VISIBILITY_CLIENT_VERSION;
+}
+
+inline bool clientSupportsBirdsEyeProjection(uint8_t clientVersion) {
+  return clientVersion >= BIRDS_EYE_CLIENT_VERSION;
 }
 
 inline uint32_t normalizedFeatureVisibilityMask(uint32_t mask) {
@@ -140,6 +147,9 @@ inline int32_t clampValue(uint8_t settingId, int32_t value) {
   case 22:
     minimum = 1;
     maximum = 5;
+    break;
+  case MAP_NAVIGATION_BIRDS_EYE_SETTING_ID:
+    maximum = 1;
     break;
   default:
     return value;

--- a/esp32/lib/ble_navigation/map_profile_protocol.hpp
+++ b/esp32/lib/ble_navigation/map_profile_protocol.hpp
@@ -12,6 +12,9 @@ constexpr uint8_t BIRDS_EYE_EXTENDED_CAPABILITY_MASK = 1 << 0;
 constexpr uint8_t BIRDS_EYE_CLIENT_VERSION = 7;
 constexpr uint8_t BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK = 1 << 1;
 constexpr uint8_t BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION = 8;
+constexpr uint8_t BIRDS_EYE_STRONGER_PERSPECTIVE_EXTENDED_CAPABILITY_MASK =
+    1 << 2;
+constexpr uint8_t BIRDS_EYE_STRONGER_PERSPECTIVE_CLIENT_VERSION = 9;
 constexpr uint8_t MAP_NAVIGATION_BIRDS_EYE_SETTING_ID = 25;
 constexpr uint8_t MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID = 26;
 constexpr uint8_t MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE = 1;
@@ -61,12 +64,18 @@ inline bool clientSupportsBirdsEyePerspective(uint8_t clientVersion) {
   return clientVersion >= BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION;
 }
 
+inline bool clientSupportsStrongerBirdsEyePerspective(uint8_t clientVersion) {
+  return clientVersion >= BIRDS_EYE_STRONGER_PERSPECTIVE_CLIENT_VERSION;
+}
+
 inline uint8_t extendedCapabilityFlagsForClient(uint8_t clientVersion) {
   uint8_t flags = 0;
   if (clientSupportsBirdsEyeProjection(clientVersion))
     flags |= BIRDS_EYE_EXTENDED_CAPABILITY_MASK;
   if (clientSupportsBirdsEyePerspective(clientVersion))
     flags |= BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK;
+  if (clientSupportsStrongerBirdsEyePerspective(clientVersion))
+    flags |= BIRDS_EYE_STRONGER_PERSPECTIVE_EXTENDED_CAPABILITY_MASK;
   return flags;
 }
 
@@ -169,7 +178,7 @@ inline int32_t clampValue(uint8_t settingId, int32_t value) {
     maximum = 1;
     break;
   case MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID:
-    maximum = 2;
+    maximum = 4;
     break;
   default:
     return value;

--- a/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
+++ b/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
@@ -22,6 +22,7 @@ constexpr bool invalidatesMap(uint8_t settingId) {
   case 21:
   case 22:
   case 25:
+  case 26:
     return true;
   default:
     return false;

--- a/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
+++ b/esp32/lib/ble_navigation/map_setting_redraw_policy.hpp
@@ -21,6 +21,7 @@ constexpr bool invalidatesMap(uint8_t settingId) {
   case 20:
   case 21:
   case 22:
+  case 25:
     return true;
   default:
     return false;

--- a/esp32/lib/maps/src/map_projection.hpp
+++ b/esp32/lib/maps/src/map_projection.hpp
@@ -20,6 +20,8 @@ enum class BirdsEyePerspective : uint8_t {
   Gentle = 0,
   Standard = 1,
   Strong = 2,
+  VeryStrong = 3,
+  Maximum = 4,
 };
 
 inline BirdsEyePerspective birdsEyePerspectiveForValue(uint8_t value) {
@@ -28,6 +30,10 @@ inline BirdsEyePerspective birdsEyePerspectiveForValue(uint8_t value) {
     return BirdsEyePerspective::Gentle;
   case static_cast<uint8_t>(BirdsEyePerspective::Strong):
     return BirdsEyePerspective::Strong;
+  case static_cast<uint8_t>(BirdsEyePerspective::VeryStrong):
+    return BirdsEyePerspective::VeryStrong;
+  case static_cast<uint8_t>(BirdsEyePerspective::Maximum):
+    return BirdsEyePerspective::Maximum;
   default:
     return BirdsEyePerspective::Standard;
   }
@@ -39,6 +45,10 @@ inline double birdsEyeTopEdgeScale(BirdsEyePerspective perspective) {
     return 0.75;
   case BirdsEyePerspective::Strong:
     return 0.48;
+  case BirdsEyePerspective::VeryStrong:
+    return 0.36;
+  case BirdsEyePerspective::Maximum:
+    return 0.24;
   case BirdsEyePerspective::Standard:
   default:
     return 0.60;
@@ -59,6 +69,10 @@ struct Config {
       birdsEyeTopEdgeScale(BirdsEyePerspective::Standard);
   double maximumDepthScale = 1.35;
   double nearPlaneMarginPixels = 8.0;
+  // Keep the inverse-projected viewport narrower than one 4096-coordinate map
+  // block per axis so the existing four-block cache remains sufficient.
+  double maximumWorldSpan = 4095.0;
+  double worldBoundsMarginPixels = 4.0;
 };
 
 struct GroundPoint {
@@ -81,11 +95,36 @@ class Projection {
 public:
   Projection() = default;
   explicit Projection(const Config &config) : config_(config) {
-    const double topScale =
+    const auto applyTopScale = [this](double topScale) {
+      config_.topEdgeScale = topScale;
+      focalDistance_ = config_.anchorY / (1.0 - topScale);
+      if (!(focalDistance_ > config_.anchorY)) {
+        focalDistance_ = std::max(1.0, config_.viewportHeight * 1.4);
+      }
+    };
+    const double requestedTopScale =
         std::max(0.05, std::min(0.95, config_.topEdgeScale));
-    focalDistance_ = config_.anchorY / (1.0 - topScale);
-    if (!(focalDistance_ > config_.anchorY)) {
-      focalDistance_ = std::max(1.0, config_.viewportHeight * 1.4);
+    applyTopScale(requestedTopScale);
+    if (isBirdsEye() && config_.maximumWorldSpan > 0.0) {
+      const auto worldSpanFits = [this]() {
+        const auto bounds = worldBounds(config_.worldBoundsMarginPixels);
+        return bounds.max.x - bounds.min.x <= config_.maximumWorldSpan &&
+               bounds.max.y - bounds.min.y <= config_.maximumWorldSpan;
+      };
+      if (!worldSpanFits()) {
+        double unsafeTopScale = requestedTopScale;
+        double safeTopScale = 0.95;
+        applyTopScale(safeTopScale);
+        for (uint8_t iteration = 0; iteration < 32; ++iteration) {
+          const double candidate = (unsafeTopScale + safeTopScale) / 2.0;
+          applyTopScale(candidate);
+          if (worldSpanFits())
+            safeTopScale = candidate;
+          else
+            unsafeTopScale = candidate;
+        }
+        applyTopScale(safeTopScale);
+      }
     }
     nearPlaneForward_ =
         inverseForward(config_.viewportHeight + config_.nearPlaneMarginPixels);

--- a/esp32/lib/maps/src/map_projection.hpp
+++ b/esp32/lib/maps/src/map_projection.hpp
@@ -16,6 +16,35 @@ namespace map_projection {
 
 enum class Mode : uint8_t { Flat = 0, BirdsEye = 1 };
 
+enum class BirdsEyePerspective : uint8_t {
+  Gentle = 0,
+  Standard = 1,
+  Strong = 2,
+};
+
+inline BirdsEyePerspective birdsEyePerspectiveForValue(uint8_t value) {
+  switch (value) {
+  case static_cast<uint8_t>(BirdsEyePerspective::Gentle):
+    return BirdsEyePerspective::Gentle;
+  case static_cast<uint8_t>(BirdsEyePerspective::Strong):
+    return BirdsEyePerspective::Strong;
+  default:
+    return BirdsEyePerspective::Standard;
+  }
+}
+
+inline double birdsEyeTopEdgeScale(BirdsEyePerspective perspective) {
+  switch (perspective) {
+  case BirdsEyePerspective::Gentle:
+    return 0.75;
+  case BirdsEyePerspective::Strong:
+    return 0.48;
+  case BirdsEyePerspective::Standard:
+  default:
+    return 0.60;
+  }
+}
+
 struct Config {
   uint16_t viewportWidth = 0;
   uint16_t viewportHeight = 0;
@@ -26,7 +55,8 @@ struct Config {
   double anchorY = 0.0;
   map_transform::PixelOffset rasterCellOffset{};
   Mode mode = Mode::Flat;
-  double topEdgeScale = 0.60;
+  double topEdgeScale =
+      birdsEyeTopEdgeScale(BirdsEyePerspective::Standard);
   double maximumDepthScale = 1.35;
   double nearPlaneMarginPixels = 8.0;
 };

--- a/esp32/lib/maps/src/map_projection.hpp
+++ b/esp32/lib/maps/src/map_projection.hpp
@@ -167,7 +167,7 @@ public:
       return {};
     }
     const double depthScale = std::min(
-        config_.maximumDepthScale, focalDistance_ / denominator);
+        effectiveMaximumDepthScale(), focalDistance_ / denominator);
     return {config_.anchorX + ground.lateral * depthScale,
             config_.anchorY - ground.forward * depthScale, depthScale, true};
   }
@@ -181,6 +181,13 @@ public:
       return {screenX - config_.anchorX, config_.anchorY - screenY};
     }
     const double screenForward = config_.anchorY - screenY;
+    const double maximumDepthScale = effectiveMaximumDepthScale();
+    const double cappedScreenForward =
+        focalDistance_ * (1.0 - maximumDepthScale);
+    if (screenForward < cappedScreenForward) {
+      return {(screenX - config_.anchorX) / maximumDepthScale,
+              screenForward / maximumDepthScale};
+    }
     const double denominator = focalDistance_ - screenForward;
     if (!(denominator > 0.0)) {
       return {0.0, nearPlaneForward_};
@@ -249,8 +256,17 @@ public:
   }
 
 private:
+  double effectiveMaximumDepthScale() const {
+    return std::max(1.0, config_.maximumDepthScale);
+  }
+
   double inverseForward(double screenY) const {
     const double screenForward = config_.anchorY - screenY;
+    const double maximumDepthScale = effectiveMaximumDepthScale();
+    const double cappedScreenForward =
+        focalDistance_ * (1.0 - maximumDepthScale);
+    if (screenForward < cappedScreenForward)
+      return screenForward / maximumDepthScale;
     const double denominator = focalDistance_ - screenForward;
     return denominator > 0.0
                ? screenForward * focalDistance_ / denominator

--- a/esp32/lib/maps/src/map_projection.hpp
+++ b/esp32/lib/maps/src/map_projection.hpp
@@ -1,0 +1,227 @@
+/**
+ * @file map_projection.hpp
+ * @brief Shared, host-testable flat and bird's-eye map projection.
+ */
+
+#pragma once
+
+#include "mapTransform.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <vector>
+
+namespace map_projection {
+
+enum class Mode : uint8_t { Flat = 0, BirdsEye = 1 };
+
+struct Config {
+  uint16_t viewportWidth = 0;
+  uint16_t viewportHeight = 0;
+  map_transform::WorldPoint worldOrigin{};
+  uint8_t zoom = map_transform::kMinimumRuntimeZoom;
+  double rotationRad = 0.0;
+  double anchorX = 0.0;
+  double anchorY = 0.0;
+  map_transform::PixelOffset rasterCellOffset{};
+  Mode mode = Mode::Flat;
+  double topEdgeScale = 0.60;
+  double maximumDepthScale = 1.35;
+  double nearPlaneMarginPixels = 8.0;
+};
+
+struct GroundPoint {
+  double lateral = 0.0;
+  double forward = 0.0;
+};
+
+struct ProjectedPoint {
+  double x = 0.0;
+  double y = 0.0;
+  double depthScale = 1.0;
+  bool valid = false;
+};
+
+inline double birdsEyeAnchorY(uint16_t viewportHeight) {
+  return std::floor((static_cast<double>(viewportHeight) * 56.0) / 100.0);
+}
+
+class Projection {
+public:
+  Projection() = default;
+  explicit Projection(const Config &config) : config_(config) {
+    const double topScale =
+        std::max(0.05, std::min(0.95, config_.topEdgeScale));
+    focalDistance_ = config_.anchorY / (1.0 - topScale);
+    if (!(focalDistance_ > config_.anchorY)) {
+      focalDistance_ = std::max(1.0, config_.viewportHeight * 1.4);
+    }
+    nearPlaneForward_ =
+        inverseForward(config_.viewportHeight + config_.nearPlaneMarginPixels);
+  }
+
+  const Config &config() const { return config_; }
+  Mode mode() const { return config_.mode; }
+  bool isBirdsEye() const { return config_.mode == Mode::BirdsEye; }
+  double anchorX() const { return config_.anchorX; }
+  double anchorY() const { return config_.anchorY; }
+  double nearPlaneForward() const { return nearPlaneForward_; }
+
+  GroundPoint groundForWorld(map_transform::WorldPoint world) const {
+    const map_transform::ScreenDelta rotated = map_transform::worldToScreen(
+        {world.x - config_.worldOrigin.x, world.y - config_.worldOrigin.y},
+        config_.zoom, config_.rotationRad);
+    return {rotated.x - config_.rasterCellOffset.x,
+            -rotated.y + config_.rasterCellOffset.y};
+  }
+
+  map_transform::WorldPoint worldForGround(GroundPoint ground) const {
+    const map_transform::WorldPoint delta = map_transform::screenToWorld(
+        {ground.lateral + config_.rasterCellOffset.x,
+         -ground.forward + config_.rasterCellOffset.y},
+        config_.zoom, config_.rotationRad);
+    return {config_.worldOrigin.x + delta.x,
+            config_.worldOrigin.y + delta.y};
+  }
+
+  ProjectedPoint projectGround(GroundPoint ground) const {
+    if (!isBirdsEye()) {
+      return {config_.anchorX + ground.lateral,
+              config_.anchorY - ground.forward, 1.0, true};
+    }
+    if (ground.forward < nearPlaneForward_) {
+      return {};
+    }
+    const double denominator = focalDistance_ + ground.forward;
+    if (!(denominator > 0.0)) {
+      return {};
+    }
+    const double depthScale = std::min(
+        config_.maximumDepthScale, focalDistance_ / denominator);
+    return {config_.anchorX + ground.lateral * depthScale,
+            config_.anchorY - ground.forward * depthScale, depthScale, true};
+  }
+
+  ProjectedPoint projectWorld(map_transform::WorldPoint world) const {
+    return projectGround(groundForWorld(world));
+  }
+
+  GroundPoint groundForScreen(double screenX, double screenY) const {
+    if (!isBirdsEye()) {
+      return {screenX - config_.anchorX, config_.anchorY - screenY};
+    }
+    const double screenForward = config_.anchorY - screenY;
+    const double denominator = focalDistance_ - screenForward;
+    if (!(denominator > 0.0)) {
+      return {0.0, nearPlaneForward_};
+    }
+    const double forward = screenForward * focalDistance_ / denominator;
+    const double depthScale = focalDistance_ / (focalDistance_ + forward);
+    return {(screenX - config_.anchorX) / depthScale, forward};
+  }
+
+  bool clipSegmentToNearPlane(GroundPoint &start, GroundPoint &end) const {
+    if (!isBirdsEye())
+      return true;
+    const bool startInside = start.forward >= nearPlaneForward_;
+    const bool endInside = end.forward >= nearPlaneForward_;
+    if (!startInside && !endInside)
+      return false;
+    if (startInside && endInside)
+      return true;
+    const double delta = end.forward - start.forward;
+    if (std::fabs(delta) < 1e-12)
+      return false;
+    const double t = (nearPlaneForward_ - start.forward) / delta;
+    const GroundPoint intersection = {
+        start.lateral + (end.lateral - start.lateral) * t,
+        nearPlaneForward_};
+    if (!startInside)
+      start = intersection;
+    else
+      end = intersection;
+    return true;
+  }
+
+  map_transform::WorldBounds worldBounds(double strokeMarginPixels = 0.0) const {
+    const double minX = -strokeMarginPixels;
+    const double maxX = config_.viewportWidth + strokeMarginPixels;
+    const double minY = -strokeMarginPixels;
+    const double maxY = config_.viewportHeight + strokeMarginPixels;
+    map_transform::WorldBounds bounds{};
+    bool first = true;
+    for (const double x : {minX, maxX}) {
+      for (const double y : {minY, maxY}) {
+        const map_transform::WorldPoint world =
+            worldForGround(groundForScreen(x, y));
+        if (first) {
+          bounds.min = world;
+          bounds.max = world;
+          first = false;
+        } else {
+          bounds.min.x = std::min(bounds.min.x, world.x);
+          bounds.min.y = std::min(bounds.min.y, world.y);
+          bounds.max.x = std::max(bounds.max.x, world.x);
+          bounds.max.y = std::max(bounds.max.y, world.y);
+        }
+      }
+    }
+    return bounds;
+  }
+
+  uint8_t scaledLineWidth(uint8_t baseWidth, double depthScale,
+                          uint8_t maximumWidth) const {
+    const double effectiveScale = isBirdsEye() ? depthScale : 1.0;
+    const int32_t scaled = static_cast<int32_t>(
+        std::floor(static_cast<double>(baseWidth) * effectiveScale + 0.5));
+    return static_cast<uint8_t>(
+        std::max<int32_t>(1, std::min<int32_t>(maximumWidth, scaled)));
+  }
+
+private:
+  double inverseForward(double screenY) const {
+    const double screenForward = config_.anchorY - screenY;
+    const double denominator = focalDistance_ - screenForward;
+    return denominator > 0.0
+               ? screenForward * focalDistance_ / denominator
+               : -focalDistance_;
+  }
+
+  Config config_{};
+  double focalDistance_ = 1.0;
+  double nearPlaneForward_ = -1.0;
+};
+
+inline void clipPolygonToNearPlane(const Projection &projection,
+                                   const std::vector<GroundPoint> &input,
+                                   std::vector<GroundPoint> &output) {
+  output.clear();
+  if (input.empty())
+    return;
+  if (!projection.isBirdsEye()) {
+    output = input;
+    return;
+  }
+  const double nearPlane = projection.nearPlaneForward();
+  GroundPoint previous = input.back();
+  bool previousInside = previous.forward >= nearPlane;
+  for (const auto &current : input) {
+    const bool currentInside = current.forward >= nearPlane;
+    if (currentInside != previousInside) {
+      const double delta = current.forward - previous.forward;
+      if (std::fabs(delta) > 1e-12) {
+        const double t = (nearPlane - previous.forward) / delta;
+        output.push_back({
+            previous.lateral + (current.lateral - previous.lateral) * t,
+            nearPlane});
+      }
+    }
+    if (currentInside)
+      output.push_back(current);
+    previous = current;
+    previousInside = currentInside;
+  }
+}
+
+} // namespace map_projection

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -11,6 +11,7 @@
 #include "mapBlockFormat.hpp"
 #include "mapLineStyle.hpp"
 #include "mapTransform.hpp"
+#include "map_projection.hpp"
 #include "../../ble_navigation/ble_navigation.hpp"
 #include "../../gui/src/guiLayout.hpp"
 #include "../../power_management/power_management.hpp"
@@ -113,6 +114,26 @@ bool validateMapBlockCooperatively(const std::string &path,
     offset += chunkSize;
   }
   return validator.finish();
+}
+
+map_projection::Projection makeMapProjection(
+    double rasterOriginX, double rasterOriginY, int32_t rasterCellOffsetX,
+    int32_t rasterCellOffsetY, uint8_t zoom, double rotation,
+    uint16_t viewportWidth, uint16_t viewportHeight,
+    map_projection::Mode mode) {
+  map_projection::Config config;
+  config.viewportWidth = viewportWidth;
+  config.viewportHeight = viewportHeight;
+  config.worldOrigin = {rasterOriginX, rasterOriginY};
+  config.zoom = zoom;
+  config.rotationRad = rotation;
+  config.anchorX = gui_layout::mapAnchorX(viewportWidth);
+  config.anchorY = mode == map_projection::Mode::BirdsEye
+                       ? map_projection::birdsEyeAnchorY(viewportHeight)
+                       : gui_layout::mapAnchorY(viewportHeight);
+  config.rasterCellOffset = {rasterCellOffsetX, rasterCellOffsetY};
+  config.mode = mode;
+  return map_projection::Projection(config);
 }
 
 } // namespace
@@ -1640,21 +1661,24 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
 
   // 1. Identify all required block offsets for the current viewport
   std::vector<Point32> requiredOffsets;
-  for (Point32 point : {bbox.min, bbox.max, Point32(bbox.min.x, bbox.max.y),
-                        Point32(bbox.max.x, bbox.min.y)}) {
-    int32_t blockMinX = point.x & (~MAPBLOCK_MASK);
-    int32_t blockMinY = point.y & (~MAPBLOCK_MASK);
-    Point32 offset(blockMinX, blockMinY);
-
-    bool alreadyListed = false;
-    for (const auto &req : requiredOffsets) {
-      if (req.x == offset.x && req.y == offset.y) {
-        alreadyListed = true;
-        break;
+  const int32_t minBlockX = bbox.min.x & (~MAPBLOCK_MASK);
+  const int32_t maxBlockX = bbox.max.x & (~MAPBLOCK_MASK);
+  const int32_t minBlockY = bbox.min.y & (~MAPBLOCK_MASK);
+  const int32_t maxBlockY = bbox.max.y & (~MAPBLOCK_MASK);
+  for (int64_t blockY = minBlockY; blockY <= maxBlockY;
+       blockY += (1 << MAPBLOCK_SIZE_BITS)) {
+    for (int64_t blockX = minBlockX; blockX <= maxBlockX;
+         blockX += (1 << MAPBLOCK_SIZE_BITS)) {
+      if (requiredOffsets.size() >= MAPBLOCKS_MAX) {
+        ESP_LOGE(TAG,
+                 "Viewport needs more than %u map blocks: bbox[(%d,%d),"
+                 "(%d,%d)]",
+                 (unsigned)MAPBLOCKS_MAX, bbox.min.x, bbox.min.y, bbox.max.x,
+                 bbox.max.y);
+        return false;
       }
-    }
-    if (!alreadyListed) {
-      requiredOffsets.push_back(offset);
+      requiredOffsets.emplace_back(static_cast<int32_t>(blockX),
+                                   static_cast<int32_t>(blockY));
     }
   }
 
@@ -1777,24 +1801,20 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
  * @param zoom -> Zoom Level
  */
 bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
-                         lv_obj_t *canvas, uint8_t zoom, double rotation) {
+                         lv_obj_t *canvas, uint8_t zoom, double rotation,
+                         const map_projection::Projection &projection) {
+  (void)rotation;
   Polygon newPolygon;
+  std::vector<map_projection::GroundPoint> groundPolygon;
+  std::vector<map_projection::GroundPoint> clippedGroundPolygon;
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const bool mapNavigationActive = isMapGuidanceScreenActive();
+  uint32_t projectionClippedCount = 0;
+  uint32_t projectionRejectedCount = 0;
   const uint32_t drawStartMs = MAPIO_TIME_MS();
   const uint32_t fillStartMs = MAPIO_TIME_MS();
   lv_canvas_fill_bg(canvas, lv_color_hex(BACKGROUND_COLOR), LV_OPA_COVER);
   const uint32_t fillMs = MAPIO_TIME_MS() - fillStartMs;
-
-  // Use the actual canvas dimensions, not mapScrHeight which may differ from
-  // canvas height in fullscreen mode.
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
-  int16_t screenAnchorX =
-      mapAnchorXForWidth(draw_buf ? draw_buf->header.w : Maps::mapScrWidth);
-  int16_t screenAnchorY = mapAnchorYForHeight(
-      draw_buf ? draw_buf->header.h
-               : (mapSet.mapFullScreen ? Maps::mapScrFull
-                                        : Maps::mapScrHeight));
 
   uint32_t totalTime = millis();
   log_i("readVectorMap: Draw start. isMapFound=%d, Blocks=%d", Maps::isMapFound,
@@ -1849,18 +1869,15 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       // if it spans multiple cells)
       std::vector<bool> visited(poly_total, false);
 
-      // Define transform lambda once, outside the loop
-      auto transformPoint = [&](Point16 p) -> Point16 {
-        const auto screen = map_transform::rasterCellPixel(
-            {static_cast<double>(p.x) + mblock->offset.x,
-             static_cast<double>(p.y) + mblock->offset.y},
-            {viewPort.rasterOriginX, viewPort.rasterOriginY},
-            {viewPort.rasterCellOffsetX, viewPort.rasterCellOffsetY}, zoom,
-            rotation);
-        int16_t sx = screen.x + screenAnchorX;
-        int16_t sy = screen.y + screenAnchorY;
-
-        return Point16(sx, sy);
+      auto worldPoint = [&](Point16 p) -> map_transform::WorldPoint {
+        return {static_cast<double>(p.x) + mblock->offset.x,
+                static_cast<double>(p.y) + mblock->offset.y};
+      };
+      auto projectedPoint = [&](map_projection::GroundPoint ground) -> Point16 {
+        const auto projected = projection.projectGround(ground);
+        return Point16(
+            static_cast<int16_t>(map_transform::quantizePixel(projected.x)),
+            static_cast<int16_t>(map_transform::quantizePixel(projected.y)));
       };
 
       // Iterate only through cells that overlap the viewport
@@ -1902,8 +1919,26 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             newPolygon.points.clear();
             int16_t minX = 32000, maxX = -32000, minY = 32000, maxY = -32000;
 
-            for (const auto &p : polygon.points) {
-              Point16 tp = transformPoint(p);
+            groundPolygon.clear();
+            groundPolygon.reserve(polygon.points.size());
+            for (const auto &p : polygon.points)
+              groundPolygon.push_back(projection.groundForWorld(worldPoint(p)));
+            const auto *projectedPolygon = &groundPolygon;
+            if (projection.isBirdsEye()) {
+              map_projection::clipPolygonToNearPlane(
+                  projection, groundPolygon, clippedGroundPolygon);
+              projectedPolygon = &clippedGroundPolygon;
+              if (clippedGroundPolygon.size() != groundPolygon.size())
+                projectionClippedCount++;
+            }
+            if (projectedPolygon->size() < 3) {
+              projectionRejectedCount++;
+              poly_drawn--;
+              continue;
+            }
+
+            for (const auto &ground : *projectedPolygon) {
+              Point16 tp = projectedPoint(ground);
               newPolygon.points.push_back(tp);
               if (tp.x < minX)
                 minX = tp.x;
@@ -1966,34 +2001,44 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
         const uint16_t color_swapped = map_line_style::displayColor(
             line.typeId, line.color, line.width, mapNavigationActive);
 
-        // Transform first point
-        auto transformPoint = [&](Point16 p) -> Point16 {
-          const auto screen = map_transform::rasterCellPixel(
-              {static_cast<double>(p.x) + mblock->offset.x,
-               static_cast<double>(p.y) + mblock->offset.y},
-              {viewPort.rasterOriginX, viewPort.rasterOriginY},
-              {viewPort.rasterCellOffsetX, viewPort.rasterCellOffsetY}, zoom,
-              rotation);
-          int16_t sx = screen.x + screenAnchorX;
-          int16_t sy = screen.y + screenAnchorY;
-          return Point16(sx, sy);
-        };
-
-        Point16 p1 = transformPoint(line.points[0]);
-        uint8_t lineWidth = shouldBoostLineWidth(line.typeId, line.width)
-                                ? blockStyle.streetLineWidth
-                                : static_cast<uint8_t>(
-                                      std::max<int32_t>(line.width, 1));
+        const uint8_t baseLineWidth =
+            shouldBoostLineWidth(line.typeId, line.width)
+                ? blockStyle.streetLineWidth
+                : static_cast<uint8_t>(std::max<int32_t>(line.width, 1));
 
         for (int i = 0; i < (int)line.points.size() - 1; i++) {
           if ((i & 0x0F) == 0 &&
               shouldInterruptMapRenderForScreenCycle()) {
             return false;
           }
-          Point16 p2 = transformPoint(line.points[i + 1]);
-          Maps::drawLine(canvas, p1.x, p1.y, p2.x, p2.y, color_swapped,
-                         lineWidth);
-          p1 = p2;
+          auto ground1 = projection.groundForWorld(worldPoint(line.points[i]));
+          auto ground2 =
+              projection.groundForWorld(worldPoint(line.points[i + 1]));
+          if (!projection.clipSegmentToNearPlane(ground1, ground2)) {
+            projectionRejectedCount++;
+            continue;
+          }
+          if (projection.isBirdsEye() &&
+              (ground1.forward == projection.nearPlaneForward() ||
+               ground2.forward == projection.nearPlaneForward())) {
+            projectionClippedCount++;
+          }
+          const auto projected1 = projection.projectGround(ground1);
+          const auto projected2 = projection.projectGround(ground2);
+          if (!projected1.valid || !projected2.valid) {
+            projectionRejectedCount++;
+            continue;
+          }
+          const uint8_t lineWidth = projection.scaledLineWidth(
+              baseLineWidth,
+              (projected1.depthScale + projected2.depthScale) / 2.0, 24);
+          Maps::drawLine(
+              canvas,
+              static_cast<int16_t>(map_transform::quantizePixel(projected1.x)),
+              static_cast<int16_t>(map_transform::quantizePixel(projected1.y)),
+              static_cast<int16_t>(map_transform::quantizePixel(projected2.x)),
+              static_cast<int16_t>(map_transform::quantizePixel(projected2.y)),
+              color_swapped, lineWidth);
         }
       }
       const uint32_t lineMs = millis() - lineStartMs;
@@ -2052,7 +2097,11 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
         uint16_t x, y, x2, y2;
       }
     }
-    MAPIO_LOG("MAPIO: canvas-draw ok=1 blocks=%u fillMs=%lu totalMs=%lu\n",
+    MAPIO_LOG("MAPIO: canvas-draw ok=1 mode=%s clipped=%lu rejected=%lu "
+              "blocks=%u fillMs=%lu totalMs=%lu\n",
+              projection.isBirdsEye() ? "birds-eye" : "flat",
+              (unsigned long)projectionClippedCount,
+              (unsigned long)projectionRejectedCount,
               (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
               (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
   } else {
@@ -2455,6 +2504,7 @@ void Maps::deleteMapScrSprites() {
   cancelPinchPreview();
   pinchZoomOutBackdrop = {};
   invalidateRollingRasterWindow();
+  hasVisibleProjection = false;
   // Maps::arrowSprite.deleteSprite();
   // Maps::mapSprite.deleteSprite();
   if (Maps::canvasArrow)
@@ -2475,6 +2525,7 @@ void Maps::deleteMapScrSprites() {
  */
 void Maps::createMapScrSprites() {
   ESP_LOGI(TAG, "createMapScrSprites start");
+  hasVisibleProjection = false;
   // Map Sprite
   // Map Sprite (Canvas)
   uint16_t w = Maps::mapScrWidth;
@@ -2690,9 +2741,15 @@ bool Maps::renderRollingRasterCell(double rasterOriginX,
   cellViewPort.rasterOriginY = rasterOriginY;
   cellViewPort.rasterCellOffsetX = cellOffsetX;
   cellViewPort.rasterCellOffsetY = cellOffsetY;
+  const auto cellProjection = makeMapProjection(
+      cellViewPort.rasterOriginX, cellViewPort.rasterOriginY,
+      cellViewPort.rasterCellOffsetX, cellViewPort.rasterCellOffsetY,
+      requestedZoom, rotation, tileWidth, tileHeight,
+      map_projection::Mode::Flat);
   if (!Maps::getMapBlocks(cellViewPort.bbox, Maps::memCache) ||
       !Maps::readVectorMap(cellViewPort, Maps::memCache,
-                           Maps::canvasMapTemp, requestedZoom, rotation)) {
+                           Maps::canvasMapTemp, requestedZoom, rotation,
+                           cellProjection)) {
     restoreVisibleState();
     return false;
   }
@@ -2703,13 +2760,7 @@ bool Maps::renderRollingRasterCell(double rasterOriginX,
   }
 
   if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
-    routeOverlay.drawRoute(
-        Maps::canvasMapTemp, cellViewPort.rasterOriginX,
-        cellViewPort.rasterOriginY,
-        requestedZoom, tileWidth, tileHeight, rotation,
-        mapAnchorXForWidth(tileWidth), mapAnchorYForHeight(tileHeight),
-        cellViewPort.rasterCellOffsetX,
-        cellViewPort.rasterCellOffsetY);
+    routeOverlay.drawRoute(Maps::canvasMapTemp, cellProjection);
   }
 
   if (shouldInterruptMapRenderForScreenCycle()) {
@@ -3221,6 +3272,11 @@ bool Maps::preparePinchZoomOutBackdrop(uint8_t baseZoom) {
   ViewPort backdropViewPort;
   backdropViewPort.zoom = backdropZoom;
   backdropViewPort.setCenter(Maps::point);
+  const auto backdropProjection = makeMapProjection(
+      backdropViewPort.rasterOriginX, backdropViewPort.rasterOriginY,
+      backdropViewPort.rasterCellOffsetX,
+      backdropViewPort.rasterCellOffsetY, backdropZoom, backdropRotation,
+      Maps::mapScrWidth, canvasHeight, map_projection::Mode::Flat);
 
   const bool previousMapFound = Maps::isMapFound;
   const tileBounds previousBounds = Maps::totalBounds;
@@ -3238,7 +3294,7 @@ bool Maps::preparePinchZoomOutBackdrop(uint8_t baseZoom) {
   if (!Maps::getMapBlocks(backdropViewPort.bbox, Maps::memCache) ||
       !Maps::readVectorMap(backdropViewPort, Maps::memCache,
                            Maps::canvasMapTemp, backdropZoom,
-                           backdropRotation)) {
+                           backdropRotation, backdropProjection)) {
     restoreVisibleMapState();
     ESP_LOGI(TAG, "Pinch backdrop preparation interrupted");
     return false;
@@ -3251,13 +3307,7 @@ bool Maps::preparePinchZoomOutBackdrop(uint8_t baseZoom) {
   }
 
   if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
-    routeOverlay.drawRoute(Maps::canvasMapTemp,
-                           backdropViewPort.rasterOriginX,
-                           backdropViewPort.rasterOriginY, backdropZoom,
-                           Maps::mapScrWidth, canvasHeight,
-                           backdropRotation,
-                           mapAnchorXForWidth(Maps::mapScrWidth),
-                           mapAnchorYForHeight(canvasHeight));
+    routeOverlay.drawRoute(Maps::canvasMapTemp, backdropProjection);
   }
 
   if (shouldInterruptMapRenderForScreenCycle()) {
@@ -4052,8 +4102,18 @@ void Maps::updatePositionOverlay() {
         gui_layout::centeredViewportOrigin(containerWidth, Maps::mapScrWidth);
     const int16_t mapOriginY =
         gui_layout::centeredViewportOrigin(containerHeight, h);
-    const int16_t anchorX = mapAnchorXForWidth(Maps::mapScrWidth);
-    const int16_t anchorY = mapAnchorYForHeight(h);
+    const bool useSharedProjection =
+        isMapGuidanceScreenActive() && hasVisibleProjection;
+    const int16_t anchorX = useSharedProjection
+                                ? static_cast<int16_t>(
+                                      map_transform::quantizePixel(
+                                          visibleProjection.anchorX()))
+                                : mapAnchorXForWidth(Maps::mapScrWidth);
+    const int16_t anchorY = useSharedProjection
+                                ? static_cast<int16_t>(
+                                      map_transform::quantizePixel(
+                                          visibleProjection.anchorY()))
+                                : mapAnchorYForHeight(h);
     updateCurrentPositionMarker(Maps::canvasArrow);
     const int16_t markerVisualHalf = currentMarkerSize() / 2;
     int16_t x, y;
@@ -4074,14 +4134,25 @@ void Maps::updatePositionOverlay() {
       int32_t gpsX = lon2x(gps.gpsData.longitude);
       int32_t gpsY = lat2y(gps.gpsData.latitude);
 
-      const auto markerDelta = map_transform::worldToScreen(
-          {static_cast<double>(gpsX - Maps::viewPort.center.x),
-           static_cast<double>(gpsY - Maps::viewPort.center.y)},
-          zoom, visibleMapRotation());
-
-      // 3. Translate to screen center (centered on arrow)
-      x = mapOriginX + round(markerDelta.x) + anchorX - markerVisualHalf;
-      y = mapOriginY + round(markerDelta.y) + anchorY - markerVisualHalf;
+      if (useSharedProjection) {
+        const auto markerPoint = visibleProjection.projectWorld(
+            {static_cast<double>(gpsX), static_cast<double>(gpsY)});
+        if (!markerPoint.valid) {
+          lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
+          return;
+        }
+        x = mapOriginX + map_transform::quantizePixel(markerPoint.x) -
+            markerVisualHalf;
+        y = mapOriginY + map_transform::quantizePixel(markerPoint.y) -
+            markerVisualHalf;
+      } else {
+        const auto markerDelta = map_transform::worldToScreen(
+            {static_cast<double>(gpsX - Maps::viewPort.center.x),
+             static_cast<double>(gpsY - Maps::viewPort.center.y)},
+            zoom, visibleMapRotation());
+        x = mapOriginX + round(markerDelta.x) + anchorX - markerVisualHalf;
+        y = mapOriginY + round(markerDelta.y) + anchorY - markerVisualHalf;
+      }
 
       ESP_LOGI(TAG, "GPS indicator updated outside follow mode zoom=%d",
                zoom);
@@ -4236,6 +4307,24 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   Maps::viewPort.zoom = zoom;
   Maps::viewPort.setCenterForCanvas(Maps::point, renderExtent.width,
                                     renderExtent.height, rotationRad);
+  const bool birdsEyeActive = isMapGuidanceScreenActive() &&
+                              mapRenderSettings.mapNavigationBirdsEyeEnabled &&
+                              routeOverlay.hasRoute();
+  const auto frameProjection = makeMapProjection(
+      Maps::viewPort.rasterOriginX, Maps::viewPort.rasterOriginY,
+      Maps::viewPort.rasterCellOffsetX, Maps::viewPort.rasterCellOffsetY, zoom,
+      rotationRad, renderExtent.width, renderExtent.height,
+      birdsEyeActive ? map_projection::Mode::BirdsEye
+                     : map_projection::Mode::Flat);
+  if (frameProjection.isBirdsEye()) {
+    const auto bounds = frameProjection.worldBounds(4.0);
+    Maps::viewPort.bbox.min =
+        Point32(static_cast<int32_t>(std::floor(bounds.min.x)),
+                static_cast<int32_t>(std::floor(bounds.min.y)));
+    Maps::viewPort.bbox.max =
+        Point32(static_cast<int32_t>(std::ceil(bounds.max.x)),
+                static_cast<int32_t>(std::ceil(bounds.max.y)));
+  }
 
   // Get Map Blocks
   const uint32_t blocksStartMs = MAPIO_TIME_MS();
@@ -4270,7 +4359,7 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   const uint32_t powerDrawStartUs = micros();
 #endif
   if (!Maps::readVectorMap(Maps::viewPort, Maps::memCache, Maps::canvasMapTemp,
-                           zoom, rotationRad)) {
+                           zoom, rotationRad, frameProjection)) {
 #if POWER_METRICS
     powerDrawUs = micros() - powerDrawStartUs;
     powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
@@ -4302,12 +4391,7 @@ bool Maps::generateVectorMap(uint8_t zoom) {
     ESP_LOGI(TAG, "Drawing route overlay: zoom=%d points=%d", zoom,
              routeOverlay.getPointCount());
 
-    routeOverlay.drawRoute(Maps::canvasMapTemp,
-                           Maps::viewPort.rasterOriginX,
-                           Maps::viewPort.rasterOriginY, zoom, renderExtent.width,
-                           renderExtent.height, rotationRad,
-                           mapAnchorXForWidth(renderExtent.width),
-                           mapAnchorYForHeight(renderExtent.height));
+    routeOverlay.drawRoute(Maps::canvasMapTemp, frameProjection);
     ESP_LOGI(TAG, "Route overlay draw complete (rotation=%.2f rad, canvasH=%d)",
              rotationRad, renderExtent.height);
   } else if (routeOverlay.hasRoute()) {
@@ -4341,6 +4425,8 @@ bool Maps::generateVectorMap(uint8_t zoom) {
                        renderExtent.height, LV_COLOR_FORMAT_RGB565);
   lv_obj_center(Maps::canvasMap);
   lv_obj_center(Maps::canvasMapTemp);
+  visibleProjection = frameProjection;
+  hasVisibleProjection = true;
   if (isPinchSettlementPending()) {
     pinchPresentation.canvasBaseX = lv_obj_get_x_aligned(Maps::canvasMap);
     pinchPresentation.canvasBaseY = lv_obj_get_y_aligned(Maps::canvasMap);
@@ -4351,9 +4437,10 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   finishDragSettlement();
   finishPinchSettlement();
 
-  MAPIO_LOG("MAPIO: generate zoom=%u blocksMs=%lu drawMs=%lu "
+  MAPIO_LOG("MAPIO: generate zoom=%u mode=%s blocksMs=%lu drawMs=%lu "
             "routeMs=%lu totalMs=%lu cache=%u hasRoute=%d\n",
-            zoom, (unsigned long)blocksMs, (unsigned long)drawMs,
+            zoom, frameProjection.isBirdsEye() ? "birds-eye" : "flat",
+            (unsigned long)blocksMs, (unsigned long)drawMs,
             (unsigned long)routeMs,
             (unsigned long)(MAPIO_TIME_MS() - generateStartMs),
             (unsigned)Maps::memCache.blocks.size(), routeOverlay.hasRoute());

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -120,7 +120,9 @@ map_projection::Projection makeMapProjection(
     double rasterOriginX, double rasterOriginY, int32_t rasterCellOffsetX,
     int32_t rasterCellOffsetY, uint8_t zoom, double rotation,
     uint16_t viewportWidth, uint16_t viewportHeight,
-    map_projection::Mode mode) {
+    map_projection::Mode mode,
+    map_projection::BirdsEyePerspective birdsEyePerspective =
+        map_projection::BirdsEyePerspective::Standard) {
   map_projection::Config config;
   config.viewportWidth = viewportWidth;
   config.viewportHeight = viewportHeight;
@@ -133,6 +135,8 @@ map_projection::Projection makeMapProjection(
                        : gui_layout::mapAnchorY(viewportHeight);
   config.rasterCellOffset = {rasterCellOffsetX, rasterCellOffsetY};
   config.mode = mode;
+  config.topEdgeScale =
+      map_projection::birdsEyeTopEdgeScale(birdsEyePerspective);
   return map_projection::Projection(config);
 }
 
@@ -4315,7 +4319,9 @@ bool Maps::generateVectorMap(uint8_t zoom) {
       Maps::viewPort.rasterCellOffsetX, Maps::viewPort.rasterCellOffsetY, zoom,
       rotationRad, renderExtent.width, renderExtent.height,
       birdsEyeActive ? map_projection::Mode::BirdsEye
-                     : map_projection::Mode::Flat);
+                     : map_projection::Mode::Flat,
+      map_projection::birdsEyePerspectiveForValue(
+          mapRenderSettings.mapNavigationBirdsEyePerspective));
   if (frameProjection.isBirdsEye()) {
     const auto bounds = frameProjection.worldBounds(4.0);
     Maps::viewPort.bbox.min =

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -14,6 +14,7 @@
 // #include "../../tft/tft.hpp" // Removed or minimal include if possible?
 #include "../../utils/src/gpsMath.hpp"
 #include "mapTransform.hpp"
+#include "map_projection.hpp"
 #include "../../utils/src/mapDragPreview.hpp"
 #include "../../utils/src/mapRasterWindow.hpp"
 #include "lvgl.h"
@@ -141,7 +142,8 @@ private:
                 int16_t y2, uint16_t color, uint8_t width);
   bool getMapBlocks(BBox &bbox, MemCache &memCache);
   bool readVectorMap(ViewPort &viewPort, MemCache &memCache, lv_obj_t *canvas,
-                     uint8_t zoom, double rotation);
+                     uint8_t zoom, double rotation,
+                     const map_projection::Projection &projection);
   bool renderRollingRasterCell(double rasterOriginX, double rasterOriginY,
                                int32_t cellOffsetX, int32_t cellOffsetY,
                                uint8_t zoom, double rotation,
@@ -271,6 +273,8 @@ private:
   } rollingRasterWindow;
 
   map_drag_preview::Controller dragPreviewController;
+  map_projection::Projection visibleProjection;
+  bool hasVisibleProjection = false;
   bool deferredVectorRedraw = false;
   struct DragPresentation {
     uint8_t baseZoom = map_transform::kMinimumRuntimeZoom;

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -24,17 +24,6 @@
 // Global instance
 RouteOverlay routeOverlay;
 
-// Screen center (466x466 display)
-static constexpr int16_t SCREEN_CENTER_X = 233;
-static constexpr int16_t SCREEN_CENTER_Y = 233;
-
-// Meters per microdegree at mid-latitudes (approximate)
-// At equator: 1° lat ≈ 111km, 1 microdegree ≈ 0.111m
-// At 45°: 1° lon ≈ 78km, so we use an average
-static constexpr double METERS_PER_MICRODEGREE_LAT = 0.000111; // ~0.111m
-static constexpr double METERS_PER_MICRODEGREE_LON =
-    0.000085; // ~0.085m at 40° lat
-
 void RouteOverlay::parseRouteData(const uint8_t *data, size_t len) {
   points.clear();
   revisionCounter++;
@@ -130,39 +119,6 @@ bool RouteOverlay::headingNear(double lat, double lon,
 #define DEG2RAD(a) ((a) / (180.0 / M_PI))
 #endif
 
-double RouteOverlay::geoToScreenX(int32_t lonMicro, double centerMercatorX,
-                                  uint8_t zoom, int16_t screenWidth,
-                                  int16_t anchorX) {
-  (void)screenWidth;
-
-  // Convert microdegrees to degrees
-  double lon = lonMicro / 1000000.0;
-
-  // Use the exact same projection as maps.cpp: lon2x(lon) = DEG2RAD(lon) *
-  // EARTH_RADIUS
-  double worldX = DEG2RAD(lon) * EARTH_RADIUS;
-  return ((worldX - centerMercatorX) *
-          map_transform::worldToScreenScale(zoom)) +
-         anchorX;
-}
-
-double RouteOverlay::geoToScreenY(int32_t latMicro, double centerMercatorY,
-                                  uint8_t zoom, int16_t screenHeight,
-                                  int16_t screenWidth, int16_t anchorY) {
-  (void)screenHeight;
-  (void)screenWidth;
-
-  // Convert microdegrees to degrees
-  double lat = latMicro / 1000000.0;
-
-  // Use the exact same projection as maps.cpp: lat2y(lat) =
-  // log(tan(DEG2RAD(lat) / 2 + M_PI / 4)) * EARTH_RADIUS
-  double worldY = log(tan(DEG2RAD(lat) / 2.0 + M_PI / 4.0)) * EARTH_RADIUS;
-  return (-(worldY - centerMercatorY) *
-          map_transform::worldToScreenScale(zoom)) +
-         anchorY;
-}
-
 void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
                                  uint32_t stride, int16_t x1, int16_t y1,
                                  int16_t x2, int16_t y2, uint16_t color,
@@ -173,23 +129,19 @@ void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
                                   color, lineWidth);
 }
 
-void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
-                             double centerMercatorY, uint8_t zoom,
-                             uint16_t mapScrWidth, uint16_t mapScrHeight,
-                             double rotationRad, int16_t anchorX,
-                             int16_t anchorY, int32_t rasterCellOffsetX,
-                             int32_t rasterCellOffsetY) {
-  (void)mapScrWidth;
-  (void)mapScrHeight;
-
+void RouteOverlay::drawRoute(
+    lv_obj_t *canvas, const map_projection::Projection &projection) {
   if (points.size() < 2) {
     Serial.println("RouteOverlay: Not enough points to draw (need >= 2)");
     return; // Need at least 2 points to draw a line
   }
 
 #if FIRMWARE_DIAGNOSTICS
-  Serial.printf("RouteOverlay::drawRoute: zoom=%d points=%d rot=%.2frad\n",
-                zoom, points.size(), rotationRad);
+  Serial.printf("RouteOverlay::drawRoute: zoom=%d points=%d rot=%.2frad "
+                "mode=%s\n",
+                projection.config().zoom, points.size(),
+                projection.config().rotationRad,
+                projection.isBirdsEye() ? "birds-eye" : "flat");
 #endif
 
   // Get canvas buffer
@@ -204,57 +156,33 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
   int32_t bufH = draw_buf->header.h;
   uint32_t stride =
       draw_buf->header.stride / 2; // stride is in bytes, we need pixels
-  if (anchorX < 0) {
-    anchorX = bufW / 2;
-  }
-  if (anchorY < 0) {
-    anchorY = bufH / 2;
-  }
-
 #if FIRMWARE_DIAGNOSTICS
   Serial.printf("RouteOverlay: Canvas buffer W=%d H=%d stride=%d\n", bufW, bufH,
                 stride);
 #endif
 
-  // Pre-calculate rotation values
-  double cosA = cos(rotationRad);
-  double sinA = sin(rotationRad);
-
   int drawnCount = 0;
   // Draw route segments
   for (size_t i = 0; i < points.size() - 1; i++) {
-    // Convert geographic coordinates to screen pixels
-    double x1 =
-        geoToScreenX(points[i].lon, centerMercatorX, zoom, bufW, anchorX);
-    double y1 = geoToScreenY(points[i].lat, centerMercatorY, zoom, bufH, bufW,
-                             anchorY);
-    double x2 =
-        geoToScreenX(points[i + 1].lon, centerMercatorX, zoom, bufW, anchorX);
-    double y2 = geoToScreenY(points[i + 1].lat, centerMercatorY, zoom, bufH,
-                             bufW, anchorY);
-
-    // Apply rotation transform if rotationRad is non-zero
-    if (rotationRad != 0.0) {
-      // Transform point 1
-      double dx1 = x1 - anchorX;
-      double dy1 = y1 - anchorY;
-      x1 = dx1 * cosA - dy1 * sinA + anchorX;
-      y1 = dx1 * sinA + dy1 * cosA + anchorY;
-
-      // Transform point 2
-      double dx2 = x2 - anchorX;
-      double dy2 = y2 - anchorY;
-      x2 = dx2 * cosA - dy2 * sinA + anchorX;
-      y2 = dx2 * sinA + dy2 * cosA + anchorY;
-    }
-
-    // Rolling cells share one raster origin. Translate the already-rotated
-    // common-raster coordinate by the exact integer cell offset so route
-    // segments keep the same pixel phase as vector features at every seam.
-    x1 -= rasterCellOffsetX;
-    y1 -= rasterCellOffsetY;
-    x2 -= rasterCellOffsetX;
-    y2 -= rasterCellOffsetY;
+    auto worldPoint = [](const GeoPoint &point) {
+      const double lon = point.lon / 1000000.0;
+      const double lat = point.lat / 1000000.0;
+      return map_transform::WorldPoint{
+          DEG2RAD(lon) * EARTH_RADIUS,
+          log(tan(DEG2RAD(lat) / 2.0 + M_PI / 4.0)) * EARTH_RADIUS};
+    };
+    auto ground1 = projection.groundForWorld(worldPoint(points[i]));
+    auto ground2 = projection.groundForWorld(worldPoint(points[i + 1]));
+    if (!projection.clipSegmentToNearPlane(ground1, ground2))
+      continue;
+    const auto projected1 = projection.projectGround(ground1);
+    const auto projected2 = projection.projectGround(ground2);
+    if (!projected1.valid || !projected2.valid)
+      continue;
+    const double x1 = projected1.x;
+    const double y1 = projected1.y;
+    const double x2 = projected2.x;
+    const double y2 = projected2.y;
 
     // LOGGING: Debug Center Offset for the first segment
     if (i == 0) {
@@ -262,7 +190,10 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
           "RouteOverlay",
           "DEBUG_OFFSET: Center(%d,%d) StartPixel(%.1f,%.1f) "
           "Diff(%.1f,%.1f) Rot(%.2f)",
-          anchorX, anchorY, x1, y1, x1 - anchorX, y1 - anchorY, rotationRad);
+          static_cast<int>(projection.anchorX()),
+          static_cast<int>(projection.anchorY()), x1, y1,
+          x1 - projection.anchorX(), y1 - projection.anchorY(),
+          projection.config().rotationRad);
     }
 
     // Skip if both endpoints are far off-screen
@@ -275,10 +206,13 @@ void RouteOverlay::drawRoute(lv_obj_t *canvas, double centerMercatorX,
     }
 
     // Draw thick line segment
-    int16_t routeLineWidth = std::min<int16_t>(
+    const uint8_t baseRouteLineWidth = static_cast<uint8_t>(std::min<int16_t>(
         std::max<int16_t>(
             1, (int16_t)currentMapStyleSettings().routeLineWidth),
-        48);
+        48));
+    const uint8_t routeLineWidth = projection.scaledLineWidth(
+        baseRouteLineWidth,
+        (projected1.depthScale + projected2.depthScale) / 2.0, 48);
     drawThickLine(buf, bufW, bufH, stride,
                   static_cast<int16_t>(map_transform::quantizePixel(x1)),
                   static_cast<int16_t>(map_transform::quantizePixel(y1)),

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -9,6 +9,7 @@
  */
 
 #include "../utils/src/psram_allocator.hpp"
+#include "../maps/src/map_projection.hpp"
 #include "navigation_visual_style.hpp"
 #include "lvgl.h"
 #include <Arduino.h>
@@ -44,23 +45,14 @@ public:
   /**
    * @brief Draw route overlay on LVGL canvas
    *
-   * Uses the current map center and zoom to transform geographic
-   * coordinates to screen pixels.
+   * Uses the same immutable projection as the base vector map so the route
+   * remains aligned in both flat and bird's-eye modes.
    *
    * @param canvas LVGL canvas object to draw on
-   * @param centerLat Map center latitude in microdegrees
-   * @param centerMercatorX Map center X in Mercator units (meters)
-   * @param centerMercatorY Map center Y in Mercator units (meters)
-   * @param zoom Current zoom level (higher = more zoomed in)
-   * @param mapScrWidth Map screen width (for coordinate centering)
-   * @param mapScrHeight Map screen height (for Y-axis flip)
+   * @param projection Projection snapshot used for the current map frame
    */
-  void drawRoute(lv_obj_t *canvas, double centerMercatorX,
-                 double centerMercatorY, uint8_t zoom, uint16_t mapScrWidth,
-                 uint16_t mapScrHeight, double rotationRad = 0.0,
-                 int16_t anchorX = -1, int16_t anchorY = -1,
-                 int32_t rasterCellOffsetX = 0,
-                 int32_t rasterCellOffsetY = 0);
+  void drawRoute(lv_obj_t *canvas,
+                 const map_projection::Projection &projection);
 
   /**
    * @brief Clear all route points
@@ -94,19 +86,6 @@ public:
 private:
   std::vector<GeoPoint, PsramAllocator<GeoPoint>> points;
   uint32_t revisionCounter = 0;
-
-  /**
-   * @brief Convert longitude to screen X coordinate
-   */
-  double geoToScreenX(int32_t lon, double centerLon, uint8_t zoom,
-                      int16_t screenWidth, int16_t anchorX);
-
-  /**
-   * @brief Convert latitude to screen Y coordinate
-   */
-  double geoToScreenY(int32_t lat, double centerLat, uint8_t zoom,
-                      int16_t screenHeight, int16_t screenWidth,
-                      int16_t anchorY);
 
   /**
    * @brief Draw a single line segment with thickness

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -83,7 +83,8 @@ int main() {
   for (uint8_t id : {uint8_t{1}, uint8_t{2}, uint8_t{3}, uint8_t{6},
                      uint8_t{7}, uint8_t{8}, uint8_t{9}, uint8_t{10},
                      uint8_t{16}, uint8_t{17}, uint8_t{18}, uint8_t{19},
-                     uint8_t{20}, uint8_t{21}, uint8_t{22}, uint8_t{25}}) {
+                     uint8_t{20}, uint8_t{21}, uint8_t{22}, uint8_t{25},
+                     uint8_t{26}}) {
     assert(map_setting_redraw_policy::invalidatesMap(id));
   }
   for (uint8_t id : {uint8_t{4}, uint8_t{5}, uint8_t{11}, uint8_t{12},

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -83,7 +83,7 @@ int main() {
   for (uint8_t id : {uint8_t{1}, uint8_t{2}, uint8_t{3}, uint8_t{6},
                      uint8_t{7}, uint8_t{8}, uint8_t{9}, uint8_t{10},
                      uint8_t{16}, uint8_t{17}, uint8_t{18}, uint8_t{19},
-                     uint8_t{20}, uint8_t{21}, uint8_t{22}}) {
+                     uint8_t{20}, uint8_t{21}, uint8_t{22}, uint8_t{25}}) {
     assert(map_setting_redraw_policy::invalidatesMap(id));
   }
   for (uint8_t id : {uint8_t{4}, uint8_t{5}, uint8_t{11}, uint8_t{12},

--- a/esp32/tools/tests/test_map_profile_persistence.cpp
+++ b/esp32/tools/tests/test_map_profile_persistence.cpp
@@ -65,6 +65,8 @@ int main() {
   TestProfile loadedNavigation;
   map_profile_persistence::load(freshStore, loadedMap, loadedNavigation);
   assert(map_profile_persistence::loadBirdsEyeEnabled(freshStore));
+  assert(map_profile_persistence::loadBirdsEyePerspective(freshStore) ==
+         MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE);
   assert(loadedMap.detailLevel == MAP_DEFAULT_DETAIL_LEVEL);
   assert(loadedMap.routeLineWidth == MAP_DEFAULT_ROUTE_LINE_WIDTH);
   assert(loadedMap.streetLineWidth == DEFAULT_STREET_WIDTH);
@@ -133,6 +135,15 @@ int main() {
   assert(!map_profile_persistence::loadBirdsEyeEnabled(independentStore));
   map_profile_persistence::persistBirdsEyeEnabled(independentStore, true);
   assert(map_profile_persistence::loadBirdsEyeEnabled(independentStore));
+  map_profile_persistence::persistBirdsEyePerspective(independentStore, 0);
+  assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
+         0);
+  map_profile_persistence::persistBirdsEyePerspective(independentStore, 2);
+  assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
+         2);
+  map_profile_persistence::persistBirdsEyePerspective(independentStore, 3);
+  assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
+         2);
 
   std::cout << "Map profile persistence tests passed\n";
   return 0;

--- a/esp32/tools/tests/test_map_profile_persistence.cpp
+++ b/esp32/tools/tests/test_map_profile_persistence.cpp
@@ -28,8 +28,13 @@ public:
     const auto value = values.find(key);
     return value == values.end() ? fallback : value->second;
   }
+  bool getBool(const char *key, bool fallback) const {
+    const auto value = values.find(key);
+    return value == values.end() ? fallback : value->second != 0;
+  }
   void putUChar(const char *key, uint8_t value) { values[key] = value; }
   void putUInt(const char *key, uint32_t value) { values[key] = value; }
+  void putBool(const char *key, bool value) { values[key] = value ? 1 : 0; }
 
 private:
   std::unordered_map<std::string, uint32_t> values;
@@ -59,6 +64,7 @@ int main() {
   TestProfile loadedMap;
   TestProfile loadedNavigation;
   map_profile_persistence::load(freshStore, loadedMap, loadedNavigation);
+  assert(map_profile_persistence::loadBirdsEyeEnabled(freshStore));
   assert(loadedMap.detailLevel == MAP_DEFAULT_DETAIL_LEVEL);
   assert(loadedMap.routeLineWidth == MAP_DEFAULT_ROUTE_LINE_WIDTH);
   assert(loadedMap.streetLineWidth == DEFAULT_STREET_WIDTH);
@@ -122,6 +128,11 @@ int main() {
   assert(independentStore.getUInt("visMask", 0) ==
          (map.visibilityMask | VISIBILITY_OVERLAY_MASK |
           VISIBILITY_EXTENDED_MARKER));
+
+  map_profile_persistence::persistBirdsEyeEnabled(independentStore, false);
+  assert(!map_profile_persistence::loadBirdsEyeEnabled(independentStore));
+  map_profile_persistence::persistBirdsEyeEnabled(independentStore, true);
+  assert(map_profile_persistence::loadBirdsEyeEnabled(independentStore));
 
   std::cout << "Map profile persistence tests passed\n";
   return 0;

--- a/esp32/tools/tests/test_map_profile_persistence.cpp
+++ b/esp32/tools/tests/test_map_profile_persistence.cpp
@@ -143,7 +143,13 @@ int main() {
          2);
   map_profile_persistence::persistBirdsEyePerspective(independentStore, 3);
   assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
-         2);
+         3);
+  map_profile_persistence::persistBirdsEyePerspective(independentStore, 4);
+  assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
+         4);
+  map_profile_persistence::persistBirdsEyePerspective(independentStore, 5);
+  assert(map_profile_persistence::loadBirdsEyePerspective(independentStore) ==
+         4);
 
   std::cout << "Map profile persistence tests passed\n";
   return 0;

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -17,6 +17,11 @@ int main() {
   assert(clientSupportsIndependentProfiles(3));
   assert(!clientSupportsExtendedVisibility(2));
   assert(clientSupportsExtendedVisibility(3));
+  assert(BIRDS_EYE_EXTENDED_CAPABILITY_MASK == (1 << 0));
+  assert(BIRDS_EYE_CLIENT_VERSION == 7);
+  assert(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID == 25);
+  assert(!clientSupportsBirdsEyeProjection(6));
+  assert(clientSupportsBirdsEyeProjection(7));
   assert(DEFAULT_STREET_WIDTH == 4);
   assert(MAP_DEFAULT_DETAIL_LEVEL == 2);
   assert(MAP_DEFAULT_ROUTE_LINE_WIDTH == 4);
@@ -93,6 +98,8 @@ int main() {
   assert(clampValue(21, -4) == -3);
   assert(clampValue(10, 0) == 1);
   assert(clampValue(22, 6) == 5);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID, -1) == 0);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID, 2) == 1);
   assert(absoluteStreetWidthFromLegacyBoost(-3) == 1);
   assert(absoluteStreetWidthFromLegacyBoost(0) == 4);
   assert(absoluteStreetWidthFromLegacyBoost(4) == 8);

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -21,19 +21,33 @@ int main() {
   assert(BIRDS_EYE_CLIENT_VERSION == 7);
   assert(BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK == (1 << 1));
   assert(BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION == 8);
+  assert(BIRDS_EYE_STRONGER_PERSPECTIVE_EXTENDED_CAPABILITY_MASK == (1 << 2));
+  assert(BIRDS_EYE_STRONGER_PERSPECTIVE_CLIENT_VERSION == 9);
   assert(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID == 25);
   assert(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID == 26);
   assert(MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE == 1);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, -1) ==
+         0);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 4) ==
+         4);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 5) ==
+         4);
   assert(!clientSupportsBirdsEyeProjection(6));
   assert(clientSupportsBirdsEyeProjection(7));
   assert(!clientSupportsBirdsEyePerspective(7));
   assert(clientSupportsBirdsEyePerspective(8));
+  assert(!clientSupportsStrongerBirdsEyePerspective(8));
+  assert(clientSupportsStrongerBirdsEyePerspective(9));
   assert(extendedCapabilityFlagsForClient(6) == 0);
   assert(extendedCapabilityFlagsForClient(7) ==
          BIRDS_EYE_EXTENDED_CAPABILITY_MASK);
   assert(extendedCapabilityFlagsForClient(8) ==
          (BIRDS_EYE_EXTENDED_CAPABILITY_MASK |
           BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK));
+  assert(extendedCapabilityFlagsForClient(9) ==
+         (BIRDS_EYE_EXTENDED_CAPABILITY_MASK |
+          BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK |
+          BIRDS_EYE_STRONGER_PERSPECTIVE_EXTENDED_CAPABILITY_MASK));
   assert(DEFAULT_STREET_WIDTH == 4);
   assert(MAP_DEFAULT_DETAIL_LEVEL == 2);
   assert(MAP_DEFAULT_ROUTE_LINE_WIDTH == 4);
@@ -117,7 +131,7 @@ int main() {
   assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 1) ==
          1);
   assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 3) ==
-         2);
+         3);
   assert(absoluteStreetWidthFromLegacyBoost(-3) == 1);
   assert(absoluteStreetWidthFromLegacyBoost(0) == 4);
   assert(absoluteStreetWidthFromLegacyBoost(4) == 8);

--- a/esp32/tools/tests/test_map_profile_protocol.cpp
+++ b/esp32/tools/tests/test_map_profile_protocol.cpp
@@ -19,9 +19,21 @@ int main() {
   assert(clientSupportsExtendedVisibility(3));
   assert(BIRDS_EYE_EXTENDED_CAPABILITY_MASK == (1 << 0));
   assert(BIRDS_EYE_CLIENT_VERSION == 7);
+  assert(BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK == (1 << 1));
+  assert(BIRDS_EYE_PERSPECTIVE_CLIENT_VERSION == 8);
   assert(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID == 25);
+  assert(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID == 26);
+  assert(MAP_NAVIGATION_DEFAULT_BIRDS_EYE_PERSPECTIVE == 1);
   assert(!clientSupportsBirdsEyeProjection(6));
   assert(clientSupportsBirdsEyeProjection(7));
+  assert(!clientSupportsBirdsEyePerspective(7));
+  assert(clientSupportsBirdsEyePerspective(8));
+  assert(extendedCapabilityFlagsForClient(6) == 0);
+  assert(extendedCapabilityFlagsForClient(7) ==
+         BIRDS_EYE_EXTENDED_CAPABILITY_MASK);
+  assert(extendedCapabilityFlagsForClient(8) ==
+         (BIRDS_EYE_EXTENDED_CAPABILITY_MASK |
+          BIRDS_EYE_PERSPECTIVE_EXTENDED_CAPABILITY_MASK));
   assert(DEFAULT_STREET_WIDTH == 4);
   assert(MAP_DEFAULT_DETAIL_LEVEL == 2);
   assert(MAP_DEFAULT_ROUTE_LINE_WIDTH == 4);
@@ -100,6 +112,12 @@ int main() {
   assert(clampValue(22, 6) == 5);
   assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID, -1) == 0);
   assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_SETTING_ID, 2) == 1);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, -1) ==
+         0);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 1) ==
+         1);
+  assert(clampValue(MAP_NAVIGATION_BIRDS_EYE_PERSPECTIVE_SETTING_ID, 3) ==
+         2);
   assert(absoluteStreetWidthFromLegacyBoost(-3) == 1);
   assert(absoluteStreetWidthFromLegacyBoost(0) == 4);
   assert(absoluteStreetWidthFromLegacyBoost(4) == 8);

--- a/esp32/tools/tests/test_map_projection.cpp
+++ b/esp32/tools/tests/test_map_projection.cpp
@@ -117,7 +117,7 @@ void assertClippingAndInverseBounds() {
 }
 
 void assertRotationAndBlockBudget() {
-  for (const auto dimensions : {
+  for (const auto &dimensions : {
            std::pair<uint16_t, uint16_t>{466, 366},
            std::pair<uint16_t, uint16_t>{466, 466},
            std::pair<uint16_t, uint16_t>{410, 430},

--- a/esp32/tools/tests/test_map_projection.cpp
+++ b/esp32/tools/tests/test_map_projection.cpp
@@ -90,6 +90,12 @@ void assertPerspectivePresets() {
   assertNear(map_projection::birdsEyeTopEdgeScale(
                  BirdsEyePerspective::Strong),
              0.48);
+  assertNear(map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::VeryStrong),
+             0.36);
+  assertNear(map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::Maximum),
+             0.24);
   assert(map_projection::birdsEyePerspectiveForValue(0) ==
          BirdsEyePerspective::Gentle);
   assert(map_projection::birdsEyePerspectiveForValue(1) ==
@@ -97,6 +103,10 @@ void assertPerspectivePresets() {
   assert(map_projection::birdsEyePerspectiveForValue(2) ==
          BirdsEyePerspective::Strong);
   assert(map_projection::birdsEyePerspectiveForValue(3) ==
+         BirdsEyePerspective::VeryStrong);
+  assert(map_projection::birdsEyePerspectiveForValue(4) ==
+         BirdsEyePerspective::Maximum);
+  assert(map_projection::birdsEyePerspectiveForValue(5) ==
          BirdsEyePerspective::Standard);
 
   const auto gentle = makeProjection(map_projection::Mode::BirdsEye, 466, 466,
@@ -106,12 +116,35 @@ void assertPerspectivePresets() {
   const auto strong = makeProjection(map_projection::Mode::BirdsEye, 466, 466,
                                      3, 0.0,
                                      BirdsEyePerspective::Strong);
+  const auto veryStrong = makeProjection(
+      map_projection::Mode::BirdsEye, 466, 466, 3, 0.0,
+      BirdsEyePerspective::VeryStrong);
+  const auto maximum = makeProjection(map_projection::Mode::BirdsEye, 466,
+                                      466, 3, 0.0,
+                                      BirdsEyePerspective::Maximum);
   const auto gentleFar = gentle.projectGround({100.0, 200.0});
   const auto standardFar = standard.projectGround({100.0, 200.0});
   const auto strongFar = strong.projectGround({100.0, 200.0});
-  assert(gentleFar.valid && standardFar.valid && strongFar.valid);
+  const auto veryStrongFar = veryStrong.projectGround({100.0, 200.0});
+  const auto maximumFar = maximum.projectGround({100.0, 200.0});
+  assert(gentleFar.valid && standardFar.valid && strongFar.valid &&
+         veryStrongFar.valid && maximumFar.valid);
   assert(gentleFar.depthScale > standardFar.depthScale);
   assert(standardFar.depthScale > strongFar.depthScale);
+  assert(strongFar.depthScale > veryStrongFar.depthScale);
+  assert(veryStrongFar.depthScale > maximumFar.depthScale);
+
+  const auto constrainedMaximum = makeProjection(
+      map_projection::Mode::BirdsEye, 466, 366, 5, 0.0,
+      BirdsEyePerspective::Maximum);
+  assert(constrainedMaximum.config().topEdgeScale >
+         map_projection::birdsEyeTopEdgeScale(BirdsEyePerspective::Maximum));
+  const auto unconstrainedMaximum = makeProjection(
+      map_projection::Mode::BirdsEye, 466, 366, 2, 0.0,
+      BirdsEyePerspective::Maximum);
+  assertNear(unconstrainedMaximum.config().topEdgeScale,
+             map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::Maximum));
 }
 
 void assertClippingAndInverseBounds() {
@@ -164,7 +197,9 @@ void assertRotationAndBlockBudget() {
       for (const auto perspective : {
                map_projection::BirdsEyePerspective::Gentle,
                map_projection::BirdsEyePerspective::Standard,
-               map_projection::BirdsEyePerspective::Strong}) {
+               map_projection::BirdsEyePerspective::Strong,
+               map_projection::BirdsEyePerspective::VeryStrong,
+               map_projection::BirdsEyePerspective::Maximum}) {
         for (int heading = 0; heading < 360; heading += 5) {
           const auto projection = makeProjection(
               map_projection::Mode::BirdsEye, dimensions.first,

--- a/esp32/tools/tests/test_map_projection.cpp
+++ b/esp32/tools/tests/test_map_projection.cpp
@@ -10,7 +10,9 @@ constexpr double kPi = 3.14159265358979323846;
 
 map_projection::Projection makeProjection(
     map_projection::Mode mode, uint16_t width = 466,
-    uint16_t height = 466, uint8_t zoom = 3, double rotation = 0.0) {
+    uint16_t height = 466, uint8_t zoom = 3, double rotation = 0.0,
+    map_projection::BirdsEyePerspective perspective =
+        map_projection::BirdsEyePerspective::Standard) {
   map_projection::Config config;
   config.viewportWidth = width;
   config.viewportHeight = height;
@@ -22,6 +24,7 @@ map_projection::Projection makeProjection(
                        ? map_projection::birdsEyeAnchorY(height)
                        : height / 2;
   config.mode = mode;
+  config.topEdgeScale = map_projection::birdsEyeTopEdgeScale(perspective);
   return map_projection::Projection(config);
 }
 
@@ -76,6 +79,41 @@ void assertPerspectiveBehavior() {
   assert(!invalid.valid);
 }
 
+void assertPerspectivePresets() {
+  using map_projection::BirdsEyePerspective;
+  assertNear(map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::Gentle),
+             0.75);
+  assertNear(map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::Standard),
+             0.60);
+  assertNear(map_projection::birdsEyeTopEdgeScale(
+                 BirdsEyePerspective::Strong),
+             0.48);
+  assert(map_projection::birdsEyePerspectiveForValue(0) ==
+         BirdsEyePerspective::Gentle);
+  assert(map_projection::birdsEyePerspectiveForValue(1) ==
+         BirdsEyePerspective::Standard);
+  assert(map_projection::birdsEyePerspectiveForValue(2) ==
+         BirdsEyePerspective::Strong);
+  assert(map_projection::birdsEyePerspectiveForValue(3) ==
+         BirdsEyePerspective::Standard);
+
+  const auto gentle = makeProjection(map_projection::Mode::BirdsEye, 466, 466,
+                                     3, 0.0,
+                                     BirdsEyePerspective::Gentle);
+  const auto standard = makeProjection(map_projection::Mode::BirdsEye);
+  const auto strong = makeProjection(map_projection::Mode::BirdsEye, 466, 466,
+                                     3, 0.0,
+                                     BirdsEyePerspective::Strong);
+  const auto gentleFar = gentle.projectGround({100.0, 200.0});
+  const auto standardFar = standard.projectGround({100.0, 200.0});
+  const auto strongFar = strong.projectGround({100.0, 200.0});
+  assert(gentleFar.valid && standardFar.valid && strongFar.valid);
+  assert(gentleFar.depthScale > standardFar.depthScale);
+  assert(standardFar.depthScale > strongFar.depthScale);
+}
+
 void assertClippingAndInverseBounds() {
   const auto projection = makeProjection(map_projection::Mode::BirdsEye);
   map_projection::GroundPoint start{30.0,
@@ -123,13 +161,19 @@ void assertRotationAndBlockBudget() {
            std::pair<uint16_t, uint16_t>{410, 430},
            std::pair<uint16_t, uint16_t>{410, 502}}) {
     for (uint8_t zoom = 1; zoom <= 5; ++zoom) {
-      for (int heading = 0; heading < 360; heading += 5) {
-        const auto projection = makeProjection(
-            map_projection::Mode::BirdsEye, dimensions.first,
-            dimensions.second, zoom, -heading * kPi / 180.0);
-        const auto bounds = projection.worldBounds(4.0);
-        assert(bounds.max.x - bounds.min.x < 4096.0);
-        assert(bounds.max.y - bounds.min.y < 4096.0);
+      for (const auto perspective : {
+               map_projection::BirdsEyePerspective::Gentle,
+               map_projection::BirdsEyePerspective::Standard,
+               map_projection::BirdsEyePerspective::Strong}) {
+        for (int heading = 0; heading < 360; heading += 5) {
+          const auto projection = makeProjection(
+              map_projection::Mode::BirdsEye, dimensions.first,
+              dimensions.second, zoom, -heading * kPi / 180.0,
+              perspective);
+          const auto bounds = projection.worldBounds(4.0);
+          assert(bounds.max.x - bounds.min.x < 4096.0);
+          assert(bounds.max.y - bounds.min.y < 4096.0);
+        }
       }
     }
   }
@@ -153,6 +197,7 @@ void assertLineWidthScaling() {
 int main() {
   assertFlatParity();
   assertPerspectiveBehavior();
+  assertPerspectivePresets();
   assertClippingAndInverseBounds();
   assertRotationAndBlockBudget();
   assertLineWidthScaling();

--- a/esp32/tools/tests/test_map_projection.cpp
+++ b/esp32/tools/tests/test_map_projection.cpp
@@ -1,0 +1,160 @@
+#include "../../lib/maps/src/map_projection.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+
+namespace {
+
+constexpr double kPi = 3.14159265358979323846;
+
+map_projection::Projection makeProjection(
+    map_projection::Mode mode, uint16_t width = 466,
+    uint16_t height = 466, uint8_t zoom = 3, double rotation = 0.0) {
+  map_projection::Config config;
+  config.viewportWidth = width;
+  config.viewportHeight = height;
+  config.worldOrigin = {100000.0, 200000.0};
+  config.zoom = zoom;
+  config.rotationRad = rotation;
+  config.anchorX = width / 2;
+  config.anchorY = mode == map_projection::Mode::BirdsEye
+                       ? map_projection::birdsEyeAnchorY(height)
+                       : height / 2;
+  config.mode = mode;
+  return map_projection::Projection(config);
+}
+
+void assertNear(double actual, double expected, double tolerance = 1e-8) {
+  assert(std::fabs(actual - expected) <= tolerance);
+}
+
+void assertFlatParity() {
+  for (uint8_t zoom = 0; zoom <= 5; ++zoom) {
+    for (const double rotation : {0.0, -0.7, 1.2}) {
+      auto projection = makeProjection(map_projection::Mode::Flat, 466, 366,
+                                       zoom, rotation);
+      for (const map_transform::WorldPoint point : {
+               map_transform::WorldPoint{100000.0, 200000.0},
+               map_transform::WorldPoint{100123.0, 199944.0},
+               map_transform::WorldPoint{99831.0, 200412.0}}) {
+        const auto expectedDelta = map_transform::worldToScreen(
+            {point.x - 100000.0, point.y - 200000.0}, zoom, rotation);
+        const auto projected = projection.projectWorld(point);
+        assert(projected.valid);
+        assert(map_transform::quantizePixel(projected.x) ==
+               233 + map_transform::quantizePixel(expectedDelta.x));
+        assert(map_transform::quantizePixel(projected.y) ==
+               183 + map_transform::quantizePixel(expectedDelta.y));
+        assertNear(projected.depthScale, 1.0);
+      }
+    }
+  }
+}
+
+void assertPerspectiveBehavior() {
+  const auto projection = makeProjection(map_projection::Mode::BirdsEye);
+  const auto center = projection.projectWorld({100000.0, 200000.0});
+  assert(center.valid);
+  assertNear(center.x, projection.anchorX());
+  assertNear(center.y, projection.anchorY());
+
+  const auto near = projection.projectGround({100.0, 20.0});
+  const auto far = projection.projectGround({100.0, 200.0});
+  assert(near.valid && far.valid);
+  assert(far.y < near.y);
+  assert(std::fabs(far.x - projection.anchorX()) <
+         std::fabs(near.x - projection.anchorX()));
+  assert(far.depthScale < near.depthScale);
+
+  const auto behind = projection.projectGround({0.0, -100.0});
+  assert(behind.valid);
+  assert(behind.depthScale > 1.0);
+  assert(behind.depthScale <= 1.35);
+  const auto invalid = projection.projectGround(
+      {0.0, projection.nearPlaneForward() - 1.0});
+  assert(!invalid.valid);
+}
+
+void assertClippingAndInverseBounds() {
+  const auto projection = makeProjection(map_projection::Mode::BirdsEye);
+  map_projection::GroundPoint start{30.0,
+                                    projection.nearPlaneForward() - 100.0};
+  map_projection::GroundPoint end{50.0,
+                                  projection.nearPlaneForward() + 100.0};
+  assert(projection.clipSegmentToNearPlane(start, end));
+  assertNear(start.forward, projection.nearPlaneForward());
+  assertNear(start.lateral, 40.0);
+  assert(projection.projectGround(start).valid);
+
+  map_projection::GroundPoint rejectedStart{
+      0.0, projection.nearPlaneForward() - 2.0};
+  map_projection::GroundPoint rejectedEnd{
+      1.0, projection.nearPlaneForward() - 1.0};
+  assert(!projection.clipSegmentToNearPlane(rejectedStart, rejectedEnd));
+
+  const std::vector<map_projection::GroundPoint> polygon = {
+      {-20.0, projection.nearPlaneForward() - 20.0},
+      {20.0, projection.nearPlaneForward() - 20.0},
+      {20.0, projection.nearPlaneForward() + 20.0},
+      {-20.0, projection.nearPlaneForward() + 20.0}};
+  std::vector<map_projection::GroundPoint> clippedPolygon;
+  map_projection::clipPolygonToNearPlane(projection, polygon,
+                                         clippedPolygon);
+  assert(clippedPolygon.size() == 4);
+  for (const auto &point : clippedPolygon)
+    assert(point.forward >= projection.nearPlaneForward());
+
+  const auto bounds = projection.worldBounds(4.0);
+  for (const double x : {0.0, 466.0}) {
+    for (const double y : {0.0, 466.0}) {
+      const auto world = projection.worldForGround(
+          projection.groundForScreen(x, y));
+      assert(world.x >= bounds.min.x && world.x <= bounds.max.x);
+      assert(world.y >= bounds.min.y && world.y <= bounds.max.y);
+    }
+  }
+}
+
+void assertRotationAndBlockBudget() {
+  for (const auto dimensions : {
+           std::pair<uint16_t, uint16_t>{466, 366},
+           std::pair<uint16_t, uint16_t>{466, 466},
+           std::pair<uint16_t, uint16_t>{410, 430},
+           std::pair<uint16_t, uint16_t>{410, 502}}) {
+    for (uint8_t zoom = 1; zoom <= 5; ++zoom) {
+      for (int heading = 0; heading < 360; heading += 5) {
+        const auto projection = makeProjection(
+            map_projection::Mode::BirdsEye, dimensions.first,
+            dimensions.second, zoom, -heading * kPi / 180.0);
+        const auto bounds = projection.worldBounds(4.0);
+        assert(bounds.max.x - bounds.min.x < 4096.0);
+        assert(bounds.max.y - bounds.min.y < 4096.0);
+      }
+    }
+  }
+
+  const auto rotated = makeProjection(map_projection::Mode::BirdsEye, 466,
+                                      466, 3, -kPi / 2.0);
+  const auto ahead = rotated.projectWorld({100000.0, 200100.0});
+  assert(ahead.valid);
+  assert(ahead.x < rotated.anchorX());
+}
+
+void assertLineWidthScaling() {
+  const auto projection = makeProjection(map_projection::Mode::BirdsEye);
+  assert(projection.scaledLineWidth(15, 0.6, 48) == 9);
+  assert(projection.scaledLineWidth(1, 0.1, 48) == 1);
+  assert(projection.scaledLineWidth(48, 1.35, 48) == 48);
+}
+
+} // namespace
+
+int main() {
+  assertFlatParity();
+  assertPerspectiveBehavior();
+  assertClippingAndInverseBounds();
+  assertRotationAndBlockBudget();
+  assertLineWidthScaling();
+  return 0;
+}

--- a/esp32/tools/tests/test_map_projection.cpp
+++ b/esp32/tools/tests/test_map_projection.cpp
@@ -187,6 +187,36 @@ void assertClippingAndInverseBounds() {
   }
 }
 
+void assertCappedInverseRoundTrip() {
+  using map_projection::BirdsEyePerspective;
+  for (const auto perspective : {
+           BirdsEyePerspective::Gentle, BirdsEyePerspective::Standard,
+           BirdsEyePerspective::Strong, BirdsEyePerspective::VeryStrong,
+           BirdsEyePerspective::Maximum}) {
+    const auto projection = makeProjection(map_projection::Mode::BirdsEye,
+                                           466, 466, 3, 0.0, perspective);
+    const double margin = projection.config().nearPlaneMarginPixels;
+    const double minX = -margin;
+    const double maxX = projection.config().viewportWidth + margin;
+    const double minY = -margin;
+    const double maxY = projection.config().viewportHeight + margin;
+    for (const double x : {minX, maxX}) {
+      for (const double y : {minY, maxY}) {
+        const auto ground = projection.groundForScreen(x, y);
+        const auto projected = projection.projectGround(ground);
+        assert(projected.valid);
+        assertNear(projected.x, x, 1e-7);
+        assertNear(projected.y, y, 1e-7);
+      }
+    }
+
+    const auto clippedBottom = projection.projectGround(
+        {0.0, projection.nearPlaneForward()});
+    assert(clippedBottom.valid);
+    assertNear(clippedBottom.y, maxY, 1e-7);
+  }
+}
+
 void assertRotationAndBlockBudget() {
   for (const auto &dimensions : {
            std::pair<uint16_t, uint16_t>{466, 366},
@@ -234,6 +264,7 @@ int main() {
   assertPerspectiveBehavior();
   assertPerspectivePresets();
   assertClippingAndInverseBounds();
+  assertCappedInverseRoundTrip();
   assertRotationAndBlockBudget();
   assertLineWidthScaling();
   return 0;

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -146,7 +146,8 @@ enum DeviceBLEProtocol {
     static let workoutTelemetryCapabilityMask: UInt8 = 1 << 7
     static let birdsEyeMapNavigationExtendedCapabilityMask: UInt8 = 1 << 0
     static let birdsEyeMapNavigationPerspectiveExtendedCapabilityMask: UInt8 = 1 << 1
-    static let deviceCapabilitiesVersion: UInt8 = 8
+    static let birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask: UInt8 = 1 << 2
+    static let deviceCapabilitiesVersion: UInt8 = 9
     static let workoutTelemetryFrameLength = 16
     static let workoutTelemetryCoreCoalescingKey = "workout-telemetry-core"
     static let workoutTelemetryExtendedCoalescingKey =
@@ -505,6 +506,8 @@ enum MapNavigationBirdsEyePerspective: Int, CaseIterable, Identifiable {
     case gentle = 0
     case standard = 1
     case strong = 2
+    case veryStrong = 3
+    case maximum = 4
 
     var id: Int { rawValue }
 
@@ -513,7 +516,17 @@ enum MapNavigationBirdsEyePerspective: Int, CaseIterable, Identifiable {
         case .gentle: return "Gentle"
         case .standard: return "Standard"
         case .strong: return "Strong"
+        case .veryStrong: return "Very Strong"
+        case .maximum: return "Maximum"
         }
+    }
+
+    static let baselineCases: [Self] = [.gentle, .standard, .strong]
+
+    func supportedValue(supportsStrongerPerspectives: Bool) -> Self {
+        supportsStrongerPerspectives || rawValue <= Self.strong.rawValue
+            ? self
+            : .strong
     }
 
     static func normalized(rawValue: Int) -> Self {
@@ -553,6 +566,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published private(set) var supportsExtendedMapVisibility: Bool = false
     @Published private(set) var supportsBirdsEyeMapNavigation: Bool = false
     @Published private(set) var supportsBirdsEyeMapNavigationPerspective: Bool = false
+    @Published private(set) var supportsBirdsEyeMapNavigationStrongerPerspective: Bool = false
     @Published private(set) var supportsBatteryStatusScreen: Bool = false
     @Published private(set) var supportsDestinationPicker: Bool = false
     @Published private(set) var supportsWorkoutTelemetry: Bool = false
@@ -2169,6 +2183,11 @@ class BLEManager: NSObject, ObservableObject {
         let deviceValue: Int32
         if id == DeviceBLEProtocol.brightnessSettingID {
             deviceValue = Int32(deviceBrightnessPercent)
+        } else if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID {
+            let maximum = supportsBirdsEyeMapNavigationStrongerPerspective
+                ? MapNavigationBirdsEyePerspective.maximum.rawValue
+                : MapNavigationBirdsEyePerspective.strong.rawValue
+            deviceValue = min(max(value, 0), Int32(maximum))
         } else if id == 9 || id == DeviceBLEProtocol.mapPlusNavigationStreetLineWidthSettingID {
             deviceValue = DeviceBLEProtocol.legacyStreetWidthBoost(
                 fromAbsoluteWidth: value
@@ -2345,6 +2364,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsExtendedMapVisibility = false
         supportsBirdsEyeMapNavigation = false
         supportsBirdsEyeMapNavigationPerspective = false
+        supportsBirdsEyeMapNavigationStrongerPerspective = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -3113,6 +3133,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsExtendedMapVisibility = false
         supportsBirdsEyeMapNavigation = false
         supportsBirdsEyeMapNavigationPerspective = false
+        supportsBirdsEyeMapNavigationStrongerPerspective = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -5019,6 +5040,7 @@ extension BLEManager: CBPeripheralDelegate {
             supportsExtendedMapVisibility = false
             supportsBirdsEyeMapNavigation = false
             supportsBirdsEyeMapNavigationPerspective = false
+            supportsBirdsEyeMapNavigationStrongerPerspective = false
             supportsBatteryStatusScreen = false
             supportsDestinationPicker = false
             updateWorkoutTelemetryCapability(false)
@@ -5059,6 +5081,9 @@ extension BLEManager: CBPeripheralDelegate {
         let hasBirdsEyeMapNavigationPerspective =
             hasBirdsEyeMapNavigation && extendedFlags &
                 DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask != 0
+        let hasBirdsEyeMapNavigationStrongerPerspective =
+            hasBirdsEyeMapNavigationPerspective && extendedFlags &
+                DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask != 0
         let hasDevicePowerButtonConfig = data.count == 8 || data.count == 9
         if hasDevicePowerButtonConfig {
             guard hasPowerButtonHonk,
@@ -5072,6 +5097,7 @@ extension BLEManager: CBPeripheralDelegate {
                 supportsExtendedMapVisibility = false
                 supportsBirdsEyeMapNavigation = false
                 supportsBirdsEyeMapNavigationPerspective = false
+                supportsBirdsEyeMapNavigationStrongerPerspective = false
                 supportsBatteryStatusScreen = false
                 supportsDestinationPicker = false
                 updateWorkoutTelemetryCapability(false)
@@ -5104,7 +5130,9 @@ extension BLEManager: CBPeripheralDelegate {
             hasReceivedDeviceCapabilities &&
             ((!supportsBirdsEyeMapNavigation && hasBirdsEyeMapNavigation) ||
              (!supportsBirdsEyeMapNavigationPerspective &&
-              hasBirdsEyeMapNavigationPerspective))
+              hasBirdsEyeMapNavigationPerspective) ||
+             (!supportsBirdsEyeMapNavigationStrongerPerspective &&
+              hasBirdsEyeMapNavigationStrongerPerspective))
         if shouldResendMapProfilesForExtendedVisibility {
             hasSentMapProfileForConnection = false
             hasSentMapNavigationProfileForConnection = false
@@ -5122,6 +5150,8 @@ extension BLEManager: CBPeripheralDelegate {
         supportsExtendedMapVisibility = hasExtendedMapVisibility
         supportsBirdsEyeMapNavigation = hasBirdsEyeMapNavigation
         supportsBirdsEyeMapNavigationPerspective = hasBirdsEyeMapNavigationPerspective
+        supportsBirdsEyeMapNavigationStrongerPerspective =
+            hasBirdsEyeMapNavigationStrongerPerspective
         supportsBatteryStatusScreen = hasBatteryStatusScreen
         supportsDestinationPicker = hasDestinationPicker
         updateWorkoutTelemetryCapability(hasWorkoutTelemetry)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -145,7 +145,8 @@ enum DeviceBLEProtocol {
     static let destinationPickerCapabilityMask: UInt8 = 1 << 6
     static let workoutTelemetryCapabilityMask: UInt8 = 1 << 7
     static let birdsEyeMapNavigationExtendedCapabilityMask: UInt8 = 1 << 0
-    static let deviceCapabilitiesVersion: UInt8 = 7
+    static let birdsEyeMapNavigationPerspectiveExtendedCapabilityMask: UInt8 = 1 << 1
+    static let deviceCapabilitiesVersion: UInt8 = 8
     static let workoutTelemetryFrameLength = 16
     static let workoutTelemetryCoreCoalescingKey = "workout-telemetry-core"
     static let workoutTelemetryExtendedCoalescingKey =
@@ -175,6 +176,7 @@ enum DeviceBLEProtocol {
     static let phoneBatteryLevelSettingID: UInt8 = 23
     static let phoneBatteryChargingSettingID: UInt8 = 24
     static let mapPlusNavigationBirdsEyeViewSettingID: UInt8 = 25
+    static let mapPlusNavigationBirdsEyePerspectiveSettingID: UInt8 = 26
     static let currentScreenMaskMarker: Int32 = 1 << 30
 
     static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
@@ -499,6 +501,26 @@ private extension CBCharacteristicProperties {
     }
 }
 
+enum MapNavigationBirdsEyePerspective: Int, CaseIterable, Identifiable {
+    case gentle = 0
+    case standard = 1
+    case strong = 2
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .gentle: return "Gentle"
+        case .standard: return "Standard"
+        case .strong: return "Strong"
+        }
+    }
+
+    static func normalized(rawValue: Int) -> Self {
+        Self(rawValue: rawValue) ?? .standard
+    }
+}
+
 private enum MapPlusNavigationDefaults {
     static let minPolygonSize: Double = 0
     static let detailLevel = 0
@@ -530,6 +552,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published private(set) var supportsIndependentMapProfiles: Bool = false
     @Published private(set) var supportsExtendedMapVisibility: Bool = false
     @Published private(set) var supportsBirdsEyeMapNavigation: Bool = false
+    @Published private(set) var supportsBirdsEyeMapNavigationPerspective: Bool = false
     @Published private(set) var supportsBatteryStatusScreen: Bool = false
     @Published private(set) var supportsDestinationPicker: Bool = false
     @Published private(set) var supportsWorkoutTelemetry: Bool = false
@@ -602,6 +625,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapPlusNavigationPositionMarkerScale = MapPlusNavigationDefaults.positionMarkerScale
     @Published var mapPlusNavigationZoomLevel = MapPlusNavigationDefaults.zoomLevel
     @Published var mapPlusNavigationBirdsEyeViewEnabled = true
+    @Published var mapPlusNavigationBirdsEyePerspective: MapNavigationBirdsEyePerspective = .standard
     @Published var tapToSwitchScreens: Bool = false
     @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
     @Published var defaultDeviceScreen: DeviceScreen = .mapPlusNavigation
@@ -770,6 +794,7 @@ class BLEManager: NSObject, ObservableObject {
         static let mapPlusNavigationPositionMarkerScale = "mapPlusNavigationSettings.positionMarkerScale"
         static let mapPlusNavigationZoomLevel = "mapPlusNavigationSettings.zoomLevel"
         static let mapPlusNavigationBirdsEyeViewEnabled = "mapPlusNavigationSettings.birdsEyeViewEnabled"
+        static let mapPlusNavigationBirdsEyePerspective = "mapPlusNavigationSettings.birdsEyePerspective"
         static let mapPlusNavigationShowBuildings = "mapPlusNavigationSettings.showBuildings"
         static let mapPlusNavigationShowGreenSpace = "mapPlusNavigationSettings.showGreenSpace"
         static let mapPlusNavigationShowPaths = "mapPlusNavigationSettings.showPaths"
@@ -1065,6 +1090,11 @@ class BLEManager: NSObject, ObservableObject {
         mapPlusNavigationBirdsEyeViewEnabled = defaults.object(
             forKey: SettingsKeys.mapPlusNavigationBirdsEyeViewEnabled
         ) as? Bool ?? true
+        mapPlusNavigationBirdsEyePerspective = .normalized(
+            rawValue: defaults.object(
+                forKey: SettingsKeys.mapPlusNavigationBirdsEyePerspective
+            ) as? Int ?? MapNavigationBirdsEyePerspective.standard.rawValue
+        )
         let shouldMigrateRecommendedDefaults = !defaults.bool(
             forKey: SettingsKeys.recommendedMapDefaultsMigrated
         )
@@ -1167,6 +1197,7 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(mapPlusNavigationPositionMarkerScale, forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale)
         defaults.set(mapPlusNavigationZoomLevel, forKey: SettingsKeys.mapPlusNavigationZoomLevel)
         defaults.set(mapPlusNavigationBirdsEyeViewEnabled, forKey: SettingsKeys.mapPlusNavigationBirdsEyeViewEnabled)
+        defaults.set(mapPlusNavigationBirdsEyePerspective.rawValue, forKey: SettingsKeys.mapPlusNavigationBirdsEyePerspective)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
         enabledDeviceScreensMask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
         defaultDeviceScreen = DeviceScreen.fallbackDefault(
@@ -2130,6 +2161,11 @@ class BLEManager: NSObject, ObservableObject {
             log("Bird's-eye map setting not sent: connected firmware does not advertise support")
             return
         }
+        if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID,
+           (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigationPerspective) {
+            log("Bird's-eye perspective setting not sent: connected firmware does not advertise support")
+            return
+        }
         let deviceValue: Int32
         if id == DeviceBLEProtocol.brightnessSettingID {
             deviceValue = Int32(deviceBrightnessPercent)
@@ -2283,6 +2319,12 @@ class BLEManager: NSObject, ObservableObject {
                     value: mapPlusNavigationBirdsEyeViewEnabled ? 1 : 0
                 )
             }
+            if supportsBirdsEyeMapNavigationPerspective {
+                sendSetting(
+                    id: DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID,
+                    value: Int32(mapPlusNavigationBirdsEyePerspective.rawValue)
+                )
+            }
         }
 
         if shouldSendMap {
@@ -2302,6 +2344,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
         supportsBirdsEyeMapNavigation = false
+        supportsBirdsEyeMapNavigationPerspective = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -3069,6 +3112,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
         supportsBirdsEyeMapNavigation = false
+        supportsBirdsEyeMapNavigationPerspective = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -4974,6 +5018,7 @@ extension BLEManager: CBPeripheralDelegate {
             supportsIndependentMapProfiles = false
             supportsExtendedMapVisibility = false
             supportsBirdsEyeMapNavigation = false
+            supportsBirdsEyeMapNavigationPerspective = false
             supportsBatteryStatusScreen = false
             supportsDestinationPicker = false
             updateWorkoutTelemetryCapability(false)
@@ -5011,6 +5056,9 @@ extension BLEManager: CBPeripheralDelegate {
         let hasBirdsEyeMapNavigation =
             extendedFlags &
                 DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask != 0
+        let hasBirdsEyeMapNavigationPerspective =
+            hasBirdsEyeMapNavigation && extendedFlags &
+                DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask != 0
         let hasDevicePowerButtonConfig = data.count == 8 || data.count == 9
         if hasDevicePowerButtonConfig {
             guard hasPowerButtonHonk,
@@ -5023,6 +5071,7 @@ extension BLEManager: CBPeripheralDelegate {
                 supportsIndependentMapProfiles = false
                 supportsExtendedMapVisibility = false
                 supportsBirdsEyeMapNavigation = false
+                supportsBirdsEyeMapNavigationPerspective = false
                 supportsBatteryStatusScreen = false
                 supportsDestinationPicker = false
                 updateWorkoutTelemetryCapability(false)
@@ -5053,8 +5102,9 @@ extension BLEManager: CBPeripheralDelegate {
             hasExtendedMapVisibility
         let shouldResendMapNavigationForBirdsEye =
             hasReceivedDeviceCapabilities &&
-            !supportsBirdsEyeMapNavigation &&
-            hasBirdsEyeMapNavigation
+            ((!supportsBirdsEyeMapNavigation && hasBirdsEyeMapNavigation) ||
+             (!supportsBirdsEyeMapNavigationPerspective &&
+              hasBirdsEyeMapNavigationPerspective))
         if shouldResendMapProfilesForExtendedVisibility {
             hasSentMapProfileForConnection = false
             hasSentMapNavigationProfileForConnection = false
@@ -5071,6 +5121,7 @@ extension BLEManager: CBPeripheralDelegate {
         supportsIndependentMapProfiles = hasIndependentMapProfiles
         supportsExtendedMapVisibility = hasExtendedMapVisibility
         supportsBirdsEyeMapNavigation = hasBirdsEyeMapNavigation
+        supportsBirdsEyeMapNavigationPerspective = hasBirdsEyeMapNavigationPerspective
         supportsBatteryStatusScreen = hasBatteryStatusScreen
         supportsDestinationPicker = hasDestinationPicker
         updateWorkoutTelemetryCapability(hasWorkoutTelemetry)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -144,7 +144,8 @@ enum DeviceBLEProtocol {
     static let batteryStatusScreenCapabilityMask: UInt8 = 1 << 5
     static let destinationPickerCapabilityMask: UInt8 = 1 << 6
     static let workoutTelemetryCapabilityMask: UInt8 = 1 << 7
-    static let deviceCapabilitiesVersion: UInt8 = 6
+    static let birdsEyeMapNavigationExtendedCapabilityMask: UInt8 = 1 << 0
+    static let deviceCapabilitiesVersion: UInt8 = 7
     static let workoutTelemetryFrameLength = 16
     static let workoutTelemetryCoreCoalescingKey = "workout-telemetry-core"
     static let workoutTelemetryExtendedCoalescingKey =
@@ -173,6 +174,7 @@ enum DeviceBLEProtocol {
     static let mapPlusNavigationPositionMarkerScaleSettingID: UInt8 = 22
     static let phoneBatteryLevelSettingID: UInt8 = 23
     static let phoneBatteryChargingSettingID: UInt8 = 24
+    static let mapPlusNavigationBirdsEyeViewSettingID: UInt8 = 25
     static let currentScreenMaskMarker: Int32 = 1 << 30
 
     static var serviceUUID: CBUUID { CBUUID(string: serviceUUIDString) }
@@ -527,6 +529,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var supportsPowerButtonHonkAcknowledgement: Bool = false
     @Published private(set) var supportsIndependentMapProfiles: Bool = false
     @Published private(set) var supportsExtendedMapVisibility: Bool = false
+    @Published private(set) var supportsBirdsEyeMapNavigation: Bool = false
     @Published private(set) var supportsBatteryStatusScreen: Bool = false
     @Published private(set) var supportsDestinationPicker: Bool = false
     @Published private(set) var supportsWorkoutTelemetry: Bool = false
@@ -598,6 +601,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapPlusNavigationStreetLineWidth = MapPlusNavigationDefaults.streetLineWidth
     @Published var mapPlusNavigationPositionMarkerScale = MapPlusNavigationDefaults.positionMarkerScale
     @Published var mapPlusNavigationZoomLevel = MapPlusNavigationDefaults.zoomLevel
+    @Published var mapPlusNavigationBirdsEyeViewEnabled = true
     @Published var tapToSwitchScreens: Bool = false
     @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
     @Published var defaultDeviceScreen: DeviceScreen = .mapPlusNavigation
@@ -765,6 +769,7 @@ class BLEManager: NSObject, ObservableObject {
         static let legacyMapPlusNavigationStreetLineWidthBoost = "mapPlusNavigationSettings.streetLineWidthBoost"
         static let mapPlusNavigationPositionMarkerScale = "mapPlusNavigationSettings.positionMarkerScale"
         static let mapPlusNavigationZoomLevel = "mapPlusNavigationSettings.zoomLevel"
+        static let mapPlusNavigationBirdsEyeViewEnabled = "mapPlusNavigationSettings.birdsEyeViewEnabled"
         static let mapPlusNavigationShowBuildings = "mapPlusNavigationSettings.showBuildings"
         static let mapPlusNavigationShowGreenSpace = "mapPlusNavigationSettings.showGreenSpace"
         static let mapPlusNavigationShowPaths = "mapPlusNavigationSettings.showPaths"
@@ -1057,6 +1062,9 @@ class BLEManager: NSObject, ObservableObject {
                 forKey: SettingsKeys.mapPlusNavigationShowOtherAreas
             ) as? Bool ?? MapPlusNavigationDefaults.showOtherAreas
         }
+        mapPlusNavigationBirdsEyeViewEnabled = defaults.object(
+            forKey: SettingsKeys.mapPlusNavigationBirdsEyeViewEnabled
+        ) as? Bool ?? true
         let shouldMigrateRecommendedDefaults = !defaults.bool(
             forKey: SettingsKeys.recommendedMapDefaultsMigrated
         )
@@ -1158,6 +1166,7 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(mapPlusNavigationStreetLineWidth, forKey: SettingsKeys.mapPlusNavigationStreetLineWidth)
         defaults.set(mapPlusNavigationPositionMarkerScale, forKey: SettingsKeys.mapPlusNavigationPositionMarkerScale)
         defaults.set(mapPlusNavigationZoomLevel, forKey: SettingsKeys.mapPlusNavigationZoomLevel)
+        defaults.set(mapPlusNavigationBirdsEyeViewEnabled, forKey: SettingsKeys.mapPlusNavigationBirdsEyeViewEnabled)
         defaults.set(tapToSwitchScreens, forKey: SettingsKeys.tapToSwitchScreens)
         enabledDeviceScreensMask = DeviceScreen.normalizedMask(enabledDeviceScreensMask)
         defaultDeviceScreen = DeviceScreen.fallbackDefault(
@@ -2116,6 +2125,11 @@ class BLEManager: NSObject, ObservableObject {
             log("Independent map setting id=\(id) not sent: connected firmware does not advertise support")
             return
         }
+        if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID,
+           (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigation) {
+            log("Bird's-eye map setting not sent: connected firmware does not advertise support")
+            return
+        }
         let deviceValue: Int32
         if id == DeviceBLEProtocol.brightnessSettingID {
             deviceValue = Int32(deviceBrightnessPercent)
@@ -2263,6 +2277,12 @@ class BLEManager: NSObject, ObservableObject {
                         value: Int32(mapPlusNavigationPositionMarkerScale))
             sendSetting(id: DeviceBLEProtocol.mapPlusNavigationZoomLevelSettingID,
                         value: Int32(mapPlusNavigationZoomLevel))
+            if supportsBirdsEyeMapNavigation {
+                sendSetting(
+                    id: DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID,
+                    value: mapPlusNavigationBirdsEyeViewEnabled ? 1 : 0
+                )
+            }
         }
 
         if shouldSendMap {
@@ -2281,6 +2301,7 @@ class BLEManager: NSObject, ObservableObject {
         guard isConnected, isNavigationReady, !hasReceivedDeviceCapabilities else { return }
         supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
+        supportsBirdsEyeMapNavigation = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -3047,6 +3068,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsPowerButtonHonkAcknowledgement = false
         supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
+        supportsBirdsEyeMapNavigation = false
         supportsBatteryStatusScreen = false
         supportsDestinationPicker = false
         updateWorkoutTelemetryCapability(false)
@@ -4944,12 +4966,14 @@ extension BLEManager: CBPeripheralDelegate {
             return false
         }
 
-        guard data.count == 5 || data.count == 8 else {
+        guard data.count == 5 || data.count == 6 ||
+                data.count == 8 || data.count == 9 else {
             supportsDeviceSounds = false
             supportsPowerButtonHonk = false
             supportsPowerButtonHonkAcknowledgement = false
             supportsIndependentMapProfiles = false
             supportsExtendedMapVisibility = false
+            supportsBirdsEyeMapNavigation = false
             supportsBatteryStatusScreen = false
             supportsDestinationPicker = false
             updateWorkoutTelemetryCapability(false)
@@ -4976,7 +5000,18 @@ extension BLEManager: CBPeripheralDelegate {
             flags & DeviceBLEProtocol.destinationPickerCapabilityMask != 0
         let hasWorkoutTelemetry =
             flags & DeviceBLEProtocol.workoutTelemetryCapabilityMask != 0
-        let hasDevicePowerButtonConfig = data.count == 8
+        let extendedFlags: UInt8
+        if data.count == 6 {
+            extendedFlags = data[5]
+        } else if data.count == 9 {
+            extendedFlags = data[8]
+        } else {
+            extendedFlags = 0
+        }
+        let hasBirdsEyeMapNavigation =
+            extendedFlags &
+                DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask != 0
+        let hasDevicePowerButtonConfig = data.count == 8 || data.count == 9
         if hasDevicePowerButtonConfig {
             guard hasPowerButtonHonk,
                   data[5] <= 1,
@@ -4987,6 +5022,7 @@ extension BLEManager: CBPeripheralDelegate {
                 supportsPowerButtonHonkAcknowledgement = false
                 supportsIndependentMapProfiles = false
                 supportsExtendedMapVisibility = false
+                supportsBirdsEyeMapNavigation = false
                 supportsBatteryStatusScreen = false
                 supportsDestinationPicker = false
                 updateWorkoutTelemetryCapability(false)
@@ -5015,8 +5051,14 @@ extension BLEManager: CBPeripheralDelegate {
             hasReceivedDeviceCapabilities &&
             !supportsExtendedMapVisibility &&
             hasExtendedMapVisibility
+        let shouldResendMapNavigationForBirdsEye =
+            hasReceivedDeviceCapabilities &&
+            !supportsBirdsEyeMapNavigation &&
+            hasBirdsEyeMapNavigation
         if shouldResendMapProfilesForExtendedVisibility {
             hasSentMapProfileForConnection = false
+            hasSentMapNavigationProfileForConnection = false
+        } else if shouldResendMapNavigationForBirdsEye {
             hasSentMapNavigationProfileForConnection = false
         }
         if hasReceivedDeviceCapabilities &&
@@ -5028,6 +5070,7 @@ extension BLEManager: CBPeripheralDelegate {
         supportsPowerButtonHonkAcknowledgement = hasPowerButtonHonkAcknowledgement
         supportsIndependentMapProfiles = hasIndependentMapProfiles
         supportsExtendedMapVisibility = hasExtendedMapVisibility
+        supportsBirdsEyeMapNavigation = hasBirdsEyeMapNavigation
         supportsBatteryStatusScreen = hasBatteryStatusScreen
         supportsDestinationPicker = hasDestinationPicker
         updateWorkoutTelemetryCapability(hasWorkoutTelemetry)
@@ -5035,7 +5078,7 @@ extension BLEManager: CBPeripheralDelegate {
             clearPendingPowerButtonHonkConfiguration()
         }
         hasReceivedDeviceCapabilities = true
-        log("Device capabilities: flags=0x\(String(format: "%02X", flags))")
+        log("Device capabilities: flags=0x\(String(format: "%02X", flags)) extended=0x\(String(format: "%02X", extendedFlags))")
         sendScreenSettingsAfterCapabilityNegotiation()
         sendMapProfilesAfterCapabilityNegotiation()
         if shouldSynchronizePowerButtonHonk {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -991,6 +991,16 @@ private struct MapStyleSettingsView: View {
         binding(map: \.showOtherAreas, mapPlusNavigation: \.mapPlusNavigationShowOtherAreas)
     }
 
+    private var birdsEyeFooter: String {
+        if !bleManager.hasReceivedDeviceCapabilities {
+            return "Connect to the Bike Computer to check bird's-eye view support."
+        }
+        if !bleManager.supportsBirdsEyeMapNavigation {
+            return "Update the Bike Computer firmware to enable bird's-eye view."
+        }
+        return "Tilts the map during active navigation. The ordinary Map screen stays flat."
+    }
+
     var body: some View {
         Form {
             if screen == .map {
@@ -1003,6 +1013,27 @@ private struct MapStyleSettingsView: View {
                     .onChange(of: bleManager.mapRotationMode) { newValue in
                         bleManager.sendSetting(id: 6, value: Int32(newValue))
                     }
+                }
+            }
+
+            if screen == .mapPlusNavigation {
+                Section(header: Text("View"), footer: Text(birdsEyeFooter)) {
+                    Toggle(
+                        "Bird's-Eye View",
+                        isOn: $bleManager.mapPlusNavigationBirdsEyeViewEnabled
+                    )
+                    .onChange(
+                        of: bleManager.mapPlusNavigationBirdsEyeViewEnabled
+                    ) { enabled in
+                        bleManager.sendSetting(
+                            id: DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID,
+                            value: enabled ? 1 : 0
+                        )
+                    }
+                    .disabled(
+                        !bleManager.hasReceivedDeviceCapabilities ||
+                            !bleManager.supportsBirdsEyeMapNavigation
+                    )
                 }
             }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -998,7 +998,10 @@ private struct MapStyleSettingsView: View {
         if !bleManager.supportsBirdsEyeMapNavigation {
             return "Update the Bike Computer firmware to enable bird's-eye view."
         }
-        return "Tilts the map during active navigation. The ordinary Map screen stays flat."
+        if !bleManager.supportsBirdsEyeMapNavigationPerspective {
+            return "Tilts the map during active navigation. Update the Bike Computer firmware to adjust the perspective."
+        }
+        return "Choose how strongly the map tilts during active navigation. The ordinary Map screen stays flat."
     }
 
     var body: some View {
@@ -1034,6 +1037,27 @@ private struct MapStyleSettingsView: View {
                         !bleManager.hasReceivedDeviceCapabilities ||
                             !bleManager.supportsBirdsEyeMapNavigation
                     )
+
+                    if bleManager.supportsBirdsEyeMapNavigationPerspective {
+                        Picker(
+                            "Perspective",
+                            selection: $bleManager.mapPlusNavigationBirdsEyePerspective
+                        ) {
+                            ForEach(MapNavigationBirdsEyePerspective.allCases) { perspective in
+                                Text(perspective.title).tag(perspective)
+                            }
+                        }
+                        .pickerStyle(.segmented)
+                        .onChange(
+                            of: bleManager.mapPlusNavigationBirdsEyePerspective
+                        ) { perspective in
+                            bleManager.sendSetting(
+                                id: DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID,
+                                value: Int32(perspective.rawValue)
+                            )
+                        }
+                        .disabled(!bleManager.mapPlusNavigationBirdsEyeViewEnabled)
+                    }
                 }
             }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1001,7 +1001,28 @@ private struct MapStyleSettingsView: View {
         if !bleManager.supportsBirdsEyeMapNavigationPerspective {
             return "Tilts the map during active navigation. Update the Bike Computer firmware to adjust the perspective."
         }
+        if !bleManager.supportsBirdsEyeMapNavigationStrongerPerspective {
+            return "Choose how strongly the map tilts during active navigation. Update the Bike Computer firmware for Very Strong and Maximum."
+        }
         return "Choose how strongly the map tilts during active navigation. The ordinary Map screen stays flat."
+    }
+
+    private var birdsEyePerspectiveOptions: [MapNavigationBirdsEyePerspective] {
+        bleManager.supportsBirdsEyeMapNavigationStrongerPerspective
+            ? MapNavigationBirdsEyePerspective.allCases
+            : MapNavigationBirdsEyePerspective.baselineCases
+    }
+
+    private var birdsEyePerspectiveSelection: Binding<MapNavigationBirdsEyePerspective> {
+        Binding(
+            get: {
+                bleManager.mapPlusNavigationBirdsEyePerspective.supportedValue(
+                    supportsStrongerPerspectives:
+                        bleManager.supportsBirdsEyeMapNavigationStrongerPerspective
+                )
+            },
+            set: { bleManager.mapPlusNavigationBirdsEyePerspective = $0 }
+        )
     }
 
     var body: some View {
@@ -1041,13 +1062,13 @@ private struct MapStyleSettingsView: View {
                     if bleManager.supportsBirdsEyeMapNavigationPerspective {
                         Picker(
                             "Perspective",
-                            selection: $bleManager.mapPlusNavigationBirdsEyePerspective
+                            selection: birdsEyePerspectiveSelection
                         ) {
-                            ForEach(MapNavigationBirdsEyePerspective.allCases) { perspective in
+                            ForEach(birdsEyePerspectiveOptions) { perspective in
                                 Text(perspective.title).tag(perspective)
                             }
                         }
-                        .pickerStyle(.segmented)
+                        .pickerStyle(.menu)
                         .onChange(
                             of: bleManager.mapPlusNavigationBirdsEyePerspective
                         ) { perspective in

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8829,7 +8829,8 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.workoutTelemetryCapabilityMask, 128, "workout telemetry uses capability bit 7")
         assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask, 1, "bird's-eye Map + Navigation uses extended capability bit 0")
         assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask, 2, "bird's-eye perspective uses extended capability bit 1")
-        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 8, "capability version advertises adjustable bird's-eye perspective support")
+        assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask, 4, "stronger bird's-eye perspectives use extended capability bit 2")
+        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 9, "capability version advertises five bird's-eye perspective levels")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCharacteristicUUIDString,
                     "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003",
                     "workout telemetry uses the dedicated 128-bit characteristic")
@@ -8865,6 +8866,10 @@ struct NavigationProtocolTests {
         assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: -1), .standard, "unknown bird's-eye perspectives use Standard")
         assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 0), .gentle, "perspective zero is Gentle")
         assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 2), .strong, "perspective two is Strong")
+        assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 3), .veryStrong, "perspective three is Very Strong")
+        assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 4), .maximum, "perspective four is Maximum")
+        assertEqual(MapNavigationBirdsEyePerspective.maximum.supportedValue(supportsStrongerPerspectives: false), .strong, "older firmware receives Strong instead of Maximum")
+        assertEqual(MapNavigationBirdsEyePerspective.maximum.supportedValue(supportsStrongerPerspectives: true), .maximum, "new firmware retains Maximum")
         assertEqual(DeviceBLEProtocol.currentScreenMaskMarker, 1 << 30, "current screen masks use bit 30 as a compatibility marker")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: -1), nil, "unavailable iPhone battery levels stay unknown")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: 0), 0, "empty iPhone battery maps to zero percent")
@@ -10329,6 +10334,19 @@ struct NavigationProtocolTests {
                "adjustable bird's-eye CAPS should be consumed")
         assert(manager.supportsBirdsEyeMapNavigationPerspective,
                "extended CAPS bit one enables the perspective control")
+        assert(!manager.supportsBirdsEyeMapNavigationStrongerPerspective,
+               "bit one alone limits the picker to the first three levels")
+
+        let strongerBirdsEyePerspective =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(strongerBirdsEyePerspective),
+               "five-level bird's-eye CAPS should be consumed")
+        assert(manager.supportsBirdsEyeMapNavigationStrongerPerspective,
+               "extended CAPS bit two enables Very Strong and Maximum")
 
         let acknowledgedFlags = supportedFlags |
             DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask
@@ -10355,7 +10373,8 @@ struct NavigationProtocolTests {
             Data([acknowledgedFlags, 1,
                   DeviceSound.rotatingBicycleBell.rawValue, 65,
                   DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
-                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask])
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask])
         assert(manager.handleDeviceCapabilitiesNotification(
             extendedDeviceConfig
         ), "extended CAPS with a PWR configuration should be consumed")
@@ -10363,6 +10382,8 @@ struct NavigationProtocolTests {
                "the extended byte follows the complete PWR configuration")
         assert(manager.supportsBirdsEyeMapNavigationPerspective,
                "the PWR configuration response also carries perspective support")
+        assert(manager.supportsBirdsEyeMapNavigationStrongerPerspective,
+               "the PWR configuration response carries five-level perspective support")
 
         let invalidDeviceConfig = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
             Data([acknowledgedFlags, 2, DeviceSound.bellDing.rawValue, 70])
@@ -10393,6 +10414,8 @@ struct NavigationProtocolTests {
                "malformed CAPS clears bird's-eye Map + Navigation support")
         assert(!manager.supportsBirdsEyeMapNavigationPerspective,
                "malformed CAPS clears bird's-eye perspective support")
+        assert(!manager.supportsBirdsEyeMapNavigationStrongerPerspective,
+               "malformed CAPS clears stronger bird's-eye perspective support")
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
@@ -10544,7 +10567,7 @@ struct NavigationProtocolTests {
                "the disabled bird's-eye preference survives a settings reload")
 
         let (perspectiveManager, perspectivePackets) = configuredManager()
-        perspectiveManager.mapPlusNavigationBirdsEyePerspective = .strong
+        perspectiveManager.mapPlusNavigationBirdsEyePerspective = .maximum
         let perspectiveCapabilities =
             Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
             Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
@@ -10558,11 +10581,26 @@ struct NavigationProtocolTests {
                     "adjustable firmware receives both bird's-eye settings")
         let perspectiveSetting = perspectivePackets().first { $0[4] == 26 }
         assertEqual(readInt32LE(perspectiveSetting!, offset: 5), 2,
-                    "the Strong perspective is sent as two")
+                    "older adjustable firmware receives Strong instead of Maximum")
         let restoredPerspectiveManager = BLEManager()
         assertEqual(restoredPerspectiveManager.mapPlusNavigationBirdsEyePerspective,
-                    .strong,
+                    .maximum,
                     "the bird's-eye perspective survives a settings reload")
+
+        let (strongerPerspectiveManager, strongerPerspectivePackets) = configuredManager()
+        strongerPerspectiveManager.mapPlusNavigationBirdsEyePerspective = .maximum
+        let strongerPerspectiveCapabilities =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveExtendedCapabilityMask])
+        assert(strongerPerspectiveManager.handleDeviceCapabilitiesNotification(
+            strongerPerspectiveCapabilities
+        ), "five-level bird's-eye perspective capability should be consumed")
+        let strongerPerspectiveSetting = strongerPerspectivePackets().first { $0[4] == 26 }
+        assertEqual(readInt32LE(strongerPerspectiveSetting!, offset: 5), 4,
+                    "Maximum is sent as four to five-level firmware")
 
         let (legacyManager, legacyPackets) = configuredManager()
         let baselineCapabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8827,7 +8827,8 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.batteryStatusScreenCapabilityMask, 32, "Battery Status support uses capability bit 5")
         assertEqual(DeviceBLEProtocol.destinationPickerCapabilityMask, 64, "destination picker support uses capability bit 6")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCapabilityMask, 128, "workout telemetry uses capability bit 7")
-        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 6, "capability version advertises workout telemetry support")
+        assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask, 1, "bird's-eye Map + Navigation uses extended capability bit 0")
+        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 7, "capability version advertises bird's-eye Map + Navigation support")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCharacteristicUUIDString,
                     "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003",
                     "workout telemetry uses the dedicated 128-bit characteristic")
@@ -8858,6 +8859,7 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.mapPlusNavigationPositionMarkerScaleSettingID, 22, "Map + Navigation marker scale uses setting ID 22")
         assertEqual(DeviceBLEProtocol.phoneBatteryLevelSettingID, 23, "phone battery level uses firmware setting ID 23")
         assertEqual(DeviceBLEProtocol.phoneBatteryChargingSettingID, 24, "phone charging state uses firmware setting ID 24")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID, 25, "bird's-eye Map + Navigation uses setting ID 25")
         assertEqual(DeviceBLEProtocol.currentScreenMaskMarker, 1 << 30, "current screen masks use bit 30 as a compatibility marker")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: -1), nil, "unavailable iPhone battery levels stay unknown")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: 0), 0, "empty iPhone battery maps to zero percent")
@@ -10303,6 +10305,14 @@ struct NavigationProtocolTests {
         assert(manager.supportsIndependentMapProfiles,
                "CAPS bit enables independent map profile controls")
 
+        let birdsEye = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(birdsEye),
+               "extended bird's-eye CAPS should be consumed")
+        assert(manager.supportsBirdsEyeMapNavigation,
+               "extended CAPS enables the bird's-eye Map + Navigation control")
+
         let acknowledgedFlags = supportedFlags |
             DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask
         let acknowledged = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
@@ -10322,6 +10332,17 @@ struct NavigationProtocolTests {
                     "versioned CAPS restores the device-persisted sound")
         assertEqual(manager.deviceSoundVolumePercent, 65,
                     "versioned CAPS restores the device-persisted volume")
+
+        let extendedDeviceConfig =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([acknowledgedFlags, 1,
+                  DeviceSound.rotatingBicycleBell.rawValue, 65,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(
+            extendedDeviceConfig
+        ), "extended CAPS with a PWR configuration should be consumed")
+        assert(manager.supportsBirdsEyeMapNavigation,
+               "the extended byte follows the complete PWR configuration")
 
         let invalidDeviceConfig = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
             Data([acknowledgedFlags, 2, DeviceSound.bellDing.rawValue, 70])
@@ -10348,6 +10369,8 @@ struct NavigationProtocolTests {
                "malformed CAPS clears extended map visibility support")
         assert(!manager.supportsIndependentMapProfiles,
                "malformed CAPS clears independent map profile support")
+        assert(!manager.supportsBirdsEyeMapNavigation,
+               "malformed CAPS clears bird's-eye Map + Navigation support")
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
@@ -10433,6 +10456,13 @@ struct NavigationProtocolTests {
     }
 
     static func testMapProfileCapabilityNegotiation() {
+        UserDefaults.standard.removeObject(
+            forKey: "mapPlusNavigationSettings.birdsEyeViewEnabled"
+        )
+        let defaultManager = BLEManager()
+        assert(defaultManager.mapPlusNavigationBirdsEyeViewEnabled,
+               "bird's-eye Map + Navigation defaults on")
+
         func configuredManager() -> (BLEManager, () -> [Data]) {
             let manager = BLEManager()
             manager.isConnected = true
@@ -10463,6 +10493,27 @@ struct NavigationProtocolTests {
         let independentDetail = independentPackets().first { $0[4] == 17 }
         assertEqual(readInt32LE(independentDetail!, offset: 5), 0,
                     "independent Map + Navigation detail remains distinct")
+
+        let (birdsEyeManager, birdsEyePackets) = configuredManager()
+        birdsEyeManager.mapPlusNavigationBirdsEyeViewEnabled = false
+        let birdsEyeCapabilities =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask])
+        assert(birdsEyeManager.handleDeviceCapabilitiesNotification(
+            birdsEyeCapabilities
+        ), "bird's-eye capability response should be consumed")
+        assert(birdsEyeManager.supportsBirdsEyeMapNavigation,
+               "bird's-eye capability enables the setting")
+        assertEqual(birdsEyePackets().map { $0[4] },
+                    [20, 16, 17, 18, 21, 22, 19, 25, 8, 1, 2, 3, 9, 10, 7],
+                    "supported firmware receives the bird's-eye preference with the Map + Navigation profile")
+        let birdsEyeSetting = birdsEyePackets().first { $0[4] == 25 }
+        assertEqual(readInt32LE(birdsEyeSetting!, offset: 5), 0,
+                    "the disabled bird's-eye preference is sent as zero")
+        let restoredManager = BLEManager()
+        assert(!restoredManager.mapPlusNavigationBirdsEyeViewEnabled,
+               "the disabled bird's-eye preference survives a settings reload")
 
         let (legacyManager, legacyPackets) = configuredManager()
         let baselineCapabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])
@@ -10503,6 +10554,9 @@ struct NavigationProtocolTests {
         assert(readInt32LE(resentMapVisibility!, offset: 5) &
                DeviceBLEProtocol.extendedVisibilityMarker != 0,
                "late extended response repairs the folded Map visibility mask")
+        UserDefaults.standard.removeObject(
+            forKey: "mapPlusNavigationSettings.birdsEyeViewEnabled"
+        )
     }
 
     static func testDeviceCapabilitySynchronizesPowerButtonHonkOnce() {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8828,7 +8828,8 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.destinationPickerCapabilityMask, 64, "destination picker support uses capability bit 6")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCapabilityMask, 128, "workout telemetry uses capability bit 7")
         assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask, 1, "bird's-eye Map + Navigation uses extended capability bit 0")
-        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 7, "capability version advertises bird's-eye Map + Navigation support")
+        assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask, 2, "bird's-eye perspective uses extended capability bit 1")
+        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 8, "capability version advertises adjustable bird's-eye perspective support")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCharacteristicUUIDString,
                     "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003",
                     "workout telemetry uses the dedicated 128-bit characteristic")
@@ -8860,6 +8861,10 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.phoneBatteryLevelSettingID, 23, "phone battery level uses firmware setting ID 23")
         assertEqual(DeviceBLEProtocol.phoneBatteryChargingSettingID, 24, "phone charging state uses firmware setting ID 24")
         assertEqual(DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID, 25, "bird's-eye Map + Navigation uses setting ID 25")
+        assertEqual(DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID, 26, "bird's-eye perspective uses setting ID 26")
+        assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: -1), .standard, "unknown bird's-eye perspectives use Standard")
+        assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 0), .gentle, "perspective zero is Gentle")
+        assertEqual(MapNavigationBirdsEyePerspective.normalized(rawValue: 2), .strong, "perspective two is Strong")
         assertEqual(DeviceBLEProtocol.currentScreenMaskMarker, 1 << 30, "current screen masks use bit 30 as a compatibility marker")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: -1), nil, "unavailable iPhone battery levels stay unknown")
         assertEqual(DeviceBLEProtocol.phoneBatteryPercentage(from: 0), 0, "empty iPhone battery maps to zero percent")
@@ -10312,6 +10317,18 @@ struct NavigationProtocolTests {
                "extended bird's-eye CAPS should be consumed")
         assert(manager.supportsBirdsEyeMapNavigation,
                "extended CAPS enables the bird's-eye Map + Navigation control")
+        assert(!manager.supportsBirdsEyeMapNavigationPerspective,
+               "bird's-eye bit zero alone preserves the fixed Standard perspective")
+
+        let birdsEyePerspective =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask])
+        assert(manager.handleDeviceCapabilitiesNotification(birdsEyePerspective),
+               "adjustable bird's-eye CAPS should be consumed")
+        assert(manager.supportsBirdsEyeMapNavigationPerspective,
+               "extended CAPS bit one enables the perspective control")
 
         let acknowledgedFlags = supportedFlags |
             DeviceBLEProtocol.powerButtonHonkAcknowledgementCapabilityMask
@@ -10337,12 +10354,15 @@ struct NavigationProtocolTests {
             Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
             Data([acknowledgedFlags, 1,
                   DeviceSound.rotatingBicycleBell.rawValue, 65,
-                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask])
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask])
         assert(manager.handleDeviceCapabilitiesNotification(
             extendedDeviceConfig
         ), "extended CAPS with a PWR configuration should be consumed")
         assert(manager.supportsBirdsEyeMapNavigation,
                "the extended byte follows the complete PWR configuration")
+        assert(manager.supportsBirdsEyeMapNavigationPerspective,
+               "the PWR configuration response also carries perspective support")
 
         let invalidDeviceConfig = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
             Data([acknowledgedFlags, 2, DeviceSound.bellDing.rawValue, 70])
@@ -10371,6 +10391,8 @@ struct NavigationProtocolTests {
                "malformed CAPS clears independent map profile support")
         assert(!manager.supportsBirdsEyeMapNavigation,
                "malformed CAPS clears bird's-eye Map + Navigation support")
+        assert(!manager.supportsBirdsEyeMapNavigationPerspective,
+               "malformed CAPS clears bird's-eye perspective support")
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
@@ -10459,9 +10481,15 @@ struct NavigationProtocolTests {
         UserDefaults.standard.removeObject(
             forKey: "mapPlusNavigationSettings.birdsEyeViewEnabled"
         )
+        UserDefaults.standard.removeObject(
+            forKey: "mapPlusNavigationSettings.birdsEyePerspective"
+        )
         let defaultManager = BLEManager()
         assert(defaultManager.mapPlusNavigationBirdsEyeViewEnabled,
                "bird's-eye Map + Navigation defaults on")
+        assertEqual(defaultManager.mapPlusNavigationBirdsEyePerspective,
+                    .standard,
+                    "bird's-eye perspective defaults to Standard")
 
         func configuredManager() -> (BLEManager, () -> [Data]) {
             let manager = BLEManager()
@@ -10515,6 +10543,27 @@ struct NavigationProtocolTests {
         assert(!restoredManager.mapPlusNavigationBirdsEyeViewEnabled,
                "the disabled bird's-eye preference survives a settings reload")
 
+        let (perspectiveManager, perspectivePackets) = configuredManager()
+        perspectiveManager.mapPlusNavigationBirdsEyePerspective = .strong
+        let perspectiveCapabilities =
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) +
+            Data([DeviceBLEProtocol.independentMapProfilesCapabilityMask,
+                  DeviceBLEProtocol.birdsEyeMapNavigationExtendedCapabilityMask |
+                    DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveExtendedCapabilityMask])
+        assert(perspectiveManager.handleDeviceCapabilitiesNotification(
+            perspectiveCapabilities
+        ), "bird's-eye perspective capability response should be consumed")
+        assertEqual(perspectivePackets().map { $0[4] },
+                    [20, 16, 17, 18, 21, 22, 19, 25, 26, 8, 1, 2, 3, 9, 10, 7],
+                    "adjustable firmware receives both bird's-eye settings")
+        let perspectiveSetting = perspectivePackets().first { $0[4] == 26 }
+        assertEqual(readInt32LE(perspectiveSetting!, offset: 5), 2,
+                    "the Strong perspective is sent as two")
+        let restoredPerspectiveManager = BLEManager()
+        assertEqual(restoredPerspectiveManager.mapPlusNavigationBirdsEyePerspective,
+                    .strong,
+                    "the bird's-eye perspective survives a settings reload")
+
         let (legacyManager, legacyPackets) = configuredManager()
         let baselineCapabilities = Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])
         assert(legacyManager.handleDeviceCapabilitiesNotification(baselineCapabilities),
@@ -10556,6 +10605,9 @@ struct NavigationProtocolTests {
                "late extended response repairs the folded Map visibility mask")
         UserDefaults.standard.removeObject(
             forKey: "mapPlusNavigationSettings.birdsEyeViewEnabled"
+        )
+        UserDefaults.standard.removeObject(
+            forKey: "mapPlusNavigationSettings.birdsEyePerspective"
         )
     }
 


### PR DESCRIPTION
## Summary

- Adds a default-on bird's-eye projection for Map + Navigation while an active route is present; the ordinary Map screen remains flat.
- Uses one immutable projection for vector features, route geometry, and the current-position marker, including near-plane clipping and depth-scaled line widths.
- Adds Gentle, Standard, Strong, Very Strong, and Maximum perspective presets, with Standard as the persisted default.
- Preserves the four-block renderer budget by easing the strongest requested angle only when an extreme zoom, viewport, or rotation would otherwise exceed it.
- Adds map setting ID 26 plus versioned extended-capability negotiation. Version 9 bit 2 advertises the two stronger levels; older perspective-capable firmware sees only the first three and receives Strong if a saved stronger choice must be sent.
- Adds a capability-gated, persisted Perspective menu under UI Customization > Map + Navigation; it is disabled when Bird's-Eye View is off.

## Validation

- [x] Projection, map-profile, and persistence C++ host tests with warnings treated as errors
- [x] ios-app/scripts/run-navigation-tests.sh
- [x] Full BikeComputer iOS simulator build, including Settings and embedded targets
- [x] Deterministic firmware build and final ELF verification for WAVESHARE_AMOLED_175 with the final projection fix
- [x] GitHub CI for commit 2c73ed7f, including WAVESHARE_AMOLED_206
- [ ] Physical-device validation of all five perspective presets and reconnect persistence

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the Open Bike Computer Contributor License Agreement: https://github.com/seichris/open-bike-computer/blob/main/CLA.md. By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
