### PR TITLE
Fix verified firmware upload wrapper

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -151,9 +151,11 @@ stamped `unverified-...` rather than advertising an exact Git SHA. AMOLED upload
 rechecks the clean source identity, generated state, managed components,
 profile-private library dependencies, isolated installed-core attestation, and
 the exact ELF and binary while holding the project-wide lock, then replays the
-complete PlatformIO-resolved esptool plan so it cannot relink different bytes or
-reconstruct offsets independently. Its final flash mode, frequency, and size
-are `keep`, preventing esptool from rewriting a bootloader after hashing. Keep the
+attested esptool plan so it cannot relink different bytes. The application offset
+comes from the built partition table, with any non-empty PlatformIO value required
+to match; other offsets remain PlatformIO-resolved. Its final flash mode,
+frequency, and size are `keep`, preventing esptool from rewriting a bootloader
+after hashing. Keep the
 structured `FIRMWARE_BUILD_PROVENANCE` and
 `FIRMWARE_UPLOAD_PROVENANCE` lines with test notes. The upload marker is a
 preflight record of the eligible USB-upload inputs: firmware binary/ELF,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,9 +47,11 @@ steady verified config after tool conversion, forces pioarduino's recursive
 build through that config, rebuilds the requested source, and requires the
 target `firmware.elf`. Direct
 `pio run -e ... -t upload` is intentionally not the documented upload path:
-PlatformIO reruns prebuild before upload, so the helper must preserve its narrow
-generated-config allowance through that pass to keep the flashed Git identity
-exact.
+PlatformIO reruns prebuild before upload. The helper instead records the fully
+resolved esptool command during the verified build, attests its uploader and
+every referenced image, normalizes the three header-mutating flash parameters
+to `keep`, and replays that immutable plan without asking PlatformIO to
+configure or build again.
 
 Use the matching `WAVESHARE_AMOLED_206` environment for a 2.06-inch board. If
 upload fails, hold BOOT (`GPIO0`) while reconnecting USB and retry.
@@ -148,14 +150,17 @@ PlatformIO builds fail with a pointer to the helper; raw legacy-board builds are
 stamped `unverified-...` rather than advertising an exact Git SHA. AMOLED upload
 rechecks the clean source identity, generated state, managed components,
 profile-private library dependencies, isolated installed-core attestation, and
-the exact ELF and binary while holding the project-wide lock, then invokes
-PlatformIO's `nobuild` upload target so it cannot relink different bytes. Keep the
+the exact ELF and binary while holding the project-wide lock, then replays the
+complete PlatformIO-resolved esptool plan so it cannot relink different bytes or
+reconstruct offsets independently. Its final flash mode, frequency, and size
+are `keep`, preventing esptool from rewriting a bootloader after hashing. Keep the
 structured `FIRMWARE_BUILD_PROVENANCE` and
 `FIRMWARE_UPLOAD_PROVENANCE` lines with test notes. The upload marker is a
 preflight record of the eligible USB-upload inputs: firmware binary/ELF,
 bootloader, partition table, OTA bootstrap, platform/package archives,
-library dependencies, and managed components. A successful command means
-PlatformIO accepted the upload. A later `BOOT_META` independently confirms the
+library dependencies, and managed components. A successful command means the
+attested esptool process completed the upload. A later `BOOT_META`
+independently confirms the
 embedded Git/profile identity; it does not contain those SHA-256 values or prove
 on-device byte equality. Flash readback or a runtime image digest is required
 for that stronger claim.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,9 +60,12 @@ Use this helper rather than a raw Waveshare `pio run`. It verifies the tracked
 pioarduino platform and executable-package archive digests, keeps pioarduino's
 recursive custom-core build on the generated local config, isolates and attests
 PlatformIO-installed package/tool/nested-runtime and ESP-IDF component state,
-and records PlatformIO's complete resolved flash plan during the preceding
-build. Upload revalidates that plan, its exact uploader, and every referenced
-image before replaying it directly without another PlatformIO build. The final
+and records PlatformIO's resolved flash plan during the preceding build. The
+application offset is taken from the built, attested partition table because
+pioarduino can clear its corresponding environment value after custom-core reuse;
+any non-empty PlatformIO value must agree. Upload revalidates that plan, its exact
+uploader, and every referenced image before replaying it directly without another
+PlatformIO build. The final
 attested command uses esptool's `keep` values for flash mode, frequency, and
 size so esptool cannot rewrite a hashed bootloader image. The original resolved
 values remain in the plan provenance. The

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,12 @@ Use this helper rather than a raw Waveshare `pio run`. It verifies the tracked
 pioarduino platform and executable-package archive digests, keeps pioarduino's
 recursive custom-core build on the generated local config, isolates and attests
 PlatformIO-installed package/tool/nested-runtime and ESP-IDF component state,
-and gives PlatformIO only the image set attested by the preceding build. The
+and records PlatformIO's complete resolved flash plan during the preceding
+build. Upload revalidates that plan, its exact uploader, and every referenced
+image before replaying it directly without another PlatformIO build. The final
+attested command uses esptool's `keep` values for flash mode, frequency, and
+size so esptool cannot rewrite a hashed bootloader image. The original resolved
+values remain in the plan provenance. The
 host Python interpreter, top-level `pio` launcher, and pioarduino's first-run
 online Python dependency resolver (including its registries, external `uv`,
 private `penv`, and ESP-IDF venv before their resulting trees are attested)

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -34,8 +34,10 @@ remain available through the manual **Speaker firmware builds** GitHub Actions
 workflow.
 
 After confirming the connected hardware profile, use the same helper for
-upload so the exact Git identity remains active through PlatformIO's upload
-prebuild:
+upload. It revalidates the exact Git identity, toolchain, and image hashes, then
+invokes the attested esptool runtime directly with the ESP32-S3 bootloader and
+partition-derived OTA offsets. This avoids a second PlatformIO build and keeps
+the bytes crossing the upload boundary identical to the verified build:
 
 ```sh
 python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -35,9 +35,13 @@ workflow.
 
 After confirming the connected hardware profile, use the same helper for
 upload. It revalidates the exact Git identity, toolchain, and image hashes, then
-invokes the attested esptool runtime directly with the ESP32-S3 bootloader and
-partition-derived OTA offsets. This avoids a second PlatformIO build and keeps
-the bytes crossing the upload boundary identical to the verified build:
+replays the esptool plan captured from PlatformIO during that build. The plan
+includes PlatformIO's chip, reset, speed, resolved flash settings, every offset,
+and every referenced image. Before attestation, the helper normalizes only
+esptool's flash-mode, frequency, and size arguments to `keep`; otherwise esptool
+can rewrite the bootloader header after it was hashed. This avoids a second
+PlatformIO build and keeps the bytes and flash layout crossing the upload
+boundary identical to the verified build:
 
 ```sh
 python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \
@@ -46,11 +50,11 @@ python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \
 
 Archive the emitted `FIRMWARE_BUILD_PROVENANCE` and
 `FIRMWARE_UPLOAD_PROVENANCE` lines with physical test results. They bind the
-clean Git/profile identity to the exact firmware, bootloader, partition-table,
-and OTA-bootstrap image set plus the content-pinned pioarduino platform archive
-and executable-package bootstraps, PlatformIO-installed compiler/uploader/nested
-runtime trees through `coreAttestationSha256`, and ignored generated dependency
-inputs presented for that upload. The helper
+clean Git/profile identity to PlatformIO's complete resolved flash plan and the
+hash of every referenced image, plus the content-pinned pioarduino platform
+archive and executable-package bootstraps, PlatformIO-installed
+compiler/uploader/nested runtime trees through `coreAttestationSha256`, and
+ignored generated dependency inputs presented for that upload. The helper
 also isolates ESP-IDF Component Manager state, rejects or scrubs ambient source
 overrides, and requires strict component checksums. This is upload-input
 preflight evidence, not flash readback: a later `BOOT_META` confirms the

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -36,8 +36,11 @@ workflow.
 After confirming the connected hardware profile, use the same helper for
 upload. It revalidates the exact Git identity, toolchain, and image hashes, then
 replays the esptool plan captured from PlatformIO during that build. The plan
-includes PlatformIO's chip, reset, speed, resolved flash settings, every offset,
-and every referenced image. Before attestation, the helper normalizes only
+includes PlatformIO's chip, reset, speed, resolved flash settings, non-application
+offsets, and every referenced image. Because pioarduino can clear its application
+offset after custom-core reuse, the helper resolves that one offset from the built,
+attested partition table and rejects any non-empty PlatformIO value that disagrees.
+Before attestation, the helper normalizes only
 esptool's flash-mode, frequency, and size arguments to `keep`; otherwise esptool
 can rewrite the bootloader header after it was hashed. This avoids a second
 PlatformIO build and keeps the bytes and flash layout crossing the upload

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -187,7 +187,9 @@ board_upload.flash_size = 16MB
 board_build.filesystem = fatfs
 monitor_speed = 115200
 monitor_filters = esp32_exception_decoder
-extra_scripts = pre:prebuild.py
+extra_scripts =
+  pre:prebuild.py
+  post:tools/record_flash_plan.py
 ; pioarduino's custom SDK build drops its private CONFIG_LIB_BUILDER_COMPILE
 ; symbol, so ESP-Diagnostics does not provide the log_printf wrapper that the
 ; stock link flags request. This firmware does not use ESP Insights; link

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -10,7 +10,6 @@ import json
 import os
 import re
 import shutil
-import struct
 import subprocess
 import sys
 import tarfile
@@ -22,6 +21,7 @@ from pathlib import Path
 from typing import Callable, Iterator, Sequence
 
 from generated_sdkconfig import (
+    FLASH_PLAN_PORT_PLACEHOLDER,
     GeneratedSdkconfigError,
     WAVESHARE_PLATFORM_ARCHIVE_SHA256,
     WAVESHARE_PLATFORM_ARCHIVE_SIZE,
@@ -162,168 +162,30 @@ PLATFORMIO_CORE_SCONS_PIOPM = json.dumps(
     },
     separators=(",", ":"),
 )
-ESP32_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
-ESP32_PARTITION_MAGIC = 0x50AA
-ESP32_PARTITION_END_MAGIC = 0xFFFF
-ESP32_PARTITION_MD5_MAGIC = 0xEBEB
-ESP32_PARTITION_TABLE_OFFSET = 0x8000
-ESP32_PARTITION_TABLE_SIZE = 0x1000
-ESP32_BOOTLOADER_OFFSET = 0x0000
-ESP32_APP_TYPE = 0x00
-ESP32_OTA_0_SUBTYPE = 0x10
-ESP32_DATA_TYPE = 0x01
-ESP32_OTA_DATA_SUBTYPE = 0x00
-WAVESHARE_UPLOAD_BAUD = "460800"
-
-
 class BuildError(RuntimeError):
     """Raised when a deterministic real-target build cannot be confirmed."""
 
 
-def _parse_partition_layout(
-    partition_table: Path,
-) -> tuple[tuple[int, int], tuple[int, int]]:
-    """Return the OTA-data and OTA-0 ranges from an ESP32 partition image."""
-    try:
-        contents = partition_table.read_bytes()
-    except OSError as error:
-        raise BuildError(f"could not read verified partition table: {error}") from error
-    if not contents or len(contents) > ESP32_PARTITION_TABLE_SIZE:
-        raise BuildError("verified partition table has an invalid size")
-
-    ota_data: tuple[int, int] | None = None
-    ota_0: tuple[int, int] | None = None
-    for entry_offset in range(0, len(contents), ESP32_PARTITION_ENTRY.size):
-        entry = contents[entry_offset : entry_offset + ESP32_PARTITION_ENTRY.size]
-        if len(entry) != ESP32_PARTITION_ENTRY.size:
-            raise BuildError("verified partition table has a truncated entry")
-        magic, entry_type, subtype, offset, size, _label, _flags = (
-            ESP32_PARTITION_ENTRY.unpack(entry)
-        )
-        if magic in (ESP32_PARTITION_END_MAGIC, ESP32_PARTITION_MD5_MAGIC):
-            break
-        if magic != ESP32_PARTITION_MAGIC or size == 0:
-            raise BuildError("verified partition table contains an invalid entry")
-        partition_range = (offset, size)
-        if entry_type == ESP32_DATA_TYPE and subtype == ESP32_OTA_DATA_SUBTYPE:
-            if ota_data is not None:
-                raise BuildError("verified partition table contains duplicate OTA data")
-            ota_data = partition_range
-        if entry_type == ESP32_APP_TYPE and subtype == ESP32_OTA_0_SUBTYPE:
-            if ota_0 is not None:
-                raise BuildError(
-                    "verified partition table contains duplicate OTA slot 0"
-                )
-            ota_0 = partition_range
-
-    if ota_data is None or ota_0 is None:
-        raise BuildError(
-            "verified partition table is missing OTA data or OTA application slot 0"
-        )
-    if ota_data[0] < ESP32_PARTITION_TABLE_OFFSET + ESP32_PARTITION_TABLE_SIZE:
-        raise BuildError("verified OTA data partition overlaps the partition table")
-    if ota_0[0] % 0x10000 != 0:
-        raise BuildError("verified OTA application slot 0 is not 64 KiB aligned")
-    return ota_data, ota_0
-
-
-def _verified_esptool_command(
-    project_dir: Path,
-    environment: str,
+def _verified_flash_command(
     upload_port: str,
     manifest: dict[str, object],
 ) -> tuple[str, ...]:
-    """Build the exact esptool command for the already-attested image set."""
-    core_attestation = manifest.get("coreAttestation")
-    if not isinstance(core_attestation, dict):
-        raise BuildError("verified build provenance is missing its core attestation")
-    core_dir_value = core_attestation.get("coreDir")
-    if not isinstance(core_dir_value, str):
-        raise BuildError("verified build provenance has an invalid core directory")
-    core_dir = Path(core_dir_value)
-    expected_core_dir = (
-        project_dir / ".pio/open-bike-build/platformio" / environment
-    ).resolve()
-    if core_dir.resolve() != expected_core_dir:
-        raise BuildError("verified build provenance references another core directory")
-
-    executable = core_dir / (
-        "penv/Scripts/esptool.exe" if os.name == "nt" else "penv/bin/esptool"
-    )
-    if executable.is_symlink() or not executable.is_file():
+    """Bind the requested port into the already-attested PlatformIO plan."""
+    flash_plan = manifest.get("flashPlan")
+    if not isinstance(flash_plan, dict):
+        raise BuildError("verified build provenance is missing its flash plan")
+    command = flash_plan.get("command")
+    if not isinstance(command, list) or not all(
+        isinstance(token, str) for token in command
+    ):
+        raise BuildError("verified build provenance has an invalid flash command")
+    if command.count(FLASH_PLAN_PORT_PLACEHOLDER) != 1:
         raise BuildError(
-            f"verified esptool uploader is missing or unsafe: {executable}"
+            "verified build provenance has an invalid upload-port placeholder"
         )
-
-    build_dir = project_dir / ".pio/build" / environment
-    bootloader = build_dir / "bootloader.bin"
-    partitions = build_dir / "partitions.bin"
-    firmware = build_dir / "firmware.bin"
-    boot_app0 = (
-        core_dir
-        / "packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin"
-    )
-    for image in (bootloader, partitions, boot_app0, firmware):
-        if image.is_symlink() or not image.is_file():
-            raise BuildError(f"verified flash image is missing or unsafe: {image}")
-
-    ota_data, ota_0 = _parse_partition_layout(partitions)
-    image_bounds = (
-        (
-            "bootloader",
-            bootloader,
-            ESP32_BOOTLOADER_OFFSET,
-            ESP32_PARTITION_TABLE_OFFSET,
-        ),
-        (
-            "partition table",
-            partitions,
-            ESP32_PARTITION_TABLE_OFFSET,
-            ESP32_PARTITION_TABLE_SIZE,
-        ),
-        ("OTA bootstrap", boot_app0, ota_data[0], ota_data[1]),
-        ("firmware", firmware, ota_0[0], ota_0[1]),
-    )
-    for label, image, _offset, capacity in image_bounds:
-        try:
-            image_size = image.stat().st_size
-        except OSError as error:
-            raise BuildError(
-                f"could not inspect verified {label} image: {error}"
-            ) from error
-        if image_size == 0 or image_size > capacity:
-            raise BuildError(f"verified {label} image does not fit its flash region")
-
-    return (
-        str(executable),
-        "--chip",
-        "esp32s3",
-        "--port",
-        upload_port,
-        "--baud",
-        WAVESHARE_UPLOAD_BAUD,
-        "--before",
-        "default-reset",
-        "--after",
-        "hard-reset",
-        "write-flash",
-        "-z",
-        # Preserve the attested bootloader header instead of letting esptool
-        # rewrite its flash configuration during upload.
-        "--flash-mode",
-        "keep",
-        "--flash-freq",
-        "keep",
-        "--flash-size",
-        "keep",
-        hex(ESP32_BOOTLOADER_OFFSET),
-        str(bootloader),
-        hex(ESP32_PARTITION_TABLE_OFFSET),
-        str(partitions),
-        hex(ota_data[0]),
-        str(boot_app0),
-        hex(ota_0[0]),
-        str(firmware),
+    return tuple(
+        upload_port if token == FLASH_PLAN_PORT_PLACEHOLDER else token
+        for token in command
     )
 
 
@@ -839,6 +701,7 @@ def _print_provenance(
         f"bootloaderBinSha256={value('bootloaderBinSha256')} "
         f"partitionTableBinSha256={value('partitionTableBinSha256')} "
         f"bootApp0Sha256={value('bootApp0Sha256')} "
+        f"flashPlanSha256={value('flashPlanSha256')} "
         f"coreAttestationSha256={value('coreAttestationSha256')} "
         f"platformArchiveSha256={value('platformArchiveSha256')} "
         f"platformPackagesSha256={value('platformPackagesSha256')} "
@@ -1169,7 +1032,7 @@ def upload_firmware(
         raise BuildError(
             "verified upload is limited to attested WAVESHARE_AMOLED profiles"
         )
-    if not upload_port.strip():
+    if not upload_port.strip() or "\0" in upload_port:
         raise BuildError("upload port must not be empty")
 
     firmware_elf = project_dir / ".pio" / "build" / environment / "firmware.elf"
@@ -1202,16 +1065,14 @@ def upload_firmware(
                 )
             except GeneratedSdkconfigError as error:
                 raise BuildError(str(error)) from error
+            command: Sequence[str] = _verified_flash_command(
+                upload_port,
+                manifest,
+            )
             _print_provenance(
                 "FIRMWARE_UPLOAD_PROVENANCE",
                 environment,
                 expected_identity,
-                manifest,
-            )
-            command: Sequence[str] = _verified_esptool_command(
-                project_dir,
-                environment,
-                upload_port,
                 manifest,
             )
             try:

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -10,6 +10,7 @@ import json
 import os
 import re
 import shutil
+import struct
 import subprocess
 import sys
 import tarfile
@@ -161,10 +162,169 @@ PLATFORMIO_CORE_SCONS_PIOPM = json.dumps(
     },
     separators=(",", ":"),
 )
+ESP32_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
+ESP32_PARTITION_MAGIC = 0x50AA
+ESP32_PARTITION_END_MAGIC = 0xFFFF
+ESP32_PARTITION_MD5_MAGIC = 0xEBEB
+ESP32_PARTITION_TABLE_OFFSET = 0x8000
+ESP32_PARTITION_TABLE_SIZE = 0x1000
+ESP32_BOOTLOADER_OFFSET = 0x0000
+ESP32_APP_TYPE = 0x00
+ESP32_OTA_0_SUBTYPE = 0x10
+ESP32_DATA_TYPE = 0x01
+ESP32_OTA_DATA_SUBTYPE = 0x00
+WAVESHARE_UPLOAD_BAUD = "460800"
 
 
 class BuildError(RuntimeError):
     """Raised when a deterministic real-target build cannot be confirmed."""
+
+
+def _parse_partition_layout(
+    partition_table: Path,
+) -> tuple[tuple[int, int], tuple[int, int]]:
+    """Return the OTA-data and OTA-0 ranges from an ESP32 partition image."""
+    try:
+        contents = partition_table.read_bytes()
+    except OSError as error:
+        raise BuildError(f"could not read verified partition table: {error}") from error
+    if not contents or len(contents) > ESP32_PARTITION_TABLE_SIZE:
+        raise BuildError("verified partition table has an invalid size")
+
+    ota_data: tuple[int, int] | None = None
+    ota_0: tuple[int, int] | None = None
+    for entry_offset in range(0, len(contents), ESP32_PARTITION_ENTRY.size):
+        entry = contents[entry_offset : entry_offset + ESP32_PARTITION_ENTRY.size]
+        if len(entry) != ESP32_PARTITION_ENTRY.size:
+            raise BuildError("verified partition table has a truncated entry")
+        magic, entry_type, subtype, offset, size, _label, _flags = (
+            ESP32_PARTITION_ENTRY.unpack(entry)
+        )
+        if magic in (ESP32_PARTITION_END_MAGIC, ESP32_PARTITION_MD5_MAGIC):
+            break
+        if magic != ESP32_PARTITION_MAGIC or size == 0:
+            raise BuildError("verified partition table contains an invalid entry")
+        partition_range = (offset, size)
+        if entry_type == ESP32_DATA_TYPE and subtype == ESP32_OTA_DATA_SUBTYPE:
+            if ota_data is not None:
+                raise BuildError("verified partition table contains duplicate OTA data")
+            ota_data = partition_range
+        if entry_type == ESP32_APP_TYPE and subtype == ESP32_OTA_0_SUBTYPE:
+            if ota_0 is not None:
+                raise BuildError(
+                    "verified partition table contains duplicate OTA slot 0"
+                )
+            ota_0 = partition_range
+
+    if ota_data is None or ota_0 is None:
+        raise BuildError(
+            "verified partition table is missing OTA data or OTA application slot 0"
+        )
+    if ota_data[0] < ESP32_PARTITION_TABLE_OFFSET + ESP32_PARTITION_TABLE_SIZE:
+        raise BuildError("verified OTA data partition overlaps the partition table")
+    if ota_0[0] % 0x10000 != 0:
+        raise BuildError("verified OTA application slot 0 is not 64 KiB aligned")
+    return ota_data, ota_0
+
+
+def _verified_esptool_command(
+    project_dir: Path,
+    environment: str,
+    upload_port: str,
+    manifest: dict[str, object],
+) -> tuple[str, ...]:
+    """Build the exact esptool command for the already-attested image set."""
+    core_attestation = manifest.get("coreAttestation")
+    if not isinstance(core_attestation, dict):
+        raise BuildError("verified build provenance is missing its core attestation")
+    core_dir_value = core_attestation.get("coreDir")
+    if not isinstance(core_dir_value, str):
+        raise BuildError("verified build provenance has an invalid core directory")
+    core_dir = Path(core_dir_value)
+    expected_core_dir = (
+        project_dir / ".pio/open-bike-build/platformio" / environment
+    ).resolve()
+    if core_dir.resolve() != expected_core_dir:
+        raise BuildError("verified build provenance references another core directory")
+
+    executable = core_dir / (
+        "penv/Scripts/esptool.exe" if os.name == "nt" else "penv/bin/esptool"
+    )
+    if executable.is_symlink() or not executable.is_file():
+        raise BuildError(
+            f"verified esptool uploader is missing or unsafe: {executable}"
+        )
+
+    build_dir = project_dir / ".pio/build" / environment
+    bootloader = build_dir / "bootloader.bin"
+    partitions = build_dir / "partitions.bin"
+    firmware = build_dir / "firmware.bin"
+    boot_app0 = (
+        core_dir
+        / "packages/framework-arduinoespressif32/tools/partitions/boot_app0.bin"
+    )
+    for image in (bootloader, partitions, boot_app0, firmware):
+        if image.is_symlink() or not image.is_file():
+            raise BuildError(f"verified flash image is missing or unsafe: {image}")
+
+    ota_data, ota_0 = _parse_partition_layout(partitions)
+    image_bounds = (
+        (
+            "bootloader",
+            bootloader,
+            ESP32_BOOTLOADER_OFFSET,
+            ESP32_PARTITION_TABLE_OFFSET,
+        ),
+        (
+            "partition table",
+            partitions,
+            ESP32_PARTITION_TABLE_OFFSET,
+            ESP32_PARTITION_TABLE_SIZE,
+        ),
+        ("OTA bootstrap", boot_app0, ota_data[0], ota_data[1]),
+        ("firmware", firmware, ota_0[0], ota_0[1]),
+    )
+    for label, image, _offset, capacity in image_bounds:
+        try:
+            image_size = image.stat().st_size
+        except OSError as error:
+            raise BuildError(
+                f"could not inspect verified {label} image: {error}"
+            ) from error
+        if image_size == 0 or image_size > capacity:
+            raise BuildError(f"verified {label} image does not fit its flash region")
+
+    return (
+        str(executable),
+        "--chip",
+        "esp32s3",
+        "--port",
+        upload_port,
+        "--baud",
+        WAVESHARE_UPLOAD_BAUD,
+        "--before",
+        "default-reset",
+        "--after",
+        "hard-reset",
+        "write-flash",
+        "-z",
+        # Preserve the attested bootloader header instead of letting esptool
+        # rewrite its flash configuration during upload.
+        "--flash-mode",
+        "keep",
+        "--flash-freq",
+        "keep",
+        "--flash-size",
+        "keep",
+        hex(ESP32_BOOTLOADER_OFFSET),
+        str(bootloader),
+        hex(ESP32_PARTITION_TABLE_OFFSET),
+        str(partitions),
+        hex(ota_data[0]),
+        str(boot_app0),
+        hex(ota_0[0]),
+        str(firmware),
+    )
 
 
 def _ensure_private_directory(project_dir: Path, relative: Path) -> Path:
@@ -999,10 +1159,9 @@ def upload_firmware(
     environment: str,
     upload_port: str,
     *,
-    pio_command: str = "pio",
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
 ) -> None:
-    """Upload a verified build without weakening its source-identity gate."""
+    """Upload the exact verified images without asking PlatformIO to rebuild."""
     project_dir = project_dir.resolve()
     _validate_environment(project_dir, environment)
     _reject_source_affecting_environment()
@@ -1029,20 +1188,6 @@ def upload_firmware(
         verified_config, platform_archive = _verified_platformio_project_config(
             project_dir
         )
-        command: Sequence[str] = (
-            pio_command,
-            "run",
-            "--project-conf",
-            str(verified_config),
-            "-e",
-            environment,
-            "-t",
-            "nobuild",
-            "-t",
-            "upload",
-            "--upload-port",
-            upload_port,
-        )
         with _deterministic_build_environment(
             project_dir,
             environment,
@@ -1063,13 +1208,21 @@ def upload_firmware(
                 expected_identity,
                 manifest,
             )
+            command: Sequence[str] = _verified_esptool_command(
+                project_dir,
+                environment,
+                upload_port,
+                manifest,
+            )
             try:
                 result = runner(command, cwd=project_dir)
             except OSError as error:
-                raise BuildError(f"could not run {pio_command!r}: {error}") from error
+                raise BuildError(
+                    f"could not run the verified esptool uploader: {error}"
+                ) from error
     if result.returncode != 0:
         raise BuildError(
-            f"PlatformIO exited with status {result.returncode} while uploading "
+            f"esptool exited with status {result.returncode} while uploading "
             f"{environment}"
         )
 
@@ -1107,7 +1260,6 @@ def main(argv: Sequence[str] | None = None) -> int:
                 args.project_dir,
                 args.environment,
                 args.upload_port,
-                pio_command=args.pio,
             )
     except BuildError as error:
         print(f"Firmware build failed: {error}", file=sys.stderr)

--- a/esp32/tools/generated_sdkconfig.py
+++ b/esp32/tools/generated_sdkconfig.py
@@ -8,6 +8,7 @@ import os
 import re
 import shutil
 import stat
+import struct
 import subprocess
 import sys
 import tempfile
@@ -19,11 +20,20 @@ from firmware_build_identity import FULL_GIT_SHA, firmware_git_identity
 ENVIRONMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 GENERATED_BANNER = b"# Automatically generated file. DO NOT EDIT."
 GENERATED_DESCRIPTION = b"Project Configuration"
-CACHE_SCHEMA = 17
-FLASH_PLAN_SCHEMA = 1
+CACHE_SCHEMA = 18
+FLASH_PLAN_SCHEMA = 2
 FLASH_PLAN_FILENAME = "open-bike-flash-plan.json"
 FLASH_PLAN_PORT_PLACEHOLDER = "__OPEN_BIKE_UPLOAD_PORT__"
+FLASH_PLAN_APP_OFFSET_PLACEHOLDER = "__OPEN_BIKE_APP_OFFSET__"
 FLASH_PLAN_MAX_BYTES = 1024 * 1024
+ESP_PARTITION_TABLE_MAX_BYTES = 0xC00
+ESP_PARTITION_ENTRY = struct.Struct("<HBBII16sI")
+ESP_PARTITION_MAGIC = 0x50AA
+ESP_PARTITION_MD5_MAGIC = 0xEBEB
+ESP_PARTITION_END_MAGIC = 0xFFFF
+ESP_PARTITION_TYPE_APP = 0x00
+ESP_PARTITION_SUBTYPE_FACTORY = 0x00
+ESP_PARTITION_SUBTYPE_OTA_0 = 0x10
 WAVESHARE_MCU = "esp32s3"
 WAVESHARE_MEMORY_TYPE = "qio_opi"
 WAVESHARE_PLATFORM_URL = (
@@ -530,6 +540,71 @@ def _path_is_within(path: Path, root: Path) -> bool:
     return True
 
 
+def _application_partition_from_partition_table(path: Path) -> tuple[int, int]:
+    """Return the slot PlatformIO must use for the application image."""
+    if path.is_symlink() or not path.is_file():
+        raise GeneratedSdkconfigError(
+            f"verified partition table is missing or unsafe: {path}"
+        )
+    try:
+        table = path.read_bytes()
+    except OSError as error:
+        raise GeneratedSdkconfigError(
+            f"could not read verified partition table: {error}"
+        ) from error
+    if (
+        not table
+        or len(table) > ESP_PARTITION_TABLE_MAX_BYTES
+        or len(table) % ESP_PARTITION_ENTRY.size != 0
+    ):
+        raise GeneratedSdkconfigError(
+            "verified partition table has an invalid size"
+        )
+
+    factory_partitions: list[tuple[int, int]] = []
+    ota_0_partitions: list[tuple[int, int]] = []
+    found_end = False
+    for entry_start in range(0, len(table), ESP_PARTITION_ENTRY.size):
+        magic, kind, subtype, offset, size, _, _ = ESP_PARTITION_ENTRY.unpack_from(
+            table, entry_start
+        )
+        if magic == ESP_PARTITION_END_MAGIC:
+            found_end = True
+            break
+        if magic == ESP_PARTITION_MD5_MAGIC:
+            continue
+        if magic != ESP_PARTITION_MAGIC:
+            raise GeneratedSdkconfigError(
+                "verified partition table contains an invalid entry"
+            )
+        if offset == 0 or size == 0 or offset + size > 0x1_0000_0000:
+            raise GeneratedSdkconfigError(
+                "verified partition table contains an invalid range"
+            )
+        if kind != ESP_PARTITION_TYPE_APP:
+            continue
+        if offset % 0x10000 != 0:
+            raise GeneratedSdkconfigError(
+                "verified partition table contains a misaligned application slot"
+            )
+        if subtype == ESP_PARTITION_SUBTYPE_FACTORY:
+            factory_partitions.append((offset, size))
+        elif subtype == ESP_PARTITION_SUBTYPE_OTA_0:
+            ota_0_partitions.append((offset, size))
+
+    if not found_end:
+        raise GeneratedSdkconfigError(
+            "verified partition table has no end marker"
+        )
+    selected_partitions = ota_0_partitions or factory_partitions
+    if len(selected_partitions) != 1:
+        raise GeneratedSdkconfigError(
+            "verified partition table does not identify exactly one bootable "
+            "application slot"
+        )
+    return selected_partitions[0]
+
+
 def _parse_esptool_options(
     tokens: tuple[str, ...],
     *,
@@ -575,9 +650,8 @@ def _validated_flash_plan(
     core_attestation: dict[str, object],
 ) -> dict[str, object]:
     """Validate and normalize PlatformIO's resolved esptool command."""
-    plan_path = (
-        project_dir / ".pio" / "build" / environment / FLASH_PLAN_FILENAME
-    )
+    build_dir = project_dir / ".pio" / "build" / environment
+    plan_path = build_dir / FLASH_PLAN_FILENAME
     if plan_path.is_symlink() or not plan_path.is_file():
         raise GeneratedSdkconfigError(
             f"verified PlatformIO flash plan is missing or unsafe: {plan_path}"
@@ -671,6 +745,11 @@ def _validated_flash_plan(
         raise GeneratedSdkconfigError(
             "verified PlatformIO flash command has an invalid port placeholder"
         )
+    if command.count(FLASH_PLAN_APP_OFFSET_PLACEHOLDER) != 1:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command has an invalid application-offset "
+            "placeholder"
+        )
     if command.count("--port") != 1:
         raise GeneratedSdkconfigError(
             "verified PlatformIO flash command has an invalid port option"
@@ -703,6 +782,35 @@ def _validated_flash_plan(
         raise GeneratedSdkconfigError(
             "verified PlatformIO flash plan has invalid resolved flash parameters"
         )
+    raw_platformio_app_offset = raw_plan.get("platformioAppOffset")
+    if (
+        not isinstance(raw_platformio_app_offset, str)
+        or "\0" in raw_platformio_app_offset
+        or len(raw_platformio_app_offset) > 64
+    ):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an invalid resolved application "
+            "offset"
+        )
+
+    application_offset, application_partition_size = (
+        _application_partition_from_partition_table(
+            build_dir / "partitions.bin"
+        )
+    )
+    if raw_platformio_app_offset:
+        try:
+            reported_application_offset = int(raw_platformio_app_offset, 0)
+        except ValueError as error:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan has an invalid resolved application "
+                "offset"
+            ) from error
+        if reported_application_offset != application_offset:
+            raise GeneratedSdkconfigError(
+                "PlatformIO's resolved application offset does not match the "
+                "verified partition table"
+            )
 
     raw_images = raw_plan.get("images")
     if not isinstance(raw_images, list) or not 1 <= len(raw_images) <= 32:
@@ -711,9 +819,11 @@ def _validated_flash_plan(
         )
     project_root = project_dir.resolve()
     normalized_images: list[dict[str, object]] = []
-    command_tail: list[str] = []
+    raw_command_tail: list[str] = []
+    normalized_command_tail: list[str] = []
     offsets: set[int] = set()
     image_ranges: list[tuple[int, int, Path]] = []
+    application_images = 0
     for raw_image in raw_images:
         if not isinstance(raw_image, dict):
             raise GeneratedSdkconfigError(
@@ -725,12 +835,19 @@ def _validated_flash_plan(
             raise GeneratedSdkconfigError(
                 "verified PlatformIO flash plan contains invalid image fields"
             )
-        try:
-            offset = int(offset_token, 0)
-        except ValueError as error:
-            raise GeneratedSdkconfigError(
-                "verified PlatformIO flash plan contains an invalid image offset"
-            ) from error
+        raw_command_tail.extend((offset_token, path_value))
+        if offset_token == FLASH_PLAN_APP_OFFSET_PLACEHOLDER:
+            application_images += 1
+            offset = application_offset
+            normalized_offset_token = hex(application_offset)
+        else:
+            try:
+                offset = int(offset_token, 0)
+            except ValueError as error:
+                raise GeneratedSdkconfigError(
+                    "verified PlatformIO flash plan contains an invalid image offset"
+                ) from error
+            normalized_offset_token = offset_token
         if offset < 0 or offset > 0xFFFFFFFF or offset in offsets:
             raise GeneratedSdkconfigError(
                 "verified PlatformIO flash plan contains a duplicate or out-of-range "
@@ -751,6 +868,14 @@ def _validated_flash_plan(
             raise GeneratedSdkconfigError(
                 f"verified PlatformIO flash image is missing or unsafe: {image}"
             )
+        if (
+            offset_token == FLASH_PLAN_APP_OFFSET_PLACEHOLDER
+            and image != (build_dir / "firmware.bin").resolve()
+        ):
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO application-offset placeholder does not "
+                "reference the firmware image"
+            )
         try:
             size = image.stat().st_size
         except OSError as error:
@@ -761,6 +886,13 @@ def _validated_flash_plan(
             raise GeneratedSdkconfigError(
                 f"verified PlatformIO flash image is empty: {image}"
             )
+        if (
+            offset_token == FLASH_PLAN_APP_OFFSET_PLACEHOLDER
+            and size > application_partition_size
+        ):
+            raise GeneratedSdkconfigError(
+                "verified firmware image exceeds its application partition"
+            )
         if offset + size > 0x1_0000_0000:
             raise GeneratedSdkconfigError(
                 "verified PlatformIO flash image exceeds the address space"
@@ -768,13 +900,19 @@ def _validated_flash_plan(
         image_ranges.append((offset, offset + size, image))
         normalized_images.append(
             {
-                "offset": offset_token,
+                "offset": normalized_offset_token,
                 "path": str(image),
                 "size": size,
                 "sha256": _file_sha256(image),
             }
         )
-        command_tail.extend((offset_token, str(image)))
+        normalized_command_tail.extend((normalized_offset_token, str(image)))
+
+    if application_images != 1:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan does not identify exactly one "
+            "application image"
+        )
 
     for previous, current in zip(
         sorted(image_ranges), sorted(image_ranges)[1:]
@@ -785,11 +923,12 @@ def _validated_flash_plan(
                 f"{previous[2]} and {current[2]}"
             )
 
-    if list(command[-len(command_tail) :]) != command_tail:
+    if list(command[-len(raw_command_tail) :]) != raw_command_tail:
         raise GeneratedSdkconfigError(
             "verified PlatformIO flash command does not exactly match its image set"
         )
-    image_boundary = len(command) - len(command_tail)
+    image_boundary = len(command) - len(raw_command_tail)
+    command = command[:image_boundary] + tuple(normalized_command_tail)
     write_flash_index = command.index("write-flash")
     if write_flash_index >= image_boundary:
         raise GeneratedSdkconfigError(
@@ -856,6 +995,8 @@ def _validated_flash_plan(
         "uploader": str(uploader),
         "command": list(command),
         "platformioFlashParameters": dict(raw_platformio_parameters),
+        "platformioAppOffset": raw_platformio_app_offset,
+        "applicationOffsetSource": "partition-table",
         "images": normalized_images,
     }
 

--- a/esp32/tools/generated_sdkconfig.py
+++ b/esp32/tools/generated_sdkconfig.py
@@ -19,7 +19,11 @@ from firmware_build_identity import FULL_GIT_SHA, firmware_git_identity
 ENVIRONMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 GENERATED_BANNER = b"# Automatically generated file. DO NOT EDIT."
 GENERATED_DESCRIPTION = b"Project Configuration"
-CACHE_SCHEMA = 16
+CACHE_SCHEMA = 17
+FLASH_PLAN_SCHEMA = 1
+FLASH_PLAN_FILENAME = "open-bike-flash-plan.json"
+FLASH_PLAN_PORT_PLACEHOLDER = "__OPEN_BIKE_UPLOAD_PORT__"
+FLASH_PLAN_MAX_BYTES = 1024 * 1024
 WAVESHARE_MCU = "esp32s3"
 WAVESHARE_MEMORY_TYPE = "qio_opi"
 WAVESHARE_PLATFORM_URL = (
@@ -444,6 +448,9 @@ def _core_attestation(
     mcu_root = libs_root / WAVESHARE_MCU
     tools_root = core_dir / "tools"
     penv_root = core_dir / "penv"
+    esptool_uploader = penv_root / (
+        "Scripts/esptool.exe" if os.name == "nt" else "bin/esptool"
+    )
     evidence_paths = {
         "frameworkPackageSha256": framework_root / "package.json",
         "bootApp0Sha256": framework_root / "tools/partitions/boot_app0.bin",
@@ -456,10 +463,13 @@ def _core_attestation(
         "boardManifestSha256": (
             platform_root / "boards/esp32-s3-devkitc-1.json"
         ),
+        "esptoolUploaderSha256": esptool_uploader,
     }
     for path in evidence_paths.values():
         if path.is_symlink() or not path.is_file():
             return None
+    if not os.access(esptool_uploader, os.X_OK):
+        return None
     if (
         framework_root.is_symlink()
         or not framework_root.is_dir()
@@ -510,6 +520,344 @@ def _core_attestation(
         }
     )
     return evidence
+
+
+def _path_is_within(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+    except ValueError:
+        return False
+    return True
+
+
+def _parse_esptool_options(
+    tokens: tuple[str, ...],
+    *,
+    value_options: set[str],
+    flag_options: set[str],
+    label: str,
+) -> dict[str, str | bool]:
+    parsed: dict[str, str | bool] = {}
+    index = 0
+    while index < len(tokens):
+        option = tokens[index]
+        if option in flag_options:
+            if option in parsed:
+                raise GeneratedSdkconfigError(
+                    f"verified esptool {label} repeats {option}"
+                )
+            parsed[option] = True
+            index += 1
+            continue
+        if option not in value_options or index + 1 >= len(tokens):
+            raise GeneratedSdkconfigError(
+                f"verified esptool {label} contains an unsupported argument: "
+                f"{option}"
+            )
+        if option in parsed:
+            raise GeneratedSdkconfigError(
+                f"verified esptool {label} repeats {option}"
+            )
+        parsed[option] = tokens[index + 1]
+        index += 2
+    expected = value_options | flag_options
+    if set(parsed) != expected:
+        missing = ", ".join(sorted(expected - set(parsed)))
+        raise GeneratedSdkconfigError(
+            f"verified esptool {label} is missing required options: {missing}"
+        )
+    return parsed
+
+
+def _validated_flash_plan(
+    project_dir: Path,
+    environment: str,
+    core_attestation: dict[str, object],
+) -> dict[str, object]:
+    """Validate and normalize PlatformIO's resolved esptool command."""
+    plan_path = (
+        project_dir / ".pio" / "build" / environment / FLASH_PLAN_FILENAME
+    )
+    if plan_path.is_symlink() or not plan_path.is_file():
+        raise GeneratedSdkconfigError(
+            f"verified PlatformIO flash plan is missing or unsafe: {plan_path}"
+        )
+    try:
+        if plan_path.stat().st_size > FLASH_PLAN_MAX_BYTES:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan exceeds its size limit"
+            )
+        raw_plan = json.loads(plan_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise GeneratedSdkconfigError(
+            f"could not read verified PlatformIO flash plan: {error}"
+        ) from error
+    if not isinstance(raw_plan, dict):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan is not an object"
+        )
+    if raw_plan.get("schema") != FLASH_PLAN_SCHEMA:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an unsupported schema"
+        )
+    if raw_plan.get("environment") != environment:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan references another environment"
+        )
+    if raw_plan.get("uploadPortPlaceholder") != FLASH_PLAN_PORT_PLACEHOLDER:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an invalid port placeholder"
+        )
+
+    core_dir_value = core_attestation.get("coreDir")
+    expected_uploader_hash = core_attestation.get("esptoolUploaderSha256")
+    if not isinstance(core_dir_value, str) or not isinstance(
+        expected_uploader_hash, str
+    ):
+        raise GeneratedSdkconfigError(
+            "verified core attestation is missing its esptool uploader"
+        )
+    core_dir = Path(core_dir_value).resolve()
+    expected_core_dir = (
+        project_dir / ".pio/open-bike-build/platformio" / environment
+    ).resolve()
+    if core_dir != expected_core_dir:
+        raise GeneratedSdkconfigError(
+            "verified core attestation references another core directory"
+        )
+    expected_uploader = core_dir / (
+        "penv/Scripts/esptool.exe" if os.name == "nt" else "penv/bin/esptool"
+    )
+    uploader_value = raw_plan.get("uploader")
+    if not isinstance(uploader_value, str):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an invalid uploader"
+        )
+    uploader = Path(uploader_value)
+    if (
+        not uploader.is_absolute()
+        or uploader != uploader.resolve()
+        or uploader != expected_uploader
+        or uploader.is_symlink()
+        or not uploader.is_file()
+        or not os.access(uploader, os.X_OK)
+        or _file_sha256(uploader) != expected_uploader_hash
+    ):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan references an unattested uploader"
+        )
+
+    raw_command = raw_plan.get("command")
+    if (
+        not isinstance(raw_command, list)
+        or not 2 <= len(raw_command) <= 256
+        or not all(
+            isinstance(token, str)
+            and token
+            and "\0" not in token
+            and len(token) <= 4096
+            for token in raw_command
+        )
+    ):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an invalid command"
+        )
+    command = tuple(raw_command)
+    if command[0] != str(uploader):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command does not invoke its uploader"
+        )
+    if command.count(FLASH_PLAN_PORT_PLACEHOLDER) != 1:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command has an invalid port placeholder"
+        )
+    if command.count("--port") != 1:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command has an invalid port option"
+        )
+    port_index = command.index("--port")
+    if (
+        port_index + 1 >= len(command)
+        or command[port_index + 1] != FLASH_PLAN_PORT_PLACEHOLDER
+    ):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command does not bind the upload port"
+        )
+    if command.count("write-flash") != 1:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command is not a single write-flash action"
+        )
+
+    raw_platformio_parameters = raw_plan.get("platformioFlashParameters")
+    if (
+        not isinstance(raw_platformio_parameters, dict)
+        or set(raw_platformio_parameters) != {"mode", "frequency", "size"}
+        or not all(
+            isinstance(value, str)
+            and value
+            and "\0" not in value
+            and len(value) <= 64
+            for value in raw_platformio_parameters.values()
+        )
+    ):
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has invalid resolved flash parameters"
+        )
+
+    raw_images = raw_plan.get("images")
+    if not isinstance(raw_images, list) or not 1 <= len(raw_images) <= 32:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash plan has an invalid image set"
+        )
+    project_root = project_dir.resolve()
+    normalized_images: list[dict[str, object]] = []
+    command_tail: list[str] = []
+    offsets: set[int] = set()
+    image_ranges: list[tuple[int, int, Path]] = []
+    for raw_image in raw_images:
+        if not isinstance(raw_image, dict):
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan contains an invalid image"
+            )
+        offset_token = raw_image.get("offset")
+        path_value = raw_image.get("path")
+        if not isinstance(offset_token, str) or not isinstance(path_value, str):
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan contains invalid image fields"
+            )
+        try:
+            offset = int(offset_token, 0)
+        except ValueError as error:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan contains an invalid image offset"
+            ) from error
+        if offset < 0 or offset > 0xFFFFFFFF or offset in offsets:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan contains a duplicate or out-of-range "
+                "image offset"
+            )
+        offsets.add(offset)
+        image = Path(path_value)
+        if (
+            not image.is_absolute()
+            or image != image.resolve()
+            or image.is_symlink()
+            or not image.is_file()
+            or not (
+                _path_is_within(image, project_root)
+                or _path_is_within(image, core_dir)
+            )
+        ):
+            raise GeneratedSdkconfigError(
+                f"verified PlatformIO flash image is missing or unsafe: {image}"
+            )
+        try:
+            size = image.stat().st_size
+        except OSError as error:
+            raise GeneratedSdkconfigError(
+                f"could not inspect verified PlatformIO flash image: {error}"
+            ) from error
+        if size <= 0:
+            raise GeneratedSdkconfigError(
+                f"verified PlatformIO flash image is empty: {image}"
+            )
+        if offset + size > 0x1_0000_0000:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash image exceeds the address space"
+            )
+        image_ranges.append((offset, offset + size, image))
+        normalized_images.append(
+            {
+                "offset": offset_token,
+                "path": str(image),
+                "size": size,
+                "sha256": _file_sha256(image),
+            }
+        )
+        command_tail.extend((offset_token, str(image)))
+
+    for previous, current in zip(
+        sorted(image_ranges), sorted(image_ranges)[1:]
+    ):
+        if previous[1] > current[0]:
+            raise GeneratedSdkconfigError(
+                "verified PlatformIO flash plan contains overlapping images: "
+                f"{previous[2]} and {current[2]}"
+            )
+
+    if list(command[-len(command_tail) :]) != command_tail:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command does not exactly match its image set"
+        )
+    image_boundary = len(command) - len(command_tail)
+    write_flash_index = command.index("write-flash")
+    if write_flash_index >= image_boundary:
+        raise GeneratedSdkconfigError(
+            "verified PlatformIO flash command has an invalid image boundary"
+        )
+    global_options = _parse_esptool_options(
+        command[1:write_flash_index],
+        value_options={"--chip", "--port", "--baud", "--before", "--after"},
+        flag_options=set(),
+        label="global options",
+    )
+    write_options = _parse_esptool_options(
+        command[write_flash_index + 1 : image_boundary],
+        value_options={"--flash-mode", "--flash-freq", "--flash-size"},
+        flag_options={"-z"},
+        label="write-flash options",
+    )
+    if global_options["--chip"] != "esp32s3":
+        raise GeneratedSdkconfigError(
+            "verified esptool command targets another chip"
+        )
+    if global_options["--port"] != FLASH_PLAN_PORT_PLACEHOLDER:
+        raise GeneratedSdkconfigError(
+            "verified esptool command has an invalid upload port"
+        )
+    baud = global_options["--baud"]
+    if (
+        not isinstance(baud, str)
+        or not baud.isdigit()
+        or not 1 <= int(baud) <= 10_000_000
+    ):
+        raise GeneratedSdkconfigError(
+            "verified esptool command has an invalid upload baud rate"
+        )
+    if global_options["--before"] not in {
+        "default-reset",
+        "usb-reset",
+        "no-reset",
+        "no-reset-no-sync",
+    }:
+        raise GeneratedSdkconfigError(
+            "verified esptool command has an invalid before-reset action"
+        )
+    if global_options["--after"] not in {
+        "hard-reset",
+        "soft-reset",
+        "no-reset",
+        "no-reset-stub",
+    }:
+        raise GeneratedSdkconfigError(
+            "verified esptool command has an invalid after-reset action"
+        )
+    if any(
+        write_options[option] != "keep"
+        for option in ("--flash-mode", "--flash-freq", "--flash-size")
+    ):
+        raise GeneratedSdkconfigError(
+            "verified esptool command may rewrite an attested flash image"
+        )
+    return {
+        "schema": FLASH_PLAN_SCHEMA,
+        "environment": environment,
+        "uploadPortPlaceholder": FLASH_PLAN_PORT_PLACEHOLDER,
+        "uploader": str(uploader),
+        "command": list(command),
+        "platformioFlashParameters": dict(raw_platformio_parameters),
+        "images": normalized_images,
+    }
 
 
 def _is_tracked(project_dir: Path, path: Path) -> bool:
@@ -722,6 +1070,23 @@ def require_validated_generated_sdkconfig_defaults(
                 "refusing AMOLED upload because the generated environment SDK "
                 "configuration changed after the verified build"
             )
+    core_attestation = manifest.get("coreAttestation")
+    if not isinstance(core_attestation, dict):
+        raise GeneratedSdkconfigError(
+            "refusing AMOLED upload without a verified core attestation"
+        )
+    current_flash_plan = _validated_flash_plan(
+        project_dir, environment, core_attestation
+    )
+    if (
+        manifest.get("flashPlan") != current_flash_plan
+        or manifest.get("flashPlanSha256")
+        != _canonical_json_sha256(current_flash_plan)
+    ):
+        raise GeneratedSdkconfigError(
+            "refusing AMOLED upload because the PlatformIO flash plan changed "
+            "after the verified build"
+        )
     return manifest
 
 
@@ -774,6 +1139,12 @@ def record_generated_sdkconfig_defaults(
         "environmentSdkconfigSha256": None,
         **firmware_artifacts,
     }
+    if environment.startswith("WAVESHARE_AMOLED_"):
+        flash_plan = _validated_flash_plan(
+            project_dir, environment, core_attestation
+        )
+        manifest["flashPlan"] = flash_plan
+        manifest["flashPlanSha256"] = _canonical_json_sha256(flash_plan)
     if os.path.lexists(environment_config):
         if not _is_generated_sdkconfig(environment_config):
             raise GeneratedSdkconfigError(

--- a/esp32/tools/record_flash_plan.py
+++ b/esp32/tools/record_flash_plan.py
@@ -1,0 +1,153 @@
+"""Record PlatformIO's fully resolved esptool command for later attestation."""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+
+FLASH_PLAN_SCHEMA = 1
+FLASH_PLAN_FILENAME = "open-bike-flash-plan.json"
+FLASH_PLAN_PORT_PLACEHOLDER = "__OPEN_BIKE_UPLOAD_PORT__"
+
+
+def _direct_argument(token: object) -> str:
+    """Remove shell-only outer quotes from an already-tokenized argument."""
+    value = str(token)
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        return value[1:-1]
+    return value
+
+
+def _resolved_path(environment, expression: str) -> str:
+    value = _direct_argument(environment.subst(expression))
+    return str(Path(value).resolve())
+
+
+def _normalize_flash_parameters(command: list[str]) -> dict[str, str]:
+    """Capture PlatformIO's values and prevent esptool from rewriting images."""
+    resolved: dict[str, str] = {}
+    for name, option in (
+        ("mode", "--flash-mode"),
+        ("frequency", "--flash-freq"),
+        ("size", "--flash-size"),
+    ):
+        if command.count(option) != 1:
+            raise RuntimeError(
+                f"Waveshare upload command must contain one {option} option"
+            )
+        option_index = command.index(option)
+        if option_index + 1 >= len(command):
+            raise RuntimeError(
+                f"Waveshare upload command is missing the {option} value"
+            )
+        resolved[name] = command[option_index + 1]
+        command[option_index + 1] = "keep"
+    return resolved
+
+
+def record_flash_plan(environment) -> None:
+    """Persist the exact command after PlatformIO has loaded the framework."""
+    profile = environment.subst("$PIOENV")
+    if not profile.startswith("WAVESHARE_AMOLED_"):
+        return
+
+    plan_environment = environment.Clone()
+    plan_environment.Replace(UPLOAD_PORT=FLASH_PLAN_PORT_PLACEHOLDER)
+    uploader = _resolved_path(plan_environment, "$UPLOADER")
+    uploader_flags = plan_environment.get("UPLOADERFLAGS")
+    if not isinstance(uploader_flags, (list, tuple)):
+        raise RuntimeError(
+            "Waveshare upload flags must resolve to an argument list"
+        )
+    firmware = _resolved_path(
+        plan_environment, "$BUILD_DIR/${PROGNAME}.bin"
+    )
+    command = [uploader]
+    command.extend(
+        _direct_argument(plan_environment.subst(str(token)))
+        for token in uploader_flags
+    )
+    command.extend(
+        (plan_environment.subst("$ESP32_APP_OFFSET"), firmware)
+    )
+    platformio_flash_parameters = _normalize_flash_parameters(command)
+
+    images: list[dict[str, str]] = []
+    for offset, image in environment.get("FLASH_EXTRA_IMAGES", []):
+        raw_image_path = plan_environment.subst(str(image))
+        resolved_image_path = _resolved_path(
+            plan_environment, str(image)
+        )
+        command = [
+            resolved_image_path if token == raw_image_path else token
+            for token in command
+        ]
+        images.append(
+            {
+                "offset": plan_environment.subst(str(offset)),
+                "path": resolved_image_path,
+            }
+        )
+    images.append(
+        {
+            "offset": plan_environment.subst("$ESP32_APP_OFFSET"),
+            "path": firmware,
+        }
+    )
+
+    expected_tail = [
+        value
+        for image in images
+        for value in (image["offset"], image["path"])
+    ]
+    if command[-len(expected_tail) :] != expected_tail:
+        raise RuntimeError(
+            "Waveshare upload command does not end with its resolved image set"
+        )
+    if command.count(FLASH_PLAN_PORT_PLACEHOLDER) != 1:
+        raise RuntimeError(
+            "Waveshare upload command must contain one upload-port placeholder"
+        )
+
+    plan = {
+        "schema": FLASH_PLAN_SCHEMA,
+        "environment": profile,
+        "uploadPortPlaceholder": FLASH_PLAN_PORT_PLACEHOLDER,
+        "uploader": uploader,
+        "command": command,
+        "platformioFlashParameters": platformio_flash_parameters,
+        "images": images,
+    }
+    output = Path(environment.subst("$BUILD_DIR")) / FLASH_PLAN_FILENAME
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary_name = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=output.parent,
+            prefix=f".{output.name}.",
+            delete=False,
+        ) as stream:
+            temporary_name = stream.name
+            json.dump(plan, stream, sort_keys=True)
+            stream.write("\n")
+        os.replace(temporary_name, output)
+        temporary_name = None
+    finally:
+        if temporary_name is not None:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+
+
+try:
+    Import("env")  # type: ignore[name-defined]  # noqa: F821
+except NameError:
+    pass
+else:
+    record_flash_plan(env)  # type: ignore[name-defined]  # noqa: F821

--- a/esp32/tools/record_flash_plan.py
+++ b/esp32/tools/record_flash_plan.py
@@ -8,9 +8,10 @@ import tempfile
 from pathlib import Path
 
 
-FLASH_PLAN_SCHEMA = 1
+FLASH_PLAN_SCHEMA = 2
 FLASH_PLAN_FILENAME = "open-bike-flash-plan.json"
 FLASH_PLAN_PORT_PLACEHOLDER = "__OPEN_BIKE_UPLOAD_PORT__"
+FLASH_PLAN_APP_OFFSET_PLACEHOLDER = "__OPEN_BIKE_APP_OFFSET__"
 
 
 def _direct_argument(token: object) -> str:
@@ -70,9 +71,8 @@ def record_flash_plan(environment) -> None:
         _direct_argument(plan_environment.subst(str(token)))
         for token in uploader_flags
     )
-    command.extend(
-        (plan_environment.subst("$ESP32_APP_OFFSET"), firmware)
-    )
+    platformio_app_offset = plan_environment.subst("$ESP32_APP_OFFSET")
+    command.extend((FLASH_PLAN_APP_OFFSET_PLACEHOLDER, firmware))
     platformio_flash_parameters = _normalize_flash_parameters(command)
 
     images: list[dict[str, str]] = []
@@ -93,7 +93,7 @@ def record_flash_plan(environment) -> None:
         )
     images.append(
         {
-            "offset": plan_environment.subst("$ESP32_APP_OFFSET"),
+            "offset": FLASH_PLAN_APP_OFFSET_PLACEHOLDER,
             "path": firmware,
         }
     )
@@ -119,6 +119,7 @@ def record_flash_plan(environment) -> None:
         "uploader": uploader,
         "command": command,
         "platformioFlashParameters": platformio_flash_parameters,
+        "platformioAppOffset": platformio_app_offset,
         "images": images,
     }
     output = Path(environment.subst("$BUILD_DIR")) / FLASH_PLAN_FILENAME

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -4,6 +4,7 @@ import hashlib
 import io
 import json
 import os
+import struct
 import subprocess
 import tarfile
 import tempfile
@@ -104,12 +105,51 @@ class FirmwareBuildTests(unittest.TestCase):
         firmware.write_bytes(b"real firmware")
         firmware.with_suffix(".bin").write_bytes(b"real flash image")
         (firmware.parent / "bootloader.bin").write_bytes(b"real bootloader")
-        (firmware.parent / "partitions.bin").write_bytes(b"real partition table")
+        self.write_partition_table(environment)
         if os.environ.get("OPEN_BIKE_DETERMINISTIC_BUILD") == "1":
             defaults = self.project_dir / "sdkconfig.defaults"
             if not defaults.exists():
                 defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
             self.write_core_attestation(environment)
+
+    def write_partition_table(
+        self,
+        environment=None,
+        *,
+        ota_data_offset=0xE000,
+        app_offset=0x10000,
+    ):
+        environment = environment or self.environment
+        build_dir = self.project_dir / ".pio/build" / environment
+        build_dir.mkdir(parents=True, exist_ok=True)
+        partition_entry = struct.Struct("<HBBII16sI")
+        partition_table = b"".join(
+            (
+                partition_entry.pack(
+                    0x50AA, 0x01, 0x02, 0x9000, 0x5000, b"nvs", 0
+                ),
+                partition_entry.pack(
+                    0x50AA,
+                    0x01,
+                    0x00,
+                    ota_data_offset,
+                    0x2000,
+                    b"otadata",
+                    0,
+                ),
+                partition_entry.pack(
+                    0x50AA,
+                    0x00,
+                    0x10,
+                    app_offset,
+                    0x300000,
+                    b"app0",
+                    0,
+                ),
+                b"\xff" * partition_entry.size,
+            )
+        )
+        (build_dir / "partitions.bin").write_bytes(partition_table)
 
     def write_core_attestation(self, environment=None):
         environment = environment or self.environment
@@ -152,9 +192,11 @@ class FirmwareBuildTests(unittest.TestCase):
         for path in (
             core / "tools/toolchain-xtensa-esp-elf/bin/xtensa-esp-elf-gcc",
             core / "penv/bin/platformio-runtime.py",
+            core / "penv/bin/esptool",
         ):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(f"attested {path.name}\n", encoding="utf-8")
+            path.chmod(0o755)
         (core / "lib").mkdir(exist_ok=True)
         (core / "globallib").mkdir(exist_ok=True)
         (core / "boards").mkdir(exist_ok=True)
@@ -476,9 +518,10 @@ class FirmwareBuildTests(unittest.TestCase):
         with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
             build_firmware(self.project_dir, self.environment, runner=second_runner)
 
-    def test_upload_preserves_exact_identity_through_prebuild(self):
+    def test_upload_preserves_exact_identity_through_direct_flash(self):
         full_sha = self.initialize_git_repo()
-        core = self.write_core_attestation()
+        core = self.write_core_attestation().resolve()
+        project_dir = self.project_dir.resolve()
         defaults = self.project_dir / "sdkconfig.defaults"
         current = self.project_dir / f"sdkconfig.{self.environment}"
         defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
@@ -497,18 +540,52 @@ class FirmwareBuildTests(unittest.TestCase):
             self.assertEqual(
                 tuple(command),
                 (
-                    "pio",
-                    "run",
-                    "--project-conf",
-                    str(self.project_dir / "platformio.ini"),
-                    "-e",
-                    self.environment,
-                    "-t",
-                    "nobuild",
-                    "-t",
-                    "upload",
-                    "--upload-port",
+                    str(core / "penv/bin/esptool"),
+                    "--chip",
+                    "esp32s3",
+                    "--port",
                     "/dev/cu.test",
+                    "--baud",
+                    "460800",
+                    "--before",
+                    "default-reset",
+                    "--after",
+                    "hard-reset",
+                    "write-flash",
+                    "-z",
+                    "--flash-mode",
+                    "keep",
+                    "--flash-freq",
+                    "keep",
+                    "--flash-size",
+                    "keep",
+                    "0x0",
+                    str(
+                        project_dir
+                        / ".pio/build"
+                        / self.environment
+                        / "bootloader.bin"
+                    ),
+                    "0x8000",
+                    str(
+                        project_dir
+                        / ".pio/build"
+                        / self.environment
+                        / "partitions.bin"
+                    ),
+                    "0xe000",
+                    str(
+                        core
+                        / "packages/framework-arduinoespressif32/tools/partitions"
+                        / "boot_app0.bin"
+                    ),
+                    "0x10000",
+                    str(
+                        project_dir
+                        / ".pio/build"
+                        / self.environment
+                        / "firmware.bin"
+                    ),
                 ),
             )
             allowed = recognized_generated_sdkconfigs(
@@ -561,6 +638,74 @@ class FirmwareBuildTests(unittest.TestCase):
                     "/dev/cu.test",
                     runner=lambda command, cwd: subprocess.CompletedProcess(
                         command, 2
+                    ),
+                )
+
+    def test_upload_uses_offsets_from_the_verified_partition_image(self):
+        core = self.write_core_attestation().resolve()
+        project_dir = self.project_dir.resolve()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        self.write_partition_table(ota_data_offset=0xF000, app_offset=0x20000)
+        calls = []
+
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+            upload_firmware(
+                self.project_dir,
+                self.environment,
+                "/dev/cu.test",
+                runner=lambda command, cwd: (
+                    calls.append(tuple(command))
+                    or subprocess.CompletedProcess(command, 0)
+                ),
+            )
+
+        self.assertEqual(len(calls), 1)
+        command = calls[0]
+        boot_app0 = str(
+            core
+            / "packages/framework-arduinoespressif32/tools/partitions"
+            / "boot_app0.bin"
+        )
+        firmware = str(
+            project_dir
+            / ".pio/build"
+            / self.environment
+            / "firmware.bin"
+        )
+        self.assertEqual(command[command.index(boot_app0) - 1], "0xf000")
+        self.assertEqual(command[command.index(firmware) - 1], "0x20000")
+        self.assertNotIn("nobuild", command)
+        self.assertNotIn("upload", command)
+
+    def test_upload_refuses_a_malformed_verified_partition_image(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        partitions = (
+            self.project_dir
+            / ".pio/build"
+            / self.environment
+            / "partitions.bin"
+        )
+        partitions.write_bytes(b"not an ESP32 partition image")
+
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+            with self.assertRaisesRegex(BuildError, "truncated entry"):
+                upload_firmware(
+                    self.project_dir,
+                    self.environment,
+                    "/dev/cu.test",
+                    runner=lambda command, cwd: self.fail(
+                        "runner must not be called"
                     ),
                 )
 

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -26,10 +26,15 @@ from build_firmware import (
 )
 from firmware_build_identity import firmware_git_identity
 from generated_sdkconfig import (
+    FLASH_PLAN_FILENAME,
+    FLASH_PLAN_PORT_PLACEHOLDER,
+    FLASH_PLAN_SCHEMA,
+    GeneratedSdkconfigError,
     WAVESHARE_PLATFORM_PACKAGES,
     record_generated_sdkconfig_defaults,
     recognized_generated_sdkconfigs,
 )
+from record_flash_plan import record_flash_plan
 
 
 DUMMY_FILES = {
@@ -106,11 +111,94 @@ class FirmwareBuildTests(unittest.TestCase):
         firmware.with_suffix(".bin").write_bytes(b"real flash image")
         (firmware.parent / "bootloader.bin").write_bytes(b"real bootloader")
         self.write_partition_table(environment)
+        self.write_flash_plan(environment)
         if os.environ.get("OPEN_BIKE_DETERMINISTIC_BUILD") == "1":
             defaults = self.project_dir / "sdkconfig.defaults"
             if not defaults.exists():
                 defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
             self.write_core_attestation(environment)
+
+    def write_flash_plan(
+        self,
+        environment=None,
+        *,
+        ota_data_offset="0xe000",
+        app_offset="0x10000",
+        flash_mode="qio",
+        extra_images=(),
+    ):
+        environment = environment or self.environment
+        project_dir = self.project_dir.resolve()
+        build_dir = project_dir / ".pio/build" / environment
+        core = (
+            project_dir
+            / ".pio/open-bike-build/platformio"
+            / environment
+        )
+        uploader = core / "penv/bin/esptool"
+        images = [
+            {"offset": "0x0", "path": str(build_dir / "bootloader.bin")},
+            {"offset": "0x8000", "path": str(build_dir / "partitions.bin")},
+            {
+                "offset": ota_data_offset,
+                "path": str(
+                    core
+                    / "packages/framework-arduinoespressif32/tools/partitions"
+                    / "boot_app0.bin"
+                ),
+            },
+        ]
+        for offset, path, contents in extra_images:
+            path = Path(path).resolve()
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(contents)
+            images.append({"offset": offset, "path": str(path)})
+        images.append(
+            {"offset": app_offset, "path": str(build_dir / "firmware.bin")}
+        )
+        command = [
+            str(uploader),
+            "--chip",
+            "esp32s3",
+            "--port",
+            FLASH_PLAN_PORT_PLACEHOLDER,
+            "--baud",
+            "460800",
+            "--before",
+            "default-reset",
+            "--after",
+            "hard-reset",
+            "write-flash",
+            "-z",
+            "--flash-mode",
+            "keep",
+            "--flash-freq",
+            "keep",
+            "--flash-size",
+            "keep",
+        ]
+        command.extend(
+            value
+            for image in images
+            for value in (image["offset"], image["path"])
+        )
+        plan = {
+            "schema": FLASH_PLAN_SCHEMA,
+            "environment": environment,
+            "uploadPortPlaceholder": FLASH_PLAN_PORT_PLACEHOLDER,
+            "uploader": str(uploader),
+            "command": command,
+            "platformioFlashParameters": {
+                "mode": flash_mode,
+                "frequency": "80m",
+                "size": "detect",
+            },
+            "images": images,
+        }
+        (build_dir / FLASH_PLAN_FILENAME).write_text(
+            json.dumps(plan) + "\n", encoding="utf-8"
+        )
+        return plan
 
     def write_partition_table(
         self,
@@ -254,6 +342,88 @@ class FirmwareBuildTests(unittest.TestCase):
         return subprocess.check_output(
             ["git", "rev-parse", "HEAD"], cwd=self.project_dir, text=True
         ).strip()
+
+    def test_records_resolved_arguments_without_shell_quote_leakage(self):
+        class FakeEnvironment:
+            def __init__(self, values):
+                self.values = values
+
+            def Clone(self):
+                return FakeEnvironment(dict(self.values))
+
+            def Replace(self, **values):
+                self.values.update(values)
+
+            def get(self, key, default=None):
+                return self.values.get(key, default)
+
+            def subst(self, expression):
+                result = expression
+                for key, value in self.values.items():
+                    if isinstance(value, str):
+                        result = result.replace(f"${{{key}}}", value)
+                        result = result.replace(f"${key}", value)
+                return result
+
+        build_dir = self.project_dir / "build with spaces"
+        uploader = self.project_dir / "core with spaces/penv/bin/esptool"
+        environment = FakeEnvironment(
+            {
+                "PIOENV": self.environment,
+                "BUILD_DIR": str(build_dir),
+                "PROGNAME": "firmware",
+                "UPLOADER": f'"{uploader}"',
+                "UPLOAD_PORT": "/dev/ignored",
+                "ESP32_APP_OFFSET": "0x10000",
+                "FLASH_EXTRA_IMAGES": [
+                    ("0x0", "$BUILD_DIR/bootloader.bin")
+                ],
+                "UPLOADERFLAGS": [
+                    "--chip",
+                    "esp32s3",
+                    "--port",
+                    '"$UPLOAD_PORT"',
+                    "--baud",
+                    "460800",
+                    "--before",
+                    "default-reset",
+                    "--after",
+                    "hard-reset",
+                    "write-flash",
+                    "-z",
+                    "--flash-mode",
+                    "qio",
+                    "--flash-freq",
+                    "80m",
+                    "--flash-size",
+                    "detect",
+                    "0x0",
+                    "$BUILD_DIR/bootloader.bin",
+                ],
+            }
+        )
+
+        record_flash_plan(environment)
+
+        plan = json.loads(
+            (build_dir / FLASH_PLAN_FILENAME).read_text(encoding="utf-8")
+        )
+        self.assertEqual(plan["command"][0], str(uploader.resolve()))
+        self.assertIn(FLASH_PLAN_PORT_PLACEHOLDER, plan["command"])
+        self.assertNotIn(
+            f'"{FLASH_PLAN_PORT_PLACEHOLDER}"', plan["command"]
+        )
+        self.assertEqual(
+            plan["platformioFlashParameters"],
+            {"mode": "qio", "frequency": "80m", "size": "detect"},
+        )
+        for option in ("--flash-mode", "--flash-freq", "--flash-size"):
+            self.assertEqual(
+                plan["command"][plan["command"].index(option) + 1], "keep"
+            )
+        self.assertEqual(
+            plan["command"][-1], str((build_dir / "firmware.bin").resolve())
+        )
 
     def test_rebuilds_after_successful_custom_core_dummy_bootstrap(self):
         return_codes = iter((0, 0))
@@ -641,17 +811,21 @@ class FirmwareBuildTests(unittest.TestCase):
                     ),
                 )
 
-    def test_upload_uses_offsets_from_the_verified_partition_image(self):
+    def test_upload_replays_offsets_from_the_verified_platformio_plan(self):
         core = self.write_core_attestation().resolve()
         project_dir = self.project_dir.resolve()
         defaults = self.project_dir / "sdkconfig.defaults"
         defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
         self.write_firmware()
-        self.write_partition_table(ota_data_offset=0xF000, app_offset=0x20000)
+        self.write_flash_plan(
+            ota_data_offset="0xf000",
+            app_offset="0x20000",
+            flash_mode="dio",
+        )
         calls = []
 
         with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
-            record_generated_sdkconfig_defaults(
+            manifest_path = record_generated_sdkconfig_defaults(
                 self.project_dir, self.environment
             )
             upload_firmware(
@@ -679,27 +853,46 @@ class FirmwareBuildTests(unittest.TestCase):
         )
         self.assertEqual(command[command.index(boot_app0) - 1], "0xf000")
         self.assertEqual(command[command.index(firmware) - 1], "0x20000")
+        self.assertEqual(command[command.index("--flash-mode") + 1], "keep")
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            manifest["flashPlan"]["platformioFlashParameters"]["mode"],
+            "dio",
+        )
         self.assertNotIn("nobuild", command)
         self.assertNotIn("upload", command)
 
-    def test_upload_refuses_a_malformed_verified_partition_image(self):
-        core = self.write_core_attestation()
+    def test_upload_replays_and_attests_additional_platformio_images(self):
+        core = self.write_core_attestation().resolve()
         defaults = self.project_dir / "sdkconfig.defaults"
         defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
         self.write_firmware()
-        partitions = (
-            self.project_dir
+        extra_image = (
+            self.project_dir.resolve()
             / ".pio/build"
             / self.environment
-            / "partitions.bin"
+            / "recovery.bin"
         )
-        partitions.write_bytes(b"not an ESP32 partition image")
+        self.write_flash_plan(
+            extra_images=(("0x310000", extra_image, b"recovery image"),)
+        )
+        calls = []
 
         with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
             record_generated_sdkconfig_defaults(
                 self.project_dir, self.environment
             )
-            with self.assertRaisesRegex(BuildError, "truncated entry"):
+            upload_firmware(
+                self.project_dir,
+                self.environment,
+                "/dev/cu.test",
+                runner=lambda command, cwd: (
+                    calls.append(tuple(command))
+                    or subprocess.CompletedProcess(command, 0)
+                ),
+            )
+            extra_image.write_bytes(b"changed recovery image")
+            with self.assertRaisesRegex(BuildError, "flash plan changed"):
                 upload_firmware(
                     self.project_dir,
                     self.environment,
@@ -708,6 +901,133 @@ class FirmwareBuildTests(unittest.TestCase):
                         "runner must not be called"
                     ),
                 )
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("0x310000", calls[0])
+        self.assertIn(str(extra_image), calls[0])
+
+    def test_upload_refuses_a_flash_plan_changed_after_attestation(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+            self.write_flash_plan(app_offset="0x20000")
+            output = StringIO()
+            with self.assertRaisesRegex(BuildError, "flash plan changed"), redirect_stdout(
+                output
+            ):
+                upload_firmware(
+                    self.project_dir,
+                    self.environment,
+                    "/dev/cu.test",
+                    runner=lambda command, cwd: self.fail(
+                        "runner must not be called"
+                    ),
+                )
+        self.assertNotIn("FIRMWARE_UPLOAD_PROVENANCE", output.getvalue())
+
+    def test_attestation_rejects_duplicate_or_overlapping_flash_ranges(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+
+        for offset, expected_error in (
+            ("0x0", "duplicate or out-of-range"),
+            ("0x1", "overlapping images"),
+        ):
+            with self.subTest(offset=offset):
+                self.write_firmware()
+                plan_path = (
+                    self.project_dir
+                    / ".pio/build"
+                    / self.environment
+                    / FLASH_PLAN_FILENAME
+                )
+                plan = json.loads(plan_path.read_text(encoding="utf-8"))
+                plan["images"][1]["offset"] = offset
+                image_tail = [
+                    value
+                    for image in plan["images"]
+                    for value in (image["offset"], image["path"])
+                ]
+                plan["command"][-len(image_tail) :] = image_tail
+                plan_path.write_text(json.dumps(plan) + "\n", encoding="utf-8")
+
+                with patch.dict(
+                    os.environ, {"PLATFORMIO_CORE_DIR": str(core)}
+                ), self.assertRaisesRegex(
+                    GeneratedSdkconfigError, expected_error
+                ):
+                    record_generated_sdkconfig_defaults(
+                        self.project_dir, self.environment
+                    )
+
+    def test_attestation_rejects_a_command_not_matching_its_image_set(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        plan_path = (
+            self.project_dir
+            / ".pio/build"
+            / self.environment
+            / FLASH_PLAN_FILENAME
+        )
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        plan["command"][-1] = str(self.project_dir / "unattested.bin")
+        plan_path.write_text(json.dumps(plan) + "\n", encoding="utf-8")
+
+        with patch.dict(
+            os.environ, {"PLATFORMIO_CORE_DIR": str(core)}
+        ), self.assertRaisesRegex(GeneratedSdkconfigError, "exactly match"):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+
+    def test_attestation_rejects_unattested_or_mutating_command_arguments(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+
+        for mutation, expected_error in (
+            ("undeclared-image", "unsupported argument"),
+            ("header-rewrite", "may rewrite"),
+        ):
+            with self.subTest(mutation=mutation):
+                self.write_firmware()
+                plan_path = (
+                    self.project_dir
+                    / ".pio/build"
+                    / self.environment
+                    / FLASH_PLAN_FILENAME
+                )
+                plan = json.loads(plan_path.read_text(encoding="utf-8"))
+                if mutation == "undeclared-image":
+                    image_tail_size = len(plan["images"]) * 2
+                    plan["command"][-image_tail_size:-image_tail_size] = [
+                        "0x700000",
+                        "/definitely/not/attested.bin",
+                    ]
+                else:
+                    mode_index = plan["command"].index("--flash-mode")
+                    plan["command"][mode_index + 1] = "qio"
+                plan_path.write_text(
+                    json.dumps(plan) + "\n", encoding="utf-8"
+                )
+
+                with patch.dict(
+                    os.environ, {"PLATFORMIO_CORE_DIR": str(core)}
+                ), self.assertRaisesRegex(
+                    GeneratedSdkconfigError, expected_error
+                ):
+                    record_generated_sdkconfig_defaults(
+                        self.project_dir, self.environment
+                    )
 
     def test_upload_allows_environment_config_absent_in_verified_build(self):
         core = self.write_core_attestation()

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -26,6 +26,7 @@ from build_firmware import (
 )
 from firmware_build_identity import firmware_git_identity
 from generated_sdkconfig import (
+    FLASH_PLAN_APP_OFFSET_PLACEHOLDER,
     FLASH_PLAN_FILENAME,
     FLASH_PLAN_PORT_PLACEHOLDER,
     FLASH_PLAN_SCHEMA,
@@ -154,7 +155,10 @@ class FirmwareBuildTests(unittest.TestCase):
             path.write_bytes(contents)
             images.append({"offset": offset, "path": str(path)})
         images.append(
-            {"offset": app_offset, "path": str(build_dir / "firmware.bin")}
+            {
+                "offset": FLASH_PLAN_APP_OFFSET_PLACEHOLDER,
+                "path": str(build_dir / "firmware.bin"),
+            }
         )
         command = [
             str(uploader),
@@ -193,6 +197,7 @@ class FirmwareBuildTests(unittest.TestCase):
                 "frequency": "80m",
                 "size": "detect",
             },
+            "platformioAppOffset": app_offset,
             "images": images,
         }
         (build_dir / FLASH_PLAN_FILENAME).write_text(
@@ -206,6 +211,7 @@ class FirmwareBuildTests(unittest.TestCase):
         *,
         ota_data_offset=0xE000,
         app_offset=0x10000,
+        app_size=0x300000,
     ):
         environment = environment or self.environment
         build_dir = self.project_dir / ".pio/build" / environment
@@ -230,7 +236,7 @@ class FirmwareBuildTests(unittest.TestCase):
                     0x00,
                     0x10,
                     app_offset,
-                    0x300000,
+                    app_size,
                     b"app0",
                     0,
                 ),
@@ -374,7 +380,7 @@ class FirmwareBuildTests(unittest.TestCase):
                 "PROGNAME": "firmware",
                 "UPLOADER": f'"{uploader}"',
                 "UPLOAD_PORT": "/dev/ignored",
-                "ESP32_APP_OFFSET": "0x10000",
+                "ESP32_APP_OFFSET": "",
                 "FLASH_EXTRA_IMAGES": [
                     ("0x0", "$BUILD_DIR/bootloader.bin")
                 ],
@@ -416,6 +422,11 @@ class FirmwareBuildTests(unittest.TestCase):
         self.assertEqual(
             plan["platformioFlashParameters"],
             {"mode": "qio", "frequency": "80m", "size": "detect"},
+        )
+        self.assertEqual(plan["platformioAppOffset"], "")
+        self.assertEqual(
+            plan["images"][-1]["offset"],
+            FLASH_PLAN_APP_OFFSET_PLACEHOLDER,
         )
         for option in ("--flash-mode", "--flash-freq", "--flash-size"):
             self.assertEqual(
@@ -811,7 +822,7 @@ class FirmwareBuildTests(unittest.TestCase):
                     ),
                 )
 
-    def test_upload_replays_offsets_from_the_verified_platformio_plan(self):
+    def test_upload_derives_app_offset_from_verified_partition_table(self):
         core = self.write_core_attestation().resolve()
         project_dir = self.project_dir.resolve()
         defaults = self.project_dir / "sdkconfig.defaults"
@@ -819,8 +830,12 @@ class FirmwareBuildTests(unittest.TestCase):
         self.write_firmware()
         self.write_flash_plan(
             ota_data_offset="0xf000",
-            app_offset="0x20000",
+            app_offset="",
             flash_mode="dio",
+        )
+        self.write_partition_table(
+            ota_data_offset=0xF000,
+            app_offset=0x20000,
         )
         calls = []
 
@@ -859,8 +874,45 @@ class FirmwareBuildTests(unittest.TestCase):
             manifest["flashPlan"]["platformioFlashParameters"]["mode"],
             "dio",
         )
+        self.assertEqual(manifest["flashPlan"]["platformioAppOffset"], "")
+        self.assertEqual(
+            manifest["flashPlan"]["applicationOffsetSource"],
+            "partition-table",
+        )
         self.assertNotIn("nobuild", command)
         self.assertNotIn("upload", command)
+
+    def test_attestation_rejects_platformio_app_offset_mismatch(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        self.write_flash_plan(app_offset="0x20000")
+
+        with patch.dict(
+            os.environ, {"PLATFORMIO_CORE_DIR": str(core)}
+        ), self.assertRaisesRegex(
+            GeneratedSdkconfigError, "does not match the verified partition table"
+        ):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+
+    def test_attestation_rejects_firmware_larger_than_app_partition(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        self.write_partition_table(app_size=1)
+
+        with patch.dict(
+            os.environ, {"PLATFORMIO_CORE_DIR": str(core)}
+        ), self.assertRaisesRegex(
+            GeneratedSdkconfigError, "exceeds its application partition"
+        ):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
 
     def test_upload_replays_and_attests_additional_platformio_images(self):
         core = self.write_core_attestation().resolve()
@@ -916,7 +968,7 @@ class FirmwareBuildTests(unittest.TestCase):
             record_generated_sdkconfig_defaults(
                 self.project_dir, self.environment
             )
-            self.write_flash_plan(app_offset="0x20000")
+            self.write_flash_plan(flash_mode="dio")
             output = StringIO()
             with self.assertRaisesRegex(BuildError, "flash plan changed"), redirect_stdout(
                 output

--- a/esp32/tools/tests/test_generated_sdkconfig.py
+++ b/esp32/tools/tests/test_generated_sdkconfig.py
@@ -53,6 +53,20 @@ class GeneratedSdkconfigTests(unittest.TestCase):
         )
         self.artifact_patch.start()
         self.addCleanup(self.artifact_patch.stop)
+        self.flash_plan = {
+            "schema": 1,
+            "environment": "WAVESHARE_AMOLED_175",
+            "uploadPortPlaceholder": "__OPEN_BIKE_UPLOAD_PORT__",
+            "uploader": "/attested/esptool",
+            "command": ["/attested/esptool", "write-flash"],
+            "images": [],
+        }
+        self.flash_plan_patch = patch(
+            "generated_sdkconfig._validated_flash_plan",
+            return_value=self.flash_plan,
+        )
+        self.flash_plan_patch.start()
+        self.addCleanup(self.flash_plan_patch.stop)
 
     def test_matches_platformio_windows_legacy_default_core(self) -> None:
         with (
@@ -98,9 +112,11 @@ class GeneratedSdkconfigTests(unittest.TestCase):
         for path in (
             core / "tools/toolchain-xtensa-esp-elf/bin/xtensa-esp-elf-gcc",
             core / "penv/bin/platformio-runtime.py",
+            core / "penv/bin/esptool",
         ):
             path.parent.mkdir(parents=True, exist_ok=True)
             path.write_text(f"attested {path.name}\n", encoding="utf-8")
+            path.chmod(0o755)
         (core / "lib").mkdir()
         (core / "boards").mkdir()
         with patch.dict(
@@ -112,6 +128,55 @@ class GeneratedSdkconfigTests(unittest.TestCase):
             },
         ):
             yield core
+
+    def test_requires_a_safe_executable_esptool_in_core_attestation(self) -> None:
+        for state in ("missing", "symlink", "not-executable"):
+            with self.subTest(state=state), tempfile.TemporaryDirectory() as directory:
+                project = Path(directory)
+                defaults = project / "sdkconfig.defaults"
+                (project / "platformio.ini").write_text(
+                    "[env:WAVESHARE_AMOLED_175]\nplatform = test\n",
+                    encoding="utf-8",
+                )
+                defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+                with self.fake_core(project) as core:
+                    uploader = core / "penv/bin/esptool"
+                    if state == "missing":
+                        uploader.unlink()
+                    elif state == "symlink":
+                        external = project / "external-esptool"
+                        external.write_text("external\n", encoding="utf-8")
+                        external.chmod(0o755)
+                        uploader.unlink()
+                        uploader.symlink_to(external)
+                    else:
+                        uploader.chmod(0o644)
+                    self.assertIsNone(
+                        record_generated_sdkconfig_defaults(
+                            project, "WAVESHARE_AMOLED_175"
+                        )
+                    )
+
+    def test_uploader_mode_change_invalidates_recorded_core(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            defaults = project / "sdkconfig.defaults"
+            (project / "platformio.ini").write_text(
+                "[env:WAVESHARE_AMOLED_175]\nplatform = test\n",
+                encoding="utf-8",
+            )
+            defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+            with self.fake_core(project) as core:
+                record_generated_sdkconfig_defaults(
+                    project, "WAVESHARE_AMOLED_175"
+                )
+                (core / "penv/bin/esptool").chmod(0o644)
+                with self.assertRaisesRegex(
+                    GeneratedSdkconfigError, "custom-core state changed"
+                ):
+                    require_validated_generated_sdkconfig_defaults(
+                        project, "WAVESHARE_AMOLED_175"
+                    )
 
     def test_preserves_only_a_successfully_recorded_defaults_cache(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- replace the malformed PlatformIO `nobuild` plus `upload` target combination with a build-recorded, attested esptool replay plan
- capture PlatformIO's resolved chip, reset, baud, non-application offsets, uploader, and complete image set after its framework scripts load
- derive the application offset from the attested built partition table because pioarduino's final core-reuse pass may clear `ESP32_APP_OFFSET`; preserve any reported value as evidence and reject disagreement
- preserve exact attested image bytes by normalizing esptool's header-mutating flash mode, frequency, and size arguments to `keep`, while retaining PlatformIO's original resolved values in provenance
- require the exact executable uploader, a closed safe argument grammar, canonical image paths, unique non-overlapping ranges, a hash for every referenced image, and a firmware image that fits its selected application partition
- fail closed before `FIRMWARE_UPLOAD_PROVENANCE` when the plan, uploader, command, generated state, partition table, or any image changes
- document the immutable upload boundary in the firmware and contributor guidance

## Root cause

PlatformIO skips the ESP32 framework build scripts for the `nobuild` target. Combining `nobuild` and `upload` therefore left `FLASH_EXTRA_IMAGES` and `ESP32_APP_OFFSET` unset, so esptool received `firmware.bin` without its required address and exited before writing any bytes.

The first repair recorded the complete plan during the verified build, but the real pioarduino core-reuse build exposed a second lifecycle detail: its final pass clears `ESP32_APP_OFFSET`. The recorder therefore emitted an empty application-offset token even though the generated partition table was correct.

The durable fix now treats the built and hashed `partitions.bin` as the source of truth for the application slot. It parses the ESP partition table under strict bounds, selects the unique OTA_0 slot (or factory fallback), verifies alignment and firmware fit, reconciles any non-empty PlatformIO-reported offset, and only then normalizes and attests the replay command.

## Validation

- `python3 -m unittest discover -s tests -p 'test_*.py'` from `esp32/tools` (143 tests passed)
- exact `WAVESHARE_AMOLED_175_LIGHT_SLEEP` PlatformIO reproduction exposed the empty final-pass offset before the fix
- regression coverage for an empty `ESP32_APP_OFFSET`, partition-table-derived replay, reported-offset mismatch rejection, and oversized firmware rejection
- `python3 -m py_compile tools/build_firmware.py tools/generated_sdkconfig.py tools/record_flash_plan.py tools/tests/test_build_firmware.py tools/tests/test_generated_sdkconfig.py`
- real SCons substitution probe for PlatformIO's quoted uploader representation with spaces in core and build paths
- esptool v5.1.0 parsed the final `keep` command successfully and failed only when opening an intentionally nonexistent serial port
- three-pass deep P0/P1/P2 review converged with clean claims, code/security, and tests/verification lenses
- `git diff --check`

## Physical validation

No device was flashed while reviewing and publishing this repair. The full CI matrix is the real PlatformIO build-integration gate; a later explicitly approved device run can independently confirm upload and boot behavior.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
