### PR TITLE
Speed up verified firmware upload retries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,8 @@ jobs:
             tools.tests.test_build_firmware \
             tools.tests.test_firmware_build_identity \
             tools.tests.test_generated_sdkconfig \
-            tools.tests.test_capture_boot
+            tools.tests.test_capture_boot \
+            tools.tests.test_resolve_upload_port
           g++ -std=c++17 \
             tools/tests/test_gui_layout.cpp \
             -o /tmp/test_gui_layout_175

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,15 @@ configure or build again. The uploader and hardware-serial resolver suppress
 Python bytecode writes inside the attested private environment so a connection
 failure cannot invalidate an otherwise unchanged retry.
 
+Verified builds use the exact Git commit's committer timestamp as
+`SOURCE_DATE_EPOCH` for PlatformIO, ESP-IDF, and the firmware metadata. The
+`BOOT_META built=` value therefore means source commit time, not workstation
+compile time. The epoch and ISO UTC value are recorded in build provenance and
+must remain identical across clean rebuilds of the same commit. Do not
+reintroduce wall-clock values into verified firmware artifacts. The wrapper also
+uses an empty isolated Git configuration for public dependency resolution, so
+ambient URL rewrites cannot change the transport or inputs.
+
 Use the matching `WAVESHARE_AMOLED_206` environment for a 2.06-inch board. If
 upload fails, hold BOOT (`GPIO0`) while reconnecting USB and retry.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,29 @@ cd esp32
 python3 tools/build_firmware.py WAVESHARE_AMOLED_175
 python3 tools/build_firmware.py WAVESHARE_AMOLED_206
 pio device list
-python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \
-  --upload-port /dev/cu.usbmodemXXXX
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --upload-only \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
 pio device monitor -b 115200
 ```
+
+Treat `/dev/cu.usbmodem*` and equivalent port names as transient. When more than
+one ESP32 is attached, record the hardware serial for each physical board before
+building or uploading and never infer the board from a port number. Prefer
+`--device-serial`: the helper resolves that stable USB identity immediately
+before esptool starts and waits up to 60 seconds for a disconnected board to
+reappear. `--device-timeout` changes that wait. Keep `--upload-port` only for a
+deliberately selected explicit port when stable serial metadata is unavailable.
+
+The normal upload command builds and attests first. If that exact build already
+completed and upload then failed because the cable, port, or bootloader was
+temporarily unavailable, retry with `--upload-only`; it revalidates the clean Git
+identity, generated state, toolchain, flash plan, and every image without
+compiling again. A commit/profile/source/generated-state/toolchain/artifact
+change must fail closed and requires a new full build. Never bypass a failed
+upload-only validation with raw esptool or PlatformIO.
 
 Use `tools/build_firmware.py` for build-only checks, upload, and CI. A clean
 pioarduino installation first converts content-pinned tool wrappers into the
@@ -51,7 +70,9 @@ PlatformIO reruns prebuild before upload. The helper instead records the fully
 resolved esptool command during the verified build, attests its uploader and
 every referenced image, normalizes the three header-mutating flash parameters
 to `keep`, and replays that immutable plan without asking PlatformIO to
-configure or build again.
+configure or build again. The uploader and hardware-serial resolver suppress
+Python bytecode writes inside the attested private environment so a connection
+failure cannot invalidate an otherwise unchanged retry.
 
 Use the matching `WAVESHARE_AMOLED_206` environment for a 2.06-inch board. If
 upload fails, hold BOOT (`GPIO0`) while reconnecting USB and retry.
@@ -64,7 +85,7 @@ hold the ESP32-S3 in reset:
 ```sh
 cd esp32
 python3 tools/capture_boot.py \
-  --port '/dev/cu.usbmodem*' \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST \
   --duration 40 \
   --expected-target WAVESHARE_AMOLED_175 \
   --expected-profile WAVESHARE_AMOLED_175 \
@@ -161,8 +182,8 @@ structured `FIRMWARE_BUILD_PROVENANCE` and
 preflight record of the eligible USB-upload inputs: firmware binary/ELF,
 bootloader, partition table, OTA bootstrap, platform/package archives,
 library dependencies, and managed components. A successful command means the
-attested esptool process completed the upload. A later `BOOT_META`
-independently confirms the
+attested esptool process completed the upload. Do not report a physical device
+as flashed until a later `BOOT_META` independently confirms the
 embedded Git/profile identity; it does not contain those SHA-256 values or prove
 on-device byte equality. Flash readback or a runtime image digest is required
 for that stronger claim.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,7 +84,12 @@ esptool runs and waits 60 seconds by default. USB port numbers are transient and
 must not be used to distinguish multiple attached boards. The upload subprocess
 also suppresses Python bytecode writes inside the attested private environment,
 keeping an unchanged build eligible for upload-only retry after a connection
-failure. The
+failure. The verified build clock is the exact Git commit's committer timestamp.
+It is exported as `SOURCE_DATE_EPOCH` to the full toolchain and embedded as
+`BOOT_META built=`, so that field is source commit time rather than local
+compile time. The manifest attests both the epoch and its ISO UTC rendering.
+Public dependency fetches use an empty isolated Git configuration so ambient
+URL rewrites cannot alter the transport. The
 host Python interpreter, top-level `pio` launcher, and pioarduino's first-run
 online Python dependency resolver (including its registries, external `uv`,
 private `penv`, and ESP-IDF venv before their resulting trees are attested)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,18 @@ Upload ESP32 firmware:
 
 ```sh
 cd esp32
-python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \
-  --upload-port /dev/cu.usbmodemXXXX
+pio device list
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
+```
+
+Retry an already verified build after a transient connection failure without
+recompiling:
+
+```sh
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --upload-only \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
 ```
 
 Use this helper rather than a raw Waveshare `pio run`. It verifies the tracked
@@ -69,6 +79,12 @@ PlatformIO build. The final
 attested command uses esptool's `keep` values for flash mode, frequency, and
 size so esptool cannot rewrite a hashed bootloader image. The original resolved
 values remain in the plan provenance. The
+hardware-serial selector resolves the current OS port immediately before
+esptool runs and waits 60 seconds by default. USB port numbers are transient and
+must not be used to distinguish multiple attached boards. The upload subprocess
+also suppresses Python bytecode writes inside the attested private environment,
+keeping an unchanged build eligible for upload-only retry after a connection
+failure. The
 host Python interpreter, top-level `pio` launcher, and pioarduino's first-run
 online Python dependency resolver (including its registries, external `uv`,
 private `penv`, and ESP-IDF venv before their resulting trees are attested)
@@ -77,8 +93,12 @@ included in the later core attestation, but this is not a pre-execution Python
 dependency lock. Command success is not a flash
 readback; confirm the embedded Git/profile with the later boot capture.
 
-If upload fails, hold BOOT (`GPIO0`) while reconnecting USB, then retry. For the
-2.06 board, use the `WAVESHARE_AMOLED_206` environment.
+If upload fails, hold BOOT (`GPIO0`) while reconnecting USB, then use the
+upload-only command. For the 2.06 board, use the `WAVESHARE_AMOLED_206`
+environment. Confirm the expected target/profile/Git identity from `BOOT_META`
+before reporting a physical installation as complete. Pass the same stable
+hardware identity to `tools/capture_boot.py --device-serial ...`; this prevents
+boot verification from following a different board after USB re-enumeration.
 
 View ESP32 serial logs:
 

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -90,6 +90,12 @@ embedded Git/profile independently but does not contain the artifact SHA-256s.
 The upload subprocess suppresses Python bytecode writes inside the attested
 private environment so a missing-port failure remains eligible for an unchanged
 upload-only retry.
+Verified builds also export the exact Git commit's committer timestamp as
+`SOURCE_DATE_EPOCH` to PlatformIO and ESP-IDF. Firmware `built=` metadata is
+therefore the reproducible source commit time, not the local compilation time;
+the manifest records both the epoch and ISO UTC timestamp. Public dependency
+fetches use an empty isolated Git configuration so workstation URL rewrites do
+not change the transport.
 The host Python interpreter, top-level `pio` launcher, and pioarduino's first-run
 online Python dependency resolver (its registries, external `uv`, private
 `penv`, and ESP-IDF venv before their resulting trees are attested) are part of

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -47,9 +47,34 @@ PlatformIO build and keeps the bytes and flash layout crossing the upload
 boundary identical to the verified build:
 
 ```sh
-python3 tools/build_firmware.py WAVESHARE_AMOLED_175 \
-  --upload-port /dev/cu.usbmodemXXXX
+pio device list
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
 ```
+
+USB port names can change whenever an ESP32-S3 resets or reconnects. Prefer the
+hardware serial reported by `pio device list`, especially when multiple boards
+are attached. The helper resolves that serial immediately before flashing and
+waits up to 60 seconds for it to appear; use `--device-timeout` to change the
+wait. `--upload-port` remains available when stable serial metadata is not.
+
+If the verified build succeeded but the upload failed because the selected
+device disappeared, entered the wrong USB mode, or needed a cable reconnect,
+retry the same attested build without compiling again:
+
+```sh
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 \
+  --upload-only \
+  --device-serial SERIAL_FROM_PIO_DEVICE_LIST
+```
+
+Upload-only still rechecks the clean Git/profile identity, generated SDK state,
+installed toolchain, flash plan, and every image hash. Any change fails closed
+and requires a new full build. Successful esptool completion is not enough to
+identify the running firmware; confirm the expected target, profile, and Git SHA
+from `BOOT_META` after reset. Use the same stable hardware identity with
+`tools/capture_boot.py --device-serial ...` so verification cannot follow a
+different attached board after USB re-enumeration.
 
 Archive the emitted `FIRMWARE_BUILD_PROVENANCE` and
 `FIRMWARE_UPLOAD_PROVENANCE` lines with physical test results. They bind the
@@ -62,6 +87,9 @@ also isolates ESP-IDF Component Manager state, rejects or scrubs ambient source
 overrides, and requires strict component checksums. This is upload-input
 preflight evidence, not flash readback: a later `BOOT_META` confirms the
 embedded Git/profile independently but does not contain the artifact SHA-256s.
+The upload subprocess suppresses Python bytecode writes inside the attested
+private environment so a missing-port failure remains eligible for an unchanged
+upload-only retry.
 The host Python interpreter, top-level `pio` launcher, and pioarduino's first-run
 online Python dependency resolver (its registries, external `uv`, private
 `penv`, and ESP-IDF venv before their resulting trees are attested) are part of

--- a/esp32/prebuild.py
+++ b/esp32/prebuild.py
@@ -16,7 +16,10 @@ TOOLS_DIR = Path(env.get("PROJECT_DIR")).resolve() / "tools"
 if str(TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(TOOLS_DIR))
 
-from firmware_build_identity import firmware_git_identity
+from firmware_build_identity import (
+    build_timestamp_from_source_date_epoch,
+    firmware_git_identity,
+)
 from generated_sdkconfig import recognized_generated_sdkconfigs
 from pioarduino_custom_core import (
     correct_nested_pio_command,
@@ -192,7 +195,6 @@ flavor = env.get("PIOENV")
 firmware_target = env.GetProjectOption("custom_firmware_target", flavor)
 revision = config.get("common","revision")
 version = config.get("common", "version")
-build_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 project_dir = Path(env.get("PROJECT_DIR")).resolve()
 allowed_generated_paths = ()
 deterministic_build = os.environ.get("OPEN_BIKE_DETERMINISTIC_BUILD") == "1"
@@ -201,6 +203,24 @@ if firmware_target.startswith("WAVESHARE_AMOLED_") and not deterministic_build:
         "Waveshare firmware builds must use tools/build_firmware.py so generated "
         "inputs and the flashed source identity are verified"
     )
+if deterministic_build:
+    source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH", "")
+    try:
+        build_timestamp = build_timestamp_from_source_date_epoch(
+            source_date_epoch
+        )
+    except ValueError as error:
+        raise RuntimeError(
+            f"invalid deterministic firmware build clock: {error}"
+        ) from error
+    expected_build_timestamp = os.environ.get("OPEN_BIKE_BUILD_TIMESTAMP")
+    if expected_build_timestamp != build_timestamp:
+        raise RuntimeError(
+            "deterministic firmware build timestamp changed before prebuild: "
+            f"expected {expected_build_timestamp or 'missing'}, got {build_timestamp}"
+        )
+else:
+    build_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 if deterministic_build:
     allowed_generated_paths = recognized_generated_sdkconfigs(project_dir, flavor)
 detected_git_sha = firmware_git_identity(

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -7,6 +7,7 @@ import argparse
 import configparser
 import hashlib
 import json
+import math
 import os
 import re
 import shutil
@@ -162,8 +163,103 @@ PLATFORMIO_CORE_SCONS_PIOPM = json.dumps(
     },
     separators=(",", ":"),
 )
+
+
 class BuildError(RuntimeError):
     """Raised when a deterministic real-target build cannot be confirmed."""
+
+
+def _resolved_device_port(
+    project_dir: Path,
+    manifest: dict[str, object],
+    device_serial: str,
+    timeout_seconds: float,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+) -> str:
+    """Resolve a stable USB hardware serial using the attested private Python."""
+    requested = device_serial.strip()
+    if (
+        not requested
+        or not requested.isprintable()
+        or "\0" in requested
+        or len(requested) > 255
+    ):
+        raise BuildError("device serial must not be empty or invalid")
+    if not math.isfinite(timeout_seconds) or timeout_seconds < 0:
+        raise BuildError("device timeout must be a finite nonnegative value")
+
+    core_attestation = manifest.get("coreAttestation")
+    if not isinstance(core_attestation, dict):
+        raise BuildError("verified build provenance is missing its core attestation")
+    core_dir_value = core_attestation.get("coreDir")
+    if not isinstance(core_dir_value, str):
+        raise BuildError("verified core attestation is missing its core directory")
+    core_dir = Path(core_dir_value)
+    manifest_environment = manifest.get("environment")
+    if not isinstance(manifest_environment, str):
+        raise BuildError("verified build provenance is missing its environment")
+    expected_core_dir = (
+        project_dir / ".pio/open-bike-build/platformio" / manifest_environment
+    ).resolve()
+    if core_dir != expected_core_dir:
+        raise BuildError("verified core attestation references another core directory")
+    private_python = core_dir / (
+        "penv/Scripts/python.exe" if os.name == "nt" else "penv/bin/python"
+    )
+    resolver = project_dir / "tools/resolve_upload_port.py"
+    if (
+        not private_python.is_file()
+        or not os.access(private_python, os.X_OK)
+        or resolver.is_symlink()
+        or not resolver.is_file()
+    ):
+        raise BuildError("verified upload device resolver is missing or unsafe")
+
+    command = (
+        str(private_python),
+        str(resolver),
+        "--device-serial",
+        requested,
+        "--timeout",
+        f"{timeout_seconds:g}",
+    )
+    try:
+        result = runner(
+            command,
+            cwd=project_dir,
+            capture_output=True,
+            text=True,
+        )
+    except OSError as error:
+        raise BuildError(f"could not run the upload device resolver: {error}") from error
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "unknown error").strip()
+        raise BuildError(f"could not resolve upload device {requested!r}: {detail}")
+    try:
+        resolved = json.loads(result.stdout)
+    except (TypeError, json.JSONDecodeError) as error:
+        raise BuildError("upload device resolver returned invalid output") from error
+    if not isinstance(resolved, dict) or resolved.get("schema") != 1:
+        raise BuildError("upload device resolver returned an unsupported result")
+    port = resolved.get("port")
+    actual_serial = resolved.get("serialNumber")
+    if (
+        not isinstance(port, str)
+        or not port.strip()
+        or not port.isprintable()
+        or "\0" in port
+        or len(port) > 4096
+        or not isinstance(actual_serial, str)
+        or not actual_serial.isprintable()
+        or actual_serial.strip().casefold() != requested.casefold()
+    ):
+        raise BuildError("upload device resolver returned a mismatched device")
+    print(
+        f"FIRMWARE_UPLOAD_DEVICE serial={actual_serial} port={port}",
+        flush=True,
+    )
+    return port
 
 
 def _verified_flash_command(
@@ -1020,9 +1116,12 @@ def build_firmware(
 def upload_firmware(
     project_dir: Path,
     environment: str,
-    upload_port: str,
+    upload_port: str | None = None,
     *,
+    device_serial: str | None = None,
+    device_timeout: float = 60.0,
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
+    resolver_runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
 ) -> None:
     """Upload the exact verified images without asking PlatformIO to rebuild."""
     project_dir = project_dir.resolve()
@@ -1032,8 +1131,16 @@ def upload_firmware(
         raise BuildError(
             "verified upload is limited to attested WAVESHARE_AMOLED profiles"
         )
-    if not upload_port.strip() or "\0" in upload_port:
+    if (upload_port is None) == (device_serial is None):
+        raise BuildError("provide exactly one upload port or device serial")
+    if upload_port is not None and (not upload_port.strip() or "\0" in upload_port):
         raise BuildError("upload port must not be empty")
+    if device_serial is not None and (
+        not device_serial.strip()
+        or not device_serial.strip().isprintable()
+        or "\0" in device_serial
+    ):
+        raise BuildError("device serial must not be empty")
 
     firmware_elf = project_dir / ".pio" / "build" / environment / "firmware.elf"
     if firmware_elf.is_symlink() or not firmware_elf.is_file():
@@ -1065,8 +1172,24 @@ def upload_firmware(
                 )
             except GeneratedSdkconfigError as error:
                 raise BuildError(str(error)) from error
+            # The attested private esptool environment must remain reusable after
+            # both successful uploads and connection failures. Importing pyserial
+            # can otherwise create new bytecode inside the attested penv and make
+            # an unchanged build fail its next validation.
+            os.environ["PYTHONDONTWRITEBYTECODE"] = "1"
+            resolved_port = upload_port
+            if device_serial is not None:
+                resolved_port = _resolved_device_port(
+                    project_dir,
+                    manifest,
+                    device_serial,
+                    device_timeout,
+                    runner=resolver_runner,
+                )
+            if resolved_port is None:
+                raise AssertionError("validated upload selector did not resolve")
             command: Sequence[str] = _verified_flash_command(
-                upload_port,
+                resolved_port,
                 manifest,
             )
             _print_provenance(
@@ -1102,12 +1225,31 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default=os.environ.get("PLATFORMIO_CMD", "pio"),
         help="PlatformIO executable (default: pio or PLATFORMIO_CMD)",
     )
-    parser.add_argument(
+    upload_selector = parser.add_mutually_exclusive_group()
+    upload_selector.add_argument(
         "--upload-port",
         help=(
             "after a verified build, upload through the same deterministic "
             "identity boundary"
         ),
+    )
+    upload_selector.add_argument(
+        "--device-serial",
+        help=(
+            "resolve the upload port immediately before flashing from this stable "
+            "USB hardware serial"
+        ),
+    )
+    parser.add_argument(
+        "--device-timeout",
+        type=float,
+        default=60.0,
+        help="seconds to wait for --device-serial to appear (default: 60)",
+    )
+    parser.add_argument(
+        "--upload-only",
+        action="store_true",
+        help="revalidate and upload an existing attested build without rebuilding",
     )
     return parser.parse_args(argv)
 
@@ -1115,12 +1257,21 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
-        build_firmware(args.project_dir, args.environment, pio_command=args.pio)
-        if args.upload_port is not None:
+        if args.upload_only and args.upload_port is None and args.device_serial is None:
+            raise BuildError("--upload-only requires --upload-port or --device-serial")
+        if args.device_serial is None and args.device_timeout != 60.0:
+            raise BuildError("--device-timeout requires --device-serial")
+        if not math.isfinite(args.device_timeout) or args.device_timeout < 0:
+            raise BuildError("device timeout must be a finite nonnegative value")
+        if not args.upload_only:
+            build_firmware(args.project_dir, args.environment, pio_command=args.pio)
+        if args.upload_port is not None or args.device_serial is not None:
             upload_firmware(
                 args.project_dir,
                 args.environment,
                 args.upload_port,
+                device_serial=args.device_serial,
+                device_timeout=args.device_timeout,
             )
     except BuildError as error:
         print(f"Firmware build failed: {error}", file=sys.stderr)

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -34,7 +34,12 @@ from generated_sdkconfig import (
     record_generated_sdkconfig_defaults,
     require_validated_generated_sdkconfig_defaults,
 )
-from firmware_build_identity import FULL_GIT_SHA
+from firmware_build_identity import (
+    FULL_GIT_SHA,
+    build_timestamp_from_source_date_epoch,
+    git_commit_source_date_epoch,
+    git_head_identity,
+)
 
 
 ENVIRONMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
@@ -659,9 +664,39 @@ def _deterministic_build_environment(
     platform_archive: Path,
     verified_config: Path,
 ) -> Iterator[None]:
+    commit_identity = expected_identity.removeprefix("dirty-")
+    try:
+        if FULL_GIT_SHA.fullmatch(commit_identity) is None:
+            commit_identity = git_head_identity(project_dir)
+        source_date_epoch = git_commit_source_date_epoch(
+            project_dir, commit_identity
+        )
+        build_timestamp = build_timestamp_from_source_date_epoch(
+            source_date_epoch
+        )
+    except ValueError as error:
+        raise BuildError(
+            "deterministic firmware build requires a Git-derived build clock: "
+            f"{error}"
+        ) from error
+
     store_root = _ensure_private_directory(
         project_dir, Path(".pio/open-bike-build/platformio") / environment
     )
+    config_root = _ensure_private_directory(
+        project_dir, Path(".pio/open-bike-build/config")
+    )
+    isolated_git_config = config_root / "gitconfig-empty"
+    if isolated_git_config.is_symlink() or (
+        isolated_git_config.exists() and not isolated_git_config.is_file()
+    ):
+        raise BuildError(
+            f"refusing to replace unsafe isolated Git config: {isolated_git_config}"
+        )
+    try:
+        isolated_git_config.write_text("", encoding="utf-8")
+    except OSError as error:
+        raise BuildError(f"could not write isolated Git config: {error}") from error
     for child in (
         "packages",
         "platforms",
@@ -701,8 +736,13 @@ def _deterministic_build_environment(
             "IDF_COMPONENT_STRICT_CHECKSUM": "1",
             "IDF_COMPONENT_VERIFY_SSL": "1",
             "IDF_TOOLS_PATH": str(store_root),
+            "GIT_CONFIG_GLOBAL": str(isolated_git_config),
+            "GIT_CONFIG_NOSYSTEM": "1",
+            "GIT_TERMINAL_PROMPT": "0",
             "OPEN_BIKE_DETERMINISTIC_BUILD": "1",
             "OPEN_BIKE_EXPECTED_GIT_SHA": expected_identity,
+            "SOURCE_DATE_EPOCH": source_date_epoch,
+            "OPEN_BIKE_BUILD_TIMESTAMP": build_timestamp,
             "OPEN_BIKE_PINNED_SCONS_PIOPM": _pinned_nested_scons_piopm(),
             "OPEN_BIKE_VERIFIED_PROJECT_CONFIG": str(verified_config),
             "OPEN_BIKE_PLATFORM_ARCHIVE_SHA256": _file_sha256(platform_archive),
@@ -792,6 +832,8 @@ def _print_provenance(
     print(
         f"{marker} schema=1 environment={environment} git={source_identity} "
         f"uploadEligible={1 if manifest else 0} "
+        f"sourceDateEpoch={value('sourceDateEpoch')} "
+        f"buildTimestamp={value('buildTimestamp')} "
         f"firmwareBinSha256={value('firmwareBinSha256')} "
         f"firmwareElfSha256={value('firmwareElfSha256')} "
         f"bootloaderBinSha256={value('bootloaderBinSha256')} "

--- a/esp32/tools/capture_boot.py
+++ b/esp32/tools/capture_boot.py
@@ -6,9 +6,13 @@ from __future__ import annotations
 import argparse
 import codecs
 import glob
+import math
 import sys
 import time
+from collections.abc import Callable
 from dataclasses import dataclass
+
+from resolve_upload_port import ResolvedDevice, resolve_device_port
 
 
 _POST_READY_BOOT_RECORD_MARKERS = (
@@ -379,7 +383,18 @@ def validation_errors(
     return errors
 
 
-def _resolve_port(requested: str | None, wait_seconds: float) -> str:
+def _resolve_port(
+    requested: str | None,
+    wait_seconds: float,
+    *,
+    device_serial: str | None = None,
+    device_resolver: Callable[[str, float], ResolvedDevice] = resolve_device_port,
+) -> str:
+    if not math.isfinite(wait_seconds) or wait_seconds < 0:
+        raise RuntimeError("wait time must be a finite nonnegative value")
+    if device_serial is not None:
+        return device_resolver(device_serial, wait_seconds).port
+
     deadline = time.monotonic() + wait_seconds
     while True:
         matches = sorted(glob.glob(requested or "/dev/cu.usbmodem*"))
@@ -410,7 +425,14 @@ def _open_serial(serial_module, port: str, baud: int):
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--port", help="serial device or glob; auto-detects one modem")
+    port_selector = parser.add_mutually_exclusive_group()
+    port_selector.add_argument(
+        "--port", help="serial device or glob; auto-detects one modem"
+    )
+    port_selector.add_argument(
+        "--device-serial",
+        help="select a USB serial device by its stable hardware serial number",
+    )
     parser.add_argument("--baud", type=int, default=115200)
     parser.add_argument("--duration", type=float, default=35.0)
     parser.add_argument("--wait-seconds", type=float, default=30.0)
@@ -464,7 +486,11 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     try:
-        port = _resolve_port(args.port, args.wait_seconds)
+        port = _resolve_port(
+            args.port,
+            args.wait_seconds,
+            device_serial=args.device_serial,
+        )
     except RuntimeError as error:
         print(f"BOOT_CAPTURE_ERROR {error}", file=sys.stderr)
         return 2

--- a/esp32/tools/firmware_build_identity.py
+++ b/esp32/tools/firmware_build_identity.py
@@ -2,11 +2,70 @@ from __future__ import annotations
 
 import re
 import subprocess
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterable
 
 
 FULL_GIT_SHA = re.compile(r"[0-9a-f]{40}")
+SOURCE_DATE_EPOCH = re.compile(r"0|[1-9][0-9]*")
+
+
+def build_timestamp_from_source_date_epoch(source_date_epoch: str) -> str:
+    """Return the canonical UTC firmware timestamp for SOURCE_DATE_EPOCH."""
+    if SOURCE_DATE_EPOCH.fullmatch(source_date_epoch) is None:
+        raise ValueError(
+            "SOURCE_DATE_EPOCH must be a canonical nonnegative integer"
+        )
+    try:
+        timestamp = datetime.fromtimestamp(int(source_date_epoch), timezone.utc)
+    except (OverflowError, OSError, ValueError) as error:
+        raise ValueError(
+            "SOURCE_DATE_EPOCH is outside the supported UTC range"
+        ) from error
+    return timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def git_commit_source_date_epoch(repo_root: Path, git_sha: str) -> str:
+    """Return the exact commit time for ``git_sha`` as SOURCE_DATE_EPOCH."""
+    if FULL_GIT_SHA.fullmatch(git_sha) is None:
+        raise ValueError("a full Git commit SHA is required for SOURCE_DATE_EPOCH")
+    try:
+        source_date_epoch = subprocess.check_output(
+            [
+                "git",
+                "--no-replace-objects",
+                "show",
+                "--no-patch",
+                "--format=%ct",
+                git_sha,
+            ],
+            cwd=repo_root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError(
+            f"could not resolve SOURCE_DATE_EPOCH for Git commit {git_sha}"
+        ) from error
+    build_timestamp_from_source_date_epoch(source_date_epoch)
+    return source_date_epoch
+
+
+def git_head_identity(repo_root: Path) -> str:
+    """Return the repository's exact HEAD commit SHA."""
+    try:
+        git_sha = subprocess.check_output(
+            ["git", "rev-parse", "--verify", "HEAD"],
+            cwd=repo_root,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError) as error:
+        raise ValueError("could not resolve the repository HEAD commit") from error
+    if FULL_GIT_SHA.fullmatch(git_sha) is None:
+        raise ValueError("repository HEAD is not a full Git commit SHA")
+    return git_sha
 
 
 def firmware_git_identity(

--- a/esp32/tools/generated_sdkconfig.py
+++ b/esp32/tools/generated_sdkconfig.py
@@ -14,13 +14,18 @@ import sys
 import tempfile
 from pathlib import Path
 
-from firmware_build_identity import FULL_GIT_SHA, firmware_git_identity
+from firmware_build_identity import (
+    FULL_GIT_SHA,
+    build_timestamp_from_source_date_epoch,
+    firmware_git_identity,
+    git_commit_source_date_epoch,
+)
 
 
 ENVIRONMENT_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
 GENERATED_BANNER = b"# Automatically generated file. DO NOT EDIT."
 GENERATED_DESCRIPTION = b"Project Configuration"
-CACHE_SCHEMA = 18
+CACHE_SCHEMA = 19
 FLASH_PLAN_SCHEMA = 2
 FLASH_PLAN_FILENAME = "open-bike-flash-plan.json"
 FLASH_PLAN_PORT_PLACEHOLDER = "__OPEN_BIKE_UPLOAD_PORT__"
@@ -1048,6 +1053,15 @@ def _cached_defaults_match(
     except GeneratedSdkconfigError:
         return False
     source_identity = current_source_identity(project_dir, environment)
+    try:
+        source_date_epoch = git_commit_source_date_epoch(
+            project_dir, source_identity
+        )
+        build_timestamp = build_timestamp_from_source_date_epoch(
+            source_date_epoch
+        )
+    except ValueError:
+        return False
     return (
         manifest.get("schema") == CACHE_SCHEMA
         and "environmentSdkconfigSha256" in manifest
@@ -1059,6 +1073,8 @@ def _cached_defaults_match(
         == WAVESHARE_PLATFORM_PACKAGES_SHA256
         and FULL_GIT_SHA.fullmatch(source_identity) is not None
         and manifest.get("sourceIdentity") == source_identity
+        and manifest.get("sourceDateEpoch") == source_date_epoch
+        and manifest.get("buildTimestamp") == build_timestamp
         and manifest.get("managedComponentsSha256") == managed_components_sha
         and manifest.get("libraryDependenciesSha256")
         == library_dependencies_sha
@@ -1260,6 +1276,17 @@ def record_generated_sdkconfig_defaults(
         if manifest_path.is_file() or manifest_path.is_symlink():
             manifest_path.unlink()
         return None
+    try:
+        source_date_epoch = git_commit_source_date_epoch(
+            project_dir, source_identity
+        )
+        build_timestamp = build_timestamp_from_source_date_epoch(
+            source_date_epoch
+        )
+    except ValueError as error:
+        raise GeneratedSdkconfigError(
+            f"could not derive the verified firmware build clock: {error}"
+        ) from error
     managed_components_sha = _managed_components_sha256(project_dir)
     library_dependencies_sha = _library_dependencies_sha256(
         project_dir, environment
@@ -1268,6 +1295,8 @@ def record_generated_sdkconfig_defaults(
     manifest = {
         "schema": CACHE_SCHEMA,
         "sourceIdentity": source_identity,
+        "sourceDateEpoch": source_date_epoch,
+        "buildTimestamp": build_timestamp,
         "managedComponentsSha256": managed_components_sha,
         "libraryDependenciesSha256": library_dependencies_sha,
         "sdkconfigDefaultsSha256": _file_sha256(defaults),

--- a/esp32/tools/resolve_upload_port.py
+++ b/esp32/tools/resolve_upload_port.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Resolve one USB serial device by its stable hardware serial number."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import sys
+import time
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from typing import Protocol
+
+
+class DeviceResolutionError(RuntimeError):
+    """Raised when a hardware serial cannot be mapped to exactly one port."""
+
+
+class PortInfo(Protocol):
+    device: str
+    serial_number: str | None
+    vid: int | None
+    pid: int | None
+    description: str | None
+
+
+@dataclass(frozen=True)
+class ResolvedDevice:
+    port: str
+    serial_number: str
+    vid: int | None
+    pid: int | None
+    description: str | None
+
+    def as_json(self) -> dict[str, object]:
+        return {
+            "schema": 1,
+            "port": self.port,
+            "serialNumber": self.serial_number,
+            "vid": self.vid,
+            "pid": self.pid,
+            "description": self.description,
+        }
+
+
+def _normalized_serial(value: str) -> str:
+    return value.strip().casefold()
+
+
+def resolve_device_port(
+    serial_number: str,
+    timeout_seconds: float,
+    *,
+    list_ports_provider: Callable[[], Iterable[PortInfo]] | None = None,
+    monotonic: Callable[[], float] = time.monotonic,
+    sleeper: Callable[[float], None] = time.sleep,
+    poll_interval_seconds: float = 0.25,
+) -> ResolvedDevice:
+    """Wait for exactly one port whose USB serial matches ``serial_number``."""
+    requested = serial_number.strip()
+    if (
+        not requested
+        or not requested.isprintable()
+        or "\0" in requested
+        or len(requested) > 255
+    ):
+        raise DeviceResolutionError("device serial must not be empty or invalid")
+    if not math.isfinite(timeout_seconds) or timeout_seconds < 0:
+        raise DeviceResolutionError("device timeout must be a finite nonnegative value")
+    if poll_interval_seconds <= 0:
+        raise DeviceResolutionError("device poll interval must be positive")
+
+    if list_ports_provider is None:
+        try:
+            from serial.tools import list_ports
+        except ImportError as error:
+            raise DeviceResolutionError(
+                "hardware-serial resolution requires pyserial"
+            ) from error
+        list_ports_provider = list_ports.comports
+
+    expected = _normalized_serial(requested)
+    deadline = monotonic() + timeout_seconds
+    while True:
+        matches = [
+            port
+            for port in list_ports_provider()
+            if port.serial_number is not None
+            and _normalized_serial(port.serial_number) == expected
+        ]
+        if len(matches) > 1:
+            ports = ", ".join(sorted(port.device for port in matches))
+            raise DeviceResolutionError(
+                f"device serial {requested!r} matched multiple ports: {ports}"
+            )
+        if len(matches) == 1:
+            match = matches[0]
+            port = str(match.device).strip()
+            if (
+                not port
+                or not port.isprintable()
+                or "\0" in port
+                or len(port) > 4096
+            ):
+                raise DeviceResolutionError(
+                    f"device serial {requested!r} resolved to an invalid port"
+                )
+            return ResolvedDevice(
+                port=port,
+                serial_number=str(match.serial_number),
+                vid=match.vid,
+                pid=match.pid,
+                description=match.description,
+            )
+        remaining = deadline - monotonic()
+        if remaining <= 0:
+            raise DeviceResolutionError(
+                f"device serial {requested!r} did not appear within "
+                f"{timeout_seconds:g} seconds"
+            )
+        sleeper(min(poll_interval_seconds, remaining))
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device-serial", required=True)
+    parser.add_argument("--timeout", type=float, default=60.0)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        resolved = resolve_device_port(args.device_serial, args.timeout)
+    except DeviceResolutionError as error:
+        print(f"Device resolution failed: {error}", file=sys.stderr)
+        return 1
+    print(json.dumps(resolved.as_json(), sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -25,7 +25,10 @@ from build_firmware import (
     main,
     upload_firmware,
 )
-from firmware_build_identity import firmware_git_identity
+from firmware_build_identity import (
+    build_timestamp_from_source_date_epoch,
+    firmware_git_identity,
+)
 from generated_sdkconfig import (
     FLASH_PLAN_APP_OFFSET_PLACEHOLDER,
     FLASH_PLAN_FILENAME,
@@ -600,11 +603,27 @@ class FirmwareBuildTests(unittest.TestCase):
         environment.write_text(GENERATED_CONFIG, encoding="utf-8")
         other.write_text(GENERATED_CONFIG, encoding="utf-8")
         calls = 0
+        expected_source_date_epoch = subprocess.check_output(
+            ["git", "show", "--no-patch", "--format=%ct", "HEAD"],
+            cwd=self.project_dir,
+            text=True,
+        ).strip()
+        observed_build_clocks = []
 
         def runner(command, cwd):
             nonlocal calls
             calls += 1
             self.assertEqual(os.environ.get("OPEN_BIKE_DETERMINISTIC_BUILD"), "1")
+            isolated_git_config = Path(os.environ["GIT_CONFIG_GLOBAL"])
+            self.assertEqual(isolated_git_config.read_text(encoding="utf-8"), "")
+            self.assertEqual(os.environ.get("GIT_CONFIG_NOSYSTEM"), "1")
+            self.assertEqual(os.environ.get("GIT_TERMINAL_PROMPT"), "0")
+            observed_build_clocks.append(
+                (
+                    os.environ.get("SOURCE_DATE_EPOCH"),
+                    os.environ.get("OPEN_BIKE_BUILD_TIMESTAMP"),
+                )
+            )
             if calls == 1:
                 self.assertFalse(defaults.exists())
                 self.assertFalse(environment.exists())
@@ -619,7 +638,9 @@ class FirmwareBuildTests(unittest.TestCase):
             return subprocess.CompletedProcess(command, 0)
 
         original = os.environ.get("OPEN_BIKE_DETERMINISTIC_BUILD")
+        original_source_date_epoch = os.environ.get("SOURCE_DATE_EPOCH")
         os.environ["OPEN_BIKE_DETERMINISTIC_BUILD"] = "original"
+        os.environ["SOURCE_DATE_EPOCH"] = "999"
         try:
             build_firmware(self.project_dir, self.environment, runner=runner)
         finally:
@@ -630,8 +651,25 @@ class FirmwareBuildTests(unittest.TestCase):
                 os.environ.pop("OPEN_BIKE_DETERMINISTIC_BUILD", None)
             else:
                 os.environ["OPEN_BIKE_DETERMINISTIC_BUILD"] = original
+            self.assertEqual(os.environ.get("SOURCE_DATE_EPOCH"), "999")
+            if original_source_date_epoch is None:
+                os.environ.pop("SOURCE_DATE_EPOCH", None)
+            else:
+                os.environ["SOURCE_DATE_EPOCH"] = original_source_date_epoch
 
         self.assertEqual(calls, 2)
+        self.assertEqual(
+            observed_build_clocks,
+            [
+                (
+                    expected_source_date_epoch,
+                    build_timestamp_from_source_date_epoch(
+                        expected_source_date_epoch
+                    ),
+                )
+            ]
+            * 2,
+        )
 
     def test_sequential_profiles_keep_second_build_identity_exact(self):
         full_sha = self.initialize_git_repo()

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -17,6 +17,7 @@ from unittest.mock import patch
 from build_firmware import (
     BuildError,
     WAVESHARE_PLATFORM_URL,
+    _resolved_device_port,
     _verified_platformio_project_config,
     _seed_pinned_scons_package,
     _print_provenance,
@@ -1250,6 +1251,159 @@ class FirmwareBuildTests(unittest.TestCase):
         self.assertEqual(result, 1)
         mocked_build.assert_called_once()
         self.assertIn("upload port must not be empty", errors.getvalue())
+
+    def test_cli_upload_only_skips_build_and_resolves_device_serial_late(self):
+        with patch("build_firmware.build_firmware") as mocked_build, patch(
+            "build_firmware.upload_firmware"
+        ) as mocked_upload:
+            result = main(
+                [
+                    self.environment,
+                    "--project-dir",
+                    str(self.project_dir),
+                    "--upload-only",
+                    "--device-serial",
+                    "3C:DC:75:6E:F0:10",
+                    "--device-timeout",
+                    "12.5",
+                ]
+            )
+
+        self.assertEqual(result, 0)
+        mocked_build.assert_not_called()
+        mocked_upload.assert_called_once_with(
+            self.project_dir,
+            self.environment,
+            None,
+            device_serial="3C:DC:75:6E:F0:10",
+            device_timeout=12.5,
+        )
+
+    def test_cli_upload_only_requires_a_device_selector(self):
+        errors = StringIO()
+        with patch("build_firmware.build_firmware") as mocked_build, patch(
+            "build_firmware.upload_firmware"
+        ) as mocked_upload, redirect_stderr(errors):
+            result = main(
+                [
+                    self.environment,
+                    "--project-dir",
+                    str(self.project_dir),
+                    "--upload-only",
+                ]
+            )
+
+        self.assertEqual(result, 1)
+        mocked_build.assert_not_called()
+        mocked_upload.assert_not_called()
+        self.assertIn("requires --upload-port or --device-serial", errors.getvalue())
+
+    def test_upload_device_serial_binds_the_resolved_port(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        calls = []
+
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+            with patch(
+                "build_firmware._resolved_device_port",
+                return_value="/dev/cu.renumbered",
+            ) as mocked_resolver:
+                upload_firmware(
+                    self.project_dir,
+                    self.environment,
+                    device_serial="3C:DC:75:6E:F0:10",
+                    device_timeout=7,
+                    runner=lambda command, cwd: (
+                        calls.append(tuple(command))
+                        or subprocess.CompletedProcess(command, 0)
+                    ),
+                )
+
+        mocked_resolver.assert_called_once()
+        self.assertEqual(len(calls), 1)
+        self.assertIn("/dev/cu.renumbered", calls[0])
+        self.assertNotIn(FLASH_PLAN_PORT_PLACEHOLDER, calls[0])
+
+    def test_failed_upload_keeps_attested_environment_retryable(self):
+        core = self.write_core_attestation()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        results = iter((2, 0))
+
+        def runner(command, cwd):
+            self.assertEqual(os.environ.get("PYTHONDONTWRITEBYTECODE"), "1")
+            return subprocess.CompletedProcess(command, next(results))
+
+        os.environ.pop("PYTHONDONTWRITEBYTECODE", None)
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+            with self.assertRaisesRegex(BuildError, "status 2"):
+                upload_firmware(
+                    self.project_dir,
+                    self.environment,
+                    "/dev/cu.missing",
+                    runner=runner,
+                )
+            upload_firmware(
+                self.project_dir,
+                self.environment,
+                "/dev/cu.returned",
+                runner=runner,
+            )
+
+        self.assertNotIn("PYTHONDONTWRITEBYTECODE", os.environ)
+
+    def test_private_device_resolver_output_is_validated(self):
+        core = self.write_core_attestation()
+        private_python = core / "penv/bin/python"
+        private_python.write_text("#!/bin/sh\n", encoding="utf-8")
+        private_python.chmod(0o755)
+        resolver = self.project_dir / "tools/resolve_upload_port.py"
+        resolver.parent.mkdir()
+        resolver.write_text("# resolver\n", encoding="utf-8")
+        manifest = {
+            "environment": self.environment,
+            "coreAttestation": {"coreDir": str(core.resolve())},
+        }
+        calls = []
+
+        def runner(command, **kwargs):
+            calls.append((tuple(command), kwargs))
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=json.dumps(
+                    {
+                        "schema": 1,
+                        "port": "/dev/cu.current",
+                        "serialNumber": "3c:dc:75:6e:f0:10",
+                    }
+                ),
+                stderr="",
+            )
+
+        port = _resolved_device_port(
+            self.project_dir,
+            manifest,
+            "3C:DC:75:6E:F0:10",
+            9,
+            runner=runner,
+        )
+
+        self.assertEqual(port, "/dev/cu.current")
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0][0][0], str(private_python.resolve()))
+        self.assertEqual(calls[0][0][-1], "9")
+        self.assertTrue(calls[0][1]["capture_output"])
+        self.assertTrue(calls[0][1]["text"])
 
     def test_refuses_unrecognized_sdkconfig_before_running_platformio(self):
         config = self.project_dir / f"sdkconfig.{self.environment}"

--- a/esp32/tools/tests/test_capture_boot.py
+++ b/esp32/tools/tests/test_capture_boot.py
@@ -7,12 +7,14 @@ from contextlib import redirect_stderr
 from capture_boot import (
     _EMPTY_RETAINED_HISTORY,
     _open_serial,
+    _resolve_port,
     cold_start_evidence,
     format_summary,
     main,
     summarize,
     validation_errors,
 )
+from resolve_upload_port import ResolvedDevice
 
 
 HEALTHY_CAPTURE = """
@@ -41,6 +43,51 @@ DISPLAY_RECOVERY_CAPTURE = HEALTHY_CAPTURE.replace(
 
 
 class CaptureBootTests(unittest.TestCase):
+    def test_hardware_serial_resolution_uses_current_port(self) -> None:
+        calls: list[tuple[str, float]] = []
+
+        def resolve(serial_number: str, timeout_seconds: float) -> ResolvedDevice:
+            calls.append((serial_number, timeout_seconds))
+            return ResolvedDevice(
+                port="/dev/cu.current",
+                serial_number=serial_number,
+                vid=0x303A,
+                pid=0x1001,
+                description="USB JTAG/serial debug unit",
+            )
+
+        self.assertEqual(
+            _resolve_port(
+                None,
+                45.0,
+                device_serial="3c:dc:75:6e:f0:10",
+                device_resolver=resolve,
+            ),
+            "/dev/cu.current",
+        )
+        self.assertEqual(calls, [("3c:dc:75:6e:f0:10", 45.0)])
+
+    def test_capture_port_rejects_invalid_wait(self) -> None:
+        for wait_seconds in (-1.0, float("nan"), float("inf")):
+            with self.subTest(wait_seconds=wait_seconds):
+                with self.assertRaisesRegex(RuntimeError, "finite nonnegative"):
+                    _resolve_port("/dev/cu.test", wait_seconds)
+
+    def test_capture_cli_rejects_two_port_selectors(self) -> None:
+        stderr = io.StringIO()
+        with redirect_stderr(stderr):
+            with self.assertRaises(SystemExit) as error:
+                main(
+                    [
+                        "--port",
+                        "/dev/cu.test",
+                        "--device-serial",
+                        "3c:dc:75:6e:f0:10",
+                    ]
+                )
+        self.assertEqual(error.exception.code, 2)
+        self.assertIn("not allowed with argument", stderr.getvalue())
+
     def test_usb_empty_history_plus_confirmation_validates_cold_start(self) -> None:
         summary = summarize(USB_COLD_CAPTURE)
         self.assertEqual(cold_start_evidence(summary), "usb_empty_history")

--- a/esp32/tools/tests/test_firmware_build_identity.py
+++ b/esp32/tools/tests/test_firmware_build_identity.py
@@ -1,11 +1,16 @@
 from __future__ import annotations
 
+import os
 import subprocess
 import tempfile
 import unittest
 from pathlib import Path
 
-from firmware_build_identity import firmware_git_identity
+from firmware_build_identity import (
+    build_timestamp_from_source_date_epoch,
+    firmware_git_identity,
+    git_commit_source_date_epoch,
+)
 
 
 class FirmwareBuildIdentityTests(unittest.TestCase):
@@ -33,6 +38,44 @@ class FirmwareBuildIdentityTests(unittest.TestCase):
 
             source.write_text("dirty\n", encoding="utf-8")
             self.assertEqual(firmware_git_identity(root), f"dirty-{full_sha}")
+
+    def test_commit_time_is_a_stable_source_date_epoch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.git(root, "init", "-q")
+            self.git(root, "config", "user.email", "test@example.invalid")
+            self.git(root, "config", "user.name", "Test")
+            (root / "firmware.cpp").write_text("clean\n", encoding="utf-8")
+            self.git(root, "add", "firmware.cpp")
+            environment = dict(os.environ)
+            environment.update(
+                {
+                    "GIT_AUTHOR_DATE": "2024-04-05T19:34:38Z",
+                    "GIT_COMMITTER_DATE": "2024-04-05T19:34:38Z",
+                }
+            )
+            subprocess.run(
+                ["git", "commit", "-qm", "candidate"],
+                cwd=root,
+                env=environment,
+                check=True,
+            )
+
+            full_sha = self.git(root, "rev-parse", "HEAD")
+            source_date_epoch = git_commit_source_date_epoch(root, full_sha)
+            self.assertEqual(source_date_epoch, "1712345678")
+            self.assertEqual(
+                build_timestamp_from_source_date_epoch(source_date_epoch),
+                "2024-04-05T19:34:38Z",
+            )
+
+    def test_source_date_epoch_validation_fails_closed(self):
+        for invalid in ("", "-1", "+1", "01", "1.5", "not-a-time"):
+            with self.subTest(invalid=invalid):
+                with self.assertRaisesRegex(ValueError, "canonical nonnegative"):
+                    build_timestamp_from_source_date_epoch(invalid)
+        with self.assertRaisesRegex(ValueError, "full Git commit SHA"):
+            git_commit_source_date_epoch(Path.cwd(), "dirty")
 
     def test_allows_only_explicit_generated_untracked_paths(self):
         with tempfile.TemporaryDirectory() as directory:

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -27,6 +27,8 @@ def inherited_option(section: str, option: str) -> str:
 prebuild_source = (project_dir / "prebuild.py").read_text()
 assert "-DBUILD_PROFILE=" in prebuild_source
 assert "OPEN_BIKE_EXPECTED_GIT_SHA" in prebuild_source
+assert "SOURCE_DATE_EPOCH" in prebuild_source
+assert "build_timestamp_from_source_date_epoch" in prebuild_source
 assert 'git_sha = f"unverified-{detected_git_sha}"' in prebuild_source
 assert "Waveshare firmware builds must use tools/build_firmware.py" in prebuild_source
 assert 'env.subst("$PROJECT_LIBDEPS_DIR")' in prebuild_source

--- a/esp32/tools/tests/test_generated_sdkconfig.py
+++ b/esp32/tools/tests/test_generated_sdkconfig.py
@@ -37,6 +37,12 @@ class GeneratedSdkconfigTests(unittest.TestCase):
         )
         self.source_identity_patch.start()
         self.addCleanup(self.source_identity_patch.stop)
+        self.source_date_epoch_patch = patch(
+            "generated_sdkconfig.git_commit_source_date_epoch",
+            return_value="1712345678",
+        )
+        self.source_date_epoch_mock = self.source_date_epoch_patch.start()
+        self.addCleanup(self.source_date_epoch_patch.stop)
         self.tracked_patch = patch(
             "generated_sdkconfig._is_tracked", return_value=False
         )
@@ -155,6 +161,35 @@ class GeneratedSdkconfigTests(unittest.TestCase):
                         record_generated_sdkconfig_defaults(
                             project, "WAVESHARE_AMOLED_175"
                         )
+                    )
+
+    def test_manifest_attests_the_git_derived_build_clock(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            project = Path(directory)
+            defaults = project / "sdkconfig.defaults"
+            (project / "platformio.ini").write_text(
+                "[env:WAVESHARE_AMOLED_175]\nplatform = test\n",
+                encoding="utf-8",
+            )
+            defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+            with self.fake_core(project):
+                manifest_path = record_generated_sdkconfig_defaults(
+                    project, "WAVESHARE_AMOLED_175"
+                )
+                manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+                self.assertEqual(manifest["schema"], 19)
+                self.assertEqual(manifest["sourceDateEpoch"], "1712345678")
+                self.assertEqual(
+                    manifest["buildTimestamp"], "2024-04-05T19:34:38Z"
+                )
+
+                self.source_date_epoch_mock.return_value = "1712345679"
+                with self.assertRaisesRegex(
+                    GeneratedSdkconfigError, "custom-core state changed"
+                ):
+                    require_validated_generated_sdkconfig_defaults(
+                        project, "WAVESHARE_AMOLED_175"
                     )
 
     def test_uploader_mode_change_invalidates_recorded_core(self) -> None:

--- a/esp32/tools/tests/test_resolve_upload_port.py
+++ b/esp32/tools/tests/test_resolve_upload_port.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+
+import json
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from resolve_upload_port import (
+    DeviceResolutionError,
+    main,
+    resolve_device_port,
+)
+
+
+def port(device, serial_number, *, vid=0x303A, pid=0x1001):
+    return SimpleNamespace(
+        device=device,
+        serial_number=serial_number,
+        vid=vid,
+        pid=pid,
+        description="USB JTAG/serial debug unit",
+    )
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self):
+        return self.now
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+class ResolveUploadPortTests(unittest.TestCase):
+    def test_waits_for_hardware_serial_and_returns_current_port(self):
+        scans = iter(
+            (
+                [port("/dev/cu.other", "28:84:85:3B:75:98")],
+                [port("/dev/cu.usbmodem901", "3c:dc:75:6e:f0:10")],
+            )
+        )
+        clock = FakeClock()
+
+        resolved = resolve_device_port(
+            "3C:DC:75:6E:F0:10",
+            5,
+            list_ports_provider=lambda: next(scans),
+            monotonic=clock.monotonic,
+            sleeper=clock.sleep,
+            poll_interval_seconds=0.5,
+        )
+
+        self.assertEqual(resolved.port, "/dev/cu.usbmodem901")
+        self.assertEqual(resolved.serial_number, "3c:dc:75:6e:f0:10")
+        self.assertEqual(clock.now, 0.5)
+
+    def test_rejects_duplicate_hardware_serials(self):
+        with self.assertRaisesRegex(DeviceResolutionError, "multiple ports"):
+            resolve_device_port(
+                "duplicate",
+                0,
+                list_ports_provider=lambda: [
+                    port("/dev/cu.one", "duplicate"),
+                    port("/dev/cu.two", "DUPLICATE"),
+                ],
+            )
+
+    def test_timeout_names_the_missing_hardware_serial(self):
+        clock = FakeClock()
+        with self.assertRaisesRegex(
+            DeviceResolutionError, "missing.*within 1 seconds"
+        ):
+            resolve_device_port(
+                "missing",
+                1,
+                list_ports_provider=lambda: [],
+                monotonic=clock.monotonic,
+                sleeper=clock.sleep,
+                poll_interval_seconds=0.25,
+            )
+
+    def test_cli_emits_machine_readable_resolution(self):
+        output = StringIO()
+        with patch(
+            "resolve_upload_port.resolve_device_port",
+            return_value=resolve_device_port(
+                "serial",
+                0,
+                list_ports_provider=lambda: [port("/dev/cu.test", "serial")],
+            ),
+        ), redirect_stdout(output):
+            result = main(["--device-serial", "serial", "--timeout", "3"])
+
+        self.assertEqual(result, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["schema"], 1)
+        self.assertEqual(payload["port"], "/dev/cu.test")
+
+    def test_cli_reports_resolution_failure(self):
+        errors = StringIO()
+        with patch(
+            "resolve_upload_port.resolve_device_port",
+            side_effect=DeviceResolutionError("not connected"),
+        ), redirect_stderr(errors):
+            result = main(["--device-serial", "serial", "--timeout", "0"])
+
+        self.assertEqual(result, 1)
+        self.assertIn("not connected", errors.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a supported `--upload-only` path that revalidates and flashes an existing attested build without recompiling
- resolve upload and boot-capture ports from a stable USB hardware serial so ESP32-S3 re-enumeration cannot switch devices
- keep the attested private uploader environment retryable by suppressing Python bytecode writes
- derive verified firmware build time from the exact Git commit and export it as `SOURCE_DATE_EPOCH`, making clean rebuilds byte-reproducible
- isolate dependency Git operations from ambient user/system configuration so URL rewrites cannot change transport or inputs
- document the workflow and `BOOT_META built=` semantics in `AGENTS.md`, the firmware README, and the contributor guide

## Root cause

The verified upload wrapper always entered the clean build path before flashing, even when a complete attested artifact already existed. A transient cable or bootloader failure therefore forced another full compile. Port paths were also treated as durable even though ESP32-S3 USB CDC names can change across reconnects. Finally, esptool imports could write `.pyc` files into the attested private Python environment after a failed upload, changing its tree hash and invalidating an otherwise unchanged retry.

Verified builds also stamped wall-clock time into the firmware. Two builds of the same clean commit could therefore produce different binaries. The wrapper now derives both `SOURCE_DATE_EPOCH` and the embedded ISO UTC build timestamp from the exact commit's committer time, validates that identity end-to-end, and records both values in provenance.

## Impact

Fresh firmware uploads still perform the full clean build and attestation. A retry can now use `--upload-only`; it still fails closed if the Git identity, profile, generated configuration, toolchain, flash plan, or any image changes, but it skips recompilation. The same hardware serial can be used for `capture_boot.py` so the post-flash `BOOT_META` proof stays bound to the intended physical board.

For verified builds, `BOOT_META built=` now means the source commit time rather than the workstation compile time. Rebuilding the same exact commit with the same attested inputs produces the same firmware bytes.

## Validation

- two independent clean `WAVESHARE_AMOLED_206` builds from `3c9418e9237f16151e19fe5652d34773305173b9` produced byte-identical firmware, ELF, bootloader, partition table, and flash plan
- firmware SHA-256 in both builds: `24a5a7d8d65132a085637d8f07fe33079324c402b37c03d17c7c14b7886247c4`
- both builds reported `sourceDateEpoch=1785680946` and `buildTimestamp=2026-08-02T14:29:06Z`
- `PYTHONPATH=tools python -m unittest discover -s tools/tests -p 'test_*.py'` — 159 tests passed
- `python -m py_compile esp32/tools/build_firmware.py esp32/tools/firmware_build_identity.py esp32/tools/generated_sdkconfig.py esp32/prebuild.py`
- `git diff --check`

No firmware image was physically reflashed by this tooling-only PR.
