### PR TITLE
Prevent map activation task allocation failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,7 @@ jobs:
             tools/tests/test_device_transfer_http_limits.cpp \
             -o /tmp/test_device_transfer_http_limits
           /tmp/test_device_transfer_http_limits
+          python -m unittest tools.tests.test_map_activation_handoff
       - name: Sound protocol host tests
         run: |
           g++ -std=c++17 \

--- a/esp32/lib/map_transfer_http/map_transfer_http.cpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.cpp
@@ -323,7 +323,7 @@ bool MapTransferHttpServer::handleRequest(
   if (request.method == "PUT" &&
       handlePut(request, client))
     return true;
-  if (request.method == "POST" && handleActivate(request.path, client))
+  if (request.method == "POST" && handleActivate(request, client))
     return true;
   return false;
 }
@@ -344,6 +344,11 @@ void MapTransferHttpServer::responseDidComplete(
   if (!transferServer_->isRequestAuthorized(request)) {
     Serial.printf("MAP_TRANSFER_HTTP: deferred activation revoked session=%s\n",
                   deferred.sessionId.c_str());
+    if (deferred.activationAlreadyBegun) {
+      finishActivation("failed", "", "transfer_cancelled",
+                       "activation authorization was revoked before the "
+                       "response completed");
+    }
     return;
   }
 
@@ -820,11 +825,11 @@ bool MapTransferHttpServer::handlePut(
   return true;
 }
 
-bool MapTransferHttpServer::handleActivate(const std::string &path,
-                                           WiFiClient &client) {
+bool MapTransferHttpServer::handleActivate(
+    const device_transfer::HttpRequest &request, WiFiClient &client) {
   std::string sessionId;
   std::string action;
-  if (!parseSessionPath(path, sessionId, action))
+  if (!parseSessionPath(request.path, sessionId, action))
     return false;
   if (action != "activate")
     return false;
@@ -857,9 +862,13 @@ bool MapTransferHttpServer::handleActivate(const std::string &path,
     return true;
   }
 
-  if (!startActivationTask(sessionId, false)) {
-    sendError(client, 500, "activation_task",
-              "could not start activation task");
+  if (!deferActivationUntilResponse(request, sessionId, false,
+                                    activationSequence, true, false)) {
+    finishActivation("failed", "", "activation_handoff",
+                     "activation could not be deferred until the response "
+                     "completed");
+    sendError(client, 500, "activation_handoff",
+              "activation could not be deferred until the response completed");
     return true;
   }
   sendJson(client, 202, activatingResponse());
@@ -1243,7 +1252,8 @@ bool MapTransferHttpServer::startActivationTask(const std::string &sessionId,
 
 bool MapTransferHttpServer::deferActivationUntilResponse(
     const device_transfer::HttpRequest &request, const std::string &sessionId,
-    bool streamProtocol, uint32_t minimumSequence) {
+    bool streamProtocol, uint32_t minimumSequence,
+    bool activationAlreadyBegun, bool automaticExitOnCleanResponse) {
   lockState();
   if (deferredActivation_.pending()) {
     unlockState();
@@ -1254,18 +1264,23 @@ bool MapTransferHttpServer::deferActivationUntilResponse(
   deferredActivation_.sessionId = sessionId;
   deferredActivation_.minimumSequence = minimumSequence;
   deferredActivation_.streamProtocol = streamProtocol;
+  deferredActivation_.activationAlreadyBegun = activationAlreadyBegun;
+  deferredActivation_.automaticExitOnCleanResponse =
+      automaticExitOnCleanResponse;
   unlockState();
   return true;
 }
 
 void MapTransferHttpServer::beginDeferredActivation(
-    const DeferredActivation &activation, bool automaticExit) {
+    const DeferredActivation &activation, bool peerClosedCleanly) {
   lockState();
-  const ActivationBeginResult beginResult =
-      activation.streamProtocol
-          ? activationState_.begin(activation.sessionId, 3,
-                                   activation.minimumSequence)
-          : activationState_.begin(activation.sessionId);
+  ActivationBeginResult beginResult = ActivationBeginResult::Started;
+  if (!activation.activationAlreadyBegun) {
+    beginResult = activation.streamProtocol
+                      ? activationState_.begin(activation.sessionId, 3,
+                                               activation.minimumSequence)
+                      : activationState_.begin(activation.sessionId);
+  }
   if (beginResult == ActivationBeginResult::Started) {
     if (activation.streamProtocol)
       activationState_.updateProgress({3, 3, 0, 1});
@@ -1274,8 +1289,14 @@ void MapTransferHttpServer::beginDeferredActivation(
   unlockState();
 
   if (beginResult == ActivationBeginResult::Started) {
-    startActivationTask(activation.sessionId, automaticExit,
-                        activation.streamProtocol);
+    // responseDidComplete runs on the existing 16 KiB transfer worker after
+    // the upload handler and stream parser have unwound. Activation needs the
+    // same stack budget, so execute it here instead of allocating a second
+    // 16 KiB task at the firmware's peak map-transfer memory watermark.
+    const bool automaticExit = activation.automaticExitOnCleanResponse &&
+                               peerClosedCleanly;
+    executeActivation(activation.sessionId, automaticExit,
+                      activation.streamProtocol);
     return;
   }
   if (beginResult == ActivationBeginResult::AlreadyInstalled) {
@@ -1289,7 +1310,7 @@ void MapTransferHttpServer::beginDeferredActivation(
       setLastError("staging_cleanup",
                    "could not remove redundant installed archive");
     }
-    if (automaticExit)
+    if (activation.automaticExitOnCleanResponse && peerClosedCleanly)
       requestAutomaticExit();
     return;
   }
@@ -1297,6 +1318,24 @@ void MapTransferHttpServer::beginDeferredActivation(
     setLastError("activation_busy",
                  "another map activation started after upload completion");
   }
+}
+
+void MapTransferHttpServer::executeActivation(const std::string &sessionId,
+                                              bool automaticExit,
+                                              bool streamProtocol) {
+  power_management::ScopedLock powerLock(
+      power_management::LockDomain::Transfer);
+  const bool waitingForRenderer =
+      streamProtocol ? runStreamActivationTask(sessionId, automaticExit)
+                     : runActivationTask(sessionId, automaticExit);
+  if (waitingForRenderer)
+    return;
+  if (!streamProtocol && !installer_.clearPendingArchiveActivation()) {
+    setLastError("activation_marker",
+                 "could not clear pending archive activation");
+  }
+  if (automaticExit)
+    requestAutomaticExit();
 }
 
 bool MapTransferHttpServer::runStreamActivationTask(
@@ -1408,35 +1447,16 @@ bool MapTransferHttpServer::runActivationTask(const std::string &sessionId,
 }
 
 void MapTransferHttpServer::activationTaskThunk(void *arg) {
-  {
-    power_management::ScopedLock powerLock(
-        power_management::LockDomain::Transfer);
-    auto *context = static_cast<ActivationTaskContext *>(arg);
-    if (context != nullptr && context->server != nullptr) {
-      MapTransferHttpServer *server = context->server;
-      std::string sessionId = context->sessionId;
-      const bool automaticExit = context->automaticExit;
-      const bool streamProtocol = context->streamProtocol;
-      delete context;
-      bool waitingForRenderer = false;
-      if (streamProtocol)
-        waitingForRenderer =
-            server->runStreamActivationTask(sessionId, automaticExit);
-      else
-        waitingForRenderer =
-            server->runActivationTask(sessionId, automaticExit);
-      if (!waitingForRenderer) {
-        if (!streamProtocol &&
-            !server->installer_.clearPendingArchiveActivation()) {
-          server->setLastError("activation_marker",
-                               "could not clear pending archive activation");
-        }
-        if (automaticExit)
-          server->requestAutomaticExit();
-      }
-    } else {
-      delete context;
-    }
+  auto *context = static_cast<ActivationTaskContext *>(arg);
+  if (context != nullptr && context->server != nullptr) {
+    MapTransferHttpServer *server = context->server;
+    std::string sessionId = context->sessionId;
+    const bool automaticExit = context->automaticExit;
+    const bool streamProtocol = context->streamProtocol;
+    delete context;
+    server->executeActivation(sessionId, automaticExit, streamProtocol);
+  } else {
+    delete context;
   }
   vTaskDelete(nullptr);
 }

--- a/esp32/lib/map_transfer_http/map_transfer_http.hpp
+++ b/esp32/lib/map_transfer_http/map_transfer_http.hpp
@@ -63,6 +63,8 @@ private:
     std::string sessionId;
     uint32_t minimumSequence = 0;
     bool streamProtocol = false;
+    bool activationAlreadyBegun = false;
+    bool automaticExitOnCleanResponse = true;
 
     bool pending() const { return !sessionId.empty(); }
   };
@@ -77,7 +79,8 @@ private:
   bool handleInstallStream(const device_transfer::HttpRequest &request,
                            WiFiClient &client);
   bool handleHead(const std::string &path, WiFiClient &client);
-  bool handleActivate(const std::string &path, WiFiClient &client);
+  bool handleActivate(const device_transfer::HttpRequest &request,
+                      WiFiClient &client);
   void handleStatus(WiFiClient &client);
   void sendHead(WiFiClient &client, int status, uint64_t contentLength = 0);
   bool sendJson(WiFiClient &client, int status, const std::string &body);
@@ -93,10 +96,14 @@ private:
                            bool streamProtocol = false);
   bool deferActivationUntilResponse(
       const device_transfer::HttpRequest &request, const std::string &sessionId,
-      bool streamProtocol, uint32_t minimumSequence = 0);
+      bool streamProtocol, uint32_t minimumSequence = 0,
+      bool activationAlreadyBegun = false,
+      bool automaticExitOnCleanResponse = true);
   void beginDeferredActivation(const DeferredActivation &activation,
-                               bool automaticExit);
+                               bool peerClosedCleanly);
   void requestAutomaticExit();
+  void executeActivation(const std::string &sessionId, bool automaticExit,
+                         bool streamProtocol);
   bool runActivationTask(const std::string &sessionId, bool automaticExit);
   bool runStreamActivationTask(const std::string &sessionId,
                                bool automaticExit);

--- a/esp32/tools/tests/test_map_activation_handoff.py
+++ b/esp32/tools/tests/test_map_activation_handoff.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import unittest
+from pathlib import Path
+
+
+PROJECT_DIR = Path(__file__).resolve().parents[2]
+SOURCE = (
+    PROJECT_DIR / "lib/map_transfer_http/map_transfer_http.cpp"
+).read_text(encoding="utf-8")
+HEADER = (
+    PROJECT_DIR / "lib/map_transfer_http/map_transfer_http.hpp"
+).read_text(encoding="utf-8")
+
+
+def method_body(name: str) -> str:
+    marker = f"MapTransferHttpServer::{name}"
+    start = SOURCE.index(marker)
+    opening = SOURCE.index("{", start)
+    depth = 0
+    for index in range(opening, len(SOURCE)):
+        if SOURCE[index] == "{":
+            depth += 1
+        elif SOURCE[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return SOURCE[opening : index + 1]
+    raise AssertionError(f"unterminated method body for {name}")
+
+
+class MapActivationHandoffTests(unittest.TestCase):
+    def test_response_completion_reuses_transfer_worker(self):
+        body = method_body("beginDeferredActivation")
+        self.assertIn("executeActivation(", body)
+        self.assertNotIn("startActivationTask(", body)
+        self.assertNotIn("xTaskCreate(", body)
+
+    def test_explicit_activation_also_crosses_response_boundary(self):
+        body = method_body("handleActivate")
+        self.assertIn("deferActivationUntilResponse(", body)
+        self.assertNotIn("startActivationTask(", body)
+        self.assertNotIn("xTaskCreate(", body)
+
+    def test_dedicated_task_is_reserved_for_boot_recovery(self):
+        self.assertEqual(SOURCE.count("startActivationTask("), 3)
+        self.assertIn(
+            "startActivationTask(",
+            method_body("resumePendingArchiveActivation"),
+        )
+        self.assertIn(
+            "startActivationTask(",
+            method_body("resumePendingStreamActivation"),
+        )
+
+    def test_inline_and_recovery_paths_share_activation_execution(self):
+        self.assertIn(
+            "executeActivation(", method_body("beginDeferredActivation")
+        )
+        self.assertIn("executeActivation(", method_body("activationTaskThunk"))
+
+    def test_deferred_state_records_response_semantics(self):
+        self.assertIn("bool activationAlreadyBegun = false;", HEADER)
+        self.assertIn("bool automaticExitOnCleanResponse = true;", HEADER)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- defer explicit map activation until the HTTP response boundary, matching automatic upload activation
- run HTTP-triggered activation on the existing 16 KiB transfer worker instead of allocating a second 16 KiB FreeRTOS task at peak transfer memory
- keep dedicated activation tasks for boot recovery, and share one activation execution path
- add CI invariants preventing the response-completion path from reintroducing task allocation

## Root cause

On the connected WAVESHARE_AMOLED_175, the production map upload completed all 5,821,335 bytes with HTTP 200, then activation failed with `activation_task`. The response-completion path still had the 16 KiB `device_http` worker alive while attempting to create a second 16 KiB `map_activate` task. That allocation failed before map installation could begin.

## Validation

- `python3 -m unittest tools.tests.test_map_activation_handoff`
- device transfer HTTP limit host tests
- map transfer host tests
- transfer control dispatch host tests
- map transfer status chunk session host tests
- full `WAVESHARE_AMOLED_175` firmware build via `tools/build_firmware.py`
- `git diff --check`

Physical re-validation is pending PR review and explicit approval before flashing.
