### PR TITLE
Make map stream hardware matrix optional

### DIFF
--- a/docs/map-stream-hardware-validation-report.example.json
+++ b/docs/map-stream-hardware-validation-report.example.json
@@ -22,6 +22,6 @@
     "approved": false,
     "approvedAt": "",
     "approvedBy": "",
-    "notes": "Copy this file outside the repository, record every required run with approved=false, review the complete matrix, then set approved=true and an approval timestamp later than every run before invoking the checker."
+    "notes": "The hardware matrix is optional manual evidence. Add any runs you performed, review the exact candidate identities and known observations, then set approved=true before invoking the checker."
   }
 }

--- a/docs/map-stream-rollout-runbook.md
+++ b/docs/map-stream-rollout-runbook.md
@@ -18,9 +18,9 @@ Four independent gates must agree before protocol v2 is used:
 4. Firmware advertises v2 only when SD/recovery initialization succeeds and
    the same compiled trust registry is non-empty.
 
-The checked-in trust registry and promotion registry are intentionally empty
-until hardware validation. Empty or invalid configuration fails closed and
-keeps ZIP/protocol-v1 compatibility available.
+The checked-in promotion registry remains empty until an operator explicitly
+approves an exact candidate identity. Empty or invalid configuration fails
+closed and keeps ZIP/protocol-v1 compatibility available.
 
 ## Commission a signing key
 
@@ -103,11 +103,11 @@ promotion record. It still requires valid installation credentials. Check
 `/healthz`; it reports the mode and allowlist count but never IDs or secrets.
 
 Copy `docs/map-stream-hardware-validation-report.example.json` to a protected
-test-results location outside the repository. Record every scenario in
-`map-platform/config/map-stream-hardware-gate.json` for both production targets. Shanghai
-clean installs require three repetitions per target. The per-board absolute
-temperature ceilings live in that reviewed requirements file; a report cannot
-raise its own limit after results are known.
+test-results location outside the repository. The scenarios in
+`map-platform/config/map-stream-hardware-gate.json` are an optional manual
+validation matrix. They do not block promotion when `matrixMode` is `optional`.
+Operators should record the checks they can measure and summarize any informal
+device observations in the approval notes.
 
 Each run records phase times, payload bytes, SD bytes written, durable bytes
 rewritten, retry bytes skipped, maximum temperature, recovery outcome, UI
@@ -122,10 +122,11 @@ or a mutable deployment label. Every stream run enforces bounded integer byte
 counters and a reviewed write-amplification ceiling; clean scenarios require
 exactly one payload write, and interruption scenarios require nonzero
 durable-prefix skipping where their interruption point guarantees one. Every
-candidate signing key must appear on both hardware targets. The checker rejects
-missing repetitions, unexercised or untrusted keys, duplicate runs, excess SD
-writes, thermal violations, failed recovery assertions, and Shanghai
-regressions:
+candidate signing key should be exercised on both hardware targets when the
+complete matrix is performed. Every recorded run is still checked strictly: the
+checker rejects duplicate runs, excess SD writes, thermal violations, failed
+recovery assertions, identity substitutions, and Shanghai regressions. It does
+not require missing scenarios or repetitions while the matrix is optional:
 
 ```json
 "observed": {
@@ -156,9 +157,10 @@ python map-platform/backend/tools/check_map_stream_hardware_gate.py \
   --promotion-id msr-20260713-first-production
 ```
 
-First record all required runs with `approval.approved=false`. After review,
-set the approval timestamp later than every run and identify the approver; then
-run the checker. When the report passes and its approval is explicit, the
+Keep `approval.approved=false` while gathering any optional runs. After review,
+set the approval timestamp later than every recorded run and identify the
+approver; a report with no runs is valid when the matrix is optional. When the
+report passes and its approval is explicit, the
 command prints a hash-bound public approval object. Add that object to
 `map-platform/config/map-stream-rollout-approvals.json` in a reviewed PR. Do not commit the
 raw report if it contains device or operator data. The record binds the report
@@ -185,7 +187,7 @@ present in the checked-in approval registry. The approval PR is expected to be
 later than the tested source commit; that control-plane-only change does not
 alter the derived worker component identity. Keep the worker image anchor in
 `map-platform/deploy/compose.yaml` on the exact
-`registry/repository@sha256:<digest>` reference exercised by the hardware report
+`registry/repository@sha256:<digest>` reference bound by the approval report
 and deploy it without rebuilding it. The production lock passes that value as
 both the worker service image and the API/worker admission identity; the
 promotion CI policy must verify the image platform and `main`-branch provenance
@@ -261,7 +263,8 @@ For a suspected signing-key compromise:
 4. Add and ship a replacement public key before resuming generation.
 5. Remove the compromised public key only after affected immutable artifacts
    are quarantined and paused device sessions are explicitly invalidated.
-6. Run the complete hardware gate again and create a new promotion record.
+6. Create a new exact-identity approval record; repeat any relevant optional
+   manual checks before resuming.
 
 Key rotation, emergency revocation, and rollout changes are separate reviewed
 changes. V1 retirement is also a separate decision after the compatibility and

--- a/map-platform/backend/README.md
+++ b/map-platform/backend/README.md
@@ -147,16 +147,18 @@ Supply map-signing secrets only to the worker service. The Internet-facing API
 does not load the private key, and inline API workers are disabled in production
 with `MAP_PLATFORM_INLINE_WORKER_ENABLED=0`.
 
-Keep `MAP_PLATFORM_MAP_STREAM_ENABLED=0` until the complete firmware and iOS v2
-path passes the rollout acceptance gate. When it is set to `1`, missing or
-invalid signing configuration fails closed; the backend never emits an unsigned
-stream artifact.
+Keep `MAP_PLATFORM_MAP_STREAM_ENABLED=0` until the firmware and iOS v2 path is
+ready for explicit operator approval. The hardware matrix is optional manual
+evidence; exact worker, signing-key, app, and firmware identities remain
+mandatory. When generation is set to `1`, missing or invalid signing
+configuration fails closed; the backend never emits an unsigned stream artifact.
 
 Street-label target-2 job creation has an independent fail-closed gate:
-`MAP_PLATFORM_LABEL_TARGET2_ENABLED=0` is the default. Enable it only in the
-hardware-validation environment, then for approved production identities after
-both Waveshare targets pass the target-2 acceptance matrix. Disabling the gate
-does not remove or invalidate existing artifacts; it prevents new target-2 jobs.
+`MAP_PLATFORM_LABEL_TARGET2_ENABLED=0` is the default. Enable it first for
+allowlisted validation installations, then for explicitly approved production
+identities. The two-board acceptance matrix is available as optional manual
+evidence rather than a deployment prerequisite. Disabling the gate does not
+remove or invalidate existing artifacts; it prevents new target-2 jobs.
 
 Signed artifact generation and client delivery are separate controls. The API
 defaults `MAP_PLATFORM_MAP_STREAM_ROLLOUT_MODE` to `disabled`. Use `allowlist`

--- a/map-platform/backend/map_platform/map_stream_hardware_requirements.py
+++ b/map-platform/backend/map_platform/map_stream_hardware_requirements.py
@@ -17,6 +17,7 @@ GIT_SHA_PATTERN = re.compile(r"[0-9a-f]{40}")
 IOS_BUILD_PATTERN = re.compile(r"[0-9]{1,18}(?:\.[0-9]{1,18}){0,2}")
 UINT32_MAX = (1 << 32) - 1
 MAXIMUM_SCENARIO_REPETITIONS = 10
+MATRIX_MODES = frozenset({"required", "optional"})
 
 
 @dataclass(frozen=True)
@@ -42,6 +43,9 @@ def parse_hardware_requirements(data: bytes) -> HardwareRequirementsDocument:
         data,
         description="map stream hardware requirements",
     )
+    schema_version = (
+        document.get("schemaVersion") if isinstance(document, dict) else None
+    )
     expected_fields = {
         "schemaVersion",
         "targets",
@@ -58,13 +62,17 @@ def parse_hardware_requirements(data: bytes) -> HardwareRequirementsDocument:
         "maximumShanghaiTemperatureRegressionC",
         "maximumTemperatureCByTarget",
     }
+    if schema_version == 2:
+        expected_fields.add("matrixMode")
     if not isinstance(document, dict) or set(document) != expected_fields:
         raise ValueError("map stream hardware requirements have invalid fields")
     if (
         type(document["schemaVersion"]) is not int
-        or document["schemaVersion"] != 1
+        or document["schemaVersion"] not in {1, 2}
     ):
         raise ValueError("unsupported map stream hardware requirements schema")
+    if schema_version == 2 and document["matrixMode"] not in MATRIX_MODES:
+        raise ValueError("hardware matrix mode must be required or optional")
     if document["targets"] != list(PRODUCTION_TARGETS):
         raise ValueError("hardware requirements must cover both production targets")
     scenarios = document["scenarios"]

--- a/map-platform/backend/tests/test_map_stream_hardware_gate.py
+++ b/map-platform/backend/tests/test_map_stream_hardware_gate.py
@@ -153,6 +153,8 @@ class MapStreamHardwareGateTests(unittest.TestCase):
 
     def test_checked_in_requirements_are_complete_and_valid(self):
         requirements = load_requirements()
+        self.assertEqual(requirements["schemaVersion"], 2)
+        self.assertEqual(requirements["matrixMode"], "optional")
         self.assertEqual(
             requirements["targets"],
             ["WAVESHARE_AMOLED_175", "WAVESHARE_AMOLED_206"],
@@ -176,6 +178,48 @@ class MapStreamHardwareGateTests(unittest.TestCase):
                     parse_hardware_requirements(
                         json.dumps(document).encode("utf-8")
                     )
+
+    def test_optional_matrix_accepts_an_explicit_approval_without_runs(self):
+        requirements = self.requirements()
+        requirements["schemaVersion"] = 2
+        requirements["matrixMode"] = "optional"
+        report = self.valid_report()
+        report["runs"] = []
+        report["approval"]["notes"] = "manual hardware matrix intentionally omitted"
+
+        validated = validate_report(
+            self.write_report(report),
+            requirements,
+            self.trusted_keys(),
+        )
+        self.assertEqual(validated["runs"], [])
+
+    def test_required_matrix_remains_the_schema_one_default(self):
+        report = self.valid_report()
+        report["runs"] = []
+        with self.assertRaisesRegex(ValueError, "does not exactly cover"):
+            validate_report(
+                self.write_report(report),
+                self.requirements(),
+                self.trusted_keys(),
+            )
+
+    def test_requirements_reject_unknown_matrix_modes(self):
+        requirements = load_requirements()
+        requirements["matrixMode"] = "advisory-ish"
+        with self.assertRaisesRegex(ValueError, "matrix mode"):
+            parse_hardware_requirements(
+                json.dumps(requirements).encode("utf-8")
+            )
+
+        report = self.valid_report()
+        report["runs"] = []
+        with self.assertRaisesRegex(ValueError, "matrix mode"):
+            validate_report(
+                self.write_report(report),
+                requirements,
+                self.trusted_keys(),
+            )
 
     def test_hostile_depth_and_numeric_overflow_are_controlled_rejections(self):
         deeply_nested = "[" * 10_000 + "0" + "]" * 10_000

--- a/map-platform/backend/tools/check_map_stream_hardware_gate.py
+++ b/map-platform/backend/tools/check_map_stream_hardware_gate.py
@@ -175,6 +175,10 @@ def validate_report_bytes(
             "hardware report uses signing material absent from production trust"
         )
 
+    matrix_mode = requirements.get("matrixMode", "required")
+    if matrix_mode not in {"required", "optional"}:
+        raise ValueError("hardware matrix mode must be required or optional")
+    matrix_required = matrix_mode == "required"
     runs = report["runs"]
     if not isinstance(runs, list):
         raise ValueError("hardware report runs must be an array")
@@ -445,28 +449,29 @@ def validate_report_bytes(
                 + requirements["maximumShanghaiTemperatureRegressionC"]
             ):
                 raise ValueError(f"hardware run {index} misses the thermal comparison gate")
-    for target in requirements["targets"]:
-        for scenario, repetitions in requirements["scenarios"].items():
-            expected_identities = {
-                (target, scenario, repetition)
-                for repetition in range(1, repetitions + 1)
-            }
-            actual_identities = {
-                identity
-                for identity in identities
-                if identity[0] == target and identity[1] == scenario
-            }
-            if actual_identities != expected_identities:
+    if matrix_required:
+        for target in requirements["targets"]:
+            for scenario, repetitions in requirements["scenarios"].items():
+                expected_identities = {
+                    (target, scenario, repetition)
+                    for repetition in range(1, repetitions + 1)
+                }
+                actual_identities = {
+                    identity
+                    for identity in identities
+                    if identity[0] == target and identity[1] == scenario
+                }
+                if actual_identities != expected_identities:
+                    raise ValueError(
+                        f"hardware report does not exactly cover {target} {scenario} repetitions"
+                    )
+        required_targets = set(requirements["targets"])
+        for signing_key in signing_keys:
+            key = (signing_key["keyId"], signing_key["publicKeySha256"])
+            if signing_key_targets.get(key, set()) != required_targets:
                 raise ValueError(
-                    f"hardware report does not exactly cover {target} {scenario} repetitions"
+                    f"hardware report did not exercise signing key {signing_key['keyId']} on both targets"
                 )
-    required_targets = set(requirements["targets"])
-    for signing_key in signing_keys:
-        key = (signing_key["keyId"], signing_key["publicKeySha256"])
-        if signing_key_targets.get(key, set()) != required_targets:
-            raise ValueError(
-                f"hardware report did not exercise signing key {signing_key['keyId']} on both targets"
-            )
 
     approval = report["approval"]
     if not isinstance(approval, dict) or set(approval) != {

--- a/map-platform/config/map-stream-hardware-gate.json
+++ b/map-platform/config/map-stream-hardware-gate.json
@@ -1,5 +1,6 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "matrixMode": "optional",
   "targets": [
     "WAVESHARE_AMOLED_175",
     "WAVESHARE_AMOLED_206"


### PR DESCRIPTION
## Summary

- Introduce requirements schema v2 with an explicit `matrixMode`.
- Configure the complete hardware scenario matrix as optional manual evidence.
- Preserve strict validation for every voluntarily recorded run and retain exact worker, artifact, signing-key, firmware, iOS, report, requirements, and operator-approval binding.
- Update the runbook and report template to describe zero-run explicit approvals honestly.

## Validation

- 225 map-platform backend tests passed (1 skipped)
- 36 deployment tests passed
- `check_map_stream_hardware_gate.py --validate-requirements`
- `git diff --check`

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.

Legal entity represented, if any: none