### PR TITLE
Allow an explicit 100% map-stream cohort

### DIFF
--- a/docs/map-stream-rollout-runbook.md
+++ b/docs/map-stream-rollout-runbook.md
@@ -177,7 +177,7 @@ Production delivery modes are:
 
 - `disabled`: default; no installation receives `.bmap` metadata.
 - `allowlist`: exact registered test installations only; no promotion record.
-- `percentage`: stable HMAC cohort from 1 to 9,999 basis points; requires a
+- `percentage`: stable HMAC cohort from 1 to 10,000 basis points; requires a
   committed promotion ID and a stable 32-byte-or-longer cohort secret.
 - `all`: every valid registered installation; requires a committed promotion
   ID.

--- a/map-platform/backend/map_platform/map_stream_rollout.py
+++ b/map-platform/backend/map_platform/map_stream_rollout.py
@@ -196,9 +196,9 @@ class MapStreamRolloutPolicy:
         if mode == MapStreamRolloutMode.ALLOWLIST and not allowlist_values:
             raise ValueError("allowlist rollout mode requires at least one installation ID")
         if mode == MapStreamRolloutMode.PERCENTAGE:
-            if not 1 <= basis_points < ROLLOUT_BUCKETS:
+            if not 1 <= basis_points <= ROLLOUT_BUCKETS:
                 raise ValueError(
-                    "percentage rollout mode requires basis points between 1 and 9999"
+                    "percentage rollout mode requires basis points between 1 and 10000"
                 )
             if len(cohort_secret) < 32:
                 raise ValueError(

--- a/map-platform/backend/tests/test_map_stream_rollout.py
+++ b/map-platform/backend/tests/test_map_stream_rollout.py
@@ -140,6 +140,23 @@ class MapStreamRolloutPolicyTests(unittest.TestCase):
         self.assertLess(len(first), len(expanded))
         self.assertNotIn(secret, repr(low))
 
+    def test_percentage_at_100_percent_includes_every_valid_installation(self):
+        promotion_id = "msr-20260713-percentage-full"
+        policy = self.policy(
+            approved_promotions={promotion_id: approval(promotion_id)},
+            MAP_PLATFORM_MAP_STREAM_ROLLOUT_MODE="percentage",
+            MAP_PLATFORM_MAP_STREAM_ROLLOUT_BASIS_POINTS="10000",
+            MAP_PLATFORM_MAP_STREAM_ROLLOUT_SECRET=(
+                "stable-map-stream-rollout-secret-32-bytes"
+            ),
+            MAP_PLATFORM_MAP_STREAM_PROMOTION_ID=promotion_id,
+        )
+
+        self.assertTrue(policy.includes(INSTALLATION_A))
+        self.assertTrue(policy.includes(INSTALLATION_B))
+        self.assertFalse(policy.includes("bad"))
+        self.assertEqual(policy.public_summary()["basisPoints"], 10_000)
+
     def test_all_mode_requires_a_valid_registered_installation_shape(self):
         policy = self.policy(
             approved_promotions={


### PR DESCRIPTION
## Summary
- allow percentage rollout mode to accept all 10,000 stable HMAC buckets
- keep `all` as the distinct final delivery mode
- document and test the 100% observation gate

## Verification
- `uv run --extra test python -m unittest discover -s tests -p 'test_*.py'` (226 passed, 1 skipped)\n- `git diff --check`