### PR TITLE
Prepare firmware 0.3.2 release

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.3.1
-revision = 90
+version = 0.3.2
+revision = 91
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
## Summary
- bump firmware metadata to version 0.3.2, revision 91
- prepare the merged 3D-building firmware for the tag-driven production release workflow

## Validation
- PYTHONPATH=tools python -m unittest discover -s tools/tests -p 'test_*.py' (177 tests)\n- production target builds are running locally from the attested wrapper\n\n## Release notes\n- After merge, push tag v0.3.2 to build and publish signed 1.75-inch and 2.06-inch firmware artifacts.