### PR TITLE
Fix firmware release environment

### DIFF
--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
-        run: python tools/build_firmware.py "${{ matrix.environment }}"
+        run: env -u LD_LIBRARY_PATH python tools/build_firmware.py "${{ matrix.environment }}"
       - name: Stage firmware image
         run: |
           mkdir -p dist


### PR DESCRIPTION
## Summary
- remove GitHub Actions setup-python's LD_LIBRARY_PATH override before invoking the attested firmware wrapper
- allow both production release targets to reach the pinned build and publish stages

## Validation
- YAML parse passed
- git diff --check passed
- release wrapper tests passed on the preceding release commit

## Root cause
The wrapper intentionally rejects source-affecting ambient overrides. GitHub setup-python exports LD_LIBRARY_PATH, so both v0.3.2 release build jobs failed before PlatformIO started.