### PR TITLE
Prepare Bicino 1.3 iOS release

### DIFF
--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -1,8 +1,8 @@
 # Watch workout companion release notes
 
-Release candidate: **1.1 (7)**. App Store version 1.0 is already distributed,
-and App Store Connect already contains builds through 5, so both the marketing
-version and build number must advance for this release.
+Release candidate: **1.3 (10)**. App Store version 1.2 is already distributed,
+and App Store Connect already contains builds through 9, so both the marketing
+version and build number advance for this release.
 
 ## App Store What's New
 
@@ -25,7 +25,7 @@ navigation requires iOS 16.4 or later.
 
 ## App Review notes
 
-BikeComputer includes a companion Apple Watch app. The Watch is the sole owner
+Bicino includes a companion Apple Watch app. The Watch is the sole owner
 and writer of outdoor cycling workouts. The iPhone uses Apple's workout-session
 mirroring APIs for display and remote controls and never saves a duplicate
 workout.
@@ -33,10 +33,10 @@ workout.
 To test:
 
 1. Install the iPhone build and its embedded Watch app on a paired Watch.
-2. Open BikeComputer on Watch, select **Set Up Health**, and grant workout and
+2. Open Bicino on Watch, select **Set Up Health**, and grant workout and
    location access.
 3. Select **Start Ride**.
-4. Open BikeComputer on iPhone to view the same live workout and use mirrored
+4. Open Bicino on iPhone to view the same live workout and use mirrored
    pause, resume, save, discard, or segment controls. Lock the iPhone to review
    the Live Activity and authenticate a Segment or Pause/Resume action.
 5. End that workout, then select **Start workout** on iPhone. With the Watch
@@ -54,7 +54,7 @@ and actual outdoor movement.
 
 The Live Activity is created after a verified Watch snapshot while the iPhone
 app is foreground. If a ride starts from Watch while iPhone is backgrounded,
-foreground BikeComputer once to create it. Active workout metrics may remain
+foreground Bicino once to create it. Active workout metrics may remain
 visible on the Lock Screen and Always-On display. Dismissing or disabling the
 Live Activity has no effect on the Watch-owned workout, and no Live Activity
 content is sent to a backend.

--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -770,12 +770,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputer/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -786,7 +787,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -813,12 +814,13 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputer/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -829,7 +831,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -853,17 +855,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = BikeComputerWatch/BikeComputerWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -885,17 +887,17 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = BikeComputerWatch/BikeComputerWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatch/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -917,7 +919,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
@@ -927,7 +929,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp.complications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -948,7 +950,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
@@ -958,7 +960,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.watchkitapp.complications;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -980,18 +982,18 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1014,18 +1016,18 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 7;
+				CURRENT_PROJECT_VERSION = 10;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = BikeComputer;
+				INFOPLIST_KEY_CFBundleDisplayName = Bicino;
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.1;
+				MARKETING_VERSION = 1.3;
 				PRODUCT_BUNDLE_IDENTIFIER = LetItRide.BikeComputer.WorkoutLiveActivity;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -76,7 +76,7 @@ class AppDelegate: NSObject, UIApplicationDelegate {
                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         
         // Configure for background location updates
-        print("BikeComputer app launched")
+        print("Bicino app launched")
         _ = coordinator
         workoutMirrorManager.installMirroringHandler()
         if #available(iOS 17.0, *) {

--- a/ios-app/BikeComputer/BikeComputer/Info.plist
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Bicino</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSSupportsLiveActivities</key>
@@ -15,32 +17,32 @@
 
 	<!-- Location Permissions -->
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>BikeComputer needs background location access to start and continue navigation from your bike computer and track rides while the app is not visible.</string>
+	<string>Bicino needs background location access to start and continue navigation from your bike computer and track rides while the app is not visible.</string>
 	
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>BikeComputer needs your location to provide turn-by-turn navigation.</string>
+	<string>Bicino needs your location to provide turn-by-turn navigation.</string>
 	
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>BikeComputer needs background location access to start or continue navigation from your bike computer when the app is not visible.</string>
+	<string>Bicino needs background location access to start or continue navigation from your bike computer when the app is not visible.</string>
 
 	<!-- Bluetooth Permission -->
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>BikeComputer uses Bluetooth to connect to your ESP32 bike computer display.</string>
+	<string>Bicino uses Bluetooth to connect to your ESP32 bike computer display.</string>
 
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>BikeComputer uses Bluetooth to communicate with your bike computer display.</string>
+	<string>Bicino uses Bluetooth to communicate with your bike computer display.</string>
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>BikeComputer connects to your bike computer over local Wi-Fi to transfer offline maps.</string>
+	<string>Bicino connects to your bike computer over local Wi-Fi to transfer offline maps.</string>
 	<key>NSHealthShareUsageDescription</key>
-	<string>BikeComputer receives live workout metrics from your Apple Watch and can read your completed BikeComputer workout summary.</string>
+	<string>Bicino receives live workout metrics from your Apple Watch and can read your completed Bicino workout summary.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>BikeComputer allows cycling workouts started on your Apple Watch to be saved to HealthKit.</string>
+	<string>Bicino allows cycling workouts started on your Apple Watch to be saved to HealthKit.</string>
 
 	<!-- Location Accuracy -->
 	<key>NSLocationTemporaryUsageDescriptionDictionary</key>
 	<dict>
 		<key>Navigation</key>
-		<string>BikeComputer needs precise location for accurate turn-by-turn navigation.</string>
+			<string>Bicino needs precise location for accurate turn-by-turn navigation.</string>
 	</dict>
 	
 	<!-- Supported Interface Orientations -->

--- a/ios-app/BikeComputer/BikeComputer/Info.plist.template
+++ b/ios-app/BikeComputer/BikeComputer/Info.plist.template
@@ -2,13 +2,15 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>Bicino</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>NSSupportsLiveActivities</key>
 	<true/>
 
 	<!-- 
-	Info.plist Configuration Template for BikeComputer
+		Info.plist Configuration Template for Bicino
 	
 	IMPORTANT: Copy these entries to your Info.plist or configure in Xcode:
 	1. Select your target
@@ -18,23 +20,23 @@
 	
 	<!-- Location Permissions -->
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
-	<string>BikeComputer needs your location to provide turn-by-turn navigation while you ride.</string>
+	<string>Bicino needs your location to provide turn-by-turn navigation while you ride.</string>
 	
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>BikeComputer needs your location to provide turn-by-turn navigation.</string>
+	<string>Bicino needs your location to provide turn-by-turn navigation.</string>
 	
 	<key>NSLocationAlwaysUsageDescription</key>
-	<string>BikeComputer needs background location access to continue navigation when the app is not visible.</string>
+	<string>Bicino needs background location access to continue navigation when the app is not visible.</string>
 
 	<!-- Bluetooth Permission -->
 	<key>NSBluetoothAlwaysUsageDescription</key>
-	<string>BikeComputer uses Bluetooth to connect to your ESP32 bike computer display.</string>
+	<string>Bicino uses Bluetooth to connect to your ESP32 bike computer display.</string>
 	
 	<key>NSBluetoothPeripheralUsageDescription</key>
-	<string>BikeComputer uses Bluetooth to communicate with your bike computer display.</string>
+	<string>Bicino uses Bluetooth to communicate with your bike computer display.</string>
 
 	<key>NSLocalNetworkUsageDescription</key>
-	<string>BikeComputer connects to your bike computer over local Wi-Fi to transfer offline maps.</string>
+	<string>Bicino connects to your bike computer over local Wi-Fi to transfer offline maps.</string>
 	
 	<!-- Background Modes -->
 	<key>UIBackgroundModes</key>
@@ -47,7 +49,7 @@
 	<key>NSLocationTemporaryUsageDescriptionDictionary</key>
 	<dict>
 		<key>Navigation</key>
-		<string>BikeComputer needs precise location for accurate turn-by-turn navigation.</string>
+			<string>Bicino needs precise location for accurate turn-by-turn navigation.</string>
 	</dict>
 	
 	<!-- Supported Interface Orientations -->

--- a/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/WorkoutLiveActivityController.swift
@@ -743,7 +743,7 @@ final class WorkoutLiveActivityController {
             cancelPendingMetricUpdate()
             reportIssue(
                 "Live Activity unavailable: iOS reports that Live Activities "
-                    + "are disabled for BikeComputer."
+                    + "are disabled for Bicino."
             )
             return
         }

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -24,7 +24,7 @@ struct ConnectionStatusView: View {
                         radius: 4
                     )
 
-                Text("BikeComputer")
+                Text("Bicino")
                     .font(.caption)
                     .foregroundColor(.primary)
                     .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
@@ -34,7 +34,7 @@ struct ConnectionStatusView: View {
         }
         .buttonStyle(.plain)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityLabel(isConnected ? "BikeComputer connected" : "Reconnect BikeComputer")
+        .accessibilityLabel(isConnected ? "Bicino connected" : "Reconnect Bicino")
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/CyclingSensorsSettingsView.swift
@@ -13,7 +13,7 @@ struct CyclingSensorProfilesSection: View {
                 VStack(alignment: .leading, spacing: 6) {
                     Label("No Sensors", systemImage: "gauge")
                     Text(
-                        "Add a sensor after BikeComputer receives cadence or power data from your Apple Watch."
+                        "Add a sensor after Bicino receives cadence or power data from your Apple Watch."
                     )
                     .font(.footnote)
                     .foregroundStyle(.secondary)
@@ -118,7 +118,7 @@ struct CyclingSensorConnectionSection: View {
         if detectionCoordinator.hasActiveWorkout {
             return "Keep pedaling so Apple Watch continues receiving cadence or power data."
         }
-        return "On Apple Watch, pair the sensor in Settings > Bluetooth > Health Devices. Wake the sensor, then start a BikeComputer cycling workout."
+        return "On Apple Watch, pair the sensor in Settings > Bluetooth > Health Devices. Wake the sensor, then start a Bicino cycling workout."
     }
 }
 
@@ -286,13 +286,13 @@ private struct CyclingSensorEnrollmentSheet: View {
                     }
                 } footer: {
                     Text(
-                        "Apple Watch keeps managing the Bluetooth connection. This choice controls which BikeComputer workout stats are shown."
+                        "Apple Watch keeps managing the Bluetooth connection. This choice controls which Bicino workout stats are shown."
                     )
                 }
 
                 Section {
                     Label(
-                        "BikeComputer detected \(candidate.capabilities.displayName.lowercased()) data during the current workout.",
+                        "Bicino detected \(candidate.capabilities.displayName.lowercased()) data during the current workout.",
                         systemImage: "applewatch.radiowaves.left.and.right"
                     )
                     .font(.footnote)
@@ -383,7 +383,7 @@ private struct CyclingSensorDetailView: View {
                     }
                 } footer: {
                     Text(
-                        "Forgetting removes this BikeComputer profile. It does not unpair the sensor from Apple Watch."
+                        "Forgetting removes this Bicino profile. It does not unpair the sensor from Apple Watch."
                     )
                 }
                 .confirmationDialog(

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
@@ -218,7 +218,7 @@ private extension OfflineMapOnboardingStep {
     var message: String {
         switch self {
         case .location:
-            return "Bike Computer needs your current location to prepare the right offline map."
+            return "Bicino needs your current location to prepare the right offline map."
         case .device:
             return "Connect your Bike Computer before downloading its first map."
         case .checkingDevice:

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1576,7 +1576,7 @@ private struct DeveloperSettingsView: View {
                 Text("Workout Heart Zones")
             } footer: {
                 Text(
-                    "BikeComputer calculates five heart zones from this value and syncs it to the paired Watch. The default is 190 BPM."
+                    "Bicino calculates five heart zones from this value and syncs it to the paired Watch. The default is 190 BPM."
                 )
             }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutViews.swift
@@ -20,11 +20,11 @@ private enum WorkoutStartAvailabilityAlert: String, Identifiable {
     var message: String {
         switch self {
         case .unsupported:
-            return "Starting a workout from iPhone requires iOS 17 or later and the BikeComputer app on Apple Watch."
+            return "Starting a workout from iPhone requires iOS 17 or later and the Bicino app on Apple Watch."
         case .activationFailed:
-            return "BikeComputer couldn’t check your Apple Watch. Make sure Bluetooth and Wi-Fi are on, then try again."
+            return "Bicino couldn’t check your Apple Watch. Make sure Bluetooth and Wi-Fi are on, then try again."
         case .noPairedWatch:
-            return "You need the BikeComputer app on an Apple Watch to start tracking your workout. Pair an Apple Watch with this iPhone first."
+            return "You need the Bicino app on an Apple Watch to start tracking your workout. Pair an Apple Watch with this iPhone first."
         }
     }
 }
@@ -746,7 +746,7 @@ struct WorkoutDashboardView: View {
             VStack(spacing: 10) {
                 if presentation.errorCode == .setupRequired
                     || presentation.errorCode == .authorizationDenied {
-                    Text("On Apple Watch, open BikeComputer and tap Set Up Health. If needed, use Watch Settings › Health › Apps › BikeComputer.")
+                    Text("On Apple Watch, open Bicino and tap Set Up Health. If needed, use Watch Settings › Health › Apps › Bicino.")
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
@@ -767,7 +767,7 @@ struct WorkoutDashboardView: View {
                 .multilineTextAlignment(.center)
         } else if presentation.connectionState == .disconnected {
             VStack(spacing: 10) {
-                Text("No verified workout state was received. Check BikeComputer on Apple Watch; if no ride is active there, try again.")
+                Text("No verified workout state was received. Check Bicino on Apple Watch; if no ride is active there, try again.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -787,7 +787,7 @@ struct WorkoutDashboardView: View {
                 .multilineTextAlignment(.center)
         } else if presentation.isWorkoutActive {
             if !store.supportsSegmentMarking {
-                Text("Update BikeComputer on Apple Watch to mark segments from iPhone.")
+                Text("Update Bicino on Apple Watch to mark segments from iPhone.")
                     .font(.footnote)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)

--- a/ios-app/BikeComputer/BikeComputerWatch/Info.plist
+++ b/ios-app/BikeComputer/BikeComputerWatch/Info.plist
@@ -24,10 +24,10 @@
 		<string>workout-processing</string>
 	</array>
 	<key>NSHealthShareUsageDescription</key>
-	<string>BikeComputer reads live cycling metrics from Apple Watch and connected cycling sensors during your workout.</string>
+	<string>Bicino reads live cycling metrics from Apple Watch and connected cycling sensors during your workout.</string>
 	<key>NSHealthUpdateUsageDescription</key>
-	<string>BikeComputer saves the cycling workouts and routes that you start in the BikeComputer Watch app.</string>
+	<string>Bicino saves the cycling workouts and routes that you start in the Bicino Watch app.</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>BikeComputer records your outdoor ride route and uses location for speed and elevation when cycling sensors are unavailable.</string>
+	<string>Bicino records your outdoor ride route and uses location for speed and elevation when cycling sensors are unavailable.</string>
 </dict>
 </plist>

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
@@ -55,7 +55,7 @@ struct WorkoutStartView: View {
             }
         } message: {
             Text(
-                "This may abandon an unfinished ride. BikeComputer will preserve the damaged recovery file for diagnosis before resetting setup."
+                "This may abandon an unfinished ride. Bicino will preserve the damaged recovery file for diagnosis before resetting setup."
             )
         }
     }
@@ -87,7 +87,7 @@ struct WorkoutStartView: View {
             .tint(.green)
             .disabled(manager.state == .failed)
         case .denied:
-            Text("BikeComputer can’t start a workout without permission to save workouts in Health.")
+            Text("Bicino can’t start a workout without permission to save workouts in Health.")
                 .font(.caption)
                 .multilineTextAlignment(.center)
             Button("Check Again") {
@@ -99,7 +99,7 @@ struct WorkoutStartView: View {
                 .multilineTextAlignment(.center)
         case .failed:
             if manager.hasCorruptRecoveryState {
-                Text("BikeComputer found damaged workout recovery data. Setup is blocked to protect a possible unfinished ride.")
+                Text("Bicino found damaged workout recovery data. Setup is blocked to protect a possible unfinished ride.")
                     .font(.caption)
                     .multilineTextAlignment(.center)
                 Button("Recover Setup") {

--- a/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
@@ -49,7 +49,7 @@ private struct StartRideComplicationView: View {
                         .font(.title2)
                         .widgetAccentable()
                     VStack(alignment: .leading, spacing: 1) {
-                        Text("BikeComputer")
+                        Text("Bicino")
                             .font(.headline)
                         Text("Start Ride")
                             .font(.caption)
@@ -72,7 +72,7 @@ private struct StartRideComplicationView: View {
             Color.clear
         }
         .widgetURL(WatchWorkoutLaunchRequest.startOutdoorCyclingURL)
-        .accessibilityLabel("Start a BikeComputer ride")
+        .accessibilityLabel("Start a Bicino ride")
     }
 }
 
@@ -84,7 +84,7 @@ private struct StartRideComplication: Widget {
             StartRideComplicationView()
         }
         .configurationDisplayName("Start Ride")
-        .description("Start an outdoor cycling workout in BikeComputer.")
+        .description("Start an outdoor cycling workout in Bicino.")
         .supportedFamilies([
             .accessoryCircular,
             .accessoryRectangular,

--- a/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
+++ b/ios-app/BikeComputer/WorkoutLiveActivityShared/WorkoutLiveActivityIntents.swift
@@ -62,7 +62,7 @@ enum WorkoutLiveActivityIntentExecution {
 struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Mark Workout Segment"
     static let description = IntentDescription(
-        "Marks a segment in the active BikeComputer workout."
+        "Marks a segment in the active Bicino workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =
@@ -94,7 +94,7 @@ struct BikeComputerMarkSegmentIntent: LiveActivityIntent {
 struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Pause Workout"
     static let description = IntentDescription(
-        "Pauses the active BikeComputer workout."
+        "Pauses the active Bicino workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =
@@ -126,7 +126,7 @@ struct BikeComputerPauseWorkoutIntent: LiveActivityIntent {
 struct BikeComputerResumeWorkoutIntent: LiveActivityIntent {
     static let title: LocalizedStringResource = "Resume Workout"
     static let description = IntentDescription(
-        "Resumes the paused BikeComputer workout."
+        "Resumes the paused Bicino workout."
     )
     static let openAppWhenRun = false
     static let authenticationPolicy: IntentAuthenticationPolicy =

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift
@@ -233,32 +233,32 @@ nonisolated enum WorkoutErrorCopyV1 {
     ) -> String {
         switch code {
         case .authorizationDenied, .setupRequired:
-            return "Open BikeComputer on Apple Watch and allow Health access, then try again."
+            return "Open Bicino on Apple Watch and allow Health access, then try again."
         case .anotherWorkoutActive:
             return "Another app may now own the workout session. Check your Apple Watch before starting or resuming a ride."
         case .watchUnavailable:
             switch context {
             case .activeWorkout:
-                return "Keep your paired Apple Watch nearby, unlocked, and wearing BikeComputer. A current workout continues on Watch."
+                return "Keep your paired Apple Watch nearby, unlocked, and wearing Bicino. A current workout continues on Watch."
             case .workoutLaunch:
-                return "BikeComputer could not reach Apple Watch, so the workout did not start. Open BikeComputer on Watch and try again."
+                return "Bicino could not reach Apple Watch, so the workout did not start. Open Bicino on Watch and try again."
             case .general:
-                return "BikeComputer could not communicate with Apple Watch. Check BikeComputer on Watch and verify the workout state."
+                return "Bicino could not communicate with Apple Watch. Check Bicino on Watch and verify the workout state."
             }
         case .finalSummaryUnavailable:
-            return "Apple Watch reported that the ride ended, but the final saved or discarded result was not received. Check BikeComputer on Watch or Health before dismissing."
+            return "Apple Watch reported that the ride ended, but the final saved or discarded result was not received. Check Bicino on Watch or Health before dismissing."
         case .terminalChoiceConflict:
             return "Apple Watch had already committed the other finish choice. The saved or discarded result shown above is authoritative."
         case .terminalChoiceUnconfirmed:
-            return "BikeComputer could not confirm whether your Save or Discard choice was applied. Check BikeComputer on Apple Watch; if the ride ended, verify the result in Health."
+            return "Bicino could not confirm whether your Save or Discard choice was applied. Check Bicino on Apple Watch; if the ride ended, verify the result in Health."
         case .segmentMarkFailed:
             return "Apple Watch couldn’t add that segment to the workout. The ride is still running, so you can try again."
         case .segmentMarkUnconfirmed:
             return "Apple Watch is still confirming that segment. You can pause or end the ride, but wait before marking another segment."
         case .segmentFinalizationPending:
-            return "Open BikeComputer on Apple Watch to retry the pending segment or save the ride anyway."
+            return "Open Bicino on Apple Watch to retry the pending segment or save the ride anyway."
         case .sessionFailed, .unknown, nil:
-            return "Check BikeComputer on Apple Watch. No workout is saved or ended by iPhone alone."
+            return "Check Bicino on Apple Watch. No workout is saved or ended by iPhone alone."
         }
     }
 

--- a/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift
@@ -853,18 +853,18 @@ nonisolated enum WorkoutCrossAppTakeoverCopyV1 {
     static func live(disposition: WorkoutFinishDisposition) -> String {
         switch disposition {
         case .save:
-            "Another workout app took over. BikeComputer is saving the partial ride."
+            "Another workout app took over. Bicino is saving the partial ride."
         case .discard:
-            "Another workout app took over. BikeComputer is discarding the partial ride as requested."
+            "Another workout app took over. Bicino is discarding the partial ride as requested."
         }
     }
 
     static func summary(disposition: WorkoutFinishDisposition) -> String {
         switch disposition {
         case .save:
-            "Another workout app took over. This is the partial BikeComputer ride saved before the handoff."
+            "Another workout app took over. This is the partial Bicino ride saved before the handoff."
         case .discard:
-            "Another workout app took over. The partial BikeComputer ride was discarded as requested."
+            "Another workout app took over. The partial Bicino ride was discarded as requested."
         }
     }
 }

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -5289,7 +5289,7 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             terminalDetail.contains("Save or Discard")
-                && terminalDetail.contains("Check BikeComputer on Apple Watch"),
+                && terminalDetail.contains("Check Bicino on Apple Watch"),
             "terminal uncertainty should tell the rider what was not confirmed and where to check"
         )
         expect(
@@ -5829,13 +5829,13 @@ private struct WorkoutContractTestSuite {
         )
         expect(
             compactIPhoneConfirmation.contains(
-                "YouneedtheBikeComputerapponanAppleWatchtostarttrackingyourworkout"
+                "YouneedtheBicinoapponanAppleWatchtostarttrackingyourworkout"
             )
                 && compactIPhoneConfirmation.contains(
                     ".alert(item:$presentedAlert)"
                 )
                 && !iPhoneConfirmationComponent.contains(
-                    "Install BikeComputer on Apple Watch"
+                    "Install Bicino on Apple Watch"
                 ),
             "iPhone must keep paired-Watch guidance without blocking on a stale companion-install flag"
         )

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -1566,7 +1566,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertEqual(
             diagnostics.issueMessage,
             "Live Activity unavailable: iOS reports that Live Activities "
-                + "are disabled for BikeComputer."
+                + "are disabled for Bicino."
         )
     }
 

--- a/ios-app/PRIVACY_POLICY.md
+++ b/ios-app/PRIVACY_POLICY.md
@@ -1,14 +1,14 @@
-# Bike Computer 2.0 Privacy Policy
+# Bicino Privacy Policy
 
 Effective date: July 19, 2026
 
-Bike Computer 2.0 is a cycling navigation and workout companion. This policy
+Bicino is a cycling navigation and workout companion. This policy
 explains what information the iPhone app, Apple Watch app, compatible bike
 computer hardware, and optional offline-map service use.
 
 ## Accounts, advertising, and analytics
 
-Bike Computer 2.0 does not require an account. We do not sell personal data,
+Bicino does not require an account. We do not sell personal data,
 use advertising SDKs, track you across other companies' apps or websites, or
 use third-party analytics SDKs.
 

--- a/ios-app/scripts/tests/test_verify_release_container.py
+++ b/ios-app/scripts/tests/test_verify_release_container.py
@@ -42,6 +42,7 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             plistlib.dump(
                 {
                     "CFBundleIdentifier": "LetItRide.BikeComputer",
+                    "CFBundleDisplayName": "Bicino",
                     "NSSupportsLiveActivities": True,
                 },
                 handle,
@@ -50,6 +51,7 @@ class ReleaseContainerVerifierTests(unittest.TestCase):
             plistlib.dump(
                 {
                     "CFBundleIdentifier": "LetItRide.BikeComputer.watchkitapp",
+                    "CFBundleDisplayName": "Bicino",
                     "CFBundleURLTypes": [
                         {"CFBundleURLSchemes": ["another-scheme"]},
                         {"CFBundleURLSchemes": ["bikecomputer"]},

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -93,13 +93,13 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
                 with self.subTest(
                     target=target_name, configuration=configuration_name
                 ):
-                    self.assertIn("CURRENT_PROJECT_VERSION = 7;", settings)
-                    self.assertIn("MARKETING_VERSION = 1.1;", settings)
+                    self.assertIn("CURRENT_PROJECT_VERSION = 10;", settings)
+                    self.assertIn("MARKETING_VERSION = 1.3;", settings)
                     self.assertIn(
                         f"PRODUCT_BUNDLE_IDENTIFIER = {bundle_identifier};",
                         settings,
                     )
-        self.assertIn("Release candidate: **1.1 (7)**", release_notes)
+        self.assertIn("Release candidate: **1.3 (10)**", release_notes)
 
     def test_privacy_policy_is_reachable_and_covers_release_obligations(self):
         shared_policy = (

--- a/ios-app/scripts/verify-release-container.sh
+++ b/ios-app/scripts/verify-release-container.sh
@@ -80,9 +80,17 @@ require_plist_value \
   ":CFBundleIdentifier" \
   "LetItRide.BikeComputer"
 require_plist_value \
+  "${APP_PATH}/Info.plist" \
+  ":CFBundleDisplayName" \
+  "Bicino"
+require_plist_value \
   "${WATCH_PATH}/Info.plist" \
   ":CFBundleIdentifier" \
   "LetItRide.BikeComputer.watchkitapp"
+require_plist_value \
+  "${WATCH_PATH}/Info.plist" \
+  ":CFBundleDisplayName" \
+  "Bicino"
 require_plist_value \
   "${COMPLICATION_PATH}/Info.plist" \
   ":CFBundleIdentifier" \


### PR DESCRIPTION
## What changed

- Rename the iPhone, Watch, complication, Live Activity, and user-facing workout surfaces to Bicino.
- Set the release identity to marketing version 1.3 and build 10 while preserving existing bundle IDs, URL schemes, and Health/BLE identifiers.
- Update the privacy policy, release notes, and release-container checks for the Bicino branding.

## Validation

- Navigation protocol, cycling sensor, destination layout, saved-map preview, and workout contract tests pass.
- Python release-asset and release-container tests pass (15 tests).
- Plist lint and git diff checks pass.
- Signed archive is still pending: this Mac's Xcode 26.6 build service hangs during its preflight clang probes, so no unverified artifact was uploaded.

## App Store Connect

- App Store version 1.3 is prepared with the Bicino description, keywords, promotional text, and What's New copy.
- The live app-info name/subtitle still require an App Store Connect web-session edit because the public API rejects changing those fields while the current app is READY_FOR_SALE.
- Do not submit until the signed build is uploaded and the release metadata/name/subtitle are confirmed.