### PR TITLE
Make new map downloads target the 3D renderer

### DIFF
--- a/docs/plans/geofabrik-osm-3d-buildings-implementation-plan.md
+++ b/docs/plans/geofabrik-osm-3d-buildings-implementation-plan.md
@@ -36,7 +36,7 @@ That baseline already contains:
 - a shared flat/bird's-eye projection in `map_projection.hpp`;
 - near-plane clipping for projected map geometry;
 - map-feature visibility settings, including Buildings;
-- CAP2 schema v1, Map + Navigation setting IDs 27–34, target-aware iOS offline-map selection, and capability-gated settings synchronization;
+- CAP2 schema v1, Map + Navigation setting IDs 27–34, target-3 iOS offline-map generation, and capability-gated settings synchronization;
 - cross-block street-label collection, bounded PSRAM workspaces, cooperative interruption, renderer diagnostics, and a foreground canvas for labels and route geometry; and
 - the isolated `compose.hardware-validation.yaml` stack used for physical map validation.
 
@@ -52,7 +52,7 @@ Renderer format 3 retains its own independent rollout gate. No renderer-format-2
 
 ## Implementation status
 
-Implemented on `agent/osm-3d-buildings` across extraction, map-platform packaging and validation, firmware parsing/rendering, BLE capability/settings, iOS target selection and saved-map compatibility, documentation, and host regression tests. Renderer-format-3 generation remains disabled by default through `MAP_PLATFORM_BUILDING_TARGET3_ENABLED=0`.
+Implemented on `agent/osm-3d-buildings` across extraction, map-platform packaging and validation, firmware parsing/rendering, BLE capability/settings, iOS target-3 map generation and saved-map compatibility, documentation, and host regression tests. Renderer-format-3 generation remains disabled by default through `MAP_PLATFORM_BUILDING_TARGET3_ENABLED=0`.
 
 The target-3 physical-device matrix, timing/PSRAM capture, signed production pack transfer, and production gate enablement remain rollout work. They are intentionally not recorded as complete by this implementation-only branch.
 
@@ -419,11 +419,15 @@ Extend the strict backend, iOS, and firmware manifest decoders together: rendere
 
 ### Capability and selection
 
-Use CAP2 feature bit 12 for 3D-building support and extend the existing `OfflineMapJobRequest.forDevice(...)` selection matrix:
+Use CAP2 feature bit 12 for 3D-building support, but make renderer format 3
+the only target used for new map generation. The iOS request builder always
+includes the connected firmware version and the renderer-format-3 label
+profile; capability flags no longer select a 2D generation target.
 
-- bit 12 present: request renderer format 3;
-- street-label support present without bit 12: request renderer format 2; and
-- otherwise, including legacy or absent CAP2: request renderer format 1.
+Devices without bit 12 can continue to transfer compatible saved format-1/2
+artifacts, but a new format-3 map is refused before transfer. If the backend
+cannot generate format 3, iOS surfaces the typed unsupported-target error and
+does not silently retry as format 2 or 1.
 
 The existing `activeRendererFormat` status remains the device's renderer-format signal; extend its accepted/installed values to include 3 rather than adding a parallel supported-format list. iOS persists the verified renderer format with each saved artifact and refuses transfer when the connected device cannot activate it.
 
@@ -594,7 +598,12 @@ The backend worker receives `target.rendererFormatVersion` through the merged no
 - renderer format `2`: FMB v3 street-label artifacts with FMA1; and
 - renderer format `3`: building extraction, height resolution, retained street-label sections/FMA1, and FMB v4.
 
-Extend `OfflineMapJobRequest.forDevice(supportsStreetLabels:firmwareVersion:)` with 3D-building capability and reuse the merged `map_artifact_validation.py`, `manifest.py`, `reuse.py`, job, and label-pipeline contracts. Renderer format 3 preserves the request's `labels` profile and languages. Do not make v4 a hidden global replacement; cache/reuse keys must distinguish renderer formats 1, 2, and 3.
+Make the iOS `OfflineMapJobRequest` builder emit renderer format 3 for every
+new bbox, polygon, route-corridor, and connected-device request. Reuse the
+merged `map_artifact_validation.py`, `manifest.py`, `reuse.py`, job, and
+label-pipeline contracts. Renderer format 3 preserves the request's `labels`
+profile and languages. Do not make v4 a hidden global replacement;
+cache/reuse keys must distinguish renderer formats 1, 2, and 3.
 
 ### Reproducibility
 
@@ -611,7 +620,7 @@ For the same complete identity, the generated FMB files and manifest building su
 
 ### Feature gate
 
-Add `MAP_PLATFORM_BUILDING_TARGET3_ENABLED=0` as a fail-closed renderer-format-3 generation gate. Initial production configuration permits it only for an explicit test allowlist. A request outside the allowlist receives a typed unsupported-target response so iOS can offer the newest explicitly supported renderer format 1 or 2 rather than mislabeling another artifact as format 3.
+Add `MAP_PLATFORM_BUILDING_TARGET3_ENABLED=0` as a fail-closed renderer-format-3 generation gate. Initial production configuration permits it only for an explicit test allowlist. A request outside the allowlist receives a typed unsupported-target response; iOS reports that error and never mislabels or silently substitutes a format-1/2 artifact.
 
 The format-3 gate is independent of `MAP_PLATFORM_LABEL_TARGET2_ENABLED`: a permitted format-3 build can invoke the shared label pipeline without requiring the client-facing format-2 gate to be enabled. Existing stream publication approvals and allowlists continue to govern artifact release.
 
@@ -687,10 +696,10 @@ Exit gate: golden blocks pass on host tests, flat ground projection is unchanged
 ### Phase 5 — BLE capability, setting, and iOS artifact gating
 
 1. Add setting ID 35 and CAP2 feature bit 12.
-2. Extend `OfflineMapJobRequest.forDevice(...)` to choose renderer format 3, 2, or 1 from bit 12 and street-label capability.
+2. Make every new iOS map request target renderer format 3; retain capability checks only for saved-artifact transfer compatibility.
 3. Persist and verify the artifact's renderer format in iOS, and accept `activeRendererFormat: 3` in status.
-4. Request renderer format 3 only for paired devices advertising CAP2 bit 12.
-5. Refuse incompatible transfers before sending bytes.
+4. Refuse format-3 transfers on devices that do not advertise CAP2 bit 12, before sending bytes.
+5. Do not downgrade a rejected format-3 generation or transfer to a 2D target.
 6. Add the iOS 3D Buildings toggle, explanatory copy, redraw policy, and fresh-profile Buildings visibility default without migrating persisted `navVis`.
 
 Exit gate: old devices continue to receive renderer format 1 or label-capable renderer format 2 with no new switch; compatible devices request/transfer renderer format 3 and round-trip the setting across reconnect and reboot.
@@ -701,7 +710,7 @@ Exit gate: old devices continue to receive renderer format 1 or label-capable re
 2. Compare coverage reports and visually inspect known fixtures.
 3. Test all supported zooms, headings, perspective levels, and route states.
 4. Run dense-route soak tests on both AMOLED board sizes.
-5. Exercise gate-off, target downgrade, saved-artifact mismatch, and firmware-setting rollback paths.
+5. Exercise gate-off, unsupported-target errors without downgrade, saved-artifact mismatch, and firmware-setting rollback paths.
 6. Reconfirm the live renderer-format-2 production/physical state, enable a small format-3 allowlist independently, inspect production build and device diagnostics, then widen deliberately.
 
 Exit gate: all acceptance criteria below are evidenced with artifacts, logs, screenshots, timings, and exact build/source identities.
@@ -791,8 +800,8 @@ Exact filenames may follow the baseline module boundaries, but the separation of
 - exact format-3 FMB v4 plus FMA1 file composition and rejection of missing/extra/mismatched files;
 - signed manifest tamper rejection;
 - manifest target/header mismatch and unsupported-target rejection on-device;
-- legacy CAP2 payload without bit 12 selecting renderer format 1 or 2 as appropriate;
-- iOS `forDevice` selection for legacy, street-label-only, and 3D-building devices;
+- legacy CAP2 payload without bit 12 refusing new renderer-format-3 transfer while retaining saved-map compatibility;
+- every new iOS map request selecting renderer format 3, with no target-2/1 generation fallback;
 - `activeRendererFormat` status values 1, 2, and 3, including unknown-value rejection;
 - saved-artifact renderer-format persistence and compatibility checks;
 - compatible and incompatible artifact transfer;
@@ -830,12 +839,12 @@ The implementation is complete only when all of the following are true:
    and the active route remain legible above them; foreground collision and
    priority behavior is unchanged.
 8. Renderer-format-1/2 activation, FMB v1/v2/v3 parsing, street-label behavior, and flat-building rendering regressions are absent.
-9. Old devices are never offered renderer format 3/FMB v4; iOS refuses an incompatible saved artifact before transfer; and new firmware rejects unsupported or mislabeled artifacts before activation.
+9. Old devices never receive renderer format 3/FMB v4; iOS refuses an incompatible saved artifact before transfer; and new firmware rejects unsupported or mislabeled artifacts before activation.
 10. The new setting is capability-gated, persisted, acknowledged, and documented.
 11. Malformed or oversized building data fails closed without unbounded allocation, reset, or navigation starvation.
 12. Both Waveshare targets pass the agreed render-time, PSRAM, responsiveness, and soak-test budgets.
 13. The target-3-aware control-plane/API and worker images are promoted, renderer-target reuse is separated, and a real signed renderer-format-3/FMB v4 pack is regenerated and transferred end to end.
-14. Format-3 gate-off, renderer-format-1/2 request, device setting-off, and saved-format-1/2 rollback paths are demonstrated.
+14. Format-3 gate-off/error handling, device setting-off, and saved-format-1/2 compatibility paths are demonstrated.
 15. Exact source checksums, build identities, firmware/iOS revisions, device targets, metrics, and visual evidence are attached to the delivery record.
 
 ## Rollout and rollback
@@ -844,10 +853,10 @@ The implementation is complete only when all of the following are true:
 
 1. Merge format docs and fixture tests before enabling production generation.
 2. Record the supplied implementation assumption that renderer format 2 is deployed and physically validated; keep its rollout gate independent.
-3. Ship new firmware support while iOS still requests the current compatible renderer format 1 or 2.
+3. Ship new firmware support before enabling the target-3-only iOS map-generation path.
 4. Build the shared target-3-aware image and complete its worker/hardware gates before promotion. The repository detects worker-input changes and deliberately prevents a new-control-plane/old-worker promotion for this release.
 5. Co-promote the control-plane/API and worker digest with `MAP_PLATFORM_BUILDING_TARGET3_ENABLED=0`; verify typed unsupported-target responses and worker health while generation remains disabled.
-6. Ship iOS capability negotiation and transfer refusal. Retain the exact legacy target-3 rejection fallback only for clients that reach a pre-promotion control plane during rollout.
+6. Ship the iOS target-3-only generation path and transfer refusal. A pre-promotion control plane returns a typed unsupported-target error; the app does not downgrade to a 2D artifact.
 7. Enable renderer format 3 for internal paired devices and regenerate packs from fresh requests.
 8. Compare production coverage/size/timing with the pinned validation artifacts.
 9. Widen the allowlist only after both hardware targets remain inside budgets.
@@ -856,8 +865,8 @@ The implementation is complete only when all of the following are true:
 
 Rollback does not require deleting or rewriting maps:
 
-- disable `MAP_PLATFORM_BUILDING_TARGET3_ENABLED` so requests use an explicit compatible renderer-format-1/2 path;
-- have iOS request renderer format 1 or 2 for subsequent generations according to device capability;
+- disable `MAP_PLATFORM_BUILDING_TARGET3_ENABLED` so new target-3 requests fail closed with a typed unavailable-target error;
+- keep existing signed renderer-format-1/2 artifacts available for compatible devices, without generating new 2D replacements;
 - turn off 3D Buildings on-device to render v4 footprints flat;
 - continue using existing signed renderer-format-1/2 artifacts; and
 - retain v3/v4 parsing in firmware so already transferred maps remain safe and readable.

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -1716,8 +1716,6 @@ final class OfflineMapManager: ObservableObject {
             let request = OfflineMapJobRequest
                 .customBBox(bounds)
                 .forDevice(
-                    supportsStreetLabels: bleManager.supportsStreetLabels,
-                    supports3DBuildings: bleManager.supports3DBuildings,
                     firmwareVersion: bleManager.firmwareVersion
                 )
                 .identified(

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -149,10 +149,13 @@ struct OfflineMapJobRequest: Encodable, Equatable {
         )
     }
 
-    private static var targetTwo: RendererTarget {
+    // Renderer target 3 is the only format generated for new maps. Older
+    // renderer targets remain supported only when transferring already-saved
+    // artifacts to compatible legacy firmware.
+    private static var targetThree: RendererTarget {
         RendererTarget(
             renderer: "esp32-fmb",
-            rendererFormatVersion: 2,
+            rendererFormatVersion: 3,
             firmwareVersion: nil
         )
     }
@@ -167,7 +170,7 @@ struct OfflineMapJobRequest: Encodable, Equatable {
             clientInstallationId: nil,
             clientRequestId: nil,
             installOnDevice: nil,
-            target: targetTwo,
+            target: targetThree,
             labels: defaultLabelProfile
         )
     }
@@ -182,7 +185,7 @@ struct OfflineMapJobRequest: Encodable, Equatable {
             clientInstallationId: nil,
             clientRequestId: nil,
             installOnDevice: nil,
-            target: targetTwo,
+            target: targetThree,
             labels: defaultLabelProfile
         )
     }
@@ -197,7 +200,7 @@ struct OfflineMapJobRequest: Encodable, Equatable {
             clientInstallationId: nil,
             clientRequestId: nil,
             installOnDevice: nil,
-            target: targetTwo,
+            target: targetThree,
             labels: defaultLabelProfile
         )
     }
@@ -221,61 +224,8 @@ struct OfflineMapJobRequest: Encodable, Equatable {
         )
     }
 
-    func forDevice(
-        supportsStreetLabels: Bool,
-        supports3DBuildings: Bool = false,
-        firmwareVersion: String
-    ) -> OfflineMapJobRequest {
+    func forDevice(firmwareVersion: String) -> OfflineMapJobRequest {
         OfflineMapJobRequest(
-            mode: mode,
-            bbox: bbox,
-            geometry: geometry,
-            route: route,
-            corridorWidthM: corridorWidthM,
-            clientInstallationId: clientInstallationId,
-            clientRequestId: clientRequestId,
-            installOnDevice: installOnDevice,
-            target: supports3DBuildings
-                ? RendererTarget(
-                    renderer: "esp32-fmb",
-                    rendererFormatVersion: 3,
-                    firmwareVersion: firmwareVersion.isEmpty ? nil : firmwareVersion
-                )
-                : supportsStreetLabels
-                ? RendererTarget(
-                    renderer: "esp32-fmb",
-                    rendererFormatVersion: 2,
-                    firmwareVersion: firmwareVersion.isEmpty ? nil : firmwareVersion
-                )
-                : RendererTarget(
-                    renderer: "esp32-fmb",
-                    rendererFormatVersion: 1,
-                    firmwareVersion: firmwareVersion.isEmpty ? nil : firmwareVersion
-                ),
-            labels: (supportsStreetLabels || supports3DBuildings)
-                ? labels ?? Self.defaultLabelProfile
-                : nil
-        )
-    }
-
-    func compatibleFallback(
-        requestedRendererFormatVersion: Int,
-        supportedRendererFormatVersions: [Int]
-    ) -> OfflineMapJobRequest? {
-        guard requestedRendererFormatVersion == 3,
-              target?.renderer == "esp32-fmb",
-              target?.rendererFormatVersion == requestedRendererFormatVersion else {
-            return nil
-        }
-        let fallbackFormat: Int
-        if labels != nil && supportedRendererFormatVersions.contains(2) {
-            fallbackFormat = 2
-        } else if supportedRendererFormatVersions.contains(1) {
-            fallbackFormat = 1
-        } else {
-            return nil
-        }
-        return OfflineMapJobRequest(
             mode: mode,
             bbox: bbox,
             geometry: geometry,
@@ -286,10 +236,10 @@ struct OfflineMapJobRequest: Encodable, Equatable {
             installOnDevice: installOnDevice,
             target: RendererTarget(
                 renderer: "esp32-fmb",
-                rendererFormatVersion: fallbackFormat,
-                firmwareVersion: target?.firmwareVersion
+                rendererFormatVersion: 3,
+                firmwareVersion: firmwareVersion.isEmpty ? nil : firmwareVersion
             ),
-            labels: fallbackFormat == 2 ? labels : nil
+            labels: labels ?? Self.defaultLabelProfile
         )
     }
 }
@@ -2512,25 +2462,10 @@ struct OfflineMapPlatformClient {
         guard jobRequest.clientInstallationId == clientInstallationId else {
             throw OfflineMapPlatformError.invalidResponse
         }
-        do {
-            return try await createJobOnce(jobRequest)
-        } catch OfflineMapPlatformError.unsupportedRendererTarget(
-            let requestedRendererFormatVersion,
-            let supportedRendererFormatVersions,
-            let message
-        ) {
-            guard let fallback = jobRequest.compatibleFallback(
-                requestedRendererFormatVersion: requestedRendererFormatVersion,
-                supportedRendererFormatVersions: supportedRendererFormatVersions
-            ) else {
-                throw OfflineMapPlatformError.unsupportedRendererTarget(
-                    requestedRendererFormatVersion: requestedRendererFormatVersion,
-                    supportedRendererFormatVersions: supportedRendererFormatVersions,
-                    message: message
-                )
-            }
-            return try await createJobOnce(fallback)
-        }
+        // Do not silently downgrade a new map to a 2D/legacy renderer. A
+        // target-3 generation failure is surfaced to the caller so the app
+        // cannot present a map that lacks 3D buildings.
+        return try await createJobOnce(jobRequest)
     }
 
     private func createJobOnce(
@@ -2843,9 +2778,9 @@ struct OfflineMapPlatformClient {
             )
         }
         // The renderer-format-2 control plane predates the typed target error
-        // envelope. Recognize only its exact target-3 rejection so an app can
-        // downgrade during a rolling deployment; arbitrary HTTP 400 responses
-        // must remain hard failures.
+        // envelope. Recognize only its exact target-3 rejection so the app
+        // can surface a useful typed error during a rolling deployment;
+        // arbitrary HTTP 400 responses must remain hard failures.
         if statusCode == 400,
            let legacy = try? JSONDecoder().decode(
                OfflineMapAPILegacyErrorEnvelope.self,

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -343,9 +343,6 @@ private struct DownloadingMapsSettingsSection: View {
 
             if let preparationTimeEstimate {
                 SettingsValueRow(title: "Estimated Preparation", value: preparationTimeEstimate)
-                Text("Feature density and water coverage can affect preparation time.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
             }
 
             if let error = manager.errorMessage {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -658,7 +658,7 @@ struct NavigationProtocolTests {
         testNavigationEngineIgnoresLiveLocationFarFromRouteStart()
         testNavigationEngineReplacesRouteWithoutResettingTelemetry()
         testOfflineMapCustomBBoxRequest()
-        await testOfflineMapClientRetriesCompatibleRendererOnce()
+        await testOfflineMapClientRejectsUnsupportedRendererWithoutDowngrade()
         testStreetLabelMapContract()
         testBikeMapStreamGoldenVector()
         testBikeMapStreamArtifactValidation()
@@ -4225,6 +4225,26 @@ struct NavigationProtocolTests {
         assert(request.bbox != nil, "custom cut-out includes bbox")
         assert(abs((request.bbox?[1] ?? 0) - 34.9) < 0.001, "bbox min latitude uses requested size")
         assert(abs((request.bbox?[3] ?? 0) - 35.1) < 0.001, "bbox max latitude uses requested size")
+        assertEqual(request.target?.rendererFormatVersion ?? 0, 3,
+                    "custom cut-outs always request renderer target 3")
+
+        let polygon = OfflineMapJobRequest.customPolygon(ring: [
+            CLLocationCoordinate2D(latitude: 35.0, longitude: 136.0),
+            CLLocationCoordinate2D(latitude: 35.01, longitude: 136.0),
+            CLLocationCoordinate2D(latitude: 35.01, longitude: 136.01)
+        ])
+        assertEqual(polygon.target?.rendererFormatVersion ?? 0, 3,
+                    "custom polygons always request renderer target 3")
+
+        let corridor = OfflineMapJobRequest.routeCorridor(
+            route: [
+                CLLocationCoordinate2D(latitude: 35.0, longitude: 136.0),
+                CLLocationCoordinate2D(latitude: 35.01, longitude: 136.01)
+            ],
+            widthMeters: 500
+        )
+        assertEqual(corridor.target?.rendererFormatVersion ?? 0, 3,
+                    "route corridors always request renderer target 3")
 
         let identified = request.identified(
             clientInstallationId: "installation-test",
@@ -4235,84 +4255,33 @@ struct NavigationProtocolTests {
         assertEqual(identified.clientRequestId, "request-test-123", "request includes idempotency identity")
         assertEqual(identified.installOnDevice, true, "request preserves install workflow intent")
 
-        let targetTwo = request.forDevice(
-            supportsStreetLabels: true,
+        let deviceRequest = request.forDevice(
             firmwareVersion: "0.4.0"
         )
-        let targetTwoJSON = try! JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(targetTwo)
+        let deviceRequestJSON = try! JSONSerialization.jsonObject(
+            with: JSONEncoder().encode(deviceRequest)
         ) as! [String: Any]
-        let target = targetTwoJSON["target"] as! [String: Any]
-        let labels = targetTwoJSON["labels"] as! [String: Any]
+        let target = deviceRequestJSON["target"] as! [String: Any]
+        let labels = deviceRequestJSON["labels"] as! [String: Any]
         assertEqual(target["renderer"] as? String, "esp32-fmb",
-                    "label-aware requests name the renderer explicitly")
-        assertEqual(target["rendererFormatVersion"] as? Int, 2,
-                    "label-aware requests select renderer target 2")
+                    "device requests name the renderer explicitly")
+        assertEqual(target["rendererFormatVersion"] as? Int, 3,
+                    "device requests select renderer target 3")
+        assertEqual(target["firmwareVersion"] as? String, "0.4.0",
+                    "device requests carry the connected firmware version")
         assertEqual(labels["profileVersion"] as? Int, 1,
-                    "label-aware requests carry label profile 1")
+                    "3D requests carry label profile 1")
         assert((labels["preferredLanguages"] as? [String])?.count ?? 0 <= 3,
-               "label-aware requests cap preferred languages")
+               "3D requests cap preferred languages")
 
-        let targetThree = request.forDevice(
-            supportsStreetLabels: true,
-            supports3DBuildings: true,
-            firmwareVersion: "0.5.0"
-        )
-        let targetThreeJSON = try! JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(targetThree)
-        ) as! [String: Any]
-        assertEqual(
-            (targetThreeJSON["target"] as? [String: Any])?["rendererFormatVersion"] as? Int,
-            3,
-            "3D-building devices request renderer target 3"
-        )
-        assert(targetThreeJSON["labels"] != nil,
-               "renderer target 3 retains the street-label profile")
-
-        let targetTwoFallback = targetThree.compatibleFallback(
-            requestedRendererFormatVersion: 3,
-            supportedRendererFormatVersions: [2, 1]
-        )
-        let targetTwoFallbackJSON = try! JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(targetTwoFallback)
-        ) as! [String: Any]
-        assertEqual(
-            (targetTwoFallbackJSON["target"] as? [String: Any])?["rendererFormatVersion"] as? Int,
-            2,
-            "unsupported target 3 prefers the server-supported label target"
-        )
-        assert(targetTwoFallbackJSON["labels"] != nil,
-               "target 2 fallback preserves the requested label profile")
-
-        let targetOneFallback = targetThree.compatibleFallback(
-            requestedRendererFormatVersion: 3,
-            supportedRendererFormatVersions: [1]
-        )
-        let targetOneFallbackJSON = try! JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(targetOneFallback)
-        ) as! [String: Any]
-        assertEqual(
-            (targetOneFallbackJSON["target"] as? [String: Any])?["rendererFormatVersion"] as? Int,
-            1,
-            "unsupported target 3 falls back to the legacy renderer when labels are unavailable"
-        )
-        assert(targetOneFallbackJSON["labels"] == nil,
-               "target 1 fallback removes unsupported label metadata")
-
-        let legacy = request.forDevice(
-            supportsStreetLabels: false,
-            firmwareVersion: "0.3.0"
-        )
-        let legacyJSON = try! JSONSerialization.jsonObject(
-            with: JSONEncoder().encode(legacy)
-        ) as! [String: Any]
-        assertEqual((legacyJSON["target"] as? [String: Any])?["rendererFormatVersion"] as? Int,
-                    1, "legacy devices request renderer target 1")
-        assert(legacyJSON["labels"] == nil,
-               "legacy requests omit unsupported label metadata")
+        let noFirmware = request.forDevice(firmwareVersion: "")
+        assertEqual(noFirmware.target?.rendererFormatVersion ?? 0, 3,
+                    "3D requests remain target 3 without firmware metadata")
+        assert(noFirmware.target?.firmwareVersion == nil,
+               "empty firmware metadata is omitted")
     }
 
-    static func testOfflineMapClientRetriesCompatibleRendererOnce() async {
+    static func testOfflineMapClientRejectsUnsupportedRendererWithoutDowngrade() async {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [OfflineMapTestURLProtocol.self]
         let session = URLSession(configuration: configuration)
@@ -4325,14 +4294,10 @@ struct NavigationProtocolTests {
             .customBBox(
                 OfflineMapBounds(minLon: 103.75, minLat: 1.24, maxLon: 103.93, maxLat: 1.37)
             )
-            .forDevice(
-                supportsStreetLabels: true,
-                supports3DBuildings: true,
-                firmwareVersion: "0.5.0"
-            )
+            .forDevice(firmwareVersion: "0.5.0")
             .identified(
                 clientInstallationId: installationID,
-                clientRequestId: "request-target3-fallback",
+                clientRequestId: "request-target3-only",
                 installOnDevice: true
             )
         let client = OfflineMapPlatformClient(
@@ -4370,51 +4335,31 @@ struct NavigationProtocolTests {
             submittedLabelProfiles.append(
                 (body["labels"] as? [String: Any])?["profileVersion"] as? Int
             )
-            if submittedFormats.count == 1 {
-                return (400, unsupportedResponse(requested: 3, supported: [2, 1]))
-            }
-            return (200, Data(#"{"jobId":"job-target2","status":"queued"}"#.utf8))
+            return (400, unsupportedResponse(requested: 3, supported: [2, 1]))
         }
-        let job = try? await client.createJob(originalRequest)
-        assertEqual(job?.jobId, "job-target2", "compatible fallback returns the created target 2 job")
-        assertEqual(submittedFormats, [3, 2], "target 3 is retried exactly once as target 2")
+        do {
+            _ = try await client.createJob(originalRequest)
+            assert(false, "an unsupported 3D target must remain an error")
+        } catch OfflineMapPlatformError.unsupportedRendererTarget(
+            let requested,
+            let supported,
+            _
+        ) {
+            assertEqual(requested, 3, "the typed rejection reports target 3")
+            assertEqual(supported, [2, 1], "the typed rejection preserves supported targets")
+        } catch {
+            assert(false, "unsupported renderer errors retain their typed form")
+        }
+        assertEqual(submittedFormats, [3], "target 3 is submitted exactly once")
         assertEqual(
             submittedRequestIDs,
-            ["request-target3-fallback", "request-target3-fallback"],
-            "fallback preserves the idempotency identity"
+            ["request-target3-only"],
+            "the target-3 request preserves its idempotency identity"
         )
         assertEqual(
             submittedLabelProfiles.compactMap { $0 },
-            [1, 1],
-            "fallback request keeps the target 2 label profile"
-        )
-
-        var legacySubmittedFormats: [Int] = []
-        OfflineMapTestURLProtocol.configure { request in
-            let body = try! JSONSerialization.jsonObject(
-                with: OfflineMapTestURLProtocol.bodyData(from: request)
-            ) as! [String: Any]
-            legacySubmittedFormats.append(
-                (body["target"] as! [String: Any])["rendererFormatVersion"] as! Int
-            )
-            if legacySubmittedFormats.count == 1 {
-                return (
-                    400,
-                    Data(#"{"detail":"target rendererFormatVersion must be 1 or 2"}"#.utf8)
-                )
-            }
-            return (200, Data(#"{"jobId":"job-legacy-target2","status":"queued"}"#.utf8))
-        }
-        let legacyJob = try? await client.createJob(originalRequest)
-        assertEqual(
-            legacyJob?.jobId,
-            "job-legacy-target2",
-            "the exact legacy control-plane rejection safely downgrades target 3"
-        )
-        assertEqual(
-            legacySubmittedFormats,
-            [3, 2],
-            "the legacy compatibility path retries once with renderer target 2"
+            [1],
+            "the target-3 request carries the street-label profile"
         )
 
         var genericBadRequestCount = 0
@@ -4424,7 +4369,7 @@ struct NavigationProtocolTests {
         }
         do {
             _ = try await client.createJob(originalRequest)
-            assert(false, "an unrelated HTTP 400 must not trigger target fallback")
+            assert(false, "an unrelated HTTP 400 must remain an error")
         } catch OfflineMapPlatformError.serverStatus(let status, _) {
             assertEqual(status, 400, "generic bad requests retain their HTTP status")
         } catch {
@@ -4433,38 +4378,31 @@ struct NavigationProtocolTests {
         assertEqual(
             genericBadRequestCount,
             1,
-            "generic bad requests are never retried as renderer downgrades"
+            "generic bad requests are submitted exactly once"
         )
 
         var rejectedRequestCount = 0
-        OfflineMapTestURLProtocol.configure { request in
+        OfflineMapTestURLProtocol.configure { _ in
             rejectedRequestCount += 1
-            let body = try! JSONSerialization.jsonObject(
-                with: OfflineMapTestURLProtocol.bodyData(from: request)
-            ) as! [String: Any]
-            let requested = (body["target"] as! [String: Any])["rendererFormatVersion"] as! Int
             return (
                 400,
-                unsupportedResponse(
-                    requested: requested,
-                    supported: requested == 3 ? [2, 1] : [1]
-                )
+                Data(#"{"detail":"target rendererFormatVersion must be 1 or 2"}"#.utf8)
             )
         }
         do {
             _ = try await client.createJob(originalRequest)
-            assert(false, "a rejected fallback should remain an error")
+            assert(false, "the legacy 2D-only rejection must remain an error")
         } catch OfflineMapPlatformError.unsupportedRendererTarget(
             let requested,
             let supported,
             _
         ) {
-            assertEqual(requested, 2, "the second rejection reports the fallback target accurately")
-            assertEqual(supported, [1], "the second rejection preserves the server contract")
+            assertEqual(requested, 3, "the legacy rejection reports target 3")
+            assertEqual(supported, [2, 1], "the legacy rejection reports its supported targets")
         } catch {
-            assert(false, "a rejected fallback should retain the typed renderer error")
+            assert(false, "the legacy rejection retains the typed renderer error")
         }
-        assertEqual(rejectedRequestCount, 2, "renderer fallback never retries more than once")
+        assertEqual(rejectedRequestCount, 1, "the legacy rejection is not retried as target 2")
     }
 
     static func testSavedMapRendererCompatibilityPolicy() {


### PR DESCRIPTION
## Summary

- Make every new bbox, polygon, route-corridor, and connected-device map request target renderer format 3.
- Remove the automatic fallback from 3D generation to renderer formats 2 or 1.
- Remove the map-preparation hint about feature density and water coverage.
- Update the 3D implementation plan and offline-map request tests to match the target-3-only policy.

## Validation

- Swift parser checks pass for the changed app and test files.
- App-wide Swift type-check passes with the repository's existing concurrency warning.
- The full Xcode build/test run was blocked by an unrelated Xcode 26 external-tool hang while probing clang; no source error was emitted before the hang.
