### PR TITLE
Confirm saved map deletion

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -495,6 +495,7 @@ private struct DownloadedMapRow: View {
     @Binding var renameInteraction: SavedMapRenameInteraction
     let onCommitRename: (SavedMapRenameCommit) -> Void
     @State private var isShowingInstalledConfirmation = false
+    @State private var isShowingDeleteConfirmation = false
 
     var body: some View {
         let displayName = manager.displayName(forCachedPack: packURL)
@@ -604,7 +605,7 @@ private struct DownloadedMapRow: View {
             Button(role: .destructive) {
                 finishRenaming()
                 focusedPackFilename = nil
-                manager.deleteCachedPack(at: packURL)
+                isShowingDeleteConfirmation = true
             } label: {
                 Image(systemName: "trash")
                     .frame(width: 32, height: 32)
@@ -617,6 +618,21 @@ private struct DownloadedMapRow: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text("This map is already installed on the device.")
+        }
+        .confirmationDialog(
+            "Delete Saved Map?",
+            isPresented: $isShowingDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                manager.deleteCachedPack(at: packURL)
+            }
+            Button("Cancel", role: .cancel) { }
+        } message: {
+            Text(
+                "This removes \(displayName) from Saved Maps on this iPhone. " +
+                    "A copy already installed on the Bike Computer remains there."
+            )
         }
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -7129,6 +7129,12 @@ struct NavigationProtocolTests {
             "tapping installed status explains that the map is already on the device"
         )
         assert(
+            source.contains("isShowingDeleteConfirmation = true") &&
+                source.contains("\"Delete Saved Map?\"") &&
+                source.contains("Button(\"Delete\", role: .destructive)"),
+            "deleting a saved map requires explicit confirmation"
+        )
+        assert(
             source.contains("manager.hasActiveBackgroundUpload"),
             "a restored upload disables conflicting saved-map upload and delete actions"
         )


### PR DESCRIPTION
## Summary

- Require explicit confirmation before deleting a saved map from the iPhone.
- Explain that deletion removes the Saved Maps copy while leaving an already-installed bike-computer copy in place.
- Add a source-level wiring assertion for the destructive confirmation flow.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- Signed device-targeted iOS build with `xcodebuild` (Debug, iPhone destination)
