### PR TITLE
Keep 3D buildings in smooth guidance rendering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,10 @@ jobs:
             -o /tmp/test_map_building_renderer
           /tmp/test_map_building_renderer
           g++ -std=c++17 -Wall -Wextra -Werror \
+            tools/tests/test_map_render_job_policy.cpp \
+            -o /tmp/test_map_render_job_policy
+          /tmp/test_map_render_job_policy
+          g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_main_screen_entry_policy.cpp \
             -o /tmp/test_main_screen_entry_policy
           /tmp/test_main_screen_entry_policy

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 esp32/.pio
+# pioarduino generates this ESP-IDF project file during verified builds.
+esp32/CMakeLists.txt
 esp32/.vscode/.browse.c_cpp.db*
 esp32/.vscode/c_cpp_properties.json
 esp32/.vscode/launch.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,10 @@
 - `hardware/`: authoritative Waveshare pinouts, board findings, schematics,
   datasheets, and physical validation records. Read `hardware/README.md` before
   changing board-specific firmware.
-- `docs/`: protocol, rollout, and implementation documentation.
+- `docs/`: protocol, rollout, and implementation documentation. The
+  [firmware map-rendering and PSRAM budget](docs/firmware-map-rendering-psram.md)
+  is the source of truth for map-frame sizes, 3D-building workspace, and
+  measured rendering/power numbers.
 
 ## Quick commands
 
@@ -202,6 +205,16 @@ as flashed until a later `BOOT_META` independently confirms the
 embedded Git/profile identity; it does not contain those SHA-256 values or prove
 on-device byte equality. Flash readback or a runtime image digest is required
 for that stronger claim.
+
+### Firmware map-rendering and PSRAM budget
+
+When a task asks about map rendering, 3D buildings, PSRAM, rendering
+performance, or battery impact—or changes or tests any of those areas—read
+`docs/firmware-map-rendering-psram.md` first. Update that document in the same
+change whenever an implementation or device test produces a relevant number;
+record the commit, board/profile, map/navigation fixture, and whether the
+number is static, runtime, or externally measured. Do not treat USB current or
+host-only estimates as a battery baseline.
 
 ### iOS app
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 - [Offline-map build and SD-card installation](offline-map-build-and-sd-install.md)
 - [Map-stream rollout runbook](map-stream-rollout-runbook.md)
 - [Firmware power management](firmware-power-management.md)
+- [Firmware map-rendering and PSRAM budget](firmware-map-rendering-psram.md)
 - [Firmware OTA hardware validation](firmware-ota-hardware-validation.md)
 - [Waveshare AMOLED 2.06 audio bring-up](waveshare-amoled-206-audio-bringup.md)
 - [App Store privacy disclosures](app-store-privacy-disclosures.md)

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -1,0 +1,49 @@
+# Firmware map-rendering and PSRAM budget
+
+This is the short source of truth for the ESP32 map renderer's memory and
+performance budget. Keep measured values tied to a Git revision and board
+profile; distinguish estimates from device measurements.
+
+## Current 1.75-inch budget
+
+The Waveshare 1.75-inch device has 8 MiB PSRAM. Guidance keeps the 466 x 466
+visible map continuously moving by rendering an overscanned 658 x 658 frame.
+The known persistent map buffers are:
+
+| Revision / frame | Screen RGB565 | Temp RGB565 | Foreground RGB565A8 | Total |
+| --- | ---: | ---: | ---: | ---: |
+| `283d2442`, 466 x 466 | 434,312 B | 508,040 B | 651,468 B | 1,593,820 B (1.52 MiB) |
+| `60407746`, 658 x 658 guidance | 865,928 B | 865,928 B | 1,298,892 B | 3,030,748 B (2.89 MiB) |
+
+The 2.89 MiB figure is within an 8 MiB PSRAM device, but free bytes,
+largest-contiguous block, temporary allocations, and the building render
+deadline still matter. A previous `60407746` device run measured 7,423,160 B
+free before Map + Navigation setup and 4,375,724 B after it (a 3,047,436 B
+drop, including renderer overhead).
+
+## 3D-building workspace
+
+The building pass now snapshots only the projected courtyard bounding box and
+clips it to the canvas. One snapshot is capped at the visible viewport size:
+
+- 1.75-inch full-screen 466 x 466: at most 434,312 B (0.41 MiB);
+- 1.75-inch non-fullscreen 466 x 366: at most 341,112 B (0.33 MiB);
+- ordinary courtyards are smaller than either bound.
+
+Before this change, a courtyard snapshot could copy the entire 658 x 658
+guidance canvas (865,928 B / 0.83 MiB). If a courtyard exceeds the cap or an
+allocation fails, its roof/hole is left unfilled so the real 2D underlay stays
+visible; the rest of the 2D map and other building surfaces still render.
+With `WAVESHARE_MAPIO_TIMING_LOG` or touch diagnostics enabled, the building
+log reports `courtyardMaxBytes` and `courtyardBudgetBytes`.
+
+## Validation and maintenance
+
+For relevant implementation or device tests, append the revision/profile,
+visible and render frame sizes, PSRAM free/largest values, building snapshot
+bytes, render timings, map/GPS fixture, and pass/fallback result here. Battery
+claims require a source-monitor test with USB disconnected; static PSRAM size
+alone is not a battery-current measurement. The current compact-snapshot
+implementation is host-tested and the deterministic
+`WAVESHARE_AMOLED_175` firmware build passes; a new device flash/navigation run
+is still required before calling its runtime behavior validated.

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -25,15 +25,16 @@ drop, including renderer overhead).
 
 Guidance bird's-eye rendering no longer enters the synchronous 3D-building
 phase from the LVGL event callback. `readVectorMap` produces the complete 2D
-underlay in `bufMapTemp`, then `Maps::GuidanceBuildingRenderJob` advances
-nearest-first admission and raw RGB565 surface drawing in short cooperative
-slices. The visible `bufMapScreen` and its projection remain unchanged until
-the job has completed, at which point the frame is copied and published as one
-unit. Navigation overlay, arrow, and the live route head continue to use the
-presented pose while the job is pending. A navigation/style invalidation,
-screen-cycle input, or motion beyond the pending frame's dynamic lead cancels
-the job (latest request wins). The same job handles flat building roofs when
-the 3D toggle is off; the toggle gates extrusion only.
+underlay in `bufMapTemp`, publishes that course-up frame immediately, then
+`Maps::GuidanceBuildingRenderJob` advances nearest-first admission and raw
+RGB565 surface drawing in short cooperative slices. The visible `bufMapScreen`
+therefore never waits for 3D admission; once the deterministic far-to-near
+pass completes, its frame is copied and published atomically over the already
+visible underlay. Navigation overlay, arrow, and the live route head continue
+to use the presented pose while the job is pending. A navigation/style
+invalidation, screen-cycle input, or motion beyond the pending frame's dynamic
+lead cancels the job (latest request wins). The same job handles flat building
+roofs when the 3D toggle is off; the toggle gates extrusion only.
 
 The guidance admission contract is deterministic for one immutable frame
 request and does not use an elapsed-time prefix:
@@ -56,6 +57,11 @@ and the 300 ms cooperative-job latency bound. The 96 px overscan and 16 px
 safety reserve therefore remain an invariant, while faster motion requests a
 new frame earlier. No additional full-frame PSRAM allocation is introduced.
 
+The presenter adapts its bounded dead-reckoning horizon to the most recent
+accepted phone-fix interval (750--1,800 ms) and decays stale velocity over
+180 ms. This keeps the arrow and live head moving between normal Core Location
+updates without allowing a disconnected phone to drift the map indefinitely.
+
 ## 3D-building workspace
 
 The building pass now snapshots only the projected courtyard bounding box and
@@ -71,8 +77,13 @@ allocation fails, its roof/hole is left unfilled so the real 2D underlay stays
 visible; the rest of the 2D map and other building surfaces still render.
 With `WAVESHARE_MAPIO_TIMING_LOG` or touch diagnostics enabled, the standalone
 building log reports `courtyardMaxBytes` and `courtyardBudgetBytes`; the
-cooperative guidance job uses the same cap and still needs a device timing
-run before its runtime workspace numbers are recorded here.
+cooperative guidance job uses the same cap. On Waveshare 1.75, revision
+`83ac3354`, profile `WAVESHARE_AMOLED_175_TOUCH_DIAGNOSTICS`, and the Shanghai
+`+206+055/4_14.fmb` fixture, the measured trace was: block read/parse 1,826 ms,
+2D bird's-eye underlay 103 ms, 2,717 building records discovered, 258 admitted
+and rendered, 48 extruded, with 3.45 ms cooperative discovery/draw slices.
+The underlay was published before the building job, so course-up navigation
+does not wait for the roughly 10-second 3D pass.
 
 ## Validation and maintenance
 
@@ -81,7 +92,7 @@ visible and render frame sizes, PSRAM free/largest values, building snapshot
 bytes, render timings, map/GPS fixture, and pass/fallback result here. Battery
 claims require a source-monitor test with USB disconnected; static PSRAM size
 alone is not a battery-current measurement. The cooperative-job policy
-and raw renderer contracts are host-tested. No new device timing, PSRAM,
-battery, or post-flash result is claimed for this implementation; the
-`WAVESHARE_AMOLED_175` build/device-navigation gate remains required before
-calling runtime behavior validated.
+and raw renderer contracts are host-tested. The diagnostic trace above is a
+renderer timing measurement, not a claim that a physical navigation session
+has passed; the normal `WAVESHARE_AMOLED_175` build/device-navigation gate
+remains required before calling runtime behavior validated.

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -61,6 +61,10 @@ The presenter adapts its bounded dead-reckoning horizon to the most recent
 accepted phone-fix interval (750--1,800 ms) and decays stale velocity over
 180 ms. This keeps the arrow and live head moving between normal Core Location
 updates without allowing a disconnected phone to drift the map indefinitely.
+Course-up activation is keyed to either the maneuver snapshot or the route
+window because those BLE inputs arrive independently; the companion derives a
+route bearing when Core Location reports an invalid course (including test
+navigation), so a valid navigation session cannot silently encode north-up.
 
 ## 3D-building workspace
 

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -21,6 +21,41 @@ deadline still matter. A previous `60407746` device run measured 7,423,160 B
 free before Map + Navigation setup and 4,375,724 B after it (a 3,047,436 B
 drop, including renderer overhead).
 
+## Guidance 3D-building job
+
+Guidance bird's-eye rendering no longer enters the synchronous 3D-building
+phase from the LVGL event callback. `readVectorMap` produces the complete 2D
+underlay in `bufMapTemp`, then `Maps::GuidanceBuildingRenderJob` advances
+nearest-first admission and raw RGB565 surface drawing in short cooperative
+slices. The visible `bufMapScreen` and its projection remain unchanged until
+the job has completed, at which point the frame is copied and published as one
+unit. Navigation overlay, arrow, and the live route head continue to use the
+presented pose while the job is pending. A navigation/style invalidation,
+screen-cycle input, or motion beyond the pending frame's dynamic lead cancels
+the job (latest request wins). The same job handles flat building roofs when
+the 3D toggle is off; the toggle gates extrusion only.
+
+The guidance admission contract is deterministic for one immutable frame
+request and does not use an elapsed-time prefix:
+
+| Rule | Guidance bound |
+| --- | ---: |
+| Discovery work per scheduler slice | 96 records, up to 3.5 ms |
+| Candidate queue | 512 records |
+| Rendered records | 64 nearest records |
+| Rendered source points | 12,288 total / 512 per record |
+| Extruded records/points | 48 / 8,192 |
+| Per-building projected pixel area | 120,000 pixels |
+
+These are static geometry quotas, not device measurements. They preserve the
+nearest useful 3D buildings while bounding each raw raster unit; an individual
+courtyard snapshot remains limited to the visible-viewport workspace below.
+
+The guidance refresh lead is derived from the measured presented-pose speed
+and the 300 ms cooperative-job latency bound. The 96 px overscan and 16 px
+safety reserve therefore remain an invariant, while faster motion requests a
+new frame earlier. No additional full-frame PSRAM allocation is introduced.
+
 ## 3D-building workspace
 
 The building pass now snapshots only the projected courtyard bounding box and
@@ -34,8 +69,10 @@ Before this change, a courtyard snapshot could copy the entire 658 x 658
 guidance canvas (865,928 B / 0.83 MiB). If a courtyard exceeds the cap or an
 allocation fails, its roof/hole is left unfilled so the real 2D underlay stays
 visible; the rest of the 2D map and other building surfaces still render.
-With `WAVESHARE_MAPIO_TIMING_LOG` or touch diagnostics enabled, the building
-log reports `courtyardMaxBytes` and `courtyardBudgetBytes`.
+With `WAVESHARE_MAPIO_TIMING_LOG` or touch diagnostics enabled, the standalone
+building log reports `courtyardMaxBytes` and `courtyardBudgetBytes`; the
+cooperative guidance job uses the same cap and still needs a device timing
+run before its runtime workspace numbers are recorded here.
 
 ## Validation and maintenance
 
@@ -43,7 +80,8 @@ For relevant implementation or device tests, append the revision/profile,
 visible and render frame sizes, PSRAM free/largest values, building snapshot
 bytes, render timings, map/GPS fixture, and pass/fallback result here. Battery
 claims require a source-monitor test with USB disconnected; static PSRAM size
-alone is not a battery-current measurement. The current compact-snapshot
-implementation is host-tested and the deterministic
-`WAVESHARE_AMOLED_175` firmware build passes; a new device flash/navigation run
-is still required before calling its runtime behavior validated.
+alone is not a battery-current measurement. The cooperative-job policy
+and raw renderer contracts are host-tested. No new device timing, PSRAM,
+battery, or post-flash result is claimed for this implementation; the
+`WAVESHARE_AMOLED_175` build/device-navigation gate remains required before
+calling runtime behavior validated.

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -1067,18 +1067,26 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
     mapView.updatePositionOverlay();
   }
 
+  if (mapView.guidanceProjectionNeedsRefresh()) {
+    mapRenderScheduler.request(map_render_policy::Reason::Position);
+  }
+
   if (mapRenderScheduler.hasPendingWork()) {
     const bool followPosition =
         mapView.followGps || activeTile == MAP_GUIDANCE;
     const bool courseUp = mapView.rotationMode == Maps::ROT_COURSE_UP;
+    const bool stableGuidanceProjection =
+        mapView.isGuidanceBirdsEyeProjection();
     const map_render_policy::Decision decision =
-        mapRenderScheduler.evaluate(nowMs, followPosition, courseUp);
+        mapRenderScheduler.evaluate(nowMs,
+                                    followPosition && !stableGuidanceProjection,
+                                    courseUp);
     if (decision.render) {
       mapRenderScheduler.commit(decision);
       noteMapRenderReasons(decision.reasons);
       if (followPosition) {
         mapView.followGps = true;
-        mapView.centerOnGps(gps.gpsData.latitude, gps.gpsData.longitude);
+        mapView.centerOnPresentedGps();
       } else {
         mapView.isPosMoved = true;
       }

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -549,12 +549,9 @@ static int16_t mapInteractionAnchorY() {
 }
 
 static uint16_t currentCourseUpHeading() {
-  uint16_t routeHeading = 0;
-  if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
-                               routeHeading)) {
-    return routeHeading;
-  }
-  return gps.gpsData.heading;
+  return mapView.courseUpHeading(gps.gpsData.latitude,
+                                 gps.gpsData.longitude,
+                                 gps.gpsData.heading);
 }
 
 static bool isMapBackedTile(uint8_t tile) {
@@ -691,6 +688,7 @@ static void applyMapRotationForActiveTile() {
         isGuidanceNavigating() ? Maps::ROT_COURSE_UP : Maps::ROT_NORTH_UP;
     if (mapView.rotationMode != desiredMode) {
       mapView.rotationMode = desiredMode;
+      mapView.resetCourseUpHeading();
       if (desiredMode == Maps::ROT_NORTH_UP) {
         mapView.rotationRad = 0;
       }
@@ -709,12 +707,14 @@ static void applyMapRotationForActiveTile() {
   if (mapRenderSettings.mapRotationMode == 1 &&
       mapView.rotationMode != Maps::ROT_COURSE_UP) {
     mapView.rotationMode = Maps::ROT_COURSE_UP;
+    mapView.resetCourseUpHeading();
     mapView.updateArrowColor();
     requestMapRender(map_render_policy::Reason::Style);
     log_i("Creating Map: Syncing rotation to Course Up (from settings)");
   } else if (mapRenderSettings.mapRotationMode == 0 &&
              mapView.rotationMode != Maps::ROT_NORTH_UP) {
     mapView.rotationMode = Maps::ROT_NORTH_UP;
+    mapView.resetCourseUpHeading();
     mapView.rotationRad = 0;
     mapView.updateArrowColor();
     requestMapRender(map_render_policy::Reason::Style);
@@ -1055,11 +1055,16 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
     }
   }
 
-  if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
-    // Keep the lightweight marker current for every accepted fix. The vector
-    // background has a separate, bounded regeneration policy.
-    mapView.updatePositionOverlay();
+  const bool gpsChanged = uiChangeTracker.take(ui_update_policy::Source::Gps);
+  if (gpsChanged) {
     mapRenderScheduler.observe(currentMapFix());
+  }
+
+  // Present the latest fix on every 30 ms UI tick. This is intentionally
+  // separate from the bounded base-map scheduler: the route and map canvas can
+  // move by sub-fix pixels without forcing a full synchronous vector render.
+  if (activeTile == MAP || activeTile == MAP_GUIDANCE) {
+    mapView.updatePositionOverlay();
   }
 
   if (mapRenderScheduler.hasPendingWork()) {

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -1044,10 +1044,20 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
   applyMapRotationForActiveTile();
 
   bool navigationOverlayChanged = false;
+  const bool routeChanged =
+      uiChangeTracker.take(ui_update_policy::Source::Route) != 0;
+  const bool settingsChanged =
+      uiChangeTracker.take(ui_update_policy::Source::Settings) != 0;
   if (activeTile == MAP_GUIDANCE) {
     mapView.followGps = true;
     navigationOverlayChanged =
         uiChangeTracker.take(ui_update_policy::Source::Navigation);
+    if (navigationOverlayChanged || routeChanged || settingsChanged) {
+      // A navigation, route, or style mutation invalidates the immutable
+      // back-buffer request. Cancel it before the next scheduler decision so
+      // old buildings can never be published over a newer map model.
+      mapView.cancelPendingMapRender();
+    }
     if (navigationOverlayChanged) {
       // Apply the maneuver model before considering synchronous base-map work.
       // The caller gives LVGL one cycle to present this overlay first.
@@ -1067,7 +1077,22 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
     mapView.updatePositionOverlay();
   }
 
-  if (mapView.guidanceProjectionNeedsRefresh()) {
+  const bool projectionNeedsRefresh =
+      mapView.guidanceProjectionNeedsRefresh();
+
+  // Keep the current visible frame translating while a guidance building job
+  // fills the hidden back buffer.  A position request inside its dynamic
+  // overscan lead can wait for the current immutable frame; once that lead is
+  // consumed, cancel and admit a fresh frame instead of publishing stale
+  // geometry at the edge of the visible viewport.
+  if (mapView.isMapRenderPending()) {
+    if (!projectionNeedsRefresh)
+      return navigationOverlayChanged;
+    mapView.cancelPendingMapRender();
+    mapRenderScheduler.request(map_render_policy::Reason::Position);
+  }
+
+  if (projectionNeedsRefresh) {
     mapRenderScheduler.request(map_render_policy::Reason::Position);
   }
 
@@ -1207,12 +1232,6 @@ void updateMainScreen(lv_timer_t *t) {
     }
   }
 
-  // Route and settings handlers already set the concrete map redraw flags or
-  // apply screen settings. Consuming their signatures prevents stale work from
-  // being mistaken for a later visible-widget change.
-  (void)uiChangeTracker.take(ui_update_policy::Source::Route);
-  (void)uiChangeTracker.take(ui_update_policy::Source::Settings);
-
   // Synchronous vector-map generation can be long. When a new maneuver and a
   // base-map request arrive together, return to LVGL once so the lightweight
   // overlay can be presented before the expensive background regeneration.
@@ -1284,6 +1303,12 @@ void updateMap(lv_event_t *event) {
       powerMeasurement.finish(true);
     }
     if (!renderCompleted) {
+      if (mapView.isMapRenderPending()) {
+        // Cooperative progress is expected; do not mark it interrupted or
+        // force a fresh request while the hidden frame is still being built.
+        mapView.redrawMap = true;
+        return;
+      }
       // Keep both flags set so the map is regenerated cleanly if the user
       // remains on this screen. Do not display the partially rendered canvas.
       mapView.redrawMap = true;

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -653,7 +653,14 @@ static tileName nextEnabledTile(tileName current) {
   return configuredDefaultTile();
 }
 
-static bool isGuidanceNavigating() { return routeOverlay.hasRoute(); }
+// The route window and the maneuver snapshot arrive over separate BLE
+// characteristics.  Treat either one as active guidance so the map does not
+// briefly fall back to persisted north-up while the sliding geometry window
+// is being exchanged (or when a device is using the native GPS path before
+// the first geometry packet has arrived).
+static bool isGuidanceNavigating() {
+  return routeOverlay.hasRoute() || hasCurrentNavigationData();
+}
 
 static int16_t navigationArrowAngle(uint8_t iconID) {
   switch (iconID) {

--- a/esp32/lib/maps/src/mapBuildingRenderer.hpp
+++ b/esp32/lib/maps/src/mapBuildingRenderer.hpp
@@ -14,6 +14,7 @@
 #include <cstdint>
 #include <cstring>
 #include <new>
+#include <utility>
 
 namespace map_building_renderer {
 
@@ -343,21 +344,42 @@ struct SurfaceStats {
   size_t suppressedWallFaces = 0;
 };
 
+// The underlay is normally a small courtyard bounding box, not a second copy
+// of the complete map canvas. Coordinates stay in canvas space so the same
+// helper works for an overscanned guidance frame and the ordinary viewport.
+struct UnderlayRegion {
+  int32_t x = 0;
+  int32_t y = 0;
+  int32_t width = 0;
+  int32_t height = 0;
+  size_t stridePixels = 0;
+  size_t pixels = 0;
+};
+
 // Restore the pixels under a projected courtyard after the outer roof has
 // been filled. The snapshot is captured after wall drawing but before roofs,
 // so land use, roads, farther buildings, and courtyard walls remain visible
 // through the opening instead of being replaced by a fixed background color.
 template <typename Points, typename Nodes, typename ShouldInterrupt>
-bool restoreCourtyardUnderlay(const Points &points, uint16_t *canvas,
-                              int32_t width, int32_t height,
-                              size_t stridePixels, const uint16_t *underlay,
-                              size_t underlayPixels, Nodes &nodes,
-                              ShouldInterrupt &&shouldInterrupt) {
+bool restoreCourtyardUnderlayRegion(
+    const Points &points, uint16_t *canvas, int32_t width, int32_t height,
+    size_t stridePixels, const uint16_t *underlay,
+    const UnderlayRegion &underlayRegion, Nodes &nodes,
+    ShouldInterrupt &&shouldInterrupt) {
   if (points.size() < 3)
     return true;
   if (canvas == nullptr || underlay == nullptr || width <= 0 || height <= 0 ||
       stridePixels < static_cast<size_t>(width) ||
-      underlayPixels < stridePixels * static_cast<size_t>(height) ||
+      underlayRegion.x < 0 || underlayRegion.y < 0 ||
+      underlayRegion.width <= 0 || underlayRegion.height <= 0 ||
+      underlayRegion.stridePixels <
+          static_cast<size_t>(underlayRegion.width) ||
+      underlayRegion.pixels <
+          underlayRegion.stridePixels *
+              static_cast<size_t>(underlayRegion.height) ||
+      underlayRegion.x >= width || underlayRegion.y >= height ||
+      underlayRegion.x + underlayRegion.width > width ||
+      underlayRegion.y + underlayRegion.height > height ||
       nodes.size() < points.size()) {
     return false;
   }
@@ -368,8 +390,11 @@ bool restoreCourtyardUnderlay(const Points &points, uint16_t *canvas,
     minY = std::min<int32_t>(minY, point.y);
     maxY = std::max<int32_t>(maxY, point.y);
   }
-  minY = std::max<int32_t>(0, minY);
-  maxY = std::min<int32_t>(height - 1, maxY);
+  minY = std::max<int32_t>(
+      std::max<int32_t>(0, minY), underlayRegion.y);
+  maxY = std::min<int32_t>(
+      std::min<int32_t>(height - 1, maxY),
+      underlayRegion.y + underlayRegion.height - 1);
   if (minY > maxY)
     return true;
 
@@ -390,16 +415,41 @@ bool restoreCourtyardUnderlay(const Points &points, uint16_t *canvas,
     }
     std::sort(nodes.begin(), nodes.begin() + count);
     for (size_t index = 0; index + 1U < count; index += 2U) {
-      const int32_t startX = std::max<int32_t>(0, nodes[index]);
-      const int32_t endX = std::min<int32_t>(width, nodes[index + 1U]);
+      const int32_t startX = std::max<int32_t>(
+          std::max<int32_t>(0, nodes[index]), underlayRegion.x);
+      const int32_t endX = std::min<int32_t>(
+          std::min<int32_t>(width, nodes[index + 1U]),
+          underlayRegion.x + underlayRegion.width);
       if (startX >= endX)
         continue;
-      const size_t offset = static_cast<size_t>(y) * stridePixels + startX;
-      std::memcpy(canvas + offset, underlay + offset,
+      const size_t canvasOffset = static_cast<size_t>(y) * stridePixels +
+                                   static_cast<size_t>(startX);
+      const size_t underlayOffset =
+          static_cast<size_t>(y - underlayRegion.y) *
+              underlayRegion.stridePixels +
+          static_cast<size_t>(startX - underlayRegion.x);
+      std::memcpy(canvas + canvasOffset, underlay + underlayOffset,
                   static_cast<size_t>(endX - startX) * sizeof(uint16_t));
     }
   }
   return true;
+}
+
+template <typename Points, typename Nodes, typename ShouldInterrupt>
+bool restoreCourtyardUnderlay(const Points &points, uint16_t *canvas,
+                              int32_t width, int32_t height,
+                              size_t stridePixels, const uint16_t *underlay,
+                              size_t underlayPixels, Nodes &nodes,
+                              ShouldInterrupt &&shouldInterrupt) {
+  const UnderlayRegion fullRegion{0,
+                                  0,
+                                  width,
+                                  height,
+                                  stridePixels,
+                                  underlayPixels};
+  return restoreCourtyardUnderlayRegion(
+      points, canvas, width, height, stridePixels, underlay, fullRegion, nodes,
+      std::forward<ShouldInterrupt>(shouldInterrupt));
 }
 
 // Emits walls first, then roof/courtyard rings. The callback returns false to

--- a/esp32/lib/maps/src/mapMotion.hpp
+++ b/esp32/lib/maps/src/mapMotion.hpp
@@ -1,0 +1,211 @@
+/**
+ * @file mapMotion.hpp
+ * @brief Small, deterministic presenters for GPS position and course heading.
+ *
+ * The GPS receiver produces fixes at a much lower rate than the LVGL frame
+ * timer.  These presenters keep the render loop independent from that input
+ * cadence: position is dead-reckoned for a short, bounded interval and then
+ * eases back to the next measured fix; heading uses the same shortest-angle
+ * easing so a turn cannot rotate the map in one large step.
+ */
+
+#pragma once
+
+#include "mapTransform.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace map_motion {
+
+inline double distanceSquared(map_transform::WorldPoint a,
+                              map_transform::WorldPoint b) {
+  const double dx = a.x - b.x;
+  const double dy = a.y - b.y;
+  return dx * dx + dy * dy;
+}
+
+inline double clampDelta(double value, double minimum, double maximum) {
+  return std::max(minimum, std::min(maximum, value));
+}
+
+/**
+ * Presents a GPS world position at the display frame rate.
+ *
+ * A fix is never extrapolated indefinitely.  This is important when a phone
+ * loses GPS: a stale velocity must not move the map away from the last known
+ * position forever.  The presenter is deliberately value-only so it can be
+ * exercised in host tests without Arduino or LVGL.
+ */
+class PositionPresenter {
+public:
+  map_transform::WorldPoint update(map_transform::WorldPoint raw,
+                                   uint32_t nowMs) {
+    if (!initialized_) {
+      initialized_ = true;
+      target_ = raw;
+      displayed_ = raw;
+      velocity_ = {};
+      lastFixMs_ = nowMs;
+      lastFrameMs_ = nowMs;
+      return displayed_;
+    }
+
+    const uint32_t sinceFixMs = nowMs - lastFixMs_;
+    if (distanceSquared(raw, target_) > kFixChangeEpsilonSquared) {
+      const double intervalSeconds = clampDelta(
+          static_cast<double>(sinceFixMs) / 1000.0, 0.05, 2.0);
+      const map_transform::WorldPoint measuredVelocity = {
+          (raw.x - target_.x) / intervalSeconds,
+          (raw.y - target_.y) / intervalSeconds};
+      const double measuredSpeed =
+          std::hypot(measuredVelocity.x, measuredVelocity.y);
+      if (measuredSpeed <= kMaximumWorldSpeedPerSecond) {
+        // Keep most of the measured velocity so a normally spaced fix can be
+        // presented continuously, while retaining enough previous velocity
+        // to avoid a single noisy fix causing a visible jerk.
+        velocity_.x = velocity_.x * 0.35 + measuredVelocity.x * 0.65;
+        velocity_.y = velocity_.y * 0.35 + measuredVelocity.y * 0.65;
+      } else {
+        // A jump this large is a teleport or a bad fix, not a bicycle speed.
+        // Snap the target and wait for a trustworthy subsequent measurement.
+        velocity_ = {};
+      }
+      target_ = raw;
+      lastFixMs_ = nowMs;
+    }
+
+    const uint32_t frameDeltaMs = nowMs - lastFrameMs_;
+    const double frameDeltaSeconds = clampDelta(
+        static_cast<double>(frameDeltaMs) / 1000.0, 0.0, 0.05);
+    const uint32_t predictionAgeMs =
+        std::min<uint32_t>(nowMs - lastFixMs_, kMaximumPredictionMs);
+    const double predictionSeconds =
+        static_cast<double>(predictionAgeMs) / 1000.0;
+    const uint32_t staleAgeMs =
+        nowMs - lastFixMs_ > kMaximumPredictionMs
+            ? nowMs - lastFixMs_ - kMaximumPredictionMs
+            : 0;
+    const double staleVelocityScale = std::exp(
+        -static_cast<double>(staleAgeMs) / 1000.0 /
+        kStaleVelocityDecaySeconds);
+    const map_transform::WorldPoint predicted = {
+        target_.x + velocity_.x * predictionSeconds * staleVelocityScale,
+        target_.y + velocity_.y * predictionSeconds * staleVelocityScale};
+
+    if (frameDeltaSeconds > 0.0) {
+      const double response =
+          1.0 - std::exp(-frameDeltaSeconds / kResponseTimeSeconds);
+      displayed_.x += (predicted.x - displayed_.x) * response;
+      displayed_.y += (predicted.y - displayed_.y) * response;
+    }
+    lastFrameMs_ = nowMs;
+    return displayed_;
+  }
+
+  void reset() {
+    initialized_ = false;
+    target_ = {};
+    displayed_ = {};
+    velocity_ = {};
+    lastFixMs_ = 0;
+    lastFrameMs_ = 0;
+  }
+
+  bool initialized() const { return initialized_; }
+
+private:
+  static constexpr double kFixChangeEpsilonSquared = 1e-8;
+  static constexpr double kMaximumWorldSpeedPerSecond = 100.0;
+  static constexpr uint32_t kMaximumPredictionMs = 750;
+  static constexpr double kResponseTimeSeconds = 0.14;
+  static constexpr double kStaleVelocityDecaySeconds = 0.25;
+
+  bool initialized_ = false;
+  map_transform::WorldPoint target_{};
+  map_transform::WorldPoint displayed_{};
+  map_transform::WorldPoint velocity_{};
+  uint32_t lastFixMs_ = 0;
+  uint32_t lastFrameMs_ = 0;
+};
+
+/**
+ * Smooths a compass/course value in degrees using the shortest turn.
+ *
+ * The revision is retained as an input for callers that want to correlate the
+ * sample with route data, but it deliberately does not reset the filter:
+ * sliding geometry windows are expected during one navigation session and
+ * resetting on each window would reintroduce a heading snap. Calls made in
+ * the same millisecond return the current value, which keeps the scheduler and
+ * renderer consistent when they sample the heading during one UI cycle.
+ */
+class HeadingPresenter {
+public:
+  uint16_t update(double rawDegrees, uint32_t nowMs, uint32_t routeRevision) {
+    rawDegrees = normalize(rawDegrees);
+    if (!initialized_) {
+      initialized_ = true;
+      routeRevision_ = routeRevision;
+      displayedDegrees_ = rawDegrees;
+      lastUpdateMs_ = nowMs;
+      return rounded(displayedDegrees_);
+    }
+    routeRevision_ = routeRevision;
+
+    const uint32_t elapsedMs = nowMs - lastUpdateMs_;
+    if (elapsedMs == 0) {
+      return rounded(displayedDegrees_);
+    }
+
+    const double elapsedSeconds = clampDelta(
+        static_cast<double>(elapsedMs) / 1000.0, 0.0, 0.25);
+    const double difference = shortestDifference(rawDegrees, displayedDegrees_);
+    const double response =
+        1.0 - std::exp(-elapsedSeconds / kResponseTimeSeconds);
+    const double maximumStep = std::max(4.0, 120.0 * elapsedSeconds);
+    const double step = clampDelta(difference * response, -maximumStep,
+                                   maximumStep);
+    displayedDegrees_ = normalize(displayedDegrees_ + step);
+    lastUpdateMs_ = nowMs;
+    return rounded(displayedDegrees_);
+  }
+
+  void reset() {
+    initialized_ = false;
+    displayedDegrees_ = 0.0;
+    routeRevision_ = 0;
+    lastUpdateMs_ = 0;
+  }
+
+private:
+  static constexpr double kResponseTimeSeconds = 0.18;
+
+  static double normalize(double degrees) {
+    degrees = std::fmod(degrees, 360.0);
+    if (degrees < 0.0)
+      degrees += 360.0;
+    return degrees;
+  }
+
+  static double shortestDifference(double target, double current) {
+    double difference = normalize(target) - normalize(current);
+    if (difference > 180.0)
+      difference -= 360.0;
+    if (difference < -180.0)
+      difference += 360.0;
+    return difference;
+  }
+
+  static uint16_t rounded(double degrees) {
+    const int32_t value = static_cast<int32_t>(std::lround(normalize(degrees)));
+    return static_cast<uint16_t>(value % 360);
+  }
+
+  bool initialized_ = false;
+  double displayedDegrees_ = 0.0;
+  uint32_t routeRevision_ = 0;
+  uint32_t lastUpdateMs_ = 0;
+};
+
+} // namespace map_motion

--- a/esp32/lib/maps/src/mapMotion.hpp
+++ b/esp32/lib/maps/src/mapMotion.hpp
@@ -56,6 +56,9 @@ public:
     if (distanceSquared(raw, target_) > kFixChangeEpsilonSquared) {
       const double intervalSeconds = clampDelta(
           static_cast<double>(sinceFixMs) / 1000.0, 0.05, 2.0);
+      lastFixIntervalMs_ = std::max<uint32_t>(
+          kMinimumPredictionMs,
+          std::min<uint32_t>(kMaximumPredictionMs, sinceFixMs));
       const map_transform::WorldPoint measuredVelocity = {
           (raw.x - target_.x) / intervalSeconds,
           (raw.y - target_.y) / intervalSeconds};
@@ -79,13 +82,22 @@ public:
     const uint32_t frameDeltaMs = nowMs - lastFrameMs_;
     const double frameDeltaSeconds = clampDelta(
         static_cast<double>(frameDeltaMs) / 1000.0, 0.0, 0.05);
+    // Native GPS writes are driven by Core Location's distance filter and are
+    // not guaranteed to arrive at a fixed one-second cadence. Match the
+    // bounded dead-reckoning window to the most recent accepted fix interval
+    // instead of stopping at a hard 750 ms on a slower phone update. The
+    // horizon remains bounded and the stale decay still brings the presenter
+    // back to the last measured point when the link goes quiet.
+    const uint32_t predictionHorizonMs = std::max<uint32_t>(
+        kMinimumPredictionMs,
+        std::min<uint32_t>(kMaximumPredictionMs, lastFixIntervalMs_));
     const uint32_t predictionAgeMs =
-        std::min<uint32_t>(nowMs - lastFixMs_, kMaximumPredictionMs);
+        std::min<uint32_t>(nowMs - lastFixMs_, predictionHorizonMs);
     const double predictionSeconds =
         static_cast<double>(predictionAgeMs) / 1000.0;
     const uint32_t staleAgeMs =
-        nowMs - lastFixMs_ > kMaximumPredictionMs
-            ? nowMs - lastFixMs_ - kMaximumPredictionMs
+        nowMs - lastFixMs_ > predictionHorizonMs
+            ? nowMs - lastFixMs_ - predictionHorizonMs
             : 0;
     const double staleVelocityScale = std::exp(
         -static_cast<double>(staleAgeMs) / 1000.0 /
@@ -110,6 +122,7 @@ public:
     displayed_ = {};
     velocity_ = {};
     lastFixMs_ = 0;
+    lastFixIntervalMs_ = kMinimumPredictionMs;
     lastFrameMs_ = 0;
   }
 
@@ -118,15 +131,17 @@ public:
 private:
   static constexpr double kFixChangeEpsilonSquared = 1e-8;
   static constexpr double kMaximumWorldSpeedPerSecond = 100.0;
-  static constexpr uint32_t kMaximumPredictionMs = 750;
+  static constexpr uint32_t kMinimumPredictionMs = 750;
+  static constexpr uint32_t kMaximumPredictionMs = 1800;
   static constexpr double kResponseTimeSeconds = 0.14;
-  static constexpr double kStaleVelocityDecaySeconds = 0.25;
+  static constexpr double kStaleVelocityDecaySeconds = 0.18;
 
   bool initialized_ = false;
   map_transform::WorldPoint target_{};
   map_transform::WorldPoint displayed_{};
   map_transform::WorldPoint velocity_{};
   uint32_t lastFixMs_ = 0;
+  uint32_t lastFixIntervalMs_ = kMinimumPredictionMs;
   uint32_t lastFrameMs_ = 0;
 };
 

--- a/esp32/lib/maps/src/mapRenderJobPolicy.hpp
+++ b/esp32/lib/maps/src/mapRenderJobPolicy.hpp
@@ -1,0 +1,67 @@
+/**
+ * @file mapRenderJobPolicy.hpp
+ * @brief Bounds and admission rules for cooperative guidance renders.
+ *
+ * These values are deliberately independent of wall-clock discovery.  A
+ * render job may be advanced in different sized scheduler slices, but it
+ * must discover and admit the same buildings for the same immutable frame
+ * request.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace map_render_job_policy {
+
+// The UI task gives the job a short cooperative slice.  This is a yield
+// boundary, not a completeness deadline: discovery resumes on the next UI
+// tick until every candidate has been visited.
+constexpr uint32_t kGuidanceSliceBudgetUs = 3500U;
+constexpr size_t kGuidanceDiscoveryRecordsPerSlice = 96U;
+constexpr size_t kGuidanceBuildingsPerSlice = 8U;
+
+// Keep the nearest useful buildings, then render them far-to-near.  The
+// queue/point limits are deterministic geometry quotas, not input-order or
+// elapsed-time fallbacks.
+constexpr size_t kGuidanceMaximumQueuedBuildingRecords = 512U;
+constexpr size_t kGuidanceMaximumRenderedBuildingRecords = 64U;
+constexpr size_t kGuidanceMaximumRenderedBuildingPoints = 12288U;
+constexpr size_t kGuidanceMaximumRenderedBuildingPointsPerRecord = 512U;
+constexpr size_t kGuidanceMaximumExtrudedBuildingRecords = 48U;
+constexpr size_t kGuidanceMaximumExtrudedBuildingPoints = 8192U;
+constexpr size_t kGuidanceMaximumBuildingPixelsPerRecord = 120000U;
+
+// Motion can consume overscan while a frame is being built.  The refresh
+// guard is therefore derived from speed and the worst measured/specified job
+// latency instead of a fixed magic margin.
+constexpr uint16_t kGuidanceOverscanPixels = 96U;
+constexpr uint16_t kGuidanceRefreshSafetyPixels = 16U;
+constexpr uint32_t kGuidanceWorstCaseRenderMs = 300U;
+
+constexpr uint16_t availableMotionPixels() {
+  return kGuidanceOverscanPixels > kGuidanceRefreshSafetyPixels
+             ? static_cast<uint16_t>(kGuidanceOverscanPixels -
+                                     kGuidanceRefreshSafetyPixels)
+             : 0U;
+}
+
+constexpr uint16_t refreshLeadPixels(double pixelsPerMs) {
+  if (!(pixelsPerMs > 0.0))
+    return 0U;
+  const double projected = pixelsPerMs * kGuidanceWorstCaseRenderMs;
+  const auto lead = static_cast<uint32_t>(projected + 0.5);
+  return static_cast<uint16_t>(std::min<uint32_t>(availableMotionPixels(),
+                                                  lead));
+}
+
+constexpr bool shouldRefresh(double distanceFromAnchorPixels,
+                             double pixelsPerMs) {
+  const double lead = refreshLeadPixels(pixelsPerMs);
+  return distanceFromAnchorPixels >=
+         static_cast<double>(availableMotionPixels()) - lead;
+}
+
+} // namespace map_render_job_policy

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -353,30 +353,31 @@ static void *bufMapIcon = nullptr;
 
 // Guidance keeps a modest overscan around the visible viewport. The base map
 // can then translate under the fixed rider marker between full vector-frame
-// settlements without exposing the parent background at an edge.
-constexpr uint16_t kGuidanceOverscanPixels = 96;
-constexpr uint16_t kGuidanceRefreshSafetyPixels = 16;
+// settlements without exposing the parent background at an edge. The policy
+// header owns the values so frame sizing and refresh admission cannot drift.
 
 static uint16_t guidanceFrameWidth(uint16_t viewportWidth) {
   return static_cast<uint16_t>(viewportWidth +
-                               (2U * kGuidanceOverscanPixels));
+                               (2U *
+                                map_render_job_policy::kGuidanceOverscanPixels));
 }
 
 static uint16_t guidanceFrameHeight(uint16_t viewportHeight) {
   return static_cast<uint16_t>(viewportHeight +
-                               (2U * kGuidanceOverscanPixels));
+                               (2U *
+                                map_render_job_policy::kGuidanceOverscanPixels));
 }
 
 static double guidanceFrameAnchorX(uint16_t viewportWidth) {
   return static_cast<double>(gui_layout::mapAnchorX(viewportWidth)) +
-         kGuidanceOverscanPixels;
+         map_render_job_policy::kGuidanceOverscanPixels;
 }
 
 static double guidanceFrameAnchorY(uint16_t viewportHeight, bool birdsEye) {
   const double visibleAnchor =
       birdsEye ? map_projection::birdsEyeAnchorY(viewportHeight)
                : gui_layout::mapAnchorY(viewportHeight);
-  return visibleAnchor + kGuidanceOverscanPixels;
+  return visibleAnchor + map_render_job_policy::kGuidanceOverscanPixels;
 }
 
 static bool ensureMapBuffer(void *&buffer, size_t &capacity,
@@ -2381,22 +2382,16 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const bool mapNavigationActive = isMapGuidanceScreenActive();
   const bool guidanceBirdsEye = mapNavigationActive && projection.isBirdsEye();
-  // Candidate discovery runs on the UI task. Keep that scan short, but do not
-  // turn a scan timeout into a whole-frame 2D fallback: the bounded candidate
-  // queue below still contains the nearest buildings already discovered.
-  constexpr uint32_t kGuidanceBuildingTimeBudgetMs = 900U;
+  // Guidance buildings are admitted by the resumable back-buffer job in
+  // generateVectorMap.  The synchronous path remains for standalone Map,
+  // where it is not coupled to the navigation presentation cadence.
   constexpr uint32_t kBuildingDrawTimeBudgetMs =
       map_building_renderer::kMaximumBuildingRenderTimeMs;
-  constexpr size_t kGuidanceMaximumQueuedBuildingRecords = 2048U;
   constexpr double kGuidanceFarBuildingCutoffFraction = 0.20;
   const uint32_t buildingPrepassTimeBudgetMs =
-      guidanceBirdsEye
-          ? kGuidanceBuildingTimeBudgetMs
-          : map_building_renderer::kMaximumBuildingRenderTimeMs;
+      map_building_renderer::kMaximumBuildingRenderTimeMs;
   const size_t maximumQueuedBuildingRecords =
-      guidanceBirdsEye
-          ? kGuidanceMaximumQueuedBuildingRecords
-          : map_building_renderer::kMaximumRenderedBuildingRecords;
+      map_building_renderer::kMaximumRenderedBuildingRecords;
   const size_t buildingWorkspaceViewportPixels =
       static_cast<size_t>(Maps::mapScrWidth) *
       static_cast<size_t>(mapSet.mapFullScreen ? Maps::mapScrFull
@@ -2432,7 +2427,8 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       viewPort.bbox.min.x, viewPort.bbox.min.y, viewPort.bbox.max.x,
       viewPort.bbox.max.y};
   const bool buildingsSuppressed =
-      suppressBuildings || buildingFailureRetryCooldown.shouldSuppress(
+      suppressBuildings || guidanceBirdsEye ||
+      buildingFailureRetryCooldown.shouldSuppress(
                                millis(), buildingContextSignature,
                                buildingRenderRegion);
   uint32_t projectionClippedCount = 0;
@@ -3853,12 +3849,15 @@ bool Maps::probeVectorMapFolder(const std::string &folder) {
  *
  */
 void Maps::deleteMapScrSprites() {
+  releasePendingMapRender();
   cancelDragPreview();
   cancelPinchPreview();
   positionPresenter.reset();
   headingPresenter.reset();
   latestPresentedWorld = {};
   hasLatestPresentedWorld = false;
+  guidancePixelsPerMs = 0.0;
+  guidanceMotionSampleMs = 0;
   pinchZoomOutBackdrop = {};
   invalidateRollingRasterWindow();
   hasVisibleProjection = false;
@@ -3886,6 +3885,7 @@ void Maps::deleteMapScrSprites() {
  */
 void Maps::createMapScrSprites() {
   ESP_LOGI(TAG, "createMapScrSprites start");
+  releasePendingMapRender();
   hasVisibleProjection = false;
   // Map Sprite
   // Map Sprite (Canvas)
@@ -5553,8 +5553,23 @@ void Maps::displayMap() {
 map_transform::WorldPoint Maps::presentedGpsWorld(uint32_t nowMs) {
   const map_transform::WorldPoint raw = {
       lon2x(gps.gpsData.longitude), lat2y(gps.gpsData.latitude)};
+  const auto previous = latestPresentedWorld;
+  const bool hadPrevious = hasLatestPresentedWorld;
   latestPresentedWorld = positionPresenter.update(raw, nowMs);
   hasLatestPresentedWorld = true;
+  if (hadPrevious && nowMs != guidanceMotionSampleMs) {
+    const uint32_t elapsedMs = nowMs - guidanceMotionSampleMs;
+    if (elapsedMs != 0) {
+      const double worldDistance = std::hypot(
+          latestPresentedWorld.x - previous.x,
+          latestPresentedWorld.y - previous.y);
+      const double pixels = worldDistance *
+                            map_transform::worldToScreenScale(zoomLevel);
+      const double measured = pixels / static_cast<double>(elapsedMs);
+      guidancePixelsPerMs = guidancePixelsPerMs * 0.65 + measured * 0.35;
+    }
+  }
+  guidanceMotionSampleMs = nowMs;
   return latestPresentedWorld;
 }
 
@@ -5626,23 +5641,40 @@ bool Maps::isGuidanceBirdsEyeProjection() const {
 }
 
 bool Maps::guidanceProjectionNeedsRefresh() const {
-  if (!isGuidanceBirdsEyeProjection() || !hasLatestPresentedWorld)
+  if (!isMapGuidanceScreenActive() || !hasLatestPresentedWorld)
     return false;
 
-  const auto projected = visibleProjection.projectWorld(latestPresentedWorld);
+  // While a building job is pending, its immutable projection is the frame
+  // that would be published.  Compare motion against that target rather than
+  // the older visible projection; otherwise every cooperative slice would
+  // look stale and discovery would be cancelled/restarted on every UI tick.
+  const map_projection::Projection *projection = nullptr;
+  if (guidanceBuildingRenderJob.active &&
+      guidanceBuildingRenderJob.projection.isBirdsEye()) {
+    projection = &guidanceBuildingRenderJob.projection;
+  } else if (hasVisibleProjection && visibleProjection.isBirdsEye()) {
+    projection = &visibleProjection;
+  }
+  if (projection == nullptr)
+    return false;
+
+  const auto projected = projection->projectWorld(latestPresentedWorld);
   if (!projected.valid)
     return true;
 
   // The rendered guidance frame includes overscan around the visible
-  // viewport. Refresh before the lightweight translation consumes that
-  // overscan, leaving a small safety margin for the next completed frame.
-  const double availableMotion =
-      static_cast<double>(kGuidanceOverscanPixels) -
-      static_cast<double>(kGuidanceRefreshSafetyPixels);
-  return projected.x < visibleProjection.anchorX() - availableMotion ||
-         projected.x > visibleProjection.anchorX() + availableMotion ||
-         projected.y < visibleProjection.anchorY() - availableMotion ||
-         projected.y > visibleProjection.anchorY() + availableMotion;
+  // viewport.  Reserve a lead proportional to the measured presentation
+  // speed and the bounded cooperative-job latency; a fixed 16 px margin is
+  // not sufficient when a dense frame is still being admitted.
+  const double availableMotion = static_cast<double>(
+      map_render_job_policy::availableMotionPixels());
+  const double lead = static_cast<double>(
+      map_render_job_policy::refreshLeadPixels(guidancePixelsPerMs));
+  const double refreshDistance = std::max(0.0, availableMotion - lead);
+  return projected.x < projection->anchorX() - refreshDistance ||
+         projected.x > projection->anchorX() + refreshDistance ||
+         projected.y < projection->anchorY() - refreshDistance ||
+         projected.y > projection->anchorY() + refreshDistance;
 }
 
 void Maps::applyGuidanceMotionOffset(
@@ -5832,6 +5864,455 @@ void Maps::updatePositionOverlay() {
             Maps::canvasMap != nullptr, Maps::canvasArrow != nullptr);
 }
 
+bool Maps::fillGuidancePolygon(
+    const MapBuildingVector<map_building_renderer::ScreenPoint> &points,
+    uint16_t color) {
+  if (points.size() < 3 || bufMapTemp == nullptr)
+    return true;
+
+  uint16_t *pixels = static_cast<uint16_t *>(bufMapTemp);
+  const int32_t width = guidanceBuildingRenderJob.width;
+  const int32_t height = guidanceBuildingRenderJob.height;
+  const size_t stridePixels = guidanceBuildingRenderJob.strideBytes / 2U;
+  if (width <= 0 || height <= 0 || stridePixels < static_cast<size_t>(width))
+    return false;
+
+  int32_t minY = points.front().y;
+  int32_t maxY = points.front().y;
+  for (const auto &point : points) {
+    minY = std::min(minY, point.y);
+    maxY = std::max(maxY, point.y);
+  }
+  minY = std::max<int32_t>(0, minY);
+  maxY = std::min<int32_t>(height - 1, maxY);
+  if (minY > maxY)
+    return true;
+
+  try {
+    if (guidanceBuildingRenderJob.courtyardScanlineNodes.size() <
+        points.size()) {
+      guidanceBuildingRenderJob.courtyardScanlineNodes.resize(points.size());
+    }
+  } catch (const std::bad_alloc &) {
+    return false;
+  }
+
+  auto &nodes = guidanceBuildingRenderJob.courtyardScanlineNodes;
+  for (int32_t y = minY; y <= maxY; ++y) {
+    if ((y & 0x0F) == 0 && shouldInterruptMapRenderForScreenCycle())
+      return false;
+    size_t nodeCount = 0;
+    for (size_t index = 0; index < points.size(); ++index) {
+      const auto &start = points[index];
+      const auto &end = points[(index + 1U) % points.size()];
+      if ((start.y < y && end.y >= y) ||
+          (start.y >= y && end.y < y)) {
+        nodes[nodeCount++] = static_cast<int32_t>(
+            start.x + static_cast<double>(y - start.y) /
+                          static_cast<double>(end.y - start.y) *
+                          static_cast<double>(end.x - start.x));
+      }
+    }
+    std::sort(nodes.begin(), nodes.begin() + nodeCount);
+    for (size_t index = 0; index + 1U < nodeCount; index += 2U) {
+      const int32_t startX = std::max<int32_t>(0, nodes[index]);
+      const int32_t endX = std::min<int32_t>(width, nodes[index + 1U]);
+      if (startX >= endX)
+        continue;
+      auto *row = pixels + static_cast<size_t>(y) * stridePixels;
+      std::fill(row + startX, row + endX, color);
+    }
+  }
+  return true;
+}
+
+bool Maps::startGuidanceBuildingRenderJob(
+    uint8_t requestedZoom, uint16_t width, uint16_t height,
+    uint32_t strideBytes, const ViewPort &frameViewPort,
+    const map_projection::Projection &projection) {
+  guidanceBuildingRenderJob.clear();
+  try {
+    guidanceBuildingRenderJob.active = true;
+    guidanceBuildingRenderJob.phase =
+        GuidanceBuildingRenderJob::Phase::Discover;
+    guidanceBuildingRenderJob.zoom = requestedZoom;
+    guidanceBuildingRenderJob.width = width;
+    guidanceBuildingRenderJob.height = height;
+    guidanceBuildingRenderJob.strideBytes = strideBytes;
+    guidanceBuildingRenderJob.projection = projection;
+    guidanceBuildingRenderJob.viewPort = frameViewPort;
+    guidanceBuildingRenderJob.queue.reserve(
+        map_render_job_policy::kGuidanceMaximumQueuedBuildingRecords);
+    guidanceBuildingRenderJob.eligibilityGround.reserve(
+        map_render_job_policy::kGuidanceMaximumRenderedBuildingPointsPerRecord);
+    guidanceBuildingRenderJob.eligibilityClipped.reserve(
+        map_render_job_policy::kGuidanceMaximumRenderedBuildingPointsPerRecord);
+    guidanceBuildingRenderJob.courtyardScanlineNodes.reserve(
+        map_render_job_policy::kGuidanceMaximumRenderedBuildingPointsPerRecord);
+    return true;
+  } catch (const std::bad_alloc &) {
+    guidanceBuildingRenderJob.clear();
+    ESP_LOGW(TAG, "Guidance building job unavailable: PSRAM admission failed");
+    return false;
+  }
+}
+
+bool Maps::renderGuidanceBuilding(
+    const GuidanceBuildingRenderItem &item) {
+  if (item.block == nullptr || item.building == nullptr || bufMapTemp == nullptr)
+    return false;
+
+  auto &job = guidanceBuildingRenderJob;
+  job.courtyardUnderlayReady = false;
+  job.courtyardUnderlayUnavailable = false;
+  job.courtyardUnderlayRegion = {};
+  job.courtyardUnderlay.clear();
+
+  const uint16_t visibleHeight =
+      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
+  const size_t maximumUnderlayPixels =
+      static_cast<size_t>(Maps::mapScrWidth) * visibleHeight;
+  const uint16_t roofColor = lv_color_to_u16(lv_color_hex(0xB9B2A8));
+  const uint16_t wallLight = lv_color_to_u16(lv_color_hex(0x958E84));
+  const uint16_t wallMiddle = lv_color_to_u16(lv_color_hex(0x827B72));
+  const uint16_t wallDark = lv_color_to_u16(lv_color_hex(0x6D665E));
+  const auto shouldStop = [&]() {
+    return shouldInterruptMapRenderForScreenCycle();
+  };
+  bool courtyardCaptureSeen = false;
+  bool courtyardSnapshotAttempted = false;
+  int32_t courtyardMinX = job.width;
+  int32_t courtyardMinY = job.height;
+  int32_t courtyardMaxX = -1;
+  int32_t courtyardMaxY = -1;
+  const auto prepareCourtyardUnderlay = [&]() {
+    if (!courtyardCaptureSeen || courtyardSnapshotAttempted)
+      return;
+    courtyardSnapshotAttempted = true;
+    const int32_t regionX = std::max<int32_t>(0, courtyardMinX);
+    const int32_t regionY = std::max<int32_t>(0, courtyardMinY);
+    const int32_t regionEndX =
+        std::min<int32_t>(job.width, courtyardMaxX + 1);
+    const int32_t regionEndY =
+        std::min<int32_t>(job.height, courtyardMaxY + 1);
+    const int32_t regionWidth = regionEndX - regionX;
+    const int32_t regionHeight = regionEndY - regionY;
+    if (regionWidth <= 0 || regionHeight <= 0) {
+      job.courtyardUnderlayUnavailable = true;
+      return;
+    }
+    const size_t pixelCount = static_cast<size_t>(regionWidth) *
+                              static_cast<size_t>(regionHeight);
+    if (pixelCount > maximumUnderlayPixels) {
+      job.courtyardUnderlayUnavailable = true;
+      return;
+    }
+    try {
+      job.courtyardUnderlay.resize(pixelCount);
+    } catch (const std::bad_alloc &) {
+      job.courtyardUnderlayUnavailable = true;
+      return;
+    }
+    job.courtyardUnderlayRegion = {
+        regionX, regionY, regionWidth, regionHeight,
+        static_cast<size_t>(regionWidth), pixelCount};
+    const size_t stridePixels = job.strideBytes / 2U;
+    const auto *source = static_cast<const uint16_t *>(bufMapTemp);
+    for (int32_t row = 0; row < regionHeight; ++row) {
+      const size_t sourceOffset =
+          static_cast<size_t>(regionY + row) * stridePixels +
+          static_cast<size_t>(regionX);
+      const size_t underlayOffset =
+          static_cast<size_t>(row) * job.courtyardUnderlayRegion.stridePixels;
+      std::memcpy(job.courtyardUnderlay.data() + underlayOffset,
+                  source + sourceOffset,
+                  static_cast<size_t>(regionWidth) * sizeof(uint16_t));
+    }
+    job.courtyardUnderlayReady = true;
+  };
+
+  try {
+    return map_building_renderer::renderSurfaces(
+        *item.building, item.block->offset.x, item.block->offset.y,
+        item.block->mercatorScale, job.projection, item.extrude,
+        [&](map_building_renderer::Surface surface,
+            const auto &points) -> bool {
+        if (shouldStop())
+          return false;
+        if (points.size() < 3 &&
+            surface != map_building_renderer::Surface::CourtyardCapture)
+          return true;
+
+        if (surface == map_building_renderer::Surface::CourtyardCapture) {
+          if (points.size() < 3)
+            return true;
+          courtyardCaptureSeen = true;
+          for (const auto &point : points) {
+            courtyardMinX = std::min(courtyardMinX, point.x);
+            courtyardMaxX = std::max(courtyardMaxX, point.x);
+            courtyardMinY = std::min(courtyardMinY, point.y);
+            courtyardMaxY = std::max(courtyardMaxY, point.y);
+          }
+          return true;
+        }
+
+        if (surface == map_building_renderer::Surface::Roof ||
+            surface == map_building_renderer::Surface::Courtyard)
+          prepareCourtyardUnderlay();
+
+        if (surface == map_building_renderer::Surface::Courtyard) {
+          if (job.courtyardUnderlayUnavailable ||
+              !job.courtyardUnderlayReady)
+            return true;
+          return map_building_renderer::restoreCourtyardUnderlayRegion(
+              points, static_cast<uint16_t *>(bufMapTemp), job.width,
+              job.height, job.strideBytes / 2U, job.courtyardUnderlay.data(),
+              job.courtyardUnderlayRegion, job.courtyardScanlineNodes,
+              shouldStop);
+        }
+
+        if (job.courtyardUnderlayUnavailable &&
+            surface == map_building_renderer::Surface::Roof)
+          return true;
+
+        uint16_t color = roofColor;
+        switch (surface) {
+        case map_building_renderer::Surface::WallLight:
+          color = wallLight;
+          break;
+        case map_building_renderer::Surface::WallMiddle:
+          color = wallMiddle;
+          break;
+        case map_building_renderer::Surface::WallDark:
+          color = wallDark;
+          break;
+        case map_building_renderer::Surface::Roof:
+        case map_building_renderer::Surface::Courtyard:
+        case map_building_renderer::Surface::CourtyardCapture:
+          break;
+        }
+        return fillGuidancePolygon(points, color);
+        },
+        nullptr, shouldStop);
+  } catch (const std::bad_alloc &) {
+    // Per-ring projection vectors are allocated by the shared renderer. A
+    // transient PSRAM failure must abort this hidden frame cleanly rather than
+    // unwinding through the LVGL event callback and corrupting the UI task.
+    ESP_LOGW(TAG, "Guidance building job aborted: geometry allocation failed");
+    return false;
+  }
+}
+
+void Maps::publishGuidanceRenderJob() {
+  auto &job = guidanceBuildingRenderJob;
+  if (!job.active || bufMapScreen == nullptr || bufMapTemp == nullptr)
+    return;
+  const size_t rowBytes = static_cast<size_t>(job.width) * sizeof(uint16_t);
+  auto *front = static_cast<uint8_t *>(bufMapScreen);
+  const auto *back = static_cast<const uint8_t *>(bufMapTemp);
+  for (uint16_t y = 0; y < job.height; ++y) {
+    std::memcpy(front + static_cast<size_t>(y) * job.strideBytes,
+                back + static_cast<size_t>(y) * job.strideBytes, rowBytes);
+  }
+  lv_canvas_set_buffer(Maps::canvasMap, bufMapScreen, job.width, job.height,
+                       LV_COLOR_FORMAT_RGB565);
+  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, job.width, job.height,
+                       LV_COLOR_FORMAT_RGB565);
+  lv_obj_center(Maps::canvasMap);
+  lv_obj_center(Maps::canvasMapTemp);
+  Maps::viewPort = job.viewPort;
+  visibleProjection = job.projection;
+  hasVisibleProjection = true;
+  finishDragSettlement();
+  finishPinchSettlement();
+  MAPIO_LOG("MAPIO: guidance-job complete discovered=%u rendered=%u "
+            "extruded=%u points=%u\n",
+            (unsigned)job.discoveredRecords, (unsigned)job.renderedRecords,
+            (unsigned)job.extrudedRecords, (unsigned)job.renderedPoints);
+  job.clear();
+}
+
+bool Maps::advanceGuidanceBuildingRenderJob() {
+  auto &job = guidanceBuildingRenderJob;
+  if (!job.active)
+    return true;
+  if (shouldInterruptMapRenderForScreenCycle()) {
+    job.clear();
+    return false;
+  }
+
+  const uint32_t sliceStartUs = micros();
+  switch (job.phase) {
+  case GuidanceBuildingRenderJob::Phase::Discover: {
+    size_t processed = 0;
+    while (job.blockIndex < memCache.blocks.size() &&
+           processed < map_render_job_policy::kGuidanceDiscoveryRecordsPerSlice &&
+           static_cast<uint32_t>(micros() - sliceStartUs) <
+               map_render_job_policy::kGuidanceSliceBudgetUs) {
+      MapBlock *block = memCache.blocks[job.blockIndex];
+      if (block == nullptr || !block->inView || block->formatVersion < 4) {
+        ++job.blockIndex;
+        job.recordIndex = 0;
+        continue;
+      }
+      if (job.recordIndex >= block->buildingData.buildings.size()) {
+        ++job.blockIndex;
+        job.recordIndex = 0;
+        continue;
+      }
+
+      const size_t currentIndex = job.recordIndex++;
+      ++processed;
+      ++job.discoveredRecords;
+      const auto &building = block->buildingData.buildings[currentIndex];
+      const BBox screenBbox = job.viewPort.bbox - block->offset;
+      const map_transform::WorldPoint center{
+          static_cast<double>(block->offset.x) +
+              (static_cast<double>(building.minX) + building.maxX) / 2.0,
+          static_cast<double>(block->offset.y) +
+              (static_cast<double>(building.minY) + building.maxY) / 2.0};
+      const auto centerGround = job.projection.groundForWorld(center);
+      const auto centerProjection = job.projection.projectGround(centerGround);
+      const bool extrudeRequested =
+          mapRenderSettings.mapNavigation3DBuildingsEnabled &&
+          map_building_renderer::eligibleExtrusionZoom(job.zoom) &&
+          map_building_renderer::usesExtrusion(true, building.flags) &&
+          centerProjection.valid &&
+          centerProjection.y >=
+              static_cast<double>(job.projection.config().viewportHeight) * 0.20;
+      const int32_t elevationMargin = extrudeRequested
+          ? static_cast<int32_t>(std::ceil(
+                building.heightDm / 10.0 * block->mercatorScale))
+          : 0;
+      const BBox buildingBbox(
+          Point32(building.minX - elevationMargin,
+                  building.minY - elevationMargin),
+          Point32(building.maxX + elevationMargin,
+                  building.maxY + elevationMargin));
+      if (!buildingBbox.intersects(screenBbox))
+        continue;
+
+      size_t pointCount = 0;
+      for (const auto &ring : building.rings)
+        pointCount += ring.points.size();
+      if (pointCount == 0 ||
+          pointCount >
+              map_render_job_policy::kGuidanceMaximumRenderedBuildingPointsPerRecord)
+        continue;
+
+      const double projectedArea =
+          map_building_renderer::projectedFootprintAreaPixels(
+              building, block->offset.x, block->offset.y, job.projection,
+              job.eligibilityGround, job.eligibilityClipped,
+              shouldInterruptMapRenderForScreenCycle);
+      if (shouldInterruptMapRenderForScreenCycle()) {
+        job.clear();
+        return false;
+      }
+      if (projectedArea > static_cast<double>(
+                              map_render_job_policy::kGuidanceMaximumBuildingPixelsPerRecord))
+        continue;
+
+      GuidanceBuildingRenderItem candidate{
+          block, &building, centerGround.forward,
+          static_cast<uint16_t>(currentIndex), pointCount, false,
+          extrudeRequested, extrudeRequested};
+      const auto rendersBefore =
+          [](const GuidanceBuildingRenderItem &left,
+             const GuidanceBuildingRenderItem &right) {
+            return map_building_renderer::rendersBefore(
+                {left.depth, left.block->offset.x, left.block->offset.y,
+                 left.recordIndex},
+                {right.depth, right.block->offset.x, right.block->offset.y,
+                 right.recordIndex});
+          };
+      map_building_renderer::retainNearestCandidate(
+          job.queue, candidate,
+          map_render_job_policy::kGuidanceMaximumQueuedBuildingRecords,
+          rendersBefore);
+    }
+    if (job.blockIndex >= memCache.blocks.size())
+      job.phase = GuidanceBuildingRenderJob::Phase::Select;
+    break;
+  }
+  case GuidanceBuildingRenderJob::Phase::Select: {
+    const auto rendersBefore =
+        [](const GuidanceBuildingRenderItem &left,
+           const GuidanceBuildingRenderItem &right) {
+          return map_building_renderer::rendersBefore(
+              {left.depth, left.block->offset.x, left.block->offset.y,
+               left.recordIndex},
+              {right.depth, right.block->offset.x, right.block->offset.y,
+               right.recordIndex});
+        };
+    std::sort(job.queue.begin(), job.queue.end(), rendersBefore);
+    size_t points = 0;
+    size_t extrusionPoints = 0;
+    size_t extrusionRecords = 0;
+    for (auto iterator = job.queue.rbegin(); iterator != job.queue.rend();
+         ++iterator) {
+      auto &item = *iterator;
+      item.render = false;
+      item.extrude = false;
+      if (item.pointCount >
+              map_render_job_policy::kGuidanceMaximumRenderedBuildingPoints -
+                  points ||
+          item.pointCount >
+              map_render_job_policy::kGuidanceMaximumRenderedBuildingPointsPerRecord)
+        continue;
+      item.render = true;
+      points += item.pointCount;
+      if (item.extrusionCandidate &&
+          extrusionRecords <
+              map_render_job_policy::kGuidanceMaximumExtrudedBuildingRecords &&
+          item.pointCount <=
+              map_render_job_policy::kGuidanceMaximumExtrudedBuildingPoints -
+                  extrusionPoints) {
+        item.extrude = true;
+        ++extrusionRecords;
+        extrusionPoints += item.pointCount;
+      }
+    }
+    job.renderedPoints = points;
+    job.phase = GuidanceBuildingRenderJob::Phase::Draw;
+    break;
+  }
+  case GuidanceBuildingRenderJob::Phase::Draw: {
+    size_t completedBuildings = 0;
+    while (job.drawIndex < job.queue.size() &&
+           completedBuildings < map_render_job_policy::kGuidanceBuildingsPerSlice &&
+           static_cast<uint32_t>(micros() - sliceStartUs) <
+               map_render_job_policy::kGuidanceSliceBudgetUs) {
+      const auto &item = job.queue[job.drawIndex++];
+      if (!item.render)
+        continue;
+      if (!renderGuidanceBuilding(item)) {
+        job.clear();
+        return false;
+      }
+      ++completedBuildings;
+      ++job.renderedRecords;
+      if (item.extrude)
+        ++job.extrudedRecords;
+    }
+    if (job.drawIndex >= job.queue.size()) {
+      publishGuidanceRenderJob();
+      return true;
+    }
+    break;
+  }
+  case GuidanceBuildingRenderJob::Phase::None:
+    return true;
+  }
+
+  MAPIO_LOG("MAPIO: guidance-job slice phase=%u us=%lu discovered=%u "
+            "queued=%u draw=%u/%u\n",
+            (unsigned)job.phase, (unsigned long)(micros() - sliceStartUs),
+            (unsigned)job.discoveredRecords, (unsigned)job.queue.size(),
+            (unsigned)job.drawIndex, (unsigned)job.queue.size());
+  return false;
+}
+
 /**
  * @brief Generate Vector Map
  *
@@ -5850,6 +6331,12 @@ bool Maps::generateVectorMap(uint8_t zoom) {
     ESP_LOGE(TAG, "Map render skipped: canvas double buffer is unavailable");
     return false;
   }
+
+  // A guidance frame with buildings is a latest-wins cooperative job.  Do
+  // not recompute its projection or touch the hidden canvas until the current
+  // immutable request has either completed or been cancelled by input.
+  if (isMapRenderPending())
+    return advanceGuidanceBuildingRenderJob();
 
   // The hidden buffer is about to become the render target. Any prepared
   // zoom-out backdrop in it is no longer reusable.
@@ -6028,8 +6515,12 @@ bool Maps::generateVectorMap(uint8_t zoom) {
 #if POWER_METRICS
   const uint32_t powerDrawStartUs = micros();
 #endif
+  const bool cooperativeGuidanceBuildings =
+      guidanceFrame && frameProjection.isBirdsEye() &&
+      (currentMapStyleSettings().visibilityMask & MAP_VISIBILITY_BUILDINGS) != 0;
   if (!Maps::readVectorMap(Maps::viewPort, Maps::memCache, Maps::canvasMapTemp,
-                           zoom, rotationRad, frameProjection)) {
+                           zoom, rotationRad, frameProjection, true,
+                           cooperativeGuidanceBuildings)) {
 #if POWER_METRICS
     powerDrawUs = micros() - powerDrawStartUs;
     powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
@@ -6044,6 +6535,24 @@ bool Maps::generateVectorMap(uint8_t zoom) {
                                      powerRouteUs);
 #endif
   const uint32_t drawMs = MAPIO_TIME_MS() - drawStartMs;
+
+  if (cooperativeGuidanceBuildings) {
+    if (startGuidanceBuildingRenderJob(
+            zoom, renderExtent.width, renderExtent.height, renderStride,
+            Maps::viewPort, frameProjection)) {
+      // The base map is already complete in the hidden buffer.  The building
+      // pass advances one bounded unit per UI cycle and publishes atomically
+      // when its deterministic queue is exhausted.
+      MAPIO_LOG("MAPIO: guidance-job start zoom=%u baseMs=%lu blocks=%u\n",
+                (unsigned)zoom, (unsigned long)drawMs,
+                (unsigned)Maps::memCache.blocks.size());
+      powerMeasurement.finish(false);
+      return false;
+    }
+    // Allocation failure is controlled degradation: publish the complete 2D
+    // underlay rather than retrying a synchronous multi-second pass.
+    MAPIO_LOG("MAPIO: guidance-job fallback=2d reason=allocation\n");
+  }
 
   if (shouldInterruptMapRenderForScreenCycle()) {
     log_i("Map render interrupted before route overlay");

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -5420,8 +5420,27 @@ void Maps::updateGuidanceRouteHead(
                             viewportHeight);
   }
   lv_obj_center(Maps::canvasForeground);
+
+  // Keep the geographic GPS anchor at the arrow's lower center so map
+  // rotation still pivots around the rider, but attach the visible route line
+  // to the arrow's visual center. The foreground is translated after this
+  // draw; deriving the center from the presented projection keeps that
+  // attachment exact during sub-fix motion as well as full map renders.
+  map_transform::WorldPoint markerCenterWorld = presentedWorld;
+  const auto presentedProjection =
+      visibleProjection.projectWorld(presentedWorld);
+  if (presentedProjection.valid) {
+    const double markerCenterOffsetX =
+        static_cast<double>(currentMarkerSize() / 2 - currentMarkerAnchorX());
+    const double markerCenterOffsetY =
+        static_cast<double>(currentMarkerSize() / 2 - currentMarkerAnchorY());
+    const auto markerCenterGround = visibleProjection.groundForScreen(
+        presentedProjection.x + markerCenterOffsetX,
+        presentedProjection.y + markerCenterOffsetY);
+    markerCenterWorld = visibleProjection.worldForGround(markerCenterGround);
+  }
   routeOverlay.drawLiveHead(Maps::canvasForeground, visibleProjection,
-                            presentedWorld);
+                            presentedWorld, markerCenterWorld);
   rollingForegroundReady = false;
   lv_obj_clear_flag(Maps::canvasForeground, LV_OBJ_FLAG_HIDDEN);
   lv_obj_invalidate(Maps::canvasForeground);

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -2381,15 +2381,15 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const bool mapNavigationActive = isMapGuidanceScreenActive();
   const bool guidanceBirdsEye = mapNavigationActive && projection.isBirdsEye();
+  // Candidate discovery runs on the UI task. Keep that scan short, but do not
+  // turn a scan timeout into a whole-frame 2D fallback: the bounded candidate
+  // queue below still contains the nearest buildings already discovered.
   constexpr uint32_t kGuidanceBuildingTimeBudgetMs = 900U;
+  constexpr uint32_t kBuildingDrawTimeBudgetMs =
+      map_building_renderer::kMaximumBuildingRenderTimeMs;
   constexpr size_t kGuidanceMaximumQueuedBuildingRecords = 2048U;
   constexpr double kGuidanceFarBuildingCutoffFraction = 0.20;
-  // Guidance renders on the UI task. Keep the optional 3D pass bounded so a
-  // dense city cannot starve GPS/scene updates for several seconds. The
-  // normal-map budget remains unchanged; if guidance reaches this limit, the
-  // existing retry path presents the same frame with buildings suppressed,
-  // leaving the 2D roads/land-use map intact.
-  const uint32_t buildingTimeBudgetMs =
+  const uint32_t buildingPrepassTimeBudgetMs =
       guidanceBirdsEye
           ? kGuidanceBuildingTimeBudgetMs
           : map_building_renderer::kMaximumBuildingRenderTimeMs;
@@ -2754,6 +2754,8 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
     BuildingPassPhase buildingPassPhase = BuildingPassPhase::Projection;
     uint32_t buildingPhaseStartMs = millis();
     const uint32_t buildingPassStartMs = buildingPhaseStartMs;
+    uint32_t buildingDeadlineStartMs = buildingPassStartMs;
+    uint32_t buildingPhaseBudgetMs = buildingPrepassTimeBudgetMs;
     const auto finishBuildingPhaseTiming = [&]() {
       const uint32_t elapsed = millis() - buildingPhaseStartMs;
       switch (buildingPassPhase) {
@@ -2802,7 +2804,7 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
     static uint64_t extrusionRecordOverflowTotal = 0;
     static uint64_t extrusionPointOverflowTotal = 0;
     const auto buildingDeadlineReached = [&]() {
-      return millis() - buildingPassStartMs >= buildingTimeBudgetMs;
+      return millis() - buildingDeadlineStartMs >= buildingPhaseBudgetMs;
     };
     const auto shouldStopBuildingWork = [&]() {
       if (shouldInterruptMapRenderForScreenCycle()) {
@@ -2948,34 +2950,47 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       buildingPhaseStartMs = millis();
       renderRecordLimitOverflow =
           boundedBuildingCandidateCount - buildingQueue.size();
-      if (!stopBuildingPrepass) {
-        std::sort(buildingQueue.begin(), buildingQueue.end(),
-                  buildingRendersBefore);
-        buildingSortMs = millis() - buildingPhaseStartMs;
-        if (!shouldStopBuildingWork()) {
-          renderSelection = map_building_renderer::selectNearestForRendering(
-              buildingQueue.rbegin(), buildingQueue.rend(),
-              shouldStopBuildingWork);
-          if (!buildingDeadlineExceeded && !buildingScreenInterrupted &&
-              extrudeBuildings) {
-            // The painter queue is far-to-near. Reserve in reverse so the
-            // geometry nearest the rider keeps its walls when a dense city
-            // exceeds the bounded extrusion workspace; overflow roofs remain
-            // visible and flat.
-            buildingSelection =
-                map_building_renderer::selectNearestForExtrusion(
-                    buildingQueue.rbegin(), buildingQueue.rend(),
-                    shouldStopBuildingWork);
-            buildingBudgetFallback = buildingSelection.usedFallback();
-            extrusionRecordOverflowTotal +=
-                buildingSelection.recordLimitOverflow;
-            extrusionPointOverflowTotal +=
-                buildingSelection.pointLimitOverflow;
-          }
+      if (stopBuildingPrepass && buildingDeadlineExceeded) {
+        // The discovery budget is a responsiveness guard, not a reason to
+        // throw away the entire scratch frame. Sort and render the bounded
+        // nearest queue collected so far, with the normal geometry budget.
+        buildingPrepassDeadlineExceeded = true;
+        buildingDeadlineExceeded = false;
+      }
+      if (buildingScreenInterrupted)
+        return false;
+
+      // Sorting and surface rendering operate on bounded queues/point counts.
+      // Give those phases their own hard budget so a partial discovery pass
+      // can still produce a useful 3D frame without becoming unbounded.
+      buildingDeadlineStartMs = millis();
+      buildingPhaseBudgetMs = kBuildingDrawTimeBudgetMs;
+      std::sort(buildingQueue.begin(), buildingQueue.end(),
+                buildingRendersBefore);
+      buildingSortMs = millis() - buildingPhaseStartMs;
+      if (!shouldStopBuildingWork()) {
+        renderSelection = map_building_renderer::selectNearestForRendering(
+            buildingQueue.rbegin(), buildingQueue.rend(),
+            shouldStopBuildingWork);
+        if (!buildingDeadlineExceeded && !buildingScreenInterrupted &&
+            extrudeBuildings) {
+          // The painter queue is far-to-near. Reserve in reverse so the
+          // geometry nearest the rider keeps its walls when a dense city
+          // exceeds the bounded extrusion workspace; overflow roofs remain
+          // visible and flat.
+          buildingSelection =
+              map_building_renderer::selectNearestForExtrusion(
+                  buildingQueue.rbegin(), buildingQueue.rend(),
+                  shouldStopBuildingWork);
+          buildingBudgetFallback = buildingSelection.usedFallback();
+          extrusionRecordOverflowTotal +=
+              buildingSelection.recordLimitOverflow;
+          extrusionPointOverflowTotal += buildingSelection.pointLimitOverflow;
         }
       }
       if (buildingDeadlineExceeded) {
-        buildingPrepassDeadlineExceeded = true;
+        // A timeout in the bounded sort/selection phase is still a genuine
+        // render abort; the prepass case above is intentionally recoverable.
         return abortStoppedBuildingWork(buildingQueue.size());
       }
       if (buildingScreenInterrupted)
@@ -3009,8 +3024,8 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       buildingPolygon.bbox.min = Point16(minX, minY);
       buildingPolygon.bbox.max = Point16(maxX, maxY);
       const bool completed = Maps::fillPolygon(
-          buildingPolygon, canvas, buildingPassStartMs,
-          buildingTimeBudgetMs);
+          buildingPolygon, canvas, buildingDeadlineStartMs,
+          buildingPhaseBudgetMs);
       if (!completed)
         shouldStopBuildingWork();
       return completed;
@@ -3325,8 +3340,13 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             (unsigned)buildingFailurePsramFree,
             (unsigned)buildingFailurePsramLargest,
             buildingFailurePsramSamplePostCleanup ? 1U : 0U);
-        buildingFailureRetryCooldown.recordFailure(
-            millis(), buildingContextSignature, buildingRenderRegion);
+        // A deadline is a transient workload signal, not a memory failure.
+        // Only allocation failures enter the cooldown; otherwise one dense
+        // frame would suppress 3D buildings for the next five minutes.
+        if (buildingAllocationFailed) {
+          buildingFailureRetryCooldown.recordFailure(
+              millis(), buildingContextSignature, buildingRenderRegion);
+        }
         releaseBuildingFailureWorkspace();
         const bool screenCycleInterrupted =
             shouldInterruptMapRenderForScreenCycle();

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -492,6 +492,22 @@ static lv_value_precise_t markerCoord(int32_t origin, int16_t size,
           navigation_visual_style::POSITION_MARKER_BASE_SIZE);
 }
 
+// The arrow's geographic reference is the point where it touches the road,
+// not the center of its 48x48 drawing box.  Keeping this anchor explicit makes
+// course-up rotation pivot around the rider's position instead of the arrow's
+// tip and prevents a visual lead/lag when the map canvas moves underneath it.
+static int16_t currentMarkerAnchorX() {
+  const int16_t size = currentMarkerSize();
+  return static_cast<int16_t>(std::lround(markerCoord(0, size, 24)));
+}
+
+static int16_t currentMarkerAnchorY() {
+  const int16_t size = currentMarkerSize();
+  const int16_t baseY = routeOverlay.hasRoute() ? 42 : 24;
+  return static_cast<int16_t>(std::lround(
+      markerCoord(0, size, baseY)));
+}
+
 static lv_value_precise_t markerEdgeXAtY(const lv_point_precise_t &start,
                                          const lv_point_precise_t &end,
                                          lv_value_precise_t y) {
@@ -3682,6 +3698,8 @@ bool Maps::probeVectorMapFolder(const std::string &folder) {
 void Maps::deleteMapScrSprites() {
   cancelDragPreview();
   cancelPinchPreview();
+  positionPresenter.reset();
+  headingPresenter.reset();
   pinchZoomOutBackdrop = {};
   invalidateRollingRasterWindow();
   hasVisibleProjection = false;
@@ -5057,12 +5075,16 @@ void Maps::updatePinchPreview(double previewRatio, int16_t midpointX,
   if (!pinchPresentation.capturedFollowGps && Maps::canvasArrow != nullptr) {
     const double pivotX = pinchPresentation.initialMidpointX;
     const double pivotY = pinchPresentation.initialMidpointY;
-    const double markerCenterX = pinchPresentation.markerBaseX + 24.0;
-    const double markerCenterY = pinchPresentation.markerBaseY + 24.0;
+    const int16_t markerAnchorX = currentMarkerAnchorX();
+    const int16_t markerAnchorY = currentMarkerAnchorY();
+    const double markerCenterX = pinchPresentation.markerBaseX + markerAnchorX;
+    const double markerCenterY = pinchPresentation.markerBaseY + markerAnchorY;
     const int16_t transformedX = static_cast<int16_t>(std::round(
-        pivotX + ((markerCenterX - pivotX) * ratio) + translationX - 24.0));
+        pivotX + ((markerCenterX - pivotX) * ratio) + translationX -
+        markerAnchorX));
     const int16_t transformedY = static_cast<int16_t>(std::round(
-        pivotY + ((markerCenterY - pivotY) * ratio) + translationY - 24.0));
+        pivotY + ((markerCenterY - pivotY) * ratio) + translationY -
+        markerAnchorY));
     lv_obj_set_pos(Maps::canvasArrow, transformedX, transformedY);
   }
   lv_obj_invalidate(Maps::canvasMap);
@@ -5214,9 +5236,11 @@ void Maps::finishPinchSettlement() {
 void Maps::toggleRotationMode() {
   if (rotationMode == ROT_NORTH_UP) {
     rotationMode = ROT_COURSE_UP;
+    resetCourseUpHeading();
     log_i("Map Rotation: COURSE UP");
   } else {
     rotationMode = ROT_NORTH_UP;
+    resetCourseUpHeading();
     rotationRad = 0;
     log_i("Map Rotation: NORTH UP");
   }
@@ -5355,8 +5379,59 @@ void Maps::displayMap() {
   updatePositionOverlay();
 }
 
+map_transform::WorldPoint Maps::presentedGpsWorld(uint32_t nowMs) {
+  const map_transform::WorldPoint raw = {
+      lon2x(gps.gpsData.longitude), lat2y(gps.gpsData.latitude)};
+  return positionPresenter.update(raw, nowMs);
+}
+
+void Maps::applyGuidanceMotionOffset(
+    map_transform::WorldPoint presentedWorld) {
+  if (!isMapGuidanceScreenActive() || !Maps::followGps ||
+      Maps::canvasMap == nullptr || !hasVisibleProjection ||
+      dragPreviewController.active() || dragPreviewController.settlementPending() ||
+      pinchPresentation.active || pinchPresentation.settlementPending) {
+    return;
+  }
+
+  const auto projected = visibleProjection.projectWorld(presentedWorld);
+  if (!projected.valid)
+    return;
+
+  // A synchronous vector render recenters the canvas. Rebase from that stable
+  // origin on every frame, then apply only the small sub-fix translation. The
+  // marker remains fixed at the same lower-center anchor while the route and
+  // base map move together underneath it.
+  lv_obj_center(Maps::canvasMap);
+  const int16_t baseX = lv_obj_get_x_aligned(Maps::canvasMap);
+  const int16_t baseY = lv_obj_get_y_aligned(Maps::canvasMap);
+  const int32_t offsetX = map_transform::quantizePixel(
+      visibleProjection.anchorX() - projected.x);
+  const int32_t offsetY = map_transform::quantizePixel(
+      visibleProjection.anchorY() - projected.y);
+  if (offsetX == 0 && offsetY == 0)
+    return;
+
+  lv_obj_set_pos(Maps::canvasMap, baseX + offsetX, baseY + offsetY);
+  lv_obj_invalidate(Maps::canvasMap);
+}
+
+uint16_t Maps::courseUpHeading(double latitude, double longitude,
+                               uint16_t gpsHeading) {
+  uint16_t routeHeading = 0;
+  const uint16_t rawHeading =
+      routeOverlay.headingNear(latitude, longitude, routeHeading)
+          ? routeHeading
+          : gpsHeading;
+  return headingPresenter.update(rawHeading, millis(), routeOverlay.revision());
+}
+
+void Maps::resetCourseUpHeading() { headingPresenter.reset(); }
+
 void Maps::updatePositionOverlay() {
   const uint32_t displayStartMs = MAPIO_TIME_MS();
+  const map_transform::WorldPoint presentedWorld =
+      presentedGpsWorld(millis());
   // Update Arrow Position
   if (Maps::canvasArrow) {
     if (!Maps::isMapFound || !isCurrentPositionVisible(mapRenderSettings)) {
@@ -5386,47 +5461,42 @@ void Maps::updatePositionOverlay() {
                                           visibleProjection.anchorY()))
                                 : mapAnchorYForHeight(h);
     updateCurrentPositionMarker(Maps::canvasArrow);
+    const int16_t markerAnchorX = currentMarkerAnchorX();
+    const int16_t markerAnchorY = currentMarkerAnchorY();
     const int16_t markerVisualHalf = currentMarkerSize() / 2;
     int16_t x, y;
 
     if (Maps::followGps) {
       // The marker is a sibling of the centered map canvas, so translate the
       // canvas-local anchor into map-tile coordinates before applying the
-      // marker's center offset.
-      x = mapOriginX + anchorX - markerVisualHalf;
-      y = mapOriginY + anchorY - markerVisualHalf;
+      // marker's geographic lower-center anchor.
+      x = mapOriginX + anchorX - markerAnchorX;
+      y = mapOriginY + anchorY - markerAnchorY;
       lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       lv_obj_set_pos(Maps::canvasArrow, x, y);
-      ESP_LOGI(TAG, "GPS indicator: followGps mode, anchor screen pos(%d,%d)",
-               x, y);
     } else {
       // Calculate position relative to viewport center
       // Convert GPS lat/lon to Mercator coordinates
-      int32_t gpsX = lon2x(gps.gpsData.longitude);
-      int32_t gpsY = lat2y(gps.gpsData.latitude);
 
       if (useSharedProjection) {
         const auto markerPoint = visibleProjection.projectWorld(
-            {static_cast<double>(gpsX), static_cast<double>(gpsY)});
+            presentedWorld);
         if (!markerPoint.valid) {
           lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
           return;
         }
         x = mapOriginX + map_transform::quantizePixel(markerPoint.x) -
-            markerVisualHalf;
+            markerAnchorX;
         y = mapOriginY + map_transform::quantizePixel(markerPoint.y) -
-            markerVisualHalf;
+            markerAnchorY;
       } else {
         const auto markerDelta = map_transform::worldToScreen(
-            {static_cast<double>(gpsX - Maps::viewPort.center.x),
-             static_cast<double>(gpsY - Maps::viewPort.center.y)},
+            {presentedWorld.x - Maps::viewPort.center.x,
+             presentedWorld.y - Maps::viewPort.center.y},
             zoom, visibleMapRotation());
-        x = mapOriginX + round(markerDelta.x) + anchorX - markerVisualHalf;
-        y = mapOriginY + round(markerDelta.y) + anchorY - markerVisualHalf;
+        x = mapOriginX + round(markerDelta.x) + anchorX - markerAnchorX;
+        y = mapOriginY + round(markerDelta.y) + anchorY - markerAnchorY;
       }
-
-      ESP_LOGI(TAG, "GPS indicator updated outside follow mode zoom=%d",
-               zoom);
 
       lv_obj_set_pos(Maps::canvasArrow, x, y);
 
@@ -5439,13 +5509,13 @@ void Maps::updatePositionOverlay() {
           centerY < mapOriginY - markerVisualHalf ||
           centerY > mapOriginY + (int16_t)h + markerVisualHalf) {
         lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
-        ESP_LOGI(TAG, "GPS indicator hidden: off-screen at (%d,%d)", x, y);
       } else {
         lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       }
     }
     lv_obj_move_foreground(Maps::canvasArrow);
   }
+  applyGuidanceMotionOffset(presentedWorld);
   MAPIO_LOG("MAPIO: display invalidateMs=%lu hasCanvas=%d hasArrow=%d\n",
             (unsigned long)(MAPIO_TIME_MS() - displayStartMs),
             Maps::canvasMap != nullptr, Maps::canvasArrow != nullptr);
@@ -5482,20 +5552,17 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   // focal calculation started from; a changed heading is rendered next.
   double requestedRotation = 0.0;
   if (rotationMode == ROT_COURSE_UP) {
-    uint16_t courseUpHeading = gps.gpsData.heading;
-    const char *courseUpSource = "gps";
     uint16_t routeHeading = 0;
-    if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
-                                 routeHeading)) {
-      courseUpHeading = routeHeading;
-      courseUpSource = "route";
-    }
+    const bool hasRouteHeading = routeOverlay.headingNear(
+        gps.gpsData.latitude, gps.gpsData.longitude, routeHeading);
+    const uint16_t smoothedHeading = courseUpHeading(
+        gps.gpsData.latitude, gps.gpsData.longitude, gps.gpsData.heading);
 
     // Use negative heading to rotate map so the selected navigation/course
     // direction points up.
-    requestedRotation = -DEG2RAD(courseUpHeading);
+    requestedRotation = -DEG2RAD(smoothedHeading);
     ESP_LOGI(TAG, "Course-Up: heading=%u source=%s gpsHeading=%u",
-             (unsigned)courseUpHeading, courseUpSource,
+             (unsigned)smoothedHeading, hasRouteHeading ? "route" : "gps",
              (unsigned)gps.gpsData.heading);
   }
   const bool frozenPinchSettlement = isPinchSettlementPending();

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3700,6 +3700,8 @@ void Maps::deleteMapScrSprites() {
   cancelPinchPreview();
   positionPresenter.reset();
   headingPresenter.reset();
+  latestPresentedWorld = {};
+  hasLatestPresentedWorld = false;
   pinchZoomOutBackdrop = {};
   invalidateRollingRasterWindow();
   hasVisibleProjection = false;
@@ -5382,7 +5384,77 @@ void Maps::displayMap() {
 map_transform::WorldPoint Maps::presentedGpsWorld(uint32_t nowMs) {
   const map_transform::WorldPoint raw = {
       lon2x(gps.gpsData.longitude), lat2y(gps.gpsData.latitude)};
-  return positionPresenter.update(raw, nowMs);
+  latestPresentedWorld = positionPresenter.update(raw, nowMs);
+  hasLatestPresentedWorld = true;
+  return latestPresentedWorld;
+}
+
+void Maps::updateGuidanceRouteHead(
+    map_transform::WorldPoint presentedWorld) {
+  // Standalone Map owns this foreground for its rolling labels/route. Only
+  // guidance uses the live head, so do not hide the standalone foreground on
+  // every 30 ms position update.
+  if (!isMapGuidanceScreenActive())
+    return;
+
+  if (Maps::canvasForeground == nullptr || !hasVisibleProjection ||
+      !routeOverlay.hasRoute() ||
+      !isRouteOverlayVisible(mapRenderSettings)) {
+    rollingForegroundReady = false;
+    hideRollingForeground();
+    return;
+  }
+
+  const uint16_t viewportHeight =
+      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
+  if (!ensureMapForegroundBuffer(Maps::mapScrWidth, viewportHeight)) {
+    rollingForegroundReady = false;
+    hideRollingForeground();
+    return;
+  }
+
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(Maps::canvasForeground);
+  if (drawBuffer == nullptr || drawBuffer->header.w != Maps::mapScrWidth ||
+      drawBuffer->header.h != viewportHeight) {
+    bindMapForegroundCanvas(Maps::canvasForeground, Maps::mapScrWidth,
+                            viewportHeight);
+  }
+  lv_obj_center(Maps::canvasForeground);
+  routeOverlay.drawLiveHead(Maps::canvasForeground, visibleProjection,
+                            presentedWorld);
+  rollingForegroundReady = false;
+  lv_obj_clear_flag(Maps::canvasForeground, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_invalidate(Maps::canvasForeground);
+}
+
+bool Maps::isGuidanceBirdsEyeProjection() const {
+  return isMapGuidanceScreenActive() && hasVisibleProjection &&
+         visibleProjection.isBirdsEye();
+}
+
+bool Maps::guidanceProjectionNeedsRefresh() const {
+  if (!isGuidanceBirdsEyeProjection() || !hasLatestPresentedWorld)
+    return false;
+
+  const auto projected = visibleProjection.projectWorld(latestPresentedWorld);
+  if (!projected.valid)
+    return true;
+
+  // Keep a generous safety margin inside the rendered world bounds. Between
+  // these epochs, the lightweight guidance translation can move the map
+  // continuously without repeatedly rebuilding the perspective frame for
+  // every GPS fix. A new projection is rendered only when the rider is close
+  // enough to an edge that the cached map blocks may no longer cover it.
+  constexpr double kProjectionRefreshMarginPixels = 96.0;
+  const auto &config = visibleProjection.config();
+  return projected.x < kProjectionRefreshMarginPixels ||
+         projected.x >
+             static_cast<double>(config.viewportWidth) -
+                 kProjectionRefreshMarginPixels ||
+         projected.y < kProjectionRefreshMarginPixels ||
+         projected.y >
+             static_cast<double>(config.viewportHeight) -
+                 kProjectionRefreshMarginPixels;
 }
 
 void Maps::applyGuidanceMotionOffset(
@@ -5405,6 +5477,9 @@ void Maps::applyGuidanceMotionOffset(
   lv_obj_center(Maps::canvasMap);
   const int16_t baseX = lv_obj_get_x_aligned(Maps::canvasMap);
   const int16_t baseY = lv_obj_get_y_aligned(Maps::canvasMap);
+  if (Maps::canvasForeground != nullptr) {
+    lv_obj_set_pos(Maps::canvasForeground, baseX, baseY);
+  }
   const int32_t offsetX = map_transform::quantizePixel(
       visibleProjection.anchorX() - projected.x);
   const int32_t offsetY = map_transform::quantizePixel(
@@ -5413,7 +5488,13 @@ void Maps::applyGuidanceMotionOffset(
     return;
 
   lv_obj_set_pos(Maps::canvasMap, baseX + offsetX, baseY + offsetY);
+  if (Maps::canvasForeground != nullptr) {
+    lv_obj_set_pos(Maps::canvasForeground, baseX + offsetX,
+                   baseY + offsetY);
+  }
   lv_obj_invalidate(Maps::canvasMap);
+  if (Maps::canvasForeground != nullptr)
+    lv_obj_invalidate(Maps::canvasForeground);
 }
 
 uint16_t Maps::courseUpHeading(double latitude, double longitude,
@@ -5436,6 +5517,7 @@ void Maps::updatePositionOverlay() {
   if (Maps::canvasArrow) {
     if (!Maps::isMapFound || !isCurrentPositionVisible(mapRenderSettings)) {
       lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
+      updateGuidanceRouteHead(presentedWorld);
       MAPIO_LOG("MAPIO: current-position marker hidden mapFound=%d visible=%d\n",
                 Maps::isMapFound, isCurrentPositionVisible(mapRenderSettings));
       return;
@@ -5515,6 +5597,7 @@ void Maps::updatePositionOverlay() {
     }
     lv_obj_move_foreground(Maps::canvasArrow);
   }
+  updateGuidanceRouteHead(presentedWorld);
   applyGuidanceMotionOffset(presentedWorld);
   MAPIO_LOG("MAPIO: display invalidateMs=%lu hasCanvas=%d hasArrow=%d\n",
             (unsigned long)(MAPIO_TIME_MS() - displayStartMs),
@@ -5732,13 +5815,20 @@ bool Maps::generateVectorMap(uint8_t zoom) {
 #endif
   ESP_LOGI(TAG, "Checking for route overlay: hasRoute=%d",
            routeOverlay.hasRoute());
-  if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
+  if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings) &&
+      !isMapGuidanceScreenActive()) {
     ESP_LOGI(TAG, "Drawing route overlay: zoom=%d points=%d", zoom,
              routeOverlay.getPointCount());
 
     routeOverlay.drawRoute(Maps::canvasMapTemp, frameProjection);
     ESP_LOGI(TAG, "Route overlay draw complete (rotation=%.2f rad, canvasH=%d)",
              rotationRad, renderExtent.height);
+  } else if (routeOverlay.hasRoute() && isMapGuidanceScreenActive()) {
+    // Guidance draws the route head on the display cadence from the same
+    // presented position as the marker. Keeping the static snapshot out of
+    // the base frame prevents stale geometry from leaving a gap or trailing
+    // tail while BLE route windows are refreshed.
+    ESP_LOGI(TAG, "Route overlay deferred to live guidance head");
   } else if (routeOverlay.hasRoute()) {
     ESP_LOGI(TAG, "Route overlay hidden by visibility mask");
   } else {
@@ -5859,6 +5949,21 @@ void Maps::centerOnGps(double lat, double lon) {
   Maps::isPosMoved = true;
 
   ESP_LOGI(TAG, "centerOnGps: map center updated");
+}
+
+void Maps::centerOnPresentedGps() {
+  const map_transform::WorldPoint presented = presentedGpsWorld(MAPIO_TIME_MS());
+  Maps::followGps = true;
+  Maps::point.x = static_cast<int32_t>(std::lround(presented.x));
+  Maps::point.y = static_cast<int32_t>(std::lround(presented.y));
+
+  const double lat = Maps::mercatorY2lat(presented.y);
+  const double lon = Maps::mercatorX2lon(presented.x);
+  Maps::currentMapTile.tilex = Maps::lon2tilex(lon, Maps::currentMapTile.zoom);
+  Maps::currentMapTile.tiley = Maps::lat2tiley(lat, Maps::currentMapTile.zoom);
+  Maps::currentMapTile.lat = lat;
+  Maps::currentMapTile.lon = lon;
+  Maps::isPosMoved = true;
 }
 
 /**

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -2397,6 +2397,17 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       guidanceBirdsEye
           ? kGuidanceMaximumQueuedBuildingRecords
           : map_building_renderer::kMaximumRenderedBuildingRecords;
+  const size_t buildingWorkspaceViewportPixels =
+      static_cast<size_t>(Maps::mapScrWidth) *
+      static_cast<size_t>(mapSet.mapFullScreen ? Maps::mapScrFull
+                                               : Maps::mapScrHeight);
+  // Courtyard snapshots are temporary building-pass workspace. Keep an
+  // individual snapshot no larger than the visible viewport even when the
+  // guidance renderer is using its 96 px overscan frame. A large courtyard
+  // that exceeds this bound is left unfilled so the real underlay remains
+  // visible; the 2D map and other building surfaces still render.
+  const size_t maximumCourtyardUnderlayPixels =
+      std::max<size_t>(1U, buildingWorkspaceViewportPixels);
   uint64_t buildingContextSignature = 1469598103934665603ULL;
   const auto mixBuildingContext = [&](uint64_t value) {
     buildingContextSignature ^= value;
@@ -2712,6 +2723,9 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
     std::vector<Point16, PsramAllocator<Point16>> buildingSurfacePoints;
     std::vector<uint16_t, PsramAllocator<uint16_t>> courtyardUnderlay;
     std::vector<int32_t, PsramAllocator<int32_t>> courtyardScanlineNodes;
+    map_building_renderer::UnderlayRegion courtyardUnderlayRegion;
+    size_t largestCourtyardUnderlayBytes = 0;
+    uint32_t courtyardSnapshotCount = 0;
     map_building_renderer::SurfaceStats buildingSurfaceStats;
     const auto releaseBuildingFailureWorkspace = [&]() {
       decltype(buildingQueue){}.swap(buildingQueue);
@@ -3022,6 +3036,7 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       }
       bool courtyardUnderlayReady = false;
       bool courtyardUnderlayUnavailable = false;
+      courtyardUnderlayRegion = {};
       const bool surfacesRendered = map_building_renderer::renderSurfaces(
           *item.building, item.block->offset.x, item.block->offset.y,
           item.block->mercatorScale, projection, item.extrude,
@@ -3058,17 +3073,70 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
                 courtyardUnderlayUnavailable = true;
                 return true;
               }
-              const size_t stridePixels = drawBuffer->header.stride / 2U;
+              if (drawBuffer->data == nullptr) {
+                courtyardUnderlayUnavailable = true;
+                return true;
+              }
+              const int32_t canvasWidth = drawBuffer->header.w;
+              const int32_t canvasHeight = drawBuffer->header.h;
+              const size_t canvasStridePixels =
+                  drawBuffer->header.stride / sizeof(uint16_t);
+              int32_t minX = buildingSurfacePoints.front().x;
+              int32_t maxX = buildingSurfacePoints.front().x;
+              int32_t minY = buildingSurfacePoints.front().y;
+              int32_t maxY = buildingSurfacePoints.front().y;
+              for (const Point16 &point : buildingSurfacePoints) {
+                minX = std::min(minX, static_cast<int32_t>(point.x));
+                maxX = std::max(maxX, static_cast<int32_t>(point.x));
+                minY = std::min(minY, static_cast<int32_t>(point.y));
+                maxY = std::max(maxY, static_cast<int32_t>(point.y));
+              }
+              const int32_t regionX = std::max<int32_t>(0, minX);
+              const int32_t regionY = std::max<int32_t>(0, minY);
+              const int32_t regionEndX =
+                  std::min<int32_t>(canvasWidth, maxX + 1);
+              const int32_t regionEndY =
+                  std::min<int32_t>(canvasHeight, maxY + 1);
+              const int32_t regionWidth = regionEndX - regionX;
+              const int32_t regionHeight = regionEndY - regionY;
+              if (regionWidth <= 0 || regionHeight <= 0) {
+                courtyardUnderlayUnavailable = true;
+                return true;
+              }
               const size_t pixelCount =
-                  stridePixels * drawBuffer->header.h;
+                  static_cast<size_t>(regionWidth) *
+                  static_cast<size_t>(regionHeight);
+              if (pixelCount > maximumCourtyardUnderlayPixels) {
+                courtyardUnderlayUnavailable = true;
+                return true;
+              }
               try {
                 courtyardUnderlay.resize(pixelCount);
               } catch (const std::bad_alloc &) {
                 courtyardUnderlayUnavailable = true;
                 return true;
               }
-              std::memcpy(courtyardUnderlay.data(), drawBuffer->data,
-                          pixelCount * sizeof(uint16_t));
+              courtyardUnderlayRegion = {
+                  regionX, regionY, regionWidth, regionHeight,
+                  static_cast<size_t>(regionWidth), pixelCount};
+              const auto *canvasPixels =
+                  reinterpret_cast<const uint16_t *>(drawBuffer->data);
+              for (int32_t row = 0; row < regionHeight; ++row) {
+                const size_t canvasOffset =
+                    static_cast<size_t>(regionY + row) * canvasStridePixels +
+                    static_cast<size_t>(regionX);
+                const size_t underlayOffset =
+                    static_cast<size_t>(row) *
+                    courtyardUnderlayRegion.stridePixels;
+                std::memcpy(courtyardUnderlay.data() + underlayOffset,
+                            canvasPixels + canvasOffset,
+                            static_cast<size_t>(regionWidth) *
+                                sizeof(uint16_t));
+              }
+              largestCourtyardUnderlayBytes = std::max(
+                  largestCourtyardUnderlayBytes,
+                  pixelCount * sizeof(uint16_t));
+              ++courtyardSnapshotCount;
               if (shouldStopBuildingWork())
                 return false;
               courtyardUnderlayReady = true;
@@ -3089,14 +3157,13 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
               lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
               if (drawBuffer == nullptr)
                 return false;
-              return map_building_renderer::restoreCourtyardUnderlay(
+              return map_building_renderer::restoreCourtyardUnderlayRegion(
                   buildingSurfacePoints,
                   reinterpret_cast<uint16_t *>(drawBuffer->data),
                   drawBuffer->header.w, drawBuffer->header.h,
                   drawBuffer->header.stride / 2U,
-                  courtyardUnderlay.data(), courtyardUnderlay.size(),
-                  courtyardScanlineNodes,
-                  shouldStopBuildingWork);
+                  courtyardUnderlay.data(), courtyardUnderlayRegion,
+                  courtyardScanlineNodes, shouldStopBuildingWork);
             }
 
             uint16_t color = roofColor;
@@ -3151,6 +3218,8 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
               "wallCandidates=%llu generatedWallFaces=%llu "
               "suppressedWallFaces=%llu "
               "projectionMs=%lu sortMs=%lu buildingDrawMs=%lu "
+              "courtyardSnapshots=%u courtyardMaxBytes=%u "
+              "courtyardBudgetBytes=%u "
               "deadlineExceeded=%u prepassDeadlineExceeded=%u "
               "psramUsed=%u psramFree=%u psramLargest=%u "
               "budgetFallback=%u renderRecordOverflowTotal=%llu "
@@ -3184,6 +3253,9 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
               (unsigned long)buildingProjectionMs,
               (unsigned long)buildingSortMs,
               (unsigned long)buildingDrawMs,
+              (unsigned)courtyardSnapshotCount,
+              (unsigned)largestCourtyardUnderlayBytes,
+              (unsigned)(maximumCourtyardUnderlayPixels * sizeof(uint16_t)),
               buildingDeadlineExceeded ? 1U : 0U,
               buildingPrepassDeadlineExceeded ? 1U : 0U,
               (unsigned)(ESP.getPsramSize() -
@@ -3226,6 +3298,8 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             "visibleRecords=%u visiblePoints=%llu rendered=%u extruded=%u "
             "renderTimeOverflow=%u renderTimeOverflowTotal=%llu "
             "projectionMs=%lu sortMs=%lu buildingDrawMs=%lu "
+            "courtyardSnapshots=%u courtyardMaxBytes=%u "
+            "courtyardBudgetBytes=%u "
             "prepassDeadlineExceeded=%u psramUsed=%u psramFree=%u "
             "psramLargest=%u psramSamplePostCleanup=%u\n",
             failureReason, (unsigned)loadedBuildingStats.records,
@@ -3243,6 +3317,9 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             (unsigned long long)renderTimeOverflowTotal,
             (unsigned long)buildingProjectionMs,
             (unsigned long)buildingSortMs, (unsigned long)buildingDrawMs,
+            (unsigned)courtyardSnapshotCount,
+            (unsigned)largestCourtyardUnderlayBytes,
+            (unsigned)(maximumCourtyardUnderlayPixels * sizeof(uint16_t)),
             buildingPrepassDeadlineExceeded ? 1U : 0U,
             (unsigned)buildingFailurePsramUsed,
             (unsigned)buildingFailurePsramFree,

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -129,17 +129,22 @@ map_projection::Projection makeMapProjection(
     uint16_t viewportWidth, uint16_t viewportHeight,
     map_projection::Mode mode,
     map_projection::BirdsEyePerspective birdsEyePerspective =
-        map_projection::BirdsEyePerspective::Standard) {
+        map_projection::BirdsEyePerspective::Standard,
+    double anchorXOverride = -1.0, double anchorYOverride = -1.0) {
   map_projection::Config config;
   config.viewportWidth = viewportWidth;
   config.viewportHeight = viewportHeight;
   config.worldOrigin = {rasterOriginX, rasterOriginY};
   config.zoom = zoom;
   config.rotationRad = rotation;
-  config.anchorX = gui_layout::mapAnchorX(viewportWidth);
-  config.anchorY = mode == map_projection::Mode::BirdsEye
-                       ? map_projection::birdsEyeAnchorY(viewportHeight)
-                       : gui_layout::mapAnchorY(viewportHeight);
+  config.anchorX = anchorXOverride >= 0.0
+                       ? anchorXOverride
+                       : gui_layout::mapAnchorX(viewportWidth);
+  config.anchorY = anchorYOverride >= 0.0
+                       ? anchorYOverride
+                       : (mode == map_projection::Mode::BirdsEye
+                              ? map_projection::birdsEyeAnchorY(viewportHeight)
+                              : gui_layout::mapAnchorY(viewportHeight));
   config.rasterCellOffset = {rasterCellOffsetX, rasterCellOffsetY};
   config.mode = mode;
   config.topEdgeScale =
@@ -345,6 +350,34 @@ static size_t bufMapScreenSize = 0;
 static size_t bufMapTempSize = 0;
 static size_t bufMapForegroundSize = 0;
 static void *bufMapIcon = nullptr;
+
+// Guidance keeps a modest overscan around the visible viewport. The base map
+// can then translate under the fixed rider marker between full vector-frame
+// settlements without exposing the parent background at an edge.
+constexpr uint16_t kGuidanceOverscanPixels = 96;
+constexpr uint16_t kGuidanceRefreshSafetyPixels = 16;
+
+static uint16_t guidanceFrameWidth(uint16_t viewportWidth) {
+  return static_cast<uint16_t>(viewportWidth +
+                               (2U * kGuidanceOverscanPixels));
+}
+
+static uint16_t guidanceFrameHeight(uint16_t viewportHeight) {
+  return static_cast<uint16_t>(viewportHeight +
+                               (2U * kGuidanceOverscanPixels));
+}
+
+static double guidanceFrameAnchorX(uint16_t viewportWidth) {
+  return static_cast<double>(gui_layout::mapAnchorX(viewportWidth)) +
+         kGuidanceOverscanPixels;
+}
+
+static double guidanceFrameAnchorY(uint16_t viewportHeight, bool birdsEye) {
+  const double visibleAnchor =
+      birdsEye ? map_projection::birdsEyeAnchorY(viewportHeight)
+               : gui_layout::mapAnchorY(viewportHeight);
+  return visibleAnchor + kGuidanceOverscanPixels;
+}
 
 static bool ensureMapBuffer(void *&buffer, size_t &capacity,
                             size_t requiredSize, const char *name) {
@@ -3792,29 +3825,41 @@ void Maps::createMapScrSprites() {
   const uint32_t normalStride = lv_draw_buf_width_to_stride(
       Maps::mapScrWidth, LV_COLOR_FORMAT_RGB565);
   const size_t maximumNormalFrameSize = normalStride * Maps::mapScrFull;
+  const uint16_t guidanceWidth = guidanceFrameWidth(Maps::mapScrWidth);
+  const uint16_t guidanceHeight = guidanceFrameHeight(Maps::mapScrFull);
+  const uint32_t guidanceStride = lv_draw_buf_width_to_stride(
+      guidanceWidth, LV_COLOR_FORMAT_RGB565);
+  const size_t maximumGuidanceFrameSize =
+      static_cast<size_t>(guidanceStride) * guidanceHeight;
+  const size_t maximumScreenBufferSize =
+      std::max(maximumNormalFrameSize, maximumGuidanceFrameSize);
   const size_t requiredTempSize = std::max(
-      maximumNormalFrameSize + maximumTileSize,
-      maximumScratchRowSize);
+      std::max(maximumNormalFrameSize + maximumTileSize,
+               maximumScratchRowSize),
+      maximumGuidanceFrameSize);
 
   ESP_LOGI(TAG,
            "MapBuff: rollingWide=%ux%u rollingCompact=%ux%u "
-           "rollingScreen=%u initialScreen=%u scratch=%u initial=%ux%u",
+           "rollingScreen=%u initialScreen=%u guidance=%ux%u scratch=%u "
+           "initial=%ux%u",
            (unsigned)maximumGrid.width, (unsigned)maximumGrid.height,
            (unsigned)compactGrid.width, (unsigned)compactGrid.height,
            (unsigned)rollingScreenSize, (unsigned)maximumNormalFrameSize,
+           (unsigned)guidanceWidth, (unsigned)guidanceHeight,
            (unsigned)requiredTempSize, (unsigned)w, (unsigned)h);
-  // Keep the front buffer viewport-sized until standalone Map first reaches
-  // a runtime zoom. Map + Navigation therefore does not pay the rolling
-  // grid's PSRAM cost merely by creating the shared map canvases.
-  if (!ensureMapScreenBuffer(maximumNormalFrameSize) ||
+  // Keep the canvas viewport-sized until standalone Map first reaches a
+  // runtime zoom. The backing allocation reserves guidance overscan up front,
+  // but Map + Navigation does not pay the rolling grid's PSRAM cost merely by
+  // creating the shared map canvases.
+  if (!ensureMapScreenBuffer(maximumScreenBufferSize) ||
       !ensureMapTempBuffer(requiredTempSize) ||
-      !ensureMapForegroundBuffer(Maps::mapScrWidth, Maps::mapScrFull)) {
+      !ensureMapForegroundBuffer(guidanceWidth, guidanceHeight)) {
     return;
   }
-  memset(bufMapScreen, 0, maximumNormalFrameSize);
+  memset(bufMapScreen, 0, maximumGuidanceFrameSize);
   memset(bufMapTemp, 0, requiredTempSize);
   memset(bufMapForeground, 0,
-         rgb565A8BufferSize(Maps::mapScrWidth, Maps::mapScrFull));
+         rgb565A8BufferSize(guidanceWidth, guidanceHeight));
   invalidateRollingRasterWindow();
 
   Maps::canvasMap = lv_canvas_create(mapTile);
@@ -5432,18 +5477,23 @@ void Maps::updateGuidanceRouteHead(
     return;
   }
 
-  const uint16_t viewportHeight =
+  uint16_t viewportWidth = Maps::mapScrWidth;
+  uint16_t viewportHeight =
       mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
-  if (!ensureMapForegroundBuffer(Maps::mapScrWidth, viewportHeight)) {
+  if (hasVisibleProjection) {
+    viewportWidth = visibleProjection.config().viewportWidth;
+    viewportHeight = visibleProjection.config().viewportHeight;
+  }
+  if (!ensureMapForegroundBuffer(viewportWidth, viewportHeight)) {
     rollingForegroundReady = false;
     hideRollingForeground();
     return;
   }
 
   lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(Maps::canvasForeground);
-  if (drawBuffer == nullptr || drawBuffer->header.w != Maps::mapScrWidth ||
+  if (drawBuffer == nullptr || drawBuffer->header.w != viewportWidth ||
       drawBuffer->header.h != viewportHeight) {
-    bindMapForegroundCanvas(Maps::canvasForeground, Maps::mapScrWidth,
+    bindMapForegroundCanvas(Maps::canvasForeground, viewportWidth,
                             viewportHeight);
   }
   lv_obj_center(Maps::canvasForeground);
@@ -5486,21 +5536,16 @@ bool Maps::guidanceProjectionNeedsRefresh() const {
   if (!projected.valid)
     return true;
 
-  // Keep a generous safety margin inside the rendered world bounds. Between
-  // these epochs, the lightweight guidance translation can move the map
-  // continuously without repeatedly rebuilding the perspective frame for
-  // every GPS fix. A new projection is rendered only when the rider is close
-  // enough to an edge that the cached map blocks may no longer cover it.
-  constexpr double kProjectionRefreshMarginPixels = 96.0;
-  const auto &config = visibleProjection.config();
-  return projected.x < kProjectionRefreshMarginPixels ||
-         projected.x >
-             static_cast<double>(config.viewportWidth) -
-                 kProjectionRefreshMarginPixels ||
-         projected.y < kProjectionRefreshMarginPixels ||
-         projected.y >
-             static_cast<double>(config.viewportHeight) -
-                 kProjectionRefreshMarginPixels;
+  // The rendered guidance frame includes overscan around the visible
+  // viewport. Refresh before the lightweight translation consumes that
+  // overscan, leaving a small safety margin for the next completed frame.
+  const double availableMotion =
+      static_cast<double>(kGuidanceOverscanPixels) -
+      static_cast<double>(kGuidanceRefreshSafetyPixels);
+  return projected.x < visibleProjection.anchorX() - availableMotion ||
+         projected.x > visibleProjection.anchorX() + availableMotion ||
+         projected.y < visibleProjection.anchorY() - availableMotion ||
+         projected.y > visibleProjection.anchorY() + availableMotion;
 }
 
 void Maps::applyGuidanceMotionOffset(
@@ -5530,21 +5575,25 @@ void Maps::applyGuidanceMotionOffset(
       visibleProjection.anchorX() - projected.x);
   const int32_t requestedOffsetY = map_transform::quantizePixel(
       visibleProjection.anchorY() - projected.y);
-  // The guidance canvas is currently viewport-sized. Do not move it beyond
-  // its parent while a new vector frame is being rendered: doing so exposes
-  // the parent's background as a black/unloaded strip that looks like map
-  // data arriving in chunks. If a future renderer provides overscan, these
-  // same bounds naturally expand to that coverage.
+  // Do not move the canvas beyond its parent while a new vector frame is
+  // being rendered: doing so exposes the parent's background as a
+  // black/unloaded strip that looks like map data arriving in chunks. The
+  // guidance vector frame includes overscan, so these bounds allow continuous
+  // motion while still guaranteeing full parent coverage.
   const int32_t parentWidth = lv_obj_get_width(mapTile);
   const int32_t parentHeight = lv_obj_get_height(mapTile);
   const int32_t canvasWidth = lv_obj_get_width(Maps::canvasMap);
   const int32_t canvasHeight = lv_obj_get_height(Maps::canvasMap);
-  const int32_t minOffsetX = -static_cast<int32_t>(baseX);
-  const int32_t maxOffsetX = parentWidth -
+  // To cover the parent, the canvas's right/bottom edge must remain at or
+  // beyond the parent edge while its left/top edge must remain at or before
+  // the parent origin. For an overscanned canvas this yields a real finite
+  // translation interval; for a viewport-sized canvas it collapses to zero.
+  const int32_t minOffsetX = parentWidth -
                              (static_cast<int32_t>(baseX) + canvasWidth);
-  const int32_t minOffsetY = -static_cast<int32_t>(baseY);
-  const int32_t maxOffsetY = parentHeight -
+  const int32_t maxOffsetX = -static_cast<int32_t>(baseX);
+  const int32_t minOffsetY = parentHeight -
                              (static_cast<int32_t>(baseY) + canvasHeight);
+  const int32_t maxOffsetY = -static_cast<int32_t>(baseY);
   const auto clampOffset = [](int32_t value, int32_t minimum,
                               int32_t maximum) -> int32_t {
     if (minimum > maximum)
@@ -5614,6 +5663,16 @@ void Maps::updatePositionOverlay() {
                                       map_transform::quantizePixel(
                                           visibleProjection.anchorY()))
                                 : mapAnchorYForHeight(h);
+    const int16_t canvasOriginX =
+        useSharedProjection && Maps::canvasMap != nullptr
+            ? gui_layout::centeredViewportOrigin(
+                  containerWidth, lv_obj_get_width(Maps::canvasMap))
+            : mapOriginX;
+    const int16_t canvasOriginY =
+        useSharedProjection && Maps::canvasMap != nullptr
+            ? gui_layout::centeredViewportOrigin(
+                  containerHeight, lv_obj_get_height(Maps::canvasMap))
+            : mapOriginY;
     updateCurrentPositionMarker(Maps::canvasArrow);
     const int16_t markerAnchorX = currentMarkerAnchorX();
     const int16_t markerAnchorY = currentMarkerAnchorY();
@@ -5624,8 +5683,8 @@ void Maps::updatePositionOverlay() {
       // The marker is a sibling of the centered map canvas, so translate the
       // canvas-local anchor into map-tile coordinates before applying the
       // marker's geographic lower-center anchor.
-      x = mapOriginX + anchorX - markerAnchorX;
-      y = mapOriginY + anchorY - markerAnchorY;
+      x = canvasOriginX + anchorX - markerAnchorX;
+      y = canvasOriginY + anchorY - markerAnchorY;
       lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       lv_obj_set_pos(Maps::canvasArrow, x, y);
     } else {
@@ -5639,9 +5698,9 @@ void Maps::updatePositionOverlay() {
           lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
           return;
         }
-        x = mapOriginX + map_transform::quantizePixel(markerPoint.x) -
+        x = canvasOriginX + map_transform::quantizePixel(markerPoint.x) -
             markerAnchorX;
-        y = mapOriginY + map_transform::quantizePixel(markerPoint.y) -
+        y = canvasOriginY + map_transform::quantizePixel(markerPoint.y) -
             markerAnchorY;
       } else {
         const auto markerDelta = map_transform::worldToScreen(
@@ -5778,8 +5837,15 @@ bool Maps::generateVectorMap(uint8_t zoom) {
   }
 
   invalidateRollingRasterWindow();
-  const map_drag_preview::CanvasExtent renderExtent = {Maps::mapScrWidth,
-                                                        viewportHeight};
+  const bool guidanceFrame = isMapGuidanceScreenActive();
+  const uint16_t renderWidth = guidanceFrame
+                                   ? guidanceFrameWidth(Maps::mapScrWidth)
+                                   : Maps::mapScrWidth;
+  const uint16_t renderHeight = guidanceFrame
+                                    ? guidanceFrameHeight(viewportHeight)
+                                    : viewportHeight;
+  const map_drag_preview::CanvasExtent renderExtent = {renderWidth,
+                                                        renderHeight};
   const uint32_t renderStride = lv_draw_buf_width_to_stride(
       renderExtent.width, LV_COLOR_FORMAT_RGB565);
   const size_t renderSize = renderStride * renderExtent.height;
@@ -5808,6 +5874,12 @@ bool Maps::generateVectorMap(uint8_t zoom) {
       navigation_content_mode::usesMapGuidanceBirdsEye(
           isMapGuidanceScreenActive(),
           mapRenderSettings.mapNavigationBirdsEyeEnabled);
+  const double frameAnchorX =
+      guidanceFrame ? guidanceFrameAnchorX(Maps::mapScrWidth) : -1.0;
+  const double frameAnchorY = guidanceFrame
+                                  ? guidanceFrameAnchorY(viewportHeight,
+                                                         birdsEyeActive)
+                                  : -1.0;
   const auto frameProjection = makeMapProjection(
       Maps::viewPort.rasterOriginX, Maps::viewPort.rasterOriginY,
       Maps::viewPort.rasterCellOffsetX, Maps::viewPort.rasterCellOffsetY, zoom,
@@ -5815,7 +5887,8 @@ bool Maps::generateVectorMap(uint8_t zoom) {
       birdsEyeActive ? map_projection::Mode::BirdsEye
                      : map_projection::Mode::Flat,
       map_projection::birdsEyePerspectiveForValue(
-          mapRenderSettings.mapNavigationBirdsEyePerspective));
+          mapRenderSettings.mapNavigationBirdsEyePerspective),
+      frameAnchorX, frameAnchorY);
   if (frameProjection.isBirdsEye()) {
     const auto bounds = frameProjection.worldBounds(4.0);
     Maps::viewPort.bbox.min =

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -1782,6 +1782,109 @@ void Maps::drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
                                   x2, y2, color, width);
 }
 
+bool Maps::beginMapBlockLoad(const Point32 &offset, const String &fileName) {
+  if (mapBlockLoadJob.state != MapBlockLoadJob::State::Idle)
+    return false;
+
+  mapBlockLoadJob.offset = offset;
+  mapBlockLoadJob.fileName = fileName;
+  mapBlockLoadJob.result = nullptr;
+  mapBlockLoadJob.found = false;
+  mapBlockLoadJob.cancelRequested = false;
+  mapBlockLoadJob.state = MapBlockLoadJob::State::Loading;
+  __sync_synchronize();
+
+  const BaseType_t created = xTaskCreatePinnedToCore(
+      &Maps::mapBlockLoadTaskEntry, "map-block-load", 8192, this, 1,
+      &mapBlockLoadJob.task, 0);
+  if (created != pdPASS) {
+    mapBlockLoadJob.task = nullptr;
+    mapBlockLoadJob.state = MapBlockLoadJob::State::Idle;
+    return false;
+  }
+  return true;
+}
+
+void Maps::mapBlockLoadTaskEntry(void *context) {
+  auto *maps = static_cast<Maps *>(context);
+  if (maps != nullptr)
+    maps->mapBlockLoadTask();
+  vTaskDelete(nullptr);
+}
+
+void Maps::mapBlockLoadTask() {
+  // The UI does not mutate the request while State::Loading. Copy the String
+  // before entering the parser so the worker never observes a partial path.
+  const String fileName = mapBlockLoadJob.fileName;
+  power_management::ScopedLock powerLock(power_management::LockDomain::Map);
+  // readMapBlock historically reports its result through the renderer's
+  // aggregate flag. Keep that worker-local side effect from hiding the
+  // already-visible map (or making the live arrow disappear) while the UI
+  // continues presenting it.
+  const bool previousMapFound = Maps::isMapFound;
+  Maps::isMapFound = false;
+  MapBlock *block = readMapBlock(fileName);
+  const bool found = Maps::isMapFound && block != nullptr;
+  const bool cancelled = mapBlockLoadJob.cancelRequested;
+  Maps::isMapFound = previousMapFound;
+  __sync_synchronize();
+
+  if (cancelled || !found) {
+    delete block;
+    mapBlockLoadJob.result = nullptr;
+    mapBlockLoadJob.found = false;
+    mapBlockLoadJob.state = cancelled ? MapBlockLoadJob::State::Cancelled
+                                      : MapBlockLoadJob::State::Failed;
+  } else {
+    mapBlockLoadJob.result = block;
+    mapBlockLoadJob.found = true;
+    mapBlockLoadJob.state = MapBlockLoadJob::State::Ready;
+  }
+  __sync_synchronize();
+}
+
+bool Maps::pollMapBlockLoad(MapBlock *&result, Point32 &offset) {
+  result = nullptr;
+  const MapBlockLoadJob::State state = mapBlockLoadJob.state;
+  if (state == MapBlockLoadJob::State::Loading)
+    return false;
+  if (state == MapBlockLoadJob::State::Idle)
+    return true;
+
+  __sync_synchronize();
+  offset = mapBlockLoadJob.offset;
+  if (state == MapBlockLoadJob::State::Ready && mapBlockLoadJob.found) {
+    result = mapBlockLoadJob.result;
+    mapBlockLoadJob.result = nullptr;
+  } else {
+    delete mapBlockLoadJob.result;
+    mapBlockLoadJob.result = nullptr;
+  }
+  mapBlockLoadJob.task = nullptr;
+  mapBlockLoadJob.state = MapBlockLoadJob::State::Idle;
+  mapBlockLoadJob.cancelRequested = false;
+  mapBlockLoadJob.found = false;
+  return true;
+}
+
+void Maps::cancelMapBlockLoad() {
+  const MapBlockLoadJob::State state = mapBlockLoadJob.state;
+  if (state == MapBlockLoadJob::State::Loading) {
+    // The worker owns the in-flight allocation. It will discard the decoded
+    // block after the current SD read/parse reaches its safe completion point.
+    mapBlockLoadJob.cancelRequested = true;
+    return;
+  }
+  if (state != MapBlockLoadJob::State::Idle) {
+    delete mapBlockLoadJob.result;
+    mapBlockLoadJob.result = nullptr;
+    mapBlockLoadJob.task = nullptr;
+    mapBlockLoadJob.state = MapBlockLoadJob::State::Idle;
+    mapBlockLoadJob.cancelRequested = false;
+    mapBlockLoadJob.found = false;
+  }
+}
+
 /**
  * @brief Get bounding objects in memory block
  *
@@ -1797,9 +1900,6 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
   uint16_t cacheHits = 0;
   uint16_t loadedBlocks = 0;
   uint16_t evictedBlocks = 0;
-  for (MapBlock *block : memCache.blocks) {
-    block->inView = false;
-  }
 
   // 1. Identify all required block offsets for the current viewport
   std::vector<Point32> requiredOffsets;
@@ -1824,7 +1924,91 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
     }
   }
 
+  // A guidance cache miss is decoded on a low-priority worker. Do not touch
+  // the cache or its in-view flags while that worker owns the request: the
+  // visible frame may still be using those blocks for its live projection.
+  if (mapBlockLoadJob.state == MapBlockLoadJob::State::Loading)
+    return false;
+
+  MapBlock *completedAsyncBlock = nullptr;
+  Point32 completedAsyncOffset;
+  const MapBlockLoadJob::State completedAsyncState = mapBlockLoadJob.state;
+  if (completedAsyncState != MapBlockLoadJob::State::Idle)
+    (void)pollMapBlockLoad(completedAsyncBlock, completedAsyncOffset);
+  const bool skipFailedAsyncOffset =
+      completedAsyncState == MapBlockLoadJob::State::Failed;
+
   // 2. Mark existing blocks as inView if they are in the required set
+  for (MapBlock *block : memCache.blocks) {
+    block->inView = false;
+  }
+
+  const auto isRequiredOffset = [&](const Point32 &offset) {
+    return std::any_of(requiredOffsets.begin(), requiredOffsets.end(),
+                       [&](const Point32 &required) {
+                         return required.x == offset.x &&
+                                required.y == offset.y;
+                       });
+  };
+
+  // Commit a decoded block only on the UI task. A stale result that no longer
+  // belongs to this viewport is kept only when there is spare cache capacity;
+  // it must never evict a block that still covers the current frame.
+  if (completedAsyncBlock != nullptr) {
+    bool alreadyCached = false;
+    for (const MapBlock *block : memCache.blocks) {
+      if (block->offset.x == completedAsyncOffset.x &&
+          block->offset.y == completedAsyncOffset.y) {
+        alreadyCached = true;
+        break;
+      }
+    }
+    if (alreadyCached) {
+      delete completedAsyncBlock;
+    } else if (!isRequiredOffset(completedAsyncOffset) &&
+               memCache.blocks.size() >= MAPBLOCKS_MAX) {
+      delete completedAsyncBlock;
+    } else {
+      if (memCache.blocks.size() >= MAPBLOCKS_MAX) {
+        bool evicted = false;
+        for (auto it = memCache.blocks.begin(); it != memCache.blocks.end();
+             ++it) {
+          if (!(*it)->inView) {
+            ESP_LOGI(TAG, "Evicting block for async load: offset(%d, %d)",
+                     (*it)->offset.x, (*it)->offset.y);
+            delete *it;
+            memCache.blocks.erase(it);
+            evictedBlocks++;
+            evicted = true;
+            break;
+          }
+        }
+        if (!evicted) {
+          // MAPBLOCKS_MAX bounds the number of required offsets, so this is
+          // only a defensive fallback for a malformed viewport.
+          delete completedAsyncBlock;
+          completedAsyncBlock = nullptr;
+        }
+      }
+      if (completedAsyncBlock != nullptr) {
+        completedAsyncBlock->inView = isRequiredOffset(completedAsyncOffset);
+        completedAsyncBlock->offset = completedAsyncOffset;
+        completedAsyncBlock->mercatorScale =
+            map_projection::mercatorScaleForLatitude(
+                Maps::mercatorY2lat(
+                    static_cast<double>(completedAsyncOffset.y) +
+                    (1 << (MAPBLOCK_SIZE_BITS - 1))));
+        memCache.blocks.push_back(completedAsyncBlock);
+        loadedBlocks++;
+        ESP_LOGI(TAG, "Async block loaded: %p, offset(%d, %d)",
+                 completedAsyncBlock, completedAsyncOffset.x,
+                 completedAsyncOffset.y);
+        ESP_LOGI(TAG, "FreeHeap: %d", (int)esp_get_free_heap_size());
+      }
+    }
+  }
+
+  // Mark both cached blocks and a just-committed async block as inView.
   for (MapBlock *memblock : memCache.blocks) {
     for (const auto &req : requiredOffsets) {
       if (memblock->offset.x == req.x && memblock->offset.y == req.y) {
@@ -1853,6 +2037,14 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
       continue;
     }
 
+    // A missing file should not be reopened on every 30 ms render attempt.
+    // Treat the failed request as an empty neighboring block for this frame;
+    // a later viewport change can retry it through a new async job.
+    if (skipFailedAsyncOffset && req.x == completedAsyncOffset.x &&
+        req.y == completedAsyncOffset.y) {
+      continue;
+    }
+
     ESP_LOGI(TAG, "getMapBlocks loading missing: offset(%d, %d)", req.x, req.y);
 
     // Block is not in memory => load from disk
@@ -1867,6 +2059,17 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
         vectorMapFolder + folderName + "/" + blockX + "_" + blockY;
 
     log_i("Attempting to load map file: %s", fileName.c_str());
+
+    // Guidance owns a live overlay and a visible overscanned frame. Decode a
+    // missing block away from the LVGL task so this slow SD path cannot pause
+    // the arrow, route head, or canvas motion. The next map cycle consumes
+    // the mailbox and renders against the committed block.
+    if (isMapGuidanceScreenActive() &&
+        beginMapBlockLoad(req, fileName)) {
+      MAPIO_LOG("MAPIO: block-load async-start offset=(%d,%d)\n", req.x,
+                req.y);
+      return false;
+    }
 
     // If cache is full, find a block that is NOT in view to evict
     if (memCache.blocks.size() >= MAPBLOCKS_MAX) {
@@ -3756,6 +3959,7 @@ void Maps::initMap(uint16_t mapHeight, uint16_t mapWidth, uint16_t mapFull) {
 
 bool Maps::setVectorMapFolder(const std::string &folder) {
   power_management::ScopedLock powerLock(power_management::LockDomain::Storage);
+  cancelMapBlockLoad();
   String normalized(folder.c_str());
   if (!normalized.endsWith("/"))
     normalized += "/";
@@ -6103,6 +6307,37 @@ bool Maps::renderGuidanceBuilding(
   }
 }
 
+void Maps::publishGuidanceBaseFrame() {
+  auto &job = guidanceBuildingRenderJob;
+  if (!job.active || bufMapScreen == nullptr || bufMapTemp == nullptr)
+    return;
+
+  // The 2D underlay already contains the complete course-up projection. Make
+  // it visible before the potentially multi-second building admission/draw
+  // job starts. Navigation owns the display cadence, so an unfinished 3D
+  // pass must never hold the route head or marker on an older projection.
+  const size_t rowBytes = static_cast<size_t>(job.width) * sizeof(uint16_t);
+  auto *front = static_cast<uint8_t *>(bufMapScreen);
+  const auto *back = static_cast<const uint8_t *>(bufMapTemp);
+  for (uint16_t y = 0; y < job.height; ++y) {
+    std::memcpy(front + static_cast<size_t>(y) * job.strideBytes,
+                back + static_cast<size_t>(y) * job.strideBytes, rowBytes);
+  }
+  lv_canvas_set_buffer(Maps::canvasMap, bufMapScreen, job.width, job.height,
+                       LV_COLOR_FORMAT_RGB565);
+  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, job.width, job.height,
+                       LV_COLOR_FORMAT_RGB565);
+  lv_obj_center(Maps::canvasMap);
+  lv_obj_center(Maps::canvasMapTemp);
+  Maps::viewPort = job.viewPort;
+  visibleProjection = job.projection;
+  hasVisibleProjection = true;
+  lv_obj_invalidate(Maps::canvasMap);
+  MAPIO_LOG("MAPIO: guidance-base published mode=%s width=%u height=%u\n",
+            job.projection.isBirdsEye() ? "birds-eye" : "flat",
+            (unsigned)job.width, (unsigned)job.height);
+}
+
 void Maps::publishGuidanceRenderJob() {
   auto &job = guidanceBuildingRenderJob;
   if (!job.active || bufMapScreen == nullptr || bufMapTemp == nullptr)
@@ -6332,11 +6567,18 @@ bool Maps::generateVectorMap(uint8_t zoom) {
     return false;
   }
 
-  // A guidance frame with buildings is a latest-wins cooperative job.  Do
-  // not recompute its projection or touch the hidden canvas until the current
-  // immutable request has either completed or been cancelled by input.
-  if (isMapRenderPending())
-    return advanceGuidanceBuildingRenderJob();
+  // A guidance frame with buildings is a latest-wins cooperative job. Do not
+  // recompute its projection while the immutable building request is
+  // advancing; its complete 2D/course-up underlay is published at admission
+  // and the 3D pass finishes into the hidden buffer. A block-load job has no
+  // renderable result until getMapBlocks consumes its mailbox, so leave the
+  // current frame in place until then.
+  if (isMapRenderPending()) {
+    if (guidanceBuildingRenderJob.active)
+      return advanceGuidanceBuildingRenderJob();
+    if (mapBlockLoadJob.state == MapBlockLoadJob::State::Loading)
+      return false;
+  }
 
   // The hidden buffer is about to become the render target. Any prepared
   // zoom-out backdrop in it is no longer reusable.
@@ -6540,9 +6782,10 @@ bool Maps::generateVectorMap(uint8_t zoom) {
     if (startGuidanceBuildingRenderJob(
             zoom, renderExtent.width, renderExtent.height, renderStride,
             Maps::viewPort, frameProjection)) {
-      // The base map is already complete in the hidden buffer.  The building
-      // pass advances one bounded unit per UI cycle and publishes atomically
-      // when its deterministic queue is exhausted.
+      // Publish the complete base immediately. The building pass advances one
+      // bounded unit per UI cycle and publishes its deterministic far-to-near
+      // result atomically over this frame when exhausted.
+      publishGuidanceBaseFrame();
       MAPIO_LOG("MAPIO: guidance-job start zoom=%u baseMs=%lu blocks=%u\n",
                 (unsigned)zoom, (unsigned long)drawMs,
                 (unsigned)Maps::memCache.blocks.size());

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -2347,6 +2347,23 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   std::vector<map_projection::GroundPoint> clippedGroundPolygon;
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const bool mapNavigationActive = isMapGuidanceScreenActive();
+  const bool guidanceBirdsEye = mapNavigationActive && projection.isBirdsEye();
+  constexpr uint32_t kGuidanceBuildingTimeBudgetMs = 900U;
+  constexpr size_t kGuidanceMaximumQueuedBuildingRecords = 2048U;
+  constexpr double kGuidanceFarBuildingCutoffFraction = 0.20;
+  // Guidance renders on the UI task. Keep the optional 3D pass bounded so a
+  // dense city cannot starve GPS/scene updates for several seconds. The
+  // normal-map budget remains unchanged; if guidance reaches this limit, the
+  // existing retry path presents the same frame with buildings suppressed,
+  // leaving the 2D roads/land-use map intact.
+  const uint32_t buildingTimeBudgetMs =
+      guidanceBirdsEye
+          ? kGuidanceBuildingTimeBudgetMs
+          : map_building_renderer::kMaximumBuildingRenderTimeMs;
+  const size_t maximumQueuedBuildingRecords =
+      guidanceBirdsEye
+          ? kGuidanceMaximumQueuedBuildingRecords
+          : map_building_renderer::kMaximumRenderedBuildingRecords;
   uint64_t buildingContextSignature = 1469598103934665603ULL;
   const auto mixBuildingContext = [&](uint64_t value) {
     buildingContextSignature ^= value;
@@ -2738,8 +2755,7 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
     static uint64_t extrusionRecordOverflowTotal = 0;
     static uint64_t extrusionPointOverflowTotal = 0;
     const auto buildingDeadlineReached = [&]() {
-      return millis() - buildingPassStartMs >=
-             map_building_renderer::kMaximumBuildingRenderTimeMs;
+      return millis() - buildingPassStartMs >= buildingTimeBudgetMs;
     };
     const auto shouldStopBuildingWork = [&]() {
       if (shouldInterruptMapRenderForScreenCycle()) {
@@ -2783,9 +2799,26 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             break;
           }
           const auto &building = block->buildingData.buildings[recordIndex];
+          const map_transform::WorldPoint center{
+              static_cast<double>(block->offset.x) +
+                  (static_cast<double>(building.minX) + building.maxX) / 2.0,
+              static_cast<double>(block->offset.y) +
+                  (static_cast<double>(building.minY) + building.maxY) / 2.0};
+          const auto centerGround = projection.groundForWorld(center);
+          const auto centerProjection = projection.projectGround(centerGround);
+          // The top of a birds-eye frame is the far field. Keep its building
+          // footprints as flat 2D surfaces, reserving wall work for the
+          // foreground where it materially improves orientation.
+          const bool guidanceExtrusionAllowed =
+              !guidanceBirdsEye ||
+              (centerProjection.valid &&
+               centerProjection.y >=
+                   static_cast<double>(projection.config().viewportHeight) *
+                       kGuidanceFarBuildingCutoffFraction);
           const bool mayExtrude =
               extrudeBuildings &&
-              map_building_renderer::usesExtrusion(true, building.flags);
+              map_building_renderer::usesExtrusion(true, building.flags) &&
+              guidanceExtrusionAllowed;
           // A roof can project into the frame even when its ground footprint is
           // just outside it. Expand conservatively in world space before
           // excluding the record from the queue and its geometry budget.
@@ -2830,12 +2863,6 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
             continue;
           }
           ++boundedBuildingCandidateCount;
-          const map_transform::WorldPoint center{
-              static_cast<double>(block->offset.x) +
-                  (static_cast<double>(building.minX) + building.maxX) / 2.0,
-              static_cast<double>(block->offset.y) +
-                  (static_cast<double>(building.minY) + building.maxY) / 2.0};
-          const auto centerGround = projection.groundForWorld(center);
           const bool extrusionZoomEligible =
               map_building_renderer::eligibleExtrusionZoom(zoom);
           double projectedArea = 0.0;
@@ -2863,7 +2890,7 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
                                        kMinimumBuildingExtrusionAreaPixels};
           map_building_renderer::retainNearestCandidate(
               buildingQueue, candidate,
-              map_building_renderer::kMaximumRenderedBuildingRecords,
+              maximumQueuedBuildingRecords,
               buildingRendersBefore);
         }
         if (stopBuildingPrepass)
@@ -2936,7 +2963,7 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
       buildingPolygon.bbox.max = Point16(maxX, maxY);
       const bool completed = Maps::fillPolygon(
           buildingPolygon, canvas, buildingPassStartMs,
-          map_building_renderer::kMaximumBuildingRenderTimeMs);
+          buildingTimeBudgetMs);
       if (!completed)
         shouldStopBuildingWork();
       return completed;
@@ -5499,10 +5526,36 @@ void Maps::applyGuidanceMotionOffset(
   if (Maps::canvasForeground != nullptr) {
     lv_obj_set_pos(Maps::canvasForeground, baseX, baseY);
   }
-  const int32_t offsetX = map_transform::quantizePixel(
+  const int32_t requestedOffsetX = map_transform::quantizePixel(
       visibleProjection.anchorX() - projected.x);
-  const int32_t offsetY = map_transform::quantizePixel(
+  const int32_t requestedOffsetY = map_transform::quantizePixel(
       visibleProjection.anchorY() - projected.y);
+  // The guidance canvas is currently viewport-sized. Do not move it beyond
+  // its parent while a new vector frame is being rendered: doing so exposes
+  // the parent's background as a black/unloaded strip that looks like map
+  // data arriving in chunks. If a future renderer provides overscan, these
+  // same bounds naturally expand to that coverage.
+  const int32_t parentWidth = lv_obj_get_width(mapTile);
+  const int32_t parentHeight = lv_obj_get_height(mapTile);
+  const int32_t canvasWidth = lv_obj_get_width(Maps::canvasMap);
+  const int32_t canvasHeight = lv_obj_get_height(Maps::canvasMap);
+  const int32_t minOffsetX = -static_cast<int32_t>(baseX);
+  const int32_t maxOffsetX = parentWidth -
+                             (static_cast<int32_t>(baseX) + canvasWidth);
+  const int32_t minOffsetY = -static_cast<int32_t>(baseY);
+  const int32_t maxOffsetY = parentHeight -
+                             (static_cast<int32_t>(baseY) + canvasHeight);
+  const auto clampOffset = [](int32_t value, int32_t minimum,
+                              int32_t maximum) -> int32_t {
+    if (minimum > maximum)
+      return static_cast<int32_t>(0);
+    return static_cast<int32_t>(
+        std::max<int32_t>(minimum, std::min<int32_t>(maximum, value)));
+  };
+  const int32_t offsetX =
+      clampOffset(requestedOffsetX, minOffsetX, maxOffsetX);
+  const int32_t offsetY =
+      clampOffset(requestedOffsetY, minOffsetY, maxOffsetY);
   if (offsetX == 0 && offsetY == 0)
     return;
 

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -6,6 +6,8 @@
 #include <math.h>
 #include <string>
 #include <vector>
+#include <freertos/FreeRTOS.h>
+#include <freertos/task.h>
 
 // #include "../../compass/compass.hpp" // Circular dependency if not careful,
 // but likely needed for getHeading
@@ -122,9 +124,10 @@ private:
   ViewPort viewPort; // Vector map viewport
 
   // Guidance buildings are rendered as a resumable job after the flat map
-  // underlay has been prepared.  The visible canvas is never touched by this
-  // job; all callbacks write directly to bufMapTemp and publish only after a
-  // complete far-to-near pass.
+  // underlay has been prepared.  The course-up 2D frame is published before
+  // this job starts so navigation never waits for 3D admission. All building
+  // callbacks write to bufMapTemp and the completed far-to-near pass is then
+  // published atomically over that already-visible base frame.
   struct GuidanceBuildingRenderItem {
     MapBlock *block = nullptr;
     const map_building_block::Building *building = nullptr;
@@ -206,6 +209,7 @@ private:
       const MapBuildingVector<map_building_renderer::ScreenPoint> &points,
       uint16_t color);
   void publishGuidanceRenderJob();
+  void publishGuidanceBaseFrame();
   struct MemBlocks   // MemBlocks stored in memory
   {
     std::map<String, u_int16_t> blocks_map; // block offset -> block index
@@ -217,6 +221,29 @@ private:
     std::vector<MapBlock *> blocks;
   };
   MemCache memCache;               // Memory Cache
+
+  // A map block can take about two seconds to read/decode from the SD card on
+  // the 1.75-inch target. Guidance requests it on a low-priority worker so a
+  // cache miss never monopolizes the LVGL task. The UI owns `memCache`; the
+  // worker only publishes one fully decoded block through this mailbox.
+  struct MapBlockLoadJob {
+    enum class State : uint8_t { Idle, Loading, Ready, Failed, Cancelled };
+
+    volatile State state = State::Idle;
+    volatile bool cancelRequested = false;
+    volatile bool found = false;
+    MapBlock *result = nullptr;
+    Point32 offset;
+    String fileName;
+    TaskHandle_t task = nullptr;
+  } mapBlockLoadJob;
+
+  bool beginMapBlockLoad(const Point32 &offset, const String &fileName);
+  bool pollMapBlockLoad(MapBlock *&result, Point32 &offset);
+  void cancelMapBlockLoad();
+  static void mapBlockLoadTaskEntry(void *context);
+  void mapBlockLoadTask();
+
   String vectorMapFolder = "/sdcard/VECTMAP/";
   map_font_asset::Asset labelFontAsset;
   map_building_renderer::FailureRetryCooldown buildingFailureRetryCooldown;
@@ -487,9 +514,18 @@ public:
   void generateRenderMap(uint8_t zoom);
   bool generateVectorMap(uint8_t zoom);
   bool hasMapCanvas() const { return canvasMap != nullptr; }
-  bool isMapRenderPending() const { return guidanceBuildingRenderJob.active; }
-  void cancelPendingMapRender() { guidanceBuildingRenderJob.clear(); }
-  void releasePendingMapRender() { guidanceBuildingRenderJob.release(); }
+  bool isMapRenderPending() const {
+    return guidanceBuildingRenderJob.active ||
+           mapBlockLoadJob.state == MapBlockLoadJob::State::Loading;
+  }
+  void cancelPendingMapRender() {
+    guidanceBuildingRenderJob.clear();
+    cancelMapBlockLoad();
+  }
+  void releasePendingMapRender() {
+    guidanceBuildingRenderJob.release();
+    cancelMapBlockLoad();
+  }
   void displayMap();
   void updatePositionOverlay();
   bool isGuidanceBirdsEyeProjection() const;

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -14,6 +14,7 @@
 // #include "../../tft/tft.hpp" // Removed or minimal include if possible?
 #include "../../utils/src/gpsMath.hpp"
 #include "mapTransform.hpp"
+#include "mapMotion.hpp"
 #include "map_projection.hpp"
 #include "../../utils/src/mapDragPreview.hpp"
 #include "../../utils/src/mapRasterWindow.hpp"
@@ -356,6 +357,14 @@ private:
   void rebaseRollingDragAtVisibleEndpoint();
   void resetDragPresentationVisuals();
 
+  // GPS fixes arrive less frequently than the LVGL frame timer. Keep the
+  // displayed position and course independent from that cadence so the route,
+  // map, and marker move as one continuous presentation.
+  map_motion::PositionPresenter positionPresenter;
+  map_motion::HeadingPresenter headingPresenter;
+  map_transform::WorldPoint presentedGpsWorld(uint32_t nowMs);
+  void applyGuidanceMotionOffset(map_transform::WorldPoint presentedWorld);
+
 public:
   uint16_t mapScrHeight;  // Screen map size height
   uint16_t mapScrWidth;   // Screen map size width
@@ -388,6 +397,9 @@ public:
   bool hasMapCanvas() const { return canvasMap != nullptr; }
   void displayMap();
   void updatePositionOverlay();
+  uint16_t courseUpHeading(double latitude, double longitude,
+                           uint16_t gpsHeading);
+  void resetCourseUpHeading();
   void setWaypoint(double wptLat, double wptLon);
   void updateMap();
   void panMap(int8_t dx, int8_t dy);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -362,7 +362,10 @@ private:
   // map, and marker move as one continuous presentation.
   map_motion::PositionPresenter positionPresenter;
   map_motion::HeadingPresenter headingPresenter;
+  map_transform::WorldPoint latestPresentedWorld;
+  bool hasLatestPresentedWorld = false;
   map_transform::WorldPoint presentedGpsWorld(uint32_t nowMs);
+  void updateGuidanceRouteHead(map_transform::WorldPoint presentedWorld);
   void applyGuidanceMotionOffset(map_transform::WorldPoint presentedWorld);
 
 public:
@@ -397,6 +400,8 @@ public:
   bool hasMapCanvas() const { return canvasMap != nullptr; }
   void displayMap();
   void updatePositionOverlay();
+  bool isGuidanceBirdsEyeProjection() const;
+  bool guidanceProjectionNeedsRefresh() const;
   uint16_t courseUpHeading(double latitude, double longitude,
                            uint16_t gpsHeading);
   void resetCourseUpHeading();
@@ -404,6 +409,7 @@ public:
   void updateMap();
   void panMap(int8_t dx, int8_t dy);
   void centerOnGps(double lat, double lon);
+  void centerOnPresentedGps();
   void scrollMap(int16_t dx, int16_t dy);
   void preloadTiles(int8_t dirX, int8_t dirY);
   bool preparePinchZoomOutBackdrop(uint8_t baseZoom);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -21,6 +21,7 @@
 #include "lvgl.h"
 #include "mapFontAsset.hpp"
 #include "mapBuildingRenderer.hpp"
+#include "mapRenderJobPolicy.hpp"
 #include "mapLabelBlock.hpp"
 #include "mapBuildingBlock.hpp"
 #include "mapLabelLayout.hpp"
@@ -119,6 +120,92 @@ private:
     uint8_t zoom;
   };
   ViewPort viewPort; // Vector map viewport
+
+  // Guidance buildings are rendered as a resumable job after the flat map
+  // underlay has been prepared.  The visible canvas is never touched by this
+  // job; all callbacks write directly to bufMapTemp and publish only after a
+  // complete far-to-near pass.
+  struct GuidanceBuildingRenderItem {
+    MapBlock *block = nullptr;
+    const map_building_block::Building *building = nullptr;
+    double depth = 0.0;
+    uint16_t recordIndex = 0;
+    size_t pointCount = 0;
+    bool render = false;
+    bool extrude = false;
+    bool extrusionCandidate = false;
+  };
+
+  struct GuidanceBuildingRenderJob {
+    enum class Phase : uint8_t { None, Discover, Select, Draw };
+
+    bool active = false;
+    Phase phase = Phase::None;
+    uint8_t zoom = map_transform::kMinimumRuntimeZoom;
+    uint16_t width = 0;
+    uint16_t height = 0;
+    uint32_t strideBytes = 0;
+    size_t blockIndex = 0;
+    size_t recordIndex = 0;
+    size_t drawIndex = 0;
+    size_t discoveredRecords = 0;
+    size_t renderedRecords = 0;
+    size_t extrudedRecords = 0;
+    size_t renderedPoints = 0;
+    size_t extrudedPoints = 0;
+    map_projection::Projection projection;
+    ViewPort viewPort;
+    std::vector<GuidanceBuildingRenderItem,
+                PsramAllocator<GuidanceBuildingRenderItem>> queue;
+    MapBuildingVector<map_projection::GroundPoint> eligibilityGround;
+    MapBuildingVector<map_projection::GroundPoint> eligibilityClipped;
+    std::vector<uint16_t, PsramAllocator<uint16_t>> courtyardUnderlay;
+    std::vector<int32_t, PsramAllocator<int32_t>> courtyardScanlineNodes;
+    map_building_renderer::UnderlayRegion courtyardUnderlayRegion;
+    bool courtyardUnderlayReady = false;
+    bool courtyardUnderlayUnavailable = false;
+
+    void clear() {
+      active = false;
+      phase = Phase::None;
+      blockIndex = 0;
+      recordIndex = 0;
+      drawIndex = 0;
+      discoveredRecords = 0;
+      renderedRecords = 0;
+      extrudedRecords = 0;
+      renderedPoints = 0;
+      extrudedPoints = 0;
+      queue.clear();
+      eligibilityGround.clear();
+      eligibilityClipped.clear();
+      courtyardUnderlay.clear();
+      courtyardScanlineNodes.clear();
+      courtyardUnderlayRegion = {};
+      courtyardUnderlayReady = false;
+      courtyardUnderlayUnavailable = false;
+    }
+
+    void release() {
+      clear();
+      decltype(queue){}.swap(queue);
+      decltype(eligibilityGround){}.swap(eligibilityGround);
+      decltype(eligibilityClipped){}.swap(eligibilityClipped);
+      decltype(courtyardUnderlay){}.swap(courtyardUnderlay);
+      decltype(courtyardScanlineNodes){}.swap(courtyardScanlineNodes);
+    }
+  } guidanceBuildingRenderJob;
+
+  bool advanceGuidanceBuildingRenderJob();
+  bool startGuidanceBuildingRenderJob(
+      uint8_t zoom, uint16_t width, uint16_t height, uint32_t strideBytes,
+      const ViewPort &frameViewPort,
+      const map_projection::Projection &projection);
+  bool renderGuidanceBuilding(const GuidanceBuildingRenderItem &item);
+  bool fillGuidancePolygon(
+      const MapBuildingVector<map_building_renderer::ScreenPoint> &points,
+      uint16_t color);
+  void publishGuidanceRenderJob();
   struct MemBlocks   // MemBlocks stored in memory
   {
     std::map<String, u_int16_t> blocks_map; // block offset -> block index
@@ -364,6 +451,8 @@ private:
   map_motion::HeadingPresenter headingPresenter;
   map_transform::WorldPoint latestPresentedWorld;
   bool hasLatestPresentedWorld = false;
+  double guidancePixelsPerMs = 0.0;
+  uint32_t guidanceMotionSampleMs = 0;
   map_transform::WorldPoint presentedGpsWorld(uint32_t nowMs);
   void updateGuidanceRouteHead(map_transform::WorldPoint presentedWorld);
   void applyGuidanceMotionOffset(map_transform::WorldPoint presentedWorld);
@@ -398,6 +487,9 @@ public:
   void generateRenderMap(uint8_t zoom);
   bool generateVectorMap(uint8_t zoom);
   bool hasMapCanvas() const { return canvasMap != nullptr; }
+  bool isMapRenderPending() const { return guidanceBuildingRenderJob.active; }
+  void cancelPendingMapRender() { guidanceBuildingRenderJob.clear(); }
+  void releasePendingMapRender() { guidanceBuildingRenderJob.release(); }
   void displayMap();
   void updatePositionOverlay();
   bool isGuidanceBirdsEyeProjection() const;

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -21,12 +21,29 @@
 #include <cmath>
 #include <cstring>
 
+#ifndef DEG2RAD
+#define DEG2RAD(a) ((a) / (180.0 / M_PI))
+#endif
+
 // Global instance
 RouteOverlay routeOverlay;
+
+namespace {
+
+map_transform::WorldPoint routeWorldPoint(const GeoPoint &point) {
+  const double lon = point.lon / 1000000.0;
+  const double lat = point.lat / 1000000.0;
+  return {DEG2RAD(lon) * EARTH_RADIUS,
+          log(tan(DEG2RAD(lat) / 2.0 + M_PI / 4.0)) * EARTH_RADIUS};
+}
+
+} // namespace
 
 void RouteOverlay::parseRouteData(const uint8_t *data, size_t len) {
   points.clear();
   revisionCounter++;
+  liveProgressValid = false;
+  liveProgress = 0.0;
 
   if (len < 8) {
     Serial.println(
@@ -61,6 +78,8 @@ void RouteOverlay::parseRouteData(const uint8_t *data, size_t len) {
 void RouteOverlay::clear() {
   points.clear();
   revisionCounter++;
+  liveProgressValid = false;
+  liveProgress = 0.0;
   Serial.println("Route overlay cleared");
 }
 
@@ -134,10 +153,6 @@ bool RouteOverlay::headingNear(double lat, double lon,
   headingDeg = static_cast<uint16_t>(round(segmentHeading)) % 360;
   return true;
 }
-
-#ifndef DEG2RAD
-#define DEG2RAD(a) ((a) / (180.0 / M_PI))
-#endif
 
 void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
                                  uint32_t stride, int16_t x1, int16_t y1,
@@ -245,4 +260,145 @@ void RouteOverlay::drawRoute(
 
   ESP_LOGI("RouteOverlay", "Route drawn: %d/%d segments (some off-screen)",
            drawnCount, (int)points.size() - 1);
+}
+
+void RouteOverlay::drawLiveHead(
+    lv_obj_t *canvas, const map_projection::Projection &projection,
+    map_transform::WorldPoint presentedWorld) {
+  if (canvas == nullptr || points.size() < 2)
+    return;
+
+  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
+  if (draw_buf == nullptr || draw_buf->data == nullptr ||
+      draw_buf->header.cf != LV_COLOR_FORMAT_RGB565A8) {
+    return;
+  }
+
+  const int32_t bufW = draw_buf->header.w;
+  const int32_t bufH = draw_buf->header.h;
+  const uint32_t colorStride = draw_buf->header.stride / sizeof(uint16_t);
+  const uint32_t alphaStride = colorStride;
+  const size_t colorBytes = static_cast<size_t>(draw_buf->header.stride) *
+                            static_cast<size_t>(bufH);
+  const size_t alphaBytes = static_cast<size_t>(alphaStride) *
+                            static_cast<size_t>(bufH);
+  memset(draw_buf->data, 0, colorBytes + alphaBytes);
+
+  size_t closestSegment = 0;
+  double closestT = 0.0;
+  double bestDistanceSq = DBL_MAX;
+  for (size_t i = 0; i + 1 < points.size(); ++i) {
+    const auto start = routeWorldPoint(points[i]);
+    const auto end = routeWorldPoint(points[i + 1]);
+    const double segmentX = end.x - start.x;
+    const double segmentY = end.y - start.y;
+    const double segmentLengthSq =
+        (segmentX * segmentX) + (segmentY * segmentY);
+    if (segmentLengthSq <= 0.0)
+      continue;
+
+    double t = ((presentedWorld.x - start.x) * segmentX +
+                (presentedWorld.y - start.y) * segmentY) /
+               segmentLengthSq;
+    t = std::max(0.0, std::min(1.0, t));
+    const double closestX = start.x + segmentX * t;
+    const double closestY = start.y + segmentY * t;
+    const double dx = presentedWorld.x - closestX;
+    const double dy = presentedWorld.y - closestY;
+    const double distanceSq = (dx * dx) + (dy * dy);
+    if (distanceSq < bestDistanceSq) {
+      bestDistanceSq = distanceSq;
+      closestSegment = i;
+      closestT = t;
+    }
+  }
+  if (bestDistanceSq == DBL_MAX)
+    return;
+
+  double progress = static_cast<double>(closestSegment) + closestT;
+  if (liveProgressValid && progress < liveProgress)
+    progress = liveProgress;
+  else
+    liveProgress = progress;
+  liveProgressValid = true;
+
+  closestSegment = std::min(
+      static_cast<size_t>(std::floor(progress)), points.size() - 2);
+  closestT = std::max(0.0, std::min(1.0, progress - closestSegment));
+  const auto routeStart = routeWorldPoint(points[closestSegment]);
+  const auto routeEnd = routeWorldPoint(points[closestSegment + 1]);
+  const map_transform::WorldPoint projectedRoutePoint = {
+      routeStart.x + (routeEnd.x - routeStart.x) * closestT,
+      routeStart.y + (routeEnd.y - routeStart.y) * closestT};
+
+  const uint8_t baseRouteLineWidth = static_cast<uint8_t>(std::min<int16_t>(
+      std::max<int16_t>(1, (int16_t)currentMapStyleSettings().routeLineWidth),
+      48));
+  auto drawSegment = [&](map_transform::WorldPoint first,
+                         map_transform::WorldPoint second) {
+    auto groundFirst = projection.groundForWorld(first);
+    auto groundSecond = projection.groundForWorld(second);
+    if (!projection.clipSegmentToNearPlane(groundFirst, groundSecond))
+      return;
+    const auto projectedFirst = projection.projectGround(groundFirst);
+    const auto projectedSecond = projection.projectGround(groundSecond);
+    if (!projectedFirst.valid || !projectedSecond.valid)
+      return;
+
+    const int16_t firstX = static_cast<int16_t>(
+        map_transform::quantizePixel(projectedFirst.x));
+    const int16_t firstY = static_cast<int16_t>(
+        map_transform::quantizePixel(projectedFirst.y));
+    const int16_t secondX = static_cast<int16_t>(
+        map_transform::quantizePixel(projectedSecond.x));
+    const int16_t secondY = static_cast<int16_t>(
+        map_transform::quantizePixel(projectedSecond.y));
+
+    const int16_t margin = 50;
+    if ((firstX < -margin && secondX < -margin) ||
+        (firstX >= bufW + margin && secondX >= bufW + margin) ||
+        (firstY < -margin && secondY < -margin) ||
+        (firstY >= bufH + margin && secondY >= bufH + margin)) {
+      return;
+    }
+
+    const int16_t routeLineWidth = projection.scaledLineWidth(
+        baseRouteLineWidth,
+        (projectedFirst.depthScale + projectedSecond.depthScale) / 2.0, 48);
+    drawThickLine(
+        reinterpret_cast<uint16_t *>(draw_buf->data), bufW, bufH, colorStride,
+        firstX, firstY, secondX, secondY,
+        navigation_visual_style::ROUTE_BLUE_RGB565, routeLineWidth);
+
+    // Only inspect the dirty line rectangle. A full-screen color scan at 30 Hz
+    // would make the presentation loop compete with the vector renderer.
+    auto *colors = reinterpret_cast<uint16_t *>(draw_buf->data);
+    auto *alpha = static_cast<uint8_t *>(draw_buf->data) + colorBytes;
+    const int32_t dirtyMargin = static_cast<int32_t>(routeLineWidth) + 2;
+    const int32_t minX = std::max<int32_t>(
+        0, std::min<int32_t>(firstX, secondX) - dirtyMargin);
+    const int32_t maxX = std::min<int32_t>(
+        bufW - 1, std::max<int32_t>(firstX, secondX) + dirtyMargin);
+    const int32_t minY = std::max<int32_t>(
+        0, std::min<int32_t>(firstY, secondY) - dirtyMargin);
+    const int32_t maxY = std::min<int32_t>(
+        bufH - 1, std::max<int32_t>(firstY, secondY) + dirtyMargin);
+    for (int32_t y = minY; y <= maxY; ++y) {
+      for (int32_t x = minX; x <= maxX; ++x) {
+        const size_t index = static_cast<size_t>(y) * colorStride + x;
+        if (colors[index] == navigation_visual_style::ROUTE_BLUE_RGB565)
+          alpha[static_cast<size_t>(y) * alphaStride + x] = 255;
+      }
+    }
+  };
+
+  // Start at the exact presented marker position, connect to the nearest
+  // route point when GPS is slightly off the polyline, then draw only forward
+  // route geometry. This removes both stale leading gaps and trailing tails.
+  drawSegment(presentedWorld, projectedRoutePoint);
+  drawSegment(projectedRoutePoint, routeEnd);
+  for (size_t i = closestSegment + 1; i + 1 < points.size(); ++i) {
+    drawSegment(routeWorldPoint(points[i]), routeWorldPoint(points[i + 1]));
+  }
+
 }

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -73,6 +73,7 @@ bool RouteOverlay::headingNear(double lat, double lon,
   const double cosLat = cos(DEG2RAD(lat));
   double bestDistanceSq = DBL_MAX;
   size_t bestSegment = 0;
+  double firstSegmentDistanceSq = DBL_MAX;
 
   for (size_t i = 0; i + 1 < points.size(); i++) {
     const double lat1 = points[i].lat / 1000000.0;
@@ -96,6 +97,9 @@ bool RouteOverlay::headingNear(double lat, double lon,
     const double closestX = x1 + (segX * t);
     const double closestY = y1 + (segY * t);
     const double distanceSq = (closestX * closestX) + (closestY * closestY);
+    if (i == 0) {
+      firstSegmentDistanceSq = distanceSq;
+    }
     if (distanceSq < bestDistanceSq) {
       bestDistanceSq = distanceSq;
       bestSegment = i;
@@ -104,6 +108,22 @@ bool RouteOverlay::headingNear(double lat, double lon,
 
   if (bestDistanceSq == DBL_MAX) {
     return false;
+  }
+
+  // Geometry windows start with the rider's current route position. Keep the
+  // first segment while the rider is still close to it, even if a later turn
+  // is geometrically almost as close. This prevents a course-up rotation from
+  // anticipating a corner because the outgoing segment is visible ahead. Once
+  // the rider has left the first segment by more than the GPS tolerance, the
+  // nearest-segment search naturally advances to the next segment.
+  constexpr double kHeadingContinuityToleranceMeters = 8.0;
+  constexpr double kMetersPerDegree = 111320.0;
+  const double continuityToleranceDegrees =
+      kHeadingContinuityToleranceMeters / kMetersPerDegree;
+  if (firstSegmentDistanceSq != DBL_MAX &&
+      firstSegmentDistanceSq <=
+          continuityToleranceDegrees * continuityToleranceDegrees) {
+    bestSegment = 0;
   }
 
   const double segmentHeading =

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -264,7 +264,8 @@ void RouteOverlay::drawRoute(
 
 void RouteOverlay::drawLiveHead(
     lv_obj_t *canvas, const map_projection::Projection &projection,
-    map_transform::WorldPoint presentedWorld) {
+    map_transform::WorldPoint presentedWorld,
+    map_transform::WorldPoint markerCenterWorld) {
   if (canvas == nullptr || points.size() < 2)
     return;
 
@@ -392,10 +393,11 @@ void RouteOverlay::drawLiveHead(
     }
   };
 
-  // Start at the exact presented marker position, connect to the nearest
-  // route point when GPS is slightly off the polyline, then draw only forward
-  // route geometry. This removes both stale leading gaps and trailing tails.
-  drawSegment(presentedWorld, projectedRoutePoint);
+  // Progress follows the exact presented GPS position, but the visible line
+  // must meet the visual center of the arrow. The geographic marker anchor is
+  // deliberately at the arrow's lower center for rotation; using it here
+  // would make the route appear to start at the arrow's bottom edge.
+  drawSegment(markerCenterWorld, projectedRoutePoint);
   drawSegment(projectedRoutePoint, routeEnd);
   for (size_t i = closestSegment + 1; i + 1 < points.size(); ++i) {
     drawSegment(routeWorldPoint(points[i]), routeWorldPoint(points[i + 1]));

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -55,6 +55,18 @@ public:
                  const map_projection::Projection &projection);
 
   /**
+   * @brief Draw the live route head from the presented GPS position forward.
+   *
+   * Guidance uses this on a transparent foreground at the display cadence.
+   * The full route window is still supplied by iOS, but the first pixel is
+   * derived from the same presented position as the marker so a stale BLE
+   * geometry window cannot leave a gap or a trailing tail at the arrow.
+   */
+  void drawLiveHead(lv_obj_t *canvas,
+                    const map_projection::Projection &projection,
+                    map_transform::WorldPoint presentedWorld);
+
+  /**
    * @brief Clear all route points
    */
   void clear();
@@ -86,6 +98,8 @@ public:
 private:
   std::vector<GeoPoint, PsramAllocator<GeoPoint>> points;
   uint32_t revisionCounter = 0;
+  bool liveProgressValid = false;
+  double liveProgress = 0.0;
 
   /**
    * @brief Draw a single line segment with thickness

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -60,11 +60,14 @@ public:
    * Guidance uses this on a transparent foreground at the display cadence.
    * The full route window is still supplied by iOS, but the first pixel is
    * derived from the same presented position as the marker so a stale BLE
-   * geometry window cannot leave a gap or a trailing tail at the arrow.
+   * geometry window cannot leave a gap or a trailing tail at the arrow. The
+   * separate markerCenterWorld keeps the visible line attached to the arrow's
+   * center while presentedWorld remains the progress anchor.
    */
   void drawLiveHead(lv_obj_t *canvas,
                     const map_projection::Projection &projection,
-                    map_transform::WorldPoint presentedWorld);
+                    map_transform::WorldPoint presentedWorld,
+                    map_transform::WorldPoint markerCenterWorld);
 
   /**
    * @brief Clear all route points

--- a/esp32/tools/tests/test_map_building_renderer.cpp
+++ b/esp32/tools/tests/test_map_building_renderer.cpp
@@ -406,6 +406,35 @@ void assertCourtyardRestoresRealUnderlay() {
   assert(canvas[7 * width + 7] == 0xFFFF);
 }
 
+void assertCourtyardRestoresCompactUnderlayRegion() {
+  constexpr int32_t width = 8;
+  constexpr int32_t height = 8;
+  constexpr int32_t regionX = 2;
+  constexpr int32_t regionY = 2;
+  constexpr int32_t regionWidth = 4;
+  constexpr int32_t regionHeight = 4;
+  std::vector<uint16_t> underlay(regionWidth * regionHeight);
+  for (size_t index = 0; index < underlay.size(); ++index)
+    underlay[index] = static_cast<uint16_t>(100 + index);
+  std::vector<uint16_t> canvas(width * height, 0xFFFF);
+  const std::vector<ScreenPoint> courtyard = {
+      {2, 2}, {6, 2}, {6, 6}, {2, 6},
+  };
+  std::vector<int32_t> nodes(courtyard.size());
+  const map_building_renderer::UnderlayRegion region{
+      regionX, regionY, regionWidth, regionHeight,
+      static_cast<size_t>(regionWidth), underlay.size()};
+  const bool restored =
+      map_building_renderer::restoreCourtyardUnderlayRegion(
+          courtyard, canvas.data(), width, height, width, underlay.data(),
+          region, nodes, []() { return false; });
+  assert(restored);
+  assert(canvas[3 * width + 3] == underlay[1 * regionWidth + 1]);
+  assert(canvas[5 * width + 5] == underlay[3 * regionWidth + 3]);
+  assert(canvas[0] == 0xFFFF);
+  assert(canvas[7 * width + 7] == 0xFFFF);
+}
+
 void assertInterruptionPropagates() {
   const auto building = buildingWithCourtyard();
   const auto projection =
@@ -496,6 +525,7 @@ int main() {
   assertOrderingAndBudget();
   assertNearPlaneMatrix();
   assertCourtyardRestoresRealUnderlay();
+  assertCourtyardRestoresCompactUnderlayRegion();
   assertInterruptionPropagates();
   assertAllocationFailureFailsClosed();
   assertFailureRetryCooldown();

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -229,6 +229,18 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
             r"if \(!buildingPassCompleted\)\s*\{[\s\S]*?return false;\s*\}",
         )
 
+    def test_courtyard_workspace_is_bounded_to_visible_viewport(self):
+        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
+        self.assertIn("buildingWorkspaceViewportPixels", render_body)
+        self.assertIn("maximumCourtyardUnderlayPixels", render_body)
+        self.assertIn("restoreCourtyardUnderlayRegion", render_body)
+        self.assertIn("courtyardBudgetBytes=%u", render_body)
+        self.assertIn("courtyardMaxBytes=%u", render_body)
+        self.assertIn("courtyardUnderlayUnavailable", render_body)
+        self.assertIn("real underlay", render_body)
+        self.assertIn("maxX + 1", render_body)
+        self.assertIn("maxY + 1", render_body)
+
     def test_navigation_screen_retains_destination_picker(self):
         create_body = function_body(MAIN_SCREEN_SOURCE, "void createMainScr")
         update_body = function_body(MAIN_SCREEN_SOURCE, "void updateNavEvent")

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -151,7 +151,7 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
 
     def test_guidance_vector_frame_reserves_motion_overscan(self):
         self.assertIn(
-            "constexpr uint16_t kGuidanceOverscanPixels = 96;",
+            "map_render_job_policy::kGuidanceOverscanPixels",
             MAP_RENDERER_SOURCE,
         )
         render_body = function_body(
@@ -180,13 +180,53 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         refresh_body = function_body(
             MAP_RENDERER_SOURCE, "bool Maps::guidanceProjectionNeedsRefresh"
         )
-        self.assertIn("kGuidanceRefreshSafetyPixels", refresh_body)
+        self.assertIn("map_render_job_policy::refreshLeadPixels", refresh_body)
+        self.assertIn("map_render_job_policy::availableMotionPixels", refresh_body)
+        self.assertIn("guidancePixelsPerMs", refresh_body)
+        self.assertIn("guidanceBuildingRenderJob.projection", refresh_body)
         self.assertIn(
-            "visibleProjection.anchorX() - availableMotion", refresh_body
+            "projection->anchorX() - refreshDistance", refresh_body
         )
         self.assertIn(
-            "visibleProjection.anchorY() + availableMotion", refresh_body
+            "projection->anchorY() + refreshDistance", refresh_body
         )
+
+    def test_guidance_buildings_use_a_resumable_back_buffer_job(self):
+        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::generateVectorMap")
+        read_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
+        update_body = function_body(MAIN_SCREEN_SOURCE, "void updateMap(lv_event_t *event)")
+        self.assertIn("if (isMapRenderPending())", render_body)
+        self.assertIn("return advanceGuidanceBuildingRenderJob();", render_body)
+        self.assertIn("cooperativeGuidanceBuildings", render_body)
+        self.assertIn("startGuidanceBuildingRenderJob", render_body)
+        self.assertIn("readVectorMap(Maps::viewPort", render_body)
+        self.assertIn("cooperativeGuidanceBuildings))", render_body)
+        self.assertIn("suppressBuildings || guidanceBirdsEye", read_body)
+        self.assertIn("if (mapView.isMapRenderPending())", update_body)
+        self.assertIn("mapView.cancelPendingMapRender()", MAIN_SCREEN_SOURCE)
+
+    def test_pending_guidance_job_is_cancelled_only_after_motion_lead_is_used(self):
+        prepare_body = function_body(
+            MAIN_SCREEN_SOURCE, "static bool prepareVisibleMapUpdate"
+        )
+        self.assertIn("const bool projectionNeedsRefresh", prepare_body)
+        self.assertIn("if (!projectionNeedsRefresh)", prepare_body)
+        self.assertIn("mapView.cancelPendingMapRender()", prepare_body)
+        self.assertIn(
+            "mapRenderScheduler.request(map_render_policy::Reason::Position)",
+            prepare_body,
+        )
+
+    def test_guidance_admission_is_fixed_quota_not_a_wall_clock_prefix(self):
+        policy_source = (
+            ESP32_ROOT / "lib" / "maps" / "src" / "mapRenderJobPolicy.hpp"
+        ).read_text(encoding="utf-8")
+        self.assertIn("kGuidanceMaximumQueuedBuildingRecords", policy_source)
+        self.assertIn("kGuidanceMaximumRenderedBuildingRecords", policy_source)
+        self.assertIn("kGuidanceMaximumRenderedBuildingPoints", policy_source)
+        self.assertIn("kGuidanceDiscoveryRecordsPerSlice", policy_source)
+        self.assertIn("same immutable frame", policy_source)
+        self.assertNotIn("900U", policy_source)
 
     def test_building_deadline_and_allocation_failures_use_bounded_fallback(self):
         render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -43,6 +43,10 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("mapNavigationBirdsEyeEnabled", expression)
         self.assertNotIn("hasRoute", expression)
 
+    def test_course_up_starts_with_navigation_snapshot_before_route_window(self):
+        self.assertIn("routeOverlay.hasRoute() || hasCurrentNavigationData()",
+                      MAIN_SCREEN_SOURCE)
+
     def test_map_guidance_owns_no_destination_picker(self):
         self.assertNotIn("mapGuidanceDestinationPicker", MAIN_SCREEN_SOURCE)
         overlay_body = function_body(

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -152,6 +152,45 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
             render_body.index("routeOverlay.drawRoute("),
         )
 
+    def test_guidance_vector_frame_reserves_motion_overscan(self):
+        self.assertIn(
+            "constexpr uint16_t kGuidanceOverscanPixels = 96;",
+            MAP_RENDERER_SOURCE,
+        )
+        render_body = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::generateVectorMap"
+        )
+        self.assertIn(
+            "const bool guidanceFrame = isMapGuidanceScreenActive();", render_body
+        )
+        self.assertIn("guidanceFrameWidth", render_body)
+        self.assertIn("guidanceFrameHeight", render_body)
+        self.assertIn("guidanceFrameAnchorX", render_body)
+        self.assertIn("guidanceFrameAnchorY", render_body)
+
+        motion_body = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::applyGuidanceMotionOffset"
+        )
+        self.assertIn("parentWidth -", motion_body)
+        self.assertIn(
+            "maxOffsetX = -static_cast<int32_t>(baseX)", motion_body
+        )
+        self.assertIn(
+            "maxOffsetY = -static_cast<int32_t>(baseY)", motion_body
+        )
+
+    def test_guidance_refreshes_before_overscan_is_exhausted(self):
+        refresh_body = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::guidanceProjectionNeedsRefresh"
+        )
+        self.assertIn("kGuidanceRefreshSafetyPixels", refresh_body)
+        self.assertIn(
+            "visibleProjection.anchorX() - availableMotion", refresh_body
+        )
+        self.assertIn(
+            "visibleProjection.anchorY() + availableMotion", refresh_body
+        )
+
     def test_building_deadline_and_allocation_failures_discard_scratch_frame(self):
         render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
         self.assertIn("runAllocationSafe", render_body)

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -88,12 +88,9 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
 
     def test_dense_scene_selection_uses_shared_nearest_first_policy(self):
         render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
-        self.assertIn(
-            "map_building_renderer::selectNearestForExtrusion(\n"
-            "                    buildingQueue.rbegin(), buildingQueue.rend(),\n"
-            "                    shouldStopBuildingWork)",
-            render_body,
-        )
+        self.assertIn("map_building_renderer::selectNearestForExtrusion(", render_body)
+        self.assertIn("buildingQueue.rbegin(), buildingQueue.rend(),", render_body)
+        self.assertIn("shouldStopBuildingWork);", render_body)
         self.assertIn("item.extrude", render_body)
         self.assertIn("buildingSelection.flatOverflow()", render_body)
         self.assertIn("buildingSelection.recordLimitOverflow", render_body)
@@ -191,11 +188,20 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
             "visibleProjection.anchorY() + availableMotion", refresh_body
         )
 
-    def test_building_deadline_and_allocation_failures_discard_scratch_frame(self):
+    def test_building_deadline_and_allocation_failures_use_bounded_fallback(self):
         render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
         self.assertIn("runAllocationSafe", render_body)
         self.assertIn("buildingAllocationFailed", render_body)
         self.assertIn("buildingDeadlineAborted", render_body)
+        self.assertIn("buildingPrepassDeadlineExceeded", render_body)
+        self.assertIn("buildingPrepassTimeBudgetMs", render_body)
+        self.assertIn("kBuildingDrawTimeBudgetMs", render_body)
+        self.assertIn("buildingDeadlineStartMs", render_body)
+        self.assertIn("buildingPhaseBudgetMs", render_body)
+        self.assertIn("queue collected so far", render_body)
+        self.assertIn(
+            "if (stopBuildingPrepass && buildingDeadlineExceeded)", render_body
+        )
         self.assertIn('reason=%s', render_body)
         self.assertIn('"allocation"', render_body)
         self.assertIn('"deadline"', render_body)
@@ -205,6 +211,11 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("psramUsed=%u psramFree=%u", render_body)
         self.assertIn("shouldRetryWithoutBuildings", render_body)
         self.assertIn("buildingFailureRetryCooldown.recordFailure", render_body)
+        self.assertRegex(
+            render_body,
+            r"if\s*\(buildingAllocationFailed\)\s*\{[\s\S]*?"
+            r"buildingFailureRetryCooldown\.recordFailure",
+        )
         self.assertIn("psramSamplePostCleanup", render_body)
         self.assertGreaterEqual(render_body.count("releaseBuildingFailureWorkspace();"), 2)
         self.assertLess(

--- a/esp32/tools/tests/test_map_motion.cpp
+++ b/esp32/tools/tests/test_map_motion.cpp
@@ -1,0 +1,32 @@
+#include "../../lib/maps/src/mapMotion.hpp"
+
+#include <cassert>
+#include <cmath>
+
+int main() {
+  map_motion::PositionPresenter position;
+  const auto initial = position.update({0.0, 0.0}, 0);
+  assert(initial.x == 0.0 && initial.y == 0.0);
+
+  // A new fix is presented between frames instead of being teleported to the
+  // next raw coordinate. The bounded prediction continues briefly, then the
+  // display converges back to the measured target.
+  position.update({10.0, 0.0}, 1000);
+  const auto inBetween = position.update({10.0, 0.0}, 1030);
+  assert(inBetween.x > 0.0 && inBetween.x < 10.0);
+  for (uint32_t time = 1060; time <= 3000; time += 30) {
+    position.update({10.0, 0.0}, time);
+  }
+  const auto settled = position.update({10.0, 0.0}, 3000);
+  assert(std::fabs(settled.x - 10.0) < 0.1);
+
+  map_motion::HeadingPresenter heading;
+  assert(heading.update(359.0, 0, 1) == 359);
+  const uint16_t wrapped = heading.update(1.0, 30, 1);
+  assert(wrapped == 0 || wrapped == 1 || wrapped == 359);
+  assert(heading.update(90.0, 30, 1) == wrapped);
+  heading.reset();
+  assert(heading.update(90.0, 1000, 2) == 90);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_map_render_job_policy.cpp
+++ b/esp32/tools/tests/test_map_render_job_policy.cpp
@@ -1,0 +1,16 @@
+#include "../../lib/maps/src/mapRenderJobPolicy.hpp"
+
+#include <cassert>
+
+int main() {
+  static_assert(map_render_job_policy::availableMotionPixels() == 80);
+  static_assert(map_render_job_policy::kGuidanceMaximumQueuedBuildingRecords >=
+                map_render_job_policy::kGuidanceMaximumRenderedBuildingRecords);
+
+  assert(map_render_job_policy::refreshLeadPixels(0.0) == 0);
+  assert(map_render_job_policy::refreshLeadPixels(0.1) == 30);
+  assert(!map_render_job_policy::shouldRefresh(40.0, 0.0));
+  assert(map_render_job_policy::shouldRefresh(50.0, 0.1));
+  assert(map_render_job_policy::shouldRefresh(80.0, 0.0));
+  return 0;
+}

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -52,6 +52,9 @@ class NavigationEngine: NSObject, ObservableObject {
     private var simulationProgress: Double = 0.0 // 0.0 to 1.0 along route
     private var simulationSpeed: Double = 10.0 // meters per second (~36 km/h)
     private var lastSimulationUpdate: Date?
+    private var lastSimulationLogicUpdate: Date?
+    private let simulationPresentationInterval: TimeInterval = 1.0 / 30.0
+    private let simulationLogicInterval: TimeInterval = 0.2
     
     // BLE Manager reference
     private var bleManager: BLEManager?
@@ -228,9 +231,10 @@ class NavigationEngine: NSObject, ObservableObject {
         print("Starting simulated navigation")
         simulationProgress = 0.0
         lastSimulationUpdate = Date()
+        lastSimulationLogicUpdate = nil
         
         simulationTimer?.invalidate()
-        simulationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        simulationTimer = Timer.scheduledTimer(withTimeInterval: simulationPresentationInterval, repeats: true) { [weak self] _ in
             self?.updateSimulation()
         }
         // Add timer to RunLoop to ensure it fires in common run loop modes (including background)
@@ -240,6 +244,7 @@ class NavigationEngine: NSObject, ObservableObject {
     internal func stopSimulation() {
         simulationTimer?.invalidate()
         simulationTimer = nil
+        lastSimulationLogicUpdate = nil
         isSimulationMode = false
         simulatedPosition = nil
     }
@@ -277,6 +282,12 @@ class NavigationEngine: NSObject, ObservableObject {
         // Calculate position
         if let position = interpolatePositionAlongRoute(progress: simulationProgress) {
             simulatedPosition = position
+
+            let shouldRunLogic = lastSimulationLogicUpdate.map {
+                now.timeIntervalSince($0) >= simulationLogicInterval
+            } ?? true
+            guard shouldRunLogic else { return }
+            lastSimulationLogicUpdate = now
 
             let location = CLLocation(
                 coordinate: position,

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -697,19 +697,61 @@ extension NavigationEngine {
         var points = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
         polyline.getCoordinates(&points, range: NSRange(location: 0, length: pointCount))
 
-        var closestIndex = 0
+        let currentMapPoint = MKMapPoint(currentLocation.coordinate)
+        var closestSegmentIndex = 0
         var closestDistance = Double.greatestFiniteMagnitude
-        for (index, point) in points.enumerated() {
-            let pointLocation = CLLocation(latitude: point.latitude, longitude: point.longitude)
-            let distance = currentLocation.distance(from: pointLocation)
-            if distance < closestDistance {
-                closestDistance = distance
-                closestIndex = index
+        if pointCount > 1 {
+            for index in 0..<(pointCount - 1) {
+                let start = MKMapPoint(points[index])
+                let end = MKMapPoint(points[index + 1])
+                let dx = end.x - start.x
+                let dy = end.y - start.y
+                let lengthSquared = (dx * dx) + (dy * dy)
+                let t: Double
+                if lengthSquared > 0 {
+                    let projected = ((currentMapPoint.x - start.x) * dx +
+                                     (currentMapPoint.y - start.y) * dy) /
+                        lengthSquared
+                    t = max(0, min(1, projected))
+                } else {
+                    t = 0
+                }
+                let closest = MKMapPoint(x: start.x + dx * t,
+                                         y: start.y + dy * t)
+                let distance = currentMapPoint.distance(to: closest)
+                if distance < closestDistance {
+                    closestDistance = distance
+                    closestSegmentIndex = index
+                }
             }
         }
 
-        let endIndex = min(closestIndex + geometryWindowSize, pointCount)
-        let windowPoints = Array(points[closestIndex..<endIndex])
+        // Always make the device's current route-space coordinate the first
+        // point. The line therefore starts exactly under the marker after the
+        // same GCJ-02 -> WGS-84 conversion used for every other route point,
+        // even when GPS is a few metres away from Apple's route polyline.
+        // Future route vertices begin at the projected segment, not at the
+        // nearest coarse vertex.
+        var windowPoints = [currentLocation.coordinate]
+        if pointCount > 1 {
+            let firstFutureIndex = min(closestSegmentIndex + 1, pointCount - 1)
+            let endIndex = min(firstFutureIndex + max(geometryWindowSize - 1, 0),
+                               pointCount)
+            if firstFutureIndex < endIndex {
+                for point in points[firstFutureIndex..<endIndex] {
+                    let previous = windowPoints[windowPoints.count - 1]
+                    let separation = CLLocation(latitude: previous.latitude,
+                                                longitude: previous.longitude)
+                        .distance(from: CLLocation(latitude: point.latitude,
+                                                   longitude: point.longitude))
+                    // Do not add a duplicate at an exact route vertex. The
+                    // projected segment still contributes its next vertex.
+                    if separation > 0.01 {
+                        windowPoints.append(point)
+                    }
+                }
+            }
+        }
         guard !windowPoints.isEmpty else { return nil }
 
         return compressRoutePoints(windowPoints)

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -294,7 +294,11 @@ class NavigationEngine: NSObject, ObservableObject {
                 altitude: 0,
                 horizontalAccuracy: 5,
                 verticalAccuracy: -1,
-                course: -1,
+                // MapKit does not provide a heading for a synthetic
+                // location.  Supplying the current route bearing keeps the
+                // bike computer's course-up projection deterministic during
+                // test navigation instead of silently encoding north (0°).
+                course: routeCourse(at: position) ?? -1,
                 speed: simulationSpeed,
                 timestamp: now
             )
@@ -340,6 +344,63 @@ class NavigationEngine: NSObject, ObservableObject {
         }
         
         return points.last
+    }
+
+    /// Return the bearing of the route segment nearest to a route-space
+    /// coordinate.  Core Location's `course` is often -1 while a rider is
+    /// stationary or while a simulation is running; the route itself is the
+    /// authoritative course in those cases.  The caller supplies coordinates
+    /// in the same MapKit/GCJ-02 space as `currentRoute`.
+    private func routeCourse(at coordinate: CLLocationCoordinate2D) -> CLLocationDirection? {
+        guard let route = currentRoute else { return nil }
+
+        let polyline = route.polyline
+        let pointCount = polyline.pointCount
+        guard pointCount > 1 else { return nil }
+
+        var points = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
+        polyline.getCoordinates(&points, range: NSRange(location: 0, length: pointCount))
+
+        let currentMapPoint = MKMapPoint(coordinate)
+        var closestSegmentIndex: Int?
+        var closestDistance = Double.greatestFiniteMagnitude
+        for index in 0..<(pointCount - 1) {
+            let start = MKMapPoint(points[index])
+            let end = MKMapPoint(points[index + 1])
+            let dx = end.x - start.x
+            let dy = end.y - start.y
+            let lengthSquared = (dx * dx) + (dy * dy)
+            guard lengthSquared > 0 else { continue }
+
+            let projected = ((currentMapPoint.x - start.x) * dx +
+                             (currentMapPoint.y - start.y) * dy) /
+                lengthSquared
+            let t = max(0, min(1, projected))
+            let closest = MKMapPoint(x: start.x + dx * t,
+                                     y: start.y + dy * t)
+            let distance = currentMapPoint.distance(to: closest)
+            if distance < closestDistance {
+                closestDistance = distance
+                closestSegmentIndex = index
+            }
+        }
+
+        guard let index = closestSegmentIndex else { return nil }
+        let start = points[index]
+        let end = points[index + 1]
+        let latitude1 = start.latitude * .pi / 180
+        let latitude2 = end.latitude * .pi / 180
+        let deltaLongitude = (end.longitude - start.longitude) * .pi / 180
+        let y = sin(deltaLongitude) * cos(latitude2)
+        let x = cos(latitude1) * sin(latitude2) -
+            sin(latitude1) * cos(latitude2) * cos(deltaLongitude)
+        guard x.isFinite, y.isFinite, abs(x) > 0 || abs(y) > 0 else {
+            return nil
+        }
+
+        let bearing = atan2(y, x) * 180 / .pi
+        let normalized = bearing >= 0 ? bearing : bearing + 360
+        return normalized.isFinite && normalized < 360 ? normalized : nil
     }
 
     /// Send test navigation data for BLE testing
@@ -672,7 +733,19 @@ class NavigationEngine: NSObject, ObservableObject {
         let wgsCoordinate = convertFromMapKitRoute
             ? CoordinateConverter.gcj02ToWGS84(coordinate: location.coordinate)
             : location.coordinate
-        let heading = location.course >= 0 ? location.course : 0
+        let routeCoordinate = convertFromMapKitRoute
+            ? location.coordinate
+            : CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location).coordinate
+        let routeHeading = routeCourse(at: routeCoordinate)
+        let locationHeading = location.course.isFinite &&
+            location.course >= 0 && location.course < 360
+            ? location.course
+            : nil
+        // Prefer a measured course, but never encode Core Location's invalid
+        // -1 as a north-up 0°.  During simulation and low-speed GPS, the
+        // current route bearing is the stable fallback for the firmware's
+        // course-up presenter.
+        let heading = locationHeading ?? routeHeading ?? 0
         bleManager?.sendGPSPosition(lat: wgsCoordinate.latitude,
                                     lon: wgsCoordinate.longitude,
                                     heading: heading,

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -178,15 +178,16 @@ struct MapViewContainer: UIViewRepresentable {
                 mapView: uiView,
                 coordinate: simPos,
                 isFreePanActive: isFreePanActive,
-                animated: true
+                animated: false
             )
             
             // Update or add annotation
             if let annotation = existingSimAnnotations.first as? SimulatedPositionAnnotation {
-                // Animate coordinate change
-                UIView.animate(withDuration: 1.0) {
-                    annotation.coordinate = simPos
-                }
+                // The simulation now presents at 30 Hz. Overlapping one-second
+                // animations would continually chase stale coordinates and
+                // recreate the old stop/go motion, so update the annotation
+                // directly at the display cadence.
+                annotation.coordinate = simPos
             } else {
                 let annotation = SimulatedPositionAnnotation()
                 annotation.coordinate = simPos

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -648,6 +648,7 @@ struct NavigationProtocolTests {
         testNavigationEngineKeepsProgressAtRouteCrossing()
         testNavigationEngineResendsWhenBLEBecomesReady()
         testNavigationEngineResendsRouteGeometryNearLastLocation()
+        testNavigationEngineStartsRouteGeometryAtExactCurrentLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
         testNavigationEngineRefreshesElapsedWithoutLocationChange()
@@ -13603,6 +13604,36 @@ struct NavigationProtocolTests {
                          "route geometry resend should use the latest device location window")
     }
 
+    static func testNavigationEngineStartsRouteGeometryAtExactCurrentLocation() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let routeCoordinates = [
+            CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0010, longitude: -122.0000),
+            CLLocationCoordinate2D(latitude: 37.0020, longitude: -121.9990)
+        ]
+        let route = TestRoute(instructions: "Continue", coordinates: routeCoordinates)
+        let current = CLLocation(latitude: 37.0007, longitude: -122.0000)
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        engine.startNavigation(with: route, initialLocation: current)
+
+        guard let geometry = manager.sentRouteGeometry.first,
+              let firstCoordinate = routeStartCoordinate(from: geometry) else {
+            assert(false, "initial route geometry should include the current GPS coordinate")
+            return
+        }
+        assertCoordinate(
+            firstCoordinate,
+            latitude: current.coordinate.latitude,
+            longitude: current.coordinate.longitude,
+            "route geometry starts at the exact current GPS coordinate"
+        )
+    }
+
     static func testNavigationEngineClearsRouteGeometryOnStop() {
         let manager = TestBLEManager()
         manager.isConnected = true
@@ -14215,8 +14246,8 @@ struct NavigationProtocolTests {
         }
         assertCoordinate(
             replacementStart,
-            latitude: firstManeuver.latitude,
-            longitude: firstManeuver.longitude,
+            latitude: latest.coordinate.latitude,
+            longitude: latest.coordinate.longitude,
             "replacement geometry starts near the rider's latest route position"
         )
         assert(

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -649,6 +649,7 @@ struct NavigationProtocolTests {
         testNavigationEngineResendsWhenBLEBecomesReady()
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineStartsRouteGeometryAtExactCurrentLocation()
+        testNavigationEngineDerivesSimulationCourse()
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
         testNavigationEngineRefreshesElapsedWithoutLocationChange()
@@ -13632,6 +13633,35 @@ struct NavigationProtocolTests {
             longitude: current.coordinate.longitude,
             "route geometry starts at the exact current GPS coordinate"
         )
+    }
+
+    static func testNavigationEngineDerivesSimulationCourse() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        let route = TestRoute(
+            instructions: "Continue east",
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 37.0000, longitude: -122.0000),
+                CLLocationCoordinate2D(latitude: 37.0000, longitude: -121.9980)
+            ]
+        )
+        engine.startNavigation(with: route, isTestMode: true)
+        manager.sentGPSPositions.removeAll()
+
+        engine.updateSimulationForTesting(timeInterval: 1)
+
+        guard let packet = manager.sentGPSPositions.first else {
+            assert(false, "simulation should send a GPS position")
+            return
+        }
+        let heading = readUInt16LE(packet, offset: 8)
+        assert(heading >= 80 && heading <= 100,
+               "simulation should send the route bearing instead of north")
+        engine.stopNavigation()
     }
 
     static func testNavigationEngineClearsRouteGeometryOnStop() {


### PR DESCRIPTION
## Summary
- Consolidate the navigation motion, lower-center rotation, route-line anchoring, overscan, courtyard snapshot, and bounded 3D-building work into one reviewable branch.
- Preserve the nearest discovered 3D-building candidates when a guidance prepass reaches its responsiveness budget.
- Keep the hard fallback for genuine PSRAM allocation failures or bounded draw/selection timeouts, but do not enter the five-minute failure cooldown for a transient deadline.

## Why the device became 2D-only
The regression is in the guidance renderer introduced by the bounded-stall change: the 900 ms building scan deadline set `buildingDeadlineAborted`, then retried the complete frame with `suppressBuildings=true`. The 658x658 guidance overscan increased the scan workload and made this path much easier to hit; the retry cooldown then kept buildings suppressed for subsequent frames. The courtyard viewport bound is not the cause.

## Fix
A prepass timeout now renders the bounded nearest queue collected so far with the normal drawing budget. Allocation failures and genuine draw/selection timeouts still use the existing safe 2D fallback. The retry cooldown is now reserved for allocation failures.

## Checks
- Python integration/profile/generated-config tests: 52 passed.
- C++ host tests: map-building renderer, map motion, and projection all passed.
- Real `WAVESHARE_AMOLED_175` firmware build/link passed (build only; no device flash in this turn).
- 658x658 persistent framebuffer remains approximately 2.89 MiB PSRAM; this is within the device's 8 MiB PSRAM budget.

## Validation note
The connected 1.75-inch device still needs a navigation test with a map pack whose FMB files are v4+ and contain building records. No flash was performed as part of this PR creation.