### PR TITLE
Update README purchase and app instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ A sleek, Garmin-mounted bike computer.
 
 ## Get started
 
-1. **Get your bike computer.** Choose the round [Waveshare 1.75-inch](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262), the larger rectangular [Waveshare 2.06-inch](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm), or a compact round build using the [Seeed Studio XIAO nRF52840](https://www.seeedstudio.com/Seeed-XIAO-BLE-nRF52840-p-5201.html) + [1.28-inch Round Touch Display](https://www.seeedstudio.com/1-28-Round-Touch-Display-for-Seeed-Studio-XIAO-ESP32.html).
-2. **Download [Bike Computer 2.0 on the App Store](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349)** on your iPhone and pair your bike computer. The Apple Watch companion is included.
-3. **Ride.** Start tracking your workout on your Apple Watch or iPhone and check your live ride statistics on your bike computer.
+1. **Buy your bike computer including Garmin mount at [bicino.com](https://bicino.com)** or get a generic [Waveshare 1.75](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262), or a [Waveshare 2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm).
+2. **Download** [**the Bicino iPhone and Apple Watch app on the App Store**](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349) and pair your bike computer.
+3. **Ride.** Track your workout and check your live ride statistics on your bike computer.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A sleek, Garmin-mounted bike computer.
 
 ## Get started
 
-1. **Buy your bike computer including Garmin mount at [bicino.com](https://bicino.com)** or get a generic [Waveshare 1.75](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262), or a [Waveshare 2.06](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm).
-2. **Download** [**the Bicino iPhone and Apple Watch app on the App Store**](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349) and pair your bike computer.
+1. **Buy your bike computer including Garmin mount at [bicino.com](https://bicino.com)** or get a generic [Waveshare 1.75"](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262), or a [Waveshare 2.06"](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm).
+2. **Download** [**the Bicino iPhone and Apple Watch app**](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349) and pair your bike computer.
 3. **Ride.** Track your workout and check your live ride statistics on your bike computer.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A sleek, Garmin-mounted bike computer.
 Explore proposed and in-progress features on our
 [open roadmap](https://github.com/seichris/open-bike-computer/issues?q=is%3Aissue%20state%3Aopen%20label%3Afeature).
 
-Ideas and feature requests are welcome—[open an issue](https://github.com/seichris/open-bike-computer/issues/new).
+Ideas and feature requests are welcome![ Open an issue](https://github.com/seichris/open-bike-computer/issues/new).
 
 For code contributions, see
 [CONTRIBUTING.md](https://github.com/seichris/open-bike-computer/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Summary

- Point the primary purchase path to Bicino and mention the included Garmin mount.
- Keep generic Waveshare 1.75-inch and 2.06-inch alternatives.
- Update the App Store and ride instructions to reference the Bicino iPhone and Apple Watch app.

## Validation

- `git diff --check`
