### PR TITLE
Set PWR-button hard-off threshold to four seconds

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -595,7 +595,8 @@ bit `2`. ACK-capable firmware uses a tracked frame:
 
 Firmware persists the complete configuration and queues the configured sound
 after an AXP2101 short-press event, so the button works without an active app
-connection. The AXP2101's six-second hardware power-off behavior is unchanged.
+connection. Firmware configures the AXP2101's hard power-off threshold to four
+seconds; this remains independent of the short-press honk behavior.
 
 Independently of hard power-off, connected firmware dims after 15 seconds and
 turns the panel off after 45 seconds without meaningful activity when no

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -227,6 +227,14 @@ bool initializePowerState() {
         static_cast<unsigned>(requestedPowerButtonOffLevel),
         static_cast<unsigned>(observedPowerButtonOffLevel), powerButtonConfig);
   }
+#if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
+  const char *bootPmicMode = powerButtonOffConfigured
+                                 ? "display-enable-only"
+                                 : "power-button-config-failed";
+#else
+  const char *bootPmicMode =
+      powerButtonOffConfigured ? "read-only" : "power-button-config-failed";
+#endif
 
   PowerStatus status;
   uint8_t ldoEnable = 0;
@@ -255,13 +263,14 @@ bool initializePowerState() {
                   status.batteryPresent ? "present" : "absent",
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoEnable, ldoReadOk ? 1 : 0);
-    Serial.printf("BOOT_PMIC schema=1 mode=display-enable-only available=1 "
+    Serial.printf("BOOT_PMIC schema=1 mode=%s available=1 "
                   "railState=%s statusRead=1 status1=0x%02X status2=0x%02X "
                   "vbus=%d battery=%d currentDirection=%u charging=%u "
                   "ldoRead=%d ldo=0x%02X displayRecovery=%d "
                   "displayChanged=%d powerButtonOffConfigured=%d "
                   "powerButtonOffSeconds=%u powerButtonOffLevel=%u "
                   "powerButtonConfigRead=%d powerButtonConfig=0x%02X\n",
+                  bootPmicMode,
                   displayRecoveryOk ? "display-enabled" : "unknown",
                   status.status1, status.status2, status.vbusGood ? 1 : 0,
                   status.batteryPresent ? 1 : 0,
@@ -281,13 +290,14 @@ bool initializePowerState() {
                   status.batteryPresent ? "present" : "absent",
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoEnable, ldoReadOk ? 1 : 0);
-    Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+    Serial.printf("BOOT_PMIC schema=1 mode=%s available=1 "
                   "railState=current-preserved "
                   "statusRead=1 status1=0x%02X status2=0x%02X vbus=%d "
                   "battery=%d currentDirection=%u charging=%u ldoRead=%d "
                   "ldo=0x%02X powerButtonOffConfigured=%d "
                   "powerButtonOffSeconds=%u powerButtonOffLevel=%u "
                   "powerButtonConfigRead=%d powerButtonConfig=0x%02X\n",
+                  bootPmicMode,
                   status.status1, status.status2, status.vbusGood ? 1 : 0,
                   status.batteryPresent ? 1 : 0,
                   status.batteryCurrentDirection, status.chargingStatus,
@@ -302,12 +312,13 @@ bool initializePowerState() {
     Serial.printf("AXP2101: preserving every non-display PMIC rail bit; "
                   "status read failed ldo=0x%02X ldoRead=%d\n",
                   ldoEnable, ldoReadOk ? 1 : 0);
-    Serial.printf("BOOT_PMIC schema=1 mode=display-enable-only available=1 "
+    Serial.printf("BOOT_PMIC schema=1 mode=%s available=1 "
                   "railState=%s statusRead=0 ldoRead=%d ldo=0x%02X "
                   "displayRecovery=%d displayChanged=%d "
                   "powerButtonOffConfigured=%d powerButtonOffSeconds=%u "
                   "powerButtonOffLevel=%u powerButtonConfigRead=%d "
                   "powerButtonConfig=0x%02X\n",
+                  bootPmicMode,
                   displayRecoveryOk ? "display-enabled" : "unknown",
                   ldoReadOk ? 1 : 0, ldoEnable,
                   displayRecoveryOk ? 1 : 0,
@@ -320,12 +331,13 @@ bool initializePowerState() {
     Serial.printf("AXP2101: preserving current PMIC rail state; status read failed "
                   "ldo=0x%02X ldoRead=%d\n",
                   ldoEnable, ldoReadOk ? 1 : 0);
-    Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
+    Serial.printf("BOOT_PMIC schema=1 mode=%s available=1 "
                   "railState=current-preserved "
                   "statusRead=0 ldoRead=%d ldo=0x%02X "
                   "powerButtonOffConfigured=%d powerButtonOffSeconds=%u "
                   "powerButtonOffLevel=%u powerButtonConfigRead=%d "
                   "powerButtonConfig=0x%02X\n",
+                  bootPmicMode,
                   ldoReadOk ? 1 : 0, ldoEnable,
                   powerButtonOffConfigured ? 1 : 0,
                   AXP2101_POWER_BUTTON_OFF_SECONDS,

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -35,6 +35,7 @@ constexpr uint8_t AXP2101_POWER_BUTTON_EVENT_MASK =
     AXP2101_POWER_BUTTON_SHORT_PRESS_MASK |
     AXP2101_POWER_BUTTON_NEGATIVE_EDGE_MASK |
     AXP2101_POWER_BUTTON_POSITIVE_EDGE_MASK;
+constexpr unsigned AXP2101_POWER_BUTTON_OFF_SECONDS = 4;
 
 bool writeRegister(uint8_t reg, uint8_t value) {
   if (!register_policy::isWriteAllowed(reg)) {
@@ -187,18 +188,44 @@ bool initializePowerState() {
     Serial.println("AXP2101 not found");
 #if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
     Serial.println("BOOT_PMIC schema=1 mode=display-enable-only available=0 "
-                   "railState=unknown displayRecovery=0");
+                   "railState=unknown displayRecovery=0 "
+                   "powerButtonOffConfigured=0 powerButtonConfigRead=0");
 #else
     Serial.println("BOOT_PMIC schema=1 mode=read-only available=0 "
-                   "railState=unknown");
+                   "railState=unknown powerButtonOffConfigured=0 "
+                   "powerButtonConfigRead=0");
 #endif
     return false;
   }
 
   // The AXP2101 default is six seconds. Configure the shorter four-second
-  // hard-off gesture without changing any other PMU power-button fields.
-  if (!setPowerButtonOffLevel(PowerButtonOffLevel::FourSeconds)) {
-    Serial.println("AXP2101: failed to set four-second power button off level");
+  // hard-off gesture without changing any other PMU power-button fields, then
+  // independently re-read REG27 so boot validation cannot pass on a partial or
+  // unverifiable update.
+  constexpr PowerButtonOffLevel requestedPowerButtonOffLevel =
+      PowerButtonOffLevel::FourSeconds;
+  const bool powerButtonOffWriteOk =
+      setPowerButtonOffLevel(requestedPowerButtonOffLevel);
+  uint8_t powerButtonConfig = 0;
+  const bool powerButtonConfigReadOk = readRegister(
+      register_policy::POWER_BUTTON_CONFIG_REGISTER, powerButtonConfig);
+  const uint8_t observedPowerButtonOffLevel =
+      powerButtonConfigReadOk
+          ? register_policy::powerButtonOffLevel(powerButtonConfig)
+          : UINT8_MAX;
+  const bool powerButtonOffConfigured =
+      powerButtonOffWriteOk && powerButtonConfigReadOk &&
+      register_policy::hasPowerButtonOffLevel(
+          powerButtonConfig,
+          static_cast<uint8_t>(requestedPowerButtonOffLevel));
+  if (!powerButtonOffConfigured) {
+    Serial.printf(
+        "BOOT_DIAGNOSTICS_ERROR schema=1 "
+        "operation=power_button_off_level write=%d read=%d "
+        "expectedLevel=%u actualLevel=%u config=0x%02X\n",
+        powerButtonOffWriteOk ? 1 : 0, powerButtonConfigReadOk ? 1 : 0,
+        static_cast<unsigned>(requestedPowerButtonOffLevel),
+        static_cast<unsigned>(observedPowerButtonOffLevel), powerButtonConfig);
   }
 
   PowerStatus status;
@@ -232,13 +259,19 @@ bool initializePowerState() {
                   "railState=%s statusRead=1 status1=0x%02X status2=0x%02X "
                   "vbus=%d battery=%d currentDirection=%u charging=%u "
                   "ldoRead=%d ldo=0x%02X displayRecovery=%d "
-                  "displayChanged=%d\n",
+                  "displayChanged=%d powerButtonOffConfigured=%d "
+                  "powerButtonOffSeconds=%u powerButtonOffLevel=%u "
+                  "powerButtonConfigRead=%d powerButtonConfig=0x%02X\n",
                   displayRecoveryOk ? "display-enabled" : "unknown",
                   status.status1, status.status2, status.vbusGood ? 1 : 0,
                   status.batteryPresent ? 1 : 0,
                   status.batteryCurrentDirection, status.chargingStatus,
                   ldoReadOk ? 1 : 0, ldoEnable, displayRecoveryOk ? 1 : 0,
-                  displayEnable.changed ? 1 : 0);
+                  displayEnable.changed ? 1 : 0,
+                  powerButtonOffConfigured ? 1 : 0,
+                  AXP2101_POWER_BUTTON_OFF_SECONDS,
+                  static_cast<unsigned>(observedPowerButtonOffLevel),
+                  powerButtonConfigReadOk ? 1 : 0, powerButtonConfig);
 #else
     Serial.printf("AXP2101: preserving current PMIC rail state; status1=0x%02X "
                   "status2=0x%02X vbus=%s battery=%s currentDir=%u "
@@ -252,11 +285,17 @@ bool initializePowerState() {
                   "railState=current-preserved "
                   "statusRead=1 status1=0x%02X status2=0x%02X vbus=%d "
                   "battery=%d currentDirection=%u charging=%u ldoRead=%d "
-                  "ldo=0x%02X\n",
+                  "ldo=0x%02X powerButtonOffConfigured=%d "
+                  "powerButtonOffSeconds=%u powerButtonOffLevel=%u "
+                  "powerButtonConfigRead=%d powerButtonConfig=0x%02X\n",
                   status.status1, status.status2, status.vbusGood ? 1 : 0,
                   status.batteryPresent ? 1 : 0,
                   status.batteryCurrentDirection, status.chargingStatus,
-                  ldoReadOk ? 1 : 0, ldoEnable);
+                  ldoReadOk ? 1 : 0, ldoEnable,
+                  powerButtonOffConfigured ? 1 : 0,
+                  AXP2101_POWER_BUTTON_OFF_SECONDS,
+                  static_cast<unsigned>(observedPowerButtonOffLevel),
+                  powerButtonConfigReadOk ? 1 : 0, powerButtonConfig);
 #endif
   } else {
 #if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
@@ -265,25 +304,39 @@ bool initializePowerState() {
                   ldoEnable, ldoReadOk ? 1 : 0);
     Serial.printf("BOOT_PMIC schema=1 mode=display-enable-only available=1 "
                   "railState=%s statusRead=0 ldoRead=%d ldo=0x%02X "
-                  "displayRecovery=%d displayChanged=%d\n",
+                  "displayRecovery=%d displayChanged=%d "
+                  "powerButtonOffConfigured=%d powerButtonOffSeconds=%u "
+                  "powerButtonOffLevel=%u powerButtonConfigRead=%d "
+                  "powerButtonConfig=0x%02X\n",
                   displayRecoveryOk ? "display-enabled" : "unknown",
                   ldoReadOk ? 1 : 0, ldoEnable,
                   displayRecoveryOk ? 1 : 0,
-                  displayEnable.changed ? 1 : 0);
+                  displayEnable.changed ? 1 : 0,
+                  powerButtonOffConfigured ? 1 : 0,
+                  AXP2101_POWER_BUTTON_OFF_SECONDS,
+                  static_cast<unsigned>(observedPowerButtonOffLevel),
+                  powerButtonConfigReadOk ? 1 : 0, powerButtonConfig);
 #else
     Serial.printf("AXP2101: preserving current PMIC rail state; status read failed "
                   "ldo=0x%02X ldoRead=%d\n",
                   ldoEnable, ldoReadOk ? 1 : 0);
     Serial.printf("BOOT_PMIC schema=1 mode=read-only available=1 "
                   "railState=current-preserved "
-                  "statusRead=0 ldoRead=%d ldo=0x%02X\n",
-                  ldoReadOk ? 1 : 0, ldoEnable);
+                  "statusRead=0 ldoRead=%d ldo=0x%02X "
+                  "powerButtonOffConfigured=%d powerButtonOffSeconds=%u "
+                  "powerButtonOffLevel=%u powerButtonConfigRead=%d "
+                  "powerButtonConfig=0x%02X\n",
+                  ldoReadOk ? 1 : 0, ldoEnable,
+                  powerButtonOffConfigured ? 1 : 0,
+                  AXP2101_POWER_BUTTON_OFF_SECONDS,
+                  static_cast<unsigned>(observedPowerButtonOffLevel),
+                  powerButtonConfigReadOk ? 1 : 0, powerButtonConfig);
 #endif
   }
 #if defined(WAVESHARE_AMOLED_206) && defined(WAVESHARE_206_FORCE_AXP_DISPLAY)
-  return displayRecoveryOk;
+  return displayRecoveryOk && powerButtonOffConfigured;
 #else
-  return true;
+  return powerButtonOffConfigured;
 #endif
 }
 

--- a/esp32/lib/waveshare_board/axp2101.cpp
+++ b/esp32/lib/waveshare_board/axp2101.cpp
@@ -107,6 +107,23 @@ bool readBatteryPercentage(uint8_t &percentage) {
   return readBatteryStatus(percentage, charging);
 }
 
+bool setPowerButtonOffLevel(PowerButtonOffLevel level) {
+  if (!pmuAvailable) {
+    return false;
+  }
+
+  i2c::Axp2101PowerButtonOffLevelResult result;
+  const bool ok = i2c::ensureAxp2101PowerButtonOffLevel(
+      static_cast<uint8_t>(level), result);
+  if (ok) {
+    Serial.printf("AXP2101: PWR button off level=%u before=0x%02X "
+                  "after=0x%02X changed=%d\n",
+                  static_cast<unsigned>(level), result.before, result.after,
+                  result.changed ? 1 : 0);
+  }
+  return ok;
+}
+
 bool setPowerButtonEventMonitoring(bool enabled) {
   if (!pmuAvailable) {
     return false;
@@ -176,6 +193,12 @@ bool initializePowerState() {
                    "railState=unknown");
 #endif
     return false;
+  }
+
+  // The AXP2101 default is six seconds. Configure the shorter four-second
+  // hard-off gesture without changing any other PMU power-button fields.
+  if (!setPowerButtonOffLevel(PowerButtonOffLevel::FourSeconds)) {
+    Serial.println("AXP2101: failed to set four-second power button off level");
   }
 
   PowerStatus status;

--- a/esp32/lib/waveshare_board/axp2101.hpp
+++ b/esp32/lib/waveshare_board/axp2101.hpp
@@ -28,12 +28,20 @@ struct PowerButtonEvents {
   bool positiveEdge = false;
 };
 
+enum class PowerButtonOffLevel : uint8_t {
+  FourSeconds = 0,
+  SixSeconds = 1,
+  EightSeconds = 2,
+  TenSeconds = 3,
+};
+
 bool begin();
 bool isAvailable();
 bool readRegister(uint8_t reg, uint8_t &value);
 bool readPowerStatus(PowerStatus &status);
 bool readBatteryStatus(uint8_t &percentage, bool &charging);
 bool readBatteryPercentage(uint8_t &percentage);
+bool setPowerButtonOffLevel(PowerButtonOffLevel level);
 bool setPowerButtonEventMonitoring(bool enabled);
 bool readAndClearPowerButtonEvents(PowerButtonEvents &events);
 // Probe and report the PMIC state. The 1.75-inch target leaves every output

--- a/esp32/lib/waveshare_board/axp2101_register_policy.hpp
+++ b/esp32/lib/waveshare_board/axp2101_register_policy.hpp
@@ -14,6 +14,10 @@ namespace waveshare_board::axp2101::register_policy {
 constexpr uint8_t DEVICE_ADDRESS = 0x34;
 constexpr uint8_t INTERRUPT_ENABLE_1 = 0x41;
 constexpr uint8_t INTERRUPT_STATUS_1 = 0x49;
+constexpr uint8_t POWER_BUTTON_CONFIG_REGISTER = 0x27;
+constexpr uint8_t POWER_BUTTON_OFF_LEVEL_MASK = 0x0C;
+constexpr uint8_t POWER_BUTTON_OFF_LEVEL_SHIFT = 2;
+constexpr uint8_t POWER_BUTTON_OFF_LEVEL_COUNT = 4;
 // The 2.06-inch target historically disabled this display bit before sleep and
 // relies on boot-time recovery after OTA rollback. The generic write helpers
 // still reject this register; only the dedicated one-way read/modify/write
@@ -46,6 +50,11 @@ constexpr bool isDisplayEnableOnlyTransition206(uint8_t current,
                                                 uint8_t updated) {
   return updated == withDisplayEnabled206(current) &&
          ((current ^ updated) & ~DISPLAY_ENABLE_MASK_206) == 0;
+}
+
+constexpr bool isPowerButtonOffLevelTransition(uint8_t current,
+                                                uint8_t updated) {
+  return ((current ^ updated) & ~POWER_BUTTON_OFF_LEVEL_MASK) == 0;
 }
 
 // Enforce the device policy at the shared I2C boundary, not only inside the

--- a/esp32/lib/waveshare_board/axp2101_register_policy.hpp
+++ b/esp32/lib/waveshare_board/axp2101_register_policy.hpp
@@ -52,6 +52,16 @@ constexpr bool isDisplayEnableOnlyTransition206(uint8_t current,
          ((current ^ updated) & ~DISPLAY_ENABLE_MASK_206) == 0;
 }
 
+constexpr uint8_t powerButtonOffLevel(uint8_t registerValue) {
+  return (registerValue & POWER_BUTTON_OFF_LEVEL_MASK) >>
+         POWER_BUTTON_OFF_LEVEL_SHIFT;
+}
+
+constexpr bool hasPowerButtonOffLevel(uint8_t registerValue, uint8_t level) {
+  return level < POWER_BUTTON_OFF_LEVEL_COUNT &&
+         powerButtonOffLevel(registerValue) == level;
+}
+
 constexpr bool isPowerButtonOffLevelTransition(uint8_t current,
                                                 uint8_t updated) {
   return ((current ^ updated) & ~POWER_BUTTON_OFF_LEVEL_MASK) == 0;

--- a/esp32/lib/waveshare_board/i2c_bus.cpp
+++ b/esp32/lib/waveshare_board/i2c_bus.cpp
@@ -325,8 +325,13 @@ bool ensureAxp2101PowerButtonOffLevel(
 
         if (current == updated) {
           result.after = current;
-          result.changed = result.before != current;
-          return true;
+          const bool valid =
+              axp_policy::isPowerButtonOffLevelTransition(result.before,
+                                                           current);
+          if (valid) {
+            result.changed = result.before != current;
+          }
+          return valid;
         }
 
         Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);

--- a/esp32/lib/waveshare_board/i2c_bus.cpp
+++ b/esp32/lib/waveshare_board/i2c_bus.cpp
@@ -280,6 +280,84 @@ bool writeRegister16(uint8_t address, uint16_t reg, uint8_t value,
                      });
 }
 
+bool ensureAxp2101PowerButtonOffLevel(
+    uint8_t level, Axp2101PowerButtonOffLevelResult &result,
+    uint8_t attempts) {
+  result = {};
+  if (level >= axp_policy::POWER_BUTTON_OFF_LEVEL_COUNT) {
+    Serial.printf("AXP_WRITE_BLOCKED schema=1 reg=0x%02X level=%u "
+                  "policy=power-button-off-level\n",
+                  axp_policy::POWER_BUTTON_CONFIG_REGISTER,
+                  static_cast<unsigned>(level));
+    return false;
+  }
+
+  bool observedInitialValue = false;
+  return withRetries(
+      axp_policy::DEVICE_ADDRESS, "AXP2101", "power-button-off-level",
+      attempts, [&result, &observedInitialValue, level]() {
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::POWER_BUTTON_CONFIG_REGISTER);
+        if (Wire.endTransmission() != 0 ||
+            Wire.requestFrom(axp_policy::DEVICE_ADDRESS,
+                             static_cast<uint8_t>(1)) != 1) {
+          return false;
+        }
+
+        const uint8_t current = Wire.read();
+        if (!observedInitialValue) {
+          result.before = current;
+          observedInitialValue = true;
+        }
+
+        const uint8_t updated =
+            (current & ~axp_policy::POWER_BUTTON_OFF_LEVEL_MASK) |
+            ((level << axp_policy::POWER_BUTTON_OFF_LEVEL_SHIFT) &
+             axp_policy::POWER_BUTTON_OFF_LEVEL_MASK);
+        if (!axp_policy::isPowerButtonOffLevelTransition(current, updated) ||
+            !axp_policy::isPowerButtonOffLevelTransition(result.before,
+                                                          updated)) {
+          Serial.printf("AXP_WRITE_BLOCKED schema=1 reg=0x%02X value=0x%02X "
+                        "policy=power-button-off-level\n",
+                        axp_policy::POWER_BUTTON_CONFIG_REGISTER, updated);
+          return false;
+        }
+
+        if (current == updated) {
+          result.after = current;
+          result.changed = result.before != current;
+          return true;
+        }
+
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::POWER_BUTTON_CONFIG_REGISTER);
+        Wire.write(updated);
+        if (Wire.endTransmission() != 0) {
+          return false;
+        }
+
+        delay(5);
+        Wire.beginTransmission(axp_policy::DEVICE_ADDRESS);
+        Wire.write(axp_policy::POWER_BUTTON_CONFIG_REGISTER);
+        if (Wire.endTransmission() != 0 ||
+            Wire.requestFrom(axp_policy::DEVICE_ADDRESS,
+                             static_cast<uint8_t>(1)) != 1) {
+          return false;
+        }
+
+        const uint8_t readback = Wire.read();
+        result.after = readback;
+        const bool valid =
+            readback == updated &&
+            axp_policy::isPowerButtonOffLevelTransition(result.before,
+                                                         readback);
+        if (valid) {
+          result.changed = result.before != readback;
+        }
+        return valid;
+      });
+}
+
 #ifdef WAVESHARE_AMOLED_206
 bool ensureAxp2101DisplayEnabled(Axp2101DisplayEnableResult &result,
                                 uint8_t attempts) {

--- a/esp32/lib/waveshare_board/i2c_bus.hpp
+++ b/esp32/lib/waveshare_board/i2c_bus.hpp
@@ -35,6 +35,20 @@ bool writeRegisterBlock8(uint8_t address, uint8_t reg, const uint8_t *data,
                          uint8_t attempts = 2);
 bool writeRegister16(uint8_t address, uint16_t reg, uint8_t value,
                      const char *label = nullptr, uint8_t attempts = 2);
+
+struct Axp2101PowerButtonOffLevelResult {
+  uint8_t before = 0;
+  uint8_t after = 0;
+  bool changed = false;
+};
+
+// Boot-time, read/modify/write operation for the AXP2101 power-button off
+// level. The operation may change only REG27 bits 3:2; generic AXP2101 write
+// helpers remain blocked for this register.
+bool ensureAxp2101PowerButtonOffLevel(
+    uint8_t level, Axp2101PowerButtonOffLevelResult &result,
+    uint8_t attempts = 3);
+
 #ifdef WAVESHARE_AMOLED_206
 struct Axp2101DisplayEnableResult {
   uint8_t before = 0;

--- a/esp32/tools/capture_boot.py
+++ b/esp32/tools/capture_boot.py
@@ -22,6 +22,10 @@ _POST_READY_BOOT_RECORD_MARKERS = (
     "BOOT_SAFE_MODE",
 )
 _SUPPORTED_BOOT_SCHEMA = "1"
+_EXPECTED_POWER_BUTTON_OFF_SECONDS = "4"
+_EXPECTED_POWER_BUTTON_OFF_LEVEL = 0
+_POWER_BUTTON_OFF_LEVEL_MASK = 0x0C
+_POWER_BUTTON_OFF_LEVEL_SHIFT = 2
 
 _EMPTY_RETAINED_HISTORY = {
     "schema": "1",
@@ -216,6 +220,12 @@ def format_summary(
         f"pmicRailState={value(summary.pmic, 'railState')} "
         f"pmicDisplayRecovery={value(summary.pmic, 'displayRecovery')} "
         f"pmicDisplayChanged={value(summary.pmic, 'displayChanged')} "
+        "pmicPowerButtonOffConfigured="
+        f"{value(summary.pmic, 'powerButtonOffConfigured')} "
+        f"pmicPowerButtonOffSeconds={value(summary.pmic, 'powerButtonOffSeconds')} "
+        f"pmicPowerButtonOffLevel={value(summary.pmic, 'powerButtonOffLevel')} "
+        f"pmicPowerButtonConfigRead={value(summary.pmic, 'powerButtonConfigRead')} "
+        f"pmicPowerButtonConfig={value(summary.pmic, 'powerButtonConfig')} "
         f"vbus={value(summary.pmic, 'vbus')} "
         f"battery={value(summary.pmic, 'battery')} "
         f"ldo={value(summary.pmic, 'ldo')} "
@@ -226,6 +236,59 @@ def format_summary(
         f"blockedWrites={summary.blocked_writes} "
         f"diagnosticErrors={summary.diagnostic_errors}"
     )
+
+
+def _validate_power_button_off_configuration(
+    summary: BootSummary, errors: list[str]
+) -> None:
+    if summary.pmic.get("powerButtonOffConfigured") != "1":
+        errors.append(
+            "PMIC four-second power-button-off configuration required "
+            f"(got {summary.pmic.get('powerButtonOffConfigured', 'missing')})"
+        )
+    if summary.pmic.get("powerButtonConfigRead") != "1":
+        errors.append(
+            "PMIC power-button config read required "
+            f"(got {summary.pmic.get('powerButtonConfigRead', 'missing')})"
+        )
+    if summary.pmic.get("powerButtonOffSeconds") != _EXPECTED_POWER_BUTTON_OFF_SECONDS:
+        errors.append(
+            "PMIC power-button-off seconds expected "
+            f"{_EXPECTED_POWER_BUTTON_OFF_SECONDS}, got "
+            f"{summary.pmic.get('powerButtonOffSeconds', 'missing')}"
+        )
+
+    expected_level = str(_EXPECTED_POWER_BUTTON_OFF_LEVEL)
+    if summary.pmic.get("powerButtonOffLevel") != expected_level:
+        errors.append(
+            "PMIC power-button-off level expected "
+            f"{expected_level}, got "
+            f"{summary.pmic.get('powerButtonOffLevel', 'missing')}"
+        )
+
+    raw_config = summary.pmic.get("powerButtonConfig")
+    try:
+        config = int(raw_config or "", 0)
+    except ValueError:
+        errors.append(
+            "PMIC power-button config byte required "
+            f"(got {raw_config or 'missing'})"
+        )
+    else:
+        if not 0 <= config <= 0xFF:
+            errors.append(
+                "PMIC power-button config byte out of range "
+                f"(got {raw_config})"
+            )
+        else:
+            observed_level = (
+                config & _POWER_BUTTON_OFF_LEVEL_MASK
+            ) >> _POWER_BUTTON_OFF_LEVEL_SHIFT
+            if observed_level != _EXPECTED_POWER_BUTTON_OFF_LEVEL:
+                errors.append(
+                    "PMIC power-button config off-level bits expected "
+                    f"{_EXPECTED_POWER_BUTTON_OFF_LEVEL}, got {observed_level}"
+                )
 
 
 def validation_errors(
@@ -376,6 +439,8 @@ def validation_errors(
                     "PMIC 2.06 display-enable bit required "
                     f"(got {summary.pmic.get('ldo', 'missing')})"
                 )
+    if require_pmic_read_only or require_pmic_display_enable_only:
+        _validate_power_button_off_configuration(summary, errors)
     if summary.blocked_writes:
         errors.append(f"blocked AXP2101 writes observed: {summary.blocked_writes}")
     if summary.diagnostic_errors:

--- a/esp32/tools/tests/test_axp2101_register_policy.cpp
+++ b/esp32/tools/tests/test_axp2101_register_policy.cpp
@@ -17,6 +17,7 @@ int main() {
 
   static_assert(isWriteAllowed(INTERRUPT_ENABLE_1));
   static_assert(isWriteAllowed(INTERRUPT_STATUS_1));
+  static_assert(!isWriteAllowed(POWER_BUTTON_CONFIG_REGISTER));
 
   std::size_t allowedCount = 0;
   for (unsigned int address = 0; address <= 0xFF; ++address) {
@@ -32,6 +33,28 @@ int main() {
   // The exhaustive loop makes any future permission an intentional test
   // change instead of an accidental hole around the known rail registers.
   assert(allowedCount == 2);
+
+  // REG27 remains blocked through generic writes. The dedicated boot-time
+  // helper may change only the OFFLEVEL bits (3:2), preserving every other
+  // power-button field.
+  assert(!isTransactionWriteAllowed(DEVICE_ADDRESS,
+                                    POWER_BUTTON_CONFIG_REGISTER, 1, 1));
+  for (unsigned int currentValue = 0; currentValue <= 0xFF; ++currentValue) {
+    for (unsigned int level = 0; level < POWER_BUTTON_OFF_LEVEL_COUNT;
+         ++level) {
+      const uint8_t current = static_cast<uint8_t>(currentValue);
+      const uint8_t updated =
+          (current & ~POWER_BUTTON_OFF_LEVEL_MASK) |
+          ((static_cast<uint8_t>(level) << POWER_BUTTON_OFF_LEVEL_SHIFT) &
+           POWER_BUTTON_OFF_LEVEL_MASK);
+      assert(isPowerButtonOffLevelTransition(current, updated));
+      assert((updated & ~POWER_BUTTON_OFF_LEVEL_MASK) ==
+             (current & ~POWER_BUTTON_OFF_LEVEL_MASK));
+      assert((updated & POWER_BUTTON_OFF_LEVEL_MASK) ==
+             ((level << POWER_BUTTON_OFF_LEVEL_SHIFT) &
+              POWER_BUTTON_OFF_LEVEL_MASK));
+    }
+  }
 
   // The shared-bus block and 16-bit helpers must not provide alternate paths
   // into the AXP2101, even when the starting register itself is allowlisted.

--- a/esp32/tools/tests/test_axp2101_register_policy.cpp
+++ b/esp32/tools/tests/test_axp2101_register_policy.cpp
@@ -53,6 +53,14 @@ int main() {
       assert((updated & POWER_BUTTON_OFF_LEVEL_MASK) ==
              ((level << POWER_BUTTON_OFF_LEVEL_SHIFT) &
               POWER_BUTTON_OFF_LEVEL_MASK));
+      assert(powerButtonOffLevel(updated) == level);
+      assert(hasPowerButtonOffLevel(updated, level));
+      assert(!hasPowerButtonOffLevel(updated, POWER_BUTTON_OFF_LEVEL_COUNT));
+
+      // The transition guard must reject collateral changes to any neighboring
+      // PWR-button setting, even when the requested OFFLEVEL bits are correct.
+      assert(!isPowerButtonOffLevelTransition(current,
+                                              updated ^ uint8_t{0x01}));
     }
   }
 

--- a/esp32/tools/tests/test_capture_boot.py
+++ b/esp32/tools/tests/test_capture_boot.py
@@ -17,29 +17,44 @@ from capture_boot import (
 from resolve_upload_port import ResolvedDevice
 
 
-HEALTHY_CAPTURE = """
+POWER_BUTTON_FIELDS = (
+    "powerButtonOffConfigured=1 powerButtonOffSeconds=4 "
+    "powerButtonOffLevel=0 powerButtonConfigRead=1 powerButtonConfig=0xF3"
+)
+READ_ONLY_PMIC_LINE = (
+    "BOOT_PMIC schema=1 mode=read-only available=1 "
+    "railState=current-preserved statusRead=1 status1=0x20 status2=0x15 "
+    "vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF "
+    + POWER_BUTTON_FIELDS
+)
+DISPLAY_RECOVERY_PMIC_LINE = (
+    "BOOT_PMIC schema=1 mode=display-enable-only available=1 "
+    "railState=display-enabled statusRead=1 status1=0x20 status2=0x15 "
+    "vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0x80 "
+    "displayRecovery=1 displayChanged=1 "
+    + POWER_BUTTON_FIELDS
+)
+
+HEALTHY_CAPTURE = f"""
 BOOT_META schema=1 sequence=2 target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=usb resetCode=11
 BOOT_PREVIOUS schema=1 history=retained valid=1 sameFirmware=1 sequence=1 fingerprint=12345678 ready=1 safeMode=0 diagnosticHold=0 reset=power_on resetCode=1 active=ready completed=ready failureCount=0 failureStage=none failureAfter=none failureReset=unknown failureResetCode=0
 BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none reset=unknown resetCode=0 safeMode=0
-BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF
+{READ_ONLY_PMIC_LINE}
 BOOT_STAGE schema=1 sequence=2 event=ready id=15 name=ready uptimeMs=1042
 """
 
-USB_COLD_CAPTURE = """
+USB_COLD_CAPTURE = f"""
 BOOT_META schema=1 sequence=1 target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175 version=0.2.2 build=7 git=0123456789012345678901234567890123456789 built=2026-07-31T01:02:03Z fingerprint=12345678 reset=usb resetCode=11
 BOOT_PREVIOUS schema=1 history=empty_or_invalid valid=0 sameFirmware=0 sequence=0 fingerprint=00000000 ready=0 safeMode=0 diagnosticHold=0 reset=unknown resetCode=0 active=none completed=none failureCount=0 failureStage=none failureAfter=none failureReset=unknown failureResetCode=0
 BOOT_FAILURE schema=1 recorded=0 count=0 threshold=3 stage=none after=none reset=unknown resetCode=0 safeMode=0
-BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF
+{READ_ONLY_PMIC_LINE}
 BOOT_STAGE schema=1 sequence=1 event=ready id=15 name=ready uptimeMs=1042
 """
 
 DISPLAY_RECOVERY_CAPTURE = HEALTHY_CAPTURE.replace(
     "target=WAVESHARE_AMOLED_175 profile=WAVESHARE_AMOLED_175",
     "target=WAVESHARE_AMOLED_206 profile=WAVESHARE_AMOLED_206",
-).replace(
-    "BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF",
-    "BOOT_PMIC schema=1 mode=display-enable-only available=1 railState=display-enabled statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0x80 displayRecovery=1 displayChanged=1",
-)
+).replace(READ_ONLY_PMIC_LINE, DISPLAY_RECOVERY_PMIC_LINE)
 
 
 class CaptureBootTests(unittest.TestCase):
@@ -239,6 +254,11 @@ class CaptureBootTests(unittest.TestCase):
         self.assertIn("ready=1", rendered)
         self.assertIn("pmicMode=read-only", rendered)
         self.assertIn("pmicRailState=current-preserved", rendered)
+        self.assertIn("pmicPowerButtonOffConfigured=1", rendered)
+        self.assertIn("pmicPowerButtonOffSeconds=4", rendered)
+        self.assertIn("pmicPowerButtonOffLevel=0", rendered)
+        self.assertIn("pmicPowerButtonConfigRead=1", rendered)
+        self.assertIn("pmicPowerButtonConfig=0xF3", rendered)
         self.assertIn("profile=WAVESHARE_AMOLED_175", rendered)
         self.assertIn("previousFingerprint=12345678", rendered)
         self.assertIn("stageSchemaMismatches=0", rendered)
@@ -458,7 +478,7 @@ BOOT_STAGE schema=1 sequence=3 event=enter id=1 name=startup uptimeMs=0
 
     def test_pmic_gate_requires_probe_and_both_reads(self) -> None:
         unavailable = HEALTHY_CAPTURE.replace(
-            "BOOT_PMIC schema=1 mode=read-only available=1 railState=current-preserved statusRead=1 status1=0x20 status2=0x15 vbus=1 battery=0 currentDirection=0 charging=5 ldoRead=1 ldo=0xFF",
+            READ_ONLY_PMIC_LINE,
             "BOOT_PMIC schema=1 mode=read-only available=0 railState=unknown",
         )
         errors = validation_errors(
@@ -488,6 +508,74 @@ BOOT_STAGE schema=1 sequence=3 event=enter id=1 name=startup uptimeMs=0
                 summarize(changed_rails), require_pmic_read_only=True
             ),
         )
+
+    def test_pmic_gate_requires_verified_four_second_power_button_config(self) -> None:
+        for capture, gate in (
+            (HEALTHY_CAPTURE, {"require_pmic_read_only": True}),
+            (
+                DISPLAY_RECOVERY_CAPTURE,
+                {"require_pmic_display_enable_only": True},
+            ),
+        ):
+            with self.subTest(mode=summarize(capture).pmic["mode"]):
+                self.assertEqual(validation_errors(summarize(capture), **gate), [])
+                legacy = capture.replace(" " + POWER_BUTTON_FIELDS, "", 1)
+                errors = validation_errors(summarize(legacy), **gate)
+                self.assertIn(
+                    "PMIC four-second power-button-off configuration required "
+                    "(got missing)",
+                    errors,
+                )
+                self.assertIn(
+                    "PMIC power-button config read required (got missing)", errors
+                )
+                self.assertIn(
+                    "PMIC power-button-off seconds expected 4, got missing", errors
+                )
+                self.assertIn(
+                    "PMIC power-button-off level expected 0, got missing", errors
+                )
+                self.assertIn(
+                    "PMIC power-button config byte required (got missing)", errors
+                )
+
+        for old, new, expected_error in (
+            (
+                "powerButtonOffConfigured=1",
+                "powerButtonOffConfigured=0",
+                "PMIC four-second power-button-off configuration required (got 0)",
+            ),
+            (
+                "powerButtonConfigRead=1",
+                "powerButtonConfigRead=0",
+                "PMIC power-button config read required (got 0)",
+            ),
+            (
+                "powerButtonOffSeconds=4",
+                "powerButtonOffSeconds=6",
+                "PMIC power-button-off seconds expected 4, got 6",
+            ),
+            (
+                "powerButtonOffLevel=0",
+                "powerButtonOffLevel=1",
+                "PMIC power-button-off level expected 0, got 1",
+            ),
+            (
+                "powerButtonConfig=0xF3",
+                "powerButtonConfig=0xF7",
+                "PMIC power-button config off-level bits expected 0, got 1",
+            ),
+            (
+                "powerButtonConfig=0xF3",
+                "powerButtonConfig=invalid",
+                "PMIC power-button config byte required (got invalid)",
+            ),
+        ):
+            errors = validation_errors(
+                summarize(HEALTHY_CAPTURE.replace(old, new, 1)),
+                require_pmic_read_only=True,
+            )
+            self.assertIn(expected_error, errors)
 
     def test_206_pmic_gate_requires_verified_display_enable_only_recovery(self) -> None:
         summary = summarize(DISPLAY_RECOVERY_CAPTURE)

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -274,8 +274,8 @@ interrupt-enable/status register pair `0x41`/`0x49`: bit `3` reports a short
 press, while bits `1` and `0` report the press and release edges. Firmware polls
 the latched status while awake and gives an active ownership comparison first
 refusal to confirm physical access. At all other times an enabled honk is queued
-on the existing
-speaker task. The PMU's six-second hard power-off is unchanged. Versioned
+on the existing speaker task. Firmware configures the PMU's hard power-off
+threshold to four seconds. Versioned
 capability discovery also returns the persisted honk configuration, so
 reconnecting from a fresh app does not overwrite device state with app
 defaults.
@@ -538,10 +538,12 @@ state when an older image may have programmed a still-powered PMIC.
 
 Safety rules:
 - Probe AXP2101 at `0x34` and read status for diagnostics only.
-- The firmware write allowlist contains exactly two addresses: interrupt-enable
-  register `0x41` and write-one-to-clear interrupt-status register `0x49`, both
-  used only for PWR-button events. Charger current/voltage, input limits,
-  BATFET, DCDC, LDO, and every other AXP2101 register are read-only.
+- The generic firmware write allowlist contains exactly two addresses:
+  interrupt-enable register `0x41` and write-one-to-clear interrupt-status
+  register `0x49`, both used only for PWR-button events. A dedicated boot-time
+  operation may read/modify/write only the PWR-button off-level bits (`3:2`) in
+  register `0x27`; charger current/voltage, input limits, BATFET, DCDC, LDO,
+  and every other AXP2101 register remain read-only.
 - Turn the AMOLED panel off with its controller command. Do not assume an
   AXP2101 enable bit belongs exclusively to the display or another peripheral.
 - A black screen is not sufficient evidence that an AXP rail should be forced;
@@ -554,8 +556,10 @@ Verified firmware behavior:
 - AXP2101 is found at `0x34`, and status plus the current LDO-enable value are
   logged without modifying them. The log labels that value as preserved current
   state, not verified factory state.
-- A register-policy guard rejects writes to all 254 non-allowlisted AXP2101
-  addresses, with an exhaustive host test covering the complete address space.
+- A register-policy guard rejects generic writes to all 254 non-allowlisted
+  AXP2101 addresses, with an exhaustive host test covering the complete
+  address space. The dedicated off-level operation verifies that it preserves
+  every bit outside register `0x27` bits `3:2`.
   A source-policy test also rejects raw `Wire.beginTransmission()` calls
   outside the guarded shared-I2C implementation.
 - Deep and light sleep preserve PMIC output state; the panel, buses, and radio
@@ -578,7 +582,8 @@ bit `0x80` if needed, and verifies the result while preserving every other bit.
 That one-way operation recovers a display supply that older 2.06 firmware could
 leave disabled; it cannot turn any output off or change a voltage. Generic
 AXP2101 writes remain limited to interrupt registers `0x41` and `0x49` on both
-targets.
+targets; the boot-time off-level operation is the only additional validated
+exception.
 
 ### Boot Failure Telemetry and Safe Mode
 


### PR DESCRIPTION
## Summary

- Configure the AXP2101 hard PWR-button shutdown threshold to four seconds during boot for both Waveshare firmware profiles.
- Add a dedicated, validated read/modify/write path for REG27 bits 3:2 while keeping generic AXP2101 writes fail-closed.
- Add exhaustive host coverage for bit preservation and update the BLE protocol and hardware safety documentation.

## Why

The AXP2101 defaults to a six-second hard-off gesture. The requested behavior is a four-second long-press, without changing the short-press honk behavior or any PMU rail settings.

## Validation

- `g++ -std=c++17 -Wall -Wextra -Iesp32/lib/waveshare_board esp32/tools/tests/test_axp2101_register_policy.cpp -o /tmp/test_axp2101_register_policy && /tmp/test_axp2101_register_policy`
- `python3 esp32/tools/tests/test_firmware_profile_config.py`
- `SSL_CERT_FILE=/etc/ssl/cert.pem python3 esp32/tools/build_firmware.py WAVESHARE_AMOLED_175`
- `SSL_CERT_FILE=/etc/ssl/cert.pem python3 esp32/tools/build_firmware.py WAVESHARE_AMOLED_206`

Both firmware builds passed their verified real-target artifact checks. No hardware was flashed or physically validated in this run.
