### PR TITLE
Implement tap-to-authorize HealthKit flow

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -7,10 +7,14 @@
 
 import SwiftUI
 import MapKit
+import UIKit
 
 struct ContentView: View {
     
     // MARK: - State
+
+    @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.openURL) private var openURL
     
     @StateObject private var coordinator = BikeComputerCoordinator()
     @StateObject private var offlineMapManager = OfflineMapManager()
@@ -83,6 +87,14 @@ struct ContentView: View {
             } message: {
                 Text(coordinator.alert.message)
             }
+            .alert("Health Access Required", isPresented: $coordinator.isHealthKitSettingsPromptPresented) {
+                Button("Open BikeComputer Settings") {
+                    openHealthKitSettings()
+                }
+                Button("Not Now", role: .cancel) { }
+            } message: {
+                Text("Enable Health access for BikeComputer in Settings > Health, then return to the app to try again.")
+            }
             .sheet(isPresented: $showingSettings) {
                 SettingsView(
                     locationAuthorized: coordinator.isLocationAuthorized,
@@ -104,6 +116,11 @@ struct ContentView: View {
         .onChange(of: coordinator.selectedView) { newValue in
             coordinator.updateSelectedView(newValue)
         }
+        .onChange(of: scenePhase) { newPhase in
+            if newPhase == .active {
+                coordinator.refreshHealthKitAuthorization()
+            }
+        }
         .onChange(of: offlineMapManager.isMapAreaSelectionActive) { isActive in
             if isActive {
                 showingSettings = false
@@ -114,6 +131,11 @@ struct ContentView: View {
                 offlineMapSelectionDragStartFrame = nil
             }
         }
+    }
+
+    private func openHealthKitSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        openURL(url)
     }
 
     private var shouldShowOfflineMapOnboarding: Bool {

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -49,6 +49,7 @@ class BikeComputerCoordinator: ObservableObject {
     @Published var isWorkoutActive: Bool = false
     @Published var isHealthKitAuthorized: Bool = false
     @Published var isHealthKitAvailable: Bool = false
+    @Published var isHealthKitSettingsPromptPresented: Bool = false
     @Published var workoutElapsedTime: TimeInterval = 0
     @Published var currentSpeedKmh: Double = 0
     @Published var distanceKm: Double = 0
@@ -278,7 +279,25 @@ class BikeComputerCoordinator: ObservableObject {
     // MARK: - Public API: Workout
 
     func startWorkout() {
-        healthKitManager.startBikeWorkout()
+        guard healthKitManager.isHealthKitAvailable else { return }
+
+        if healthKitManager.refreshAuthorizationStatus() {
+            healthKitManager.startBikeWorkout()
+            return
+        }
+
+        healthKitManager.requestAuthorization { [weak self] authorized in
+            guard let self else { return }
+            if authorized {
+                self.healthKitManager.startBikeWorkout()
+            } else {
+                self.isHealthKitSettingsPromptPresented = true
+            }
+        }
+    }
+
+    func refreshHealthKitAuthorization() {
+        _ = healthKitManager.refreshAuthorizationStatus()
     }
 
     func endWorkout() {

--- a/ios-app/BikeComputer/BikeComputer/Managers/HealthKitManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/HealthKitManager.swift
@@ -52,50 +52,69 @@ class HealthKitManager: NSObject, ObservableObject {
         super.init()
         isHealthKitAvailable = HKHealthStore.isHealthDataAvailable()
         if isHealthKitAvailable {
-            requestAuthorization()
+            refreshAuthorizationStatus()
         }
     }
 
-    func requestAuthorization() {
+    @discardableResult
+    func refreshAuthorizationStatus() -> Bool {
         guard HKHealthStore.isHealthDataAvailable() else {
             isHealthKitAvailable = false
+            isAuthorized = false
+            return false
+        }
+
+        let hasRequiredShareAuthorization = typesToWrite.allSatisfy {
+            healthStore.authorizationStatus(for: $0) == .sharingAuthorized
+        }
+        isAuthorized = hasRequiredShareAuthorization
+        return hasRequiredShareAuthorization
+    }
+
+    func requestAuthorization(completion: ((Bool) -> Void)? = nil) {
+        guard HKHealthStore.isHealthDataAvailable() else {
+            isHealthKitAvailable = false
+            isAuthorized = false
+            completion?(false)
             print("HealthKit not available on this device")
             return
         }
 
-        let typesToWrite: Set<HKSampleType> = [
-            HKObjectType.workoutType(),
-            HKObjectType.quantityType(forIdentifier: .distanceCycling)!
-        ]
-        
-        let typesToRead: Set<HKObjectType> = [
-            HKObjectType.quantityType(forIdentifier: .heartRate)!
-        ]
-
         healthStore.requestAuthorization(toShare: typesToWrite, read: typesToRead) { [weak self] success, error in
             DispatchQueue.main.async {
-                guard success else {
-                    self?.isAuthorized = false
-                    if let error = error {
-                        print("HealthKit authorization failed: \(error.localizedDescription)")
-                    }
+                guard let self else {
+                    completion?(false)
                     return
                 }
 
-                let requiredShareTypes = typesToWrite
-                let hasRequiredShareAuthorization = requiredShareTypes.allSatisfy {
-                    self?.healthStore.authorizationStatus(for: $0) == .sharingAuthorized
-                }
+                let hasRequiredShareAuthorization = success && self.refreshAuthorizationStatus()
 
                 if hasRequiredShareAuthorization {
-                    self?.isAuthorized = true
                     print("HealthKit authorization granted")
                 } else {
-                    self?.isAuthorized = false
-                    print("HealthKit authorization incomplete")
+                    if let error {
+                        print("HealthKit authorization failed: \(error.localizedDescription)")
+                    } else {
+                        print("HealthKit authorization incomplete")
+                    }
                 }
+
+                completion?(hasRequiredShareAuthorization)
             }
         }
+    }
+
+    private var typesToWrite: Set<HKSampleType> {
+        [
+            HKObjectType.workoutType(),
+            HKObjectType.quantityType(forIdentifier: .distanceCycling)!
+        ]
+    }
+
+    private var typesToRead: Set<HKObjectType> {
+        [
+            HKObjectType.quantityType(forIdentifier: .heartRate)!
+        ]
     }
     
     func updateLocation(speed: Double, distance: Double) {
@@ -271,8 +290,15 @@ class HealthKitManager: NSObject, ObservableObject {
         isAuthorized = false
     }
 
-    func requestAuthorization() {
+    @discardableResult
+    func refreshAuthorizationStatus() -> Bool {
         isAuthorized = false
+        return false
+    }
+
+    func requestAuthorization(completion: ((Bool) -> Void)? = nil) {
+        isAuthorized = false
+        completion?(false)
     }
 
     func updateLocation(speed: Double, distance: Double) {

--- a/ios-app/BikeComputer/BikeComputer/Views/CombinedNavigationWorkoutView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/CombinedNavigationWorkoutView.swift
@@ -49,13 +49,12 @@ struct CombinedNavigationWorkoutView: View {
                             .foregroundColor(.white)
                             .padding(.horizontal, 20)
                             .padding(.vertical, 8)
-                            .background(coordinator.isHealthKitAuthorized ? Color.green : Color.gray)
+                            .background(coordinator.isHealthKitAuthorized ? Color.green : Color.accentColor)
                             .cornerRadius(10)
                     }
-                    .disabled(!coordinator.isHealthKitAuthorized)
 
                     if !coordinator.isHealthKitAuthorized {
-                        Text("HealthKit access required")
+                        Text("Tap to enable HealthKit access")
                             .font(.caption2)
                             .foregroundColor(.secondary)
                     }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -971,6 +971,7 @@ private struct DeveloperSettingsView: View {
                 currentLocation: currentLocation,
                 onStartNavigation: onStartTestNavigation
             )
+            HealthKitSettingsSection()
 
             Section {
                 HStack {
@@ -1055,6 +1056,29 @@ private struct DeveloperSettingsView: View {
         }
 
         return "Connected"
+    }
+}
+
+private struct HealthKitSettingsSection: View {
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        Section {
+            Button {
+                openHealthKitSettings()
+            } label: {
+                Label("Open BikeComputer Settings", systemImage: "heart.text.square")
+            }
+        } header: {
+            Text("HealthKit")
+        } footer: {
+            Text("Review BikeComputer's Health access in Settings > Health, then return to the app.")
+        }
+    }
+
+    private func openHealthKitSettings() {
+        guard let url = URL(string: UIApplication.openSettingsURLString) else { return }
+        openURL(url)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/WorkoutMetricsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/WorkoutMetricsView.swift
@@ -164,18 +164,20 @@ struct StartWorkoutView: View {
 
             if isHealthKitAvailable {
                 Button(action: onStartWorkout) {
-                    Label("Start Bike Workout", systemImage: "play.circle.fill")
+                    Label(
+                        isHealthKitAuthorized ? "Start Bike Workout" : "Enable HealthKit & Start",
+                        systemImage: "play.circle.fill"
+                    )
                         .font(.headline)
                         .foregroundColor(.white)
                         .frame(maxWidth: .infinity)
                         .padding()
-                        .background(isHealthKitAuthorized ? Color.green : Color.gray)
+                        .background(isHealthKitAuthorized ? Color.green : Color.accentColor)
                         .cornerRadius(15)
                 }
-                .disabled(!isHealthKitAuthorized)
 
                 if !isHealthKitAuthorized {
-                    Text("HealthKit access required for workout tracking")
+                    Text("HealthKit access is needed to save this workout")
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)


### PR DESCRIPTION
## Summary

- Check HealthKit write authorization at startup and when the app becomes active.
- Request access when the user taps Start Workout, then start automatically if granted.
- Show a Settings fallback after denial and add a HealthKit shortcut under Developer Settings.

## Test plan

- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Release -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO build`
- [ ] Verify the native HealthKit sheet and Settings fallback on a physical iPhone.
