### PR TITLE
Fix HealthKit permission recovery on Watch

### DIFF
--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -412,6 +412,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var mirrorRetryTask: Task<Void, Never>?
     private var mirrorShutdownWatchdogTask: Task<Void, Never>?
     private var complicationStartTask: Task<Void, Never>?
+    private var authorizationRefreshTask: Task<Void, Never>?
     private var segmentOperationTask: Task<Void, Never>?
     private var segmentOperationTimeoutTask: Task<Void, Never>?
     private var segmentOperationAttemptID: UUID?
@@ -657,6 +658,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         mirrorRetryTask?.cancel()
         mirrorShutdownWatchdogTask?.cancel()
         complicationStartTask?.cancel()
+        authorizationRefreshTask?.cancel()
         segmentOperationTask?.cancel()
         segmentOperationTimeoutTask?.cancel()
         finalSegmentOperationTask?.cancel()
@@ -696,6 +698,30 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     func requestAuthorization() {
         Task { [weak self] in
             await self?.authorizeHealthKit()
+        }
+    }
+
+    /// Re-reads HealthKit authorization after the user returns from the
+    /// system's Health settings. This deliberately never presents a new
+    /// authorization sheet, so a previously denied request remains a
+    /// settings-only recovery path.
+    func refreshAuthorizationIfNeeded() {
+        guard !isWorkoutActive,
+              !isRecovering,
+              !isRecoveryLoopRunning,
+              session == nil,
+              setupState != .authorizing,
+              authorizationRefreshTask == nil else {
+            return
+        }
+
+        authorizationRefreshTask = Task { [weak self] in
+            guard let self else { return }
+            defer {
+                self.authorizationRefreshTask = nil
+                self.drainPendingComplicationStartIfPossible()
+            }
+            await self.refreshAuthorizationState()
         }
     }
 
@@ -1099,7 +1125,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
 
     private func authorizeHealthKit() async {
         defer { drainPendingComplicationStartIfPossible() }
-        guard !isWorkoutActive else { return }
+        guard !isWorkoutActive,
+              setupState != .denied,
+              setupState != .authorizing else {
+            return
+        }
         guard HKHealthStore.isHealthDataAvailable() else {
             setupState = .unavailable
             return
@@ -1136,6 +1166,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             return
         }
         if setupState != .ready {
+            guard setupState != .denied else { return }
             await authorizeHealthKit()
         }
         guard setupState == .ready,

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct WatchWorkoutRootView: View {
     @ObservedObject var manager: WatchWorkoutManager
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         Group {
@@ -27,6 +28,13 @@ struct WatchWorkoutRootView: View {
                     WorkoutStartView(manager: manager)
                 }
             }
+        }
+        .onAppear {
+            manager.refreshAuthorizationIfNeeded()
+        }
+        .onChange(of: scenePhase) { newValue in
+            guard newValue == .active else { return }
+            manager.refreshAuthorizationIfNeeded()
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutStartView.swift
@@ -87,12 +87,21 @@ struct WorkoutStartView: View {
             .tint(.green)
             .disabled(manager.state == .failed)
         case .denied:
-            Text("Bicino can’t start a workout without permission to save workouts in Health.")
-                .font(.caption)
-                .multilineTextAlignment(.center)
-            Button("Check Again") {
-                manager.requestAuthorization()
+            VStack(spacing: 6) {
+                Text("Bicino can’t start a workout without permission to save workouts in Health.")
+                    .font(.caption)
+                    .multilineTextAlignment(.center)
+                Text(
+                    "On Apple Watch, open Settings > Health > Apps > Bicino and enable Workouts and Workout Routes, then return here."
+                )
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
             }
+            Button("Check Again") {
+                manager.refreshAuthorizationIfNeeded()
+            }
+            .tint(.blue)
         case .unavailable:
             Text("Health data isn’t available on this Watch.")
                 .font(.caption)

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -1047,6 +1047,36 @@ final class WatchWorkoutManagerTests: XCTestCase {
         XCTAssertEqual(manager.setupState, .needsAuthorization)
     }
 
+    func testDeniedAuthorizationDoesNotRetryFromStartOrExplicitRequest()
+        async throws {
+        let refresh = AsyncVoidProbe()
+        var authorizationRequestCount = 0
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: WatchWorkoutRecoveryStore(
+                persistence: ToggleRecoveryPersistence()
+            ),
+            requestAuthorization: { authorizationRequestCount += 1 },
+            refreshAuthorization: { await refresh.run() },
+            authorizationRefreshState: .denied,
+            initializeOnLaunch: false
+        )
+
+        manager.refreshAuthorizationIfNeeded()
+        manager.refreshAuthorizationIfNeeded()
+        try await waitUntil { refresh.callCount == 1 }
+        refresh.complete()
+        try await waitUntil { manager.setupState == .denied }
+
+        manager.requestAuthorization()
+        await manager.startOutdoorCyclingWorkout()
+        await Task.yield()
+
+        XCTAssertEqual(authorizationRequestCount, 0)
+        XCTAssertEqual(manager.setupState, .denied)
+    }
+
     func testComplicationStartRequeuesIfRecoveryBeginsBeforeTaskRuns() async throws {
         let recovery = RecoveryProbe()
         var startCount = 0


### PR DESCRIPTION
## What changed

- Prevent denied HealthKit authorization from retrying the permission sheet from Start Workout or Check Again.
- Show Apple Watch Settings instructions when Health access is denied.
- Re-check HealthKit authorization when the Watch app appears or returns to the foreground.
- Keep refreshes single-flight and drain queued complication starts after access becomes ready.
- Add a regression test covering denied start/request behavior and refresh single-flight.

## Why

HealthKit permission denial is a settings-only recovery path. Re-presenting authorization after a denial leaves the user stuck without a clear way to recover, and returning from Settings previously required a manual relaunch or retry.

## Validation

- `./scripts/run-workout-contract-tests.sh`
- `./scripts/run-workout-platform-tests.sh ios`
- `./scripts/run-workout-platform-tests.sh watchos`
- `xcodebuild -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputerWatch -sdk watchsimulator -configuration Debug build CODE_SIGNING_ALLOWED=NO`
- `git diff --check`