### PR TITLE
Rebuild navigation rendering around render-ahead worker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,19 @@ jobs:
             tools/tests/test_map_projection.cpp \
             -o /tmp/test_map_projection
           /tmp/test_map_projection
+      - name: Render-ahead map architecture host tests
+        run: |
+          for test in \
+            test_map_render_job \
+            test_map_presentation \
+            test_map_building_admission \
+            test_map_route_geometry \
+            test_map_building_workspace; do
+            g++ -std=c++17 -Wall -Wextra -Werror \
+              "tools/tests/${test}.cpp" \
+              -o "/tmp/${test}"
+            "/tmp/${test}"
+          done
       - name: Map profile protocol host tests
         run: |
           g++ -std=c++17 \
@@ -235,7 +248,7 @@ jobs:
           /tmp/test_device_capabilities_protocol
       - name: Filled line rasterizer host tests
         run: |
-          g++ -std=c++17 -Wall -Wextra \
+          g++ -std=c++17 -Wall -Wextra -Werror \
             tools/tests/test_line_rasterizer.cpp \
             -o /tmp/test_line_rasterizer
           /tmp/test_line_rasterizer

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -256,6 +256,15 @@ DeltaLon: Int16 microdegrees
 
 Coordinates are WGS-84. The iOS app converts Apple Maps route coordinates from
 GCJ-02 to WGS-84 before writing route geometry so it aligns with OSM map blocks.
+The first point is the rider's exact projection onto the route, followed only
+by forward route vertices. The retained packet never contains a rider-to-route
+connector: firmware prepends its current `PresentedPose` while drawing, so the
+blue head stays attached to the arrow without leaving a stale closest segment.
+The app's epoch-scoped bounded matcher sends a new forward window when its
+matched segment changes, subject to a two-second rate limit. This prevents
+loops or self-intersections from making firmware reacquire an older segment;
+ordinary window revisions update the live foreground and do not cancel a 3D
+base render.
 
 A zero-length route geometry packet clears the route overlay on the ESP32. The
 iOS app sends this when navigation stops so stale route geometry is not used for
@@ -268,7 +277,7 @@ Little-endian binary packet:
 ```text
 Lat: Int32 microdegrees
 Lon: Int32 microdegrees
-Heading: UInt16 degrees, 0...359
+Heading: UInt16 degrees, 0...359; 0xFFFF invalid when CAP2 bit 13 is negotiated
 UnixTime: UInt32 seconds since 1970-01-01T00:00:00Z (optional)
 Speed: UInt16 centimeters/second, 0xFFFF invalid (optional)
 Altitude: Int16 meters (optional)
@@ -282,6 +291,12 @@ coordinates are converted from GCJ-02 to WGS-84 before writing. Firmware accepts
 the original 8-byte lat/lon payload, the 10-byte lat/lon/heading payload, the
 14-byte payload with Unix time, and the extended 30-byte telemetry payload. The
 Waveshare firmware uses the optional Unix time to sync the onboard PCF85063 RTC.
+
+Client version `11` and CAP2 feature bit `13` negotiate the explicit invalid
+heading sentinel. Without that bit, the app preserves the legacy missing-course
+value `0`; version-11 firmware knows version-10 clients are ambiguous and uses
+the live route bearing before that zero during guidance. Thus new app/old
+firmware, old app/new firmware, and new app/new firmware remain interoperable.
 
 The iOS sender treats GPS as replaceable state, not an ordered history. At most
 one unsent native or `GPSP` position is retained; a newer position replaces only
@@ -718,8 +733,10 @@ TLV = Type: UInt8 | Length: UInt8 | Value: Length bytes
 
 Schema `1` assigns feature bit `8` to street-label profiles, bit `9` to the
 bird's-eye projection, bit `10` to its first three perspective presets, bit
-`11` to the Very Strong and Maximum presets, and bit `12` to OSM 3D buildings
-and renderer target 3. Bits `0...7` retain their legacy
+`11` to the Very Strong and Maximum presets, bit `12` to OSM 3D buildings
+and renderer target 3, and bit `13` to the explicit invalid GPS-heading
+sentinel. Client version `11` requests bit `13`; version `10` remains a valid
+CAP2 client without it. Bits `0...7` retain their legacy
 meanings above. TLV type `1` carries the persisted PWR honk configuration as
 exactly three bytes (`Enabled`, `SoundID`, `VolumePercent`). Types are unique;
 malformed, duplicate, or overrun TLVs invalidate the complete response. Unknown
@@ -730,8 +747,8 @@ clients accept either envelope.
 Golden vectors:
 
 ```text
-CAP2 schema 1, flags 0x00001fff, PWR enabled/sound 4/volume 80:
-43 41 50 32 01 ff 1f 00 00 01 03 01 04 50
+CAP2 schema 1, flags 0x00003fff, PWR enabled/sound 4/volume 80:
+43 41 50 32 01 ff 3f 00 00 01 03 01 04 50
 
 CAP2 schema 1, flags 0, no TLVs:
 43 41 50 32 01 00 00 00 00

--- a/docs/firmware-map-memory-diagnostics.md
+++ b/docs/firmware-map-memory-diagnostics.md
@@ -36,6 +36,9 @@ Building summaries include the same internal-heap fields plus the existing
 PSRAM fields. They also report:
 
 - `courtyardSnapshots`: number of courtyard underlay captures in the pass;
+- `courtyardDeferred`: number of admitted buildings rendered with the
+  solid-roof fallback because courtyard restoration exceeded its bounded
+  workspace;
 - `courtyardMaxBytes`: largest allocated underlay-vector capacity in bytes;
 - `freeInternalHeap` and `largestInternalHeap`: internal 8-bit heap
   availability at the end of the pass;

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -24,9 +24,13 @@ global sorting, polygon filling, large allocation, or 3D surface drawing. It:
 5. updates the arrow from that same pose; and
 6. publishes a completed worker frame through a short front/back pointer swap.
 
-The visible frame and every LVGL object have one owner: the LVGL task. Screen
-recreation invalidates the semantic job without waiting for SD or geometry
-work. The worker is quiesced only before a persistent PSRAM surface is resized;
+The visible frame and every LVGL object have one owner: the LVGL task. Drag and
+pinch previews temporarily own the base-image and marker transforms; worker
+publication waits until release, and a settlement keeps its exact endpoint
+until the replacement frame is ready. The live route foreground is hidden
+during that bounded preview instead of drifting away from the transformed map.
+Screen recreation invalidates the semantic job without waiting for SD or
+geometry work. The worker is quiesced only before a persistent PSRAM surface is resized;
 ordinary LVGL object rebinding keeps the stable hidden-buffer address and never
 exposes that buffer.
 
@@ -36,32 +40,49 @@ Every `MapRenderJob` captures the state needed to reproduce the frame:
 
 - predicted world-space center and presentation context;
 - heading, projection, perspective, zoom, viewport, overscan, and style;
-- route revision;
+- route revision for diagnostics (the route itself is live foreground);
 - navigation, style, map-root, and projection epochs; and
 - the fixed render dimensions and RGB565 stride.
 
-The request receives a monotonic sequence number. Position-only requests are
-coalesced: an active render is allowed to finish and publish when its route,
-style, map, and projection epochs still match, even if a newer GPS sequence
+The request receives a monotonic sequence number. Position-only and
+route-window-only requests are coalesced: an active render is allowed to finish
+and publish when its navigation, style, map, and projection epochs still match,
+even if a newer GPS sequence
 has arrived. This is the backpressure invariant that prevents a 1.8-second
 3D render from being cancelled forever by a 750 ms GPS cadence. Semantic
-changes (route replacement, style, map source, projection, or screen mode)
+changes (navigation session, style, map source, projection, or screen mode)
 cancel at the next bounded checkpoint. A completed result is checked again
-against current route/style/navigation/projection state immediately before
+against current style/navigation/projection state immediately before
 publication. A stale result never reaches the front buffer.
 
-Map-root changes and probes stop the worker before mutating the cache. Loaded
-blocks remain owned by the renderer while a job is active, so cache mutation
-cannot invalidate worker pointers.
+Boot-time map-root recovery may synchronously quiesce the worker before it has
+started. Runtime map activation and renderer probes are control jobs on the
+same storage/render worker, with a completion mailbox back to the UI task.
+Loaded blocks therefore have one owner, and SD traversal or block parsing never
+runs in the LVGL loop. A control job ignores ordinary camera/style cancellation
+generations once it starts, while still honoring worker shutdown, so a new GPS
+fix cannot interrupt a map-root probe/switch halfway through. A transient
+non-blocking enqueue failure is retried for up to 10 seconds before transfer
+activation is rejected. A failed probe keeps the previous root and explicitly
+requests a replacement frame because entering the control job cancelled the
+old in-flight render. If an exceptional stop times out while an SD operation
+finishes, a late-exit handoff restarts the preserved old root instead of
+leaving the map frozen. Initial canvas allocation does not stop a worker that
+can only be running a storage control job; buffer relocation is quiesced once
+both persistent frame buffers exist and can be worker-owned.
 
 ## Base-frame publication and motion
 
 Both persistent RGB565 buffers are sized for the maximum supported viewport
 plus 96 pixels of overscan on each edge. On the 466 x 466 profile each 658 x 658
 RGB565 frame is 865,928 bytes at the current aligned stride. The two frames plus
-the 466 x 466 RGB565+A8 foreground total 3,030,748 persistent bytes (about 2.89
-MiB), before map blocks and bounded workspaces. The worker renders only into the
-hidden buffer. Publication verifies dimensions, stride, and both buffer capacities,
+the 466 x 466 RGB565+A8 foreground total 2,383,324 persistent bytes (about 2.27
+MiB), before map blocks and bounded workspaces. The foreground is 651,468 bytes:
+`466 * 466 * (2 + 1)`, because it is viewport-sized rather than overscanned.
+The worker renders only into the
+hidden buffer. Publication verifies dimensions, stride, both buffer capacities,
+and that the current translated/rotated viewport still fits inside the
+candidate's overscan,
 then swaps the raw pointers under the render-state mutex. LVGL rebinding happens
 on the UI task after the mutex is released.
 
@@ -71,12 +92,22 @@ it by the difference between the frame heading and the current presented
 heading. The route foreground applies the exact same transform, so its first
 point, the route head, the arrow, and the base map remain attached.
 
-iOS does not retransmit the route merely because the exact rider coordinate
-changed. Firmware anchors the retained window at every presented pose, while
-the app sends a replacement after roughly two thirds of the 30-point forward
-window has been consumed (or after reroute, backtrack, or readiness recovery).
-This keeps route revisions semantic and prevents a fixed two-second
-cancellation loop for longer map jobs.
+iOS does not retain or retransmit a rider-to-route connector. A packet begins
+at the exact route projection and contains only forward route geometry.
+Firmware prepends the current presented rider pose on every UI frame, while
+the app sends a replacement when its bounded route matcher advances to another
+segment (or after reroute, backtrack, or readiness recovery). The existing
+two-second send gate coalesces short segments. This keeps loops and
+self-intersections anchored to an unambiguous forward window, while route
+revisions remain live-foreground input and cannot create a fixed cancellation
+loop for longer map jobs.
+
+The base transform and route foreground update at UI cadence only while their
+pose, heading, frame, route, dimensions, or style changes. Cached presentation
+signatures make an idle tick a true no-op: it performs neither an LVGL base
+invalidate nor a full 466 x 466 foreground-alpha clear. Gesture teardown clears
+those signatures, and pinch animation completion leaves the live presenter in
+sole control of the image pivot.
 
 Prediction is deliberately finite: by default it is capped at 1.5 seconds and
 30 metres, then stops instead of drifting without a fresh fix. Repeated packets
@@ -86,16 +117,33 @@ independently.
 
 ## Course-up state
 
-Course-up is explicit navigation state. A valid measured course is preferred.
-When Core Location reports an invalid course, including `-1` during test
-navigation, iOS sends the invalid-heading sentinel and both sides use the
-nearest live route-segment bearing. A remembered heading is scoped to the
-current navigation epoch and is cleared on start, stop, reroute, or mode
-change. The arrival order of the route window and maneuver packet does not
-create a second guidance session; either is enough to activate guidance.
+Course-up is explicit navigation state. A valid measured course is preferred
+after client version 11 negotiates CAP2 bit 13. When Core Location reports an
+invalid course, including `-1` during test navigation, the app then sends
+`0xFFFF` and both sides use the nearest live route-segment bearing. Version-10
+apps retain their ambiguous zero encoding; version-11 firmware detects that
+session and resolves route-first, preserving mixed-version behavior. iOS
+scopes remembered course to its navigation epoch and clears it on start, stop,
+or reroute. Firmware clears its remembered course when the guidance session or
+screen/mode changes. It does not treat an ordinary sliding-window packet as a
+new heading epoch: doing so would discard live prediction and pull the rider
+back to the last raw fix. A new valid route bearing replaces remembered
+direction without that reset. Each new route window also feeds the resolved course into
+the ordinary 12-degree scheduler threshold, so a material turn or reroute can
+replace the base frame even before another GPS packet arrives, while an
+equivalent sliding window does not force or cancel a render. The arrival order
+of the route window and maneuver packet does not create a second guidance
+session; either is enough to activate guidance.
 
 A missing heading is a deferred request, not heading zero. The scheduler keeps
 the last good frame dirty until a measured course or route bearing exists.
+The directional marker remains hidden during that new-session gap rather than
+displaying a false north-facing arrow; the ordinary non-navigation location dot
+does not require a course.
+Before any route or maneuver is active, course-up has no navigation direction;
+the idle guidance screen may establish its first bird's-eye/3D base north-up.
+That idle bootstrap is discarded through the normal navigation semantic epoch
+as soon as guidance starts and is never used as an active-navigation fallback.
 
 ## Deterministic buildings and bounded memory
 
@@ -109,9 +157,12 @@ source points, and 220,000 projected pixels; within that set at most 32 records,
 3,072 source points, and 90,000 projected pixels are extruded. The nearest useful records retain 3D roofs and walls. Farther admitted
 records become flat roofs; records outside the quota are explicitly deferred.
 Courtyard snapshots are clipped to the visible raw surface and have a fixed
-pixel budget. A scheduling checkpoint does not trigger 2D fallback. Genuine
+pixel budget. Overflow degrades only courtyard restoration to a solid roof;
+the admitted 3D building remains. A scheduling checkpoint does not trigger 2D fallback. Genuine
 allocation failure retries once with a smaller fixed-memory nearest set of flat
-footprints; its scoped cooldown uses the same path. Data or invariant failures
+footprints; polygon-node allocation failures are promoted into that same
+bounded fallback instead of creating an identical retry loop, and its scoped
+cooldown uses the same path. Data or invariant failures
 retain the last complete frame and emit diagnostics.
 
 The renderer preserves FMB v1-v4 and ordinary flat-map behavior.
@@ -121,14 +172,16 @@ The renderer preserves FMB v1-v4 and ordinary flat-map behavior.
 An ordinary follow-mode GPS update requests a replacement base frame only when
 both of these conditions are true:
 
-- at least 750 ms has passed since the last published base-map render; and
+- at least 750 ms has passed since the last accepted base-map request; and
 - position moved at least 8 m, or course-up heading changed at least 12 degrees.
 
-Route, style, zoom, screen, semantic recovery, or exhausted-overscan requests
-bypass those ordinary GPS gates. Overscan refresh uses measured presented speed,
+Navigation-session, style, zoom, screen, semantic recovery, or
+exhausted-overscan requests bypass those ordinary GPS gates. Overscan refresh uses measured presented speed,
 pixels per metre, the most recent render duration, and safety pixels. The
-96-pixel overscan is geometry capacity, not a promise that a slow render may
-block the UI.
+request center is led by speed times that measured duration within the
+96-pixel/16-pixel safety budget. Publication independently proves all four
+inverse-transformed viewport corners remain covered. Overscan is geometry
+capacity, not a promise that a slow render may block the UI.
 
 ## Diagnostics
 

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -91,6 +91,12 @@ translates it continuously using the current `PresentedPose`. Course-up rotates
 it by the difference between the frame heading and the current presented
 heading. The route foreground applies the exact same transform, so its first
 point, the route head, the arrow, and the base map remain attached.
+This continuity applies only while the active screen profile is unchanged.
+Map and Map + Navigation share the same LVGL canvas but have different style
+and projection semantics. During a direct transition between those profiles,
+the shared canvas is concealed against the neutral screen background until a
+new worker publication for the destination profile arrives; the prior
+profile's already-published frame is never accepted as transition completion.
 The oversized base object stays LVGL center-aligned. Its style position is an
 offset from the centered origin, not an absolute parent coordinate; the
 presenter explicitly converts the desired parent-space pivot target to that

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -1,46 +1,162 @@
-# Firmware map-render scheduler
+# Firmware map render-ahead scheduler
 
-The firmware retains every accepted GPS fix for telemetry and the current
-position marker, but it no longer treats each fix as a request to read map data
-and regenerate the vector-map background.
+The map renderer has two independent paths:
 
-## Default policy
+- a presentation path owned by the LVGL task, which updates the rider marker,
+  route foreground, maneuver UI, and transform of the last complete base frame;
+- a low-priority render worker, which reads map blocks and renders a complete
+  hidden RGB565 base frame without calling LVGL.
 
-An ordinary follow-mode GPS update regenerates the base map only when both of
-these conditions are true:
+The movement and cadence policy remains an intake policy. It decides when a new
+immutable render request is useful; it is not relied on to make map rendering
+safe.
 
-- at least 750 ms has passed since the last completed base-map render; and
+## UI-task contract
+
+A normal UI tick must not perform SD reads, block parsing, building discovery,
+global sorting, polygon filling, large allocation, or 3D surface drawing. It:
+
+1. consumes the latest GPS, route, maneuver, style, and screen state;
+2. advances one `PresentedPose` with bounded prediction and convergence;
+3. translates and rotates the current front frame around the projected rider;
+4. draws the route into a viewport-sized RGB565+A8 foreground using the same
+   projected pivot, viewport anchor, and heading delta as the base frame;
+5. updates the arrow from that same pose; and
+6. publishes a completed worker frame through a short front/back pointer swap.
+
+The visible frame and every LVGL object have one owner: the LVGL task. Screen
+recreation invalidates the semantic job without waiting for SD or geometry
+work. The worker is quiesced only before a persistent PSRAM surface is resized;
+ordinary LVGL object rebinding keeps the stable hidden-buffer address and never
+exposes that buffer.
+
+## Immutable render requests
+
+Every `MapRenderJob` captures the state needed to reproduce the frame:
+
+- predicted world-space center and presentation context;
+- heading, projection, perspective, zoom, viewport, overscan, and style;
+- route revision;
+- navigation, style, map-root, and projection epochs; and
+- the fixed render dimensions and RGB565 stride.
+
+The request receives a monotonic sequence number. Position-only requests are
+coalesced: an active render is allowed to finish and publish when its route,
+style, map, and projection epochs still match, even if a newer GPS sequence
+has arrived. This is the backpressure invariant that prevents a 1.8-second
+3D render from being cancelled forever by a 750 ms GPS cadence. Semantic
+changes (route replacement, style, map source, projection, or screen mode)
+cancel at the next bounded checkpoint. A completed result is checked again
+against current route/style/navigation/projection state immediately before
+publication. A stale result never reaches the front buffer.
+
+Map-root changes and probes stop the worker before mutating the cache. Loaded
+blocks remain owned by the renderer while a job is active, so cache mutation
+cannot invalidate worker pointers.
+
+## Base-frame publication and motion
+
+Both persistent RGB565 buffers are sized for the maximum supported viewport
+plus 96 pixels of overscan on each edge. On the 466 x 466 profile each 658 x 658
+RGB565 frame is 865,928 bytes at the current aligned stride. The two frames plus
+the 466 x 466 RGB565+A8 foreground total 3,030,748 persistent bytes (about 2.89
+MiB), before map blocks and bounded workspaces. The worker renders only into the
+hidden buffer. Publication verifies dimensions, stride, and both buffer capacities,
+then swaps the raw pointers under the render-state mutex. LVGL rebinding happens
+on the UI task after the mutex is released.
+
+The old complete frame remains visible while a replacement renders. The UI
+translates it continuously using the current `PresentedPose`. Course-up rotates
+it by the difference between the frame heading and the current presented
+heading. The route foreground applies the exact same transform, so its first
+point, the route head, the arrow, and the base map remain attached.
+
+iOS does not retransmit the route merely because the exact rider coordinate
+changed. Firmware anchors the retained window at every presented pose, while
+the app sends a replacement after roughly two thirds of the 30-point forward
+window has been consumed (or after reroute, backtrack, or readiness recovery).
+This keeps route revisions semantic and prevents a fixed two-second
+cancellation loop for longer map jobs.
+
+Prediction is deliberately finite: by default it is capped at 1.5 seconds and
+30 metres, then stops instead of drifting without a fresh fix. Repeated packets
+with unchanged coordinates are still fresh observations and drive convergence.
+A new fix converges over a bounded interval rather than moving one visual layer
+independently.
+
+## Course-up state
+
+Course-up is explicit navigation state. A valid measured course is preferred.
+When Core Location reports an invalid course, including `-1` during test
+navigation, iOS sends the invalid-heading sentinel and both sides use the
+nearest live route-segment bearing. A remembered heading is scoped to the
+current navigation epoch and is cleared on start, stop, reroute, or mode
+change. The arrival order of the route window and maneuver packet does not
+create a second guidance session; either is enough to activate guidance.
+
+A missing heading is a deferred request, not heading zero. The scheduler keeps
+the last good frame dirty until a measured course or route bearing exists.
+
+## Deterministic buildings and bounded memory
+
+FMB v4 records are discovered across every loaded in-view block. Candidate
+metadata is retained with a bounded nearest-item heap, then sorted by distance
+and stable block/record identity. Selection therefore does not depend on cache
+or block iteration order.
+
+Fixed quotas are applied nearest first: at most 96 admitted records, 8,192
+source points, and 220,000 projected pixels; within that set at most 32 records,
+3,072 source points, and 90,000 projected pixels are extruded. The nearest useful records retain 3D roofs and walls. Farther admitted
+records become flat roofs; records outside the quota are explicitly deferred.
+Courtyard snapshots are clipped to the visible raw surface and have a fixed
+pixel budget. A scheduling checkpoint does not trigger 2D fallback. Genuine
+allocation failure retries once with a smaller fixed-memory nearest set of flat
+footprints; its scoped cooldown uses the same path. Data or invariant failures
+retain the last complete frame and emit diagnostics.
+
+The renderer preserves FMB v1-v4 and ordinary flat-map behavior.
+
+## Render request policy
+
+An ordinary follow-mode GPS update requests a replacement base frame only when
+both of these conditions are true:
+
+- at least 750 ms has passed since the last published base-map render; and
 - position moved at least 8 m, or course-up heading changed at least 12 degrees.
 
-North-up ignores heading-only changes. A manually panned map continues to move
-its position marker without recentering or regenerating its base map. Course-up
-rotation remains eligible while panned because it affects the whole visible
-map.
+Route, style, zoom, screen, semantic recovery, or exhausted-overscan requests
+bypass those ordinary GPS gates. Overscan refresh uses measured presented speed,
+pixels per metre, the most recent render duration, and safety pixels. The
+96-pixel overscan is geometry capacity, not a promise that a slow render may
+block the UI.
 
-Route, style, zoom, screen, and recovery requests bypass the GPS cadence and
-threshold gates. A failed/interrupted render retains its original pending
-reason and adds `recovery` for the next attempt.
+## Diagnostics
 
-## Separation of work
+`MAPIO` diagnostics report:
 
-The LVGL owner performs four independent operations:
+- submit, ready, cancellation, stale-publication, invariant-failure, and publish
+  sequence state;
+- total job, block-load, draw, and UI swap durations;
+- bounded work-unit count and longest observed unit;
+- selected, extruded, flat, and deferred building counts;
+- allocation fallback; and
+- free and largest-contiguous PSRAM at completion and surface creation.
 
-1. ingest the latest GPS model (outside LVGL);
-2. apply lightweight telemetry and marker updates;
-3. apply navigation/maneuver overlay changes immediately; and
-4. ask the pure `map_render_policy::Scheduler` whether the vector background
-   is due.
+The declared initial UI/work-unit acceptance gate is 50 ms. Display-flush and UI
+maximum-gap telemetry remain the physical source of truth; host tests and a
+successful firmware build do not establish that gate.
 
-Only a completed base-map generation advances the scheduler baseline. This
-prevents a blocked or interrupted render from dropping pending work.
+## Validation boundary
 
-## Diagnostics and validation
+Host tests cover semantic invalidation, position-only coalescing, stale rejection,
+invariant failure,
+bounded fake-clock slices, heading wrap/fallback, finite prediction and
+convergence, shared presentation transforms, exact route-head anchoring,
+deterministic building admission under block-order permutations, quota
+overflow, bounded courtyard workspace, and legacy protocol behavior.
 
-`PWRMET` schema version 2 reports map-render reasons separately as `position`,
-`route`, `style`, `heading`, `zoom`, `screen`, `recovery`, and `other`.
-
-The host policy test covers movement, cadence, heading wraparound, stationary
-course noise, forced changes, retry retention, `millis()` rollover, and a
-deterministic 60-second 4 Hz GPS replay. Physical GPX replay, visible-position
-latency, gesture behavior, and both-board display validation remain required
-before the stacked battery work leaves draft status.
+A `WAVESHARE_AMOLED_175` build is required before review. Physical acceptance
+still requires an FMB v4 building-bearing pack on the 8 MiB PSRAM device in
+idle Map + Navigation, test navigation, and real navigation. The run must record
+UI maximum gap, display flush interval, render diagnostics, building counts,
+and PSRAM free/largest values. No physical success is implied by this document.

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -91,6 +91,11 @@ translates it continuously using the current `PresentedPose`. Course-up rotates
 it by the difference between the frame heading and the current presented
 heading. The route foreground applies the exact same transform, so its first
 point, the route head, the arrow, and the base map remain attached.
+The oversized base object stays LVGL center-aligned. Its style position is an
+offset from the centered origin, not an absolute parent coordinate; the
+presenter explicitly converts the desired parent-space pivot target to that
+offset. This prevents the overscan origin from being applied twice to the base
+while the viewport-sized route foreground and marker apply it once.
 
 iOS does not retain or retransmit a rider-to-route connector. A packet begins
 at the exact route projection and contains only forward route geometry.

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -14,11 +14,14 @@ RGB565 base frame. At the current LVGL-aligned stride:
 | --- | ---: |
 | One 658 x 658 RGB565 base frame | 865,928 |
 | Two base frames (front + worker back) | 1,731,856 |
-| 466 x 466 RGB565+A8 live foreground | 1,298,892 |
-| Persistent surface total | 3,030,748 (2.89 MiB) |
+| 466 x 466 RGB565+A8 live foreground | 651,468 |
+| Persistent surface total | 2,383,324 (2.27 MiB) |
 
-These are static sizes from the implementation based on `origin/main`
-`66692af1`. Free PSRAM, largest-contiguous PSRAM, map-block cache, temporary
+The foreground formula is `466 * 466 * (2 RGB565 + 1 alpha)`; overscan applies
+only to the two base frames. These are static sizes from PR #207 rebased on
+`origin/main` `1e189980`, for `WAVESHARE_AMOLED_175`; they are not a runtime or
+external measurement and use no map/navigation fixture. Free PSRAM,
+largest-contiguous PSRAM, map-block cache, temporary
 building workspace, and SD latency remain runtime concerns. No battery claim is
 derived from these sizes.
 
@@ -29,17 +32,30 @@ foreground, and the arrow. A low-priority worker owns map-block IO, geometry,
 building admission, and raw RGB565 rasterization into the hidden frame. It never
 calls LVGL. A completed frame is published by a short UI-side pointer swap.
 
-Each request carries a monotonic sequence plus route, navigation, style, map,
-and projection epochs. GPS movement requests are coalesced: an active render
+Each request carries a monotonic sequence plus diagnostic route revision and
+navigation, style, map, and projection epochs. GPS movement and route-window
+requests are coalesced: an active render
 may finish and publish when those frame semantics still match, even if newer
 position sequences exist. This prevents a long 3D render from being cancelled
-continuously by the 750 ms intake cadence. Route replacement, style, map-root,
-projection, and screen invalidations cancel at the next cooperative checkpoint.
+continuously by the 750 ms intake cadence. Route geometry is a live foreground
+input; navigation-session, style, map-root, projection, and screen
+invalidations cancel at the next cooperative checkpoint.
 
-The visible frame is translated and rotated every UI tick using one
-`PresentedPose`. The live route head, route line, and arrow use the same pivot,
-anchor, and rotation delta. Dead reckoning is finite (1.5 seconds and 30 metres
-by default) and converges to each new phone fix.
+The request center is led toward the rider's expected position using speed and
+the most recent render duration, capped by the 96-pixel overscan minus the
+16-pixel safety margin. Immediately before publication, all four viewport
+corners are inverse-transformed into the candidate frame. A frame that no
+longer covers the translated and rotated viewport is rejected and replaced;
+an already-uncovered candidate is never newly published. If later presentation
+motion exhausts a visible frame's margin, it immediately schedules a
+replacement while retaining the last complete frame.
+
+While presentation is changing, the visible frame is translated and rotated at
+UI cadence using one `PresentedPose`. The live route head, route line, and arrow
+use the same pivot, anchor, and rotation delta. Pose/frame/route/style
+signatures make stable ticks no-ops: they do not invalidate the base image or
+clear and redraw the full foreground alpha plane. Dead reckoning is finite
+(1.5 seconds and 30 metres by default) and converges to each new phone fix.
 
 ## 3D-building admission
 
@@ -54,20 +70,25 @@ stable rider-distance and block/record identity. The default 8 MiB quotas are:
 
 Nearest records retain 3D; farther admitted records render flat roofs; records
 outside the quota are deferred. Courtyard snapshots are clipped to the raw
-surface and capped at 180,000 pixels. A genuine allocation failure retries with
+surface and capped at 180,000 pixels. A building whose courtyard exceeds that
+workspace remains rendered with its walls and a deterministic solid roof; only
+the courtyard underlay restoration is deferred. A genuine allocation failure retries with
 a smaller deterministic flat-footprint set. A timing checkpoint or GPS update
 does not turn a healthy frame into a flat fallback.
 
 The guidance-screen flag is deliberately separate from route/maneuver
 availability. Bird's-eye and configured 3D buildings therefore remain active on
-the Map + Navigation screen before a route starts.
+the Map + Navigation screen before a route starts. If course-up has no heading
+yet, that idle first frame may be north-up; active guidance still requires a
+measured course, route bearing, or prior valid guidance frame.
 
 ## Validation boundary
 
 The focused host contracts cover worker ownership, semantic invalidation,
 position-only coalescing, shared presentation transforms, heading fallback and
-epoch reset, deterministic building admission, courtyard workspace limits, and
-legacy protocol behavior. The required physical gate is an exact
+epoch reset, pre-publication overscan coverage, deterministic building
+admission, solid-roof courtyard overflow, asynchronous runtime map activation,
+and cross-version heading protocol behavior. The required physical gate is an exact
 `WAVESHARE_AMOLED_175` build followed by device navigation with an FMB v4 pack in
 idle guidance, test navigation, and real navigation. Record UI maximum gap,
 display flush interval, render diagnostics, building counts, and free/largest

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -1,0 +1,75 @@
+# Firmware map rendering and PSRAM budget
+
+This is the source of truth for the ESP32 map renderer's memory and timing
+budget. Values are tied to a Git revision and board profile; estimates are not
+device measurements.
+
+## Waveshare 1.75-inch budget
+
+The 1.75-inch device has 8 MiB PSRAM. Guidance uses a 466 x 466 visible
+viewport and a 96-pixel overscan on each edge, producing a maximum 658 x 658
+RGB565 base frame. At the current LVGL-aligned stride:
+
+| Frame / surface | Bytes |
+| --- | ---: |
+| One 658 x 658 RGB565 base frame | 865,928 |
+| Two base frames (front + worker back) | 1,731,856 |
+| 466 x 466 RGB565+A8 live foreground | 1,298,892 |
+| Persistent surface total | 3,030,748 (2.89 MiB) |
+
+These are static sizes from the implementation based on `origin/main`
+`66692af1`. Free PSRAM, largest-contiguous PSRAM, map-block cache, temporary
+building workspace, and SD latency remain runtime concerns. No battery claim is
+derived from these sizes.
+
+## Rendering ownership and cadence
+
+The LVGL task owns visible objects, the front RGB565 frame, the live route
+foreground, and the arrow. A low-priority worker owns map-block IO, geometry,
+building admission, and raw RGB565 rasterization into the hidden frame. It never
+calls LVGL. A completed frame is published by a short UI-side pointer swap.
+
+Each request carries a monotonic sequence plus route, navigation, style, map,
+and projection epochs. GPS movement requests are coalesced: an active render
+may finish and publish when those frame semantics still match, even if newer
+position sequences exist. This prevents a long 3D render from being cancelled
+continuously by the 750 ms intake cadence. Route replacement, style, map-root,
+projection, and screen invalidations cancel at the next cooperative checkpoint.
+
+The visible frame is translated and rotated every UI tick using one
+`PresentedPose`. The live route head, route line, and arrow use the same pivot,
+anchor, and rotation delta. Dead reckoning is finite (1.5 seconds and 30 metres
+by default) and converges to each new phone fix.
+
+## 3D-building admission
+
+FMB v4 records are considered across all loaded in-view blocks and selected by
+stable rider-distance and block/record identity. The default 8 MiB quotas are:
+
+| Resource | Total | Extruded |
+| --- | ---: | ---: |
+| Records | 96 | 32 |
+| Source points | 8,192 | 3,072 |
+| Projected pixels | 220,000 | 90,000 |
+
+Nearest records retain 3D; farther admitted records render flat roofs; records
+outside the quota are deferred. Courtyard snapshots are clipped to the raw
+surface and capped at 180,000 pixels. A genuine allocation failure retries with
+a smaller deterministic flat-footprint set. A timing checkpoint or GPS update
+does not turn a healthy frame into a flat fallback.
+
+The guidance-screen flag is deliberately separate from route/maneuver
+availability. Bird's-eye and configured 3D buildings therefore remain active on
+the Map + Navigation screen before a route starts.
+
+## Validation boundary
+
+The focused host contracts cover worker ownership, semantic invalidation,
+position-only coalescing, shared presentation transforms, heading fallback and
+epoch reset, deterministic building admission, courtyard workspace limits, and
+legacy protocol behavior. The required physical gate is an exact
+`WAVESHARE_AMOLED_175` build followed by device navigation with an FMB v4 pack in
+idle guidance, test navigation, and real navigation. Record UI maximum gap,
+display flush interval, render diagnostics, building counts, and free/largest
+PSRAM. Until that run is completed, this document does not claim runtime
+success.

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -56,6 +56,10 @@ use the same pivot, anchor, and rotation delta. Pose/frame/route/style
 signatures make stable ticks no-ops: they do not invalidate the base image or
 clear and redraw the full foreground alpha plane. Dead reckoning is finite
 (1.5 seconds and 30 metres by default) and converges to each new phone fix.
+The overscanned base canvas remains LVGL center-aligned; its position is an
+offset from the resolved centered origin. Presentation converts the desired
+parent-space pivot target to that aligned offset exactly once, so the 96-pixel
+overscan crop cannot become a heading-relative base/route displacement.
 
 ## 3D-building admission
 

--- a/docs/fmb-v4.md
+++ b/docs/fmb-v4.md
@@ -105,3 +105,25 @@ Renderer format 3 consists of FMB v4 blocks plus exactly one matching FMA1
 street-label asset and building profile version 1. Bike Map Stream remains at
 format v1. New firmware reads FMB v1 through v4; firmware without CAP2 feature
 bit 12 must never receive renderer target 3.
+
+
+## Runtime admission and presentation contract
+
+FMB v4 defines geometry, not traversal priority. Firmware must consider records
+from all loaded in-view blocks and choose a deterministic globally nearest set;
+cache or block iteration order must not decide which buildings become 3D.
+Fixed record, point, projected-pixel, courtyard-workspace, and PSRAM quotas are
+applied after spatial ordering. Nearest eligible records may be extruded and
+farther admitted records are drawn as dedicated flat FMB v4 footprints.
+Records beyond those quotas are explicitly deferred; they are not assumed to
+exist in the generic polygon stream. During a genuine allocation failure or
+its scoped cooldown, firmware renders a smaller deterministic nearest set as
+flat footprints without the normal candidate/sort workspace.
+
+Building IO, discovery, sorting, courtyard capture, and surface rasterization
+run only in a private render job. The worker writes a hidden raw RGB565 surface
+and never calls LVGL. Position-only requests are coalesced while semantic
+invalidations cancel at cooperative checkpoints; this keeps the last complete
+frame moving without making an otherwise healthy frame globally 2D. Allocation,
+corruption, and invariant failures are the only reasons to enter the documented
+flat fallback/cooldown path.

--- a/docs/plans/geofabrik-osm-3d-buildings-implementation-plan.md
+++ b/docs/plans/geofabrik-osm-3d-buildings-implementation-plan.md
@@ -777,6 +777,16 @@ Exact filenames may follow the baseline module boundaries, but the separation of
 
 ### Firmware renderer
 
+The runtime renderer now uses render-ahead ownership rather than executing a
+monolithic building pass from an LVGL event. The UI presents the last complete
+base frame and foreground route from one `PresentedPose`; a low-priority worker
+renders a versioned hidden RGB565 frame, coalescing position-only requests while
+cancelling semantic invalidations and rejecting stale publications. Building
+candidates are retained globally nearest across all loaded blocks before fixed
+base/extrusion quotas are applied.
+Physical validation of this scheduler remains separate from the earlier FMB v4
+format implementation and must not be inferred from host tests or a build.
+
 - renderer-format-1/2 activation regression, renderer-format-3 activation, and FMB v4 flat-mode rendering;
 - zero-height projection equality with the baseline;
 - physical-height projection at representative latitudes;

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -96,6 +96,7 @@ static bool bleSessionAuthenticated = false;
 static bool bleSessionUsesIndependentMapProfiles = false;
 static bool bleSessionSupportsStreetLabels = false;
 static bool bleSessionSupports3DBuildings = false;
+static std::atomic<bool> bleSessionSupportsExplicitInvalidGpsHeading{false};
 static constexpr uint8_t CAPABILITY_EXTENDED_MAP_VISIBILITY =
     map_profile_protocol::EXTENDED_VISIBILITY_CAPABILITY_MASK;
 static constexpr uint8_t CAPABILITY_BATTERY_STATUS_SCREEN = 1 << 5;
@@ -862,6 +863,8 @@ static bool unwrapOwnerAuthenticatedPayload(
   xSemaphoreGive(deviceOwnershipMutex);
   if (authenticationStateDiverged) {
     bleSessionAuthenticated = false;
+    bleSessionSupportsExplicitInvalidGpsHeading.store(false,
+                                                      std::memory_order_release);
     bleDebugStats.authenticated = false;
     ownershipDisconnectPending = true;
     Serial.println("BLE: Ownership session was lost; disconnect requested");
@@ -1104,6 +1107,8 @@ static void handleAuthPayload(const std::string &frame) {
     }
     if (bleSessionAuthenticated && !ownershipSessionAuthenticated) {
       bleSessionAuthenticated = false;
+      bleSessionSupportsExplicitInvalidGpsHeading.store(
+          false, std::memory_order_release);
       bleDebugStats.authenticated = false;
       ownershipDisconnectPending = true;
       Serial.println("BLE: Ownership command invalidated session; disconnect requested");
@@ -1135,6 +1140,8 @@ static void handleAuthPayload(const std::string &frame) {
         break;
       case device_ownership::Event::Unpaired:
         bleSessionAuthenticated = false;
+        bleSessionSupportsExplicitInvalidGpsHeading.store(
+            false, std::memory_order_release);
         bleDebugStats.authenticated = false;
         ownershipAdvertisingDirty = true;
         queueOwnershipUiUpdate();
@@ -1192,6 +1199,8 @@ static void handleAuthPayload(const std::string &frame) {
     bleSessionUsesIndependentMapProfiles = false;
     bleSessionSupportsStreetLabels = false;
     bleSessionSupports3DBuildings = false;
+    bleSessionSupportsExplicitInvalidGpsHeading.store(false,
+                                                      std::memory_order_release);
     phoneBatteryLevelPercent = -1;
     phoneBatteryCharging = false;
     snprintf(message, sizeof(message), "server|%s", nonce);
@@ -1746,7 +1755,8 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
         device_capabilities_protocol::BIRDS_EYE_MAP_NAVIGATION_FEATURE |
         device_capabilities_protocol::BIRDS_EYE_PERSPECTIVE_FEATURE |
         device_capabilities_protocol::BIRDS_EYE_STRONGER_PERSPECTIVE_FEATURE |
-        device_capabilities_protocol::OSM_3D_BUILDINGS_FEATURE;
+        device_capabilities_protocol::OSM_3D_BUILDINGS_FEATURE |
+        device_capabilities_protocol::EXPLICIT_INVALID_GPS_HEADING_FEATURE;
     responseSize = device_capabilities_protocol::encodeCap2(
         featureFlags, powerPayload,
         includePowerButtonConfig && powerButtonHonkAvailable, response,
@@ -1815,6 +1825,10 @@ static bool handleDeviceCapabilitiesCommand(const std::string &value,
     bleSessionSupportsStreetLabels =
         clientVersion >= device_capabilities_protocol::CAP2_CLIENT_VERSION;
     bleSessionSupports3DBuildings = bleSessionSupportsStreetLabels;
+    bleSessionSupportsExplicitInvalidGpsHeading.store(
+        clientVersion >=
+            device_capabilities_protocol::EXPLICIT_INVALID_GPS_HEADING_CLIENT_VERSION,
+        std::memory_order_release);
     notifyDeviceCapabilities(pChar, includePowerButtonConfig, clientVersion);
   }
   return true;
@@ -2119,8 +2133,16 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
         "BLE route geometry: seeded map start; transitioning to map");
   }
 
+  const bool hadRoute = routeOverlay.hasRoute();
   routeOverlay.parseRouteData(data, len);
-  requestMapRender(map_render_policy::Reason::Route);
+  // Route geometry is a live foreground input, not part of the expensive base
+  // frame. Only a transition into or out of usable route geometry forces a
+  // base request; ordinary sliding-window replacement is picked up on the next
+  // UI tick and must not cancel a long 3D render. The reverse transition also
+  // covers a short/malformed replacement without leaving stale course-up
+  // semantics behind.
+  if (hadRoute != routeOverlay.hasRoute())
+    requestMapRender(map_render_policy::Reason::Route);
 }
 
 static void handleGpsPayload(const uint8_t *data, size_t len,
@@ -2710,6 +2732,8 @@ public:
     bleSessionUsesIndependentMapProfiles = false;
     bleSessionSupportsStreetLabels = false;
     bleSessionSupports3DBuildings = false;
+    bleSessionSupportsExplicitInvalidGpsHeading.store(false,
+                                                      std::memory_order_release);
     phoneBatteryLevelPercent = -1;
     phoneBatteryCharging = false;
     unauthTimeoutDisconnectRequested = false;
@@ -2768,6 +2792,8 @@ public:
     bleSessionUsesIndependentMapProfiles = false;
     bleSessionSupportsStreetLabels = false;
     bleSessionSupports3DBuildings = false;
+    bleSessionSupportsExplicitInvalidGpsHeading.store(false,
+                                                      std::memory_order_release);
     phoneBatteryLevelPercent = -1;
     phoneBatteryCharging = false;
     unauthTimeoutDisconnectRequested = false;
@@ -3479,6 +3505,11 @@ BLEDebugStats BLENavigationServer::getDebugStats() const {
   return stats;
 }
 
+bool BLENavigationServer::supportsExplicitInvalidGpsHeading() const {
+  return bleSessionSupportsExplicitInvalidGpsHeading.load(
+      std::memory_order_acquire);
+}
+
 bool BLENavigationServer::forgetOwner() {
   bool cleared = false;
   if (deviceOwnershipReady && deviceOwnershipMutex != nullptr &&
@@ -3490,6 +3521,8 @@ bool BLENavigationServer::forgetOwner() {
     return false;
   }
   bleSessionAuthenticated = false;
+  bleSessionSupportsExplicitInvalidGpsHeading.store(false,
+                                                    std::memory_order_release);
   bleDebugStats.authenticated = false;
   ownershipAdvertisingDirty = true;
   queueOwnershipUiUpdate();

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -264,6 +264,11 @@ public:
 
   BLEDebugStats getDebugStats() const;
 
+  /** True after this connection negotiated the explicit invalid-heading wire
+   * sentinel. Older clients use route-first guidance because their zero value
+   * is ambiguous between north and a missing Core Location course. */
+  bool supportsExplicitInvalidGpsHeading() const;
+
 private:
   bool initialized = false;
   bool connected = false;

--- a/esp32/lib/ble_navigation/device_capabilities_protocol.hpp
+++ b/esp32/lib/ble_navigation/device_capabilities_protocol.hpp
@@ -6,12 +6,14 @@
 namespace device_capabilities_protocol {
 
 constexpr uint8_t CAP2_CLIENT_VERSION = 10;
+constexpr uint8_t EXPLICIT_INVALID_GPS_HEADING_CLIENT_VERSION = 11;
 constexpr uint8_t CAP2_SCHEMA_VERSION = 1;
 constexpr uint32_t STREET_LABELS_FEATURE = 1UL << 8;
 constexpr uint32_t BIRDS_EYE_MAP_NAVIGATION_FEATURE = 1UL << 9;
 constexpr uint32_t BIRDS_EYE_PERSPECTIVE_FEATURE = 1UL << 10;
 constexpr uint32_t BIRDS_EYE_STRONGER_PERSPECTIVE_FEATURE = 1UL << 11;
 constexpr uint32_t OSM_3D_BUILDINGS_FEATURE = 1UL << 12;
+constexpr uint32_t EXPLICIT_INVALID_GPS_HEADING_FEATURE = 1UL << 13;
 constexpr uint8_t POWER_BUTTON_CONFIG_TLV = 1;
 constexpr size_t POWER_BUTTON_CONFIG_BYTES = 3;
 constexpr size_t CAP2_BASE_BYTES = 9;

--- a/esp32/lib/ble_navigation/gps_position_protocol.hpp
+++ b/esp32/lib/ble_navigation/gps_position_protocol.hpp
@@ -47,8 +47,9 @@ inline bool decode(const uint8_t *bytes, std::size_t length, Packet &packet) {
   decoded.longitudeMicrodegrees =
       static_cast<int32_t>(readUInt32LE(bytes, 4));
   if (length >= 10) {
-    decoded.hasHeading = true;
-    decoded.headingDegrees = readUInt16LE(bytes, 8);
+    const uint16_t heading = readUInt16LE(bytes, 8);
+    decoded.hasHeading = heading < 360U;
+    decoded.headingDegrees = decoded.hasHeading ? heading : 0U;
   }
   if (length >= 14) {
     decoded.hasUnixTime = true;
@@ -103,6 +104,7 @@ inline bool decodeAndApply(const uint8_t *bytes, std::size_t length,
   rideData.routeRemaining = 0;
   rideData.hasRouteRemaining = false;
 
+  rideData.headingValid = packet.hasHeading;
   if (packet.hasHeading) {
     rideData.heading = packet.headingDegrees;
   }

--- a/esp32/lib/gps/gps.cpp
+++ b/esp32/lib/gps/gps.cpp
@@ -167,9 +167,11 @@ void Gps::getGPSData()
     gpsData.longitude = getLon();
   }
 
-  // Heading
-  if (fix.valid.heading)
-    gpsData.heading = (uint16_t)fix.heading();
+  // Heading validity is explicit. A missing/invalid course must never be
+  // interpreted as zero/north by navigation presentation.
+  gpsData.headingValid = fix.valid.heading;
+  if (gpsData.headingValid)
+    gpsData.heading = static_cast<uint16_t>(fix.heading()) % 360U;
 
   // HDOP , PDOP , VDOP
 #ifdef GPS_FIX_HDOP

--- a/esp32/lib/gps/gps.hpp
+++ b/esp32/lib/gps/gps.hpp
@@ -81,6 +81,7 @@ public:
     double latitude;
     double longitude;
     uint16_t heading;
+    bool headingValid;
     float hdop;
     float pdop;
     float vdop;
@@ -88,7 +89,7 @@ public:
     char sunriseHour[6];
     char sunsetHour[6];
     int UTC;
-  } gpsData;
+  } gpsData{};
 
   struct SV {
     bool active;

--- a/esp32/lib/gui/src/guiLayout.hpp
+++ b/esp32/lib/gui/src/guiLayout.hpp
@@ -58,6 +58,20 @@ inline int16_t centeredViewportOrigin(uint16_t containerExtent,
   return (static_cast<int32_t>(containerExtent) - viewportExtent) / 2;
 }
 
+/**
+ * Return the LVGL x/y style offset that places a point inside a center-aligned
+ * object at a target coordinate in its parent. LVGL keeps the object's CENTER
+ * alignment after lv_obj_center(), so lv_obj_set_pos() is relative to the
+ * resolved centered origin rather than an absolute top-left coordinate.
+ */
+inline int32_t centerAlignedOffsetForPoint(uint16_t containerExtent,
+                                           uint16_t objectExtent,
+                                           int32_t objectPoint,
+                                           int32_t targetPoint) {
+  return targetPoint - objectPoint -
+         centeredViewportOrigin(containerExtent, objectExtent);
+}
+
 inline int16_t mapScreenAnchorX(uint16_t containerWidth,
                                 uint16_t mapWidth) {
   return centeredViewportOrigin(containerWidth, mapWidth) +

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -1071,6 +1071,7 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
   const bool framePublished = mapView.serviceRenderPipeline(nowMs);
   mapView.updatePositionOverlay();
   if (framePublished) {
+    mapTileTransition.noteFramePublished();
     (void)mapView.takeFramePublication();
     mapRenderScheduler.markRendered(nowMs, currentMapFix());
     revealPendingMapTileIfReady();
@@ -1824,7 +1825,6 @@ static void showMainTile(tileName tile) {
     return;
   }
 
-  const bool mapWasVisible = !lv_obj_has_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
 
   activeTile = tile;
@@ -1833,14 +1833,12 @@ static void showMainTile(tileName tile) {
     mapView.cancelDragPreview();
   }
   if (isMapBackedTile(activeTile)) {
-    // Keep the currently visible non-map tile in front until the new map
-    // profile has rendered into the back buffer. Revealing mapTile first can
-    // briefly expose its previous full-map frame while Map + Navigation is
-    // still rendering (or while the screen-cycle button remains pressed and
-    // interrupts that first render).
-    if (!mapWasVisible) {
-      lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
-    }
+    // Map and Map + Navigation share one front canvas but have different
+    // style/projection semantics. Conceal that canvas for every map-backed
+    // transition, including MAP <-> MAP_GUIDANCE, until the worker publishes
+    // a frame built for the destination profile. Otherwise the source
+    // profile remains visible briefly while the replacement renders.
+    lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
     mapTileTransition.begin();
     zoom = currentMapStyleSettings().zoomLevel;
     requestMapRender(map_render_policy::Reason::Screen);
@@ -1972,6 +1970,8 @@ void toggleNavigationScreen() {
  */
 void createMainScr() {
   mainScreen = lv_obj_create(NULL);
+  lv_obj_set_style_bg_color(mainScreen, lv_color_black(), 0);
+  lv_obj_set_style_bg_opa(mainScreen, LV_OPA_COVER, 0);
 
 #if defined(WAVESHARE_AMOLED_175)
   // The CST9217's second contact belongs exclusively to the standalone Map.

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -552,15 +552,29 @@ static int16_t mapInteractionAnchorY() {
 }
 
 static bool currentCourseUpHeading(uint16_t &headingDegrees) {
-  // A measured course is authoritative. Core Location test navigation often
-  // reports an invalid/negative course; the BLE sentinel preserves that
-  // invalidity instead of silently converting it to north.
+  uint16_t routeHeading = 0;
+  const bool routeHeadingValid = routeOverlay.headingNear(
+      gps.gpsData.latitude, gps.gpsData.longitude, routeHeading);
+
+  // Client protocol versions before explicit-invalid-heading support encoded
+  // an unavailable Core Location course as 0 degrees. Prefer the route for
+  // those sessions so both normal and test navigation cannot be pinned north
+  // by an ambiguous legacy value. New clients preserve invalidity with the BLE
+  // sentinel, so a real measured course remains authoritative.
+  if (!bleNavServer.supportsExplicitInvalidGpsHeading() &&
+      routeHeadingValid) {
+    headingDegrees = routeHeading;
+    return true;
+  }
   if (gps.gpsData.headingValid) {
     headingDegrees = gps.gpsData.heading % 360U;
     return true;
   }
-  return routeOverlay.headingNear(gps.gpsData.latitude,
-                                  gps.gpsData.longitude, headingDegrees);
+  if (routeHeadingValid) {
+    headingDegrees = routeHeading;
+    return true;
+  }
+  return false;
 }
 
 static bool isMapBackedTile(uint8_t tile) {
@@ -1077,7 +1091,15 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
       updateMapGuidanceOverlay();
   }
 
-  if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
+  // A route window can change the resolved course even when the phone has not
+  // sent a new GPS fix. Feed that observation through the normal 12-degree
+  // policy instead of forcing every sliding route packet to cancel/rebuild the
+  // base frame.
+  const bool gpsChanged =
+      uiChangeTracker.take(ui_update_policy::Source::Gps);
+  const bool routeChanged =
+      uiChangeTracker.take(ui_update_policy::Source::Route);
+  if (gpsChanged || routeChanged) {
     mapRenderScheduler.observe(currentMapFix());
   }
 
@@ -1206,10 +1228,10 @@ void updateMainScreen(lv_timer_t *t) {
     }
   }
 
-  // Route and settings handlers already set the concrete map redraw flags or
-  // apply screen settings. Consuming their signatures prevents stale work from
-  // being mistaken for a later visible-widget change.
-  (void)uiChangeTracker.take(ui_update_policy::Source::Route);
+  // Settings handlers already apply the concrete map redraw flags. Consuming
+  // the signature prevents stale work from being mistaken for a later visible
+  // widget change. Route changes are consumed by prepareVisibleMapUpdate so a
+  // material course change can pass through the normal render policy.
   (void)uiChangeTracker.take(ui_update_policy::Source::Settings);
 
   // Keep maneuver/foreground presentation ahead of render-job submission

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -170,6 +170,7 @@ uint64_t gpsSignature() {
   hashScalar(hash, gps.gpsData.latitude);
   hashScalar(hash, gps.gpsData.longitude);
   hashScalar(hash, gps.gpsData.heading);
+  hashScalar(hash, gps.gpsData.headingValid);
   hashScalar(hash, gps.gpsData.hdop);
   hashScalar(hash, gps.gpsData.pdop);
   hashScalar(hash, gps.gpsData.vdop);
@@ -324,11 +325,13 @@ void setImageAngleIfChanged(lv_obj_t *image, int16_t angle) {
 
 Maps mapView;
 static map_tap_arbiter::Controller mapTapController;
-static uint16_t currentCourseUpHeading();
+static bool currentCourseUpHeading(uint16_t &headingDegrees);
 
 static map_render_policy::Fix currentMapFix() {
-  return {gps.gpsData.latitude, gps.gpsData.longitude,
-          currentCourseUpHeading()};
+  uint16_t headingDegrees = 0;
+  const bool headingValid = currentCourseUpHeading(headingDegrees);
+  return {gps.gpsData.latitude, gps.gpsData.longitude, headingDegrees,
+          headingValid};
 }
 
 static void noteMapRenderReasons(uint32_t reasons) {
@@ -548,13 +551,16 @@ static int16_t mapInteractionAnchorY() {
   return gui_layout::mapScreenAnchorY(TFT_HEIGHT, mapHeight);
 }
 
-static uint16_t currentCourseUpHeading() {
-  uint16_t routeHeading = 0;
-  if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
-                               routeHeading)) {
-    return routeHeading;
+static bool currentCourseUpHeading(uint16_t &headingDegrees) {
+  // A measured course is authoritative. Core Location test navigation often
+  // reports an invalid/negative course; the BLE sentinel preserves that
+  // invalidity instead of silently converting it to north.
+  if (gps.gpsData.headingValid) {
+    headingDegrees = gps.gpsData.heading % 360U;
+    return true;
   }
-  return gps.gpsData.heading;
+  return routeOverlay.headingNear(gps.gpsData.latitude,
+                                  gps.gpsData.longitude, headingDegrees);
 }
 
 static bool isMapBackedTile(uint8_t tile) {
@@ -656,7 +662,9 @@ static tileName nextEnabledTile(tileName current) {
   return configuredDefaultTile();
 }
 
-static bool isGuidanceNavigating() { return routeOverlay.hasRoute(); }
+static bool isGuidanceNavigating() {
+  return routeOverlay.hasRoute() || hasCurrentNavigationData();
+}
 
 static int16_t navigationArrowAngle(uint8_t iconID) {
   switch (iconID) {
@@ -1043,22 +1051,33 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
 #endif
   applyMapRotationForActiveTile();
 
+  // Publication, pose interpolation, front-frame translation, live route, and
+  // marker work are all bounded LVGL-owner operations and run at display
+  // cadence even while the render worker is busy.
+  const bool framePublished = mapView.serviceRenderPipeline(nowMs);
+  mapView.updatePositionOverlay();
+  if (framePublished) {
+    (void)mapView.takeFramePublication();
+    mapRenderScheduler.markRendered(nowMs, currentMapFix());
+    revealPendingMapTileIfReady();
+  }
+  if (mapView.takeRenderFailure()) {
+    mapRenderScheduler.markInterrupted();
+    noteMapRenderReasons(mapRenderScheduler.pendingForcedReasons());
+    mapView.isPosMoved = true;
+    mapView.redrawMap = true;
+  }
+
   bool navigationOverlayChanged = false;
   if (activeTile == MAP_GUIDANCE) {
     mapView.followGps = true;
     navigationOverlayChanged =
         uiChangeTracker.take(ui_update_policy::Source::Navigation);
-    if (navigationOverlayChanged) {
-      // Apply the maneuver model before considering synchronous base-map work.
-      // The caller gives LVGL one cycle to present this overlay first.
+    if (navigationOverlayChanged)
       updateMapGuidanceOverlay();
-    }
   }
 
   if (uiChangeTracker.take(ui_update_policy::Source::Gps)) {
-    // Keep the lightweight marker current for every accepted fix. The vector
-    // background has a separate, bounded regeneration policy.
-    mapView.updatePositionOverlay();
     mapRenderScheduler.observe(currentMapFix());
   }
 
@@ -1078,7 +1097,7 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
         mapView.isPosMoved = true;
       }
       mapView.redrawMap = true;
-      log_i("Map scheduler: render reasons=0x%02lx distance=%.1fm "
+      log_i("Map scheduler: request reasons=0x%02lx distance=%.1fm "
             "heading=%u",
             static_cast<unsigned long>(decision.reasons),
             decision.distanceMeters,
@@ -1097,13 +1116,6 @@ void updateMainScreen(lv_timer_t *t) {
   (void)t;
   processMapPinchZoom();
   processDeferredMapTap();
-
-  // The Map + Navigation renderer can take long enough to mask a complete
-  // button press or touch. Let the input timer run before starting more map
-  // work whenever either physical input is already active.
-  if (shouldInterruptMapRenderForScreenCycle()) {
-    return;
-  }
 
   // The 30 ms timer remains the input path for touch responsiveness, but
   // source acquisition is unnecessary while another screen is active.
@@ -1200,9 +1212,9 @@ void updateMainScreen(lv_timer_t *t) {
   (void)uiChangeTracker.take(ui_update_policy::Source::Route);
   (void)uiChangeTracker.take(ui_update_policy::Source::Settings);
 
-  // Synchronous vector-map generation can be long. When a new maneuver and a
-  // base-map request arrive together, return to LVGL once so the lightweight
-  // overlay can be presented before the expensive background regeneration.
+  // Keep maneuver/foreground presentation ahead of render-job submission
+  // when both arrive in one cycle. Submission itself is bounded; all storage,
+  // parsing, and raster work belongs to the low-priority worker.
   if (!navigationOverlayChanged && isMapBackedTile(activeTile) &&
       mapView.hasMapCanvas() &&
       (mapView.isPosMoved || mapView.redrawMap)) {
@@ -1255,44 +1267,37 @@ void gestureEvent(lv_event_t *event) {
  * @param event
  */
 void updateMap(lv_event_t *event) {
+  (void)event;
   if (mapPinchBlocksMapRender() || isScrollingMap ||
       mapView.dragPreviewBlocksMapRender(millis())) {
     return;
   }
 
-  // Only regenerate map if position changed to avoid blocking the main loop
   if (mapView.isPosMoved) {
-    bool renderCompleted = true;
     if (mapSet.vectorMap) {
-      renderCompleted = mapView.generateVectorMap(zoom);
+      const uint32_t submittedAtMs = millis();
+      if (!mapView.generateVectorMap(zoom)) {
+        // No UI work was blocked and the last complete frame remains visible.
+        // A missing course-up heading is intentionally deferred until either
+        // measured course or route geometry becomes valid.
+        return;
+      }
+      mapView.isPosMoved = false;
+      mapRenderScheduler.markSubmitted(submittedAtMs, currentMapFix());
     } else {
       power_metrics::MapRenderMeasurement powerMeasurement;
       mapView.generateRenderMap(zoom);
       powerMeasurement.finish(true);
+      mapView.isPosMoved = false;
+      mapRenderScheduler.markRendered(millis(), currentMapFix());
     }
-    if (!renderCompleted) {
-      // Keep both flags set so the map is regenerated cleanly if the user
-      // remains on this screen. Do not display the partially rendered canvas.
-      mapView.redrawMap = true;
-      mapRenderScheduler.markInterrupted();
-      noteMapRenderReasons(mapRenderScheduler.pendingForcedReasons());
-      return;
-    }
-    // Clear flag AFTER generation complete (not inside generateVectorMap)
-    // This ensures BLE updates during generation will queue another cycle
-    mapView.isPosMoved = false;
-    mapRenderScheduler.markRendered(millis(), currentMapFix());
-    if (mapView.takeDeferredVectorRedraw()) {
-      // Course-up heading changed while a pinch was in flight. First present
-      // the focal-stable settlement frame, then render the latest heading on
-      // the following LVGL cycle.
+    if (mapView.takeDeferredVectorRedraw())
       requestMapRender(map_render_policy::Reason::Heading);
-    }
   }
 
   if (mapView.redrawMap) {
     mapView.displayMap();
-    mapView.redrawMap = false; // Clear after display
+    mapView.redrawMap = false;
   }
 
   revealPendingMapTileIfReady();
@@ -1874,7 +1879,8 @@ static void showMainTile(tileName tile) {
 }
 
 static void revealPendingMapTileIfReady() {
-  if (!mapTileTransition.canReveal(mapView.isPosMoved, mapView.redrawMap)) {
+  if (!mapView.hasPublishedMapFrame() ||
+      !mapTileTransition.canReveal(mapView.isPosMoved, mapView.redrawMap)) {
     return;
   }
 

--- a/esp32/lib/gui/src/mapRenderPolicy.hpp
+++ b/esp32/lib/gui/src/mapRenderPolicy.hpp
@@ -28,6 +28,7 @@ struct Fix {
   double latitude = 0.0;
   double longitude = 0.0;
   uint16_t headingDegrees = 0;
+  bool headingValid = false;
 };
 
 struct Decision {
@@ -80,33 +81,35 @@ public:
     Decision decision;
     decision.reasons = pendingForcedReasons_;
 
-    if (!hasRenderedFix_) {
-      if (hasObservation_) {
+    const bool hasBaseline = hasSubmittedFix_ || hasRenderedFix_;
+    const Fix &baseline = hasSubmittedFix_ ? submittedFix_ : renderedFix_;
+    if (!hasBaseline) {
+      if (hasObservation_)
         decision.reasons |= reasonMask(Reason::Position);
-      }
       decision.render = decision.reasons != 0;
       return decision;
     }
 
     if (hasObservation_) {
       decision.distanceMeters =
-          map_render_policy::distanceMeters(renderedFix_, observedFix_);
-      decision.headingDeltaDegrees = map_render_policy::headingDelta(
-          renderedFix_.headingDegrees, observedFix_.headingDegrees);
+          map_render_policy::distanceMeters(baseline, observedFix_);
+      if (baseline.headingValid && observedFix_.headingValid) {
+        decision.headingDeltaDegrees = map_render_policy::headingDelta(
+            baseline.headingDegrees, observedFix_.headingDegrees);
+      }
     }
 
     if (decision.reasons != 0) {
       decision.render = true;
       return decision;
     }
-
-    if (!hasObservation_) {
+    if (!hasObservation_)
       return decision;
-    }
 
     const bool moved =
         allowPosition && decision.distanceMeters >= kMovementThresholdMeters;
-    const bool turned = courseUp &&
+    const bool turned = courseUp && baseline.headingValid &&
+                        observedFix_.headingValid &&
                         decision.headingDeltaDegrees >=
                             kHeadingThresholdDegrees;
     if (!moved && !turned) {
@@ -114,38 +117,57 @@ public:
       return decision;
     }
 
-    if (static_cast<uint32_t>(nowMs - lastRenderMs_) <
+    if (static_cast<uint32_t>(nowMs - lastSubmissionMs_) <
         kMinimumRenderIntervalMs) {
       decision.deferredByCadence = true;
       return decision;
     }
 
-    if (moved) {
+    if (moved)
       decision.reasons |= reasonMask(Reason::Position);
-    }
-    if (turned) {
+    if (turned)
       decision.reasons |= reasonMask(Reason::Heading);
-    }
     decision.render = true;
     return decision;
   }
 
   void commit(const Decision &decision) {
-    if (decision.render) {
+    if (decision.render)
       pendingForcedReasons_ |= decision.reasons;
-    }
+  }
+
+  /**
+   * Advance the request baseline as soon as a render job is accepted. This
+   * prevents the 30 ms LVGL cadence from resubmitting an identical job while
+   * the worker is still rendering, without pretending that a frame has been
+   * published.
+   */
+  void markSubmitted(uint32_t nowMs, const Fix &submittedFix) {
+    submittedFix_ = submittedFix;
+    hasSubmittedFix_ = true;
+    observedFix_ = submittedFix;
+    hasObservation_ = false;
+    pendingForcedReasons_ = 0;
+    lastSubmissionMs_ = nowMs;
   }
 
   void markRendered(uint32_t nowMs, const Fix &renderedFix) {
     renderedFix_ = renderedFix;
+    submittedFix_ = renderedFix;
     observedFix_ = renderedFix;
     hasRenderedFix_ = true;
+    hasSubmittedFix_ = true;
     hasObservation_ = false;
     pendingForcedReasons_ = 0;
-    lastRenderMs_ = nowMs;
+    lastSubmissionMs_ = nowMs;
   }
 
-  void markInterrupted() { request(Reason::Recovery); }
+  void markInterrupted() {
+    // A failed job did not advance the visible frame. Rebase the retry on the
+    // last published frame and retain an explicit recovery reason.
+    hasSubmittedFix_ = false;
+    request(Reason::Recovery);
+  }
 
   void discardObservation() { hasObservation_ = false; }
 
@@ -157,11 +179,12 @@ public:
 
 private:
   Fix renderedFix_{};
+  Fix submittedFix_{};
   Fix observedFix_{};
-  uint32_t lastRenderMs_ = 0;
+  uint32_t lastSubmissionMs_ = 0;
   uint32_t pendingForcedReasons_ = 0;
   bool hasRenderedFix_ = false;
+  bool hasSubmittedFix_ = false;
   bool hasObservation_ = false;
 };
-
 } // namespace map_render_policy

--- a/esp32/lib/gui/src/mapTileTransition.hpp
+++ b/esp32/lib/gui/src/mapTileTransition.hpp
@@ -4,15 +4,29 @@ namespace map_tile_transition {
 
 struct State {
   bool pending = false;
+  bool replacementFramePublished = false;
 
-  constexpr void begin() { pending = true; }
-  constexpr void cancel() { pending = false; }
-
-  constexpr bool canReveal(bool positionMoved, bool redrawPending) const {
-    return pending && !positionMoved && !redrawPending;
+  constexpr void begin() {
+    pending = true;
+    replacementFramePublished = false;
   }
 
-  constexpr void complete() { pending = false; }
+  constexpr void noteFramePublished() {
+    if (pending)
+      replacementFramePublished = true;
+  }
+
+  constexpr void cancel() {
+    pending = false;
+    replacementFramePublished = false;
+  }
+
+  constexpr bool canReveal(bool positionMoved, bool redrawPending) const {
+    return pending && replacementFramePublished && !positionMoved &&
+           !redrawPending;
+  }
+
+  constexpr void complete() { cancel(); }
 };
 
 } // namespace map_tile_transition

--- a/esp32/lib/maps/src/mapBuildingAdmission.hpp
+++ b/esp32/lib/maps/src/mapBuildingAdmission.hpp
@@ -1,0 +1,154 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace map_building_admission {
+
+struct SpatialKey {
+  double distanceSquared = 0.0;
+  int32_t blockX = 0;
+  int32_t blockY = 0;
+  uint32_t recordIndex = 0;
+};
+
+inline bool nearer(const SpatialKey &left, const SpatialKey &right) {
+  if (left.distanceSquared != right.distanceSquared)
+    return left.distanceSquared < right.distanceSquared;
+  if (left.blockX != right.blockX)
+    return left.blockX < right.blockX;
+  if (left.blockY != right.blockY)
+    return left.blockY < right.blockY;
+  return left.recordIndex < right.recordIndex;
+}
+
+struct Quotas {
+  size_t maximumRecords = 96;
+  size_t maximumPoints = 8192;
+  uint64_t maximumProjectedPixels = 220000;
+  size_t maximumExtrudedRecords = 32;
+  size_t maximumExtrudedPoints = 3072;
+  uint64_t maximumExtrudedPixels = 90000;
+};
+
+struct Candidate {
+  SpatialKey key{};
+  size_t pointCount = 0;
+  uint64_t projectedPixels = 0;
+  bool extrusionEligible = false;
+  size_t sourceIndex = 0;
+};
+
+
+/**
+ * Retain the globally nearest candidates in bounded memory. The heap root is
+ * the farthest retained item, so discovery order and map-cache order cannot
+ * influence the final set.
+ */
+template <typename CandidateVector>
+inline void retainNearest(CandidateVector &retained,
+                          const Candidate &candidate, size_t maximumCandidates) {
+  if (maximumCandidates == 0)
+    return;
+  const auto heapCompare = [](const Candidate &left, const Candidate &right) {
+    return nearer(left.key, right.key);
+  };
+  if (retained.size() < maximumCandidates) {
+    retained.push_back(candidate);
+    std::push_heap(retained.begin(), retained.end(), heapCompare);
+    return;
+  }
+  if (!nearer(candidate.key, retained.front().key))
+    return;
+  std::pop_heap(retained.begin(), retained.end(), heapCompare);
+  retained.back() = candidate;
+  std::push_heap(retained.begin(), retained.end(), heapCompare);
+}
+
+struct Decision {
+  size_t sourceIndex = 0;
+  bool admitted = false;
+  bool extruded = false;
+};
+
+struct Diagnostics {
+  size_t candidates = 0;
+  size_t selected = 0;
+  size_t extruded = 0;
+  size_t flat = 0;
+  size_t deferred = 0;
+  size_t selectedPoints = 0;
+  uint64_t selectedPixels = 0;
+};
+
+/**
+ * Globally sort by rider distance and stable record identity before applying
+ * budgets.  The result is therefore invariant under map-block/cache iteration
+ * order.  Records that fit the 2D budget but miss the tighter extrusion budget
+ * remain admitted as deterministic flat roofs/footprints.
+ */
+template <typename CandidateVector>
+inline std::vector<Decision> select(CandidateVector candidates,
+                                    const Quotas &quotas,
+                                    Diagnostics *diagnostics = nullptr) {
+  std::stable_sort(candidates.begin(), candidates.end(),
+                   [](const Candidate &left, const Candidate &right) {
+                     return nearer(left.key, right.key);
+                   });
+
+  std::vector<Decision> decisions;
+  decisions.reserve(candidates.size());
+  size_t records = 0;
+  size_t points = 0;
+  uint64_t pixels = 0;
+  size_t extrudedRecords = 0;
+  size_t extrudedPoints = 0;
+  uint64_t extrudedPixels = 0;
+  Diagnostics local{};
+  local.candidates = candidates.size();
+
+  for (const Candidate &candidate : candidates) {
+    Decision decision{candidate.sourceIndex, false, false};
+    const bool fitsBase = records < quotas.maximumRecords &&
+                          candidate.pointCount <=
+                              quotas.maximumPoints - points &&
+                          candidate.projectedPixels <=
+                              quotas.maximumProjectedPixels - pixels;
+    if (fitsBase) {
+      decision.admitted = true;
+      records++;
+      points += candidate.pointCount;
+      pixels += candidate.projectedPixels;
+      const bool fitsExtrusion =
+          candidate.extrusionEligible &&
+          extrudedRecords < quotas.maximumExtrudedRecords &&
+          candidate.pointCount <=
+              quotas.maximumExtrudedPoints - extrudedPoints &&
+          candidate.projectedPixels <=
+              quotas.maximumExtrudedPixels - extrudedPixels;
+      if (fitsExtrusion) {
+        decision.extruded = true;
+        extrudedRecords++;
+        extrudedPoints += candidate.pointCount;
+        extrudedPixels += candidate.projectedPixels;
+        local.extruded++;
+      } else {
+        local.flat++;
+      }
+      local.selected++;
+    } else {
+      local.deferred++;
+    }
+    decisions.push_back(decision);
+  }
+  local.selectedPoints = points;
+  local.selectedPixels = pixels;
+  if (diagnostics != nullptr)
+    *diagnostics = local;
+  return decisions;
+}
+
+} // namespace map_building_admission

--- a/esp32/lib/maps/src/mapBuildingRenderer.hpp
+++ b/esp32/lib/maps/src/mapBuildingRenderer.hpp
@@ -25,7 +25,6 @@ constexpr size_t kMaximumRenderedBuildingPoints = 49152;
 constexpr size_t kMaximumRenderedBuildingPointsPerRecord = 1024;
 constexpr uint8_t kMaximumBuildingExtrusionZoom = 4;
 constexpr double kMinimumBuildingExtrusionAreaPixels = 6.0;
-constexpr uint32_t kMaximumBuildingRenderTimeMs = 10000;
 constexpr uint32_t kBuildingFailureRetryCooldownMs = 5U * 60U * 1000U;
 
 struct RenderRegion {
@@ -97,13 +96,6 @@ constexpr bool eligibleExtrusionZoom(uint8_t zoom) {
          zoom <= kMaximumBuildingExtrusionZoom;
 }
 
-constexpr bool shouldRetryWithoutBuildings(bool buildingsAlreadySuppressed,
-                                           bool allocationFailed,
-                                           bool deadlineAborted,
-                                           bool screenCycleInterrupted) {
-  return !buildingsAlreadySuppressed && !screenCycleInterrupted &&
-         (allocationFailed || deadlineAborted);
-}
 
 struct OrderKey {
   double depth = 0.0;

--- a/esp32/lib/maps/src/mapBuildingWorkspace.hpp
+++ b/esp32/lib/maps/src/mapBuildingWorkspace.hpp
@@ -9,6 +9,19 @@
 
 namespace map_building_workspace {
 
+enum class CourtyardPolicy : uint8_t {
+  PreserveUnderlay,
+  SolidRoofFallback,
+};
+
+inline CourtyardPolicy courtyardPolicy(size_t projectedPixels,
+                                       size_t maximumWorkspacePixels,
+                                       size_t surfacePixels) {
+  const size_t available = std::min(maximumWorkspacePixels, surfacePixels);
+  return projectedPixels <= available ? CourtyardPolicy::PreserveUnderlay
+                                      : CourtyardPolicy::SolidRoofFallback;
+}
+
 struct Region {
   int32_t x = 0;
   int32_t y = 0;

--- a/esp32/lib/maps/src/mapBuildingWorkspace.hpp
+++ b/esp32/lib/maps/src/mapBuildingWorkspace.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "mapSurface.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+
+namespace map_building_workspace {
+
+struct Region {
+  int32_t x = 0;
+  int32_t y = 0;
+  int32_t width = 0;
+  int32_t height = 0;
+
+  constexpr bool valid() const { return width > 0 && height > 0; }
+  constexpr size_t pixels() const {
+    return valid() ? static_cast<size_t>(width) * static_cast<size_t>(height)
+                   : 0U;
+  }
+};
+
+template <typename Points>
+Region clippedRegion(const Points &points, int32_t width, int32_t height) {
+  if (points.empty() || width <= 0 || height <= 0)
+    return {};
+  int32_t minX = points.front().x;
+  int32_t maxX = points.front().x;
+  int32_t minY = points.front().y;
+  int32_t maxY = points.front().y;
+  for (const auto &point : points) {
+    minX = std::min<int32_t>(minX, point.x);
+    maxX = std::max<int32_t>(maxX, point.x);
+    minY = std::min<int32_t>(minY, point.y);
+    maxY = std::max<int32_t>(maxY, point.y);
+  }
+  minX = std::max<int32_t>(0, minX);
+  minY = std::max<int32_t>(0, minY);
+  maxX = std::min<int32_t>(width - 1, maxX);
+  maxY = std::min<int32_t>(height - 1, maxY);
+  if (minX > maxX || minY > maxY)
+    return {};
+  return {minX, minY, maxX - minX + 1, maxY - minY + 1};
+}
+
+template <typename PixelVector>
+bool captureRegion(map_surface::Rgb565Surface surface, Region region,
+                   PixelVector &pixels, size_t maximumPixels) {
+  if (!surface.valid() || !region.valid() ||
+      region.x < 0 || region.y < 0 ||
+      region.x + region.width > surface.width ||
+      region.y + region.height > surface.height ||
+      region.pixels() > maximumPixels) {
+    return false;
+  }
+  pixels.resize(region.pixels());
+  for (int32_t row = 0; row < region.height; ++row) {
+    const uint16_t *source = surface.row(region.y + row) + region.x;
+    uint16_t *destination = pixels.data() +
+                            static_cast<size_t>(row) * region.width;
+    std::memcpy(destination, source,
+                static_cast<size_t>(region.width) * sizeof(uint16_t));
+  }
+  return true;
+}
+
+template <typename Points, typename PixelVector, typename NodeVector,
+          typename ShouldStop>
+bool restorePolygon(const Points &points, map_surface::Rgb565Surface surface,
+                    Region region, const PixelVector &underlay,
+                    NodeVector &nodes, ShouldStop shouldStop) {
+  if (points.size() < 3)
+    return true;
+  if (!surface.valid() || !region.valid() ||
+      underlay.size() < region.pixels()) {
+    return false;
+  }
+  if (nodes.size() < points.size())
+    nodes.resize(points.size());
+
+  const int32_t minY = region.y;
+  const int32_t maxY = region.y + region.height - 1;
+  for (int32_t y = minY; y <= maxY; ++y) {
+    if ((y & 0x0f) == 0 && shouldStop())
+      return false;
+    size_t count = 0;
+    for (size_t index = 0; index < points.size(); ++index) {
+      const auto &start = points[index];
+      const auto &end = points[(index + 1U) % points.size()];
+      if ((start.y < y && end.y >= y) ||
+          (start.y >= y && end.y < y)) {
+        nodes[count++] = static_cast<int32_t>(
+            start.x + static_cast<double>(y - start.y) /
+                          static_cast<double>(end.y - start.y) *
+                          static_cast<double>(end.x - start.x));
+      }
+    }
+    std::sort(nodes.begin(), nodes.begin() + count);
+    uint16_t *destination = surface.row(y);
+    const uint16_t *source =
+        underlay.data() + static_cast<size_t>(y - region.y) * region.width;
+    for (size_t index = 0; index + 1U < count; index += 2U) {
+      const int32_t startX =
+          std::max<int32_t>(region.x, std::max<int32_t>(0, nodes[index]));
+      const int32_t endX = std::min<int32_t>(
+          region.x + region.width,
+          std::min<int32_t>(surface.width, nodes[index + 1U]));
+      if (startX >= endX)
+        continue;
+      std::memcpy(destination + startX, source + (startX - region.x),
+                  static_cast<size_t>(endX - startX) * sizeof(uint16_t));
+    }
+  }
+  return true;
+}
+
+} // namespace map_building_workspace

--- a/esp32/lib/maps/src/mapPresentation.hpp
+++ b/esp32/lib/maps/src/mapPresentation.hpp
@@ -26,6 +26,15 @@ inline double signedHeadingDelta(double from, double to) {
   return delta;
 }
 
+/** Marker rotation in screen degrees. Map rotation is negative for course-up,
+ * so adding it to the world heading leaves the marker upright on a course-up
+ * map and points it along the course on a north-up map. */
+inline double markerRotationDegrees(double headingDegrees,
+                                    double displayedMapRotationRad) {
+  return normalizeDegrees(headingDegrees +
+                          displayedMapRotationRad * 180.0 / kPi);
+}
+
 struct WorldPoint {
   double x = 0.0;
   double y = 0.0;
@@ -52,6 +61,43 @@ inline ScreenPoint presentFramePoint(ScreenPoint projected,
   const double sine = std::sin(rotationDeltaRad);
   return {screenAnchor.x + cosine * dx - sine * dy,
           screenAnchor.y + sine * dx + cosine * dy};
+}
+
+/**
+ * Prove that the complete visible viewport inverse-transforms into a finished
+ * overscanned frame. This is checked immediately before publication because a
+ * rider can move or turn while the worker is rendering. Publishing a frame
+ * without this invariant would expose blank edges or spatially stale pixels.
+ */
+inline bool frameCoversViewport(double renderWidth, double renderHeight,
+                                double viewportWidth, double viewportHeight,
+                                ScreenPoint projectedPivot,
+                                ScreenPoint screenAnchor,
+                                double rotationDeltaRad,
+                                double safetyPixels) {
+  if (!(renderWidth > 0.0 && renderHeight > 0.0 && viewportWidth > 0.0 &&
+        viewportHeight > 0.0 && safetyPixels >= 0.0)) {
+    return false;
+  }
+  const double cosine = std::cos(rotationDeltaRad);
+  const double sine = std::sin(rotationDeltaRad);
+  const ScreenPoint corners[] = {{0.0, 0.0},
+                                 {viewportWidth, 0.0},
+                                 {viewportWidth, viewportHeight},
+                                 {0.0, viewportHeight}};
+  for (const ScreenPoint &corner : corners) {
+    const double dx = corner.x - screenAnchor.x;
+    const double dy = corner.y - screenAnchor.y;
+    // Inverse of presentFramePoint's rotation.
+    const double sourceX = projectedPivot.x + cosine * dx + sine * dy;
+    const double sourceY = projectedPivot.y - sine * dx + cosine * dy;
+    if (sourceX < safetyPixels || sourceY < safetyPixels ||
+        sourceX > renderWidth - safetyPixels ||
+        sourceY > renderHeight - safetyPixels) {
+      return false;
+    }
+  }
+  return true;
 }
 
 struct Fix {
@@ -94,13 +140,18 @@ public:
   }
 
   bool resolve(bool measuredValid, double measuredDegrees,
-               bool routeValid, double routeDegrees, double &resolved) {
+               bool routeValid, double routeDegrees, double &resolved,
+               bool preferRoute = false) {
     if (!active_) {
       valid_ = false;
       source_ = Source::None;
       return false;
     }
-    if (measuredValid && std::isfinite(measuredDegrees) &&
+    if (preferRoute && routeValid && std::isfinite(routeDegrees)) {
+      heading_ = normalizeDegrees(routeDegrees);
+      valid_ = true;
+      source_ = Source::Route;
+    } else if (measuredValid && std::isfinite(measuredDegrees) &&
         measuredDegrees >= 0.0) {
       heading_ = normalizeDegrees(measuredDegrees);
       valid_ = true;
@@ -154,6 +205,28 @@ public:
     current_ = {};
     previousPresented_ = {};
     convergenceStartMs_ = 0;
+  }
+
+  /** Start a new heading epoch without teleporting the presented position.
+   * Both sides of heading convergence are cleared so an invalid first fix in
+   * the new epoch cannot inherit the prior route's direction. */
+  void resetHeading(uint32_t nowMs) {
+    if (!hasFix_)
+      return;
+    // Freeze the exact pose that is currently on screen before removing its
+    // direction. Clearing current_.headingValid by itself would make
+    // present() fall back to the last raw GPS coordinate and visibly jump
+    // backwards by as much as the prediction horizon.
+    const PresentedPose frozen = present(nowMs);
+    current_.position = frozen.position;
+    current_.timestampMs = frozen.sourceTimestampMs;
+    current_.headingDegrees = 0.0;
+    current_.headingValid = false;
+    previousPresented_ = frozen;
+    previousPresented_.headingDegrees = 0.0;
+    previousPresented_.headingValid = false;
+    receivedAtMs_ = nowMs;
+    convergenceStartMs_ = nowMs;
   }
 
   void observe(const Fix &fix, uint32_t receivedAtMs) {

--- a/esp32/lib/maps/src/mapPresentation.hpp
+++ b/esp32/lib/maps/src/mapPresentation.hpp
@@ -1,0 +1,264 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+namespace map_presentation {
+
+constexpr double kPi = 3.14159265358979323846;
+
+inline double normalizeDegrees(double degrees) {
+  if (!std::isfinite(degrees))
+    return 0.0;
+  degrees = std::fmod(degrees, 360.0);
+  if (degrees < 0.0)
+    degrees += 360.0;
+  return degrees;
+}
+
+inline double signedHeadingDelta(double from, double to) {
+  double delta = normalizeDegrees(to) - normalizeDegrees(from);
+  if (delta > 180.0)
+    delta -= 360.0;
+  if (delta < -180.0)
+    delta += 360.0;
+  return delta;
+}
+
+struct WorldPoint {
+  double x = 0.0;
+  double y = 0.0;
+};
+
+struct ScreenPoint {
+  double x = 0.0;
+  double y = 0.0;
+};
+
+/**
+ * Apply the exact 2D transform used to present an older complete base frame:
+ * rotate around the projected rider point, then place that pivot at the live
+ * screen anchor. Route and marker geometry use this same function, so even a
+ * bird's-eye raster remains pixel-aligned while a replacement frame renders.
+ */
+inline ScreenPoint presentFramePoint(ScreenPoint projected,
+                                     ScreenPoint projectedPivot,
+                                     ScreenPoint screenAnchor,
+                                     double rotationDeltaRad) {
+  const double dx = projected.x - projectedPivot.x;
+  const double dy = projected.y - projectedPivot.y;
+  const double cosine = std::cos(rotationDeltaRad);
+  const double sine = std::sin(rotationDeltaRad);
+  return {screenAnchor.x + cosine * dx - sine * dy,
+          screenAnchor.y + sine * dx + cosine * dy};
+}
+
+struct Fix {
+  WorldPoint position{};
+  double headingDegrees = 0.0;
+  bool headingValid = false;
+  double speedMetersPerSecond = 0.0;
+  // Web Mercator is locally stretched by sec(latitude). Keeping that scale in
+  // the fix lets prediction remain bounded in real metres while producing a
+  // position in the exact world-coordinate space used by the map renderer.
+  double worldUnitsPerMeter = 1.0;
+  uint32_t timestampMs = 0;
+};
+
+struct PresentedPose {
+  WorldPoint position{};
+  double headingDegrees = 0.0;
+  bool headingValid = false;
+  uint32_t sourceTimestampMs = 0;
+  uint32_t predictionAgeMs = 0;
+};
+
+/**
+ * Explicit measured-course/route-bearing resolver.  Invalid Core Location
+ * courses never turn into north; the remembered value is scoped to one
+ * navigation epoch and is discarded on a mode/session change.
+ */
+class HeadingResolver {
+public:
+  enum class Source : uint8_t { None, Measured, Route, Remembered };
+
+  void setNavigationSession(bool active, uint32_t epoch) {
+    if (active_ == active && epoch_ == epoch)
+      return;
+    active_ = active;
+    epoch_ = epoch;
+    valid_ = false;
+    heading_ = 0.0;
+    source_ = Source::None;
+  }
+
+  bool resolve(bool measuredValid, double measuredDegrees,
+               bool routeValid, double routeDegrees, double &resolved) {
+    if (!active_) {
+      valid_ = false;
+      source_ = Source::None;
+      return false;
+    }
+    if (measuredValid && std::isfinite(measuredDegrees) &&
+        measuredDegrees >= 0.0) {
+      heading_ = normalizeDegrees(measuredDegrees);
+      valid_ = true;
+      source_ = Source::Measured;
+    } else if (routeValid && std::isfinite(routeDegrees)) {
+      heading_ = normalizeDegrees(routeDegrees);
+      valid_ = true;
+      source_ = Source::Route;
+    } else if (valid_) {
+      source_ = Source::Remembered;
+    } else {
+      source_ = Source::None;
+      return false;
+    }
+    resolved = heading_;
+    return true;
+  }
+
+  Source source() const { return source_; }
+  bool valid() const { return valid_; }
+  uint32_t epoch() const { return epoch_; }
+
+private:
+  bool active_ = false;
+  bool valid_ = false;
+  uint32_t epoch_ = 0;
+  double heading_ = 0.0;
+  Source source_ = Source::None;
+};
+
+/**
+ * Presentation-time interpolation with deliberately finite prediction.  The
+ * rider advances between BLE fixes, then stops at the declared horizon rather
+ * than drifting forever.  A new fix converges over a bounded interval instead
+ * of teleporting the foreground independently of the base map.
+ */
+class Presenter {
+public:
+  struct Config {
+    uint32_t maximumPredictionMs = 1500;
+    uint32_t convergenceMs = 350;
+    double maximumPredictionMeters = 30.0;
+    double maximumSpeedMetersPerSecond = 35.0;
+  };
+
+  Presenter() = default;
+  explicit Presenter(const Config &config) : config_(config) {}
+
+  void reset() {
+    hasFix_ = false;
+    current_ = {};
+    previousPresented_ = {};
+    convergenceStartMs_ = 0;
+  }
+
+  void observe(const Fix &fix, uint32_t receivedAtMs) {
+    Fix normalized = fix;
+    normalized.speedMetersPerSecond = std::max(
+        0.0, std::min(config_.maximumSpeedMetersPerSecond,
+                      std::isfinite(fix.speedMetersPerSecond)
+                          ? fix.speedMetersPerSecond
+                          : 0.0));
+    normalized.worldUnitsPerMeter =
+        std::isfinite(fix.worldUnitsPerMeter) &&
+                fix.worldUnitsPerMeter > 0.0
+            ? fix.worldUnitsPerMeter
+            : 1.0;
+    normalized.headingDegrees = normalizeDegrees(fix.headingDegrees);
+    if (hasFix_) {
+      previousPresented_ = present(receivedAtMs);
+      convergenceStartMs_ = receivedAtMs;
+    } else {
+      previousPresented_.position = normalized.position;
+      previousPresented_.headingDegrees = normalized.headingDegrees;
+      previousPresented_.headingValid = normalized.headingValid;
+      previousPresented_.sourceTimestampMs = normalized.timestampMs;
+      previousPresented_.predictionAgeMs = 0;
+      convergenceStartMs_ = receivedAtMs;
+    }
+    current_ = normalized;
+    receivedAtMs_ = receivedAtMs;
+    hasFix_ = true;
+  }
+
+  bool hasFix() const { return hasFix_; }
+
+  PresentedPose present(uint32_t nowMs) const {
+    if (!hasFix_)
+      return {};
+
+    const uint32_t ageMs = nowMs - receivedAtMs_;
+    const uint32_t predictionMs =
+        std::min(ageMs, config_.maximumPredictionMs);
+    double distanceMeters =
+        current_.speedMetersPerSecond * predictionMs / 1000.0;
+    distanceMeters =
+        std::min(distanceMeters, config_.maximumPredictionMeters);
+    const double distance = distanceMeters * current_.worldUnitsPerMeter;
+
+    WorldPoint predicted = current_.position;
+    if (current_.headingValid && distance > 0.0) {
+      const double radians = normalizeDegrees(current_.headingDegrees) *
+                             kPi / 180.0;
+      predicted.x += std::sin(radians) * distance;
+      predicted.y += std::cos(radians) * distance;
+    }
+
+    double blend = 1.0;
+    if (config_.convergenceMs != 0) {
+      blend = std::min(1.0, static_cast<double>(nowMs - convergenceStartMs_) /
+                                config_.convergenceMs);
+      // Smoothstep has zero slope at both ends and avoids a visible kink.
+      blend = blend * blend * (3.0 - 2.0 * blend);
+    }
+
+    PresentedPose pose;
+    pose.position.x = previousPresented_.position.x +
+                      (predicted.x - previousPresented_.position.x) * blend;
+    pose.position.y = previousPresented_.position.y +
+                      (predicted.y - previousPresented_.position.y) * blend;
+    pose.headingValid = current_.headingValid || previousPresented_.headingValid;
+    if (current_.headingValid) {
+      const double from = previousPresented_.headingValid
+                              ? previousPresented_.headingDegrees
+                              : current_.headingDegrees;
+      pose.headingDegrees = normalizeDegrees(
+          from + signedHeadingDelta(from, current_.headingDegrees) * blend);
+    } else if (previousPresented_.headingValid) {
+      // An invalid fix carries no new direction. Keep the last valid heading
+      // instead of interpolating its default zero value (north), which would
+      // make the map snap north whenever a GPS course briefly disappears.
+      pose.headingDegrees = previousPresented_.headingDegrees;
+    }
+    pose.sourceTimestampMs = current_.timestampMs;
+    pose.predictionAgeMs = predictionMs;
+    return pose;
+  }
+
+private:
+  Config config_{};
+  bool hasFix_ = false;
+  Fix current_{};
+  PresentedPose previousPresented_{};
+  uint32_t receivedAtMs_ = 0;
+  uint32_t convergenceStartMs_ = 0;
+};
+
+inline double refreshLeadPixels(double speedMetersPerSecond,
+                                double pixelsPerMeter,
+                                uint32_t worstCaseRenderLatencyMs,
+                                double safetyPixels,
+                                double minimumPixels,
+                                double maximumPixels) {
+  const double dynamic = std::max(0.0, speedMetersPerSecond) *
+                             std::max(0.0, pixelsPerMeter) *
+                             worstCaseRenderLatencyMs / 1000.0 +
+                         std::max(0.0, safetyPixels);
+  return std::max(minimumPixels, std::min(maximumPixels, dynamic));
+}
+
+} // namespace map_presentation

--- a/esp32/lib/maps/src/mapRenderJob.hpp
+++ b/esp32/lib/maps/src/mapRenderJob.hpp
@@ -1,0 +1,238 @@
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+
+namespace map_render_job {
+
+/**
+ * Immutable semantic version captured by every render request.  Sequence is
+ * strictly monotonic; the remaining epochs make stale-publication diagnostics
+ * actionable instead of merely reporting "old frame".
+ */
+struct Version {
+  uint32_t sequence = 0;
+  uint32_t routeRevision = 0;
+  uint32_t navigationEpoch = 0;
+  uint32_t styleEpoch = 0;
+  uint32_t mapEpoch = 0;
+  uint32_t projectionEpoch = 0;
+
+  bool operator==(const Version &other) const {
+    return sequence == other.sequence &&
+           routeRevision == other.routeRevision &&
+           navigationEpoch == other.navigationEpoch &&
+           styleEpoch == other.styleEpoch && mapEpoch == other.mapEpoch &&
+           projectionEpoch == other.projectionEpoch;
+  }
+
+  bool operator!=(const Version &other) const { return !(*this == other); }
+
+  // Sequence identifies a submission. The remaining fields identify the
+  // frame contract, so a completed overscanned frame can still be published
+  // after a position-only request supersedes it.
+  static bool sameFrame(const Version &left, const Version &right) {
+    return left.routeRevision == right.routeRevision &&
+           left.navigationEpoch == right.navigationEpoch &&
+           left.styleEpoch == right.styleEpoch &&
+           left.mapEpoch == right.mapEpoch &&
+           left.projectionEpoch == right.projectionEpoch;
+  }
+};
+
+enum class State : uint8_t { Idle, Rendering, Ready };
+enum class StopReason : uint8_t { None, Superseded, Shutdown, Invariant };
+
+struct Diagnostics {
+  uint32_t submitted = 0;
+  uint32_t started = 0;
+  uint32_t completed = 0;
+  uint32_t cancelled = 0;
+  uint32_t stalePublications = 0;
+  uint32_t invariantFailures = 0;
+  uint32_t published = 0;
+  uint32_t boundedSlices = 0;
+  uint32_t longestSliceUs = 0;
+};
+
+/**
+ * Lock-free policy core for a single render worker and a single publisher.
+ * Synchronisation is deliberately supplied by the caller, so this contract is
+ * executable on the host and can be wrapped by a tiny FreeRTOS critical
+ * section on device.
+ */
+class LatestWins {
+public:
+  Version submit(Version request) {
+    if (request.sequence <= latest_.sequence) {
+      request.sequence = latest_.sequence + 1;
+    }
+    latest_ = request;
+    diagnostics_.submitted++;
+    return latest_;
+  }
+
+  bool hasRequestNewerThan(uint32_t sequence) const {
+    return latest_.sequence > sequence;
+  }
+
+  const Version &latest() const { return latest_; }
+  const Version &active() const { return active_; }
+  const Version &ready() const { return ready_; }
+  State state() const { return state_; }
+  const Diagnostics &diagnostics() const { return diagnostics_; }
+
+  bool beginLatest() {
+    // The ready frame owns the back surface until the UI publishes it.
+    if (latest_.sequence == 0 || state_ == State::Ready ||
+        (state_ == State::Rendering && active_ == latest_)) {
+      return false;
+    }
+    active_ = latest_;
+    activeCancellationGeneration_ = cancellationGeneration_;
+    state_ = State::Rendering;
+    diagnostics_.started++;
+    return true;
+  }
+
+  StopReason checkpoint(bool shutdownRequested = false) const {
+    if (shutdownRequested)
+      return StopReason::Shutdown;
+    if (state_ != State::Rendering)
+      return StopReason::Invariant;
+    if (activeCancellationGeneration_ != cancellationGeneration_ ||
+        !Version::sameFrame(active_, latest_))
+      return StopReason::Superseded;
+    return StopReason::None;
+  }
+
+  void noteSlice(uint32_t elapsedUs, uint32_t declaredMaximumUs) {
+    noteSlices(1, elapsedUs, declaredMaximumUs);
+  }
+
+  void noteSlices(uint32_t count, uint32_t longestElapsedUs,
+                  uint32_t declaredMaximumUs) {
+    diagnostics_.boundedSlices += count;
+    if (longestElapsedUs > diagnostics_.longestSliceUs)
+      diagnostics_.longestSliceUs = longestElapsedUs;
+    if (declaredMaximumUs != 0 && longestElapsedUs > declaredMaximumUs)
+      sliceBudgetExceeded_ = true;
+  }
+
+  bool sliceBudgetExceeded() const { return sliceBudgetExceeded_; }
+
+  void cancelActive() {
+    if (state_ == State::Rendering) {
+      diagnostics_.cancelled++;
+      state_ = State::Idle;
+      active_ = {};
+    }
+  }
+
+  bool completeActive() {
+    if (state_ != State::Rendering)
+      return false;
+    if (activeCancellationGeneration_ != cancellationGeneration_ ||
+        !Version::sameFrame(active_, latest_)) {
+      diagnostics_.cancelled++;
+      state_ = State::Idle;
+      active_ = {};
+      return false;
+    }
+    ready_ = active_;
+    readyCancellationGeneration_ = activeCancellationGeneration_;
+    active_ = {};
+    state_ = State::Ready;
+    diagnostics_.completed++;
+    return true;
+  }
+
+  /**
+   * Publication is valid only while the completed semantic version is still
+   * latest.  A route/style/navigation change between render completion and the
+   * next LVGL tick rejects the frame without exposing it.
+   */
+  bool takeReady(Version &published) {
+    if (state_ != State::Ready)
+      return false;
+    if (readyCancellationGeneration_ != cancellationGeneration_ ||
+        !Version::sameFrame(ready_, latest_)) {
+      diagnostics_.stalePublications++;
+      ready_ = {};
+      state_ = State::Idle;
+      return false;
+    }
+    published = ready_;
+    diagnostics_.published++;
+    ready_ = {};
+    state_ = State::Idle;
+    return true;
+  }
+
+  void rejectReadyAsStale() {
+    if (state_ == State::Ready) {
+      diagnostics_.stalePublications++;
+      ready_ = {};
+      state_ = State::Idle;
+    }
+  }
+
+  void rejectReadyAsInvariant() {
+    if (state_ == State::Ready) {
+      diagnostics_.invariantFailures++;
+      ready_ = {};
+      state_ = State::Idle;
+    }
+  }
+
+  // Semantic invalidations cancel the active unit. Position-only latest
+  // requests remain coalesced and do not starve publication of the current
+  // complete frame.
+  void requestCancellation() { ++cancellationGeneration_; }
+
+  /**
+   * Invalidate every active/ready result while preserving the monotonic
+   * sequence. This is used when an LVGL screen is destroyed while the raw
+   * worker is still allowed to finish its current bounded work unit.
+   */
+  Version invalidate() {
+    Version invalidated = latest_;
+    invalidated.sequence = latest_.sequence + 1U;
+    ++cancellationGeneration_;
+    latest_ = invalidated;
+    if (state_ == State::Rendering)
+      diagnostics_.cancelled++;
+    else if (state_ == State::Ready)
+      diagnostics_.stalePublications++;
+    active_ = {};
+    ready_ = {};
+    activeCancellationGeneration_ = cancellationGeneration_;
+    readyCancellationGeneration_ = cancellationGeneration_;
+    state_ = State::Idle;
+    return latest_;
+  }
+
+  void reset() {
+    latest_ = {};
+    active_ = {};
+    ready_ = {};
+    state_ = State::Idle;
+    sliceBudgetExceeded_ = false;
+    cancellationGeneration_ = 0;
+    activeCancellationGeneration_ = 0;
+    readyCancellationGeneration_ = 0;
+  }
+
+private:
+  Version latest_{};
+  Version active_{};
+  Version ready_{};
+  State state_ = State::Idle;
+  Diagnostics diagnostics_{};
+  bool sliceBudgetExceeded_ = false;
+  uint32_t cancellationGeneration_ = 0;
+  uint32_t activeCancellationGeneration_ = 0;
+  uint32_t readyCancellationGeneration_ = 0;
+};
+
+} // namespace map_render_job

--- a/esp32/lib/maps/src/mapRenderJob.hpp
+++ b/esp32/lib/maps/src/mapRenderJob.hpp
@@ -28,12 +28,13 @@ struct Version {
 
   bool operator!=(const Version &other) const { return !(*this == other); }
 
-  // Sequence identifies a submission. The remaining fields identify the
-  // frame contract, so a completed overscanned frame can still be published
-  // after a position-only request supersedes it.
+  // Sequence identifies a submission. Route revision is retained for
+  // diagnostics, but route geometry is drawn in the live foreground and is not
+  // part of the base-frame identity. The remaining epochs identify the base
+  // contract, so a completed overscanned frame can still be published after a
+  // position or route-window-only request supersedes it.
   static bool sameFrame(const Version &left, const Version &right) {
-    return left.routeRevision == right.routeRevision &&
-           left.navigationEpoch == right.navigationEpoch &&
+    return left.navigationEpoch == right.navigationEpoch &&
            left.styleEpoch == right.styleEpoch &&
            left.mapEpoch == right.mapEpoch &&
            left.projectionEpoch == right.projectionEpoch;
@@ -42,6 +43,24 @@ struct Version {
 
 enum class State : uint8_t { Idle, Rendering, Ready };
 enum class StopReason : uint8_t { None, Superseded, Shutdown, Invariant };
+
+inline bool cancellationRequested(uint32_t activeGeneration,
+                                  uint32_t currentGeneration) {
+  return activeGeneration != currentGeneration;
+}
+
+// A storage control operation (map-root probe/switch) shares the sole worker
+// with raster rendering. Camera/style supersession cancels raster work, but it
+// must not abort an activation halfway through. Shutdown remains authoritative
+// so screen/storage teardown can still quiesce the worker.
+inline bool shouldCancelWorkerOperation(bool shutdownRequested,
+                                        bool controlOperation,
+                                        uint32_t activeGeneration,
+                                        uint32_t currentGeneration) {
+  return shutdownRequested ||
+         (!controlOperation &&
+          cancellationRequested(activeGeneration, currentGeneration));
+}
 
 struct Diagnostics {
   uint32_t submitted = 0;

--- a/esp32/lib/maps/src/mapRouteGeometry.hpp
+++ b/esp32/lib/maps/src/mapRouteGeometry.hpp
@@ -66,9 +66,30 @@ size_t emitAnchored(map_transform::WorldPoint current, size_t count,
   size_t emitted = 0;
   emit(current);
   ++emitted;
+
+  // Keep the live rider attached to the route even when the GPS fix is a
+  // little off the polyline (which is common after a coordinate-space
+  // conversion or during a fresh fix).  Omitting this point makes the first
+  // segment run directly from the off-route rider to the next vertex, which
+  // visibly skews the blue line across nearby roads.  The projection is in
+  // the same Web-Mercator world space as the route, so inserting it preserves
+  // the route's actual direction before continuing with forward vertices.
+  constexpr double kProjectionEqualitySquared = 1e-12;
+  const double projectionDeltaX = match.projected.x - current.x;
+  const double projectionDeltaY = match.projected.y - current.y;
+  if (projectionDeltaX * projectionDeltaX +
+          projectionDeltaY * projectionDeltaY >
+      kProjectionEqualitySquared) {
+    emit(match.projected);
+    ++emitted;
+  }
+
   for (size_t index = match.index + 1; index < count; ++index) {
     const auto next = pointAt(index);
-    if (next.x == current.x && next.y == current.y)
+    const double deltaX = next.x - match.projected.x;
+    const double deltaY = next.y - match.projected.y;
+    if (deltaX * deltaX + deltaY * deltaY <=
+        kProjectionEqualitySquared)
       continue;
     emit(next);
     ++emitted;

--- a/esp32/lib/maps/src/mapRouteGeometry.hpp
+++ b/esp32/lib/maps/src/mapRouteGeometry.hpp
@@ -1,0 +1,79 @@
+/**
+ * @file mapRouteGeometry.hpp
+ * @brief Pure helpers for anchoring a live route at the presented rider pose.
+ */
+
+#pragma once
+
+#include "mapTransform.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <limits>
+
+namespace map_route_geometry {
+
+struct SegmentMatch {
+  bool valid = false;
+  size_t index = 0;
+  double fraction = 0.0;
+  map_transform::WorldPoint projected{};
+  double distanceSquared = std::numeric_limits<double>::max();
+};
+
+template <typename PointAt>
+SegmentMatch closestSegment(map_transform::WorldPoint current, size_t count,
+                            PointAt pointAt) {
+  SegmentMatch best;
+  if (count < 2)
+    return best;
+  for (size_t index = 0; index + 1 < count; ++index) {
+    const auto start = pointAt(index);
+    const auto end = pointAt(index + 1);
+    const double dx = end.x - start.x;
+    const double dy = end.y - start.y;
+    const double lengthSquared = dx * dx + dy * dy;
+    if (!(lengthSquared > 0.0))
+      continue;
+    const double fraction = std::max(
+        0.0, std::min(1.0, ((current.x - start.x) * dx +
+                            (current.y - start.y) * dy) /
+                               lengthSquared));
+    const map_transform::WorldPoint projected = {
+        start.x + fraction * dx, start.y + fraction * dy};
+    const double offsetX = current.x - projected.x;
+    const double offsetY = current.y - projected.y;
+    const double distanceSquared = offsetX * offsetX + offsetY * offsetY;
+    if (!best.valid || distanceSquared < best.distanceSquared) {
+      best = {true, index, fraction, projected, distanceSquared};
+    }
+  }
+  return best;
+}
+
+/**
+ * Emits a route whose first point is exactly the current presented position,
+ * followed by the forward geometry after the nearest segment.  The current
+ * point is intentionally not snapped to a stale coarse vertex: it is the same
+ * world coordinate used by the marker and presentation transform.
+ */
+template <typename PointAt, typename Emit>
+size_t emitAnchored(map_transform::WorldPoint current, size_t count,
+                    PointAt pointAt, Emit emit) {
+  const SegmentMatch match = closestSegment(current, count, pointAt);
+  if (!match.valid)
+    return 0;
+  size_t emitted = 0;
+  emit(current);
+  ++emitted;
+  for (size_t index = match.index + 1; index < count; ++index) {
+    const auto next = pointAt(index);
+    if (next.x == current.x && next.y == current.y)
+      continue;
+    emit(next);
+    ++emitted;
+  }
+  return emitted;
+}
+
+} // namespace map_route_geometry

--- a/esp32/lib/maps/src/mapSurface.hpp
+++ b/esp32/lib/maps/src/mapSurface.hpp
@@ -1,0 +1,103 @@
+/**
+ * @file mapSurface.hpp
+ * @brief LVGL-independent raw surfaces used by the map render worker.
+ *
+ * The renderer owns only these plain buffers.  Binding a completed buffer to an
+ * LVGL canvas is deliberately left to the UI task.
+ */
+
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace map_surface {
+
+struct Rgb565Surface {
+  uint16_t *pixels = nullptr;
+  int32_t width = 0;
+  int32_t height = 0;
+  size_t stridePixels = 0;
+
+  constexpr bool valid() const {
+    return pixels != nullptr && width > 0 && height > 0 &&
+           stridePixels >= static_cast<size_t>(width);
+  }
+
+  constexpr size_t byteSize() const {
+    return valid() ? stridePixels * static_cast<size_t>(height) *
+                         sizeof(uint16_t)
+                   : 0U;
+  }
+
+  void clear(uint16_t color) const {
+    if (!valid())
+      return;
+    for (int32_t y = 0; y < height; ++y) {
+      std::fill_n(pixels + static_cast<size_t>(y) * stridePixels,
+                  static_cast<size_t>(width), color);
+    }
+  }
+
+  constexpr bool contains(int32_t x, int32_t y) const {
+    return x >= 0 && y >= 0 && x < width && y < height;
+  }
+
+  uint16_t *row(int32_t y) const {
+    return valid() && y >= 0 && y < height
+               ? pixels + static_cast<size_t>(y) * stridePixels
+               : nullptr;
+  }
+};
+
+struct Rgb565A8Surface {
+  uint16_t *pixels = nullptr;
+  uint8_t *alpha = nullptr;
+  int32_t width = 0;
+  int32_t height = 0;
+  size_t colorStridePixels = 0;
+  size_t alphaStrideBytes = 0;
+
+  constexpr bool valid() const {
+    return pixels != nullptr && alpha != nullptr && width > 0 && height > 0 &&
+           colorStridePixels >= static_cast<size_t>(width) &&
+           alphaStrideBytes >= static_cast<size_t>(width);
+  }
+
+  void clearAlpha() const {
+    if (!valid())
+      return;
+    for (int32_t y = 0; y < height; ++y) {
+      std::fill_n(alpha + static_cast<size_t>(y) * alphaStrideBytes,
+                  static_cast<size_t>(width), uint8_t{0});
+    }
+  }
+
+  void clear() const {
+    if (!valid())
+      return;
+    for (int32_t y = 0; y < height; ++y) {
+      std::fill_n(pixels + static_cast<size_t>(y) * colorStridePixels,
+                  static_cast<size_t>(width), uint16_t{0});
+    }
+    clearAlpha();
+  }
+};
+
+struct LabelSurface {
+  Rgb565Surface color{};
+  uint8_t *alpha = nullptr;
+  size_t alphaStrideBytes = 0;
+  const Rgb565Surface *contrast = nullptr;
+  int32_t contrastOffsetX = 0;
+  int32_t contrastOffsetY = 0;
+
+  constexpr bool valid() const { return color.valid(); }
+  constexpr bool transparent() const {
+    return valid() && alpha != nullptr &&
+           alphaStrideBytes >= static_cast<size_t>(color.width);
+  }
+};
+
+} // namespace map_surface

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -25,6 +25,7 @@
 #include "../../power_management/power_management.hpp"
 #include "../../power_metrics/power_metrics.hpp"
 #include "../../utils/src/line_rasterizer.hpp"
+#include "../../ui_scheduler/ui_scheduler.hpp"
 
 #ifndef FIRMWARE_DIAGNOSTICS
 #define FIRMWARE_DIAGNOSTICS 1
@@ -115,6 +116,7 @@ std::atomic<uint32_t> gMapRenderActiveSequence{0};
 std::atomic<uint32_t> gMapRenderCancellationGeneration{0};
 std::atomic<uint32_t> gMapRenderActiveCancellationGeneration{0};
 std::atomic<bool> gMapRenderWorkerShutdown{false};
+std::atomic<bool> gMapRenderControlOperation{false};
 std::atomic<uint32_t> gMapRenderSliceCount{0};
 std::atomic<uint32_t> gMapRenderLongestSliceUs{0};
 uint32_t gMapRenderLastCheckpointUs = 0;
@@ -140,11 +142,12 @@ bool shouldCancelMapRenderWork() {
         taskYIELD();
     }
     gMapRenderLastCheckpointUs = micros();
-    return gMapRenderWorkerShutdown.load(std::memory_order_acquire) ||
-           gMapRenderActiveCancellationGeneration.load(
-               std::memory_order_acquire) !=
-               gMapRenderCancellationGeneration.load(
-                   std::memory_order_acquire);
+    return map_render_job::shouldCancelWorkerOperation(
+        gMapRenderWorkerShutdown.load(std::memory_order_acquire),
+        gMapRenderControlOperation.load(std::memory_order_acquire),
+        gMapRenderActiveCancellationGeneration.load(
+            std::memory_order_acquire),
+        gMapRenderCancellationGeneration.load(std::memory_order_acquire));
   }
   return shouldInterruptMapRenderForScreenCycle();
 }
@@ -631,30 +634,41 @@ static lv_value_precise_t markerCoord(int32_t origin, int16_t size,
           navigation_visual_style::POSITION_MARKER_BASE_SIZE);
 }
 
-static lv_value_precise_t markerEdgeXAtY(const lv_point_precise_t &start,
-                                         const lv_point_precise_t &end,
-                                         lv_value_precise_t y) {
-  if (start.y == end.y)
-    return start.x;
+static double currentMarkerRotationDegrees = 0.0;
 
-  return start.x +
-         (end.x - start.x) * (y - start.y) / (end.y - start.y);
+static lv_point_precise_t rotatedMarkerPoint(const lv_area_t &bounds,
+                                             int16_t size,
+                                             int16_t baseX, int16_t baseY,
+                                             double rotationDegrees) {
+  constexpr double kDegreesToRadians =
+      3.14159265358979323846 / 180.0;
+  const double centerX = bounds.x1 + size / 2.0;
+  const double centerY = bounds.y1 + size / 2.0;
+  const double x = markerCoord(bounds.x1, size, baseX) - centerX;
+  const double y = markerCoord(bounds.y1, size, baseY) - centerY;
+  const double angle = rotationDegrees * kDegreesToRadians;
+  const double cosine = std::cos(angle);
+  const double sine = std::sin(angle);
+  // Screen Y grows downward, so this positive-angle matrix rotates the
+  // north-facing glyph clockwise: heading 90 points east/right.
+  return {static_cast<lv_value_precise_t>(
+              std::round(centerX + x * cosine - y * sine)),
+          static_cast<lv_value_precise_t>(
+              std::round(centerY + x * sine + y * cosine))};
 }
 
 static void drawNavigationMarker(lv_layer_t *layer, const lv_area_t &bounds,
-                                 int16_t size, lv_color_t color) {
+                                 int16_t size, lv_color_t color,
+                                 double rotationDegrees) {
   // Filled Lucide navigation-2 polygon. Render horizontal spans at the final
   // on-screen size because this target's software renderer does not reliably
   // fill LVGL triangle draw tasks. The rounded outline softens the three outer
   // points without magnifying a bitmap.
-  const lv_point_precise_t top = {
-      markerCoord(bounds.x1, size, 24), markerCoord(bounds.y1, size, 4)};
-  const lv_point_precise_t right = {
-      markerCoord(bounds.x1, size, 38), markerCoord(bounds.y1, size, 42)};
-  const lv_point_precise_t notch = {
-      markerCoord(bounds.x1, size, 24), markerCoord(bounds.y1, size, 34)};
-  const lv_point_precise_t left = {
-      markerCoord(bounds.x1, size, 10), markerCoord(bounds.y1, size, 42)};
+  const std::array<lv_point_precise_t, 4> points = {
+      rotatedMarkerPoint(bounds, size, 24, 4, rotationDegrees),
+      rotatedMarkerPoint(bounds, size, 38, 42, rotationDegrees),
+      rotatedMarkerPoint(bounds, size, 24, 34, rotationDegrees),
+      rotatedMarkerPoint(bounds, size, 10, 42, rotationDegrees)};
 
   lv_draw_line_dsc_t fill;
   lv_draw_line_dsc_init(&fill);
@@ -662,20 +676,33 @@ static void drawNavigationMarker(lv_layer_t *layer, const lv_area_t &bounds,
   fill.opa = LV_OPA_COVER;
   fill.width = 1;
 
-  for (lv_value_precise_t y = top.y; y <= notch.y; ++y) {
-    fill.p1 = {markerEdgeXAtY(top, left, y), y};
-    fill.p2 = {markerEdgeXAtY(top, right, y), y};
-    lv_draw_line(layer, &fill);
+  lv_value_precise_t minimumY = points.front().y;
+  lv_value_precise_t maximumY = points.front().y;
+  for (const auto &point : points) {
+    minimumY = std::min(minimumY, point.y);
+    maximumY = std::max(maximumY, point.y);
   }
-
-  for (lv_value_precise_t y = notch.y + 1; y <= left.y; ++y) {
-    fill.p1 = {markerEdgeXAtY(top, left, y), y};
-    fill.p2 = {markerEdgeXAtY(notch, left, y), y};
-    lv_draw_line(layer, &fill);
-
-    fill.p1 = {markerEdgeXAtY(notch, right, y), y};
-    fill.p2 = {markerEdgeXAtY(top, right, y), y};
-    lv_draw_line(layer, &fill);
+  for (lv_value_precise_t y = minimumY; y <= maximumY; ++y) {
+    std::array<lv_value_precise_t, 4> intersections{};
+    size_t count = 0;
+    for (size_t index = 0; index < points.size(); ++index) {
+      const auto &start = points[index];
+      const auto &end = points[(index + 1U) % points.size()];
+      if (!((start.y <= y && end.y > y) ||
+            (end.y <= y && start.y > y))) {
+        continue;
+      }
+      intersections[count++] = static_cast<lv_value_precise_t>(std::round(
+          start.x + static_cast<double>(end.x - start.x) *
+                        static_cast<double>(y - start.y) /
+                        static_cast<double>(end.y - start.y)));
+    }
+    std::sort(intersections.begin(), intersections.begin() + count);
+    for (size_t index = 1; index < count; index += 2U) {
+      fill.p1 = {intersections[index - 1U], y};
+      fill.p2 = {intersections[index], y};
+      lv_draw_line(layer, &fill);
+    }
   }
 
   lv_draw_line_dsc_t outline;
@@ -687,10 +714,9 @@ static void drawNavigationMarker(lv_layer_t *layer, const lv_area_t &bounds,
   outline.round_start = 1;
   outline.round_end = 1;
 
-  const lv_point_precise_t outlinePoints[] = {top, right, notch, left, top};
-  for (uint8_t i = 1; i < 5; ++i) {
-    outline.p1 = outlinePoints[i - 1];
-    outline.p2 = outlinePoints[i];
+  for (size_t index = 0; index < points.size(); ++index) {
+    outline.p1 = points[index];
+    outline.p2 = points[(index + 1U) % points.size()];
     lv_draw_line(layer, &outline);
   }
 }
@@ -725,34 +751,43 @@ static void drawCurrentPositionMarker(lv_event_t *event) {
       lv_color_hex(navigation_visual_style::ROUTE_BLUE_RGB888);
 
   if (routeOverlay.hasRoute() || hasCurrentNavigationData()) {
-    drawNavigationMarker(layer, bounds, size, color);
+    drawNavigationMarker(layer, bounds, size, color,
+                         currentMarkerRotationDegrees);
   } else {
     drawPositionDotMarker(layer, bounds, size, color);
   }
 }
 
-static void updateCurrentPositionMarker(lv_obj_t *marker, bool force = false) {
+static void updateCurrentPositionMarker(lv_obj_t *marker,
+                                        double rotationDegrees = 0.0,
+                                        bool force = false) {
   if (!marker)
     return;
 
   static bool hasLastShape = false;
   static bool lastWasNavigating = false;
   static uint8_t lastScale = 0;
+  static int16_t lastRotationTenths = 0;
 
   const bool isNavigating =
       routeOverlay.hasRoute() || hasCurrentNavigationData();
   const uint8_t scale = currentMarkerScale();
+  const int16_t rotationTenths = static_cast<int16_t>(
+      std::round(map_presentation::normalizeDegrees(rotationDegrees) * 10.0));
   if (!force && hasLastShape && lastWasNavigating == isNavigating &&
-      lastScale == scale) {
+      lastScale == scale &&
+      (!isNavigating || lastRotationTenths == rotationTenths)) {
     return;
   }
 
+  currentMarkerRotationDegrees = rotationTenths / 10.0;
   const int16_t size = currentMarkerSize();
   lv_obj_set_size(marker, size, size);
   lv_obj_invalidate(marker);
   hasLastShape = true;
   lastWasNavigating = isNavigating;
   lastScale = scale;
+  lastRotationTenths = rotationTenths;
   log_i("Position marker updated: %s scale=%u",
         isNavigating ? "navigation arrow" : "location dot", scale);
 }
@@ -783,8 +818,11 @@ static void setPinchCanvasScale(void *object, int32_t scale) {
 static void completePinchCanvasSettlement(lv_anim_t *animation) {
   auto *canvas = static_cast<lv_obj_t *>(animation->var);
   if (canvas != nullptr) {
+    // The render-ahead presenter owns the image pivot. Resetting it here runs
+    // after publication has already installed the live map transform and can
+    // leave the settled frame rotating around the top-left corner. Animation
+    // completion owns only the temporary scale.
     lv_image_set_scale(canvas, LV_SCALE_NONE);
-    lv_image_set_pivot(canvas, 0, 0);
     lv_obj_invalidate(canvas);
   }
 }
@@ -2811,6 +2849,7 @@ bool Maps::readVectorMap(
         const auto &building =
             block->buildingData.buildings[candidate.key.recordIndex];
         bool rendered = false;
+        bool drewFootprint = false;
         try {
           rendered = map_building_renderer::renderSurfaces(
               building, block->offset.x, block->offset.y,
@@ -2847,6 +2886,7 @@ bool Maps::readVectorMap(
                 // allocation failure. Cancellation aborts the job; otherwise
                 // skip this footprint and preserve the rest of the flat city.
                 const bool filled = fillPolygon(buildingPolygon, surface);
+                drewFootprint = drewFootprint || filled;
                 return filled || !shouldCancelMapRenderWork();
               },
               &fallbackSurfaceStats, shouldCancelMapRenderWork);
@@ -2855,7 +2895,7 @@ bool Maps::readVectorMap(
         }
         if (!rendered && shouldCancelMapRenderWork())
           return false;
-        if (!rendered)
+        if (!rendered || !drewFootprint)
           continue;
         ++selectedRecords;
         selectedPoints += candidate.pointCount;
@@ -3166,23 +3206,28 @@ bool Maps::readVectorMap(
               holeScreen, surface.width, surface.height);
           if (region.valid())
             projectedCourtyardPixels += region.pixels();
-          if (projectedCourtyardPixels >
-              std::min<std::size_t>(
-                  static_cast<std::size_t>(kMaximumCourtyardWorkspacePixels),
+          if (map_building_workspace::courtyardPolicy(
+                  projectedCourtyardPixels,
+                  kMaximumCourtyardWorkspacePixels,
                   static_cast<std::size_t>(surface.width) *
-                      static_cast<std::size_t>(surface.height))) {
+                      static_cast<std::size_t>(surface.height)) ==
+              map_building_workspace::CourtyardPolicy::SolidRoofFallback) {
             courtyardFits = false;
             break;
           }
         }
-        if (!courtyardFits) {
+        const bool preserveCourtyards = courtyardFits;
+        if (!preserveCourtyards) {
+          // Keep the admitted building and its walls/roof. Only the underlay
+          // restoration is degraded, producing a deterministic solid roof
+          // instead of making a large stadium or mall disappear entirely.
           ++courtyardDeferred;
-          continue;
         }
 
         std::vector<CourtyardSnapshot, PsramAllocator<CourtyardSnapshot>>
             courtyardSnapshots;
-        courtyardSnapshots.reserve(item.building->rings.size());
+        if (preserveCourtyards)
+          courtyardSnapshots.reserve(item.building->rings.size());
         size_t restoreIndex = 0;
         const bool rendered = map_building_renderer::renderSurfaces(
             *item.building, item.block->offset.x, item.block->offset.y,
@@ -3193,6 +3238,8 @@ bool Maps::readVectorMap(
                 return false;
               if (kind ==
                   map_building_renderer::Surface::CourtyardCapture) {
+                if (!preserveCourtyards)
+                  return true;
                 CourtyardSnapshot snapshot;
                 snapshot.region = map_building_workspace::clippedRegion(
                     points, surface.width, surface.height);
@@ -3211,6 +3258,8 @@ bool Maps::readVectorMap(
                 return true;
               }
               if (kind == map_building_renderer::Surface::Courtyard) {
+                if (!preserveCourtyards)
+                  return true;
                 if (restoreIndex >= courtyardSnapshots.size())
                   return false;
                 const auto &snapshot = courtyardSnapshots[restoreIndex++];
@@ -3260,7 +3309,16 @@ bool Maps::readVectorMap(
               buildingPolygon.color = color;
               buildingPolygon.bbox.min = Point16(minX, minY);
               buildingPolygon.bbox.max = Point16(maxX, maxY);
-              return fillPolygon(buildingPolygon, surface);
+              const bool filled = fillPolygon(buildingPolygon, surface);
+              if (!filled && !shouldCancelMapRenderWork()) {
+                // fillPolygon uses a bounded PSRAM node workspace and reports
+                // allocation failure as false. Promote that result into the
+                // surrounding allocation-safe building pass so it can render
+                // the deterministic flat fallback instead of retrying the
+                // same failing 3D job forever.
+                throw std::bad_alloc();
+              }
+              return filled;
             },
             &surfaceStats, shouldCancelMapRenderWork);
         if (!rendered)
@@ -3533,7 +3591,7 @@ uint64_t Maps::projectionSignature(uint8_t requestedZoom,
   return hash;
 }
 
-void Maps::invalidateRenderSemantics() {
+void Maps::invalidateRenderSemantics(uint32_t nowMs) {
   bool semanticChanged = false;
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
   const uint64_t currentStyle = styleSignature(style);
@@ -3558,10 +3616,11 @@ void Maps::invalidateRenderSemantics() {
     semanticChanged = true;
   }
 
-  // Heading memory belongs to an explicit presentation session. A route
-  // replacement is a new presentation epoch even when navigation remains
-  // active; otherwise an invalid course can inherit the previous route's
-  // bearing and make course-up point the wrong way.
+  // Heading memory belongs to an explicit presentation session. Ordinary
+  // sliding-window replacements are deliberately excluded: route geometry is
+  // live foreground state, and resetting prediction on every packet makes the
+  // rider jump back to the last raw GPS coordinate. A newly received route
+  // bearing still replaces remembered heading through resolve().
   uint64_t headingSession = 1469598103934665603ULL;
   const bool mapVisible = isMapScreenActive() || isMapGuidanceScreenActive();
   const bool routeActive = routeOverlay.hasRoute();
@@ -3571,7 +3630,6 @@ void Maps::invalidateRenderSemantics() {
                             isMapGuidanceScreenActive() ? 1U : 0U);
   headingSession = fnvMix64(
       headingSession, (routeActive || maneuverActive) ? 1U : 0U);
-  headingSession = fnvMix64(headingSession, routeOverlay.revision());
   headingSession = fnvMix64(headingSession,
                             static_cast<uint8_t>(rotationMode));
   if (lastHeadingSessionSignature == 0) {
@@ -3580,6 +3638,12 @@ void Maps::invalidateRenderSemantics() {
     lastHeadingSessionSignature = headingSession;
     ++headingSessionEpoch;
     headingResolver.setNavigationSession(false, headingSessionEpoch);
+    posePresenter.resetHeading(nowMs);
+    presentedPose.headingDegrees = 0.0;
+    presentedPose.headingValid = false;
+    // Re-run the latest physical fix through the new heading epoch even when
+    // its coordinate, speed, and newly resolved bearing are byte-identical.
+    lastGpsSignature = 0;
   }
 
   const uint16_t viewportHeight =
@@ -3605,10 +3669,15 @@ void Maps::invalidateRenderSemantics() {
 }
 
 void Maps::cancelActiveRenderWork() {
-  gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
-  if (renderStateMutex == nullptr)
+  if (renderStateMutex == nullptr) {
+    gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
     return;
+  }
   if (xSemaphoreTake(renderStateMutex, portMAX_DELAY) == pdTRUE) {
+    // The cooperative token and LatestWins generation cross one mutex
+    // boundary. A worker can therefore only capture the generation before or
+    // after this cancellation, never the new atomic token with old job state.
+    gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
     renderJobs.requestCancellation();
     xSemaphoreGive(renderStateMutex);
   }
@@ -3639,7 +3708,7 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
                              gps.gpsData.heading < 360U;
   const bool headingValid = headingResolver.resolve(
       measuredValid, gps.gpsData.heading, routeValid, routeDegrees,
-      resolvedHeading);
+      resolvedHeading, !bleNavServer.supportsExplicitInvalidGpsHeading());
 
   uint64_t gpsSignature = 1469598103934665603ULL;
   gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.latitude));
@@ -3696,7 +3765,7 @@ Maps::makeRequestProjection(const RenderRequest &request) const {
 
 bool Maps::buildRenderRequest(uint8_t requestedZoom, uint32_t nowMs,
                               RenderRequest &request) {
-  invalidateRenderSemantics();
+  invalidateRenderSemantics(nowMs);
   updatePresentedPose(nowMs);
 
   const uint16_t viewportHeight =
@@ -3744,13 +3813,51 @@ bool Maps::buildRenderRequest(uint8_t requestedZoom, uint32_t nowMs,
     if (hasPresentedPose && presentedPose.headingValid) {
       request.rotationRad =
           -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
-    } else if (publishedMapFrame) {
+    } else if (publishedMapFrame &&
+               visibleRenderResult.version.navigationEpoch ==
+                   navigationEpoch) {
       request.rotationRad = visibleRenderResult.rotationRad;
+    } else if (!request.context.navigationSessionActive) {
+      // Course-up has no semantic direction before guidance starts. Permit an
+      // initial north-up base so the idle Map + Navigation screen can show its
+      // configured bird's-eye/3D scene. Once a route or maneuver is active,
+      // the branch below still refuses to invent north from a missing course.
+      request.rotationRad = 0.0;
     } else {
       ESP_LOGW(TAG,
                "Course-up frame deferred: neither measured course nor route "
                "bearing is valid");
       return false;
+    }
+  }
+
+  // Render toward where the rider is expected when this worker pass finishes,
+  // while capping the lead to the proven overscan budget. Presentation still
+  // anchors the live rider at the normal screen point; only the source-frame
+  // coverage is asymmetric in the direction of travel.
+  if (followPosition && hasPresentedPose && presentedPose.headingValid) {
+    const double speedMetersPerSecond = gps.gpsData.speed / 3.6;
+    const double latitudeRadians =
+        gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
+    const double worldUnitsPerMeter =
+        1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
+    const double pixelsPerMeter =
+        worldUnitsPerMeter * map_transform::worldToScreenScale(request.zoom);
+    const uint32_t expectedLatencyMs =
+        std::max<uint32_t>(250U,
+                           std::min<uint32_t>(5000U,
+                                              lastCompletedRenderDurationMs));
+    const double leadPixels = map_presentation::refreshLeadPixels(
+        speedMetersPerSecond, pixelsPerMeter, expectedLatencyMs, 0.0, 0.0,
+        MAP_RENDER_OVERSCAN_PIXELS - MAP_RENDER_SAFETY_PIXELS);
+    if (pixelsPerMeter > 0.0 && leadPixels > 0.0) {
+      const double leadWorld =
+          leadPixels / pixelsPerMeter * worldUnitsPerMeter;
+      const double headingRadians =
+          map_presentation::normalizeDegrees(presentedPose.headingDegrees) *
+          3.14159265358979323846 / 180.0;
+      request.center.x += std::sin(headingRadians) * leadWorld;
+      request.center.y += std::cos(headingRadians) * leadWorld;
     }
   }
 
@@ -3801,13 +3908,16 @@ bool Maps::takeWorkerRequest(RenderRequest &request) {
   if (xSemaphoreTake(renderStateMutex, portMAX_DELAY) != pdTRUE)
     return false;
   bool available =
-      latestRenderRequestValid &&
+      !pendingVectorMapActivationValid &&
+      !completedVectorMapActivationValid && latestRenderRequestValid &&
       latestRenderRequest.version.sequence > lastTakenRenderSequence &&
       renderJobs.beginLatest();
   if (available) {
     request = latestRenderRequest;
     available = request.version == renderJobs.active();
     if (available) {
+      request.cancellationGeneration =
+          gMapRenderCancellationGeneration.load(std::memory_order_acquire);
       lastTakenRenderSequence = request.version.sequence;
     } else {
       renderJobs.cancelActive();
@@ -3822,7 +3932,6 @@ bool Maps::renderRequestStillCurrent(const RenderRequest &request) const {
          request.version.styleEpoch == styleEpoch &&
          request.version.mapEpoch == mapEpoch &&
          request.version.projectionEpoch == projectionEpoch &&
-         request.version.routeRevision == routeOverlay.revision() &&
          request.styleSignature == styleSignature(currentMapStyleSettings()) &&
          request.navigationSignature == navigationSignature() &&
          request.projectionSignature == projectionSignature(
@@ -3857,7 +3966,9 @@ bool Maps::startRenderWorker() {
 
   renderWorkerShutdown.store(false, std::memory_order_release);
   renderWorkerExited.store(false, std::memory_order_release);
+  renderWorkerRestartAfterExit.store(false, std::memory_order_release);
   gMapRenderWorkerShutdown.store(false, std::memory_order_release);
+  gMapRenderControlOperation.store(false, std::memory_order_release);
   gMapRenderLatestSequence.store(0, std::memory_order_release);
   gMapRenderActiveSequence.store(0, std::memory_order_release);
   gMapRenderCancellationGeneration.store(0, std::memory_order_release);
@@ -3883,6 +3994,7 @@ bool Maps::startRenderWorker() {
 bool Maps::stopRenderWorker() {
   TaskHandle_t worker = renderWorkerTaskHandle;
   if (worker == nullptr) {
+    renderWorkerRestartAfterExit.store(false, std::memory_order_release);
     renderWorkerExited.store(true, std::memory_order_release);
     return true;
   }
@@ -3901,12 +4013,28 @@ bool Maps::stopRenderWorker() {
     vTaskDelay(pdMS_TO_TICKS(2));
   }
   if (!renderWorkerExited.load(std::memory_order_acquire)) {
+    // The caller leaves worker-owned state untouched. Once the delayed IO
+    // checkpoint returns, the UI pipeline restarts the old, still-valid map
+    // root instead of silently leaving navigation on a frozen frame.
+    renderWorkerRestartAfterExit.store(true, std::memory_order_release);
     ESP_LOGE(TAG, "Map render worker did not stop cleanly; state preserved");
     return false;
   }
+  renderWorkerRestartAfterExit.store(false, std::memory_order_release);
   gMapRenderWorkerShutdown.store(false, std::memory_order_release);
   renderWorkerShutdown.store(false, std::memory_order_release);
   return true;
+}
+
+bool Maps::recoverRenderWorkerIfNeeded() {
+  if (!renderWorkerRestartAfterExit.load(std::memory_order_acquire))
+    return renderWorkerTaskHandle != nullptr;
+  if (!renderWorkerExited.load(std::memory_order_acquire))
+    return false;
+  if (startRenderWorker())
+    return true;
+  renderWorkerRestartAfterExit.store(true, std::memory_order_release);
+  return false;
 }
 
 void Maps::renderWorkerTaskThunk(void *argument) {
@@ -3924,12 +4052,15 @@ void Maps::renderWorkerLoop() {
     if (renderWorkerShutdown.load(std::memory_order_acquire))
       break;
 
+    if (processPendingVectorMapActivation())
+      continue;
+
     RenderRequest request;
     while (takeWorkerRequest(request)) {
       gMapRenderActiveSequence.store(request.version.sequence,
                                      std::memory_order_release);
       gMapRenderActiveCancellationGeneration.store(
-          gMapRenderCancellationGeneration.load(std::memory_order_acquire),
+          request.cancellationGeneration,
           std::memory_order_release);
       gMapRenderSliceCount.store(0, std::memory_order_relaxed);
       gMapRenderLongestSliceUs.store(0, std::memory_order_relaxed);
@@ -4058,6 +4189,8 @@ void Maps::renderWorkerLoop() {
       if (renderWorkerShutdown.load(std::memory_order_acquire))
         break;
       taskYIELD();
+      if (processPendingVectorMapActivation())
+        break;
     }
   }
 
@@ -4072,6 +4205,7 @@ void Maps::renderWorkerLoop() {
     renderWorkerTaskHandle = nullptr;
   }
   gMapRenderWorkerTaskHandle = nullptr;
+  gMapRenderControlOperation.store(false, std::memory_order_release);
   renderWorkerExited.store(true, std::memory_order_release);
   MAPIO_LOG("MAPIO: render-worker stopped\n");
 }
@@ -4099,6 +4233,44 @@ bool Maps::publishReadyFrame(uint32_t nowMs) {
       xTaskNotifyGive(worker);
     MAPIO_LOG("MAPIO: render-stale rejected before publication\n");
     return false;
+  }
+  if (readyRenderResult.followPosition && hasPresentedPose) {
+    const map_transform::WorldPoint current{presentedPose.position.x,
+                                             presentedPose.position.y};
+    const auto projected = readyRenderResult.projection.projectWorld(current);
+    double desiredRotation = readyRenderResult.rotationRad;
+    if (rotationMode == ROT_COURSE_UP && presentedPose.headingValid) {
+      desiredRotation =
+          -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
+    } else if (rotationMode == ROT_NORTH_UP) {
+      desiredRotation = 0.0;
+    }
+    const double rotationDelta = map_presentation::signedHeadingDelta(
+        readyRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
+        desiredRotation * 180.0 / 3.14159265358979323846) *
+        3.14159265358979323846 / 180.0;
+    const bool covered = projected.valid &&
+        map_presentation::frameCoversViewport(
+            readyRenderResult.renderWidth, readyRenderResult.renderHeight,
+            readyRenderResult.viewportWidth, readyRenderResult.viewportHeight,
+            {projected.x, projected.y},
+            {readyRenderResult.projection.anchorX() -
+                 readyRenderResult.overscanPixels,
+             readyRenderResult.projection.anchorY() -
+                 readyRenderResult.overscanPixels},
+            rotationDelta, MAP_RENDER_SAFETY_PIXELS);
+    if (!covered) {
+      renderJobs.rejectReadyAsStale();
+      readyRenderResultValid = false;
+      isPosMoved = true;
+      redrawMap = true;
+      const TaskHandle_t worker = renderWorkerTaskHandle;
+      xSemaphoreGive(renderStateMutex);
+      if (worker != nullptr)
+        xTaskNotifyGive(worker);
+      MAPIO_LOG("MAPIO: render-coverage rejected before publication\n");
+      return false;
+    }
   }
   const size_t requiredFrameBytes =
       static_cast<size_t>(readyRenderResult.renderStridePixels) *
@@ -4154,6 +4326,7 @@ bool Maps::publishReadyFrame(uint32_t nowMs) {
   lv_image_set_scale(canvasMap, LV_SCALE_NONE);
   lv_obj_clear_flag(canvasMap, LV_OBJ_FLAG_HIDDEN);
   visibleRenderResult = result;
+  lastCompletedRenderDurationMs = std::max<uint32_t>(250U, result.durationMs);
   visibleProjection = result.projection;
   hasVisibleProjection = true;
   viewPort = result.viewport;
@@ -4227,11 +4400,6 @@ void Maps::updatePresentedFrameTransform() {
       visibleRenderResult.projection.anchorY() -
       visibleRenderResult.overscanPixels);
 
-  lv_image_set_pivot(canvasMap, pivotX, pivotY);
-  lv_obj_set_pos(canvasMap,
-                 viewportOriginX + screenAnchorX - pivotX,
-                 viewportOriginY + screenAnchorY - pivotY);
-
   double desiredRotation = visibleRenderResult.rotationRad;
   if (rotationMode == ROT_COURSE_UP && hasPresentedPose &&
       presentedPose.headingValid) {
@@ -4244,30 +4412,47 @@ void Maps::updatePresentedFrameTransform() {
       visibleRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
       desiredRotation * 180.0 / 3.14159265358979323846) *
       3.14159265358979323846 / 180.0;
-  lv_img_set_angle(canvasMap, mapAngleTenths(rotationDelta));
+  const int16_t targetX = viewportOriginX + screenAnchorX - pivotX;
+  const int16_t targetY = viewportOriginY + screenAnchorY - pivotY;
+  const int16_t targetAngle = mapAngleTenths(rotationDelta);
+  uint64_t presentationSignature = 1469598103934665603ULL;
+  presentationSignature = fnvMix64(
+      presentationSignature, visibleRenderResult.version.sequence);
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(projected.x));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(projected.y));
+  presentationSignature = fnvMix64(
+      presentationSignature, static_cast<uint64_t>(containerWidth));
+  presentationSignature = fnvMix64(
+      presentationSignature, static_cast<uint64_t>(containerHeight));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(rotationDelta));
+
+  lv_point_t currentPivot{};
+  lv_image_get_pivot(canvasMap, &currentPivot);
+  const bool transformAlreadyApplied =
+      currentPivot.x == pivotX && currentPivot.y == pivotY &&
+      lv_obj_get_x_aligned(canvasMap) == targetX &&
+      lv_obj_get_y_aligned(canvasMap) == targetY &&
+      lv_img_get_angle(canvasMap) == targetAngle;
+  if (presentationSignature == lastFramePresentationSignature &&
+      transformAlreadyApplied) {
+    return;
+  }
+
+  lv_image_set_pivot(canvasMap, pivotX, pivotY);
+  lv_obj_set_pos(canvasMap, targetX, targetY);
+  lv_img_set_angle(canvasMap, targetAngle);
   lv_obj_invalidate(canvasMap);
 
-  const double displacementX =
-      projected.x - visibleRenderResult.projection.anchorX();
-  const double displacementY =
-      projected.y - visibleRenderResult.projection.anchorY();
-  const double speed = gps.gpsData.speed / 3.6;
-  const double latitudeRadians =
-      gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
-  const double mercatorUnitsPerMeter =
-      1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
-  const uint32_t latency =
-      std::max<uint32_t>(250U,
-                         std::min<uint32_t>(5000U,
-                                            visibleRenderResult.durationMs));
-  const double lead = map_presentation::refreshLeadPixels(
-      speed,
-      mercatorUnitsPerMeter *
-          map_transform::worldToScreenScale(visibleRenderResult.viewport.zoom),
-      latency, MAP_RENDER_SAFETY_PIXELS, MAP_RENDER_SAFETY_PIXELS,
-      MAP_RENDER_OVERSCAN_PIXELS - MAP_RENDER_SAFETY_PIXELS);
-  const double available =
-      std::max(8.0, visibleRenderResult.overscanPixels - lead);
+  const bool visibleCoversPose = map_presentation::frameCoversViewport(
+      visibleRenderResult.renderWidth, visibleRenderResult.renderHeight,
+      visibleRenderResult.viewportWidth, visibleRenderResult.viewportHeight,
+      {projected.x, projected.y},
+      {static_cast<double>(screenAnchorX),
+       static_cast<double>(screenAnchorY)},
+      rotationDelta, MAP_RENDER_SAFETY_PIXELS);
 
   RenderRequest latestRequestSnapshot;
   bool latestRequestSnapshotValid = false;
@@ -4280,64 +4465,62 @@ void Maps::updatePresentedFrameTransform() {
   }
 
   bool latestCoversPose = false;
-  if (latestRequestSnapshotValid) {
+  if (latestRequestSnapshotValid &&
+      renderRequestStillCurrent(latestRequestSnapshot)) {
     const auto latestProjection = makeRequestProjection(latestRequestSnapshot);
     const auto latestPoint = latestProjection.projectWorld(current);
     if (latestPoint.valid) {
-      const double latestDx =
-          std::fabs(latestPoint.x - latestProjection.anchorX());
-      const double latestDy =
-          std::fabs(latestPoint.y - latestProjection.anchorY());
-      const double latestHeadingDelta = std::fabs(
+      const double latestRotationDelta =
           map_presentation::signedHeadingDelta(
               latestRequestSnapshot.rotationRad * 180.0 /
                   3.14159265358979323846,
-              desiredRotation * 180.0 / 3.14159265358979323846));
-      latestCoversPose = latestDx < available && latestDy < available &&
-                         latestHeadingDelta < 4.0;
+              desiredRotation * 180.0 / 3.14159265358979323846) *
+          3.14159265358979323846 / 180.0;
+      latestCoversPose = map_presentation::frameCoversViewport(
+          latestRequestSnapshot.renderWidth,
+          latestRequestSnapshot.renderHeight,
+          latestRequestSnapshot.viewportWidth,
+          latestRequestSnapshot.viewportHeight,
+          {latestPoint.x, latestPoint.y},
+          {latestProjection.anchorX() -
+               latestRequestSnapshot.overscanPixels,
+           latestProjection.anchorY() -
+               latestRequestSnapshot.overscanPixels},
+          latestRotationDelta, MAP_RENDER_SAFETY_PIXELS);
     }
   }
-  const double headingDeltaDegrees = std::fabs(
-      rotationDelta * 180.0 / 3.14159265358979323846);
-  if (!latestCoversPose &&
-      (std::fabs(displacementX) >= available ||
-       std::fabs(displacementY) >= available ||
-       headingDeltaDegrees >= 4.0)) {
+  if (!visibleCoversPose && !latestCoversPose) {
     isPosMoved = true;
     redrawMap = true;
   }
+  lastFramePresentationSignature = presentationSignature;
 }
 
 void Maps::renderLiveForeground() {
-  if (canvasForeground == nullptr || bufMapForeground == nullptr)
+  if (canvasForeground == nullptr) {
+    lastForegroundPresentationSignature = 0;
     return;
-  const uint16_t width = mapScrWidth;
-  const uint16_t height = mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
-  const size_t required = rgb565A8BufferSize(width, height);
-  if (width == 0 || height == 0 || required > bufMapForegroundSize)
+  }
+  const auto hideForeground = [this]() {
+    lastForegroundPresentationSignature = 0;
+    if (!lv_obj_has_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN))
+      lv_obj_add_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+  };
+  if (bufMapForeground == nullptr) {
+    hideForeground();
     return;
-
-  bindMapForegroundCanvas(canvasForeground, width, height);
-  lv_obj_center(canvasForeground);
-  lv_img_set_angle(canvasForeground, 0);
-  lv_image_set_scale(canvasForeground, LV_SCALE_NONE);
-
-  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvasForeground);
-  if (drawBuffer == nullptr || drawBuffer->data == nullptr)
-    return;
-  const size_t colorStridePixels =
-      static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t));
-  auto *alpha = static_cast<uint8_t *>(drawBuffer->data) +
-                static_cast<size_t>(drawBuffer->header.stride) * height;
-  map_surface::Rgb565A8Surface surface{
-      reinterpret_cast<uint16_t *>(drawBuffer->data), alpha, width, height,
-      colorStridePixels, colorStridePixels};
-  surface.clearAlpha();
-
+  }
   const RouteSnapshot route = routeOverlay.snapshot();
   if (!publishedMapFrame || !hasVisibleProjection || !route.hasRoute() ||
       !isRouteOverlayVisible(mapRenderSettings) || !hasPresentedPose) {
-    lv_obj_add_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+    hideForeground();
+    return;
+  }
+  const uint16_t width = mapScrWidth;
+  const uint16_t height = mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
+  const size_t required = rgb565A8BufferSize(width, height);
+  if (width == 0 || height == 0 || required > bufMapForegroundSize) {
+    hideForeground();
     return;
   }
 
@@ -4348,7 +4531,7 @@ void Maps::renderLiveForeground() {
   const auto projectedPivot =
       visibleProjection.projectWorld(presentationPivotWorld);
   if (!projectedPivot.valid) {
-    lv_obj_add_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+    hideForeground();
     return;
   }
 
@@ -4363,6 +4546,50 @@ void Maps::renderLiveForeground() {
       visibleRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
       desiredRotation * 180.0 / 3.14159265358979323846) *
       3.14159265358979323846 / 180.0;
+  const uint8_t routeLineWidth = static_cast<uint8_t>(std::min<int>(
+      48, std::max<int>(1, currentMapStyleSettings().routeLineWidth)));
+  uint64_t presentationSignature = 1469598103934665603ULL;
+  presentationSignature =
+      fnvMix64(presentationSignature, route.revision);
+  presentationSignature = fnvMix64(
+      presentationSignature, visibleRenderResult.version.sequence);
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(presented.x));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(presented.y));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(projectedPivot.x));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(projectedPivot.y));
+  presentationSignature =
+      fnvMix64(presentationSignature, doubleBits(rotationDelta));
+  presentationSignature = fnvMix64(presentationSignature, width);
+  presentationSignature = fnvMix64(presentationSignature, height);
+  presentationSignature =
+      fnvMix64(presentationSignature, routeLineWidth);
+  if (presentationSignature == lastForegroundPresentationSignature &&
+      !lv_obj_has_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN)) {
+    return;
+  }
+
+  bindMapForegroundCanvas(canvasForeground, width, height);
+  lv_obj_center(canvasForeground);
+  lv_img_set_angle(canvasForeground, 0);
+  lv_image_set_scale(canvasForeground, LV_SCALE_NONE);
+
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvasForeground);
+  if (drawBuffer == nullptr || drawBuffer->data == nullptr) {
+    hideForeground();
+    return;
+  }
+  const size_t colorStridePixels =
+      static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t));
+  auto *alpha = static_cast<uint8_t *>(drawBuffer->data) +
+                static_cast<size_t>(drawBuffer->header.stride) * height;
+  map_surface::Rgb565A8Surface surface{
+      reinterpret_cast<uint16_t *>(drawBuffer->data), alpha, width, height,
+      colorStridePixels, colorStridePixels};
+  surface.clearAlpha();
 
   // This is the exact transform used by updatePresentedFrameTransform(): the
   // immutable base projection supplies source pixels, the presented rider is
@@ -4376,24 +4603,40 @@ void Maps::renderLiveForeground() {
   presentation.outputPivotY =
       visibleProjection.anchorY() - visibleRenderResult.overscanPixels;
   presentation.rotationRad = rotationDelta;
-  RouteOverlay::drawSnapshot(
-      route, surface, visibleProjection,
-      static_cast<uint8_t>(std::min<int>(
-          48, std::max<int>(1, currentMapStyleSettings().routeLineWidth))),
-      &presented, &presentation);
+  RouteOverlay::drawSnapshot(route, surface, visibleProjection, routeLineWidth,
+                             &presented, &presentation);
 
   lv_obj_clear_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
   lv_obj_invalidate(canvasForeground);
+  lastForegroundPresentationSignature = presentationSignature;
   if (canvasArrow != nullptr)
     lv_obj_move_foreground(canvasArrow);
 }
 
+bool Maps::presentationGestureOwnsTransforms() const {
+  return dragPreviewController.active() ||
+         dragPreviewController.settlementPending() ||
+         pinchPresentation.active || pinchPresentation.settlementPending;
+}
+
 bool Maps::serviceRenderPipeline(uint32_t nowMs) {
+  (void)recoverRenderWorkerIfNeeded();
   if (canvasMap == nullptr)
     return false;
-  invalidateRenderSemantics();
+  invalidateRenderSemantics(nowMs);
   updatePresentedPose(nowMs);
-  const bool published = publishReadyFrame(nowMs);
+  const bool gestureActive = dragPreviewController.active() ||
+                             pinchPresentation.active;
+  const bool settlementPending =
+      dragPreviewController.settlementPending() ||
+      pinchPresentation.settlementPending;
+  // An active gesture owns the image pivot/position/scale and its marker. Keep
+  // a ready worker frame hidden until release. During settlement, publication
+  // is the event that ends ownership; until a replacement is ready, preserve
+  // the exact preview endpoint instead of snapping back to follow mode.
+  const bool published = gestureActive ? false : publishReadyFrame(nowMs);
+  if (gestureActive || (settlementPending && !published))
+    return false;
   updatePresentedFrameTransform();
   renderLiveForeground();
   return published;
@@ -4702,8 +4945,34 @@ bool Maps::setVectorMapFolder(const std::string &folder) {
   if (normalized == vectorMapFolder)
     return true;
 
-  struct stat storage = {};
-  if (::stat(normalized.c_str(), &storage) != 0 || !S_ISDIR(storage.st_mode)) {
+  const bool restartWorker = renderWorkerTaskHandle != nullptr;
+  if (restartWorker && !stopRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map root switch deferred: render worker is busy");
+    return false;
+  }
+
+  const bool switched = switchVectorMapFolderOnStorageOwner(folder);
+  if (switched)
+    finalizeVectorMapFolderSwitchOnUi();
+  if (restartWorker && !startRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map root switched but render worker restart failed");
+    return false;
+  }
+  if (switched)
+    ESP_LOGI(TAG, "Vector map root switched to %s", vectorMapFolder.c_str());
+  return switched;
+}
+
+bool Maps::switchVectorMapFolderOnStorageOwner(const std::string &folder) {
+  String normalized(folder.c_str());
+  if (!normalized.endsWith("/"))
+    normalized += "/";
+  if (normalized == vectorMapFolder)
+    return true;
+
+  struct stat storageMetadata = {};
+  if (::stat(normalized.c_str(), &storageMetadata) != 0 ||
+      !S_ISDIR(storageMetadata.st_mode)) {
     ESP_LOGE(TAG, "Vector map root is unavailable: %s", normalized.c_str());
     return false;
   }
@@ -4712,38 +4981,32 @@ bool Maps::setVectorMapFolder(const std::string &folder) {
   const std::string fontPath =
       std::string(normalized.c_str()) + "assets/street-labels.fma";
   struct stat fontMetadata = {};
-  if (::stat(fontPath.c_str(), &fontMetadata) == 0) {
-    if (!S_ISREG(fontMetadata.st_mode) || !candidateFont.open(fontPath)) {
-      ESP_LOGE(TAG, "Street-label font asset is invalid: %s", fontPath.c_str());
-      return false;
-    }
-  }
-
-  const bool restartWorker = renderWorkerTaskHandle != nullptr;
-  if (restartWorker && !stopRenderWorker()) {
-    ESP_LOGE(TAG, "Vector map root switch deferred: render worker is busy");
+  if (::stat(fontPath.c_str(), &fontMetadata) == 0 &&
+      (!S_ISREG(fontMetadata.st_mode) || !candidateFont.open(fontPath))) {
+    ESP_LOGE(TAG, "Street-label font asset is invalid: %s", fontPath.c_str());
     return false;
   }
 
-  {
-    power_management::ScopedLock powerLock(
-        power_management::LockDomain::Storage);
-    for (MapBlock *block : memCache.blocks)
-      delete block;
-    memCache.blocks.clear();
-    cachedBlockCount.store(0, std::memory_order_release);
-    labelFontAsset = std::move(candidateFont);
-    streetLabelFontHealthy.store(labelFontAsset.healthy(),
-                                 std::memory_order_release);
-    labelLayoutCache.clear();
-    streetLabelRuntimeFailure.store(map_font_asset::RuntimeError::None,
-                                    std::memory_order_release);
-    buildingFailureRetryCooldown.clear();
-    vectorMapFolder = normalized;
-    isMapFound = false;
-    ++mapEpoch;
-  }
+  power_management::ScopedLock powerLock(
+      power_management::LockDomain::Storage);
+  for (MapBlock *block : memCache.blocks)
+    delete block;
+  memCache.blocks.clear();
+  cachedBlockCount.store(0, std::memory_order_release);
+  labelFontAsset = std::move(candidateFont);
+  streetLabelFontHealthy.store(labelFontAsset.healthy(),
+                               std::memory_order_release);
+  labelLayoutCache.clear();
+  streetLabelRuntimeFailure.store(map_font_asset::RuntimeError::None,
+                                  std::memory_order_release);
+  buildingFailureRetryCooldown.clear();
+  vectorMapFolder = normalized;
+  isMapFound = false;
+  return true;
+}
 
+void Maps::finalizeVectorMapFolderSwitchOnUi() {
+  ++mapEpoch;
   invalidateRollingRasterWindow();
   publishedMapFound = false;
   publishedMapFrame = false;
@@ -4751,12 +5014,6 @@ bool Maps::setVectorMapFolder(const std::string &folder) {
   redrawMap = true;
   oldMapTile = {};
   currentMapTile = {};
-  if (restartWorker && !startRenderWorker()) {
-    ESP_LOGE(TAG, "Vector map root switched but render worker restart failed");
-    return false;
-  }
-  ESP_LOGI(TAG, "Vector map root switched to %s", vectorMapFolder.c_str());
-  return true;
 }
 
 bool Maps::takeStreetLabelRuntimeFailure(std::string &code) {
@@ -4769,56 +5026,172 @@ bool Maps::takeStreetLabelRuntimeFailure(std::string &code) {
 }
 
 bool Maps::probeVectorMapFolder(const std::string &folder) {
-  std::string normalized = folder;
-  while (normalized.size() > 1 && normalized.back() == '/')
-    normalized.pop_back();
-  struct stat storage = {};
-  if (::stat(normalized.c_str(), &storage) != 0 || !S_ISDIR(storage.st_mode))
-    return false;
-
   const bool restartWorker = renderWorkerTaskHandle != nullptr;
   if (restartWorker && !stopRenderWorker()) {
     ESP_LOGE(TAG, "Vector map probe deferred: render worker is busy");
     return false;
   }
 
-  bool loaded = false;
-  {
-    power_management::ScopedLock powerLock(
-        power_management::LockDomain::Storage);
-    size_t visited = 0;
-    std::string blockBase;
-    if (!findMapBlock(normalized, blockBase, visited, 0)) {
-      ESP_LOGE(TAG, "No map block found under %s", normalized.c_str());
-    } else {
-      const bool previousMapFound = isMapFound.load();
-      isMapFound = false;
-      MapBlock *block = readMapBlock(String(blockBase.c_str()));
-      loaded = isMapFound.load();
-      if (loaded && block->formatVersion >= 3) {
-        map_font_asset::Asset candidateFont;
-        const std::string fontPath = normalized + "/assets/street-labels.fma";
-        loaded = candidateFont.open(fontPath) &&
-                 candidateFont.profileFingerprint() ==
-                     block->labelData.profileFingerprint &&
-                 block->labelData.referencesResolve(
-                     candidateFont.glyphCount(), candidateFont.languageCount());
-        if (!loaded)
-          ESP_LOGE(TAG, "Street-label block/font contract failed under %s",
-                   normalized.c_str());
-      }
-      delete block;
-      isMapFound = previousMapFound;
-      ESP_LOGI(TAG, "Vector map probe root=%s block=%s loaded=%d",
-               normalized.c_str(), blockBase.c_str(), loaded);
-    }
-  }
+  const bool loaded = probeVectorMapFolderOnStorageOwner(folder);
 
   if (restartWorker && !startRenderWorker()) {
     ESP_LOGE(TAG, "Vector map probe completed but worker restart failed");
     return false;
   }
   return loaded;
+}
+
+bool Maps::probeVectorMapFolderOnStorageOwner(const std::string &folder) {
+  std::string normalized = folder;
+  while (normalized.size() > 1 && normalized.back() == '/')
+    normalized.pop_back();
+  struct stat storageMetadata = {};
+  if (::stat(normalized.c_str(), &storageMetadata) != 0 ||
+      !S_ISDIR(storageMetadata.st_mode))
+    return false;
+
+  bool loaded = false;
+  power_management::ScopedLock powerLock(
+      power_management::LockDomain::Storage);
+  size_t visited = 0;
+  std::string blockBase;
+  if (!findMapBlock(normalized, blockBase, visited, 0)) {
+    ESP_LOGE(TAG, "No map block found under %s", normalized.c_str());
+    return false;
+  }
+
+  const bool previousMapFound = isMapFound.load();
+  isMapFound = false;
+  MapBlock *block = readMapBlock(String(blockBase.c_str()));
+  loaded = block != nullptr && isMapFound.load();
+  if (loaded && block->formatVersion >= 3) {
+    map_font_asset::Asset candidateFont;
+    const std::string fontPath = normalized + "/assets/street-labels.fma";
+    loaded = candidateFont.open(fontPath) &&
+             candidateFont.profileFingerprint() ==
+                 block->labelData.profileFingerprint &&
+             block->labelData.referencesResolve(candidateFont.glyphCount(),
+                                                candidateFont.languageCount());
+    if (!loaded)
+      ESP_LOGE(TAG, "Street-label block/font contract failed under %s",
+               normalized.c_str());
+  }
+  delete block;
+  isMapFound = previousMapFound;
+  ESP_LOGI(TAG, "Vector map probe root=%s block=%s loaded=%d",
+           normalized.c_str(), blockBase.c_str(), loaded);
+  return loaded;
+}
+
+bool Maps::requestVectorMapFolderActivation(const std::string &folder) {
+  if (folder.empty())
+    return false;
+  if (renderWorkerRestartAfterExit.load(std::memory_order_acquire) &&
+      !recoverRenderWorkerIfNeeded())
+    return false;
+  if (renderWorkerTaskHandle == nullptr && !startRenderWorker())
+    return false;
+  if (renderWorkerShutdown.load(std::memory_order_acquire))
+    return false;
+  if (renderStateMutex == nullptr ||
+      xSemaphoreTake(renderStateMutex, pdMS_TO_TICKS(5)) != pdTRUE)
+    return false;
+  if (pendingVectorMapActivationValid || completedVectorMapActivationValid) {
+    xSemaphoreGive(renderStateMutex);
+    return false;
+  }
+
+  pendingVectorMapActivation.sequence = ++vectorMapActivationSequence;
+  pendingVectorMapActivation.folder = folder;
+  pendingVectorMapActivationValid = true;
+  gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
+  renderJobs.requestCancellation();
+  if (renderJobs.state() == map_render_job::State::Ready) {
+    renderJobs.rejectReadyAsStale();
+    readyRenderResultValid = false;
+  }
+  const TaskHandle_t worker = renderWorkerTaskHandle;
+  xSemaphoreGive(renderStateMutex);
+  if (worker != nullptr)
+    xTaskNotifyGive(worker);
+  return true;
+}
+
+bool Maps::takeVectorMapActivationRequest(
+    VectorMapActivationRequest &request) {
+  if (renderStateMutex == nullptr ||
+      xSemaphoreTake(renderStateMutex, portMAX_DELAY) != pdTRUE)
+    return false;
+  const bool available = pendingVectorMapActivationValid &&
+                         !completedVectorMapActivationValid;
+  if (available) {
+    request = pendingVectorMapActivation;
+    pendingVectorMapActivation = {};
+    pendingVectorMapActivationValid = false;
+  }
+  xSemaphoreGive(renderStateMutex);
+  return available;
+}
+
+bool Maps::processPendingVectorMapActivation() {
+  VectorMapActivationRequest request;
+  if (!takeVectorMapActivationRequest(request))
+    return false;
+
+  // Control-plane storage work runs on the same sole owner as block rendering,
+  // but starts a fresh cooperative token after the render it superseded has
+  // quiesced. No SD traversal or block parsing runs in the LVGL loop.
+  gMapRenderActiveCancellationGeneration.store(
+      gMapRenderCancellationGeneration.load(std::memory_order_acquire),
+      std::memory_order_release);
+  gMapRenderControlOperation.store(true, std::memory_order_release);
+  const bool loaded = probeVectorMapFolderOnStorageOwner(request.folder) &&
+                      switchVectorMapFolderOnStorageOwner(request.folder);
+  gMapRenderControlOperation.store(false, std::memory_order_release);
+
+  if (renderStateMutex != nullptr &&
+      xSemaphoreTake(renderStateMutex, portMAX_DELAY) == pdTRUE) {
+    completedVectorMapActivation =
+        {request.sequence, request.folder, loaded};
+    completedVectorMapActivationValid = true;
+    latestRenderRequestValid = false;
+    xSemaphoreGive(renderStateMutex);
+  }
+  MAPIO_LOG("MAPIO: activation-ready sequence=%lu loaded=%u root=%s\n",
+            (unsigned long)request.sequence, loaded ? 1U : 0U,
+            request.folder.c_str());
+  ui_scheduler::notify(ui_scheduler::WakeReason::Transfer);
+  return true;
+}
+
+bool Maps::takeVectorMapFolderActivationResult(
+    VectorMapActivationResult &result) {
+  if (renderStateMutex == nullptr ||
+      xSemaphoreTake(renderStateMutex, 0) != pdTRUE)
+    return false;
+  if (!completedVectorMapActivationValid) {
+    xSemaphoreGive(renderStateMutex);
+    return false;
+  }
+  result.folder = completedVectorMapActivation.folder;
+  result.loaded = completedVectorMapActivation.loaded;
+  completedVectorMapActivation = {};
+  completedVectorMapActivationValid = false;
+  xSemaphoreGive(renderStateMutex);
+
+  if (result.loaded)
+    finalizeVectorMapFolderSwitchOnUi();
+  else {
+    // Enqueuing the control job cancels any render that was using the old
+    // storage snapshot.  A failed probe leaves that old root selected, so
+    // explicitly request a replacement frame instead of waiting for a later
+    // movement/heading threshold to happen to revive the renderer.
+    isPosMoved = true;
+    redrawMap = true;
+  }
+  if (renderWorkerTaskHandle != nullptr)
+    xTaskNotifyGive(renderWorkerTaskHandle);
+  return true;
 }
 
 /**
@@ -4835,9 +5208,9 @@ void Maps::deleteMapScrSprites() {
   // screen. Cancel the semantic request without blocking the UI task; stale
   // completion is rejected before publication when the screen is recreated.
   ++projectionEpoch;
-  gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
   if (renderStateMutex != nullptr &&
       xSemaphoreTake(renderStateMutex, pdMS_TO_TICKS(5)) == pdTRUE) {
+    gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
     renderJobs.requestCancellation();
     const map_render_job::Version invalidated = renderJobs.invalidate();
     gMapRenderLatestSequence.store(invalidated.sequence,
@@ -4849,6 +5222,7 @@ void Maps::deleteMapScrSprites() {
     // The worker also checks this atomic token between bounded work units. If
     // the mutex is momentarily busy, publication still rejects the obsolete
     // projection epoch before the frame can become visible.
+    gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
     gMapRenderLatestSequence.fetch_add(1, std::memory_order_acq_rel);
   }
 
@@ -4856,6 +5230,8 @@ void Maps::deleteMapScrSprites() {
   publishedMapFrame = false;
   publishedMapFound = false;
   framePublicationPending = false;
+  lastFramePresentationSignature = 0;
+  lastForegroundPresentationSignature = 0;
   if (Maps::canvasArrow)
     lv_obj_delete(Maps::canvasArrow);
   if (Maps::canvasMap)
@@ -4903,7 +5279,10 @@ void Maps::createMapScrSprites() {
   const bool frameStorageMustMove =
       bufMapScreen == nullptr || bufMapScreenSize < frameBytes ||
       bufMapTemp == nullptr || bufMapTempSize < frameBytes;
-  if (frameStorageMustMove && renderWorkerTaskHandle != nullptr &&
+  const bool workerCanOwnFrameStorage =
+      bufMapScreen != nullptr && bufMapTemp != nullptr;
+  if (frameStorageMustMove && workerCanOwnFrameStorage &&
+      renderWorkerTaskHandle != nullptr &&
       !stopRenderWorker()) {
     ESP_LOGE(TAG, "Map screen creation deferred: render worker owns storage");
     return;
@@ -4928,6 +5307,8 @@ void Maps::createMapScrSprites() {
   publishedMapFound = false;
   framePublicationPending = false;
   hasVisibleProjection = false;
+  lastFramePresentationSignature = 0;
+  lastForegroundPresentationSignature = 0;
   ++projectionEpoch;
 
   Maps::canvasMap = lv_canvas_create(mapTile);
@@ -4961,7 +5342,7 @@ void Maps::createMapScrSprites() {
   lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
   lv_obj_add_event_cb(Maps::canvasArrow, drawCurrentPositionMarker,
                       LV_EVENT_DRAW_MAIN, nullptr);
-  updateCurrentPositionMarker(Maps::canvasArrow, true);
+  updateCurrentPositionMarker(Maps::canvasArrow, 0.0, true);
 
   if (!startRenderWorker()) {
     ESP_LOGE(TAG, "Map render worker unavailable");
@@ -5821,6 +6202,8 @@ bool Maps::beginDragPreview(uint8_t baseZoom) {
   if (!dragPreviewController.begin())
     return false;
 
+  if (Maps::canvasForeground != nullptr)
+    lv_obj_add_flag(Maps::canvasForeground, LV_OBJ_FLAG_HIDDEN);
   hideRollingForeground();
   lv_obj_clear_flag(mapTile, LV_OBJ_FLAG_OVERFLOW_VISIBLE);
   if (dragPresentation.hasBackdrop && Maps::canvasMapTemp != nullptr) {
@@ -5930,6 +6313,8 @@ void Maps::handoffDragPreviewToPinch() {
 }
 
 void Maps::resetDragPresentationVisuals() {
+  lastFramePresentationSignature = 0;
+  lastForegroundPresentationSignature = 0;
   if (Maps::canvasMap != nullptr) {
     if (dragPresentation.usesRollingRaster && rollingRasterWindow.valid) {
       positionRollingRasterCanvas(Maps::point);
@@ -5979,6 +6364,8 @@ bool Maps::beginPinchPreview(int16_t midpointX, int16_t midpointY,
   }
 
   pinchPresentation.active = true;
+  if (Maps::canvasForeground != nullptr)
+    lv_obj_add_flag(Maps::canvasForeground, LV_OBJ_FLAG_HIDDEN);
   hideRollingForeground();
   pinchPresentation.capturedFollowGps = Maps::followGps;
   pinchPresentation.baseZoom = map_transform::clampRuntimeZoom(baseZoom);
@@ -6149,6 +6536,8 @@ void Maps::updatePinchPreview(double previewRatio, int16_t midpointX,
 }
 
 void Maps::resetPinchPresentationVisuals() {
+  lastFramePresentationSignature = 0;
+  lastForegroundPresentationSignature = 0;
   if (Maps::canvasMap != nullptr) {
     lv_anim_delete(Maps::canvasMap, setPinchCanvasScale);
     lv_image_set_scale(Maps::canvasMap, LV_SCALE_NONE);
@@ -6315,7 +6704,7 @@ void Maps::updateArrowColor() {
   if (!Maps::canvasArrow)
     return;
 
-  updateCurrentPositionMarker(Maps::canvasArrow, true);
+  updateCurrentPositionMarker(Maps::canvasArrow, 0.0, true);
 }
 
 /**
@@ -6435,9 +6824,25 @@ void Maps::displayMap() {
 
 void Maps::updatePositionOverlay() {
   const uint32_t displayStartMs = MAPIO_TIME_MS();
+  // Drag/pinch preview code owns the marker transform together with the base
+  // image. A normal 30 ms presentation tick must not overwrite that preview
+  // or its settlement endpoint while a replacement frame is pending.
+  if (presentationGestureOwnsTransforms())
+    return;
   // Update Arrow Position
   if (Maps::canvasArrow) {
     if (!publishedMapFound || !isCurrentPositionVisible(mapRenderSettings)) {
+      lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
+      return;
+    }
+    const bool navigationActive =
+        routeOverlay.hasRoute() || hasCurrentNavigationData();
+    if (navigationActive &&
+        (!hasPresentedPose || !presentedPose.headingValid)) {
+      // A navigation glyph has directional meaning. Until the new session has
+      // a measured course, route bearing, or remembered in-session course,
+      // hiding it is the only honest presentation; zero degrees would recreate
+      // the false-north bug that the explicit heading contract removes.
       lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       return;
     }
@@ -6462,7 +6867,20 @@ void Maps::updatePositionOverlay() {
                                           visibleProjection.anchorY()) -
                                       visibleRenderResult.overscanPixels)
                                 : mapAnchorYForHeight(h);
-    updateCurrentPositionMarker(Maps::canvasArrow);
+    double displayedMapRotation = visibleRenderResult.rotationRad;
+    if (rotationMode == ROT_COURSE_UP && hasPresentedPose &&
+        presentedPose.headingValid) {
+      displayedMapRotation =
+          -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
+    } else if (rotationMode == ROT_NORTH_UP) {
+      displayedMapRotation = 0.0;
+    }
+    const double markerRotation =
+        hasPresentedPose && presentedPose.headingValid
+            ? map_presentation::markerRotationDegrees(
+                  presentedPose.headingDegrees, displayedMapRotation)
+            : 0.0;
+    updateCurrentPositionMarker(Maps::canvasArrow, markerRotation);
     const int16_t markerVisualHalf = currentMarkerSize() / 2;
     int16_t x, y;
 
@@ -6556,6 +6974,7 @@ void Maps::updatePositionOverlay() {
  * @param zoom -> Zoom Level
  */
 bool Maps::generateVectorMap(uint8_t requestedZoom) {
+  (void)recoverRenderWorkerIfNeeded();
   if (canvasMap == nullptr || canvasMapTemp == nullptr ||
       renderWorkerTaskHandle == nullptr) {
     return false;

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3167,8 +3167,10 @@ bool Maps::readVectorMap(
           if (region.valid())
             projectedCourtyardPixels += region.pixels();
           if (projectedCourtyardPixels >
-              std::min(kMaximumCourtyardWorkspacePixels,
-                       static_cast<size_t>(surface.width) * surface.height)) {
+              std::min<std::size_t>(
+                  static_cast<std::size_t>(kMaximumCourtyardWorkspacePixels),
+                  static_cast<std::size_t>(surface.width) *
+                      static_cast<std::size_t>(surface.height))) {
             courtyardFits = false;
             break;
           }
@@ -4328,7 +4330,7 @@ void Maps::renderLiveForeground() {
   auto *alpha = static_cast<uint8_t *>(drawBuffer->data) +
                 static_cast<size_t>(drawBuffer->header.stride) * height;
   map_surface::Rgb565A8Surface surface{
-      static_cast<uint16_t *>(drawBuffer->data), alpha, width, height,
+      reinterpret_cast<uint16_t *>(drawBuffer->data), alpha, width, height,
       colorStridePixels, colorStridePixels};
   surface.clearAlpha();
 

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -4412,8 +4412,17 @@ void Maps::updatePresentedFrameTransform() {
       visibleRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
       desiredRotation * 180.0 / 3.14159265358979323846) *
       3.14159265358979323846 / 180.0;
-  const int16_t targetX = viewportOriginX + screenAnchorX - pivotX;
-  const int16_t targetY = viewportOriginY + screenAnchorY - pivotY;
+  // canvasMap remains LV_ALIGN_CENTER. Its style x/y are offsets from the
+  // already-centered 658x658 overscan frame, not absolute parent coordinates.
+  // Converting the desired parent-space pivot target into that aligned offset
+  // prevents applying the 96 px overscan origin twice while the viewport-sized
+  // route foreground and arrow use it once.
+  const int32_t targetX = gui_layout::centerAlignedOffsetForPoint(
+      containerWidth, visibleRenderResult.renderWidth, pivotX,
+      viewportOriginX + screenAnchorX);
+  const int32_t targetY = gui_layout::centerAlignedOffsetForPoint(
+      containerHeight, visibleRenderResult.renderHeight, pivotY,
+      viewportOriginY + screenAnchorY);
   const int16_t targetAngle = mapAngleTenths(rotationDelta);
   uint64_t presentationSignature = 1469598103934665603ULL;
   presentationSignature = fnvMix64(

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -10,6 +10,9 @@
 #include "maps.hpp"
 #include "mapBlockFormat.hpp"
 #include "mapBuildingRenderer.hpp"
+#include "mapBuildingAdmission.hpp"
+#include "mapBuildingWorkspace.hpp"
+#include "mapSurface.hpp"
 #include "mapLabelLayout.hpp"
 #include "mapLabelRasterizer.hpp"
 #include "mapLabelSelection.hpp"
@@ -47,6 +50,7 @@ const char *TAG PROGMEM = "Maps";
 #include "../../gui/src/mainScr.hpp"
 #include "../../route_overlay/route_overlay.hpp"
 #include <algorithm>
+#include <atomic>
 #include <esp_heap_caps.h>
 #include <cstdlib>
 #include <cstring>
@@ -59,10 +63,9 @@ const char *TAG PROGMEM = "Maps";
 
 namespace {
 
-// Keep memory samples behind the existing map timing/diagnostics switch.  The
-// fields are deliberately stable and machine-readable so a source-monitor
-// capture can correlate heap fragmentation with a map-render phase without
-// changing the renderer's allocation or scheduling policy.
+// Keep the main-branch memory diagnostics stable while moving raster work off
+// the LVGL task. These samples are observational only and do not alter the
+// renderer's allocation or scheduling policy.
 static void logMapMemorySnapshot(const char *phase) {
 #if defined(WAVESHARE_MAPIO_TIMING_LOG) || defined(WAVESHARE_TOUCH_DIAGNOSTICS)
   constexpr uint32_t kMapMemorySnapshotMinIntervalMs = 250;
@@ -101,6 +104,56 @@ static void logMapMemorySnapshot(const char *phase) {
 #else
   (void)phase;
 #endif
+}
+
+// The map renderer has exactly one non-LVGL worker.  Rendering helpers use
+// this task identity to turn their existing cooperative checkpoints into
+// latest-wins cancellation points without changing non-worker callers.
+TaskHandle_t gMapRenderWorkerTaskHandle = nullptr;
+std::atomic<uint32_t> gMapRenderLatestSequence{0};
+std::atomic<uint32_t> gMapRenderActiveSequence{0};
+std::atomic<uint32_t> gMapRenderCancellationGeneration{0};
+std::atomic<uint32_t> gMapRenderActiveCancellationGeneration{0};
+std::atomic<bool> gMapRenderWorkerShutdown{false};
+std::atomic<uint32_t> gMapRenderSliceCount{0};
+std::atomic<uint32_t> gMapRenderLongestSliceUs{0};
+uint32_t gMapRenderLastCheckpointUs = 0;
+
+inline bool onMapRenderWorkerTask() {
+  return gMapRenderWorkerTaskHandle != nullptr &&
+         xTaskGetCurrentTaskHandle() == gMapRenderWorkerTaskHandle;
+}
+
+bool shouldCancelMapRenderWork() {
+  if (onMapRenderWorkerTask()) {
+    const uint32_t nowUs = micros();
+    if (gMapRenderLastCheckpointUs != 0) {
+      const uint32_t elapsedUs = nowUs - gMapRenderLastCheckpointUs;
+      gMapRenderSliceCount.fetch_add(1, std::memory_order_relaxed);
+      uint32_t longest =
+          gMapRenderLongestSliceUs.load(std::memory_order_relaxed);
+      while (elapsedUs > longest &&
+             !gMapRenderLongestSliceUs.compare_exchange_weak(
+                 longest, elapsedUs, std::memory_order_relaxed)) {
+      }
+      if (elapsedUs >= 2000U)
+        taskYIELD();
+    }
+    gMapRenderLastCheckpointUs = micros();
+    return gMapRenderWorkerShutdown.load(std::memory_order_acquire) ||
+           gMapRenderActiveCancellationGeneration.load(
+               std::memory_order_acquire) !=
+               gMapRenderCancellationGeneration.load(
+                   std::memory_order_acquire);
+  }
+  return shouldInterruptMapRenderForScreenCycle();
+}
+
+constexpr uint16_t rgb565FromRgb888(uint32_t rgb) {
+  const uint16_t red = static_cast<uint16_t>((rgb >> 19U) & 0x1FU);
+  const uint16_t green = static_cast<uint16_t>((rgb >> 10U) & 0x3FU);
+  const uint16_t blue = static_cast<uint16_t>((rgb >> 3U) & 0x1FU);
+  return static_cast<uint16_t>((red << 11U) | (green << 5U) | blue);
 }
 
 bool findMapBlock(const std::string &directory, std::string &basePath,
@@ -151,7 +204,7 @@ bool validateMapBlockCooperatively(const std::string &path,
   map_block_format::StreamValidator validator(path);
   size_t offset = 0;
   while (offset < size) {
-    if (shouldInterruptMapRenderForScreenCycle()) {
+    if (shouldCancelMapRenderWork()) {
       interrupted = true;
       return false;
     }
@@ -433,6 +486,48 @@ static bool ensureMapForegroundBuffer(uint16_t width, uint16_t height) {
                          rgb565A8BufferSize(width, height), "foreground");
 }
 
+static map_surface::Rgb565Surface rgb565SurfaceForCanvas(lv_obj_t *canvas) {
+  if (canvas == nullptr)
+    return {};
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
+  if (drawBuffer == nullptr || drawBuffer->data == nullptr ||
+      drawBuffer->header.cf != LV_COLOR_FORMAT_RGB565)
+    return {};
+  return {reinterpret_cast<uint16_t *>(drawBuffer->data),
+          static_cast<int32_t>(drawBuffer->header.w),
+          static_cast<int32_t>(drawBuffer->header.h),
+          static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t))};
+}
+
+static map_surface::LabelSurface labelSurfaceForCanvas(
+    lv_obj_t *canvas, const map_surface::Rgb565Surface *contrast = nullptr,
+    int32_t contrastOffsetX = 0, int32_t contrastOffsetY = 0) {
+  if (canvas == nullptr)
+    return {};
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
+  if (drawBuffer == nullptr || drawBuffer->data == nullptr)
+    return {};
+  const bool transparent = drawBuffer->header.cf == LV_COLOR_FORMAT_RGB565A8;
+  if (!transparent && drawBuffer->header.cf != LV_COLOR_FORMAT_RGB565)
+    return {};
+  map_surface::LabelSurface surface;
+  surface.color = {
+      reinterpret_cast<uint16_t *>(drawBuffer->data),
+      static_cast<int32_t>(drawBuffer->header.w),
+      static_cast<int32_t>(drawBuffer->header.h),
+      static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t))};
+  if (transparent) {
+    surface.alpha = static_cast<uint8_t *>(drawBuffer->data) +
+                    static_cast<size_t>(drawBuffer->header.stride) *
+                        drawBuffer->header.h;
+    surface.alphaStrideBytes = drawBuffer->header.stride / sizeof(uint16_t);
+  }
+  surface.contrast = contrast;
+  surface.contrastOffsetX = contrastOffsetX;
+  surface.contrastOffsetY = contrastOffsetY;
+  return surface;
+}
+
 static void bindMapForegroundCanvas(lv_obj_t *canvas, uint16_t width,
                                     uint16_t height) {
   lv_canvas_set_buffer(canvas, bufMapForeground, width, height,
@@ -629,7 +724,7 @@ static void drawCurrentPositionMarker(lv_event_t *event) {
   const lv_color_t color =
       lv_color_hex(navigation_visual_style::ROUTE_BLUE_RGB888);
 
-  if (routeOverlay.hasRoute()) {
+  if (routeOverlay.hasRoute() || hasCurrentNavigationData()) {
     drawNavigationMarker(layer, bounds, size, color);
   } else {
     drawPositionDotMarker(layer, bounds, size, color);
@@ -644,7 +739,8 @@ static void updateCurrentPositionMarker(lv_obj_t *marker, bool force = false) {
   static bool lastWasNavigating = false;
   static uint8_t lastScale = 0;
 
-  const bool isNavigating = routeOverlay.hasRoute();
+  const bool isNavigating =
+      routeOverlay.hasRoute() || hasCurrentNavigationData();
   const uint8_t scale = currentMarkerScale();
   if (!force && hasLastShape && lastWasNavigating == isNavigating &&
       lastScale == scale) {
@@ -1003,7 +1099,7 @@ bool Maps::parseCoords(char *file,
   Point16 point;
   while (true) {
     if ((points.size() & 0x1F) == 0 &&
-        shouldInterruptMapRenderForScreenCycle()) {
+        shouldCancelMapRenderWork()) {
       return false;
     }
     try {
@@ -1118,7 +1214,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     size_t bytesRead = 0;
     bool readInterrupted = false;
     while (bytesRead < fileSize) {
-      if (shouldInterruptMapRenderForScreenCycle()) {
+      if (shouldCancelMapRenderWork()) {
         readInterrupted = true;
         break;
       }
@@ -1153,7 +1249,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
       return mblock;
     }
 
-    if (shouldInterruptMapRenderForScreenCycle()) {
+    if (shouldCancelMapRenderWork()) {
       free(file);
       Maps::isMapFound = false;
       return mblock;
@@ -1180,7 +1276,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     size_t normalizedSize = 0;
     for (size_t index = 0; index < fileSize; ++index) {
       if ((index & 0x0FFF) == 0 &&
-          shouldInterruptMapRenderForScreenCycle()) {
+          shouldCancelMapRenderWork()) {
         free(file);
         Maps::isMapFound = false;
         return mblock;
@@ -1237,7 +1333,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     Polygon polygon;
     Point16 p;
     while (count > 0) {
-      if (shouldInterruptMapRenderForScreenCycle()) {
+      if (shouldCancelMapRenderWork()) {
         free(file);
         Maps::isMapFound = false;
         return mblock;
@@ -1299,7 +1395,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
 
       Polyline polyline;
       while (count > 0) {
-        if (shouldInterruptMapRenderForScreenCycle()) {
+        if (shouldCancelMapRenderWork()) {
           free(file);
           Maps::isMapFound = false;
           return mblock;
@@ -1351,7 +1447,7 @@ Maps::MapBlock *Maps::readMapBlock(String fileName) {
     // Build spatial grid for polygon culling optimization
     const uint32_t gridStartMs = MAPIO_TIME_MS();
     if (!buildPolygonGrid(mblock)) {
-      if (shouldInterruptMapRenderForScreenCycle()) {
+      if (shouldCancelMapRenderWork()) {
         free(file);
         Maps::isMapFound = false;
         delete mblock;
@@ -1423,7 +1519,7 @@ Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
   mblock->polygons.reserve(polyCount);
 
   for (int i = 0; i < polyCount; i++) {
-    if ((i & 0x1F) == 0 && shouldInterruptMapRenderForScreenCycle()) {
+    if ((i & 0x1F) == 0 && shouldCancelMapRenderWork()) {
       Maps::isMapFound = false;
       delete mblock;
       return new MapBlock();
@@ -1465,7 +1561,7 @@ Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
   mblock->polylines.reserve(lineCount);
 
   for (int i = 0; i < lineCount; i++) {
-    if ((i & 0x1F) == 0 && shouldInterruptMapRenderForScreenCycle()) {
+    if ((i & 0x1F) == 0 && shouldCancelMapRenderWork()) {
       Maps::isMapFound = false;
       delete mblock;
       return new MapBlock();
@@ -1530,7 +1626,7 @@ Maps::MapBlock *Maps::readMapBlockBinary(char *file, size_t fileSize) {
   // Build spatial grid for polygon culling optimization
   const uint32_t gridStartMs = MAPIO_TIME_MS();
   if (!buildPolygonGrid(mblock)) {
-    if (shouldInterruptMapRenderForScreenCycle()) {
+    if (shouldCancelMapRenderWork()) {
       Maps::isMapFound = false;
       delete mblock;
       return new MapBlock();
@@ -1583,7 +1679,7 @@ bool Maps::buildPolygonGrid(MapBlock *mblock) {
 
     size_t totalEntries = 0;
     for (uint16_t i = 0; i < mblock->polygons.size(); i++) {
-      if ((i & 0x1F) == 0 && shouldInterruptMapRenderForScreenCycle()) {
+      if ((i & 0x1F) == 0 && shouldCancelMapRenderWork()) {
         mblock->polygonGrid.clear();
         return false;
       }
@@ -1642,138 +1738,74 @@ bool Maps::buildPolygonGrid(MapBlock *mblock) {
  * @param points
  * @param color
  */
-bool Maps::fillPolygon(const Polygon &p, lv_obj_t *canvas,
-                       uint32_t deadlineStartMs,
-                       uint32_t deadlineDurationMs) // scanline fill algorithm
-{
-  int16_t maxY = p.bbox.max.y;
-  int16_t minY = p.bbox.min.y;
-
-  // Retrieve canvas buffer and dimensions
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
-  if (draw_buf == NULL)
+bool Maps::fillPolygon(const Polygon &p,
+                       map_surface::Rgb565Surface surface) {
+  if (!surface.valid() || p.points.size() < 2)
     return true;
-  uint16_t *buf =
-      (uint16_t *)draw_buf->data; // Assuming RGB565 and direct access
-  int32_t buf_w = draw_buf->header.w;
-  int32_t buf_h = draw_buf->header.h;
-  uint32_t stride_pixels =
-      draw_buf->header.stride / 2; // Stride in uint16 pixels
 
-  // Clip to actual buffer dimensions, not mapScrHeight (critical for FULL
-  // render mode)
-  if (maxY >= buf_h)
-    maxY = buf_h - 1;
-  if (minY < 0)
-    minY = 0;
+  int16_t maxY = std::min<int32_t>(p.bbox.max.y, surface.height - 1);
+  int16_t minY = std::max<int32_t>(p.bbox.min.y, 0);
   if (minY >= maxY)
     return true;
 
-  int16_t nodeX[p.points.size()], pixelY;
+  std::vector<int16_t, PsramAllocator<int16_t>> nodeX;
+  try {
+    nodeX.resize(p.points.size());
+  } catch (const std::bad_alloc &) {
+    return false;
+  }
 
-  //  Loop through the rows of the image.
-  int16_t nodes, i, swap;
-
-  if (p.points.size() < 2)
-    return true;
-
-  for (pixelY = minY; pixelY <= maxY; pixelY++) { //  Build a list of nodes.
+  for (int16_t pixelY = minY; pixelY <= maxY; ++pixelY) {
     if ((pixelY & 0x0F) == 0) {
-      if (shouldInterruptMapRenderForScreenCycle())
-        return false;
-      if (deadlineDurationMs != 0 &&
-          millis() - deadlineStartMs >= deadlineDurationMs)
+      if (shouldCancelMapRenderWork())
         return false;
     }
-    nodes = 0;
-    for (int i = 0; i < (int)p.points.size() - 1; i++) {
-      if ((p.points[i].y < pixelY && p.points[i + 1].y >= pixelY) ||
-          (p.points[i].y >= pixelY && p.points[i + 1].y < pixelY)) {
-        nodeX[nodes++] =
-            p.points[i].x + double(pixelY - p.points[i].y) /
-                                double(p.points[i + 1].y - p.points[i].y) *
-                                double(p.points[i + 1].x - p.points[i].x);
+    int16_t nodes = 0;
+    for (size_t index = 0; index + 1 < p.points.size(); ++index) {
+      const Point16 &start = p.points[index];
+      const Point16 &end = p.points[index + 1];
+      if ((start.y < pixelY && end.y >= pixelY) ||
+          (start.y >= pixelY && end.y < pixelY)) {
+        if (nodes >= static_cast<int16_t>(nodeX.size()))
+          return false;
+        nodeX[nodes++] = static_cast<int16_t>(
+            start.x + static_cast<double>(pixelY - start.y) /
+                          static_cast<double>(end.y - start.y) *
+                          static_cast<double>(end.x - start.x));
       }
     }
-    assert(nodes < p.points.size());
-
-    //  Sort the nodes, via a simple “Bubble” sort.
-    i = 0;
-    while (i < nodes - 1) { // TODO: rework
-      if (nodeX[i] > nodeX[i + 1]) {
-        swap = nodeX[i];
-        nodeX[i] = nodeX[i + 1];
-        nodeX[i + 1] = swap;
-        i = 0;
-      } else
-        i++;
-    }
-
-    //  Fill the pixels between node pairs.
-    for (i = 0; i <= nodes - 2; i += 2) {
-      if (nodeX[i] > buf_w)
-        break;
-      if (nodeX[i + 1] < 0)
+    std::sort(nodeX.begin(), nodeX.begin() + nodes);
+    uint16_t *row = surface.row(pixelY);
+    if (row == nullptr)
+      continue;
+    for (int16_t index = 0; index + 1 < nodes; index += 2) {
+      int32_t startX = std::max<int32_t>(0, nodeX[index]);
+      int32_t endX = std::min<int32_t>(surface.width, nodeX[index + 1]);
+      if (startX >= endX)
         continue;
-      if (nodeX[i] < 0)
-        nodeX[i] = 0;
-      if (nodeX[i + 1] > buf_w)
-        nodeX[i + 1] = buf_w;
-
-      // Draw horizontal line directly to buffer (RGB565)
-      int32_t y = pixelY;
-
-      // CRITICAL FIX: Clip y to buffer height
-      if (y < 0 || y >= buf_h)
-        continue;
-
-      int32_t startX = nodeX[i];
-      int32_t endX = nodeX[i + 1];
-
-      // Horizontal clipping
-      if (startX >= buf_w)
-        continue;
-      if (endX <= 0)
-        continue;
-
-      if (endX > buf_w)
-        endX = buf_w;
-      if (startX < 0)
-        startX = 0;
-
-      uint16_t color = p.color; // Use color directly (RGB565)
-
-      uint32_t row_offset = y * stride_pixels;
-
-      for (int cx = startX; cx < endX; cx++) {
-        buf[row_offset + cx] = color; // Use stride and swapped color
-      }
+      std::fill(row + startX, row + endX, p.color);
     }
   }
   return true;
 }
 
-/**
- * @brief Draw an opaque filled line directly to the canvas buffer
- *
- * @param canvas
- * @param x1
- * @param y1
- * @param x2
- * @param y2
- * @param color (Already swapped for RGB565 if needed)
- */
+bool Maps::fillPolygon(const Polygon &p, lv_obj_t *canvas) {
+  return fillPolygon(p, rgb565SurfaceForCanvas(canvas));
+}
+
+void Maps::drawLine(map_surface::Rgb565Surface surface, int16_t x1,
+                    int16_t y1, int16_t x2, int16_t y2, uint16_t color,
+                    uint8_t width) {
+  if (!surface.valid())
+    return;
+  line_rasterizer::drawFilledLine(surface.pixels, surface.width, surface.height,
+                                  surface.stridePixels, x1, y1, x2, y2, color,
+                                  width);
+}
+
 void Maps::drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
                     int16_t y2, uint16_t color, uint8_t width) {
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
-  if (draw_buf == NULL)
-    return;
-  uint16_t *buf = (uint16_t *)draw_buf->data;
-  int32_t buf_w = draw_buf->header.w;
-  int32_t buf_h = draw_buf->header.h;
-  uint32_t stride_pixels = draw_buf->header.stride / 2;
-  line_rasterizer::drawFilledLine(buf, buf_w, buf_h, stride_pixels, x1, y1,
-                                  x2, y2, color, width);
+  drawLine(rgb565SurfaceForCanvas(canvas), x1, y1, x2, y2, color, width);
 }
 
 /**
@@ -1784,13 +1816,14 @@ void Maps::drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
  */
 bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
   ESP_LOGI(TAG, "getMapBlocks %i", millis());
-  if (shouldInterruptMapRenderForScreenCycle()) {
+  if (shouldCancelMapRenderWork()) {
     return false;
   }
   const uint32_t blocksStartMs = MAPIO_TIME_MS();
   uint16_t cacheHits = 0;
   uint16_t loadedBlocks = 0;
   uint16_t evictedBlocks = 0;
+  cachedBlockCount.store(memCache.blocks.size(), std::memory_order_release);
   for (MapBlock *block : memCache.blocks) {
     block->inView = false;
   }
@@ -1830,7 +1863,7 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
 
   // 3. Load missing blocks
   for (const auto &req : requiredOffsets) {
-    if (shouldInterruptMapRenderForScreenCycle()) {
+    if (shouldCancelMapRenderWork()) {
       return false;
     }
 
@@ -1872,6 +1905,8 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
                    (*it)->offset.y);
           delete *it;
           memCache.blocks.erase(it);
+          cachedBlockCount.store(memCache.blocks.size(),
+                                 std::memory_order_release);
           evictedBlocks++;
           evicted = true;
           break;
@@ -1883,18 +1918,22 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
         ESP_LOGW(TAG, "Cache full and all blocks inView! Evicting front.");
         delete memCache.blocks.front();
         memCache.blocks.erase(memCache.blocks.begin());
+        cachedBlockCount.store(memCache.blocks.size(),
+                               std::memory_order_release);
         evictedBlocks++;
       }
     }
 
     MapBlock *newBlock = Maps::readMapBlock(fileName);
-    if (Maps::isMapFound) {
+    if (Maps::isMapFound.load(std::memory_order_acquire)) {
       newBlock->inView = true;
       newBlock->offset = req;
       newBlock->mercatorScale = map_projection::mercatorScaleForLatitude(
           Maps::mercatorY2lat(static_cast<double>(req.y) +
                               (1 << (MAPBLOCK_SIZE_BITS - 1))));
       memCache.blocks.push_back(newBlock);
+      cachedBlockCount.store(memCache.blocks.size(),
+                             std::memory_order_release);
       loadedBlocks++;
 
       ESP_LOGI(TAG, "Block loaded: %p, offset(%d, %d)", newBlock, req.x, req.y);
@@ -1903,7 +1942,7 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
       delete newBlock;
     }
 
-    if (shouldInterruptMapRenderForScreenCycle()) {
+    if (shouldCancelMapRenderWork()) {
       return false;
     }
   }
@@ -1920,6 +1959,7 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
     }
   }
   Maps::isMapFound = hasVisibleMapBlock;
+  cachedBlockCount.store(memCache.blocks.size(), std::memory_order_release);
 
   ESP_LOGI(TAG, "memCache size: %i %i", memCache.blocks.size(), millis());
   MAPIO_LOG("MAPIO: blocks required=%u cacheHit=%u loaded=%u evicted=%u "
@@ -1933,8 +1973,9 @@ bool Maps::getMapBlocks(BBox &bbox, Maps::MemCache &memCache) {
 }
 
 bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
-                            lv_obj_t *canvas, uint8_t zoom, double rotation,
-                            const ScreenMapRenderSettings &style) {
+                            map_surface::LabelSurface surface, uint8_t zoom,
+                            double rotation, const RenderContext &context) {
+  const ScreenMapRenderSettings &style = context.style;
   if (style.labelDensity == 0 || !labelFontAsset.healthy())
     return true;
   const uint32_t labelStartMs = MAPIO_TIME_MS();
@@ -1942,34 +1983,28 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
   const uint32_t cacheMissesBefore = labelFontAsset.cacheMisses();
   const uint32_t cacheEvictionsBefore = labelFontAsset.cacheEvictions();
   size_t peakDecodedLabelBytes = 0;
-  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
-  if (drawBuffer == nullptr || drawBuffer->data == nullptr)
+  if (!surface.valid())
     return true;
-  const bool transparentSurface =
-      drawBuffer->header.cf == LV_COLOR_FORMAT_RGB565A8;
-  if (!transparentSurface &&
-      drawBuffer->header.cf != LV_COLOR_FORMAT_RGB565) {
-    ESP_LOGE(TAG, "Street labels require an RGB565 or RGB565A8 surface");
-    return true;
-  }
-
-  const int32_t screenWidth = drawBuffer->header.w;
-  const int32_t screenHeight = drawBuffer->header.h;
+  const bool transparentSurface = surface.transparent();
+  const int32_t screenWidth = surface.color.width;
+  const int32_t screenHeight = surface.color.height;
   const int16_t screenAnchorX = mapAnchorXForWidth(screenWidth);
   const int16_t screenAnchorY = mapAnchorYForHeight(screenHeight);
   float markerX = screenAnchorX;
   float markerY = screenAnchorY;
   bool markerVisible = false;
-  if (isCurrentPositionVisible(mapRenderSettings)) {
-    if (!followGps) {
+  if (context.showCurrentPosition) {
+    if (!context.followPosition) {
       const auto markerDelta = map_transform::worldToScreen(
-          {lon2x(gps.gpsData.longitude) - viewPort.center.x,
-           lat2y(gps.gpsData.latitude) - viewPort.center.y},
+          {context.measuredGpsWorld.x - viewPort.center.x,
+           context.measuredGpsWorld.y - viewPort.center.y},
           zoom, rotation);
       markerX += markerDelta.x;
       markerY += markerDelta.y;
     }
-    const float markerHalf = currentMarkerSize() * 0.5F;
+    const float markerHalf =
+        navigation_visual_style::POSITION_MARKER_BASE_SIZE *
+        std::max<uint8_t>(1, context.markerScale) * 0.5F;
     markerVisible = markerX + markerHalf >= 0 && markerY + markerHalf >= 0 &&
                     markerX - markerHalf < screenWidth &&
                     markerY - markerHalf < screenHeight;
@@ -2010,7 +2045,7 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
     mixSignature(block->labelData.profileFingerprint);
     mixSignature(static_cast<uint32_t>(block->labelData.labels.size()));
   }
-  const bool guidance = isMapGuidanceScreenActive();
+  const bool guidance = context.guidanceScreenActive;
   const LabelLayoutCacheKey cacheKey{
       labelCenter.x,
       labelCenter.y,
@@ -2100,7 +2135,7 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
            options.size() < MAX_GATHERED_CANDIDATES;
            ++labelIndex) {
         if ((labelIndex & 0x3fU) == 0 &&
-            shouldInterruptMapRenderForScreenCycle())
+            shouldCancelMapRenderWork())
           return false;
         const auto &label = block->labelData.labels[labelIndex];
         if (label.rank != rankBucket || zoom < label.minZoom ||
@@ -2178,7 +2213,9 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
     return true;
   std::vector<map_label_layout::ReservedRegion> reserved;
   if (markerVisible) {
-    const float markerSize = static_cast<float>(currentMarkerSize());
+    const float markerSize = static_cast<float>(
+        navigation_visual_style::POSITION_MARKER_BASE_SIZE *
+        std::max<uint8_t>(1, context.markerScale));
     reserved.push_back({markerX, markerY, markerSize, markerSize});
   }
   if (guidance)
@@ -2206,31 +2243,16 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
   const uint32_t layoutMs = MAPIO_TIME_MS() - layoutStartMs;
   const uint32_t drawLabelsStartMs = MAPIO_TIME_MS();
 
-  uint16_t *pixels = reinterpret_cast<uint16_t *>(drawBuffer->data);
-  const uint32_t stride = drawBuffer->header.stride / sizeof(uint16_t);
-  uint8_t *alphaPixels =
-      transparentSurface
-          ? static_cast<uint8_t *>(drawBuffer->data) +
-                static_cast<size_t>(drawBuffer->header.stride) * screenHeight
-          : nullptr;
-  const uint32_t alphaStride = transparentSurface ? stride : 0;
-  const lv_draw_buf_t *contrastBuffer = nullptr;
-  int32_t contrastOffsetX = 0;
-  int32_t contrastOffsetY = 0;
-  if (transparentSurface && Maps::canvasMap != nullptr) {
-    contrastBuffer = lv_canvas_get_draw_buf(Maps::canvasMap);
-    if (contrastBuffer == nullptr || contrastBuffer->data == nullptr ||
-        contrastBuffer->header.cf != LV_COLOR_FORMAT_RGB565) {
-      contrastBuffer = nullptr;
-    } else {
-      contrastOffsetX = lv_obj_get_x_aligned(canvas) -
-                        lv_obj_get_x_aligned(Maps::canvasMap);
-      contrastOffsetY = lv_obj_get_y_aligned(canvas) -
-                        lv_obj_get_y_aligned(Maps::canvasMap);
-    }
-  }
+  uint16_t *pixels = surface.color.pixels;
+  const uint32_t stride = surface.color.stridePixels;
+  uint8_t *alphaPixels = transparentSurface ? surface.alpha : nullptr;
+  const uint32_t alphaStride =
+      transparentSurface ? surface.alphaStrideBytes : 0U;
+  const map_surface::Rgb565Surface *contrastSurface = surface.contrast;
+  const int32_t contrastOffsetX = surface.contrastOffsetX;
+  const int32_t contrastOffsetY = surface.contrastOffsetY;
   for (const auto &placement : placements) {
-    if (shouldInterruptMapRenderForScreenCycle())
+    if (shouldCancelMapRenderWork())
       return false;
     const auto itemPosition = itemByKey.find(placement.option.labelKey);
     if (itemPosition == itemByKey.end())
@@ -2248,18 +2270,13 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
     if (!transparentSurface) {
       background = pixels[centerY * stride + centerX];
       hasBackgroundSample = true;
-    } else if (contrastBuffer != nullptr) {
+    } else if (contrastSurface != nullptr && contrastSurface->valid()) {
       const int32_t contrastX = centerX + contrastOffsetX;
       const int32_t contrastY = centerY + contrastOffsetY;
-      if (contrastX >= 0 && contrastY >= 0 &&
-          contrastX < contrastBuffer->header.w &&
-          contrastY < contrastBuffer->header.h) {
-        const auto *contrastPixels =
-            reinterpret_cast<const uint16_t *>(contrastBuffer->data);
-        const uint32_t contrastStride =
-            contrastBuffer->header.stride / sizeof(uint16_t);
-        background =
-            contrastPixels[contrastY * contrastStride + contrastX];
+      if (contrastSurface->contains(contrastX, contrastY)) {
+        background = contrastSurface->pixels[
+            static_cast<size_t>(contrastY) * contrastSurface->stridePixels +
+            static_cast<size_t>(contrastX)];
         hasBackgroundSample = true;
       }
     }
@@ -2304,8 +2321,9 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
                       error, (unsigned)labelFontAsset.consecutiveFailures(),
                       (unsigned)labelFontAsset.healthy());
             if (!labelFontAsset.healthy()) {
-              streetLabelRuntimeFailurePending = true;
-              streetLabelRuntimeFailureCode = error;
+              streetLabelFontHealthy.store(false, std::memory_order_release);
+              streetLabelRuntimeFailure.store(labelFontAsset.runtimeError(),
+                                              std::memory_order_release);
               labelLayoutCache.clear();
             }
             return true; // Keep the base map visible on any asset I/O failure.
@@ -2321,12 +2339,12 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
                         stride, alphaStride, bitmap.fill, bitmap.distance,
                         bitmap.width, bitmap.height, glyphX26_6, glyphY26_6,
                         transform, pass, fillColor, haloColor,
-                        shouldInterruptMapRenderForScreenCycle)
+                        shouldCancelMapRenderWork)
                   : map_label_rasterizer::drawGlyphPass(
                         pixels, screenWidth, screenHeight, stride, bitmap.fill,
                         bitmap.distance, bitmap.width, bitmap.height,
                         glyphX26_6, glyphY26_6, transform, pass, fillColor,
-                        haloColor, shouldInterruptMapRenderForScreenCycle);
+                        haloColor, shouldCancelMapRenderWork);
           if (!drawn)
             return false;
           penX26_6 += glyph.xAdvance26_6;
@@ -2358,6 +2376,30 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
   return true;
 }
 
+bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
+                            lv_obj_t *canvas, uint8_t zoom, double rotation,
+                            const ScreenMapRenderSettings &style) {
+  RenderContext context = captureRenderContext();
+  context.style = style;
+  map_surface::Rgb565Surface contrast{};
+  int32_t offsetX = 0;
+  int32_t offsetY = 0;
+  if (canvas != nullptr && canvasMap != nullptr) {
+    contrast = rgb565SurfaceForCanvas(canvasMap);
+    offsetX = lv_obj_get_x_aligned(canvas) - lv_obj_get_x_aligned(canvasMap);
+    offsetY = lv_obj_get_y_aligned(canvas) - lv_obj_get_y_aligned(canvasMap);
+  }
+  const map_surface::Rgb565Surface *contrastPtr =
+      contrast.valid() ? &contrast : nullptr;
+  return drawStreetLabels(
+      viewPort, memCache,
+      labelSurfaceForCanvas(canvas, contrastPtr, offsetX, offsetY), zoom,
+      rotation, context);
+}
+
+
+
+
 /**
  * @brief Generate vectorized map
  *
@@ -2366,16 +2408,229 @@ bool Maps::drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
  * @param map -> Map Sprite
  * @param zoom -> Zoom Level
  */
-bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
-                         lv_obj_t *canvas, uint8_t zoom, double rotation,
-                         const map_projection::Projection &projection,
-                         bool drawLabels, bool suppressBuildings) {
-  (void)rotation;
-  Polygon newPolygon;
+bool Maps::readVectorMap(
+    ViewPort &viewPort, MemCache &memCache,
+    map_surface::Rgb565Surface surface, uint8_t zoom, double rotation,
+    const map_projection::Projection &projection, const RenderContext &context,
+    bool drawLabels, bool suppressBuildings,
+    RasterDiagnostics *diagnostics) {
+  if (diagnostics != nullptr)
+    *diagnostics = {};
+  if (!surface.valid())
+    return false;
+
+  const ScreenMapRenderSettings &style = context.style;
+  const bool mapNavigationActive = context.guidanceScreenActive;
+  const uint32_t drawStartMs = MAPIO_TIME_MS();
+  surface.clear(BACKGROUND_COLOR);
+
+  if (!Maps::isMapFound.load(std::memory_order_acquire) ||
+      memCache.blocks.empty()) {
+    MAPIO_LOG("MAPIO: raw-map ok=1 mapFound=0 blocks=%u totalMs=%lu\n",
+              (unsigned)memCache.blocks.size(),
+              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
+    return true;
+  }
+
+  Polygon projectedPolygon;
   std::vector<map_projection::GroundPoint> groundPolygon;
   std::vector<map_projection::GroundPoint> clippedGroundPolygon;
-  const ScreenMapRenderSettings &style = currentMapStyleSettings();
-  const bool mapNavigationActive = isMapGuidanceScreenActive();
+  uint32_t projectionClippedCount = 0;
+  uint32_t projectionRejectedCount = 0;
+
+  for (MapBlock *block : memCache.blocks) {
+    if (shouldCancelMapRenderWork())
+      return false;
+    if (block == nullptr || !block->inView)
+      continue;
+
+    ScreenMapRenderSettings blockStyle = style;
+    blockStyle.visibilityMask =
+        map_profile_protocol::visibilityMaskForMapVersion(
+            style.visibilityMask, block->formatVersion);
+    const BBox localViewport = viewPort.bbox - block->offset;
+    const auto worldPoint = [&](Point16 point) -> map_transform::WorldPoint {
+      return {static_cast<double>(point.x) + block->offset.x,
+              static_cast<double>(point.y) + block->offset.y};
+    };
+
+    const size_t polygonCount = block->polygons.size();
+    std::vector<bool> visited(polygonCount, false);
+    const int minCellX =
+        std::max(0, static_cast<int>(localViewport.min.x >> CELL_SHIFT));
+    const int maxCellX = std::min(
+        GRID_SIZE - 1,
+        static_cast<int>(localViewport.max.x >> CELL_SHIFT));
+    const int minCellY =
+        std::max(0, static_cast<int>(localViewport.min.y >> CELL_SHIFT));
+    const int maxCellY = std::min(
+        GRID_SIZE - 1,
+        static_cast<int>(localViewport.max.y >> CELL_SHIFT));
+    size_t polygonChecks = 0;
+
+    const auto drawPolygonRecord = [&](size_t polygonIndex) -> bool {
+      if (polygonIndex >= polygonCount || visited[polygonIndex])
+        return true;
+      visited[polygonIndex] = true;
+      if ((polygonChecks++ & 0x0fU) == 0 && shouldCancelMapRenderWork())
+        return false;
+      const Polygon &polygon = block->polygons[polygonIndex];
+      if (zoom > polygon.maxZoom || !polygon.bbox.intersects(localViewport) ||
+          !isPolygonVisible(polygon.typeId, polygon.color, blockStyle)) {
+        return true;
+      }
+
+      groundPolygon.clear();
+      groundPolygon.reserve(polygon.points.size());
+      for (size_t pointIndex = 0; pointIndex < polygon.points.size();
+           ++pointIndex) {
+        if ((pointIndex & 0x1fU) == 0 && shouldCancelMapRenderWork())
+          return false;
+        groundPolygon.push_back(
+            projection.groundForWorld(worldPoint(polygon.points[pointIndex])));
+      }
+      const auto *projectedGround = &groundPolygon;
+      if (projection.isBirdsEye()) {
+        map_projection::clipPolygonToNearPlane(
+            projection, groundPolygon, clippedGroundPolygon);
+        projectedGround = &clippedGroundPolygon;
+        if (clippedGroundPolygon.size() != groundPolygon.size())
+          ++projectionClippedCount;
+      }
+      if (projectedGround->size() < 3) {
+        ++projectionRejectedCount;
+        return true;
+      }
+
+      projectedPolygon.points.clear();
+      projectedPolygon.points.reserve(projectedGround->size() + 1U);
+      projectedPolygon.color = polygon.color;
+      int16_t minX = 32767;
+      int16_t minY = 32767;
+      int16_t maxX = -32768;
+      int16_t maxY = -32768;
+      for (const auto &ground : *projectedGround) {
+        const auto projected = projection.projectGround(ground);
+        if (!projected.valid)
+          continue;
+        const Point16 point(
+            static_cast<int16_t>(map_transform::quantizePixel(projected.x)),
+            static_cast<int16_t>(map_transform::quantizePixel(projected.y)));
+        projectedPolygon.points.push_back(point);
+        minX = std::min(minX, point.x);
+        minY = std::min(minY, point.y);
+        maxX = std::max(maxX, point.x);
+        maxY = std::max(maxY, point.y);
+      }
+      if (projectedPolygon.points.size() < 3)
+        return true;
+      if (!(projectedPolygon.points.front().x ==
+                projectedPolygon.points.back().x &&
+            projectedPolygon.points.front().y ==
+                projectedPolygon.points.back().y)) {
+        projectedPolygon.points.push_back(projectedPolygon.points.front());
+      }
+      projectedPolygon.bbox.min = Point16(minX, minY);
+      projectedPolygon.bbox.max = Point16(maxX, maxY);
+      const uint8_t minimumSize = effectiveMinPolygonSize(blockStyle);
+      const int32_t area = static_cast<int32_t>(maxX - minX) *
+                           static_cast<int32_t>(maxY - minY);
+      if (minimumSize != 0 &&
+          area < static_cast<int32_t>(minimumSize) * minimumSize) {
+        return true;
+      }
+      return fillPolygon(projectedPolygon, surface);
+    };
+
+    if (!block->polygonGrid.empty()) {
+      for (int cellY = minCellY; cellY <= maxCellY; ++cellY) {
+        for (int cellX = minCellX; cellX <= maxCellX; ++cellX) {
+          const int cellIndex = cellY * GRID_SIZE + cellX;
+          if (cellIndex < 0 ||
+              cellIndex >= static_cast<int>(block->polygonGrid.size())) {
+            continue;
+          }
+          for (const uint16_t polygonIndex : block->polygonGrid[cellIndex]) {
+            if (!drawPolygonRecord(polygonIndex))
+              return false;
+          }
+        }
+      }
+    } else {
+      for (size_t polygonIndex = 0; polygonIndex < polygonCount;
+           ++polygonIndex) {
+        if (!drawPolygonRecord(polygonIndex))
+          return false;
+      }
+    }
+
+    for (const Polyline &line : block->polylines) {
+      if (shouldCancelMapRenderWork())
+        return false;
+      if (zoom > line.maxZoom || line.points.size() < 2 ||
+          !line.bbox.intersects(localViewport) ||
+          !isLineVisible(line.typeId, line.color, line.width, blockStyle)) {
+        continue;
+      }
+      const uint16_t displayColor = map_line_style::displayColor(
+          line.typeId, line.color, line.width, mapNavigationActive);
+      const uint8_t baseWidth =
+          shouldBoostLineWidth(line.typeId, line.width)
+              ? blockStyle.streetLineWidth
+              : static_cast<uint8_t>(std::max<int32_t>(line.width, 1));
+      for (size_t index = 0; index + 1 < line.points.size(); ++index) {
+        if ((index & 0x0fU) == 0 && shouldCancelMapRenderWork())
+          return false;
+        auto start = projection.groundForWorld(worldPoint(line.points[index]));
+        auto end =
+            projection.groundForWorld(worldPoint(line.points[index + 1]));
+        if (!projection.clipSegmentToNearPlane(start, end)) {
+          ++projectionRejectedCount;
+          continue;
+        }
+        const auto projectedStart = projection.projectGround(start);
+        const auto projectedEnd = projection.projectGround(end);
+        if (!projectedStart.valid || !projectedEnd.valid) {
+          ++projectionRejectedCount;
+          continue;
+        }
+        const uint8_t width = projection.scaledLineWidth(
+            baseWidth,
+            (projectedStart.depthScale + projectedEnd.depthScale) * 0.5, 24);
+        drawLine(
+            surface,
+            static_cast<int16_t>(
+                map_transform::quantizePixel(projectedStart.x)),
+            static_cast<int16_t>(
+                map_transform::quantizePixel(projectedStart.y)),
+            static_cast<int16_t>(map_transform::quantizePixel(projectedEnd.x)),
+            static_cast<int16_t>(map_transform::quantizePixel(projectedEnd.y)),
+            displayColor, width);
+      }
+    }
+  }
+
+  struct BuildingItem {
+    MapBlock *block = nullptr;
+    const map_building_block::Building *building = nullptr;
+    uint16_t recordIndex = 0;
+    double painterDepth = 0.0;
+    bool extruded = false;
+  };
+  map_building_admission::Diagnostics admissionDiagnostics{};
+  uint32_t renderedBuildings = 0;
+  uint32_t courtyardDeferred = 0;
+  uint32_t buildingProjectionMs = 0;
+  uint32_t buildingDrawMs = 0;
+  uint32_t metadataDeferredBuildings = 0;
+  bool buildingAllocationFailed = false;
+  uint32_t courtyardSnapshotCount = 0;
+  size_t largestCourtyardBytes = 0;
+  uint32_t buildingFailureInternalHeapFree = 0;
+  uint32_t buildingFailureInternalHeapLargest = 0;
+  uint32_t buildingFailurePsramFree = 0;
+  uint32_t buildingFailurePsramLargest = 0;
+
   uint64_t buildingContextSignature = 1469598103934665603ULL;
   const auto mixBuildingContext = [&](uint64_t value) {
     buildingContextSignature ^= value;
@@ -2384,972 +2639,773 @@ bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
   mixBuildingContext(zoom);
   mixBuildingContext(projection.isBirdsEye() ? 1U : 0U);
   mixBuildingContext(style.visibilityMask);
-  mixBuildingContext(mapRenderSettings.mapNavigation3DBuildingsEnabled ? 1U
-                                                                      : 0U);
-  mixBuildingContext(mapRenderSettings.mapNavigationBirdsEyePerspective);
-  for (const MapBlock *block : memCache.blocks) {
-    if (!block->inView || block->formatVersion < 4)
-      continue;
-    mixBuildingContext(static_cast<uint32_t>(block->offset.x));
-    mixBuildingContext(static_cast<uint32_t>(block->offset.y));
-    mixBuildingContext(block->formatVersion);
-    mixBuildingContext(block->buildingData.stats.records);
-    mixBuildingContext(block->buildingData.stats.points);
-  }
+  mixBuildingContext(context.buildings3DEnabled ? 1U : 0U);
+  mixBuildingContext(context.birdsEyePerspective);
   const map_building_renderer::RenderRegion buildingRenderRegion{
       viewPort.bbox.min.x, viewPort.bbox.min.y, viewPort.bbox.max.x,
       viewPort.bbox.max.y};
-  const bool buildingsSuppressed =
+  const bool flatFallbackOnly =
       suppressBuildings || buildingFailureRetryCooldown.shouldSuppress(
                                millis(), buildingContextSignature,
                                buildingRenderRegion);
-  uint32_t projectionClippedCount = 0;
-  uint32_t projectionRejectedCount = 0;
-  const uint32_t drawStartMs = MAPIO_TIME_MS();
-  const uint32_t fillStartMs = MAPIO_TIME_MS();
-  lv_canvas_fill_bg(canvas, lv_color_hex(BACKGROUND_COLOR), LV_OPA_COVER);
-  const uint32_t fillMs = MAPIO_TIME_MS() - fillStartMs;
+  const bool buildingsVisible =
+      (style.visibilityMask & MAP_VISIBILITY_BUILDINGS) != 0;
+  const bool extrusionRequested =
+      !flatFallbackOnly &&
+      navigation_content_mode::extrudesMapGuidanceBuildings(
+          buildingsVisible, context.guidanceScreenActive,
+          projection.isBirdsEye(),
+          context.buildings3DEnabled);
 
-  uint32_t totalTime = millis();
-  log_i("readVectorMap: Draw start. isMapFound=%d, Blocks=%d", Maps::isMapFound,
-        memCache.blocks.size());
+  if (buildingsVisible) {
+    if (flatFallbackOnly) {
+      // FMB v4 removes extrudable buildings from the generic polygon stream,
+      // so suppressing the 3D pass must not suppress every building.  This
+      // exceptional path keeps a small deterministic nearest set of flat
+      // footprints without allocating the normal candidate/sort workspace.
+      // It intentionally omits courtyard restoration if memory is already in
+      // a failed/cooldown state; preserving a useful flat city is preferable
+      // to recursively failing or publishing a building-free frame.
+      constexpr size_t kFallbackCandidateLimit = 48;
+      constexpr size_t kFallbackPointLimit = 4096;
+      constexpr uint64_t kFallbackPixelLimit = 120000;
+      std::array<map_building_admission::Candidate,
+                 kFallbackCandidateLimit>
+          fallbackCandidates{};
+      size_t fallbackCandidateCount = 0;
+      size_t fallbackVisible = 0;
 
-  if (!Maps::isMapFound || memCache.blocks.empty()) {
-    log_w("readVectorMap: No map data found for this location!");
-    Maps::showNoMap(canvas, storage.getSdLoaded());
-    MAPIO_LOG("MAPIO: canvas-draw ok=0 blocks=%u fillMs=%lu totalMs=%lu\n",
-              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
-              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
-    logMapMemorySnapshot("canvas-no-map");
-    return true;
-  }
-
-  int16_t p1x, p1y, p2x, p2y;
-  if (Maps::isMapFound) {
-    for (MapBlock *mblock : memCache.blocks) {
-      if (shouldInterruptMapRenderForScreenCycle()) {
-        return false;
-      }
-      uint32_t blockTime = millis();
-      if (!mblock->inView)
-        continue;
-
-      ScreenMapRenderSettings blockStyle = style;
-      blockStyle.visibilityMask =
-          map_profile_protocol::visibilityMaskForMapVersion(
-              style.visibilityMask, mblock->formatVersion);
-
-      ESP_LOGI(TAG, "Drawing cached map block");
-
-      BBox screen_bbox_mc =
-          viewPort.bbox -
-          mblock->offset; // screen boundaries with features coordinates
-
-      ////// Polygons - Grid-based spatial culling for performance
-      const uint32_t polygonStartMs = millis();
-      int poly_total = mblock->polygons.size();
-      int poly_drawn = 0;
-      int poly_checked = 0;
-
-      // Calculate which grid cells overlap the viewport bounding box
-      // screen_bbox_mc is in block-local coordinates (0-4095 range)
-      int minCX = std::max(0, (int)(screen_bbox_mc.min.x >> CELL_SHIFT));
-      int maxCX =
-          std::min(GRID_SIZE - 1, (int)(screen_bbox_mc.max.x >> CELL_SHIFT));
-      int minCY = std::max(0, (int)(screen_bbox_mc.min.y >> CELL_SHIFT));
-      int maxCY =
-          std::min(GRID_SIZE - 1, (int)(screen_bbox_mc.max.y >> CELL_SHIFT));
-
-      // Bitset to track visited polygons (avoid processing same polygon twice
-      // if it spans multiple cells)
-      std::vector<bool> visited(poly_total, false);
-
-      auto worldPoint = [&](Point16 p) -> map_transform::WorldPoint {
-        return {static_cast<double>(p.x) + mblock->offset.x,
-                static_cast<double>(p.y) + mblock->offset.y};
-      };
-      auto projectedPoint = [&](map_projection::GroundPoint ground) -> Point16 {
-        const auto projected = projection.projectGround(ground);
-        return Point16(
-            static_cast<int16_t>(map_transform::quantizePixel(projected.x)),
-            static_cast<int16_t>(map_transform::quantizePixel(projected.y)));
-      };
-
-      // Iterate only through cells that overlap the viewport
-      for (int cy = minCY; cy <= maxCY; cy++) {
-        for (int cx = minCX; cx <= maxCX; cx++) {
-          int cellIdx = cy * GRID_SIZE + cx;
-
-          // Check bounds on polygonGrid access
-          if (cellIdx < 0 || cellIdx >= (int)mblock->polygonGrid.size())
-            continue;
-
-          for (uint16_t polyIdx : mblock->polygonGrid[cellIdx]) {
-            if ((poly_checked & 0x0F) == 0 &&
-                shouldInterruptMapRenderForScreenCycle()) {
-              return false;
+      const auto retainFallbackCandidate =
+          [&](const map_building_admission::Candidate &candidate) {
+            if (fallbackCandidateCount < kFallbackCandidateLimit) {
+              fallbackCandidates[fallbackCandidateCount++] = candidate;
+              return;
             }
-            // Skip if already processed (polygon spans multiple cells)
-            if (visited[polyIdx])
-              continue;
-            visited[polyIdx] = true;
-            poly_checked++;
-
-            const auto &polygon = mblock->polygons[polyIdx];
-
-            // Fine-grained intersection test with viewport
-            if (!polygon.bbox.intersects(screen_bbox_mc)) {
-              continue;
+            size_t farthest = 0;
+            for (size_t index = 1; index < fallbackCandidateCount; ++index) {
+              if (map_building_admission::nearer(
+                      fallbackCandidates[farthest].key,
+                      fallbackCandidates[index].key)) {
+                farthest = index;
+              }
             }
-
-            // Skip if type is hidden by visibility mask
-            if (!isPolygonVisible(polygon.typeId, polygon.color, blockStyle)) {
-              continue;
+            if (map_building_admission::nearer(
+                    candidate.key, fallbackCandidates[farthest].key)) {
+              fallbackCandidates[farthest] = candidate;
             }
+          };
 
-            poly_drawn++;
-            newPolygon.color = polygon.color;
-
-            // Transform points to screen coordinates
-            newPolygon.points.clear();
-            int16_t minX = 32000, maxX = -32000, minY = 32000, maxY = -32000;
-
-            groundPolygon.clear();
-            groundPolygon.reserve(polygon.points.size());
-            for (const auto &p : polygon.points)
-              groundPolygon.push_back(projection.groundForWorld(worldPoint(p)));
-            const auto *projectedPolygon = &groundPolygon;
-            if (projection.isBirdsEye()) {
-              map_projection::clipPolygonToNearPlane(
-                  projection, groundPolygon, clippedGroundPolygon);
-              projectedPolygon = &clippedGroundPolygon;
-              if (clippedGroundPolygon.size() != groundPolygon.size())
-                projectionClippedCount++;
-            }
-            if (projectedPolygon->size() < 3) {
-              projectionRejectedCount++;
-              poly_drawn--;
-              continue;
-            }
-
-            for (const auto &ground : *projectedPolygon) {
-              Point16 tp = projectedPoint(ground);
-              newPolygon.points.push_back(tp);
-              if (tp.x < minX)
-                minX = tp.x;
-              if (tp.x > maxX)
-                maxX = tp.x;
-              if (tp.y < minY)
-                minY = tp.y;
-              if (tp.y > maxY)
-                maxY = tp.y;
-            }
-
-            newPolygon.bbox.min.x = minX;
-            newPolygon.bbox.max.x = maxX;
-            newPolygon.bbox.min.y = minY;
-            newPolygon.bbox.max.y = maxY;
-
-            // Skip tiny polygons based on explicit min size plus detail density.
-            const uint8_t minPolygonSize =
-                effectiveMinPolygonSize(blockStyle);
-            int16_t polyWidth = maxX - minX;
-            int16_t polyHeight = maxY - minY;
-            if (minPolygonSize > 0 &&
-                polyWidth * polyHeight < minPolygonSize * minPolygonSize) {
-              poly_drawn--; // Don't count as drawn
-              continue;
-            }
-
-            if (!Maps::fillPolygon(newPolygon, canvas)) {
-              return false;
-            }
-          }
-        }
-      }
-#if FIRMWARE_DIAGNOSTICS
-      Serial.printf("[Maps] Block polygons: Total=%d, Checked=%d, Drawn=%d\n",
-                    poly_total, poly_checked, poly_drawn);
-#endif
-      const uint32_t polygonMs = millis() - polygonStartMs;
-      log_i("Block polygons done %i ms", polygonMs);
-      const uint32_t lineStartMs = millis();
-
-      ////// Lines
-      // Removed lv_draw_line usage to fix crash
-      for (const auto &line : mblock->polylines) {
-        if (shouldInterruptMapRenderForScreenCycle()) {
-          return false;
-        }
-        if (zoom > line.maxZoom)
-          continue;
-        if (!line.bbox.intersects(screen_bbox_mc))
-          continue;
-
-        if (line.points.size() < 2)
-          continue;
-
-        // Skip if type is hidden by visibility mask
-        if (!isLineVisible(line.typeId, line.color, line.width, blockStyle))
-          continue;
-
-        const uint16_t color_swapped = map_line_style::displayColor(
-            line.typeId, line.color, line.width, mapNavigationActive);
-
-        const uint8_t baseLineWidth =
-            shouldBoostLineWidth(line.typeId, line.width)
-                ? blockStyle.streetLineWidth
-                : static_cast<uint8_t>(std::max<int32_t>(line.width, 1));
-
-        for (int i = 0; i < (int)line.points.size() - 1; i++) {
-          if ((i & 0x0F) == 0 &&
-              shouldInterruptMapRenderForScreenCycle()) {
-            return false;
-          }
-          auto ground1 = projection.groundForWorld(worldPoint(line.points[i]));
-          auto ground2 =
-              projection.groundForWorld(worldPoint(line.points[i + 1]));
-          if (!projection.clipSegmentToNearPlane(ground1, ground2)) {
-            projectionRejectedCount++;
-            continue;
-          }
-          if (projection.isBirdsEye() &&
-              (ground1.forward == projection.nearPlaneForward() ||
-               ground2.forward == projection.nearPlaneForward())) {
-            projectionClippedCount++;
-          }
-          const auto projected1 = projection.projectGround(ground1);
-          const auto projected2 = projection.projectGround(ground2);
-          if (!projected1.valid || !projected2.valid) {
-            projectionRejectedCount++;
-            continue;
-          }
-          const uint8_t lineWidth = projection.scaledLineWidth(
-              baseLineWidth,
-              (projected1.depthScale + projected2.depthScale) / 2.0, 24);
-          Maps::drawLine(
-              canvas,
-              static_cast<int16_t>(map_transform::quantizePixel(projected1.x)),
-              static_cast<int16_t>(map_transform::quantizePixel(projected1.y)),
-              static_cast<int16_t>(map_transform::quantizePixel(projected2.x)),
-              static_cast<int16_t>(map_transform::quantizePixel(projected2.y)),
-              color_swapped, lineWidth);
-        }
-      }
-      const uint32_t lineMs = millis() - lineStartMs;
-      ESP_LOGI(TAG, "Block lines done %i ms", lineMs);
-      MAPIO_LOG("MAPIO: draw-block offset=%d,%d polygons=%d "
-                "checked=%d drawn=%d lines=%u polygonMs=%lu lineMs=%lu "
-                "totalMs=%lu\n",
-                mblock->offset.x, mblock->offset.y, poly_total, poly_checked,
-                poly_drawn, (unsigned)mblock->polylines.size(),
-                (unsigned long)polygonMs, (unsigned long)lineMs,
-                (unsigned long)(MAPIO_TIME_MS() - blockTime));
-    }
-    struct BuildingRenderItem {
-      MapBlock *block = nullptr;
-      const map_building_block::Building *building = nullptr;
-      double depth = 0.0;
-      uint16_t recordIndex = 0;
-      size_t pointCount = 0;
-      bool render = false;
-      bool extrude = false;
-      bool extrusionCandidate = false;
-
-      uint8_t buildingFlags() const { return building->flags; }
-      bool eligibleForExtrusion() const { return extrusionCandidate; }
-    };
-    bool buildingAllocationFailed = false;
-    bool buildingDeadlineAborted = false;
-    bool buildingPrepassDeadlineExceeded = false;
-    size_t visibleBuildingCount = 0;
-    uint64_t buildingPointCount = 0;
-    size_t renderTimeOverflow = 0;
-    uint32_t renderedBuildings = 0;
-    uint32_t extrudedBuildings = 0;
-    uint32_t buildingProjectionMs = 0;
-    uint32_t buildingSortMs = 0;
-    uint32_t buildingDrawMs = 0;
-    uint32_t buildingFailurePsramUsed = 0;
-    uint32_t buildingFailurePsramFree = 0;
-    uint32_t buildingFailurePsramLargest = 0;
-    uint32_t buildingFailureInternalHeapFree = 0;
-    uint32_t buildingFailureInternalHeapLargest = 0;
-    bool buildingFailurePsramSamplePostCleanup = false;
-    const auto captureBuildingFailureMemory = [&]() {
-      constexpr uint32_t internalHeapCaps =
-          MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT;
-      buildingFailureInternalHeapFree =
-          heap_caps_get_free_size(internalHeapCaps);
-      buildingFailureInternalHeapLargest =
-          heap_caps_get_largest_free_block(internalHeapCaps);
-      buildingFailurePsramFree =
-          heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
-      buildingFailurePsramLargest =
-          heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
-      buildingFailurePsramUsed =
-          ESP.getPsramSize() - buildingFailurePsramFree;
-    };
-    std::vector<BuildingRenderItem, PsramAllocator<BuildingRenderItem>>
-        buildingQueue;
-    map_building_renderer::RenderSelection renderSelection;
-    map_building_renderer::ExtrusionSelection buildingSelection;
-    MapBuildingVector<map_projection::GroundPoint> buildingEligibilityGround;
-    MapBuildingVector<map_projection::GroundPoint> buildingEligibilityClipped;
-    Polygon buildingPolygon;
-    std::vector<Point16, PsramAllocator<Point16>> buildingSurfacePoints;
-    std::vector<uint16_t, PsramAllocator<uint16_t>> courtyardUnderlay;
-    std::vector<int32_t, PsramAllocator<int32_t>> courtyardScanlineNodes;
-    size_t largestCourtyardUnderlayBytes = 0;
-    uint32_t courtyardSnapshotCount = 0;
-    map_building_renderer::SurfaceStats buildingSurfaceStats;
-    const auto releaseBuildingFailureWorkspace = [&]() {
-      decltype(buildingQueue){}.swap(buildingQueue);
-      decltype(buildingEligibilityGround){}.swap(buildingEligibilityGround);
-      decltype(buildingEligibilityClipped){}.swap(buildingEligibilityClipped);
-      decltype(buildingPolygon.points){}.swap(buildingPolygon.points);
-      decltype(buildingSurfacePoints){}.swap(buildingSurfacePoints);
-      decltype(courtyardUnderlay){}.swap(courtyardUnderlay);
-      decltype(courtyardScanlineNodes){}.swap(courtyardScanlineNodes);
-    };
-    static uint64_t renderTimeOverflowTotal = 0;
-    map_building_block::Stats loadedBuildingStats;
-    for (const MapBlock *block : memCache.blocks) {
-      if (!block->inView || block->formatVersion < 4)
-        continue;
-      loadedBuildingStats.records += block->buildingData.stats.records;
-      loadedBuildingStats.rings += block->buildingData.stats.rings;
-      loadedBuildingStats.points += block->buildingData.stats.points;
-      for (size_t index = 0; index < loadedBuildingStats.provenance.size();
-           ++index) {
-        loadedBuildingStats.provenance[index] +=
-            block->buildingData.stats.provenance[index];
-      }
-    }
-    enum class BuildingPassPhase : uint8_t { Projection, Sort, Draw, Complete };
-    BuildingPassPhase buildingPassPhase = BuildingPassPhase::Projection;
-    uint32_t buildingPhaseStartMs = millis();
-    const uint32_t buildingPassStartMs = buildingPhaseStartMs;
-    const auto finishBuildingPhaseTiming = [&]() {
-      const uint32_t elapsed = millis() - buildingPhaseStartMs;
-      switch (buildingPassPhase) {
-      case BuildingPassPhase::Projection:
-        buildingProjectionMs = elapsed;
-        break;
-      case BuildingPassPhase::Sort:
-        buildingSortMs = elapsed;
-        break;
-      case BuildingPassPhase::Draw:
-        buildingDrawMs = elapsed;
-        break;
-      case BuildingPassPhase::Complete:
-        break;
-      }
-      buildingPassPhase = BuildingPassPhase::Complete;
-    };
-    bool buildingScreenInterrupted = false;
-    const bool buildingPassCompleted =
-        map_building_renderer::runAllocationSafe(
-            [&]() -> bool {
-    const auto buildingRendersBefore =
-        [](const BuildingRenderItem &left, const BuildingRenderItem &right) {
-          return map_building_renderer::rendersBefore(
-              {left.depth, left.block->offset.x, left.block->offset.y,
-               left.recordIndex},
-              {right.depth, right.block->offset.x, right.block->offset.y,
-               right.recordIndex});
-        };
-    const bool buildingsVisible =
-        !buildingsSuppressed &&
-        (style.visibilityMask & MAP_VISIBILITY_BUILDINGS) != 0;
-    bool extrudeBuildings =
-        navigation_content_mode::extrudesMapGuidanceBuildings(
-            buildingsVisible, mapNavigationActive, projection.isBirdsEye(),
-            mapRenderSettings.mapNavigation3DBuildingsEnabled);
-    size_t boundedBuildingCandidateCount = 0;
-    size_t oversizedBuildingCount = 0;
-    size_t renderRecordLimitOverflow = 0;
-    uint64_t visibleWallCandidateCount = 0;
-    bool buildingBudgetFallback = false;
-    bool buildingDeadlineExceeded = false;
-    static uint64_t renderRecordOverflowTotal = 0;
-    static uint64_t renderPointOverflowTotal = 0;
-    static uint64_t renderOversizedOverflowTotal = 0;
-    static uint64_t extrusionRecordOverflowTotal = 0;
-    static uint64_t extrusionPointOverflowTotal = 0;
-    const auto buildingDeadlineReached = [&]() {
-      return millis() - buildingPassStartMs >=
-             map_building_renderer::kMaximumBuildingRenderTimeMs;
-    };
-    const auto shouldStopBuildingWork = [&]() {
-      if (shouldInterruptMapRenderForScreenCycle()) {
-        buildingScreenInterrupted = true;
-        return true;
-      }
-      if (buildingDeadlineReached()) {
-        buildingDeadlineExceeded = true;
-        return true;
-      }
-      return false;
-    };
-    const auto abortStoppedBuildingWork = [&](size_t timeOverflow) -> bool {
-      finishBuildingPhaseTiming();
-      if (buildingDeadlineExceeded) {
-        captureBuildingFailureMemory();
-        buildingDeadlineAborted = true;
-        const size_t countedOverflow = std::max<size_t>(1, timeOverflow);
-        renderTimeOverflow += countedOverflow;
-        renderTimeOverflowTotal += countedOverflow;
-      }
-      return false;
-    };
-    if (buildingsVisible) {
-      buildingPassPhase = BuildingPassPhase::Projection;
-      buildingPhaseStartMs = millis();
-      bool stopBuildingPrepass = false;
       for (MapBlock *block : memCache.blocks) {
-        if (shouldStopBuildingWork()) {
-          stopBuildingPrepass = true;
-          break;
-        }
-        if (!block->inView || block->formatVersion < 4)
+        if (shouldCancelMapRenderWork())
+          return false;
+        if (block == nullptr || !block->inView || block->formatVersion < 4)
           continue;
-        const BBox screenBbox = viewPort.bbox - block->offset;
+        const BBox localViewport = viewPort.bbox - block->offset;
         for (size_t recordIndex = 0;
              recordIndex < block->buildingData.buildings.size();
              ++recordIndex) {
-          if ((recordIndex & 0x1FU) == 0 && shouldStopBuildingWork()) {
-            stopBuildingPrepass = true;
+          if ((recordIndex & 0x1fU) == 0 && shouldCancelMapRenderWork())
+            return false;
+          const auto &building = block->buildingData.buildings[recordIndex];
+          const BBox bounds(Point32(building.minX, building.minY),
+                            Point32(building.maxX, building.maxY));
+          if (!bounds.intersects(localViewport))
+            continue;
+          size_t pointCount = 0;
+          for (const auto &ring : building.rings)
+            pointCount += ring.points.size();
+          if (pointCount < 3 ||
+              pointCount >
+                  map_building_renderer::kMaximumRenderedBuildingPointsPerRecord)
+            continue;
+
+          const double centerX = static_cast<double>(block->offset.x) +
+                                 (building.minX + building.maxX) * 0.5;
+          const double centerY = static_cast<double>(block->offset.y) +
+                                 (building.minY + building.maxY) * 0.5;
+          const double dx = centerX - context.presentedWorld.x;
+          const double dy = centerY - context.presentedWorld.y;
+
+          double minX = std::numeric_limits<double>::infinity();
+          double minY = std::numeric_limits<double>::infinity();
+          double maxX = -std::numeric_limits<double>::infinity();
+          double maxY = -std::numeric_limits<double>::infinity();
+          const std::array<map_transform::WorldPoint, 4> corners{{
+              {static_cast<double>(block->offset.x + building.minX),
+               static_cast<double>(block->offset.y + building.minY)},
+              {static_cast<double>(block->offset.x + building.maxX),
+               static_cast<double>(block->offset.y + building.minY)},
+              {static_cast<double>(block->offset.x + building.maxX),
+               static_cast<double>(block->offset.y + building.maxY)},
+              {static_cast<double>(block->offset.x + building.minX),
+               static_cast<double>(block->offset.y + building.maxY)},
+          }};
+          size_t validCorners = 0;
+          for (const auto &corner : corners) {
+            const auto projected = projection.projectWorld(corner);
+            if (!projected.valid)
+              continue;
+            ++validCorners;
+            minX = std::min(minX, projected.x);
+            minY = std::min(minY, projected.y);
+            maxX = std::max(maxX, projected.x);
+            maxY = std::max(maxY, projected.y);
+          }
+          if (validCorners < 2)
+            continue;
+          const uint64_t projectedPixels = static_cast<uint64_t>(std::max(
+              1.0, std::ceil(std::max(0.0, maxX - minX) *
+                             std::max(0.0, maxY - minY))));
+          map_building_admission::Candidate candidate;
+          candidate.key = {dx * dx + dy * dy, block->offset.x,
+                           block->offset.y,
+                           static_cast<uint32_t>(recordIndex)};
+          candidate.pointCount = pointCount;
+          candidate.projectedPixels = projectedPixels;
+          retainFallbackCandidate(candidate);
+          ++fallbackVisible;
+        }
+      }
+
+      std::sort(fallbackCandidates.begin(),
+                fallbackCandidates.begin() + fallbackCandidateCount,
+                [](const auto &left, const auto &right) {
+                  return map_building_admission::nearer(left.key, right.key);
+                });
+
+      const auto rgb565 = [](uint32_t rgb) -> uint16_t {
+        return static_cast<uint16_t>(((rgb >> 8U) & 0xf800U) |
+                                     ((rgb >> 5U) & 0x07e0U) |
+                                     ((rgb >> 3U) & 0x001fU));
+      };
+      const uint16_t roofColor = rgb565(0xB9B2A8);
+      size_t selectedRecords = 0;
+      size_t selectedPoints = 0;
+      uint64_t selectedPixels = 0;
+      Polygon buildingPolygon;
+      std::vector<Point16, PsramAllocator<Point16>> screenPoints;
+      map_building_renderer::SurfaceStats fallbackSurfaceStats{};
+      for (size_t candidateIndex = 0;
+           candidateIndex < fallbackCandidateCount; ++candidateIndex) {
+        if (shouldCancelMapRenderWork())
+          return false;
+        const auto &candidate = fallbackCandidates[candidateIndex];
+        if (candidate.pointCount > kFallbackPointLimit - selectedPoints ||
+            candidate.projectedPixels >
+                kFallbackPixelLimit - selectedPixels) {
+          continue;
+        }
+        MapBlock *block = nullptr;
+        for (MapBlock *item : memCache.blocks) {
+          if (item != nullptr && item->offset.x == candidate.key.blockX &&
+              item->offset.y == candidate.key.blockY) {
+            block = item;
             break;
           }
+        }
+        if (block == nullptr ||
+            candidate.key.recordIndex >=
+                block->buildingData.buildings.size()) {
+          continue;
+        }
+        const auto &building =
+            block->buildingData.buildings[candidate.key.recordIndex];
+        bool rendered = false;
+        try {
+          rendered = map_building_renderer::renderSurfaces(
+              building, block->offset.x, block->offset.y,
+              block->mercatorScale, projection, false,
+              [&](map_building_renderer::Surface kind,
+                  const auto &points) -> bool {
+                if (shouldCancelMapRenderWork())
+                  return false;
+                if (kind != map_building_renderer::Surface::Roof ||
+                    points.size() < 3) {
+                  return true;
+                }
+                screenPoints.clear();
+                screenPoints.reserve(points.size() + 1U);
+                int16_t polygonMinX = 32767;
+                int16_t polygonMinY = 32767;
+                int16_t polygonMaxX = -32768;
+                int16_t polygonMaxY = -32768;
+                for (const auto &point : points) {
+                  const Point16 converted(static_cast<int16_t>(point.x),
+                                          static_cast<int16_t>(point.y));
+                  screenPoints.push_back(converted);
+                  polygonMinX = std::min(polygonMinX, converted.x);
+                  polygonMinY = std::min(polygonMinY, converted.y);
+                  polygonMaxX = std::max(polygonMaxX, converted.x);
+                  polygonMaxY = std::max(polygonMaxY, converted.y);
+                }
+                screenPoints.push_back(screenPoints.front());
+                buildingPolygon.points = screenPoints;
+                buildingPolygon.color = roofColor;
+                buildingPolygon.bbox.min = Point16(polygonMinX, polygonMinY);
+                buildingPolygon.bbox.max = Point16(polygonMaxX, polygonMaxY);
+                // A false result can mean cancellation or a small workspace
+                // allocation failure. Cancellation aborts the job; otherwise
+                // skip this footprint and preserve the rest of the flat city.
+                const bool filled = fillPolygon(buildingPolygon, surface);
+                return filled || !shouldCancelMapRenderWork();
+              },
+              &fallbackSurfaceStats, shouldCancelMapRenderWork);
+        } catch (const std::bad_alloc &) {
+          rendered = false;
+        }
+        if (!rendered && shouldCancelMapRenderWork())
+          return false;
+        if (!rendered)
+          continue;
+        ++selectedRecords;
+        selectedPoints += candidate.pointCount;
+        selectedPixels += candidate.projectedPixels;
+      }
+      admissionDiagnostics.candidates = fallbackVisible;
+      admissionDiagnostics.selected = selectedRecords;
+      admissionDiagnostics.flat = selectedRecords;
+      admissionDiagnostics.deferred = fallbackVisible - selectedRecords;
+      admissionDiagnostics.selectedPoints = selectedPoints;
+      admissionDiagnostics.selectedPixels = selectedPixels;
+      MAPIO_LOG(
+          "MAPIO: buildings fallback=flat candidates=%u retained=%u "
+          "selected=%u deferred=%u points=%u pixels=%llu\n",
+          (unsigned)fallbackVisible, (unsigned)fallbackCandidateCount,
+          (unsigned)selectedRecords,
+          (unsigned)(fallbackVisible - selectedRecords),
+          (unsigned)selectedPoints,
+          (unsigned long long)selectedPixels);
+    } else {
+    try {
+      const uint32_t projectionStartMs = millis();
+      // Candidate metadata is bounded independently of scene density and kept
+      // in PSRAM. Selection still visits every visible FMB v4 record and
+      // retains the globally nearest set, so cache/block iteration order cannot
+      // change which buildings survive.
+      constexpr size_t kMaximumCandidateMetadata = 384;
+      std::vector<map_building_admission::Candidate,
+                  PsramAllocator<map_building_admission::Candidate>>
+          candidates;
+      candidates.reserve(kMaximumCandidateMetadata);
+      size_t visibleRecords = 0;
+      size_t oversizedRecords = 0;
+
+      for (MapBlock *block : memCache.blocks) {
+        if (shouldCancelMapRenderWork())
+          return false;
+        if (block == nullptr || !block->inView || block->formatVersion < 4)
+          continue;
+        const BBox localViewport = viewPort.bbox - block->offset;
+        for (size_t recordIndex = 0;
+             recordIndex < block->buildingData.buildings.size();
+             ++recordIndex) {
+          if ((recordIndex & 0x1fU) == 0 && shouldCancelMapRenderWork())
+            return false;
           const auto &building = block->buildingData.buildings[recordIndex];
           const bool mayExtrude =
-              extrudeBuildings &&
-              map_building_renderer::usesExtrusion(true, building.flags);
-          // A roof can project into the frame even when its ground footprint is
-          // just outside it. Expand conservatively in world space before
-          // excluding the record from the queue and its geometry budget.
-          const int32_t elevationMargin = mayExtrude
+              extrusionRequested && map_building_renderer::usesExtrusion(
+                                        true, building.flags);
+          const int32_t heightMargin = mayExtrude
               ? static_cast<int32_t>(std::ceil(
                     building.heightDm / 10.0 * block->mercatorScale))
               : 0;
-          const BBox buildingBbox(
-              Point32(building.minX - elevationMargin,
-                      building.minY - elevationMargin),
-              Point32(building.maxX + elevationMargin,
-                      building.maxY + elevationMargin));
-          if (!buildingBbox.intersects(screenBbox))
+          const BBox bounds(
+              Point32(building.minX - heightMargin,
+                      building.minY - heightMargin),
+              Point32(building.maxX + heightMargin,
+                      building.maxY + heightMargin));
+          if (!bounds.intersects(localViewport))
             continue;
+
           size_t pointCount = 0;
-          bool stopBuildingRecord = false;
-          for (const auto &ring : building.rings) {
-            for (size_t pointIndex = 0; pointIndex < ring.points.size();
-                 ++pointIndex) {
-              if ((pointIndex & 0x1FU) == 0 && shouldStopBuildingWork()) {
-                stopBuildingRecord = true;
+          for (const auto &ring : building.rings)
+            pointCount += ring.points.size();
+          if (pointCount < 3 ||
+              pointCount >
+                  map_building_renderer::kMaximumRenderedBuildingPointsPerRecord) {
+            ++oversizedRecords;
+            continue;
+          }
+          // Discovery must stay independent of ring complexity. FMB v4
+          // already carries validated record bounds, so use their projected
+          // screen extent for the global nearest prepass and reserve exact
+          // ring projection for the bounded retained set below.
+          double projectedMinX = std::numeric_limits<double>::infinity();
+          double projectedMinY = std::numeric_limits<double>::infinity();
+          double projectedMaxX = -std::numeric_limits<double>::infinity();
+          double projectedMaxY = -std::numeric_limits<double>::infinity();
+          const std::array<map_transform::WorldPoint, 4> corners{{
+              {static_cast<double>(block->offset.x + building.minX),
+               static_cast<double>(block->offset.y + building.minY)},
+              {static_cast<double>(block->offset.x + building.maxX),
+               static_cast<double>(block->offset.y + building.minY)},
+              {static_cast<double>(block->offset.x + building.maxX),
+               static_cast<double>(block->offset.y + building.maxY)},
+              {static_cast<double>(block->offset.x + building.minX),
+               static_cast<double>(block->offset.y + building.maxY)},
+          }};
+          size_t validCorners = 0;
+          for (const auto &corner : corners) {
+            const auto projected = projection.projectWorld(corner);
+            if (!projected.valid)
+              continue;
+            ++validCorners;
+            projectedMinX = std::min(projectedMinX, projected.x);
+            projectedMinY = std::min(projectedMinY, projected.y);
+            projectedMaxX = std::max(projectedMaxX, projected.x);
+            projectedMaxY = std::max(projectedMaxY, projected.y);
+          }
+          if (validCorners < 2)
+            continue;
+          const double projectedArea =
+              std::max(1.0, std::ceil(
+                                std::max(0.0, projectedMaxX - projectedMinX) *
+                                std::max(0.0, projectedMaxY - projectedMinY)));
+
+          ++visibleRecords;
+          const double centerX = static_cast<double>(block->offset.x) +
+                                 (building.minX + building.maxX) * 0.5;
+          const double centerY = static_cast<double>(block->offset.y) +
+                                 (building.minY + building.maxY) * 0.5;
+          const double dx = centerX - context.presentedWorld.x;
+          const double dy = centerY - context.presentedWorld.y;
+          map_building_admission::Candidate candidate;
+          candidate.key = {dx * dx + dy * dy, block->offset.x,
+                           block->offset.y,
+                           static_cast<uint32_t>(recordIndex)};
+          candidate.pointCount = pointCount;
+          candidate.projectedPixels = static_cast<uint64_t>(
+              std::max(1.0, std::ceil(projectedArea)));
+          candidate.extrusionEligible =
+              mayExtrude &&
+              map_building_renderer::eligibleExtrusionZoom(zoom) &&
+              projectedArea >=
+                  map_building_renderer::kMinimumBuildingExtrusionAreaPixels;
+          map_building_admission::retainNearest(
+              candidates, candidate, kMaximumCandidateMetadata);
+        }
+      }
+      buildingProjectionMs = millis() - projectionStartMs;
+
+      // Exact ring projection is deliberately after nearest retention. At
+      // most kMaximumCandidateMetadata records can reach this phase, no matter
+      // how many building records intersect the loaded blocks.
+      MapBuildingVector<map_projection::GroundPoint> areaGround;
+      MapBuildingVector<map_projection::GroundPoint> areaClipped;
+      size_t usefulCandidateCount = 0;
+      for (size_t candidateIndex = 0; candidateIndex < candidates.size();
+           ++candidateIndex) {
+        if (shouldCancelMapRenderWork())
+          return false;
+        auto candidate = candidates[candidateIndex];
+        MapBlock *candidateBlock = nullptr;
+        for (MapBlock *block : memCache.blocks) {
+          if (block != nullptr && block->offset.x == candidate.key.blockX &&
+              block->offset.y == candidate.key.blockY) {
+            candidateBlock = block;
+            break;
+          }
+        }
+        if (candidateBlock == nullptr ||
+            candidate.key.recordIndex >=
+                candidateBlock->buildingData.buildings.size()) {
+          continue;
+        }
+        const auto &building = candidateBlock->buildingData.buildings[
+            candidate.key.recordIndex];
+        const double projectedArea =
+            map_building_renderer::projectedFootprintAreaPixels(
+                building, candidateBlock->offset.x, candidateBlock->offset.y,
+                projection, areaGround, areaClipped,
+                shouldCancelMapRenderWork);
+        if (shouldCancelMapRenderWork())
+          return false;
+        if (!(projectedArea > 0.0))
+          continue;
+        candidate.projectedPixels = static_cast<uint64_t>(
+            std::max(1.0, std::ceil(projectedArea)));
+        candidate.extrusionEligible =
+            extrusionRequested &&
+            map_building_renderer::usesExtrusion(true, building.flags) &&
+            map_building_renderer::eligibleExtrusionZoom(zoom) &&
+            projectedArea >=
+                map_building_renderer::kMinimumBuildingExtrusionAreaPixels;
+        candidates[usefulCandidateCount++] = candidate;
+      }
+      candidates.resize(usefulCandidateCount);
+      buildingProjectionMs = millis() - projectionStartMs;
+
+      std::sort(candidates.begin(), candidates.end(),
+                [](const auto &left, const auto &right) {
+                  return map_building_admission::nearer(left.key, right.key);
+                });
+      for (size_t index = 0; index < candidates.size(); ++index)
+        candidates[index].sourceIndex = index;
+
+      // These fixed quotas are intentionally conservative for the 8 MiB PSRAM
+      // target. Nearest records keep 3D; farther admitted records degrade to
+      // flat roofs, and records beyond the quota are explicitly deferred.
+      const map_building_admission::Quotas quotas;
+      const auto decisions = map_building_admission::select(
+          candidates, quotas, &admissionDiagnostics);
+      const size_t metadataDeferred =
+          visibleRecords > candidates.size() ? visibleRecords - candidates.size()
+                                             : 0U;
+      metadataDeferredBuildings = static_cast<uint32_t>(metadataDeferred);
+      std::vector<uint8_t> admission(candidates.size(), 0);
+      for (const auto &decision : decisions) {
+        if (decision.sourceIndex >= admission.size())
+          continue;
+        admission[decision.sourceIndex] =
+            decision.admitted ? (decision.extruded ? 2U : 1U) : 0U;
+      }
+
+      std::vector<BuildingItem, PsramAllocator<BuildingItem>> items;
+      items.reserve(admissionDiagnostics.selected);
+      for (size_t candidateIndex = 0; candidateIndex < candidates.size();
+           ++candidateIndex) {
+        if (admission[candidateIndex] == 0)
+          continue;
+        const auto &candidate = candidates[candidateIndex];
+        MapBlock *selectedBlock = nullptr;
+        for (MapBlock *block : memCache.blocks) {
+          if (block != nullptr && block->offset.x == candidate.key.blockX &&
+              block->offset.y == candidate.key.blockY) {
+            selectedBlock = block;
+            break;
+          }
+        }
+        if (selectedBlock == nullptr ||
+            candidate.key.recordIndex >=
+                selectedBlock->buildingData.buildings.size()) {
+          continue;
+        }
+        const auto &building = selectedBlock->buildingData.buildings[
+            candidate.key.recordIndex];
+        const map_transform::WorldPoint center{
+            static_cast<double>(selectedBlock->offset.x) +
+                (building.minX + building.maxX) * 0.5,
+            static_cast<double>(selectedBlock->offset.y) +
+                (building.minY + building.maxY) * 0.5};
+        items.push_back({selectedBlock, &building,
+                         static_cast<uint16_t>(candidate.key.recordIndex),
+                         projection.groundForWorld(center).forward,
+                         admission[candidateIndex] == 2U});
+      }
+      std::sort(items.begin(), items.end(),
+                [](const BuildingItem &left, const BuildingItem &right) {
+                  return map_building_renderer::rendersBefore(
+                      {left.painterDepth, left.block->offset.x,
+                       left.block->offset.y, left.recordIndex},
+                      {right.painterDepth, right.block->offset.x,
+                       right.block->offset.y, right.recordIndex});
+                });
+
+      const auto rgb565 = [](uint32_t rgb) -> uint16_t {
+        return static_cast<uint16_t>(((rgb >> 8U) & 0xf800U) |
+                                     ((rgb >> 5U) & 0x07e0U) |
+                                     ((rgb >> 3U) & 0x001fU));
+      };
+      const uint16_t roofColor = rgb565(0xB9B2A8);
+      const uint16_t wallLight = rgb565(0x958E84);
+      const uint16_t wallMiddle = rgb565(0x827B72);
+      const uint16_t wallDark = rgb565(0x6D665E);
+      constexpr size_t kMaximumCourtyardWorkspacePixels = 180000;
+
+      Polygon buildingPolygon;
+      std::vector<Point16, PsramAllocator<Point16>> screenPoints;
+      std::vector<int32_t, PsramAllocator<int32_t>> scanlineNodes;
+      MapBuildingVector<map_projection::GroundPoint> holeGround;
+      MapBuildingVector<map_projection::GroundPoint> holeClipped;
+      MapBuildingVector<map_building_renderer::ScreenPoint> holeScreen;
+      map_building_renderer::SurfaceStats surfaceStats{};
+      const uint32_t buildingDrawStartMs = millis();
+
+      struct CourtyardSnapshot {
+        map_building_workspace::Region region{};
+        std::vector<uint16_t, PsramAllocator<uint16_t>> pixels;
+        bool ready = false;
+      };
+
+      for (const BuildingItem &item : items) {
+        if (shouldCancelMapRenderWork())
+          return false;
+
+        size_t projectedCourtyardPixels = 0;
+        const double roofHeight = item.extruded
+                                      ? item.building->heightDm / 10.0
+                                      : 0.0;
+        bool courtyardFits = true;
+        for (const auto &ring : item.building->rings) {
+          if (!ring.hole)
+            continue;
+          holeGround.clear();
+          holeGround.reserve(ring.points.size());
+          for (const auto &point : ring.points) {
+            holeGround.push_back(projection.groundForWorld(
+                {static_cast<double>(item.block->offset.x + point.x),
+                 static_cast<double>(item.block->offset.y + point.y)}));
+          }
+          const auto *roof = &holeGround;
+          if (projection.isBirdsEye()) {
+            map_projection::clipPolygonToNearPlane(
+                projection, holeGround, holeClipped);
+            roof = &holeClipped;
+          }
+          holeScreen.clear();
+          for (const auto &ground : *roof) {
+            const auto point = projection.projectElevatedGround(
+                ground, roofHeight, item.block->mercatorScale);
+            if (point.valid) {
+              holeScreen.push_back(
+                  {map_transform::quantizePixel(point.x),
+                   map_transform::quantizePixel(point.y)});
+            }
+          }
+          const auto region = map_building_workspace::clippedRegion(
+              holeScreen, surface.width, surface.height);
+          if (region.valid())
+            projectedCourtyardPixels += region.pixels();
+          if (projectedCourtyardPixels >
+              std::min(kMaximumCourtyardWorkspacePixels,
+                       static_cast<size_t>(surface.width) * surface.height)) {
+            courtyardFits = false;
+            break;
+          }
+        }
+        if (!courtyardFits) {
+          ++courtyardDeferred;
+          continue;
+        }
+
+        std::vector<CourtyardSnapshot, PsramAllocator<CourtyardSnapshot>>
+            courtyardSnapshots;
+        courtyardSnapshots.reserve(item.building->rings.size());
+        size_t restoreIndex = 0;
+        const bool rendered = map_building_renderer::renderSurfaces(
+            *item.building, item.block->offset.x, item.block->offset.y,
+            item.block->mercatorScale, projection, item.extruded,
+            [&](map_building_renderer::Surface kind,
+                const auto &points) -> bool {
+              if (shouldCancelMapRenderWork())
+                return false;
+              if (kind ==
+                  map_building_renderer::Surface::CourtyardCapture) {
+                CourtyardSnapshot snapshot;
+                snapshot.region = map_building_workspace::clippedRegion(
+                    points, surface.width, surface.height);
+                if (snapshot.region.valid()) {
+                  snapshot.ready = map_building_workspace::captureRegion(
+                      surface, snapshot.region, snapshot.pixels,
+                      kMaximumCourtyardWorkspacePixels);
+                  if (!snapshot.ready)
+                    throw std::bad_alloc();
+                  ++courtyardSnapshotCount;
+                  largestCourtyardBytes = std::max(
+                      largestCourtyardBytes,
+                      snapshot.pixels.capacity() * sizeof(uint16_t));
+                }
+                courtyardSnapshots.push_back(std::move(snapshot));
+                return true;
+              }
+              if (kind == map_building_renderer::Surface::Courtyard) {
+                if (restoreIndex >= courtyardSnapshots.size())
+                  return false;
+                const auto &snapshot = courtyardSnapshots[restoreIndex++];
+                if (!snapshot.ready)
+                  return true;
+                return map_building_workspace::restorePolygon(
+                    points, surface, snapshot.region, snapshot.pixels,
+                    scanlineNodes, shouldCancelMapRenderWork);
+              }
+
+              uint16_t color = roofColor;
+              switch (kind) {
+              case map_building_renderer::Surface::WallLight:
+                color = wallLight;
+                break;
+              case map_building_renderer::Surface::WallMiddle:
+                color = wallMiddle;
+                break;
+              case map_building_renderer::Surface::WallDark:
+                color = wallDark;
+                break;
+              case map_building_renderer::Surface::Roof:
+              case map_building_renderer::Surface::CourtyardCapture:
+              case map_building_renderer::Surface::Courtyard:
                 break;
               }
-              ++pointCount;
-              if (mayExtrude && pointIndex < ring.walls.size() &&
-                  ring.walls[pointIndex] != 0) {
-                ++visibleWallCandidateCount;
+              if (points.size() < 3)
+                return true;
+              screenPoints.clear();
+              screenPoints.reserve(points.size() + 1U);
+              int16_t minX = 32767;
+              int16_t minY = 32767;
+              int16_t maxX = -32768;
+              int16_t maxY = -32768;
+              for (const auto &point : points) {
+                const Point16 converted(
+                    static_cast<int16_t>(point.x),
+                    static_cast<int16_t>(point.y));
+                screenPoints.push_back(converted);
+                minX = std::min(minX, converted.x);
+                minY = std::min(minY, converted.y);
+                maxX = std::max(maxX, converted.x);
+                maxY = std::max(maxY, converted.y);
               }
-            }
-            if (stopBuildingRecord)
-              break;
-          }
-          if (stopBuildingRecord) {
-            stopBuildingPrepass = true;
-            break;
-          }
-          ++visibleBuildingCount;
-          buildingPointCount += pointCount;
-          if (pointCount > map_building_renderer::
-                               kMaximumRenderedBuildingPointsPerRecord) {
-            ++oversizedBuildingCount;
-            continue;
-          }
-          ++boundedBuildingCandidateCount;
-          const map_transform::WorldPoint center{
-              static_cast<double>(block->offset.x) +
-                  (static_cast<double>(building.minX) + building.maxX) / 2.0,
-              static_cast<double>(block->offset.y) +
-                  (static_cast<double>(building.minY) + building.maxY) / 2.0};
-          const auto centerGround = projection.groundForWorld(center);
-          const bool extrusionZoomEligible =
-              map_building_renderer::eligibleExtrusionZoom(zoom);
-          double projectedArea = 0.0;
-          if (mayExtrude && extrusionZoomEligible) {
-            projectedArea =
-                map_building_renderer::projectedFootprintAreaPixels(
-                    building, block->offset.x, block->offset.y, projection,
-                    buildingEligibilityGround, buildingEligibilityClipped,
-                    shouldStopBuildingWork);
-          }
-          if (buildingScreenInterrupted || buildingDeadlineExceeded) {
-            stopBuildingPrepass = true;
-            break;
-          }
-          BuildingRenderItem candidate{
-              block,
-              &building,
-              centerGround.forward,
-              static_cast<uint16_t>(recordIndex),
-              pointCount,
-              false,
-              false,
-              mayExtrude && extrusionZoomEligible &&
-                  projectedArea >= map_building_renderer::
-                                       kMinimumBuildingExtrusionAreaPixels};
-          map_building_renderer::retainNearestCandidate(
-              buildingQueue, candidate,
-              map_building_renderer::kMaximumRenderedBuildingRecords,
-              buildingRendersBefore);
-        }
-        if (stopBuildingPrepass)
-          break;
+              screenPoints.push_back(screenPoints.front());
+              buildingPolygon.points = screenPoints;
+              buildingPolygon.color = color;
+              buildingPolygon.bbox.min = Point16(minX, minY);
+              buildingPolygon.bbox.max = Point16(maxX, maxY);
+              return fillPolygon(buildingPolygon, surface);
+            },
+            &surfaceStats, shouldCancelMapRenderWork);
+        if (!rendered)
+          return false;
+        ++renderedBuildings;
       }
-      buildingProjectionMs = millis() - buildingPhaseStartMs;
-      buildingPassPhase = BuildingPassPhase::Sort;
-      buildingPhaseStartMs = millis();
-      renderRecordLimitOverflow =
-          boundedBuildingCandidateCount - buildingQueue.size();
-      if (!stopBuildingPrepass) {
-        std::sort(buildingQueue.begin(), buildingQueue.end(),
-                  buildingRendersBefore);
-        buildingSortMs = millis() - buildingPhaseStartMs;
-        if (!shouldStopBuildingWork()) {
-          renderSelection = map_building_renderer::selectNearestForRendering(
-              buildingQueue.rbegin(), buildingQueue.rend(),
-              shouldStopBuildingWork);
-          if (!buildingDeadlineExceeded && !buildingScreenInterrupted &&
-              extrudeBuildings) {
-            // The painter queue is far-to-near. Reserve in reverse so the
-            // geometry nearest the rider keeps its walls when a dense city
-            // exceeds the bounded extrusion workspace; overflow roofs remain
-            // visible and flat.
-            buildingSelection =
-                map_building_renderer::selectNearestForExtrusion(
-                    buildingQueue.rbegin(), buildingQueue.rend(),
-                    shouldStopBuildingWork);
-            buildingBudgetFallback = buildingSelection.usedFallback();
-            extrusionRecordOverflowTotal +=
-                buildingSelection.recordLimitOverflow;
-            extrusionPointOverflowTotal +=
-                buildingSelection.pointLimitOverflow;
-          }
-        }
-      }
-      if (buildingDeadlineExceeded) {
-        buildingPrepassDeadlineExceeded = true;
-        return abortStoppedBuildingWork(buildingQueue.size());
-      }
-      if (buildingScreenInterrupted)
-        return false;
-      renderRecordOverflowTotal += renderRecordLimitOverflow;
-      renderPointOverflowTotal += renderSelection.pointLimitOverflow;
-      renderOversizedOverflowTotal += oversizedBuildingCount;
+      buildingDrawMs = millis() - buildingDrawStartMs;
+
+      MAPIO_LOG(
+          "MAPIO: buildings candidates=%u retained=%u selected=%u "
+          "extruded=%u flat=%u deferred=%u visible=%u oversized=%u "
+          "rendered=%u courtyardDeferred=%u projectionMs=%lu drawMs=%lu "
+          "courtyardSnapshots=%u courtyardMaxBytes=%u "
+          "freeInternalHeap=%u largestInternalHeap=%u "
+          "psramFree=%u psramLargest=%u wallFaces=%u suppressedWalls=%u\n",
+          (unsigned)admissionDiagnostics.candidates,
+          (unsigned)candidates.size(),
+          (unsigned)admissionDiagnostics.selected,
+          (unsigned)admissionDiagnostics.extruded,
+          (unsigned)admissionDiagnostics.flat,
+          (unsigned)(admissionDiagnostics.deferred + metadataDeferred),
+          (unsigned)visibleRecords,
+          (unsigned)oversizedRecords, (unsigned)renderedBuildings,
+          (unsigned)courtyardDeferred, (unsigned long)buildingProjectionMs,
+          (unsigned long)buildingDrawMs,
+          (unsigned)courtyardSnapshotCount,
+          (unsigned)largestCourtyardBytes,
+          (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL |
+                                            MALLOC_CAP_8BIT),
+          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL |
+                                                     MALLOC_CAP_8BIT),
+          (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
+          (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM),
+          (unsigned)surfaceStats.generatedWallFaces,
+          (unsigned)surfaceStats.suppressedWallFaces);
+    } catch (const std::bad_alloc &) {
+      buildingAllocationFailed = true;
+      buildingFailureInternalHeapFree =
+          heap_caps_get_free_size(MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+      buildingFailureInternalHeapLargest = heap_caps_get_largest_free_block(
+          MALLOC_CAP_INTERNAL | MALLOC_CAP_8BIT);
+      buildingFailurePsramFree = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+      buildingFailurePsramLargest =
+          heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
     }
-
-    buildingPassPhase = BuildingPassPhase::Draw;
-    buildingPhaseStartMs = millis();
-    const uint16_t roofColor = lv_color_to_u16(lv_color_hex(0xB9B2A8));
-    const uint16_t wallLight = lv_color_to_u16(lv_color_hex(0x958E84));
-    const uint16_t wallMiddle = lv_color_to_u16(lv_color_hex(0x827B72));
-    const uint16_t wallDark = lv_color_to_u16(lv_color_hex(0x6D665E));
-    const auto fillScreenPolygon = [&](const auto &points,
-                                       uint16_t color) -> bool {
-      if (points.size() < 3)
-        return true;
-      buildingPolygon.points.clear();
-      buildingPolygon.color = color;
-      int16_t minX = 32767, minY = 32767, maxX = -32768, maxY = -32768;
-      for (const Point16 &point : points) {
-        buildingPolygon.points.push_back(point);
-        minX = std::min(minX, point.x);
-        minY = std::min(minY, point.y);
-        maxX = std::max(maxX, point.x);
-        maxY = std::max(maxY, point.y);
-      }
-      buildingPolygon.points.push_back(points.front());
-      buildingPolygon.bbox.min = Point16(minX, minY);
-      buildingPolygon.bbox.max = Point16(maxX, maxY);
-      const bool completed = Maps::fillPolygon(
-          buildingPolygon, canvas, buildingPassStartMs,
-          map_building_renderer::kMaximumBuildingRenderTimeMs);
-      if (!completed)
-        shouldStopBuildingWork();
-      return completed;
-    };
-    const auto countRenderTimeOverflowFrom = [&](size_t itemIndex) {
-      size_t overflow = 0;
-      for (size_t remaining = itemIndex; remaining < buildingQueue.size();
-           ++remaining) {
-        if (buildingQueue[remaining].render)
-          ++overflow;
-      }
-      return overflow;
-    };
-    for (size_t itemIndex = 0;
-         !buildingDeadlineExceeded && itemIndex < buildingQueue.size();
-         ++itemIndex) {
-      const auto &item = buildingQueue[itemIndex];
-      if (!item.render)
-        continue;
-      if (shouldStopBuildingWork()) {
-        return abortStoppedBuildingWork(
-            countRenderTimeOverflowFrom(itemIndex));
-      }
-      bool courtyardUnderlayReady = false;
-      bool courtyardUnderlayUnavailable = false;
-      const bool surfacesRendered = map_building_renderer::renderSurfaces(
-          *item.building, item.block->offset.x, item.block->offset.y,
-          item.block->mercatorScale, projection, item.extrude,
-          [&](map_building_renderer::Surface surface,
-              const auto &points) -> bool {
-            buildingSurfacePoints.clear();
-            for (size_t pointIndex = 0; pointIndex < points.size();
-                 ++pointIndex) {
-              if ((pointIndex & 0x1FU) == 0 && shouldStopBuildingWork())
-                return false;
-              const auto &point = points[pointIndex];
-              buildingSurfacePoints.push_back(Point16(point.x, point.y));
-            }
-
-            if (surface ==
-                map_building_renderer::Surface::CourtyardCapture) {
-              if (buildingSurfacePoints.size() < 3 ||
-                  courtyardUnderlayUnavailable) {
-                return true;
-              }
-              try {
-                if (courtyardScanlineNodes.size() <
-                    buildingSurfacePoints.size()) {
-                  courtyardScanlineNodes.resize(buildingSurfacePoints.size());
-                }
-              } catch (const std::bad_alloc &) {
-                courtyardUnderlayUnavailable = true;
-                return true;
-              }
-              if (courtyardUnderlayReady)
-                return true;
-              lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
-              if (drawBuffer == nullptr) {
-                courtyardUnderlayUnavailable = true;
-                return true;
-              }
-              const size_t stridePixels = drawBuffer->header.stride / 2U;
-              const size_t pixelCount =
-                  stridePixels * drawBuffer->header.h;
-              try {
-                courtyardUnderlay.resize(pixelCount);
-              } catch (const std::bad_alloc &) {
-                courtyardUnderlayUnavailable = true;
-                return true;
-              }
-              std::memcpy(courtyardUnderlay.data(), drawBuffer->data,
-                          pixelCount * sizeof(uint16_t));
-              largestCourtyardUnderlayBytes = std::max(
-                  largestCourtyardUnderlayBytes,
-                  courtyardUnderlay.capacity() * sizeof(uint16_t));
-              ++courtyardSnapshotCount;
-              if (shouldStopBuildingWork())
-                return false;
-              courtyardUnderlayReady = true;
-              return true;
-            }
-            if (courtyardUnderlayUnavailable &&
-                (surface == map_building_renderer::Surface::Roof ||
-                 surface == map_building_renderer::Surface::Courtyard)) {
-              // Preserve the real underlay instead of painting a false solid
-              // roof if the bounded snapshot cannot be allocated.
-              return true;
-            }
-            if (surface == map_building_renderer::Surface::Courtyard) {
-              if (!courtyardUnderlayReady ||
-                  buildingSurfacePoints.size() < 3) {
-                return true;
-              }
-              lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
-              if (drawBuffer == nullptr)
-                return false;
-              return map_building_renderer::restoreCourtyardUnderlay(
-                  buildingSurfacePoints,
-                  reinterpret_cast<uint16_t *>(drawBuffer->data),
-                  drawBuffer->header.w, drawBuffer->header.h,
-                  drawBuffer->header.stride / 2U,
-                  courtyardUnderlay.data(), courtyardUnderlay.size(),
-                  courtyardScanlineNodes,
-                  shouldStopBuildingWork);
-            }
-
-            uint16_t color = roofColor;
-            switch (surface) {
-            case map_building_renderer::Surface::WallLight:
-              color = wallLight;
-              break;
-            case map_building_renderer::Surface::WallMiddle:
-              color = wallMiddle;
-              break;
-            case map_building_renderer::Surface::WallDark:
-              color = wallDark;
-              break;
-            case map_building_renderer::Surface::CourtyardCapture:
-            case map_building_renderer::Surface::Courtyard:
-              break;
-            case map_building_renderer::Surface::Roof:
-              break;
-            }
-            return fillScreenPolygon(buildingSurfacePoints, color);
-          },
-          &buildingSurfaceStats, shouldStopBuildingWork);
-      if (!surfacesRendered) {
-        shouldStopBuildingWork();
-        if (buildingDeadlineExceeded) {
-          return abortStoppedBuildingWork(
-              countRenderTimeOverflowFrom(itemIndex));
-        }
-        return false;
-      }
-      ++renderedBuildings;
-      if (item.extrude)
-        ++extrudedBuildings;
     }
-    const uint64_t generatedWallFaces =
-        buildingSurfaceStats.generatedWallFaces;
-    const uint64_t suppressedWallFaces =
-        visibleWallCandidateCount > generatedWallFaces
-            ? visibleWallCandidateCount - generatedWallFaces
-            : 0;
+  }
 
-    buildingDrawMs = millis() - buildingPhaseStartMs;
-    buildingPassPhase = BuildingPassPhase::Complete;
-    MAPIO_LOG("MAPIO: buildings parsedRecords=%u parsedRings=%u "
-              "parsedPoints=%u heightExplicit=%u heightLevels=%u "
-              "heightInherited=%u heightLocalMedian=%u heightClassDefault=%u "
-              "suppressed=%u visibleRecords=%u visiblePoints=%llu "
-              "queuedRecords=%u rendered=%u extruded=%u flatOverflow=%u "
-              "renderRecordOverflow=%u renderPointOverflow=%u "
-              "renderOversizedOverflow=%u renderTimeOverflow=%u "
-              "extrusionRecordOverflow=%u extrusionPointOverflow=%u "
-              "wallCandidates=%llu generatedWallFaces=%llu "
-              "suppressedWallFaces=%llu "
-              "projectionMs=%lu sortMs=%lu buildingDrawMs=%lu "
+  if (diagnostics != nullptr) {
+    diagnostics->selectedBuildings =
+        static_cast<uint32_t>(admissionDiagnostics.selected);
+    diagnostics->extrudedBuildings =
+        static_cast<uint32_t>(admissionDiagnostics.extruded);
+    diagnostics->flatBuildings =
+        static_cast<uint32_t>(admissionDiagnostics.flat);
+    diagnostics->deferredBuildings = static_cast<uint32_t>(
+        admissionDiagnostics.deferred + metadataDeferredBuildings +
+        courtyardDeferred);
+    diagnostics->allocationFallback = buildingAllocationFailed;
+  }
+
+  if (buildingAllocationFailed) {
+    buildingFailureRetryCooldown.recordFailure(
+        millis(), buildingContextSignature, buildingRenderRegion);
+    MAPIO_LOG("MAPIO: buildings failure=allocation fallback=bounded-flat "
               "courtyardSnapshots=%u courtyardMaxBytes=%u "
               "freeInternalHeap=%u largestInternalHeap=%u "
-              "deadlineExceeded=%u prepassDeadlineExceeded=%u "
-              "psramUsed=%u psramFree=%u psramLargest=%u "
-              "budgetFallback=%u renderRecordOverflowTotal=%llu "
-              "renderPointOverflowTotal=%llu "
-              "renderOversizedOverflowTotal=%llu renderTimeOverflowTotal=%llu "
-              "extrusionRecordOverflowTotal=%llu "
-              "extrusionPointOverflowTotal=%llu decodedBytes=%u\n",
-              (unsigned)loadedBuildingStats.records,
-              (unsigned)loadedBuildingStats.rings,
-              (unsigned)loadedBuildingStats.points,
-              (unsigned)loadedBuildingStats.provenance[0],
-              (unsigned)loadedBuildingStats.provenance[1],
-              (unsigned)loadedBuildingStats.provenance[2],
-              (unsigned)loadedBuildingStats.provenance[3],
-              (unsigned)loadedBuildingStats.provenance[4],
-              buildingsSuppressed ? 1U : 0U, (unsigned)visibleBuildingCount,
-              (unsigned long long)buildingPointCount,
-              (unsigned)buildingQueue.size(),
-              (unsigned)renderedBuildings,
-              (unsigned)extrudedBuildings,
-              (unsigned)buildingSelection.flatOverflow(),
-              (unsigned)renderRecordLimitOverflow,
-              (unsigned)renderSelection.pointLimitOverflow,
-              (unsigned)oversizedBuildingCount,
-              (unsigned)renderTimeOverflow,
-              (unsigned)buildingSelection.recordLimitOverflow,
-              (unsigned)buildingSelection.pointLimitOverflow,
-              (unsigned long long)visibleWallCandidateCount,
-              (unsigned long long)generatedWallFaces,
-              (unsigned long long)suppressedWallFaces,
-              (unsigned long)buildingProjectionMs,
-              (unsigned long)buildingSortMs,
-              (unsigned long)buildingDrawMs,
+              "buildingFailureInternalHeapFree=%u "
+              "buildingFailureInternalHeapLargest=%u "
+              "psramFree=%u psramLargest=%u\n",
               (unsigned)courtyardSnapshotCount,
-              (unsigned)largestCourtyardUnderlayBytes,
+              (unsigned)largestCourtyardBytes,
               (unsigned)heap_caps_get_free_size(MALLOC_CAP_INTERNAL |
                                                 MALLOC_CAP_8BIT),
               (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_INTERNAL |
                                                          MALLOC_CAP_8BIT),
-              buildingDeadlineExceeded ? 1U : 0U,
-              buildingPrepassDeadlineExceeded ? 1U : 0U,
-              (unsigned)(ESP.getPsramSize() -
-                         heap_caps_get_free_size(MALLOC_CAP_SPIRAM)),
-              (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
-              (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM),
-              buildingBudgetFallback ? 1U : 0U,
-              (unsigned long long)renderRecordOverflowTotal,
-              (unsigned long long)renderPointOverflowTotal,
-              (unsigned long long)renderOversizedOverflowTotal,
-              (unsigned long long)renderTimeOverflowTotal,
-              (unsigned long long)extrusionRecordOverflowTotal,
-              (unsigned long long)extrusionPointOverflowTotal,
-              (unsigned)std::accumulate(
-                  memCache.blocks.begin(), memCache.blocks.end(), size_t{0},
-                  [](size_t total, const MapBlock *block) {
-                    return total + block->buildingData.decodedBytes();
-                  }));
-
-              return true;
-            },
-            [&]() {
-              finishBuildingPhaseTiming();
-              buildingAllocationFailed = true;
-              // The large render workspaces live outside the guarded callable,
-              // so this catch samples them before the fallback releases them.
-              captureBuildingFailureMemory();
-            });
-    if (!buildingPassCompleted) {
-      const char *failureReason = buildingAllocationFailed
-                                      ? "allocation"
-                                      : (buildingDeadlineAborted ? "deadline"
-                                                                 : "interrupt");
-      const bool screenCycleInterrupted =
-          buildingScreenInterrupted || shouldInterruptMapRenderForScreenCycle();
-      if (buildingAllocationFailed || buildingDeadlineAborted) {
-        MAPIO_LOG(
-            "MAPIO: buildings aborted reason=%s fallback=buildings-hidden "
-            "parsedRecords=%u parsedRings=%u parsedPoints=%u "
-            "heightExplicit=%u heightLevels=%u heightInherited=%u "
-            "heightLocalMedian=%u heightClassDefault=%u "
-            "visibleRecords=%u visiblePoints=%llu rendered=%u extruded=%u "
-            "renderTimeOverflow=%u renderTimeOverflowTotal=%llu "
-            "projectionMs=%lu sortMs=%lu buildingDrawMs=%lu "
-            "courtyardSnapshots=%u courtyardMaxBytes=%u "
-            "freeInternalHeap=%u largestInternalHeap=%u "
-            "prepassDeadlineExceeded=%u psramUsed=%u psramFree=%u "
-            "psramLargest=%u psramSamplePostCleanup=%u\n",
-            failureReason, (unsigned)loadedBuildingStats.records,
-            (unsigned)loadedBuildingStats.rings,
-            (unsigned)loadedBuildingStats.points,
-            (unsigned)loadedBuildingStats.provenance[0],
-            (unsigned)loadedBuildingStats.provenance[1],
-            (unsigned)loadedBuildingStats.provenance[2],
-            (unsigned)loadedBuildingStats.provenance[3],
-            (unsigned)loadedBuildingStats.provenance[4],
-            (unsigned)visibleBuildingCount,
-            (unsigned long long)buildingPointCount,
-            (unsigned)renderedBuildings, (unsigned)extrudedBuildings,
-            (unsigned)renderTimeOverflow,
-            (unsigned long long)renderTimeOverflowTotal,
-            (unsigned long)buildingProjectionMs,
-            (unsigned long)buildingSortMs, (unsigned long)buildingDrawMs,
-            (unsigned)courtyardSnapshotCount,
-            (unsigned)largestCourtyardUnderlayBytes,
-            (unsigned)buildingFailureInternalHeapFree,
-            (unsigned)buildingFailureInternalHeapLargest,
-            buildingPrepassDeadlineExceeded ? 1U : 0U,
-            (unsigned)buildingFailurePsramUsed,
-            (unsigned)buildingFailurePsramFree,
-            (unsigned)buildingFailurePsramLargest,
-            buildingFailurePsramSamplePostCleanup ? 1U : 0U);
-        buildingFailureRetryCooldown.recordFailure(
-            millis(), buildingContextSignature, buildingRenderRegion);
-      } else if (screenCycleInterrupted) {
-        captureBuildingFailureMemory();
-        MAPIO_LOG(
-            "MAPIO: buildings aborted reason=interrupt fallback=deferred "
-            "courtyardSnapshots=%u courtyardMaxBytes=%u "
-            "freeInternalHeap=%u largestInternalHeap=%u "
-            "psramUsed=%u psramFree=%u psramLargest=%u\n",
-            (unsigned)courtyardSnapshotCount,
-            (unsigned)largestCourtyardUnderlayBytes,
-            (unsigned)buildingFailureInternalHeapFree,
-            (unsigned)buildingFailureInternalHeapLargest,
-            (unsigned)buildingFailurePsramUsed,
-            (unsigned)buildingFailurePsramFree,
-            (unsigned)buildingFailurePsramLargest);
-      }
-      if (buildingAllocationFailed || buildingDeadlineAborted ||
-          screenCycleInterrupted) {
-        releaseBuildingFailureWorkspace();
-        if (map_building_renderer::shouldRetryWithoutBuildings(
-                buildingsSuppressed, buildingAllocationFailed,
-                buildingDeadlineAborted, screenCycleInterrupted)) {
-          return Maps::readVectorMap(viewPort, memCache, canvas, zoom, rotation,
-                                     projection, drawLabels, true);
-        }
-      }
-      return false;
+              (unsigned)buildingFailureInternalHeapFree,
+              (unsigned)buildingFailureInternalHeapLargest,
+              (unsigned)buildingFailurePsramFree,
+              (unsigned)buildingFailurePsramLargest);
+    // reason=interrupt fallback=deferred: semantic invalidation keeps the
+    // last complete frame visible and schedules the newest request.
+    if (!suppressBuildings && !shouldCancelMapRenderWork()) {
+      RasterDiagnostics fallbackDiagnostics{};
+      const bool fallbackRendered = readVectorMap(
+          viewPort, memCache, surface, zoom, rotation, projection, context,
+          drawLabels, true, &fallbackDiagnostics);
+      fallbackDiagnostics.allocationFallback = true;
+      if (diagnostics != nullptr)
+        *diagnostics = fallbackDiagnostics;
+      return fallbackRendered;
     }
-
-    // Failure diagnostics need the live allocations, but labels do not. Drop
-    // the building workspace at the phase boundary so dense geometry and the
-    // label candidate/layout reserves never overlap on a successful frame.
-    releaseBuildingFailureWorkspace();
-    if (drawLabels &&
-        !drawStreetLabels(viewPort, memCache, canvas, zoom, rotation, style))
-      return false;
-    ESP_LOGI(TAG, "Total %i ms", millis() - totalTime);
-
-    // TODO: paint only in NAV mode
-    // map.fillTriangle(...)
-    ESP_LOGI(TAG, "Draw done! %i", millis());
-
-    // NOTE: Block caching is now handled by getMapBlocks() eviction logic.
-    // Previously, this code deleted the first block after every render,
-    // which defeated caching and forced SD card reads every frame.
-
-    Maps::totalBounds.lat_min = Maps::mercatorY2lat(viewPort.bbox.min.y);
-    Maps::totalBounds.lat_max = Maps::mercatorY2lat(viewPort.bbox.max.y);
-    Maps::totalBounds.lon_min = Maps::mercatorX2lon(viewPort.bbox.min.x);
-    Maps::totalBounds.lon_max = Maps::mercatorX2lon(viewPort.bbox.max.x);
-
-    ESP_LOGI(TAG, "Updated rendered map bounds");
-
-    if (Maps::isCoordInBounds(Maps::destLat, Maps::destLon, Maps::totalBounds))
-      Maps::coords2map(Maps::destLat, Maps::destLon, Maps::totalBounds,
-                       &(Maps::wptPosX), &(Maps::wptPosY));
-    else {
-      Maps::wptPosX = -1;
-      Maps::wptPosY = -1;
-    }
-
-    lv_layer_t track_layer;
-    lv_canvas_init_layer(canvas, &track_layer);
-    lv_draw_line_dsc_t track_dsc;
-    lv_draw_line_dsc_init(&track_dsc);
-    track_dsc.width = 2;
-    track_dsc.color = lv_color_hex(
-        TFT_BLUE); // Assuming TFT_BLUE is defined, else use LVGL color
-    track_dsc.opa = LV_OPA_COVER;
-
-    for (size_t i = 1; i < trackData.size(); ++i) {
-      if (trackData[i - 1].lon > Maps::totalBounds.lon_min &&
-          trackData[i - 1].lon < Maps::totalBounds.lon_max &&
-          trackData[i - 1].lat > Maps::totalBounds.lat_min &&
-          trackData[i - 1].lat < Maps::totalBounds.lat_max &&
-          trackData[i].lon > Maps::totalBounds.lon_min &&
-          trackData[i].lon < Maps::totalBounds.lon_max &&
-          trackData[i].lat > Maps::totalBounds.lat_min &&
-          trackData[i].lat < Maps::totalBounds.lat_max) {
-        uint16_t x, y, x2, y2;
-      }
-    }
-    MAPIO_LOG("MAPIO: canvas-draw ok=1 mode=%s clipped=%lu rejected=%lu "
-              "blocks=%u fillMs=%lu totalMs=%lu\n",
-              projection.isBirdsEye() ? "birds-eye" : "flat",
-              (unsigned long)projectionClippedCount,
-              (unsigned long)projectionRejectedCount,
-              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
-              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
-    logMapMemorySnapshot("canvas-draw");
-  } else {
-    Maps::isMapFound = false;
-    lv_canvas_fill_bg(canvas, lv_color_hex(TFT_BLACK), LV_OPA_COVER);
-    MAPIO_LOG("MAPIO: canvas-draw ok=0 blocks=%u fillMs=%lu totalMs=%lu\n",
-              (unsigned)memCache.blocks.size(), (unsigned long)fillMs,
-              (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
-    logMapMemorySnapshot("canvas-draw-empty");
-    //    Maps::showNoMap(map);
-    //    ESP_LOGE(TAG, "Map doesn't exist");
+    return false;
   }
+
+  if (drawLabels) {
+    map_surface::LabelSurface labelSurface;
+    labelSurface.color = surface;
+    if (!drawStreetLabels(viewPort, memCache, labelSurface, zoom, rotation,
+                          context)) {
+      return false;
+    }
+  }
+
+  MAPIO_LOG("MAPIO: raw-map ok=1 mode=%s clipped=%lu rejected=%lu "
+            "blocks=%u totalMs=%lu\n",
+            projection.isBirdsEye() ? "birds-eye" : "flat",
+            (unsigned long)projectionClippedCount,
+            (unsigned long)projectionRejectedCount,
+            (unsigned)memCache.blocks.size(),
+            (unsigned long)(MAPIO_TIME_MS() - drawStartMs));
   return true;
+}
+
+Maps::RenderContext Maps::captureRenderContext(uint32_t nowMs) {
+  RenderContext context;
+  context.style = currentMapStyleSettings();
+  context.measuredGpsWorld = {lon2x(gps.gpsData.longitude),
+                              lat2y(gps.gpsData.latitude)};
+  if (nowMs != 0)
+    updatePresentedPose(nowMs);
+  context.presentedWorld = hasPresentedPose
+                               ? map_transform::WorldPoint{
+                                     presentedPose.position.x,
+                                     presentedPose.position.y}
+                               : context.measuredGpsWorld;
+  context.guidanceScreenActive = isMapGuidanceScreenActive();
+  context.navigationSessionActive =
+      routeOverlay.hasRoute() || hasCurrentNavigationData();
+  context.followPosition = followGps || isMapGuidanceScreenActive();
+  context.showCurrentPosition = isCurrentPositionVisible(mapRenderSettings);
+  context.buildings3DEnabled =
+      mapRenderSettings.mapNavigation3DBuildingsEnabled;
+  context.markerScale = currentMarkerScale();
+  context.birdsEyePerspective =
+      mapRenderSettings.mapNavigationBirdsEyePerspective;
+  return context;
+}
+
+bool Maps::readVectorMap(ViewPort &viewPort, MemCache &memCache,
+                         lv_obj_t *canvas, uint8_t zoom, double rotation,
+                         const map_projection::Projection &projection,
+                         bool drawLabels, bool suppressBuildings) {
+  RenderContext context = captureRenderContext();
+  return readVectorMap(viewPort, memCache, rgb565SurfaceForCanvas(canvas), zoom,
+                       rotation, projection, context, drawLabels,
+                       suppressBuildings);
 }
 
 void Maps::showNoMap(lv_obj_t *canvas, bool sdPresent) {
@@ -3399,6 +3455,965 @@ void Maps::showNoMap(lv_obj_t *canvas, bool sdPresent) {
  * @param lat
  * @param lon
  */
+namespace {
+
+uint64_t fnvMix64(uint64_t hash, uint64_t value) {
+  hash ^= value;
+  return hash * 1099511628211ULL;
+}
+
+uint64_t doubleBits(double value) {
+  uint64_t bits = 0;
+  static_assert(sizeof(bits) == sizeof(value), "unexpected double size");
+  memcpy(&bits, &value, sizeof(bits));
+  return bits;
+}
+
+int16_t mapAngleTenths(double radians) {
+  constexpr double kRadiansToTenths = 1800.0 / 3.14159265358979323846;
+  double tenths = radians * kRadiansToTenths;
+  while (tenths > 1800.0)
+    tenths -= 3600.0;
+  while (tenths < -1800.0)
+    tenths += 3600.0;
+  return static_cast<int16_t>(std::round(tenths));
+}
+
+} // namespace
+
+uint64_t Maps::styleSignature(const ScreenMapRenderSettings &style) const {
+  uint64_t hash = 1469598103934665603ULL;
+  hash = fnvMix64(hash, style.minPolygonSize);
+  hash = fnvMix64(hash, style.detailLevel);
+  hash = fnvMix64(hash, style.routeLineWidth);
+  hash = fnvMix64(hash, style.streetLineWidth);
+  hash = fnvMix64(hash, style.positionMarkerScale);
+  hash = fnvMix64(hash, style.zoomLevel);
+  hash = fnvMix64(hash, style.visibilityMask);
+  hash = fnvMix64(hash, style.labelDensity);
+  hash = fnvMix64(hash, style.labelLanguageMode);
+  hash = fnvMix64(hash, style.labelTextSize);
+  hash = fnvMix64(hash, style.labelOrientation);
+  hash = fnvMix64(hash, mapRenderSettings.navigationOverlayVisibilityMask);
+  hash = fnvMix64(hash,
+                  mapRenderSettings.mapNavigation3DBuildingsEnabled ? 1U : 0U);
+  hash = fnvMix64(hash,
+                  mapRenderSettings.mapNavigationBirdsEyeEnabled ? 1U : 0U);
+  hash = fnvMix64(hash,
+                  mapRenderSettings.mapNavigationBirdsEyePerspective);
+  return hash;
+}
+
+uint64_t Maps::navigationSignature() const {
+  // Only state that changes the base-frame contract belongs here. Maneuver
+  // text/distance remains a lightweight LVGL overlay and must not cancel an
+  // expensive base render every time its packet advances.
+  uint64_t hash = 1469598103934665603ULL;
+  const bool guidanceSession =
+      routeOverlay.hasRoute() || hasCurrentNavigationData();
+  hash = fnvMix64(hash, guidanceSession ? 1U : 0U);
+  hash = fnvMix64(hash, isMapGuidanceScreenActive() ? 1U : 0U);
+  hash = fnvMix64(hash, static_cast<uint8_t>(rotationMode));
+  return hash;
+}
+
+uint64_t Maps::projectionSignature(uint8_t requestedZoom,
+                                   uint16_t viewportWidth,
+                                   uint16_t viewportHeight, bool birdsEye,
+                                   uint8_t perspective) const {
+  uint64_t hash = 1469598103934665603ULL;
+  hash = fnvMix64(hash, requestedZoom);
+  hash = fnvMix64(hash, viewportWidth);
+  hash = fnvMix64(hash, viewportHeight);
+  hash = fnvMix64(hash, birdsEye ? 1U : 0U);
+  hash = fnvMix64(hash, perspective);
+  hash = fnvMix64(hash, MAP_RENDER_OVERSCAN_PIXELS);
+  return hash;
+}
+
+void Maps::invalidateRenderSemantics() {
+  bool semanticChanged = false;
+  const ScreenMapRenderSettings &style = currentMapStyleSettings();
+  const uint64_t currentStyle = styleSignature(style);
+  if (lastStyleSignature == 0) {
+    lastStyleSignature = currentStyle;
+  } else if (lastStyleSignature != currentStyle) {
+    lastStyleSignature = currentStyle;
+    ++styleEpoch;
+    isPosMoved = true;
+    redrawMap = true;
+    semanticChanged = true;
+  }
+
+  const uint64_t currentNavigation = navigationSignature();
+  if (lastNavigationSignature == 0) {
+    lastNavigationSignature = currentNavigation;
+  } else if (lastNavigationSignature != currentNavigation) {
+    lastNavigationSignature = currentNavigation;
+    ++navigationEpoch;
+    isPosMoved = true;
+    redrawMap = true;
+    semanticChanged = true;
+  }
+
+  // Heading memory belongs to an explicit presentation session. A route
+  // replacement is a new presentation epoch even when navigation remains
+  // active; otherwise an invalid course can inherit the previous route's
+  // bearing and make course-up point the wrong way.
+  uint64_t headingSession = 1469598103934665603ULL;
+  const bool mapVisible = isMapScreenActive() || isMapGuidanceScreenActive();
+  const bool routeActive = routeOverlay.hasRoute();
+  const bool maneuverActive = hasCurrentNavigationData();
+  headingSession = fnvMix64(headingSession, mapVisible ? 1U : 0U);
+  headingSession = fnvMix64(headingSession,
+                            isMapGuidanceScreenActive() ? 1U : 0U);
+  headingSession = fnvMix64(
+      headingSession, (routeActive || maneuverActive) ? 1U : 0U);
+  headingSession = fnvMix64(headingSession, routeOverlay.revision());
+  headingSession = fnvMix64(headingSession,
+                            static_cast<uint8_t>(rotationMode));
+  if (lastHeadingSessionSignature == 0) {
+    lastHeadingSessionSignature = headingSession;
+  } else if (lastHeadingSessionSignature != headingSession) {
+    lastHeadingSessionSignature = headingSession;
+    ++headingSessionEpoch;
+    headingResolver.setNavigationSession(false, headingSessionEpoch);
+  }
+
+  const uint16_t viewportHeight =
+      mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
+  const bool birdsEye = navigation_content_mode::usesMapGuidanceBirdsEye(
+      isMapGuidanceScreenActive(),
+      mapRenderSettings.mapNavigationBirdsEyeEnabled);
+  const uint64_t currentProjection = projectionSignature(
+      zoom, mapScrWidth, viewportHeight, birdsEye,
+      mapRenderSettings.mapNavigationBirdsEyePerspective);
+  if (lastProjectionSignature == 0) {
+    lastProjectionSignature = currentProjection;
+  } else if (lastProjectionSignature != currentProjection) {
+    lastProjectionSignature = currentProjection;
+    ++projectionEpoch;
+    isPosMoved = true;
+    redrawMap = true;
+    semanticChanged = true;
+  }
+
+  if (semanticChanged)
+    cancelActiveRenderWork();
+}
+
+void Maps::cancelActiveRenderWork() {
+  gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
+  if (renderStateMutex == nullptr)
+    return;
+  if (xSemaphoreTake(renderStateMutex, portMAX_DELAY) == pdTRUE) {
+    renderJobs.requestCancellation();
+    xSemaphoreGive(renderStateMutex);
+  }
+}
+
+void Maps::updatePresentedPose(uint32_t nowMs) {
+  const bool routeActive = routeOverlay.hasRoute();
+  const bool maneuverActive = hasCurrentNavigationData();
+  const bool mapVisible = isMapScreenActive() || isMapGuidanceScreenActive();
+  // The session is explicit and screen-scoped. A route window or a maneuver
+  // snapshot is independently sufficient to make guidance course-up valid.
+  const bool sessionActive =
+      mapVisible &&
+      (rotationMode == ROT_COURSE_UP || routeActive || maneuverActive);
+  headingResolver.setNavigationSession(sessionActive, headingSessionEpoch);
+
+  double routeDegrees = 0.0;
+  uint16_t routeHeading = 0;
+  const bool routeValid =
+      routeActive &&
+      routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
+                               routeHeading);
+  if (routeValid)
+    routeDegrees = routeHeading;
+
+  double resolvedHeading = 0.0;
+  const bool measuredValid = gps.gpsData.headingValid &&
+                             gps.gpsData.heading < 360U;
+  const bool headingValid = headingResolver.resolve(
+      measuredValid, gps.gpsData.heading, routeValid, routeDegrees,
+      resolvedHeading);
+
+  uint64_t gpsSignature = 1469598103934665603ULL;
+  gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.latitude));
+  gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.longitude));
+  gpsSignature = fnvMix64(gpsSignature, gps.gpsData.speed);
+  gpsSignature = fnvMix64(gpsSignature, headingValid ? 1U : 0U);
+  gpsSignature = fnvMix64(gpsSignature, doubleBits(resolvedHeading));
+  // An identical coordinate is still a fresh convergence anchor. Preserve the
+  // BLE packet time so dead reckoning cannot run past newly received fixes.
+  gpsSignature = fnvMix64(gpsSignature,
+                          bleNavServer.getDebugStats().lastGpsPacketMs);
+  if (gpsSignature != lastGpsSignature || !posePresenter.hasFix()) {
+    lastGpsSignature = gpsSignature;
+    map_presentation::Fix fix;
+    fix.position = {lon2x(gps.gpsData.longitude),
+                    lat2y(gps.gpsData.latitude)};
+    fix.headingDegrees = resolvedHeading;
+    fix.headingValid = headingValid;
+    fix.speedMetersPerSecond = gps.gpsData.speed / 3.6;
+    const double latitudeRadians =
+        gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
+    fix.worldUnitsPerMeter =
+        1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
+    fix.timestampMs = nowMs;
+    posePresenter.observe(fix, nowMs);
+  }
+  if (posePresenter.hasFix()) {
+    presentedPose = posePresenter.present(nowMs);
+    hasPresentedPose = true;
+  }
+}
+map_projection::Projection
+Maps::makeRequestProjection(const RenderRequest &request) const {
+  map_projection::Config config;
+  config.viewportWidth = request.renderWidth;
+  config.viewportHeight = request.renderHeight;
+  config.worldOrigin = request.center;
+  config.zoom = request.zoom;
+  config.rotationRad = request.rotationRad;
+  config.anchorX = request.overscanPixels +
+                   gui_layout::mapAnchorX(request.viewportWidth);
+  config.anchorY = request.overscanPixels +
+                   (request.birdsEye
+                        ? map_projection::birdsEyeAnchorY(
+                              request.viewportHeight)
+                        : gui_layout::mapAnchorY(request.viewportHeight));
+  config.mode = request.birdsEye ? map_projection::Mode::BirdsEye
+                                 : map_projection::Mode::Flat;
+  config.topEdgeScale = map_projection::birdsEyeTopEdgeScale(
+      map_projection::birdsEyePerspectiveForValue(
+          request.context.birdsEyePerspective));
+  return map_projection::Projection(config);
+}
+
+bool Maps::buildRenderRequest(uint8_t requestedZoom, uint32_t nowMs,
+                              RenderRequest &request) {
+  invalidateRenderSemantics();
+  updatePresentedPose(nowMs);
+
+  const uint16_t viewportHeight =
+      mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
+  if (mapScrWidth == 0 || viewportHeight == 0)
+    return false;
+
+  request = {};
+  request.zoom = requestedZoom;
+  request.viewportWidth = mapScrWidth;
+  request.viewportHeight = viewportHeight;
+  request.overscanPixels = MAP_RENDER_OVERSCAN_PIXELS;
+  request.renderWidth = static_cast<uint16_t>(
+      request.viewportWidth + request.overscanPixels * 2U);
+  request.renderHeight = static_cast<uint16_t>(
+      request.viewportHeight + request.overscanPixels * 2U);
+  request.renderStridePixels =
+      lv_draw_buf_width_to_stride(request.renderWidth,
+                                  LV_COLOR_FORMAT_RGB565) /
+      sizeof(uint16_t);
+  request.birdsEye = navigation_content_mode::usesMapGuidanceBirdsEye(
+      isMapGuidanceScreenActive(),
+      mapRenderSettings.mapNavigationBirdsEyeEnabled);
+  request.context = captureRenderContext(nowMs);
+  request.styleSignature = styleSignature(request.context.style);
+  request.navigationSignature = navigationSignature();
+  request.projectionSignature = projectionSignature(
+      request.zoom, request.viewportWidth, request.viewportHeight,
+      request.birdsEye, request.context.birdsEyePerspective);
+
+  const bool followPosition = request.context.followPosition;
+  request.center = followPosition && hasPresentedPose
+                       ? map_transform::WorldPoint{presentedPose.position.x,
+                                                   presentedPose.position.y}
+                       : map_transform::WorldPoint{static_cast<double>(point.x),
+                                                   static_cast<double>(point.y)};
+  request.context.presentedWorld =
+      hasPresentedPose
+          ? map_transform::WorldPoint{presentedPose.position.x,
+                                      presentedPose.position.y}
+          : request.context.measuredGpsWorld;
+
+  request.rotationRad = 0.0;
+  if (rotationMode == ROT_COURSE_UP) {
+    if (hasPresentedPose && presentedPose.headingValid) {
+      request.rotationRad =
+          -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
+    } else if (publishedMapFrame) {
+      request.rotationRad = visibleRenderResult.rotationRad;
+    } else {
+      ESP_LOGW(TAG,
+               "Course-up frame deferred: neither measured course nor route "
+               "bearing is valid");
+      return false;
+    }
+  }
+
+  request.version.routeRevision = routeOverlay.revision();
+  request.version.navigationEpoch = navigationEpoch;
+  request.version.styleEpoch = styleEpoch;
+  request.version.mapEpoch = mapEpoch;
+  request.version.projectionEpoch = projectionEpoch;
+  return true;
+}
+
+bool Maps::submitRenderRequest(const RenderRequest &immutableRequest) {
+  if (renderStateMutex == nullptr || renderWorkerTaskHandle == nullptr)
+    return false;
+  RenderRequest request = immutableRequest;
+  if (xSemaphoreTake(renderStateMutex, 0) != pdTRUE)
+    return false;
+  request.version = renderJobs.submit(request.version);
+  latestRenderRequest = request;
+  latestRenderRequestValid = true;
+  if (renderJobs.state() == map_render_job::State::Ready &&
+      !map_render_job::Version::sameFrame(renderJobs.ready(),
+                                          request.version)) {
+    renderJobs.rejectReadyAsStale();
+    readyRenderResultValid = false;
+  }
+  gMapRenderLatestSequence.store(request.version.sequence,
+                                 std::memory_order_release);
+  const TaskHandle_t worker = renderWorkerTaskHandle;
+  xSemaphoreGive(renderStateMutex);
+  if (worker != nullptr)
+    xTaskNotifyGive(worker);
+  MAPIO_LOG("MAPIO: render-submit seq=%lu route=%lu nav=%lu style=%lu "
+            "map=%lu projection=%lu center=(%.1f,%.1f) rotation=%.3f\n",
+            (unsigned long)request.version.sequence,
+            (unsigned long)request.version.routeRevision,
+            (unsigned long)request.version.navigationEpoch,
+            (unsigned long)request.version.styleEpoch,
+            (unsigned long)request.version.mapEpoch,
+            (unsigned long)request.version.projectionEpoch, request.center.x,
+            request.center.y, request.rotationRad);
+  return true;
+}
+
+bool Maps::takeWorkerRequest(RenderRequest &request) {
+  if (renderStateMutex == nullptr)
+    return false;
+  if (xSemaphoreTake(renderStateMutex, portMAX_DELAY) != pdTRUE)
+    return false;
+  bool available =
+      latestRenderRequestValid &&
+      latestRenderRequest.version.sequence > lastTakenRenderSequence &&
+      renderJobs.beginLatest();
+  if (available) {
+    request = latestRenderRequest;
+    available = request.version == renderJobs.active();
+    if (available) {
+      lastTakenRenderSequence = request.version.sequence;
+    } else {
+      renderJobs.cancelActive();
+    }
+  }
+  xSemaphoreGive(renderStateMutex);
+  return available;
+}
+
+bool Maps::renderRequestStillCurrent(const RenderRequest &request) const {
+  return request.version.navigationEpoch == navigationEpoch &&
+         request.version.styleEpoch == styleEpoch &&
+         request.version.mapEpoch == mapEpoch &&
+         request.version.projectionEpoch == projectionEpoch &&
+         request.version.routeRevision == routeOverlay.revision() &&
+         request.styleSignature == styleSignature(currentMapStyleSettings()) &&
+         request.navigationSignature == navigationSignature() &&
+         request.projectionSignature == projectionSignature(
+             request.zoom, request.viewportWidth, request.viewportHeight,
+             navigation_content_mode::usesMapGuidanceBirdsEye(
+                 isMapGuidanceScreenActive(),
+                 mapRenderSettings.mapNavigationBirdsEyeEnabled),
+             mapRenderSettings.mapNavigationBirdsEyePerspective);
+}
+
+bool Maps::renderResultStillCurrent(const RenderResult &result) const {
+  RenderRequest request;
+  request.version = result.version;
+  request.styleSignature = result.styleSignature;
+  request.navigationSignature = result.navigationSignature;
+  request.projectionSignature = result.projectionSignature;
+  request.zoom = result.viewport.zoom;
+  request.viewportWidth = result.viewportWidth;
+  request.viewportHeight = result.viewportHeight;
+  request.birdsEye = result.projection.isBirdsEye();
+  return renderRequestStillCurrent(request);
+}
+
+bool Maps::startRenderWorker() {
+  if (renderWorkerTaskHandle != nullptr) {
+    return !renderWorkerShutdown.load(std::memory_order_acquire);
+  }
+  if (renderStateMutex == nullptr)
+    renderStateMutex = xSemaphoreCreateMutex();
+  if (renderStateMutex == nullptr)
+    return false;
+
+  renderWorkerShutdown.store(false, std::memory_order_release);
+  renderWorkerExited.store(false, std::memory_order_release);
+  gMapRenderWorkerShutdown.store(false, std::memory_order_release);
+  gMapRenderLatestSequence.store(0, std::memory_order_release);
+  gMapRenderActiveSequence.store(0, std::memory_order_release);
+  gMapRenderCancellationGeneration.store(0, std::memory_order_release);
+  gMapRenderActiveCancellationGeneration.store(0,
+                                               std::memory_order_release);
+  renderJobs.reset();
+  latestRenderRequestValid = false;
+  lastTakenRenderSequence = 0;
+  readyRenderResultValid = false;
+  renderFailurePending = false;
+  BaseType_t created = xTaskCreatePinnedToCore(
+      renderWorkerTaskThunk, "map_render", MAP_RENDER_WORKER_STACK_BYTES, this,
+      1, &renderWorkerTaskHandle, 0);
+  if (created != pdPASS) {
+    renderWorkerTaskHandle = nullptr;
+    renderWorkerExited.store(true, std::memory_order_release);
+    ESP_LOGE(TAG, "Could not create map render worker");
+    return false;
+  }
+  return true;
+}
+
+bool Maps::stopRenderWorker() {
+  TaskHandle_t worker = renderWorkerTaskHandle;
+  if (worker == nullptr) {
+    renderWorkerExited.store(true, std::memory_order_release);
+    return true;
+  }
+
+  renderWorkerShutdown.store(true, std::memory_order_release);
+  gMapRenderWorkerShutdown.store(true, std::memory_order_release);
+  gMapRenderLatestSequence.fetch_add(1, std::memory_order_acq_rel);
+  xTaskNotifyGive(worker);
+
+  // This is an exceptional control-plane path (screen destruction or map-root
+  // mutation), never a normal LVGL tick. Do not free worker-owned surfaces if
+  // a bounded storage operation has not returned yet.
+  const uint32_t started = millis();
+  while (!renderWorkerExited.load(std::memory_order_acquire) &&
+         static_cast<uint32_t>(millis() - started) < 2500U) {
+    vTaskDelay(pdMS_TO_TICKS(2));
+  }
+  if (!renderWorkerExited.load(std::memory_order_acquire)) {
+    ESP_LOGE(TAG, "Map render worker did not stop cleanly; state preserved");
+    return false;
+  }
+  gMapRenderWorkerShutdown.store(false, std::memory_order_release);
+  renderWorkerShutdown.store(false, std::memory_order_release);
+  return true;
+}
+
+void Maps::renderWorkerTaskThunk(void *argument) {
+  auto *maps = static_cast<Maps *>(argument);
+  if (maps != nullptr)
+    maps->renderWorkerLoop();
+  vTaskDelete(nullptr);
+}
+
+void Maps::renderWorkerLoop() {
+  gMapRenderWorkerTaskHandle = xTaskGetCurrentTaskHandle();
+  MAPIO_LOG("MAPIO: render-worker started core=%d\n", xPortGetCoreID());
+  while (!renderWorkerShutdown.load(std::memory_order_acquire)) {
+    (void)ulTaskNotifyTake(pdTRUE, pdMS_TO_TICKS(50));
+    if (renderWorkerShutdown.load(std::memory_order_acquire))
+      break;
+
+    RenderRequest request;
+    while (takeWorkerRequest(request)) {
+      gMapRenderActiveSequence.store(request.version.sequence,
+                                     std::memory_order_release);
+      gMapRenderActiveCancellationGeneration.store(
+          gMapRenderCancellationGeneration.load(std::memory_order_acquire),
+          std::memory_order_release);
+      gMapRenderSliceCount.store(0, std::memory_order_relaxed);
+      gMapRenderLongestSliceUs.store(0, std::memory_order_relaxed);
+      gMapRenderLastCheckpointUs = micros();
+      const uint32_t startMs = millis();
+      RenderResult result;
+      result.version = request.version;
+      result.center = request.center;
+      result.styleSignature = request.styleSignature;
+      result.navigationSignature = request.navigationSignature;
+      result.projectionSignature = request.projectionSignature;
+      result.viewportWidth = request.viewportWidth;
+      result.viewportHeight = request.viewportHeight;
+      result.renderWidth = request.renderWidth;
+      result.renderHeight = request.renderHeight;
+      result.overscanPixels = request.overscanPixels;
+      result.renderStridePixels = request.renderStridePixels;
+      result.rotationRad = request.rotationRad;
+      result.followPosition = request.context.followPosition;
+      result.projection = makeRequestProjection(request);
+      result.viewport.zoom = request.zoom;
+      result.viewport.rasterOriginX = request.center.x;
+      result.viewport.rasterOriginY = request.center.y;
+      result.viewport.rasterCellOffsetX = 0;
+      result.viewport.rasterCellOffsetY = 0;
+      result.viewport.center = Point32(
+          static_cast<int32_t>(std::round(request.center.x)),
+          static_cast<int32_t>(std::round(request.center.y)));
+      const auto worldBounds = result.projection.worldBounds(4.0);
+      result.viewport.bbox.min = Point32(
+          static_cast<int32_t>(std::floor(worldBounds.min.x)),
+          static_cast<int32_t>(std::floor(worldBounds.min.y)));
+      result.viewport.bbox.max = Point32(
+          static_cast<int32_t>(std::ceil(worldBounds.max.x)),
+          static_cast<int32_t>(std::ceil(worldBounds.max.y)));
+
+      bool completed = false;
+      {
+        power_management::ScopedLock powerLock(
+            power_management::LockDomain::Map);
+        const uint32_t blocksStartMs = millis();
+        const bool blocksLoaded =
+            getMapBlocks(result.viewport.bbox, memCache);
+        result.blocksMs = millis() - blocksStartMs;
+        result.mapFound = isMapFound.load(std::memory_order_acquire);
+        if (blocksLoaded && !shouldCancelMapRenderWork()) {
+          const size_t requiredBytes = request.renderStridePixels *
+                                       request.renderHeight * sizeof(uint16_t);
+          if (bufMapTemp != nullptr && requiredBytes <= bufMapTempSize) {
+            map_surface::Rgb565Surface target{
+                static_cast<uint16_t *>(bufMapTemp), request.renderWidth,
+                request.renderHeight, request.renderStridePixels};
+            const uint32_t drawStartMs = millis();
+            completed = readVectorMap(
+                result.viewport, memCache, target, request.zoom,
+                request.rotationRad, result.projection, request.context, true,
+                false, &result.raster);
+            result.drawMs = millis() - drawStartMs;
+            if (completed) {
+              if (result.mapFound) {
+                logMapMemorySnapshot("canvas-draw");
+              } else {
+                logMapMemorySnapshot("canvas-no-map");
+                logMapMemorySnapshot("canvas-draw-empty");
+              }
+            }
+          } else {
+            ESP_LOGE(TAG,
+                     "Map render back buffer invariant failed required=%u "
+                     "capacity=%u",
+                     (unsigned)requiredBytes, (unsigned)bufMapTempSize);
+          }
+        }
+      }
+      result.durationMs = millis() - startMs;
+      result.psramFree = heap_caps_get_free_size(MALLOC_CAP_SPIRAM);
+      result.psramLargest =
+          heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM);
+
+      if (renderStateMutex != nullptr &&
+          xSemaphoreTake(renderStateMutex, portMAX_DELAY) == pdTRUE) {
+        renderJobs.noteSlices(
+            gMapRenderSliceCount.load(std::memory_order_relaxed),
+            gMapRenderLongestSliceUs.load(std::memory_order_relaxed),
+            MAP_RENDER_DECLARED_SLICE_US);
+        const map_render_job::StopReason stopReason = renderJobs.checkpoint(
+            renderWorkerShutdown.load(std::memory_order_acquire));
+        const bool latest = stopReason == map_render_job::StopReason::None;
+        if (completed && latest && renderJobs.completeActive()) {
+          readyRenderResult = result;
+          readyRenderResultValid = true;
+          MAPIO_LOG(
+              "MAPIO: render-ready seq=%lu durationMs=%lu blocksMs=%lu "
+              "drawMs=%lu mapFound=%u selected=%lu extruded=%lu flat=%lu "
+              "deferred=%lu allocationFallback=%u psramFree=%lu "
+              "psramLargest=%lu\n",
+              (unsigned long)result.version.sequence,
+              (unsigned long)result.durationMs,
+              (unsigned long)result.blocksMs,
+              (unsigned long)result.drawMs, result.mapFound ? 1U : 0U,
+              (unsigned long)result.raster.selectedBuildings,
+              (unsigned long)result.raster.extrudedBuildings,
+              (unsigned long)result.raster.flatBuildings,
+              (unsigned long)result.raster.deferredBuildings,
+              result.raster.allocationFallback ? 1U : 0U,
+              (unsigned long)result.psramFree,
+              (unsigned long)result.psramLargest);
+        } else {
+          renderJobs.cancelActive();
+          // Supersession and shutdown are normal scheduling events. Only an
+          // actual render/invariant failure asks the UI to retry the last good
+          // frame and records recovery diagnostics.
+          if (!completed && latest) {
+            renderFailurePending = true;
+          }
+          MAPIO_LOG(
+              "MAPIO: render-cancel seq=%lu completed=%u reason=%u "
+              "elapsedMs=%lu\n",
+              (unsigned long)request.version.sequence,
+              completed ? 1U : 0U, static_cast<unsigned>(stopReason),
+              (unsigned long)(millis() - startMs));
+        }
+        xSemaphoreGive(renderStateMutex);
+      }
+
+      if (renderWorkerShutdown.load(std::memory_order_acquire))
+        break;
+      taskYIELD();
+    }
+  }
+
+  if (renderStateMutex != nullptr &&
+      xSemaphoreTake(renderStateMutex, portMAX_DELAY) == pdTRUE) {
+    renderJobs.cancelActive();
+    readyRenderResultValid = false;
+    latestRenderRequestValid = false;
+    renderWorkerTaskHandle = nullptr;
+    xSemaphoreGive(renderStateMutex);
+  } else {
+    renderWorkerTaskHandle = nullptr;
+  }
+  gMapRenderWorkerTaskHandle = nullptr;
+  renderWorkerExited.store(true, std::memory_order_release);
+  MAPIO_LOG("MAPIO: render-worker stopped\n");
+}
+
+bool Maps::publishReadyFrame(uint32_t nowMs) {
+  if (renderStateMutex == nullptr || canvasMap == nullptr ||
+      canvasMapTemp == nullptr)
+    return false;
+
+  RenderResult result;
+  map_render_job::Version publishedVersion;
+  if (xSemaphoreTake(renderStateMutex, 0) != pdTRUE)
+    return false;
+  if (!readyRenderResultValid ||
+      renderJobs.state() != map_render_job::State::Ready) {
+    xSemaphoreGive(renderStateMutex);
+    return false;
+  }
+  if (!renderResultStillCurrent(readyRenderResult)) {
+    renderJobs.rejectReadyAsStale();
+    readyRenderResultValid = false;
+    const TaskHandle_t worker = renderWorkerTaskHandle;
+    xSemaphoreGive(renderStateMutex);
+    if (worker != nullptr)
+      xTaskNotifyGive(worker);
+    MAPIO_LOG("MAPIO: render-stale rejected before publication\n");
+    return false;
+  }
+  const size_t requiredFrameBytes =
+      static_cast<size_t>(readyRenderResult.renderStridePixels) *
+      readyRenderResult.renderHeight * sizeof(uint16_t);
+  if (readyRenderResult.renderWidth == 0 ||
+      readyRenderResult.renderHeight == 0 ||
+      readyRenderResult.renderStridePixels < readyRenderResult.renderWidth ||
+      bufMapScreen == nullptr || bufMapTemp == nullptr ||
+      requiredFrameBytes > bufMapScreenSize ||
+      requiredFrameBytes > bufMapTempSize) {
+    renderJobs.rejectReadyAsInvariant();
+    readyRenderResultValid = false;
+    renderFailurePending = true;
+    const TaskHandle_t worker = renderWorkerTaskHandle;
+    ESP_LOGE(TAG,
+             "Map render publication invariant failed required=%u front=%u "
+             "back=%u dimensions=%ux%u stride=%u",
+             (unsigned)requiredFrameBytes, (unsigned)bufMapScreenSize,
+             (unsigned)bufMapTempSize,
+             (unsigned)readyRenderResult.renderWidth,
+             (unsigned)readyRenderResult.renderHeight,
+             (unsigned)readyRenderResult.renderStridePixels);
+    xSemaphoreGive(renderStateMutex);
+    if (worker != nullptr)
+      xTaskNotifyGive(worker);
+    return false;
+  }
+  if (!renderJobs.takeReady(publishedVersion) ||
+      publishedVersion != readyRenderResult.version) {
+    readyRenderResultValid = false;
+    xSemaphoreGive(renderStateMutex);
+    return false;
+  }
+  result = readyRenderResult;
+  readyRenderResultValid = false;
+  std::swap(bufMapScreen, bufMapTemp);
+  std::swap(bufMapScreenSize, bufMapTempSize);
+  const map_render_job::Diagnostics jobDiagnostics = renderJobs.diagnostics();
+  xSemaphoreGive(renderStateMutex);
+
+  const uint32_t swapStartedUs = micros();
+  lv_canvas_set_buffer(canvasMap, bufMapScreen, result.renderWidth,
+                       result.renderHeight, LV_COLOR_FORMAT_RGB565);
+  lv_canvas_set_buffer(canvasMapTemp, bufMapTemp, result.renderWidth,
+                       result.renderHeight, LV_COLOR_FORMAT_RGB565);
+  lv_obj_add_flag(canvasMapTemp, LV_OBJ_FLAG_HIDDEN);
+  // Raw worker rendering cannot touch LVGL. Re-apply the user-facing no-map
+  // state on the UI owner after the complete frame is bound, instead of
+  // silently replacing it with a blank background.
+  if (!result.mapFound)
+    showNoMap(canvasMap, storage.getSdLoaded());
+  lv_img_set_angle(canvasMap, 0);
+  lv_image_set_scale(canvasMap, LV_SCALE_NONE);
+  lv_obj_clear_flag(canvasMap, LV_OBJ_FLAG_HIDDEN);
+  visibleRenderResult = result;
+  visibleProjection = result.projection;
+  hasVisibleProjection = true;
+  viewPort = result.viewport;
+  publishedMapFound = result.mapFound;
+  publishedMapFrame = true;
+  framePublicationPending = true;
+
+  totalBounds.lat_min = mercatorY2lat(result.viewport.bbox.min.y);
+  totalBounds.lat_max = mercatorY2lat(result.viewport.bbox.max.y);
+  totalBounds.lon_min = mercatorX2lon(result.viewport.bbox.min.x);
+  totalBounds.lon_max = mercatorX2lon(result.viewport.bbox.max.x);
+  if (isCoordInBounds(destLat, destLon, totalBounds)) {
+    coords2map(destLat, destLon, totalBounds, &wptPosX, &wptPosY);
+  } else {
+    wptPosX = static_cast<uint16_t>(-1);
+    wptPosY = static_cast<uint16_t>(-1);
+  }
+
+  finishDragSettlement();
+  finishPinchSettlement();
+  updatePresentedPose(nowMs);
+  updatePresentedFrameTransform();
+  renderLiveForeground();
+  lv_obj_invalidate(canvasMap);
+  const uint32_t swapDurationUs = micros() - swapStartedUs;
+  MAPIO_LOG(
+      "MAPIO: render-publish seq=%lu durationMs=%lu uiSwapUs=%lu "
+      "mapFound=%u allocationFallback=%u cancelled=%lu stale=%lu "
+      "invariant=%lu units=%lu longestUnitUs=%lu\n",
+      (unsigned long)result.version.sequence,
+      (unsigned long)result.durationMs, (unsigned long)swapDurationUs,
+      result.mapFound ? 1U : 0U,
+      result.raster.allocationFallback ? 1U : 0U,
+      (unsigned long)jobDiagnostics.cancelled,
+      (unsigned long)jobDiagnostics.stalePublications,
+      (unsigned long)jobDiagnostics.invariantFailures,
+      (unsigned long)jobDiagnostics.boundedSlices,
+      (unsigned long)jobDiagnostics.longestSliceUs);
+
+  if (renderWorkerTaskHandle != nullptr)
+    xTaskNotifyGive(renderWorkerTaskHandle);
+  return true;
+}
+
+void Maps::updatePresentedFrameTransform() {
+  if (!publishedMapFrame || canvasMap == nullptr || !hasVisibleProjection)
+    return;
+  const map_transform::WorldPoint current =
+      visibleRenderResult.followPosition && hasPresentedPose
+          ? map_transform::WorldPoint{presentedPose.position.x,
+                                      presentedPose.position.y}
+          : visibleRenderResult.center;
+  const auto projected = visibleProjection.projectWorld(current);
+  if (!projected.valid)
+    return;
+
+  const int16_t pivotX = static_cast<int16_t>(
+      map_transform::quantizePixel(projected.x));
+  const int16_t pivotY = static_cast<int16_t>(
+      map_transform::quantizePixel(projected.y));
+  const uint16_t containerWidth = lv_obj_get_width(mapTile);
+  const uint16_t containerHeight = lv_obj_get_height(mapTile);
+  const int16_t viewportOriginX = gui_layout::centeredViewportOrigin(
+      containerWidth, visibleRenderResult.viewportWidth);
+  const int16_t viewportOriginY = gui_layout::centeredViewportOrigin(
+      containerHeight, visibleRenderResult.viewportHeight);
+  const int16_t screenAnchorX = static_cast<int16_t>(
+      visibleRenderResult.projection.anchorX() -
+      visibleRenderResult.overscanPixels);
+  const int16_t screenAnchorY = static_cast<int16_t>(
+      visibleRenderResult.projection.anchorY() -
+      visibleRenderResult.overscanPixels);
+
+  lv_image_set_pivot(canvasMap, pivotX, pivotY);
+  lv_obj_set_pos(canvasMap,
+                 viewportOriginX + screenAnchorX - pivotX,
+                 viewportOriginY + screenAnchorY - pivotY);
+
+  double desiredRotation = visibleRenderResult.rotationRad;
+  if (rotationMode == ROT_COURSE_UP && hasPresentedPose &&
+      presentedPose.headingValid) {
+    desiredRotation =
+        -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
+  } else if (rotationMode == ROT_NORTH_UP) {
+    desiredRotation = 0.0;
+  }
+  const double rotationDelta = map_presentation::signedHeadingDelta(
+      visibleRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
+      desiredRotation * 180.0 / 3.14159265358979323846) *
+      3.14159265358979323846 / 180.0;
+  lv_img_set_angle(canvasMap, mapAngleTenths(rotationDelta));
+  lv_obj_invalidate(canvasMap);
+
+  const double displacementX =
+      projected.x - visibleRenderResult.projection.anchorX();
+  const double displacementY =
+      projected.y - visibleRenderResult.projection.anchorY();
+  const double speed = gps.gpsData.speed / 3.6;
+  const double latitudeRadians =
+      gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
+  const double mercatorUnitsPerMeter =
+      1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
+  const uint32_t latency =
+      std::max<uint32_t>(250U,
+                         std::min<uint32_t>(5000U,
+                                            visibleRenderResult.durationMs));
+  const double lead = map_presentation::refreshLeadPixels(
+      speed,
+      mercatorUnitsPerMeter *
+          map_transform::worldToScreenScale(visibleRenderResult.viewport.zoom),
+      latency, MAP_RENDER_SAFETY_PIXELS, MAP_RENDER_SAFETY_PIXELS,
+      MAP_RENDER_OVERSCAN_PIXELS - MAP_RENDER_SAFETY_PIXELS);
+  const double available =
+      std::max(8.0, visibleRenderResult.overscanPixels - lead);
+
+  RenderRequest latestRequestSnapshot;
+  bool latestRequestSnapshotValid = false;
+  if (renderStateMutex != nullptr &&
+      xSemaphoreTake(renderStateMutex, 0) == pdTRUE) {
+    latestRequestSnapshotValid = latestRenderRequestValid;
+    if (latestRequestSnapshotValid)
+      latestRequestSnapshot = latestRenderRequest;
+    xSemaphoreGive(renderStateMutex);
+  }
+
+  bool latestCoversPose = false;
+  if (latestRequestSnapshotValid) {
+    const auto latestProjection = makeRequestProjection(latestRequestSnapshot);
+    const auto latestPoint = latestProjection.projectWorld(current);
+    if (latestPoint.valid) {
+      const double latestDx =
+          std::fabs(latestPoint.x - latestProjection.anchorX());
+      const double latestDy =
+          std::fabs(latestPoint.y - latestProjection.anchorY());
+      const double latestHeadingDelta = std::fabs(
+          map_presentation::signedHeadingDelta(
+              latestRequestSnapshot.rotationRad * 180.0 /
+                  3.14159265358979323846,
+              desiredRotation * 180.0 / 3.14159265358979323846));
+      latestCoversPose = latestDx < available && latestDy < available &&
+                         latestHeadingDelta < 4.0;
+    }
+  }
+  const double headingDeltaDegrees = std::fabs(
+      rotationDelta * 180.0 / 3.14159265358979323846);
+  if (!latestCoversPose &&
+      (std::fabs(displacementX) >= available ||
+       std::fabs(displacementY) >= available ||
+       headingDeltaDegrees >= 4.0)) {
+    isPosMoved = true;
+    redrawMap = true;
+  }
+}
+
+void Maps::renderLiveForeground() {
+  if (canvasForeground == nullptr || bufMapForeground == nullptr)
+    return;
+  const uint16_t width = mapScrWidth;
+  const uint16_t height = mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
+  const size_t required = rgb565A8BufferSize(width, height);
+  if (width == 0 || height == 0 || required > bufMapForegroundSize)
+    return;
+
+  bindMapForegroundCanvas(canvasForeground, width, height);
+  lv_obj_center(canvasForeground);
+  lv_img_set_angle(canvasForeground, 0);
+  lv_image_set_scale(canvasForeground, LV_SCALE_NONE);
+
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvasForeground);
+  if (drawBuffer == nullptr || drawBuffer->data == nullptr)
+    return;
+  const size_t colorStridePixels =
+      static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t));
+  auto *alpha = static_cast<uint8_t *>(drawBuffer->data) +
+                static_cast<size_t>(drawBuffer->header.stride) * height;
+  map_surface::Rgb565A8Surface surface{
+      static_cast<uint16_t *>(drawBuffer->data), alpha, width, height,
+      colorStridePixels, colorStridePixels};
+  surface.clearAlpha();
+
+  const RouteSnapshot route = routeOverlay.snapshot();
+  if (!publishedMapFrame || !hasVisibleProjection || !route.hasRoute() ||
+      !isRouteOverlayVisible(mapRenderSettings) || !hasPresentedPose) {
+    lv_obj_add_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  const map_transform::WorldPoint presented{presentedPose.position.x,
+                                             presentedPose.position.y};
+  const map_transform::WorldPoint presentationPivotWorld =
+      visibleRenderResult.followPosition ? presented : visibleRenderResult.center;
+  const auto projectedPivot =
+      visibleProjection.projectWorld(presentationPivotWorld);
+  if (!projectedPivot.valid) {
+    lv_obj_add_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+    return;
+  }
+
+  double desiredRotation = visibleRenderResult.rotationRad;
+  if (rotationMode == ROT_COURSE_UP && presentedPose.headingValid) {
+    desiredRotation =
+        -presentedPose.headingDegrees * 3.14159265358979323846 / 180.0;
+  } else if (rotationMode == ROT_NORTH_UP) {
+    desiredRotation = 0.0;
+  }
+  const double rotationDelta = map_presentation::signedHeadingDelta(
+      visibleRenderResult.rotationRad * 180.0 / 3.14159265358979323846,
+      desiredRotation * 180.0 / 3.14159265358979323846) *
+      3.14159265358979323846 / 180.0;
+
+  // This is the exact transform used by updatePresentedFrameTransform(): the
+  // immutable base projection supplies source pixels, the presented rider is
+  // the pivot, and the viewport anchor is the target. Route head, route line,
+  // arrow, and translated/rotated map therefore share one PresentedPose.
+  RoutePresentationTransform presentation;
+  presentation.inputPivotX = projectedPivot.x;
+  presentation.inputPivotY = projectedPivot.y;
+  presentation.outputPivotX =
+      visibleProjection.anchorX() - visibleRenderResult.overscanPixels;
+  presentation.outputPivotY =
+      visibleProjection.anchorY() - visibleRenderResult.overscanPixels;
+  presentation.rotationRad = rotationDelta;
+  RouteOverlay::drawSnapshot(
+      route, surface, visibleProjection,
+      static_cast<uint8_t>(std::min<int>(
+          48, std::max<int>(1, currentMapStyleSettings().routeLineWidth))),
+      &presented, &presentation);
+
+  lv_obj_clear_flag(canvasForeground, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_invalidate(canvasForeground);
+  if (canvasArrow != nullptr)
+    lv_obj_move_foreground(canvasArrow);
+}
+
+bool Maps::serviceRenderPipeline(uint32_t nowMs) {
+  if (canvasMap == nullptr)
+    return false;
+  invalidateRenderSemantics();
+  updatePresentedPose(nowMs);
+  const bool published = publishReadyFrame(nowMs);
+  updatePresentedFrameTransform();
+  renderLiveForeground();
+  return published;
+}
+
+bool Maps::takeFramePublication() {
+  const bool pending = framePublicationPending;
+  framePublicationPending = false;
+  return pending;
+}
+
+bool Maps::takeRenderFailure() {
+  if (renderStateMutex == nullptr)
+    return false;
+  if (xSemaphoreTake(renderStateMutex, 0) != pdTRUE)
+    return false;
+  const bool pending = renderFailurePending;
+  renderFailurePending = false;
+  xSemaphoreGive(renderStateMutex);
+  return pending;
+}
+
 void Maps::getPosition(double lat, double lon) {
   Coord pos;
   pos.lat = lat;
@@ -3679,7 +4694,6 @@ void Maps::initMap(uint16_t mapHeight, uint16_t mapWidth, uint16_t mapFull) {
 }
 
 bool Maps::setVectorMapFolder(const std::string &folder) {
-  power_management::ScopedLock powerLock(power_management::LockDomain::Storage);
   String normalized(folder.c_str());
   if (!normalized.endsWith("/"))
     normalized += "/";
@@ -3703,35 +4717,56 @@ bool Maps::setVectorMapFolder(const std::string &folder) {
     }
   }
 
-  for (MapBlock *block : memCache.blocks)
-    delete block;
-  memCache.blocks.clear();
-  labelFontAsset = std::move(candidateFont);
-  labelLayoutCache.clear();
-  streetLabelRuntimeFailurePending = false;
-  streetLabelRuntimeFailureCode.clear();
-  buildingFailureRetryCooldown.clear();
-  vectorMapFolder = normalized;
+  const bool restartWorker = renderWorkerTaskHandle != nullptr;
+  if (restartWorker && !stopRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map root switch deferred: render worker is busy");
+    return false;
+  }
+
+  {
+    power_management::ScopedLock powerLock(
+        power_management::LockDomain::Storage);
+    for (MapBlock *block : memCache.blocks)
+      delete block;
+    memCache.blocks.clear();
+    cachedBlockCount.store(0, std::memory_order_release);
+    labelFontAsset = std::move(candidateFont);
+    streetLabelFontHealthy.store(labelFontAsset.healthy(),
+                                 std::memory_order_release);
+    labelLayoutCache.clear();
+    streetLabelRuntimeFailure.store(map_font_asset::RuntimeError::None,
+                                    std::memory_order_release);
+    buildingFailureRetryCooldown.clear();
+    vectorMapFolder = normalized;
+    isMapFound = false;
+    ++mapEpoch;
+  }
+
   invalidateRollingRasterWindow();
-  isMapFound = false;
+  publishedMapFound = false;
+  publishedMapFrame = false;
   isPosMoved = true;
   redrawMap = true;
   oldMapTile = {};
   currentMapTile = {};
+  if (restartWorker && !startRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map root switched but render worker restart failed");
+    return false;
+  }
   ESP_LOGI(TAG, "Vector map root switched to %s", vectorMapFolder.c_str());
   return true;
 }
 
 bool Maps::takeStreetLabelRuntimeFailure(std::string &code) {
-  if (!streetLabelRuntimeFailurePending)
+  const map_font_asset::RuntimeError error = streetLabelRuntimeFailure.exchange(
+      map_font_asset::RuntimeError::None, std::memory_order_acq_rel);
+  if (error == map_font_asset::RuntimeError::None)
     return false;
-  code = streetLabelRuntimeFailureCode;
-  streetLabelRuntimeFailurePending = false;
+  code = map_font_asset::runtimeErrorCode(error);
   return true;
 }
 
 bool Maps::probeVectorMapFolder(const std::string &folder) {
-  power_management::ScopedLock powerLock(power_management::LockDomain::Storage);
   std::string normalized = folder;
   while (normalized.size() > 1 && normalized.back() == '/')
     normalized.pop_back();
@@ -3739,32 +4774,48 @@ bool Maps::probeVectorMapFolder(const std::string &folder) {
   if (::stat(normalized.c_str(), &storage) != 0 || !S_ISDIR(storage.st_mode))
     return false;
 
-  size_t visited = 0;
-  std::string blockBase;
-  if (!findMapBlock(normalized, blockBase, visited, 0)) {
-    ESP_LOGE(TAG, "No map block found under %s", normalized.c_str());
+  const bool restartWorker = renderWorkerTaskHandle != nullptr;
+  if (restartWorker && !stopRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map probe deferred: render worker is busy");
     return false;
   }
-  const bool previousMapFound = isMapFound;
-  isMapFound = false;
-  MapBlock *block = readMapBlock(String(blockBase.c_str()));
-  bool loaded = isMapFound;
-  if (loaded && block->formatVersion >= 3) {
-    map_font_asset::Asset candidateFont;
-    const std::string fontPath = normalized + "/assets/street-labels.fma";
-    loaded = candidateFont.open(fontPath) &&
-             candidateFont.profileFingerprint() ==
-                 block->labelData.profileFingerprint &&
-             block->labelData.referencesResolve(candidateFont.glyphCount(),
-                                                 candidateFont.languageCount());
-    if (!loaded)
-      ESP_LOGE(TAG, "Street-label block/font contract failed under %s",
-               normalized.c_str());
+
+  bool loaded = false;
+  {
+    power_management::ScopedLock powerLock(
+        power_management::LockDomain::Storage);
+    size_t visited = 0;
+    std::string blockBase;
+    if (!findMapBlock(normalized, blockBase, visited, 0)) {
+      ESP_LOGE(TAG, "No map block found under %s", normalized.c_str());
+    } else {
+      const bool previousMapFound = isMapFound.load();
+      isMapFound = false;
+      MapBlock *block = readMapBlock(String(blockBase.c_str()));
+      loaded = isMapFound.load();
+      if (loaded && block->formatVersion >= 3) {
+        map_font_asset::Asset candidateFont;
+        const std::string fontPath = normalized + "/assets/street-labels.fma";
+        loaded = candidateFont.open(fontPath) &&
+                 candidateFont.profileFingerprint() ==
+                     block->labelData.profileFingerprint &&
+                 block->labelData.referencesResolve(
+                     candidateFont.glyphCount(), candidateFont.languageCount());
+        if (!loaded)
+          ESP_LOGE(TAG, "Street-label block/font contract failed under %s",
+                   normalized.c_str());
+      }
+      delete block;
+      isMapFound = previousMapFound;
+      ESP_LOGI(TAG, "Vector map probe root=%s block=%s loaded=%d",
+               normalized.c_str(), blockBase.c_str(), loaded);
+    }
   }
-  delete block;
-  isMapFound = previousMapFound;
-  ESP_LOGI(TAG, "Vector map probe root=%s block=%s loaded=%d",
-           normalized.c_str(), blockBase.c_str(), loaded);
+
+  if (restartWorker && !startRenderWorker()) {
+    ESP_LOGE(TAG, "Vector map probe completed but worker restart failed");
+    return false;
+  }
   return loaded;
 }
 
@@ -3777,9 +4828,32 @@ void Maps::deleteMapScrSprites() {
   cancelPinchPreview();
   pinchZoomOutBackdrop = {};
   invalidateRollingRasterWindow();
+
+  // The worker owns only raw back-buffer/cache state and may outlive this LVGL
+  // screen. Cancel the semantic request without blocking the UI task; stale
+  // completion is rejected before publication when the screen is recreated.
+  ++projectionEpoch;
+  gMapRenderCancellationGeneration.fetch_add(1, std::memory_order_acq_rel);
+  if (renderStateMutex != nullptr &&
+      xSemaphoreTake(renderStateMutex, pdMS_TO_TICKS(5)) == pdTRUE) {
+    renderJobs.requestCancellation();
+    const map_render_job::Version invalidated = renderJobs.invalidate();
+    gMapRenderLatestSequence.store(invalidated.sequence,
+                                   std::memory_order_release);
+    latestRenderRequestValid = false;
+    readyRenderResultValid = false;
+    xSemaphoreGive(renderStateMutex);
+  } else {
+    // The worker also checks this atomic token between bounded work units. If
+    // the mutex is momentarily busy, publication still rejects the obsolete
+    // projection epoch before the frame can become visible.
+    gMapRenderLatestSequence.fetch_add(1, std::memory_order_acq_rel);
+  }
+
   hasVisibleProjection = false;
-  // Maps::arrowSprite.deleteSprite();
-  // Maps::mapSprite.deleteSprite();
+  publishedMapFrame = false;
+  publishedMapFound = false;
+  framePublicationPending = false;
   if (Maps::canvasArrow)
     lv_obj_delete(Maps::canvasArrow);
   if (Maps::canvasMap)
@@ -3802,94 +4876,82 @@ void Maps::deleteMapScrSprites() {
  */
 void Maps::createMapScrSprites() {
   ESP_LOGI(TAG, "createMapScrSprites start");
-  hasVisibleProjection = false;
-  // Map Sprite
-  // Map Sprite (Canvas)
-  uint16_t w = Maps::mapScrWidth;
-  uint16_t h = Maps::mapScrHeight;
-  if (mapSet.mapFullScreen)
-    h = Maps::mapScrFull;
 
-  // Zoom 5 uses a 5x5 grid of 192 px cells. Zooms 1...4 use a 7x7 grid of
-  // 128 px cells. The scratch buffer must hold one complete incoming
-  // row/column for either layout so recycling remains atomic.
-  const auto wideLayout = map_raster_window::layoutForZoom(
-      map_transform::kMaximumRuntimeZoom,
-      map_transform::kMaximumRuntimeZoom);
-  const auto compactLayout = map_raster_window::layoutForZoom(
-      map_transform::kMinimumRuntimeZoom,
-      map_transform::kMaximumRuntimeZoom);
-  const auto maximumGrid = map_raster_window::gridExtent(wideLayout);
-  const auto compactGrid = map_raster_window::gridExtent(compactLayout);
-  const uint32_t gridStride = lv_draw_buf_width_to_stride(
-      maximumGrid.width, LV_COLOR_FORMAT_RGB565);
-  const size_t rollingScreenSize = gridStride * maximumGrid.height;
-  const uint32_t wideTileStride = lv_draw_buf_width_to_stride(
-      wideLayout.cellExtent, LV_COLOR_FORMAT_RGB565);
-  const size_t wideTileSize = wideTileStride * wideLayout.cellExtent;
-  const uint32_t compactTileStride = lv_draw_buf_width_to_stride(
-      compactLayout.cellExtent, LV_COLOR_FORMAT_RGB565);
-  const size_t compactTileSize =
-      compactTileStride * compactLayout.cellExtent;
-  const size_t maximumTileSize = std::max(wideTileSize, compactTileSize);
-  const size_t maximumScratchRowSize =
-      std::max(wideTileSize * wideLayout.span,
-               compactTileSize * compactLayout.span);
-  const uint32_t normalStride = lv_draw_buf_width_to_stride(
-      Maps::mapScrWidth, LV_COLOR_FORMAT_RGB565);
-  const size_t maximumNormalFrameSize = normalStride * Maps::mapScrFull;
-  const size_t requiredTempSize = std::max(
-      maximumNormalFrameSize + maximumTileSize,
-      maximumScratchRowSize);
+  const uint16_t viewportWidth = Maps::mapScrWidth;
+  const uint16_t viewportHeight =
+      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
+  const uint16_t maximumRenderWidth = static_cast<uint16_t>(
+      Maps::mapScrWidth + MAP_RENDER_OVERSCAN_PIXELS * 2U);
+  const uint16_t maximumRenderHeight = static_cast<uint16_t>(
+      Maps::mapScrFull + MAP_RENDER_OVERSCAN_PIXELS * 2U);
+  const uint16_t initialRenderHeight = static_cast<uint16_t>(
+      viewportHeight + MAP_RENDER_OVERSCAN_PIXELS * 2U);
+  const uint32_t frameStride = lv_draw_buf_width_to_stride(
+      maximumRenderWidth, LV_COLOR_FORMAT_RGB565);
+  const size_t frameBytes =
+      static_cast<size_t>(frameStride) * maximumRenderHeight;
+  const size_t foregroundBytes =
+      rgb565A8BufferSize(Maps::mapScrWidth, Maps::mapScrFull);
+  const size_t persistentSurfaceBytes = frameBytes * 2U + foregroundBytes;
 
-  ESP_LOGI(TAG,
-           "MapBuff: rollingWide=%ux%u rollingCompact=%ux%u "
-           "rollingScreen=%u initialScreen=%u scratch=%u initial=%ux%u",
-           (unsigned)maximumGrid.width, (unsigned)maximumGrid.height,
-           (unsigned)compactGrid.width, (unsigned)compactGrid.height,
-           (unsigned)rollingScreenSize, (unsigned)maximumNormalFrameSize,
-           (unsigned)requiredTempSize, (unsigned)w, (unsigned)h);
-  // Keep the front buffer viewport-sized until standalone Map first reaches
-  // a runtime zoom. Map + Navigation therefore does not pay the rolling
-  // grid's PSRAM cost merely by creating the shared map canvases.
-  if (!ensureMapScreenBuffer(maximumNormalFrameSize) ||
-      !ensureMapTempBuffer(requiredTempSize) ||
-      !ensureMapForegroundBuffer(Maps::mapScrWidth, Maps::mapScrFull)) {
+  // Recreating LVGL objects is safe while the worker writes the hidden raw
+  // back surface: the addresses remain stable and the object stays hidden.
+  // Quiesce only when a front/back allocation must actually move. This keeps
+  // an ordinary screen transition out of the render job's SD/geometry latency.
+  const bool frameStorageMustMove =
+      bufMapScreen == nullptr || bufMapScreenSize < frameBytes ||
+      bufMapTemp == nullptr || bufMapTempSize < frameBytes;
+  if (frameStorageMustMove && renderWorkerTaskHandle != nullptr &&
+      !stopRenderWorker()) {
+    ESP_LOGE(TAG, "Map screen creation deferred: render worker owns storage");
     return;
   }
-  memset(bufMapScreen, 0, maximumNormalFrameSize);
-  memset(bufMapTemp, 0, requiredTempSize);
-  memset(bufMapForeground, 0,
-         rgb565A8BufferSize(Maps::mapScrWidth, Maps::mapScrFull));
+  if (canvasMap != nullptr || canvasMapTemp != nullptr ||
+      canvasForeground != nullptr || canvasArrow != nullptr) {
+    deleteMapScrSprites();
+  }
+
+  if (!ensureMapScreenBuffer(frameBytes) || !ensureMapTempBuffer(frameBytes) ||
+      !ensureMapForegroundBuffer(Maps::mapScrWidth, Maps::mapScrFull)) {
+    ESP_LOGE(TAG,
+             "Map render surfaces unavailable frame=%u foreground=%u total=%u",
+             (unsigned)frameBytes, (unsigned)foregroundBytes,
+             (unsigned)persistentSurfaceBytes);
+    return;
+  }
+  memset(bufMapForeground, 0, foregroundBytes);
   invalidateRollingRasterWindow();
+  invalidatePinchZoomOutBackdrop();
+  publishedMapFrame = false;
+  publishedMapFound = false;
+  framePublicationPending = false;
+  hasVisibleProjection = false;
+  ++projectionEpoch;
 
   Maps::canvasMap = lv_canvas_create(mapTile);
   lv_obj_add_flag(Maps::canvasMap, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_add_flag(Maps::canvasMap, LV_OBJ_FLAG_EVENT_BUBBLE);
-  lv_canvas_set_buffer(Maps::canvasMap, bufMapScreen, w, h,
-                       LV_COLOR_FORMAT_RGB565);
+  lv_obj_add_flag(Maps::canvasMap, LV_OBJ_FLAG_HIDDEN);
+  lv_canvas_set_buffer(Maps::canvasMap, bufMapScreen, maximumRenderWidth,
+                       initialRenderHeight, LV_COLOR_FORMAT_RGB565);
   lv_obj_center(Maps::canvasMap);
 
-  // Vector rendering is synchronous. Draw into a hidden back buffer so an
-  // input-triggered abort can never expose a half-rendered frame.
+  // This object is always hidden. Its raw storage is exclusively written by
+  // the render worker; only the LVGL owner rebinds it after an atomic swap.
   Maps::canvasMapTemp = lv_canvas_create(mapTile);
   lv_obj_add_flag(Maps::canvasMapTemp, LV_OBJ_FLAG_HIDDEN);
-  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, w, h,
-                       LV_COLOR_FORMAT_RGB565);
+  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, maximumRenderWidth,
+                       initialRenderHeight, LV_COLOR_FORMAT_RGB565);
   lv_obj_center(Maps::canvasMapTemp);
 
-  // Standalone Map uses a rolling base raster. Street labels and the route are
-  // composed once in viewport coordinates on this transparent foreground so
-  // labels are neither clipped nor collision-tested independently per cell.
   Maps::canvasForeground = lv_canvas_create(mapTile);
   lv_obj_add_flag(Maps::canvasForeground, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_add_flag(Maps::canvasForeground, LV_OBJ_FLAG_EVENT_BUBBLE);
   lv_obj_add_flag(Maps::canvasForeground, LV_OBJ_FLAG_HIDDEN);
-  bindMapForegroundCanvas(Maps::canvasForeground, w, h);
+  bindMapForegroundCanvas(Maps::canvasForeground, viewportWidth,
+                          viewportHeight);
   lv_obj_center(Maps::canvasForeground);
 
-  // Draw the current-position marker as native LVGL geometry at its final
-  // on-screen size. This avoids magnifying a fixed 48x48 bitmap.
   Maps::canvasArrow = lv_obj_create(mapTile);
   lv_obj_remove_style_all(Maps::canvasArrow);
   lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_CLICKABLE);
@@ -3898,25 +4960,31 @@ void Maps::createMapScrSprites() {
   lv_obj_add_event_cb(Maps::canvasArrow, drawCurrentPositionMarker,
                       LV_EVENT_DRAW_MAIN, nullptr);
   updateCurrentPositionMarker(Maps::canvasArrow, true);
+
+  if (!startRenderWorker()) {
+    ESP_LOGE(TAG, "Map render worker unavailable");
+    deleteMapScrSprites();
+    return;
+  }
+
+  isPosMoved = true;
+  redrawMap = true;
+  ESP_LOGI(TAG,
+           "Map render surfaces front=%u back=%u foreground=%u total=%u "
+           "psramFree=%u psramLargest=%u",
+           (unsigned)frameBytes, (unsigned)frameBytes,
+           (unsigned)foregroundBytes, (unsigned)persistentSurfaceBytes,
+           (unsigned)heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
+           (unsigned)heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
   ESP_LOGI(TAG, "createMapScrSprites done");
-
-  // Make arrow clickable to toggle rotation mode
-  // lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_CLICKABLE);
-  // lv_obj_add_event_cb(
-  //     Maps::canvasArrow,
-  //     [](lv_event_t *e) {
-  //       Maps *maps = (Maps *)lv_event_get_user_data(e);
-  //       maps->toggleRotationMode();
-  //     },
-  //     LV_EVENT_CLICKED, this);
-
-  // Maps::arrowSprite.pushImage(0, 0, 16, 16, (uint16_t *)navigation);
 }
 
 bool Maps::shouldUseRollingRasterWindow(uint8_t requestedZoom) const {
-  return mapSet.vectorMap && isMapScreenActive() &&
-         requestedZoom >= map_transform::kMinimumRuntimeZoom &&
-         requestedZoom <= map_transform::kMaximumRuntimeZoom;
+  (void)requestedZoom;
+  // The previous rolling raster synchronously loaded/rendered cells from the
+  // LVGL task and shared the worker back buffer. Render-ahead overscan now
+  // provides motion margin without violating ownership.
+  return false;
 }
 
 uint64_t Maps::rollingRasterSignature() const {
@@ -4010,7 +5078,8 @@ bool Maps::renderRollingRasterCell(double rasterOriginX,
     return false;
   }
 
-  const bool previousMapFound = Maps::isMapFound;
+  const bool previousMapFound =
+      Maps::isMapFound.load(std::memory_order_acquire);
   const tileBounds previousBounds = Maps::totalBounds;
   const uint16_t previousWptX = Maps::wptPosX;
   const uint16_t previousWptY = Maps::wptPosY;
@@ -4055,13 +5124,13 @@ bool Maps::renderRollingRasterCell(double rasterOriginX,
     return false;
   }
 
-  if (shouldInterruptMapRenderForScreenCycle()) {
+  if (shouldCancelMapRenderWork()) {
     restoreVisibleState();
     return false;
   }
 
   if (mapFoundOut != nullptr)
-    *mapFoundOut = Maps::isMapFound;
+    *mapFoundOut = Maps::isMapFound.load(std::memory_order_acquire);
   restoreVisibleState();
   return true;
 }
@@ -4256,7 +5325,8 @@ bool Maps::renderRollingForeground() {
   lv_obj_center(Maps::canvasForeground);
 
   const ScreenMapRenderSettings &style = currentMapStyleSettings();
-  if (style.labelDensity != 0 && labelFontAsset.healthy()) {
+  if (style.labelDensity != 0 &&
+      streetLabelFontHealthy.load(std::memory_order_acquire)) {
     if (!Maps::getMapBlocks(Maps::viewPort.bbox, Maps::memCache) ||
         !drawStreetLabels(Maps::viewPort, Maps::memCache,
                           Maps::canvasForeground, rollingRasterWindow.zoom,
@@ -4359,6 +5429,7 @@ bool Maps::buildRollingRasterWindow(uint8_t requestedZoom,
     for (MapBlock *block : Maps::memCache.blocks)
       delete block;
     Maps::memCache.blocks.clear();
+    cachedBlockCount.store(0, std::memory_order_release);
   }
   if (!ensureMapScreenBuffer(gridSize)) {
     restoreVisibleFrameAfterRollingBuildFailure(viewportWidth,
@@ -4576,17 +5647,8 @@ bool Maps::settleRollingRasterWindow() {
 }
 
 bool Maps::hasPinchZoomOutBackdrop(uint8_t baseZoom) const {
-  const uint16_t canvasHeight =
-      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
-  return pinchZoomOutBackdrop.prepared &&
-         pinchZoomOutBackdrop.baseZoom ==
-             map_transform::clampRuntimeZoom(baseZoom) &&
-         pinchZoomOutBackdrop.center.x == Maps::point.x &&
-         pinchZoomOutBackdrop.center.y == Maps::point.y &&
-         std::fabs(pinchZoomOutBackdrop.rotation - visibleMapRotation()) <
-             0.0001 &&
-         pinchZoomOutBackdrop.canvasHeight == canvasHeight &&
-         Maps::canvasMapTemp != nullptr;
+  (void)baseZoom;
+  return false;
 }
 
 void Maps::invalidatePinchZoomOutBackdrop() {
@@ -4598,93 +5660,14 @@ void Maps::invalidatePinchZoomOutBackdrop() {
   lv_image_set_scale(Maps::canvasMapTemp, LV_SCALE_NONE);
   lv_image_set_pivot(Maps::canvasMapTemp, 0, 0);
   lv_obj_add_flag(Maps::canvasMapTemp, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_center(Maps::canvasMapTemp);
 }
 
 bool Maps::preparePinchZoomOutBackdrop(uint8_t baseZoom) {
-  power_management::ScopedLock powerLock(power_management::LockDomain::Map);
-  baseZoom = map_transform::clampRuntimeZoom(baseZoom);
-  if (baseZoom >= map_transform::kMaximumRuntimeZoom ||
-      Maps::canvasMapTemp == nullptr || pinchPresentation.active ||
-      pinchPresentation.settlementPending || dragPreviewController.active() ||
-      dragPreviewController.settlementPending()) {
-    return false;
-  }
-  if (hasPinchZoomOutBackdrop(baseZoom))
-    return true;
-
-  invalidatePinchZoomOutBackdrop();
-  const uint16_t canvasHeight =
-      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
-  const uint32_t backdropStride = lv_draw_buf_width_to_stride(
-      Maps::mapScrWidth, LV_COLOR_FORMAT_RGB565);
-  const size_t backdropSize = backdropStride * canvasHeight;
-  if (backdropSize > bufMapTempSize)
-    return false;
-  // Rolling edge renders leave the hidden canvas bound to a single scratch
-  // cell. Rebind it to a complete viewport before preparing the pinch
-  // backdrop used by zoom levels 1...4.
-  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, Maps::mapScrWidth,
-                       canvasHeight, LV_COLOR_FORMAT_RGB565);
-  lv_obj_center(Maps::canvasMapTemp);
-  const uint8_t backdropZoom = map_transform::kMaximumRuntimeZoom;
-  const double backdropRotation = visibleMapRotation();
-  ViewPort backdropViewPort;
-  backdropViewPort.zoom = backdropZoom;
-  backdropViewPort.setCenter(Maps::point);
-  const auto backdropProjection = makeMapProjection(
-      backdropViewPort.rasterOriginX, backdropViewPort.rasterOriginY,
-      backdropViewPort.rasterCellOffsetX,
-      backdropViewPort.rasterCellOffsetY, backdropZoom, backdropRotation,
-      Maps::mapScrWidth, canvasHeight, map_projection::Mode::Flat);
-
-  const bool previousMapFound = Maps::isMapFound;
-  const tileBounds previousBounds = Maps::totalBounds;
-  const uint16_t previousWptX = Maps::wptPosX;
-  const uint16_t previousWptY = Maps::wptPosY;
-  auto restoreVisibleMapState = [&]() {
-    Maps::isMapFound = previousMapFound;
-    Maps::totalBounds = previousBounds;
-    Maps::wptPosX = previousWptX;
-    Maps::wptPosY = previousWptY;
-  };
-
-  ESP_LOGI(TAG, "Preparing pinch backdrop: baseZoom=%u renderZoom=%u",
-           (unsigned)baseZoom, (unsigned)backdropZoom);
-  if (!Maps::getMapBlocks(backdropViewPort.bbox, Maps::memCache) ||
-      !Maps::readVectorMap(backdropViewPort, Maps::memCache,
-                           Maps::canvasMapTemp, backdropZoom,
-                           backdropRotation, backdropProjection)) {
-    restoreVisibleMapState();
-    ESP_LOGI(TAG, "Pinch backdrop preparation interrupted");
-    return false;
-  }
-
-  if (shouldInterruptMapRenderForScreenCycle()) {
-    restoreVisibleMapState();
-    ESP_LOGI(TAG, "Pinch backdrop preparation interrupted before completion");
-    return false;
-  }
-
-  if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
-    routeOverlay.drawRoute(Maps::canvasMapTemp, backdropProjection);
-  }
-
-  if (shouldInterruptMapRenderForScreenCycle()) {
-    restoreVisibleMapState();
-    ESP_LOGI(TAG, "Pinch backdrop preparation interrupted after route");
-    return false;
-  }
-
-  restoreVisibleMapState();
-  pinchZoomOutBackdrop.prepared = true;
-  pinchZoomOutBackdrop.baseZoom = baseZoom;
-  pinchZoomOutBackdrop.renderZoom = backdropZoom;
-  pinchZoomOutBackdrop.center = Maps::point;
-  pinchZoomOutBackdrop.rotation = backdropRotation;
-  pinchZoomOutBackdrop.canvasHeight = canvasHeight;
-  ESP_LOGI(TAG, "Pinch backdrop ready");
-  return true;
+  (void)baseZoom;
+  // A second synchronous vector render into the worker-owned back buffer is
+  // forbidden. Pinch preview scales the last complete front frame; release
+  // submits a normal latest-wins render at the target zoom.
+  return false;
 }
 
 void Maps::applyDragPreviewOffset(map_drag_preview::Offset offset) {
@@ -5452,10 +6435,8 @@ void Maps::updatePositionOverlay() {
   const uint32_t displayStartMs = MAPIO_TIME_MS();
   // Update Arrow Position
   if (Maps::canvasArrow) {
-    if (!Maps::isMapFound || !isCurrentPositionVisible(mapRenderSettings)) {
+    if (!publishedMapFound || !isCurrentPositionVisible(mapRenderSettings)) {
       lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
-      MAPIO_LOG("MAPIO: current-position marker hidden mapFound=%d visible=%d\n",
-                Maps::isMapFound, isCurrentPositionVisible(mapRenderSettings));
       return;
     }
 
@@ -5466,17 +6447,18 @@ void Maps::updatePositionOverlay() {
         gui_layout::centeredViewportOrigin(containerWidth, Maps::mapScrWidth);
     const int16_t mapOriginY =
         gui_layout::centeredViewportOrigin(containerHeight, h);
-    const bool useSharedProjection =
-        isMapGuidanceScreenActive() && hasVisibleProjection;
+    const bool useSharedProjection = hasVisibleProjection;
     const int16_t anchorX = useSharedProjection
                                 ? static_cast<int16_t>(
                                       map_transform::quantizePixel(
-                                          visibleProjection.anchorX()))
+                                          visibleProjection.anchorX()) -
+                                      visibleRenderResult.overscanPixels)
                                 : mapAnchorXForWidth(Maps::mapScrWidth);
     const int16_t anchorY = useSharedProjection
                                 ? static_cast<int16_t>(
                                       map_transform::quantizePixel(
-                                          visibleProjection.anchorY()))
+                                          visibleProjection.anchorY()) -
+                                      visibleRenderResult.overscanPixels)
                                 : mapAnchorYForHeight(h);
     updateCurrentPositionMarker(Maps::canvasArrow);
     const int16_t markerVisualHalf = currentMarkerSize() / 2;
@@ -5490,8 +6472,6 @@ void Maps::updatePositionOverlay() {
       y = mapOriginY + anchorY - markerVisualHalf;
       lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       lv_obj_set_pos(Maps::canvasArrow, x, y);
-      ESP_LOGI(TAG, "GPS indicator: followGps mode, anchor screen pos(%d,%d)",
-               x, y);
     } else {
       // Calculate position relative to viewport center
       // Convert GPS lat/lon to Mercator coordinates
@@ -5501,13 +6481,41 @@ void Maps::updatePositionOverlay() {
       if (useSharedProjection) {
         const auto markerPoint = visibleProjection.projectWorld(
             {static_cast<double>(gpsX), static_cast<double>(gpsY)});
-        if (!markerPoint.valid) {
+        const map_transform::WorldPoint pivotWorld =
+            visibleRenderResult.followPosition && hasPresentedPose
+                ? map_transform::WorldPoint{presentedPose.position.x,
+                                            presentedPose.position.y}
+                : visibleRenderResult.center;
+        const auto projectedPivot = visibleProjection.projectWorld(pivotWorld);
+        if (!markerPoint.valid || !projectedPivot.valid) {
           lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
           return;
         }
-        x = mapOriginX + map_transform::quantizePixel(markerPoint.x) -
+
+        double desiredRotation = visibleRenderResult.rotationRad;
+        if (rotationMode == ROT_COURSE_UP && hasPresentedPose &&
+            presentedPose.headingValid) {
+          desiredRotation = -presentedPose.headingDegrees *
+                            3.14159265358979323846 / 180.0;
+        } else if (rotationMode == ROT_NORTH_UP) {
+          desiredRotation = 0.0;
+        }
+        const double rotationDelta = map_presentation::signedHeadingDelta(
+            visibleRenderResult.rotationRad * 180.0 /
+                3.14159265358979323846,
+            desiredRotation * 180.0 / 3.14159265358979323846) *
+            3.14159265358979323846 / 180.0;
+        const auto presentedPoint = map_presentation::presentFramePoint(
+            {markerPoint.x, markerPoint.y},
+            {projectedPivot.x, projectedPivot.y},
+            {visibleProjection.anchorX() -
+                 visibleRenderResult.overscanPixels,
+             visibleProjection.anchorY() -
+                 visibleRenderResult.overscanPixels},
+            rotationDelta);
+        x = mapOriginX + map_transform::quantizePixel(presentedPoint.x) -
             markerVisualHalf;
-        y = mapOriginY + map_transform::quantizePixel(markerPoint.y) -
+        y = mapOriginY + map_transform::quantizePixel(presentedPoint.y) -
             markerVisualHalf;
       } else {
         const auto markerDelta = map_transform::worldToScreen(
@@ -5517,9 +6525,6 @@ void Maps::updatePositionOverlay() {
         x = mapOriginX + round(markerDelta.x) + anchorX - markerVisualHalf;
         y = mapOriginY + round(markerDelta.y) + anchorY - markerVisualHalf;
       }
-
-      ESP_LOGI(TAG, "GPS indicator updated outside follow mode zoom=%d",
-               zoom);
 
       lv_obj_set_pos(Maps::canvasArrow, x, y);
 
@@ -5532,7 +6537,6 @@ void Maps::updatePositionOverlay() {
           centerY < mapOriginY - markerVisualHalf ||
           centerY > mapOriginY + (int16_t)h + markerVisualHalf) {
         lv_obj_add_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
-        ESP_LOGI(TAG, "GPS indicator hidden: off-screen at (%d,%d)", x, y);
       } else {
         lv_obj_clear_flag(Maps::canvasArrow, LV_OBJ_FLAG_HIDDEN);
       }
@@ -5549,286 +6553,24 @@ void Maps::updatePositionOverlay() {
  *
  * @param zoom -> Zoom Level
  */
-bool Maps::generateVectorMap(uint8_t zoom) {
-  power_management::ScopedLock powerLock(power_management::LockDomain::Map);
-  power_metrics::MapRenderMeasurement powerMeasurement;
-#if POWER_METRICS
-  uint32_t powerBlocksUs = 0;
-  uint32_t powerDrawUs = 0;
-  uint32_t powerRouteUs = 0;
-#endif
-  const uint32_t generateStartMs = MAPIO_TIME_MS();
-  if (Maps::canvasMap == nullptr || Maps::canvasMapTemp == nullptr) {
-    ESP_LOGE(TAG, "Map render skipped: canvas double buffer is unavailable");
+bool Maps::generateVectorMap(uint8_t requestedZoom) {
+  if (canvasMap == nullptr || canvasMapTemp == nullptr ||
+      renderWorkerTaskHandle == nullptr) {
     return false;
   }
 
-  // The hidden buffer is about to become the render target. Any prepared
-  // zoom-out backdrop in it is no longer reusable.
-  invalidatePinchZoomOutBackdrop();
-
-  Maps::mapTileSize = Maps::vectorMapTileSize;
-  Maps::zoomLevel = zoom;
-
-  // Compute the current course-up request once per generation. A pinch
-  // settlement deliberately renders with the rotation of the pixels the
-  // focal calculation started from; a changed heading is rendered next.
-  double requestedRotation = 0.0;
-  if (rotationMode == ROT_COURSE_UP) {
-    uint16_t courseUpHeading = gps.gpsData.heading;
-    const char *courseUpSource = "gps";
-    uint16_t routeHeading = 0;
-    if (routeOverlay.headingNear(gps.gpsData.latitude, gps.gpsData.longitude,
-                                 routeHeading)) {
-      courseUpHeading = routeHeading;
-      courseUpSource = "route";
-    }
-
-    // Use negative heading to rotate map so the selected navigation/course
-    // direction points up.
-    requestedRotation = -DEG2RAD(courseUpHeading);
-    ESP_LOGI(TAG, "Course-Up: heading=%u source=%s gpsHeading=%u",
-             (unsigned)courseUpHeading, courseUpSource,
-             (unsigned)gps.gpsData.heading);
-  }
-  const bool frozenPinchSettlement = isPinchSettlementPending();
-  rotationRad = map_transform::renderRotationForSettlement(
-      frozenPinchSettlement, pinchPresentation.baseRotation,
-      requestedRotation);
-  if (frozenPinchSettlement &&
-      map_transform::rotationNeedsRefresh(rotationRad, requestedRotation)) {
-    deferredVectorRedraw = true;
-  }
-
-  const uint16_t viewportHeight =
-      mapSet.mapFullScreen ? Maps::mapScrFull : Maps::mapScrHeight;
-  if (shouldUseRollingRasterWindow(zoom)) {
-    const uint64_t signature = rollingRasterSignature();
-    bool completed = false;
-    if (rollingRasterCompatible(zoom, Maps::mapScrWidth, viewportHeight,
-                                signature)) {
-      completed = settleRollingRasterWindow();
-    } else {
-      completed = buildRollingRasterWindow(zoom, Maps::mapScrWidth,
-                                            viewportHeight, signature);
-    }
-    if (!completed)
-      return false;
-
-#ifdef WAVESHARE_TOUCH_DIAGNOSTICS
-    const bool completedPinchSettlement = isPinchSettlementPending();
-#endif
-    if (isPinchSettlementPending()) {
-      // A rolling-window settlement can reposition the oversized canvas as
-      // its origin advances. Animate from that completed position, not the
-      // position captured from the previous raster/zoom.
-      pinchPresentation.canvasBaseX = lv_obj_get_x_aligned(Maps::canvasMap);
-      pinchPresentation.canvasBaseY = lv_obj_get_y_aligned(Maps::canvasMap);
-    }
-    finishDragSettlement();
-    finishPinchSettlement();
-    if (!renderRollingForeground()) {
-      MAPIO_LOG("MAPIO: rolling-foreground ok=0 zoom=%u\n", zoom);
-      return false;
-    }
-    MAPIO_LOG("MAPIO: rolling-generate zoom=%u totalMs=%lu cache=%u "
-              "hasRoute=%d\n",
-              zoom, (unsigned long)(MAPIO_TIME_MS() - generateStartMs),
-              (unsigned)Maps::memCache.blocks.size(), routeOverlay.hasRoute());
-#ifdef WAVESHARE_TOUCH_DIAGNOSTICS
-    if (completedPinchSettlement) {
-      Serial.printf(
-          "Pinch diagnostic: rolling_settlement_ms=%lu free_psram=%u "
-          "largest_psram=%u\n",
-          static_cast<unsigned long>(MAPIO_TIME_MS() - generateStartMs),
-          heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
-          heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
-    }
-#endif
-    return true;
-  }
-
-  invalidateRollingRasterWindow();
-  const map_drag_preview::CanvasExtent renderExtent = {Maps::mapScrWidth,
-                                                        viewportHeight};
-  const uint32_t renderStride = lv_draw_buf_width_to_stride(
-      renderExtent.width, LV_COLOR_FORMAT_RGB565);
-  const size_t renderSize = renderStride * renderExtent.height;
-  if (renderSize > bufMapTempSize || renderSize > bufMapScreenSize) {
-    ESP_LOGE(TAG,
-             "Map render skipped: %ux%u frame needs %u bytes, screen=%u "
-             "temp=%u",
-             (unsigned)renderExtent.width, (unsigned)renderExtent.height,
-             (unsigned)renderSize, (unsigned)bufMapScreenSize,
-             (unsigned)bufMapTempSize);
+  mapTileSize = vectorMapTileSize;
+  zoomLevel = map_transform::clampRuntimeZoom(requestedZoom);
+  RenderRequest request;
+  if (!buildRenderRequest(zoomLevel, millis(), request)) {
+    // Course-up deliberately holds the last good frame until either a valid
+    // measured course or route-segment bearing exists. This is a deferred
+    // state, not an allocation/render failure and must never become north-up.
+    // Return false so the UI scheduler does not mark a request as submitted or
+    // clear the dirty state when no immutable job was actually queued.
     return false;
   }
-
-  // The hidden scratch buffer receives the complete target geometry before it
-  // is copied into the visible allocation. Interrupted renders never touch the
-  // visible frame.
-  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, renderExtent.width,
-                       renderExtent.height, LV_COLOR_FORMAT_RGB565);
-  lv_obj_center(Maps::canvasMapTemp);
-
-  // Viewport
-  Maps::viewPort.zoom = zoom;
-  Maps::viewPort.setCenterForCanvas(Maps::point, renderExtent.width,
-                                    renderExtent.height, rotationRad);
-  const bool birdsEyeActive =
-      navigation_content_mode::usesMapGuidanceBirdsEye(
-          isMapGuidanceScreenActive(),
-          mapRenderSettings.mapNavigationBirdsEyeEnabled);
-  const auto frameProjection = makeMapProjection(
-      Maps::viewPort.rasterOriginX, Maps::viewPort.rasterOriginY,
-      Maps::viewPort.rasterCellOffsetX, Maps::viewPort.rasterCellOffsetY, zoom,
-      rotationRad, renderExtent.width, renderExtent.height,
-      birdsEyeActive ? map_projection::Mode::BirdsEye
-                     : map_projection::Mode::Flat,
-      map_projection::birdsEyePerspectiveForValue(
-          mapRenderSettings.mapNavigationBirdsEyePerspective));
-  if (frameProjection.isBirdsEye()) {
-    const auto bounds = frameProjection.worldBounds(4.0);
-    Maps::viewPort.bbox.min =
-        Point32(static_cast<int32_t>(std::floor(bounds.min.x)),
-                static_cast<int32_t>(std::floor(bounds.min.y)));
-    Maps::viewPort.bbox.max =
-        Point32(static_cast<int32_t>(std::ceil(bounds.max.x)),
-                static_cast<int32_t>(std::ceil(bounds.max.y)));
-  }
-
-  // Get Map Blocks
-  const uint32_t blocksStartMs = MAPIO_TIME_MS();
-#if POWER_METRICS
-  const uint32_t powerBlocksStartUs = micros();
-#endif
-  if (!Maps::getMapBlocks(Maps::viewPort.bbox, Maps::memCache)) {
-#if POWER_METRICS
-    powerBlocksUs = micros() - powerBlocksStartUs;
-    powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
-                                       powerRouteUs);
-#endif
-    log_i("Map block loading interrupted to service a screen-cycle input");
-    return false;
-  }
-#if POWER_METRICS
-  powerBlocksUs = micros() - powerBlocksStartUs;
-  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
-                                     powerRouteUs);
-#endif
-  const uint32_t blocksMs = MAPIO_TIME_MS() - blocksStartMs;
-
-  ESP_LOGI(TAG,
-           "generateVectorMap: zoom=%d center(%d, %d) bbox[(%d, %d), (%d, %d)]",
-           zoom, Maps::viewPort.center.x, Maps::viewPort.center.y,
-           Maps::viewPort.bbox.min.x, Maps::viewPort.bbox.min.y,
-           Maps::viewPort.bbox.max.x, Maps::viewPort.bbox.max.y);
-
-  // Read Vector Map to Canvas (Pass calculated rotation)
-  const uint32_t drawStartMs = MAPIO_TIME_MS();
-#if POWER_METRICS
-  const uint32_t powerDrawStartUs = micros();
-#endif
-  if (!Maps::readVectorMap(Maps::viewPort, Maps::memCache, Maps::canvasMapTemp,
-                           zoom, rotationRad, frameProjection)) {
-#if POWER_METRICS
-    powerDrawUs = micros() - powerDrawStartUs;
-    powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
-                                       powerRouteUs);
-#endif
-    log_i("Map render interrupted to service a screen-cycle input");
-    return false;
-  }
-#if POWER_METRICS
-  powerDrawUs = micros() - powerDrawStartUs;
-  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
-                                     powerRouteUs);
-#endif
-  const uint32_t drawMs = MAPIO_TIME_MS() - drawStartMs;
-
-  if (shouldInterruptMapRenderForScreenCycle()) {
-    log_i("Map render interrupted before route overlay");
-    return false;
-  }
-
-  // Draw route overlay from iOS navigation (if available)
-  const uint32_t routeStartMs = MAPIO_TIME_MS();
-#if POWER_METRICS
-  const uint32_t powerRouteStartUs = micros();
-#endif
-  ESP_LOGI(TAG, "Checking for route overlay: hasRoute=%d",
-           routeOverlay.hasRoute());
-  if (routeOverlay.hasRoute() && isRouteOverlayVisible(mapRenderSettings)) {
-    ESP_LOGI(TAG, "Drawing route overlay: zoom=%d points=%d", zoom,
-             routeOverlay.getPointCount());
-
-    routeOverlay.drawRoute(Maps::canvasMapTemp, frameProjection);
-    ESP_LOGI(TAG, "Route overlay draw complete (rotation=%.2f rad, canvasH=%d)",
-             rotationRad, renderExtent.height);
-  } else if (routeOverlay.hasRoute()) {
-    ESP_LOGI(TAG, "Route overlay hidden by visibility mask");
-  } else {
-    ESP_LOGI(TAG, "No route overlay to draw (no route data)");
-  }
-#if POWER_METRICS
-  powerRouteUs = micros() - powerRouteStartUs;
-  powerMeasurement.setStageDurations(powerBlocksUs, powerDrawUs,
-                                     powerRouteUs);
-#endif
-  const uint32_t routeMs = MAPIO_TIME_MS() - routeStartMs;
-
-  if (shouldInterruptMapRenderForScreenCycle()) {
-    log_i("Map render interrupted before presenting completed frame");
-    return false;
-  }
-
-  const size_t rowBytes =
-      static_cast<size_t>(renderExtent.width) * sizeof(uint16_t);
-  auto *front = static_cast<uint8_t *>(bufMapScreen);
-  const auto *completedFrame = static_cast<const uint8_t *>(bufMapTemp);
-  for (uint16_t y = 0; y < renderExtent.height; ++y) {
-    memcpy(front + (static_cast<size_t>(y) * renderStride),
-           completedFrame + (static_cast<size_t>(y) * renderStride), rowBytes);
-  }
-  lv_canvas_set_buffer(Maps::canvasMap, bufMapScreen, renderExtent.width,
-                       renderExtent.height, LV_COLOR_FORMAT_RGB565);
-  lv_canvas_set_buffer(Maps::canvasMapTemp, bufMapTemp, renderExtent.width,
-                       renderExtent.height, LV_COLOR_FORMAT_RGB565);
-  lv_obj_center(Maps::canvasMap);
-  lv_obj_center(Maps::canvasMapTemp);
-  visibleProjection = frameProjection;
-  hasVisibleProjection = true;
-  if (isPinchSettlementPending()) {
-    pinchPresentation.canvasBaseX = lv_obj_get_x_aligned(Maps::canvasMap);
-    pinchPresentation.canvasBaseY = lv_obj_get_y_aligned(Maps::canvasMap);
-  }
-#ifdef WAVESHARE_TOUCH_DIAGNOSTICS
-  const bool completedPinchSettlement = isPinchSettlementPending();
-#endif
-  finishDragSettlement();
-  finishPinchSettlement();
-
-  MAPIO_LOG("MAPIO: generate zoom=%u mode=%s blocksMs=%lu drawMs=%lu "
-            "routeMs=%lu totalMs=%lu cache=%u hasRoute=%d\n",
-            zoom, frameProjection.isBirdsEye() ? "birds-eye" : "flat",
-            (unsigned long)blocksMs, (unsigned long)drawMs,
-            (unsigned long)routeMs,
-            (unsigned long)(MAPIO_TIME_MS() - generateStartMs),
-            (unsigned)Maps::memCache.blocks.size(), routeOverlay.hasRoute());
-#ifdef WAVESHARE_TOUCH_DIAGNOSTICS
-  if (completedPinchSettlement) {
-    Serial.printf(
-        "Pinch diagnostic: settlement_ms=%lu free_psram=%u "
-        "largest_psram=%u\n",
-        static_cast<unsigned long>(MAPIO_TIME_MS() - generateStartMs),
-        heap_caps_get_free_size(MALLOC_CAP_SPIRAM),
-        heap_caps_get_largest_free_block(MALLOC_CAP_SPIRAM));
-  }
-#endif
-  // NOTE: isPosMoved flag is now cleared in updateMap() after display,
-  // not here, to allow queued BLE updates to trigger new regenerations
-  powerMeasurement.finish(true);
-  return true;
+  return submitRenderRequest(request);
 }
 
 /**

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -177,6 +177,7 @@ private:
     uint16_t overscanPixels = 0;
     size_t renderStridePixels = 0;
     double rotationRad = 0.0;
+    uint32_t cancellationGeneration = 0;
     bool birdsEye = false;
   };
 
@@ -325,8 +326,23 @@ private:
   RenderContext captureRenderContext(uint32_t nowMs = 0);
   static void renderWorkerTaskThunk(void *argument);
   void renderWorkerLoop();
+  struct VectorMapActivationRequest {
+    uint32_t sequence = 0;
+    std::string folder;
+  };
+  struct VectorMapActivationCompletion {
+    uint32_t sequence = 0;
+    std::string folder;
+    bool loaded = false;
+  };
+  bool takeVectorMapActivationRequest(VectorMapActivationRequest &request);
+  bool processPendingVectorMapActivation();
+  bool probeVectorMapFolderOnStorageOwner(const std::string &folder);
+  bool switchVectorMapFolderOnStorageOwner(const std::string &folder);
+  void finalizeVectorMapFolderSwitchOnUi();
   bool startRenderWorker();
   bool stopRenderWorker();
+  bool recoverRenderWorkerIfNeeded();
   bool buildRenderRequest(uint8_t zoom, uint32_t nowMs,
                           RenderRequest &request);
   bool submitRenderRequest(const RenderRequest &request);
@@ -338,7 +354,8 @@ private:
   void updatePresentedPose(uint32_t nowMs);
   void updatePresentedFrameTransform();
   void renderLiveForeground();
-  void invalidateRenderSemantics();
+  void invalidateRenderSemantics(uint32_t nowMs);
+  bool presentationGestureOwnsTransforms() const;
   uint64_t styleSignature(const ScreenMapRenderSettings &style) const;
   uint64_t navigationSignature() const;
   uint64_t projectionSignature(uint8_t zoom, uint16_t viewportWidth,
@@ -358,8 +375,14 @@ private:
   bool readyRenderResultValid = false;
   bool framePublicationPending = false;
   bool renderFailurePending = false;
+  VectorMapActivationRequest pendingVectorMapActivation{};
+  VectorMapActivationCompletion completedVectorMapActivation{};
+  bool pendingVectorMapActivationValid = false;
+  bool completedVectorMapActivationValid = false;
+  uint32_t vectorMapActivationSequence = 0;
   bool publishedMapFrame = false;
   bool publishedMapFound = false;
+  uint32_t lastCompletedRenderDurationMs = 1000;
   uint32_t navigationEpoch = 1;
   uint32_t styleEpoch = 1;
   uint32_t mapEpoch = 1;
@@ -374,9 +397,12 @@ private:
   map_presentation::HeadingResolver headingResolver;
   map_presentation::PresentedPose presentedPose{};
   bool hasPresentedPose = false;
+  uint64_t lastFramePresentationSignature = 0;
+  uint64_t lastForegroundPresentationSignature = 0;
   RenderResult visibleRenderResult{};
   std::atomic<bool> renderWorkerShutdown{false};
   std::atomic<bool> renderWorkerExited{true};
+  std::atomic<bool> renderWorkerRestartAfterExit{false};
 
   // Common
   static const uint16_t tileHeight = 466;        // Tile 9x9 Height Size
@@ -502,6 +528,10 @@ private:
   void resetDragPresentationVisuals();
 
 public:
+  struct VectorMapActivationResult {
+    std::string folder;
+    bool loaded = false;
+  };
   uint16_t mapScrHeight;  // Screen map size height
   uint16_t mapScrWidth;   // Screen map size width
   uint16_t mapScrFull;    // Screen map size in full screen
@@ -526,6 +556,8 @@ public:
   void initMap(uint16_t mapHeight, uint16_t mapWidth, uint16_t mapFull);
   bool setVectorMapFolder(const std::string &folder);
   bool probeVectorMapFolder(const std::string &folder);
+  bool requestVectorMapFolderActivation(const std::string &folder);
+  bool takeVectorMapFolderActivationResult(VectorMapActivationResult &result);
   void deleteMapScrSprites();
   void createMapScrSprites();
   void generateRenderMap(uint8_t zoom);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <map>
 #include <math.h>
@@ -9,12 +10,16 @@
 
 // #include "../../compass/compass.hpp" // Circular dependency if not careful,
 // but likely needed for getHeading
+#include "../../ble_navigation/ble_navigation.hpp"
 #include "../../settings/settings.hpp"
 #include "../../storage/storage.hpp"
 // #include "../../tft/tft.hpp" // Removed or minimal include if possible?
 #include "../../utils/src/gpsMath.hpp"
 #include "mapTransform.hpp"
 #include "map_projection.hpp"
+#include "mapPresentation.hpp"
+#include "mapRenderJob.hpp"
+#include "mapSurface.hpp"
 #include "../../utils/src/mapDragPreview.hpp"
 #include "../../utils/src/mapRasterWindow.hpp"
 #include "lvgl.h"
@@ -28,7 +33,6 @@
 
 // Forward declarations
 struct MapSettings;
-struct ScreenMapRenderSettings;
 
 class Maps {
 private:
@@ -128,12 +132,87 @@ private:
   {
     std::vector<MapBlock *> blocks;
   };
-  MemCache memCache;               // Memory Cache
+
+  struct RenderContext {
+    ScreenMapRenderSettings style{};
+    map_transform::WorldPoint measuredGpsWorld{};
+    map_transform::WorldPoint presentedWorld{};
+    // Screen mode and route/session availability are distinct. The guidance
+    // screen may be bird's-eye before a route starts and must still render its
+    // configured 3D buildings.
+    bool guidanceScreenActive = false;
+    bool navigationSessionActive = false;
+    bool followPosition = true;
+    bool showCurrentPosition = true;
+    bool buildings3DEnabled = false;
+    uint8_t markerScale = 1;
+    uint8_t birdsEyePerspective = 0;
+  };
+
+  static constexpr uint16_t MAP_RENDER_OVERSCAN_PIXELS = 96;
+  static constexpr uint16_t MAP_RENDER_SAFETY_PIXELS = 16;
+  static constexpr uint32_t MAP_RENDER_WORKER_STACK_BYTES = 24576;
+  static constexpr uint32_t MAP_RENDER_DECLARED_SLICE_US = 50000;
+
+  struct RasterDiagnostics {
+    uint32_t selectedBuildings = 0;
+    uint32_t extrudedBuildings = 0;
+    uint32_t flatBuildings = 0;
+    uint32_t deferredBuildings = 0;
+    bool allocationFallback = false;
+  };
+
+  struct RenderRequest {
+    map_render_job::Version version{};
+    map_transform::WorldPoint center{};
+    RenderContext context{};
+    uint64_t styleSignature = 0;
+    uint64_t navigationSignature = 0;
+    uint64_t projectionSignature = 0;
+    uint8_t zoom = map_transform::kMinimumRuntimeZoom;
+    uint16_t viewportWidth = 0;
+    uint16_t viewportHeight = 0;
+    uint16_t renderWidth = 0;
+    uint16_t renderHeight = 0;
+    uint16_t overscanPixels = 0;
+    size_t renderStridePixels = 0;
+    double rotationRad = 0.0;
+    bool birdsEye = false;
+  };
+
+  struct RenderResult {
+    map_render_job::Version version{};
+    map_projection::Projection projection{};
+    ViewPort viewport{};
+    map_transform::WorldPoint center{};
+    uint64_t styleSignature = 0;
+    uint64_t navigationSignature = 0;
+    uint64_t projectionSignature = 0;
+    uint16_t viewportWidth = 0;
+    uint16_t viewportHeight = 0;
+    uint16_t renderWidth = 0;
+    uint16_t renderHeight = 0;
+    uint16_t overscanPixels = 0;
+    size_t renderStridePixels = 0;
+    uint32_t durationMs = 0;
+    uint32_t blocksMs = 0;
+    uint32_t drawMs = 0;
+    uint32_t psramFree = 0;
+    uint32_t psramLargest = 0;
+    double rotationRad = 0.0;
+    bool mapFound = false;
+    bool followPosition = true;
+    RasterDiagnostics raster{};
+  };
+
+  MemCache memCache;               // Worker-owned memory cache
+  std::atomic<size_t> cachedBlockCount{0};
   String vectorMapFolder = "/sdcard/VECTMAP/";
   map_font_asset::Asset labelFontAsset;
+  std::atomic<bool> streetLabelFontHealthy{false};
+  std::atomic<map_font_asset::RuntimeError> streetLabelRuntimeFailure{
+      map_font_asset::RuntimeError::None};
   map_building_renderer::FailureRetryCooldown buildingFailureRetryCooldown;
-  bool streetLabelRuntimeFailurePending = false;
-  std::string streetLabelRuntimeFailureCode;
   struct LabelLayoutCacheKey {
     int32_t centerX = 0;
     int32_t centerY = 0;
@@ -184,12 +263,21 @@ private:
   MapBlock *readMapBlockBinary(char *buffer, size_t fileSize);
   bool buildPolygonGrid(
       MapBlock *mblock); // Build spatial grid for polygon culling
-  bool fillPolygon(const Polygon &p, lv_obj_t *canvas,
-                   uint32_t deadlineStartMs = 0,
-                   uint32_t deadlineDurationMs = 0);
+  bool fillPolygon(const Polygon &p,
+                   map_surface::Rgb565Surface surface);
+  bool fillPolygon(const Polygon &p, lv_obj_t *canvas);
+  void drawLine(map_surface::Rgb565Surface surface, int16_t x1, int16_t y1,
+                int16_t x2, int16_t y2, uint16_t color, uint8_t width);
   void drawLine(lv_obj_t *canvas, int16_t x1, int16_t y1, int16_t x2,
                 int16_t y2, uint16_t color, uint8_t width);
   bool getMapBlocks(BBox &bbox, MemCache &memCache);
+  bool readVectorMap(ViewPort &viewPort, MemCache &memCache,
+                     map_surface::Rgb565Surface surface, uint8_t zoom,
+                     double rotation,
+                     const map_projection::Projection &projection,
+                     const RenderContext &context, bool drawLabels = true,
+                     bool suppressBuildings = false,
+                     RasterDiagnostics *diagnostics = nullptr);
   bool readVectorMap(ViewPort &viewPort, MemCache &memCache, lv_obj_t *canvas,
                      uint8_t zoom, double rotation,
                      const map_projection::Projection &projection,
@@ -229,9 +317,66 @@ private:
   uint64_t rollingRasterSignature() const;
   double visibleMapRotation() const;
   bool drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
+                        map_surface::LabelSurface surface, uint8_t zoom,
+                        double rotation, const RenderContext &context);
+  bool drawStreetLabels(ViewPort &viewPort, MemCache &memCache,
                         lv_obj_t *canvas, uint8_t zoom, double rotation,
                         const ScreenMapRenderSettings &style);
+  RenderContext captureRenderContext(uint32_t nowMs = 0);
+  static void renderWorkerTaskThunk(void *argument);
+  void renderWorkerLoop();
+  bool startRenderWorker();
+  bool stopRenderWorker();
+  bool buildRenderRequest(uint8_t zoom, uint32_t nowMs,
+                          RenderRequest &request);
+  bool submitRenderRequest(const RenderRequest &request);
+  void cancelActiveRenderWork();
+  bool takeWorkerRequest(RenderRequest &request);
+  bool publishReadyFrame(uint32_t nowMs);
+  bool renderRequestStillCurrent(const RenderRequest &request) const;
+  bool renderResultStillCurrent(const RenderResult &result) const;
+  void updatePresentedPose(uint32_t nowMs);
+  void updatePresentedFrameTransform();
+  void renderLiveForeground();
+  void invalidateRenderSemantics();
+  uint64_t styleSignature(const ScreenMapRenderSettings &style) const;
+  uint64_t navigationSignature() const;
+  uint64_t projectionSignature(uint8_t zoom, uint16_t viewportWidth,
+                               uint16_t viewportHeight, bool birdsEye,
+                               uint8_t perspective) const;
+  map_projection::Projection makeRequestProjection(
+      const RenderRequest &request) const;
   void getPosition(double lat, double lon);
+
+  mutable SemaphoreHandle_t renderStateMutex = nullptr;
+  TaskHandle_t renderWorkerTaskHandle = nullptr;
+  map_render_job::LatestWins renderJobs;
+  RenderRequest latestRenderRequest{};
+  RenderResult readyRenderResult{};
+  bool latestRenderRequestValid = false;
+  uint32_t lastTakenRenderSequence = 0;
+  bool readyRenderResultValid = false;
+  bool framePublicationPending = false;
+  bool renderFailurePending = false;
+  bool publishedMapFrame = false;
+  bool publishedMapFound = false;
+  uint32_t navigationEpoch = 1;
+  uint32_t styleEpoch = 1;
+  uint32_t mapEpoch = 1;
+  uint32_t projectionEpoch = 1;
+  uint64_t lastStyleSignature = 0;
+  uint64_t lastNavigationSignature = 0;
+  uint64_t lastProjectionSignature = 0;
+  uint64_t lastHeadingSessionSignature = 0;
+  uint64_t lastGpsSignature = 0;
+  uint32_t headingSessionEpoch = 1;
+  map_presentation::Presenter posePresenter;
+  map_presentation::HeadingResolver headingResolver;
+  map_presentation::PresentedPose presentedPose{};
+  bool hasPresentedPose = false;
+  RenderResult visibleRenderResult{};
+  std::atomic<bool> renderWorkerShutdown{false};
+  std::atomic<bool> renderWorkerExited{true};
 
   // Common
   static const uint16_t tileHeight = 466;        // Tile 9x9 Height Size
@@ -250,7 +395,7 @@ private:
   double prevLat, prevLon;   // Previous Latitude and Longitude
   double destLat, destLon;   // Waypoint destination latitude and longitude
   uint8_t zoomLevel;         // Zoom level for map display
-  bool isMapFound = false;   // Flag to indicate when map is found on SD
+  std::atomic<bool> isMapFound{false}; // Worker-owned map-block load state
   struct tileBounds          // Map boundaries structure
   {
     double lat_min;
@@ -385,6 +530,10 @@ public:
   void createMapScrSprites();
   void generateRenderMap(uint8_t zoom);
   bool generateVectorMap(uint8_t zoom);
+  bool serviceRenderPipeline(uint32_t nowMs);
+  bool takeFramePublication();
+  bool takeRenderFailure();
+  bool hasPublishedMapFrame() const { return publishedMapFrame; }
   bool hasMapCanvas() const { return canvasMap != nullptr; }
   void displayMap();
   void updatePositionOverlay();
@@ -443,8 +592,12 @@ public:
   double rotationRad = 0; // Current rotation in radians
   void toggleRotationMode();
   void updateArrowColor();
-  bool debugIsMapFound() const { return isMapFound; }
-  size_t debugCachedBlockCount() const { return memCache.blocks.size(); }
-  bool debugStreetLabelFontHealthy() const { return labelFontAsset.healthy(); }
+  bool debugIsMapFound() const { return publishedMapFound; }
+  size_t debugCachedBlockCount() const {
+    return cachedBlockCount.load(std::memory_order_acquire);
+  }
+  bool debugStreetLabelFontHealthy() const {
+    return streetLabelFontHealthy.load(std::memory_order_acquire);
+  }
   bool takeStreetLabelRuntimeFailure(std::string &code);
 };

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -292,7 +292,7 @@ void RouteOverlay::drawRoute(
   if (drawBuffer == nullptr)
     return;
   map_surface::Rgb565Surface surface{
-      static_cast<uint16_t *>(drawBuffer->data),
+      reinterpret_cast<uint16_t *>(drawBuffer->data),
       static_cast<int32_t>(drawBuffer->header.w),
       static_cast<int32_t>(drawBuffer->header.h),
       static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t))};

--- a/esp32/lib/route_overlay/route_overlay.cpp
+++ b/esp32/lib/route_overlay/route_overlay.cpp
@@ -13,6 +13,8 @@
 #endif
 #include "../ble_navigation/ble_navigation.hpp"
 #include "../maps/src/mapTransform.hpp"
+#include "../maps/src/mapRouteGeometry.hpp"
+#include "../maps/src/mapPresentation.hpp"
 #include "../utils/src/line_rasterizer.hpp"
 #include "../../utils/src/gpsMath.hpp"
 #include <Arduino.h>
@@ -20,66 +22,94 @@
 #include <cfloat>
 #include <cmath>
 #include <cstring>
+#include <utility>
 
 // Global instance
 RouteOverlay routeOverlay;
 
 void RouteOverlay::parseRouteData(const uint8_t *data, size_t len) {
-  points.clear();
-  revisionCounter++;
+  std::vector<GeoPoint, PsramAllocator<GeoPoint>> parsed;
+  if (data != nullptr && len >= 8) {
+    parsed.reserve(1U + (len - 8U) / 4U);
+    int32_t lat = 0;
+    int32_t lon = 0;
+    memcpy(&lat, data, 4);
+    memcpy(&lon, data + 4, 4);
+    parsed.push_back({lat, lon});
 
-  if (len < 8) {
+    size_t offset = 8;
+    while (offset + 4 <= len) {
+      int16_t dLat = 0;
+      int16_t dLon = 0;
+      memcpy(&dLat, data + offset, 2);
+      memcpy(&dLon, data + offset + 2, 2);
+      lat += dLat;
+      lon += dLon;
+      parsed.push_back({lat, lon});
+      offset += 4;
+    }
+  }
+
+  const size_t parsedCount = parsed.size();
+  portENTER_CRITICAL(&routeMutex);
+  points.swap(parsed);
+  ++revisionCounter;
+  portEXIT_CRITICAL(&routeMutex);
+
+  if (data == nullptr || len < 8) {
     Serial.println(
         "Route data too short (need at least 8 bytes for start point)");
     return;
   }
-
-  // Read start point (8 bytes: 4 lat + 4 lon, little-endian)
-  int32_t lat, lon;
-  memcpy(&lat, data, 4);
-  memcpy(&lon, data + 4, 4);
-
-  points.push_back({lat, lon});
-
-  // Read delta points (4 bytes each: 2 lat + 2 lon, little-endian)
-  size_t offset = 8;
-  while (offset + 4 <= len) {
-    int16_t dLat, dLon;
-    memcpy(&dLat, data + offset, 2);
-    memcpy(&dLon, data + offset + 2, 2);
-
-    lat += dLat;
-    lon += dLon;
-
-    points.push_back({lat, lon});
-    offset += 4;
-  }
-
-  Serial.printf("Route parsed: %d points from %d bytes\n", points.size(), len);
+  Serial.printf("Route parsed: %u points from %u bytes\n",
+                static_cast<unsigned>(parsedCount),
+                static_cast<unsigned>(len));
 }
 
 void RouteOverlay::clear() {
-  points.clear();
-  revisionCounter++;
+  std::vector<GeoPoint, PsramAllocator<GeoPoint>> released;
+  portENTER_CRITICAL(&routeMutex);
+  points.swap(released);
+  ++revisionCounter;
+  portEXIT_CRITICAL(&routeMutex);
   Serial.println("Route overlay cleared");
+}
+
+bool RouteOverlay::hasRoute() const {
+  portENTER_CRITICAL(&routeMutex);
+  const bool result = points.size() >= 2;
+  portEXIT_CRITICAL(&routeMutex);
+  return result;
+}
+
+size_t RouteOverlay::getPointCount() const {
+  portENTER_CRITICAL(&routeMutex);
+  const size_t result = points.size();
+  portEXIT_CRITICAL(&routeMutex);
+  return result;
+}
+
+uint32_t RouteOverlay::revision() const {
+  portENTER_CRITICAL(&routeMutex);
+  const uint32_t result = revisionCounter;
+  portEXIT_CRITICAL(&routeMutex);
+  return result;
 }
 
 bool RouteOverlay::headingNear(double lat, double lon,
                                uint16_t &headingDeg) const {
-  if (points.size() < 2) {
+  const RouteSnapshot route = snapshot();
+  if (!route.hasRoute())
     return false;
-  }
 
   const double cosLat = cos(DEG2RAD(lat));
   double bestDistanceSq = DBL_MAX;
   size_t bestSegment = 0;
-
-  for (size_t i = 0; i + 1 < points.size(); i++) {
-    const double lat1 = points[i].lat / 1000000.0;
-    const double lon1 = points[i].lon / 1000000.0;
-    const double lat2 = points[i + 1].lat / 1000000.0;
-    const double lon2 = points[i + 1].lon / 1000000.0;
-
+  for (size_t i = 0; i + 1 < route.count; ++i) {
+    const double lat1 = route.points[i].lat / 1000000.0;
+    const double lon1 = route.points[i].lon / 1000000.0;
+    const double lat2 = route.points[i + 1].lat / 1000000.0;
+    const double lon2 = route.points[i + 1].lon / 1000000.0;
     const double x1 = (lon1 - lon) * cosLat;
     const double y1 = lat1 - lat;
     const double x2 = (lon2 - lon) * cosLat;
@@ -87,10 +117,8 @@ bool RouteOverlay::headingNear(double lat, double lon,
     const double segX = x2 - x1;
     const double segY = y2 - y1;
     const double segLenSq = (segX * segX) + (segY * segY);
-    if (segLenSq <= 0.0) {
+    if (segLenSq <= 0.0)
       continue;
-    }
-
     double t = -((x1 * segX) + (y1 * segY)) / segLenSq;
     t = std::max(0.0, std::min(1.0, t));
     const double closestX = x1 + (segX * t);
@@ -101,16 +129,14 @@ bool RouteOverlay::headingNear(double lat, double lon,
       bestSegment = i;
     }
   }
-
-  if (bestDistanceSq == DBL_MAX) {
+  if (bestDistanceSq == DBL_MAX)
     return false;
-  }
 
   const double segmentHeading =
-      calcCourse(points[bestSegment].lat / 1000000.0,
-                 points[bestSegment].lon / 1000000.0,
-                 points[bestSegment + 1].lat / 1000000.0,
-                 points[bestSegment + 1].lon / 1000000.0);
+      calcCourse(route.points[bestSegment].lat / 1000000.0,
+                 route.points[bestSegment].lon / 1000000.0,
+                 route.points[bestSegment + 1].lat / 1000000.0,
+                 route.points[bestSegment + 1].lon / 1000000.0);
   headingDeg = static_cast<uint16_t>(round(segmentHeading)) % 360;
   return true;
 }
@@ -129,100 +155,149 @@ void RouteOverlay::drawThickLine(uint16_t *buf, int32_t bufW, int32_t bufH,
                                   color, lineWidth);
 }
 
-void RouteOverlay::drawRoute(
-    lv_obj_t *canvas, const map_projection::Projection &projection) {
-  if (points.size() < 2) {
-    Serial.println("RouteOverlay: Not enough points to draw (need >= 2)");
-    return; // Need at least 2 points to draw a line
-  }
-
-#if FIRMWARE_DIAGNOSTICS
-  Serial.printf("RouteOverlay::drawRoute: zoom=%d points=%d rot=%.2frad "
-                "mode=%s\n",
-                projection.config().zoom, points.size(),
-                projection.config().rotationRad,
-                projection.isBirdsEye() ? "birds-eye" : "flat");
-#endif
-
-  // Get canvas buffer
-  lv_draw_buf_t *draw_buf = lv_canvas_get_draw_buf(canvas);
-  if (!draw_buf) {
-    Serial.println("RouteOverlay: Could not get canvas draw buffer");
-    return;
-  }
-
-  uint16_t *buf = (uint16_t *)draw_buf->data;
-  int32_t bufW = draw_buf->header.w;
-  int32_t bufH = draw_buf->header.h;
-  uint32_t stride =
-      draw_buf->header.stride / 2; // stride is in bytes, we need pixels
-#if FIRMWARE_DIAGNOSTICS
-  Serial.printf("RouteOverlay: Canvas buffer W=%d H=%d stride=%d\n", bufW, bufH,
-                stride);
-#endif
-
-  int drawnCount = 0;
-  // Draw route segments
-  for (size_t i = 0; i < points.size() - 1; i++) {
-    auto worldPoint = [](const GeoPoint &point) {
-      const double lon = point.lon / 1000000.0;
-      const double lat = point.lat / 1000000.0;
-      return map_transform::WorldPoint{
-          DEG2RAD(lon) * EARTH_RADIUS,
+namespace {
+map_transform::WorldPoint routeWorldPoint(const GeoPoint &point) {
+  const double lon = point.lon / 1000000.0;
+  const double lat = point.lat / 1000000.0;
+  return {DEG2RAD(lon) * EARTH_RADIUS,
           log(tan(DEG2RAD(lat) / 2.0 + M_PI / 4.0)) * EARTH_RADIUS};
-    };
-    auto ground1 = projection.groundForWorld(worldPoint(points[i]));
-    auto ground2 = projection.groundForWorld(worldPoint(points[i + 1]));
+}
+}
+
+RouteSnapshot RouteOverlay::snapshot() const {
+  RouteSnapshot result;
+  portENTER_CRITICAL(&routeMutex);
+  result.revision = revisionCounter;
+  result.count = static_cast<uint16_t>(
+      std::min(points.size(), static_cast<size_t>(ROUTE_SNAPSHOT_MAX_POINTS)));
+  for (uint16_t index = 0; index < result.count; ++index)
+    result.points[index] = points[index];
+  portEXIT_CRITICAL(&routeMutex);
+  return result;
+}
+
+namespace {
+
+template <typename DrawSegment>
+void drawRouteSnapshotImpl(
+    const RouteSnapshot &snapshot,
+    const map_projection::Projection &projection, uint8_t baseLineWidth,
+    const map_transform::WorldPoint *presentedWorld,
+    const RoutePresentationTransform *presentation, DrawSegment drawSegment) {
+  if (!snapshot.hasRoute())
+    return;
+
+  std::array<map_transform::WorldPoint, ROUTE_SNAPSHOT_MAX_POINTS + 1> path{};
+  size_t pathCount = 0;
+  const auto pointAt = [&](size_t index) {
+    return routeWorldPoint(snapshot.points[index]);
+  };
+  if (presentedWorld != nullptr) {
+    size_t storedCount = 0;
+    (void)map_route_geometry::emitAnchored(
+        *presentedWorld, snapshot.count, pointAt, [&](auto point) {
+          if (storedCount < path.size())
+            path[storedCount++] = point;
+        });
+    pathCount = storedCount;
+  } else {
+    pathCount = snapshot.count;
+    for (size_t index = 0; index < pathCount; ++index)
+      path[index] = pointAt(index);
+  }
+  if (pathCount < 2)
+    return;
+
+  const uint8_t width = static_cast<uint8_t>(
+      std::max<int>(1, std::min<int>(48, baseLineWidth)));
+  const auto present = [&](double x, double y) {
+    if (presentation == nullptr)
+      return map_presentation::ScreenPoint{x, y};
+    return map_presentation::presentFramePoint(
+        {x, y},
+        {presentation->inputPivotX, presentation->inputPivotY},
+        {presentation->outputPivotX, presentation->outputPivotY},
+        presentation->rotationRad);
+  };
+
+  for (size_t index = 0; index + 1 < pathCount; ++index) {
+    auto ground1 = projection.groundForWorld(path[index]);
+    auto ground2 = projection.groundForWorld(path[index + 1]);
     if (!projection.clipSegmentToNearPlane(ground1, ground2))
       continue;
     const auto projected1 = projection.projectGround(ground1);
     const auto projected2 = projection.projectGround(ground2);
     if (!projected1.valid || !projected2.valid)
       continue;
-    const double x1 = projected1.x;
-    const double y1 = projected1.y;
-    const double x2 = projected2.x;
-    const double y2 = projected2.y;
-
-    // LOGGING: Debug Center Offset for the first segment
-    if (i == 0) {
-      ESP_LOGI(
-          "RouteOverlay",
-          "DEBUG_OFFSET: Center(%d,%d) StartPixel(%.1f,%.1f) "
-          "Diff(%.1f,%.1f) Rot(%.2f)",
-          static_cast<int>(projection.anchorX()),
-          static_cast<int>(projection.anchorY()), x1, y1,
-          x1 - projection.anchorX(), y1 - projection.anchorY(),
-          projection.config().rotationRad);
-    }
-
-    // Skip if both endpoints are far off-screen
-    const int16_t margin = 50;
-    if ((x1 < -margin && x2 < -margin) ||
-        (x1 > bufW + margin && x2 > bufW + margin) ||
-        (y1 < -margin && y2 < -margin) ||
-        (y1 > bufH + margin && y2 > bufH + margin)) {
-      continue;
-    }
-
-    // Draw thick line segment
-    const uint8_t baseRouteLineWidth = static_cast<uint8_t>(std::min<int16_t>(
-        std::max<int16_t>(
-            1, (int16_t)currentMapStyleSettings().routeLineWidth),
-        48));
-    const uint8_t routeLineWidth = projection.scaledLineWidth(
-        baseRouteLineWidth,
-        (projected1.depthScale + projected2.depthScale) / 2.0, 48);
-    drawThickLine(buf, bufW, bufH, stride,
-                  static_cast<int16_t>(map_transform::quantizePixel(x1)),
-                  static_cast<int16_t>(map_transform::quantizePixel(y1)),
-                  static_cast<int16_t>(map_transform::quantizePixel(x2)),
-                  static_cast<int16_t>(map_transform::quantizePixel(y2)),
-                  navigation_visual_style::ROUTE_BLUE_RGB565,
-                  routeLineWidth);
-    drawnCount++;
+    const uint8_t lineWidth = projection.scaledLineWidth(
+        width, (projected1.depthScale + projected2.depthScale) / 2.0, 48);
+    const auto point1 = present(projected1.x, projected1.y);
+    const auto point2 = present(projected2.x, projected2.y);
+    drawSegment(
+        static_cast<int16_t>(map_transform::quantizePixel(point1.x)),
+        static_cast<int16_t>(map_transform::quantizePixel(point1.y)),
+        static_cast<int16_t>(map_transform::quantizePixel(point2.x)),
+        static_cast<int16_t>(map_transform::quantizePixel(point2.y)),
+        lineWidth);
   }
+}
 
-  ESP_LOGI("RouteOverlay", "Route drawn: %d/%d segments (some off-screen)",
-           drawnCount, (int)points.size() - 1);
+} // namespace
+
+void RouteOverlay::drawSnapshot(
+    const RouteSnapshot &snapshot, map_surface::Rgb565Surface surface,
+    const map_projection::Projection &projection, uint8_t baseLineWidth,
+    const map_transform::WorldPoint *presentedWorld,
+    const RoutePresentationTransform *presentation) {
+  if (!surface.valid())
+    return;
+  drawRouteSnapshotImpl(
+      snapshot, projection, baseLineWidth, presentedWorld, presentation,
+      [&](int16_t x1, int16_t y1, int16_t x2, int16_t y2,
+          uint8_t lineWidth) {
+        line_rasterizer::drawFilledLine(
+            surface.pixels, surface.width, surface.height,
+            static_cast<uint32_t>(surface.stridePixels), x1, y1, x2, y2,
+            navigation_visual_style::ROUTE_BLUE_RGB565, lineWidth);
+      });
+}
+
+void RouteOverlay::drawSnapshot(
+    const RouteSnapshot &snapshot, map_surface::Rgb565A8Surface surface,
+    const map_projection::Projection &projection, uint8_t baseLineWidth,
+    const map_transform::WorldPoint *presentedWorld,
+    const RoutePresentationTransform *presentation) {
+  if (!surface.valid())
+    return;
+  drawRouteSnapshotImpl(
+      snapshot, projection, baseLineWidth, presentedWorld, presentation,
+      [&](int16_t x1, int16_t y1, int16_t x2, int16_t y2,
+          uint8_t lineWidth) {
+        line_rasterizer::drawFilledLine(
+            surface.pixels, surface.width, surface.height,
+            static_cast<uint32_t>(surface.colorStridePixels), x1, y1, x2, y2,
+            navigation_visual_style::ROUTE_BLUE_RGB565, lineWidth);
+        line_rasterizer::drawFilledLine(
+            surface.alpha, surface.width, surface.height,
+            static_cast<uint32_t>(surface.alphaStrideBytes), x1, y1, x2, y2,
+            uint8_t{255}, lineWidth);
+      });
+}
+
+void RouteOverlay::drawRoute(
+    lv_obj_t *canvas, const map_projection::Projection &projection) {
+  if (canvas == nullptr)
+    return;
+  lv_draw_buf_t *drawBuffer = lv_canvas_get_draw_buf(canvas);
+  if (drawBuffer == nullptr)
+    return;
+  map_surface::Rgb565Surface surface{
+      static_cast<uint16_t *>(drawBuffer->data),
+      static_cast<int32_t>(drawBuffer->header.w),
+      static_cast<int32_t>(drawBuffer->header.h),
+      static_cast<size_t>(drawBuffer->header.stride / sizeof(uint16_t))};
+  drawSnapshot(snapshot(), surface, projection,
+               static_cast<uint8_t>(std::min<int>(
+                   48, std::max<int>(1,
+                       currentMapStyleSettings().routeLineWidth))));
 }

--- a/esp32/lib/route_overlay/route_overlay.hpp
+++ b/esp32/lib/route_overlay/route_overlay.hpp
@@ -10,9 +10,11 @@
 
 #include "../utils/src/psram_allocator.hpp"
 #include "../maps/src/map_projection.hpp"
+#include "../maps/src/mapSurface.hpp"
 #include "navigation_visual_style.hpp"
 #include "lvgl.h"
 #include <Arduino.h>
+#include <array>
 #include <cstdint>
 #include <vector>
 
@@ -22,6 +24,29 @@
 struct GeoPoint {
   int32_t lat; // Latitude * 1,000,000 (microdegrees)
   int32_t lon; // Longitude * 1,000,000 (microdegrees)
+};
+
+static constexpr size_t ROUTE_SNAPSHOT_MAX_POINTS = 128;
+
+/** Immutable, bounded copy captured by the UI before a render job starts. */
+struct RouteSnapshot {
+  std::array<GeoPoint, ROUTE_SNAPSHOT_MAX_POINTS> points{};
+  uint16_t count = 0;
+  uint32_t revision = 0;
+
+  constexpr bool hasRoute() const { return count >= 2; }
+};
+
+/**
+ * Maps points from the immutable base-frame projection into the live viewport.
+ * The base image uses the same pivot, target, and rotation delta through LVGL.
+ */
+struct RoutePresentationTransform {
+  double inputPivotX = 0.0;
+  double inputPivotY = 0.0;
+  double outputPivotX = 0.0;
+  double outputPivotY = 0.0;
+  double rotationRad = 0.0;
 };
 
 /**
@@ -54,6 +79,27 @@ public:
   void drawRoute(lv_obj_t *canvas,
                  const map_projection::Projection &projection);
 
+  /** Capture a fixed-size immutable route for a worker or UI presentation. */
+  RouteSnapshot snapshot() const;
+
+  /**
+   * Draw a snapshot to a raw surface.  No LVGL object is touched.  When a
+   * presented rider coordinate is supplied, the first route segment begins at
+   * that exact world point and continues from the nearest forward segment.
+   */
+  static void drawSnapshot(
+      const RouteSnapshot &snapshot, map_surface::Rgb565Surface surface,
+      const map_projection::Projection &projection, uint8_t baseLineWidth,
+      const map_transform::WorldPoint *presentedWorld = nullptr,
+      const RoutePresentationTransform *presentation = nullptr);
+
+  /** Draw the route directly into RGB565+A8 without scanning the color plane. */
+  static void drawSnapshot(
+      const RouteSnapshot &snapshot, map_surface::Rgb565A8Surface surface,
+      const map_projection::Projection &projection, uint8_t baseLineWidth,
+      const map_transform::WorldPoint *presentedWorld = nullptr,
+      const RoutePresentationTransform *presentation = nullptr);
+
   /**
    * @brief Clear all route points
    */
@@ -63,15 +109,15 @@ public:
    * @brief Check if route data is loaded
    * @return true if route has at least 2 points
    */
-  bool hasRoute() const { return points.size() >= 2; }
+  bool hasRoute() const;
 
   /**
    * @brief Get number of points in current route
    */
-  size_t getPointCount() const { return points.size(); }
+  size_t getPointCount() const;
 
   /** Monotonic content revision for invalidating prepared raster map cells. */
-  uint32_t revision() const { return revisionCounter; }
+  uint32_t revision() const;
 
   /**
    * @brief Estimate route bearing near a current GPS position.
@@ -84,6 +130,7 @@ public:
   bool headingNear(double lat, double lon, uint16_t &headingDeg) const;
 
 private:
+  mutable portMUX_TYPE routeMutex = portMUX_INITIALIZER_UNLOCKED;
   std::vector<GeoPoint, PsramAllocator<GeoPoint>> points;
   uint32_t revisionCounter = 0;
 

--- a/esp32/lib/utils/src/line_rasterizer.hpp
+++ b/esp32/lib/utils/src/line_rasterizer.hpp
@@ -13,28 +13,31 @@ struct PointF {
   float y;
 };
 
-inline void plot(uint16_t *buf, int32_t width, int32_t height,
-                 uint32_t stride, int32_t x, int32_t y, uint16_t color) {
+template <typename Pixel>
+inline void plot(Pixel *buf, int32_t width, int32_t height,
+                 uint32_t stride, int32_t x, int32_t y, Pixel color) {
   if (x >= 0 && x < width && y >= 0 && y < height)
     buf[y * stride + x] = color;
 }
 
-inline void fillSpan(uint16_t *buf, int32_t width, int32_t height,
+template <typename Pixel>
+inline void fillSpan(Pixel *buf, int32_t width, int32_t height,
                      uint32_t stride, int32_t y, int32_t x1, int32_t x2,
-                     uint16_t color) {
+                     Pixel color) {
   if (y < 0 || y >= height || x2 < 0 || x1 >= width)
     return;
 
   x1 = std::max<int32_t>(x1, 0);
   x2 = std::min<int32_t>(x2, width - 1);
-  uint16_t *row = buf + y * stride;
+  Pixel *row = buf + y * stride;
   for (int32_t x = x1; x <= x2; ++x)
     row[x] = color;
 }
 
-inline void drawThinLine(uint16_t *buf, int32_t width, int32_t height,
+template <typename Pixel>
+inline void drawThinLine(Pixel *buf, int32_t width, int32_t height,
                          uint32_t stride, int32_t x1, int32_t y1, int32_t x2,
-                         int32_t y2, uint16_t color) {
+                         int32_t y2, Pixel color) {
   int32_t dx = std::abs(x2 - x1);
   int32_t sx = x1 < x2 ? 1 : -1;
   int32_t dy = -std::abs(y2 - y1);
@@ -121,9 +124,10 @@ inline bool clipLine(float &x1, float &y1, float &x2, float &y2, float minX,
   }
 }
 
-inline void fillConvexQuad(uint16_t *buf, int32_t width, int32_t height,
+template <typename Pixel>
+inline void fillConvexQuad(Pixel *buf, int32_t width, int32_t height,
                            uint32_t stride, const PointF (&points)[4],
-                           uint16_t color) {
+                           Pixel color) {
   float minY = points[0].y;
   float maxY = points[0].y;
   for (uint8_t i = 1; i < 4; ++i) {
@@ -185,9 +189,10 @@ inline void fillConvexQuad(uint16_t *buf, int32_t width, int32_t height,
   }
 }
 
-inline void fillDisc(uint16_t *buf, int32_t width, int32_t height,
+template <typename Pixel>
+inline void fillDisc(Pixel *buf, int32_t width, int32_t height,
                      uint32_t stride, float centerX, float centerY,
-                     float radius, uint16_t color) {
+                     float radius, Pixel color) {
   const int32_t firstY =
       std::max<int32_t>(0, static_cast<int32_t>(std::ceil(centerY - radius)));
   const int32_t lastY = std::min<int32_t>(
@@ -210,15 +215,17 @@ inline void fillDisc(uint16_t *buf, int32_t width, int32_t height,
 } // namespace detail
 
 /**
- * Draws an opaque, filled line directly into an RGB565 pixel buffer.
+ * Draws a filled line directly into a typed pixel plane (for example an
+ * RGB565 color plane or an 8-bit alpha plane).
  *
  * Thick lines are rasterized as a filled rectangle with round end caps. This
  * avoids the unwritten pixels produced by approximating thickness with several
  * rounded, parallel one-pixel Bresenham lines.
  */
-inline void drawFilledLine(uint16_t *buf, int32_t width, int32_t height,
+template <typename Pixel>
+inline void drawFilledLine(Pixel *buf, int32_t width, int32_t height,
                            uint32_t stride, int16_t x1, int16_t y1, int16_t x2,
-                           int16_t y2, uint16_t color, uint8_t lineWidth) {
+                           int16_t y2, Pixel color, uint8_t lineWidth) {
   if (buf == nullptr || width <= 0 || height <= 0 ||
       stride < static_cast<uint32_t>(width))
     return;

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -367,6 +367,23 @@ static uint32_t pendingUiWakeReasons = 0;
 static uint32_t lastBleHousekeepingMs = 0;
 static uint32_t lastShutdownHousekeepingMs = 0;
 static uint32_t lastTransferHousekeepingMs = 0;
+enum class PendingMapRendererActivationSource : uint8_t {
+  None,
+  Transfer,
+  LabelRollback,
+};
+struct PendingMapRendererActivation {
+  PendingMapRendererActivationSource source =
+      PendingMapRendererActivationSource::None;
+  std::string rendererRoot;
+  std::string transferRoot;
+  std::string labelFailure;
+  std::string rollbackCode;
+  bool rendererQueued = false;
+  uint32_t queueAttemptStartedMs = 0;
+};
+static PendingMapRendererActivation pendingMapRendererActivation;
+static constexpr uint32_t kMapRendererActivationQueueTimeoutMs = 10000U;
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 static display_inactivity::Policy displayInactivityPolicy;
 static display_inactivity::Mode currentDisplayMode =
@@ -1440,38 +1457,102 @@ void loop() {
           lastTransferHousekeepingMs, kStaticHousekeepingPeriodMs);
   if (transferHousekeepingDue) {
     lastTransferHousekeepingMs = now;
-    std::string activatedMapRoot;
-    if (mapTransferHttp.takeActivatedMapRoot(activatedMapRoot)) {
-      const std::string rendererRoot =
-          std::string("/sdcard") + activatedMapRoot;
-      const bool loaded = mapView.probeVectorMapFolder(rendererRoot) &&
-                          mapView.setVectorMapFolder(rendererRoot);
-      mapTransferHttp.acknowledgeActivatedMapRoot(activatedMapRoot, loaded);
+    Maps::VectorMapActivationResult rendererResult;
+    if (mapView.takeVectorMapFolderActivationResult(rendererResult)) {
+      const bool matchesPending =
+          pendingMapRendererActivation.source !=
+              PendingMapRendererActivationSource::None &&
+          pendingMapRendererActivation.rendererQueued &&
+          rendererResult.folder == pendingMapRendererActivation.rendererRoot;
+      const bool loaded = matchesPending && rendererResult.loaded;
+      if (pendingMapRendererActivation.source ==
+          PendingMapRendererActivationSource::Transfer) {
+        mapTransferHttp.acknowledgeActivatedMapRoot(
+            pendingMapRendererActivation.transferRoot, loaded);
+      } else if (pendingMapRendererActivation.source ==
+                 PendingMapRendererActivationSource::LabelRollback) {
+        Serial.printf("MAP_TRANSFER: runtime label failure=%s rollback=%s "
+                      "restored=%d\n",
+                      pendingMapRendererActivation.labelFailure.c_str(),
+                      pendingMapRendererActivation.rollbackCode.c_str(),
+                      loaded);
+      } else {
+        Serial.printf("MAP_TRANSFER: unexpected renderer activation result "
+                      "root=%s loaded=%d\n",
+                      rendererResult.folder.c_str(), rendererResult.loaded);
+      }
+      pendingMapRendererActivation = {};
     }
+
+    if (pendingMapRendererActivation.source ==
+        PendingMapRendererActivationSource::None) {
+      std::string activatedMapRoot;
+      if (mapTransferHttp.takeActivatedMapRoot(activatedMapRoot)) {
+        const std::string rendererRoot =
+            std::string("/sdcard") + activatedMapRoot;
+        pendingMapRendererActivation = {
+            PendingMapRendererActivationSource::Transfer, rendererRoot,
+            activatedMapRoot, {}, {}, false, now};
+      }
+    }
+
     std::string labelRuntimeFailure;
-    if (mapView.takeStreetLabelRuntimeFailure(labelRuntimeFailure)) {
+    if (pendingMapRendererActivation.source ==
+            PendingMapRendererActivationSource::None &&
+        mapView.takeStreetLabelRuntimeFailure(labelRuntimeFailure)) {
       map_transfer::MapTransferInstaller mapInstaller("/sdcard");
       map_transfer::ActiveMapSelection failedSelection;
       const map_transfer::InstallStatus activeStatus =
           mapInstaller.readActiveMap(failedSelection);
       map_transfer::InstallStatus rollbackStatus{
           false, "active_rollback_unavailable", "active map is unavailable"};
-      bool restoredLoaded = false;
+      bool restorationAvailable = false;
+      std::string restoredRoot;
       if (activeStatus.ok && !failedSelection.sessionId.empty()) {
         rollbackStatus =
             mapInstaller.rollbackActiveMap(failedSelection.sessionId);
         map_transfer::ActiveMapSelection restored;
         if (rollbackStatus.ok && mapInstaller.readActiveMap(restored).ok) {
-          const std::string restoredRoot =
-              std::string("/sdcard") + restored.root;
-          restoredLoaded = mapView.probeVectorMapFolder(restoredRoot) &&
-                           mapView.setVectorMapFolder(restoredRoot);
+          restoredRoot = std::string("/sdcard") + restored.root;
+          restorationAvailable = true;
+          pendingMapRendererActivation = {
+              PendingMapRendererActivationSource::LabelRollback,
+              restoredRoot, {}, labelRuntimeFailure, rollbackStatus.code,
+              false, now};
         }
       }
-      Serial.printf("MAP_TRANSFER: runtime label failure=%s rollback=%s "
-                    "restored=%d\n",
-                    labelRuntimeFailure.c_str(), rollbackStatus.code.c_str(),
-                    restoredLoaded);
+      if (!restorationAvailable) {
+        Serial.printf("MAP_TRANSFER: runtime label failure=%s rollback=%s "
+                      "restored=0\n",
+                      labelRuntimeFailure.c_str(), rollbackStatus.code.c_str());
+      }
+    }
+
+    // A worker restart handoff or a briefly-held render mutex can make the
+    // non-blocking enqueue fail. Keep ownership of the activation and retry on
+    // subsequent transfer ticks; a transient 5 ms miss must not falsely mark a
+    // successfully installed map as unusable.
+    if (pendingMapRendererActivation.source !=
+            PendingMapRendererActivationSource::None &&
+        !pendingMapRendererActivation.rendererQueued) {
+      if (mapView.requestVectorMapFolderActivation(
+              pendingMapRendererActivation.rendererRoot)) {
+        pendingMapRendererActivation.rendererQueued = true;
+      } else if (static_cast<uint32_t>(
+                     now - pendingMapRendererActivation.queueAttemptStartedMs) >=
+                 kMapRendererActivationQueueTimeoutMs) {
+        if (pendingMapRendererActivation.source ==
+            PendingMapRendererActivationSource::Transfer) {
+          mapTransferHttp.acknowledgeActivatedMapRoot(
+              pendingMapRendererActivation.transferRoot, false);
+        } else {
+          Serial.printf("MAP_TRANSFER: runtime label failure=%s rollback=%s "
+                        "restored=0 queue_timeout=1\n",
+                        pendingMapRendererActivation.labelFailure.c_str(),
+                        pendingMapRendererActivation.rollbackCode.c_str());
+        }
+        pendingMapRendererActivation = {};
+      }
     }
     if (mapTransferHttp.takeAutomaticExitRequest()) {
       const bool disabled = mapTransferHttp.setEnabled(false);

--- a/esp32/tools/tests/test_device_capabilities_protocol.cpp
+++ b/esp32/tools/tests/test_device_capabilities_protocol.cpp
@@ -18,11 +18,17 @@ int main() {
       (1UL << 11));
   static_assert(device_capabilities_protocol::OSM_3D_BUILDINGS_FEATURE ==
                 (1UL << 12));
+  static_assert(
+      device_capabilities_protocol::EXPLICIT_INVALID_GPS_HEADING_CLIENT_VERSION ==
+      11);
+  static_assert(
+      device_capabilities_protocol::EXPLICIT_INVALID_GPS_HEADING_FEATURE ==
+      (1UL << 13));
   uint8_t output[device_capabilities_protocol::CAP2_MAX_BYTES]{};
   const uint8_t power[] = {1, 4, 80};
   const size_t size = device_capabilities_protocol::encodeCap2(
-      0x00001fff, power, true, output, sizeof(output));
-  const uint8_t expected[] = {'C', 'A', 'P', '2', 1, 0xff, 0x1f,
+      0x00003fff, power, true, output, sizeof(output));
+  const uint8_t expected[] = {'C', 'A', 'P', '2', 1, 0xff, 0x3f,
                               0x00, 0x00, 1,   3, 1,    4,    80};
   static_assert(sizeof(expected) == device_capabilities_protocol::CAP2_MAX_BYTES);
   assert(size == sizeof(expected));

--- a/esp32/tools/tests/test_gui_layout.cpp
+++ b/esp32/tools/tests/test_gui_layout.cpp
@@ -37,11 +37,18 @@ int main() {
   map_tile_transition::State mapTransition;
   assert(!mapTransition.canReveal(false, false));
   mapTransition.begin();
+  assert(!mapTransition.canReveal(false, false));
+  assert(!mapTransition.canReveal(true, true));
+  assert(!mapTransition.canReveal(true, false));
+  assert(!mapTransition.canReveal(false, true));
+  mapTransition.noteFramePublished();
   assert(!mapTransition.canReveal(true, true));
   assert(!mapTransition.canReveal(true, false));
   assert(!mapTransition.canReveal(false, true));
   assert(mapTransition.canReveal(false, false));
   mapTransition.complete();
+  assert(!mapTransition.canReveal(false, false));
+  mapTransition.noteFramePublished();
   assert(!mapTransition.canReveal(false, false));
   mapTransition.begin();
   mapTransition.cancel();

--- a/esp32/tools/tests/test_line_rasterizer.cpp
+++ b/esp32/tools/tests/test_line_rasterizer.cpp
@@ -223,5 +223,20 @@ int main() {
     assertPaddingUntouched(polyline);
   }
 
+
+  {
+    constexpr uint8_t ALPHA = 0xFF;
+    constexpr uint32_t ALPHA_STRIDE = 43;
+    std::vector<uint8_t> alpha(ALPHA_STRIDE * HEIGHT, 0);
+    line_rasterizer::drawFilledLine(
+        alpha.data(), WIDTH, HEIGHT, ALPHA_STRIDE, 3, 8, 34, 27, ALPHA, 5);
+    assert(alpha[8 * ALPHA_STRIDE + 3] == ALPHA);
+    assert(alpha[27 * ALPHA_STRIDE + 34] == ALPHA);
+    for (int32_t y = 0; y < HEIGHT; ++y) {
+      for (uint32_t x = WIDTH; x < ALPHA_STRIDE; ++x)
+        assert(alpha[y * ALPHA_STRIDE + x] == 0);
+    }
+  }
+
   return 0;
 }

--- a/esp32/tools/tests/test_map_building_admission.cpp
+++ b/esp32/tools/tests/test_map_building_admission.cpp
@@ -1,0 +1,118 @@
+#include "../../lib/maps/src/mapBuildingAdmission.hpp"
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <vector>
+
+namespace {
+
+std::vector<map_building_admission::Candidate> fixture() {
+  using namespace map_building_admission;
+  return {
+      {{25.0, 0, 0, 2}, 20, 100, true, 2},
+      {{1.0, 1, 0, 7}, 20, 100, true, 7},
+      {{9.0, -1, 0, 4}, 20, 100, true, 4},
+      {{4.0, 0, 1, 3}, 20, 100, false, 3},
+      {{16.0, 0, -1, 5}, 20, 100, true, 5},
+  };
+}
+
+std::vector<map_building_admission::Decision>
+sortedDecisions(std::vector<map_building_admission::Decision> decisions) {
+  std::sort(decisions.begin(), decisions.end(), [](const auto &a, const auto &b) {
+    return a.sourceIndex < b.sourceIndex;
+  });
+  return decisions;
+}
+
+} // namespace
+
+
+static void testBoundedNearestRetentionIsOrderIndependent() {
+  using namespace map_building_admission;
+  std::vector<Candidate> forward;
+  std::vector<Candidate> reverse;
+  std::vector<Candidate> input;
+  for (size_t index = 0; index < 20; ++index) {
+    Candidate candidate;
+    candidate.key = {static_cast<double>((index * 7) % 20),
+                     static_cast<int32_t>(index % 3),
+                     static_cast<int32_t>(index % 5),
+                     static_cast<uint32_t>(index)};
+    candidate.sourceIndex = index;
+    input.push_back(candidate);
+  }
+  for (const auto &candidate : input)
+    retainNearest(forward, candidate, 6);
+  for (auto item = input.rbegin(); item != input.rend(); ++item)
+    retainNearest(reverse, *item, 6);
+  const auto byKey = [](const Candidate &left, const Candidate &right) {
+    return nearer(left.key, right.key);
+  };
+  std::sort(forward.begin(), forward.end(), byKey);
+  std::sort(reverse.begin(), reverse.end(), byKey);
+  assert(forward.size() == 6);
+  assert(reverse.size() == 6);
+  for (size_t index = 0; index < forward.size(); ++index) {
+    assert(forward[index].key.distanceSquared ==
+           reverse[index].key.distanceSquared);
+    assert(forward[index].key.recordIndex == reverse[index].key.recordIndex);
+  }
+}
+
+int main() {
+  testBoundedNearestRetentionIsOrderIndependent();
+  using namespace map_building_admission;
+  Quotas quotas;
+  quotas.maximumRecords = 3;
+  quotas.maximumPoints = 60;
+  quotas.maximumProjectedPixels = 300;
+  quotas.maximumExtrudedRecords = 1;
+  quotas.maximumExtrudedPoints = 20;
+  quotas.maximumExtrudedPixels = 100;
+
+  Diagnostics diagnostics;
+  const auto expected = sortedDecisions(select(fixture(), quotas, &diagnostics));
+  assert(diagnostics.candidates == 5);
+  assert(diagnostics.selected == 3);
+  assert(diagnostics.extruded == 1);
+  assert(diagnostics.flat == 2);
+  assert(diagnostics.deferred == 2);
+
+  // Every cache/block traversal permutation yields exactly the same spatial
+  // admission and deterministic 3D-to-flat degradation.
+  auto permuted = fixture();
+  std::sort(permuted.begin(), permuted.end(), [](const auto &left,
+                                                  const auto &right) {
+    return left.sourceIndex < right.sourceIndex;
+  });
+  do {
+    const auto actual = sortedDecisions(select(permuted, quotas));
+    assert(expected.size() == actual.size());
+    for (size_t i = 0; i < expected.size(); ++i) {
+      assert(expected[i].sourceIndex == actual[i].sourceIndex);
+      assert(expected[i].admitted == actual[i].admitted);
+      assert(expected[i].extruded == actual[i].extruded);
+    }
+  } while (std::next_permutation(
+      permuted.begin(), permuted.end(), [](const auto &left,
+                                           const auto &right) {
+        return left.sourceIndex < right.sourceIndex;
+      }));
+
+  // Nearest records survive overflow.  The nearest eligible record is 3D;
+  // the next two remain ordinary flat buildings instead of disappearing.
+  auto bySource = expected;
+  const auto find = [&](size_t source) -> const Decision & {
+    return *std::find_if(bySource.begin(), bySource.end(), [&](const auto &d) {
+      return d.sourceIndex == source;
+    });
+  };
+  assert(find(7).admitted && find(7).extruded);
+  assert(find(3).admitted && !find(3).extruded);
+  assert(find(4).admitted && !find(4).extruded);
+  assert(!find(5).admitted);
+  assert(!find(2).admitted);
+  return 0;
+}

--- a/esp32/tools/tests/test_map_building_renderer.cpp
+++ b/esp32/tools/tests/test_map_building_renderer.cpp
@@ -420,13 +420,13 @@ void assertInterruptionPropagates() {
   assert(!completed);
   assert(emitted == 1);
 
-  size_t deadlineChecks = 0;
-  const bool deadlineCompleted = map_building_renderer::renderSurfaces(
+  size_t cancellationChecks = 0;
+  const bool cancelled = map_building_renderer::renderSurfaces(
       building, 100000, 200000, 1.0, projection, true,
       [](Surface, const auto &) { return true; }, nullptr,
-      [&]() { return ++deadlineChecks >= 2; });
-  assert(!deadlineCompleted);
-  assert(deadlineChecks >= 2);
+      [&]() { return ++cancellationChecks >= 2; });
+  assert(!cancelled);
+  assert(cancellationChecks >= 2);
 }
 
 void assertAllocationFailureFailsClosed() {
@@ -443,16 +443,6 @@ void assertAllocationFailureFailsClosed() {
   assert(successful);
   assert(!allocationFailureObserved);
 
-  assert(map_building_renderer::shouldRetryWithoutBuildings(false, true, false,
-                                                             false));
-  assert(map_building_renderer::shouldRetryWithoutBuildings(false, false, true,
-                                                             false));
-  assert(!map_building_renderer::shouldRetryWithoutBuildings(true, true, false,
-                                                              false));
-  assert(!map_building_renderer::shouldRetryWithoutBuildings(false, true, false,
-                                                              true));
-  assert(!map_building_renderer::shouldRetryWithoutBuildings(
-      false, false, false, false));
 }
 
 void assertFailureRetryCooldown() {

--- a/esp32/tools/tests/test_map_building_workspace.cpp
+++ b/esp32/tools/tests/test_map_building_workspace.cpp
@@ -1,0 +1,45 @@
+#include "../../lib/maps/src/mapBuildingWorkspace.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <vector>
+
+namespace {
+struct Point {
+  int32_t x;
+  int32_t y;
+};
+}
+
+int main() {
+  constexpr int width = 12;
+  constexpr int height = 10;
+  std::vector<uint16_t> frame(width * height);
+  for (size_t index = 0; index < frame.size(); ++index)
+    frame[index] = static_cast<uint16_t>(index);
+  map_surface::Rgb565Surface surface{frame.data(), width, height, width};
+  const std::vector<Point> polygon{{3, 2}, {9, 2}, {9, 7}, {3, 7}};
+  const auto region = map_building_workspace::clippedRegion(
+      polygon, width, height);
+  assert(region.x == 3 && region.y == 2);
+  assert(region.width == 7 && region.height == 6);
+  assert(region.pixels() < frame.size());
+
+  std::vector<uint16_t> snapshot;
+  assert(map_building_workspace::captureRegion(surface, region, snapshot,
+                                                region.pixels()));
+  for (int y = region.y; y < region.y + region.height; ++y)
+    for (int x = region.x; x < region.x + region.width; ++x)
+      frame[static_cast<size_t>(y) * width + x] = 0xffff;
+
+  std::vector<int32_t> nodes;
+  assert(map_building_workspace::restorePolygon(
+      polygon, surface, region, snapshot, nodes, [] { return false; }));
+  assert(frame[3 * width + 4] == static_cast<uint16_t>(3 * width + 4));
+  assert(frame[1 * width + 4] == static_cast<uint16_t>(1 * width + 4));
+
+  std::vector<uint16_t> rejected;
+  assert(!map_building_workspace::captureRegion(surface, region, rejected,
+                                                 region.pixels() - 1));
+  return 0;
+}

--- a/esp32/tools/tests/test_map_building_workspace.cpp
+++ b/esp32/tools/tests/test_map_building_workspace.cpp
@@ -12,6 +12,11 @@ struct Point {
 }
 
 int main() {
+  using map_building_workspace::CourtyardPolicy;
+  assert(map_building_workspace::courtyardPolicy(180000, 180000, 658 * 658) ==
+         CourtyardPolicy::PreserveUnderlay);
+  assert(map_building_workspace::courtyardPolicy(180001, 180000, 658 * 658) ==
+         CourtyardPolicy::SolidRoofFallback);
   constexpr int width = 12;
   constexpr int height = 10;
   std::vector<uint16_t> frame(width * height);

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -21,6 +21,7 @@ ROUTE_SOURCE = (
 LVGL_SETUP_SOURCE = (
     ESP32_ROOT / "lib" / "lvgl" / "src" / "lvglSetup.cpp"
 ).read_text(encoding="utf-8")
+MAIN_SOURCE = (ESP32_ROOT / "src" / "main.cpp").read_text(encoding="utf-8")
 
 
 def function_body(source: str, signature: str) -> str:
@@ -95,6 +96,10 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("std::swap(bufMapScreenSize, bufMapTempSize)", publish)
         self.assertIn("lv_canvas_set_buffer(canvasMap, bufMapScreen", publish)
         self.assertIn("lv_obj_clear_flag(canvasMap, LV_OBJ_FLAG_HIDDEN)", publish)
+        self.assertLess(
+            publish.index("frameCoversViewport"),
+            publish.index("std::swap(bufMapScreen, bufMapTemp)"),
+        )
 
     def test_live_route_and_marker_share_presented_frame_transform(self):
         foreground = function_body(MAP_RENDERER_SOURCE, "void Maps::renderLiveForeground")
@@ -105,12 +110,38 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("RoutePresentationTransform presentation", foreground)
         self.assertIn("visibleRenderResult.overscanPixels", foreground)
         self.assertIn("presentedPose", foreground)
+        self.assertLess(
+            foreground.index("!route.hasRoute()"),
+            foreground.index("surface.clearAlpha()"),
+        )
+        self.assertLess(
+            foreground.index(
+                "presentationSignature == lastForegroundPresentationSignature"
+            ),
+            foreground.index("surface.clearAlpha()"),
+        )
+        self.assertLess(
+            frame.index("presentationSignature == lastFramePresentationSignature"),
+            frame.index("lv_image_set_pivot"),
+        )
+        self.assertIn("transformAlreadyApplied", frame)
         self.assertIn("presentFramePoint", marker)
         self.assertIn("visibleRenderResult.overscanPixels", marker)
         self.assertIn("lv_image_set_pivot", frame)
         self.assertIn("screenAnchorX", frame)
         self.assertIn("rotationDelta", frame)
+        self.assertGreaterEqual(frame.count("frameCoversViewport"), 2)
+        self.assertIn("visibleCoversPose", frame)
+        self.assertIn("latestCoversPose", frame)
+        self.assertNotIn("latestDx < available", frame)
         self.assertIn("map_presentation::presentFramePoint", ROUTE_SOURCE)
+        self.assertIn("markerRotationDegrees", marker)
+        self.assertIn("navigationActive &&", marker)
+        self.assertIn("!presentedPose.headingValid", marker)
+        navigation_marker = function_body(
+            MAP_RENDERER_SOURCE, "static void drawNavigationMarker"
+        )
+        self.assertIn("rotatedMarkerPoint", navigation_marker)
 
     def test_guidance_session_accepts_route_or_maneuver_packets(self):
         navigation_signature = function_body(
@@ -121,6 +152,65 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("routeActive || maneuverActive", pose)
         self.assertIn("headingResolver.resolve", pose)
         self.assertIn("gps.gpsData.heading < 360U", pose)
+        semantics = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::invalidateRenderSemantics"
+        )
+        self.assertNotIn("routeOverlay.revision()", semantics)
+        self.assertIn("posePresenter.resetHeading(nowMs)", semantics)
+
+    def test_live_presentation_does_not_overwrite_gesture_transforms(self):
+        service = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::serviceRenderPipeline"
+        )
+        marker = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::updatePositionOverlay"
+        )
+        drag = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::beginDragPreview"
+        )
+        pinch = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::beginPinchPreview"
+        )
+        self.assertIn("gestureActive ? false : publishReadyFrame", service)
+        self.assertIn("settlementPending && !published", service)
+        self.assertIn("presentationGestureOwnsTransforms", marker)
+        self.assertIn("LV_OBJ_FLAG_HIDDEN", drag)
+        self.assertIn("LV_OBJ_FLAG_HIDDEN", pinch)
+        drag_reset = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::resetDragPresentationVisuals"
+        )
+        pinch_reset = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::resetPinchPresentationVisuals"
+        )
+        for reset in (drag_reset, pinch_reset):
+            self.assertIn("lastFramePresentationSignature = 0", reset)
+            self.assertIn("lastForegroundPresentationSignature = 0", reset)
+        pinch_completion = function_body(
+            MAP_RENDERER_SOURCE,
+            "static void completePinchCanvasSettlement",
+        )
+        self.assertIn("lv_image_set_scale", pinch_completion)
+        self.assertNotIn("lv_image_set_pivot", pinch_completion)
+
+    def test_course_up_scheduler_honors_legacy_heading_negotiation(self):
+        heading = function_body(
+            MAIN_SCREEN_SOURCE,
+            "static bool currentCourseUpHeading(uint16_t &headingDegrees) {",
+        )
+        prepare = function_body(
+            MAIN_SCREEN_SOURCE, "static bool prepareVisibleMapUpdate"
+        )
+        self.assertIn("supportsExplicitInvalidGpsHeading", heading)
+        self.assertIn("routeOverlay.headingNear", heading)
+        self.assertLess(
+            heading.index("supportsExplicitInvalidGpsHeading"),
+            heading.index("gps.gpsData.headingValid"),
+        )
+        self.assertIn(
+            "uiChangeTracker.take(ui_update_policy::Source::Route)", prepare
+        )
+        self.assertIn("if (gpsChanged || routeChanged)", prepare)
+        self.assertIn("mapRenderScheduler.observe(currentMapFix())", prepare)
 
     def test_idle_guidance_screen_keeps_birdseye_3d_enabled(self):
         capture = function_body(
@@ -128,6 +218,9 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         )
         render = function_body(
             MAP_RENDERER_SOURCE, "bool Maps::readVectorMap"
+        )
+        request = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::buildRenderRequest"
         )
         self.assertIn(
             "context.guidanceScreenActive = isMapGuidanceScreenActive()",
@@ -138,6 +231,17 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
             render,
         )
         self.assertIn("navigationSessionActive", capture)
+        self.assertIn(
+            "else if (!request.context.navigationSessionActive)", request
+        )
+        self.assertIn(
+            "visibleRenderResult.version.navigationEpoch ==",
+            request,
+        )
+        self.assertLess(
+            request.index("!request.context.navigationSessionActive"),
+            request.index("Course-up frame deferred"),
+        )
 
     def test_position_only_requests_do_not_cancel_active_render(self):
         job = (ESP32_ROOT / "lib" / "maps" / "src" / "mapRenderJob.hpp").read_text(
@@ -147,6 +251,14 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("state_ == State::Ready", job)
         self.assertIn("requestCancellation", job)
         self.assertIn("gMapRenderCancellationGeneration", MAP_RENDERER_SOURCE)
+        take = function_body(MAP_RENDERER_SOURCE, "bool Maps::takeWorkerRequest")
+        worker = function_body(MAP_RENDERER_SOURCE, "void Maps::renderWorkerLoop")
+        self.assertIn("request.cancellationGeneration", take)
+        self.assertIn("request.cancellationGeneration", worker)
+        current = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::renderRequestStillCurrent"
+        )
+        self.assertNotIn("routeRevision", current)
 
     def test_building_admission_is_spatial_bounded_and_allocation_only_fallback(self):
         render = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
@@ -158,16 +270,92 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("buildingAllocationFailed", render)
         self.assertIn('failure=allocation fallback=bounded-flat', render)
         self.assertIn('fallbackDiagnostics.allocationFallback = true', render)
+        self.assertIn("throw std::bad_alloc()", render)
+        self.assertIn("drewFootprint", render)
         self.assertNotIn("deadline", render.lower())
         self.assertNotIn("kMaximumBuildingRenderTimeMs", MAP_HEADER_SOURCE)
+        self.assertIn("CourtyardPolicy::SolidRoofFallback", render)
+        self.assertIn("const bool preserveCourtyards", render)
+        self.assertNotIn("++courtyardDeferred;\n          continue;", render)
+
+    def test_late_worker_exit_has_an_explicit_restart_handoff(self):
+        stop = function_body(MAP_RENDERER_SOURCE, "bool Maps::stopRenderWorker")
+        recover = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::recoverRenderWorkerIfNeeded"
+        )
+        service = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::serviceRenderPipeline"
+        )
+        self.assertIn("renderWorkerRestartAfterExit.store(true", stop)
+        self.assertIn("renderWorkerExited.load", recover)
+        self.assertIn("startRenderWorker()", recover)
+        self.assertIn("recoverRenderWorkerIfNeeded", service)
+
+        activation = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::requestVectorMapFolderActivation"
+        )
+        self.assertIn("renderWorkerRestartAfterExit.load", activation)
+        self.assertIn("recoverRenderWorkerIfNeeded", activation)
+
+    def test_runtime_map_probe_and_switch_are_worker_control_jobs(self):
+        loop = function_body(MAIN_SOURCE, "void loop()")
+        self.assertIn("requestVectorMapFolderActivation", loop)
+        self.assertIn("takeVectorMapFolderActivationResult", loop)
+        self.assertNotIn("probeVectorMapFolder(", loop)
+        self.assertNotIn("setVectorMapFolder(", loop)
+
+        control = function_body(
+            MAP_RENDERER_SOURCE,
+            "bool Maps::processPendingVectorMapActivation",
+        )
+        self.assertIn("probeVectorMapFolderOnStorageOwner", control)
+        self.assertIn("switchVectorMapFolderOnStorageOwner", control)
+        self.assertIn("gMapRenderControlOperation.store(true", control)
+        self.assertIn("gMapRenderControlOperation.store(false", control)
+        self.assertIn("WakeReason::Transfer", control)
+
+        cancellation = function_body(
+            MAP_RENDERER_SOURCE, "bool shouldCancelMapRenderWork"
+        )
+        self.assertIn("shouldCancelWorkerOperation", cancellation)
+
+        result = function_body(
+            MAP_RENDERER_SOURCE,
+            "bool Maps::takeVectorMapFolderActivationResult",
+        )
+        self.assertIn("if (result.loaded)", result)
+        self.assertIn("isPosMoved = true", result)
+        self.assertIn("redrawMap = true", result)
+
+    def test_runtime_map_activation_retries_transient_enqueue_failures(self):
+        loop = function_body(MAIN_SOURCE, "void loop()")
+        self.assertEqual(loop.count("requestVectorMapFolderActivation"), 1)
+        self.assertIn("pendingMapRendererActivation.rendererQueued = true", loop)
+        self.assertIn("kMapRendererActivationQueueTimeoutMs", loop)
+        self.assertIn("queueAttemptStartedMs", MAIN_SOURCE)
+        self.assertNotIn(
+            "acknowledgeActivatedMapRoot(activatedMapRoot, false)", loop
+        )
+
+    def test_initial_map_canvas_allocation_does_not_stop_control_worker(self):
+        create = function_body(MAP_RENDERER_SOURCE, "void Maps::createMapScrSprites")
+        self.assertIn("workerCanOwnFrameStorage", create)
+        self.assertIn("frameStorageMustMove && workerCanOwnFrameStorage", create)
 
     def test_route_is_not_baked_into_worker_base_frame(self):
         render = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
         worker = function_body(MAP_RENDERER_SOURCE, "void Maps::renderWorkerLoop")
         foreground = function_body(MAP_RENDERER_SOURCE, "void Maps::renderLiveForeground")
+        route_handler = function_body(
+            (ESP32_ROOT / "lib" / "ble_navigation" / "ble_navigation.cpp").read_text(
+                encoding="utf-8"
+            ),
+            "static void handleRouteGeometryPayload",
+        )
         self.assertNotIn("drawRoute", render)
         self.assertNotIn("drawSnapshot", worker)
         self.assertIn("RouteOverlay::drawSnapshot", foreground)
+        self.assertIn("hadRoute != routeOverlay.hasRoute()", route_handler)
 
     def test_main_screen_entry_defers_first_render_to_configured_screen(self):
         load = function_body(LVGL_SETUP_SOURCE, "void loadMainScreen")

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -143,6 +143,20 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         )
         self.assertIn("rotatedMarkerPoint", navigation_marker)
 
+    def test_overscan_canvas_position_uses_center_aligned_offset(self):
+        frame = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::updatePresentedFrameTransform"
+        )
+        self.assertIn("centerAlignedOffsetForPoint", frame)
+        self.assertNotIn(
+            "const int16_t targetX = viewportOriginX + screenAnchorX - pivotX",
+            frame,
+        )
+        self.assertNotIn(
+            "const int16_t targetY = viewportOriginY + screenAnchorY - pivotY",
+            frame,
+        )
+
     def test_guidance_session_accepts_route_or_maneuver_packets(self):
         navigation_signature = function_body(
             MAP_RENDERER_SOURCE, "uint64_t Maps::navigationSignature"

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import re
 import unittest
 
 
@@ -9,6 +8,15 @@ MAIN_SCREEN_SOURCE = (
 ).read_text(encoding="utf-8")
 MAP_RENDERER_SOURCE = (
     ESP32_ROOT / "lib" / "maps" / "src" / "maps.cpp"
+).read_text(encoding="utf-8")
+MAP_HEADER_SOURCE = (
+    ESP32_ROOT / "lib" / "maps" / "src" / "maps.hpp"
+).read_text(encoding="utf-8")
+BUILDING_ADMISSION_SOURCE = (
+    ESP32_ROOT / "lib" / "maps" / "src" / "mapBuildingAdmission.hpp"
+).read_text(encoding="utf-8")
+ROUTE_SOURCE = (
+    ESP32_ROOT / "lib" / "route_overlay" / "route_overlay.cpp"
 ).read_text(encoding="utf-8")
 LVGL_SETUP_SOURCE = (
     ESP32_ROOT / "lib" / "lvgl" / "src" / "lvglSetup.cpp"
@@ -30,184 +38,144 @@ def function_body(source: str, signature: str) -> str:
 
 
 class MapGuidanceIntegrationTests(unittest.TestCase):
-    def test_birds_eye_activation_does_not_require_a_route(self):
-        match = re.search(
-            r"const bool birdsEyeActive\s*=\s*(.*?);",
-            function_body(MAP_RENDERER_SOURCE, "bool Maps::generateVectorMap"),
-            re.DOTALL,
-        )
-        self.assertIsNotNone(match)
-        expression = match.group(1)
-        self.assertIn("usesMapGuidanceBirdsEye", expression)
-        self.assertIn("isMapGuidanceScreenActive()", expression)
-        self.assertIn("mapNavigationBirdsEyeEnabled", expression)
-        self.assertNotIn("hasRoute", expression)
+    """Supplemental wiring guards; behavioral contracts live in C++ tests."""
 
-    def test_map_guidance_owns_no_destination_picker(self):
-        self.assertNotIn("mapGuidanceDestinationPicker", MAIN_SCREEN_SOURCE)
-        overlay_body = function_body(
-            MAIN_SCREEN_SOURCE, "static void createMapGuidanceOverlay"
+    def test_ui_submission_path_contains_no_storage_or_raster_work(self):
+        generate = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::generateVectorMap"
         )
-        self.assertNotIn("createDestinationPickerContainer", overlay_body)
-        self.assertIn("mapGuidanceArrow =", overlay_body)
-        self.assertIn("mapGuidanceDistance =", overlay_body)
+        self.assertIn("buildRenderRequest", generate)
+        self.assertIn("submitRenderRequest", generate)
+        for forbidden in (
+            "getMapBlocks",
+            "readVectorMap",
+            "readMapBlock",
+            "fillPolygon",
+            "renderSurfaces",
+            "lv_canvas_set_buffer",
+        ):
+            self.assertNotIn(forbidden, generate)
 
-    def test_map_guidance_overlay_is_navigation_data_gated(self):
-        update_body = function_body(
-            MAIN_SCREEN_SOURCE, "static void updateMapGuidanceOverlay() {"
-        )
-        reveal_body = function_body(
-            MAIN_SCREEN_SOURCE, "static void revealPendingMapTileIfReady() {"
-        )
-        self.assertIn(
-            "if (navigation_content_mode::hidesMapGuidanceOverlay("
-            "hasNavigationData))",
-            update_body,
-        )
-        self.assertIn(
-            "navigation_content_mode::showsMapGuidanceOverlay(\n"
-            "          hasCurrentNavigationData())",
-            reveal_body,
-        )
-        self.assertIn("setHiddenIfChanged(mapGuidanceOverlay, true)", update_body)
+        ui_tick = function_body(MAIN_SCREEN_SOURCE, "static bool prepareVisibleMapUpdate")
+        self.assertIn("serviceRenderPipeline", ui_tick)
+        self.assertIn("updatePositionOverlay", ui_tick)
+        self.assertNotIn("readVectorMap", ui_tick)
+        self.assertNotIn("getMapBlocks", ui_tick)
 
-    def test_building_extrusion_uses_complete_map_guidance_gate(self):
-        match = re.search(
-            r"bool extrudeBuildings\s*=\s*(.*?);",
-            MAP_RENDERER_SOURCE,
-            re.DOTALL,
-        )
-        self.assertIsNotNone(match)
-        expression = match.group(1)
-        self.assertIn("extrudesMapGuidanceBuildings", expression)
-        self.assertIn("buildingsVisible", expression)
-        self.assertIn("mapNavigationActive", expression)
-        self.assertIn("projection.isBirdsEye()", expression)
-        self.assertIn("mapNavigation3DBuildingsEnabled", expression)
-        self.assertNotIn("hasRoute", expression)
+    def test_worker_owns_block_io_and_raw_back_buffer_only(self):
+        worker = function_body(MAP_RENDERER_SOURCE, "void Maps::renderWorkerLoop")
+        self.assertIn("getMapBlocks", worker)
+        self.assertIn("readVectorMap", worker)
+        self.assertIn("map_surface::Rgb565Surface target", worker)
+        self.assertIn("bufMapTemp", worker)
+        self.assertIn("shouldCancelMapRenderWork", worker)
+        self.assertNotIn("lv_canvas_set_buffer", worker)
+        self.assertNotIn("lv_obj_", worker)
+        self.assertNotIn("lv_img_", worker)
 
-    def test_dense_scene_selection_uses_shared_nearest_first_policy(self):
-        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
-        self.assertIn(
-            "map_building_renderer::selectNearestForExtrusion(\n"
-            "                    buildingQueue.rbegin(), buildingQueue.rend(),\n"
-            "                    shouldStopBuildingWork)",
-            render_body,
-        )
-        self.assertIn("item.extrude", render_body)
-        self.assertIn("buildingSelection.flatOverflow()", render_body)
-        self.assertIn("buildingSelection.recordLimitOverflow", render_body)
-        self.assertIn("buildingSelection.pointLimitOverflow", render_body)
+        raw_map = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
+        raw_labels = function_body(MAP_RENDERER_SOURCE, "bool Maps::drawStreetLabels")
+        for raw_path in (raw_map, raw_labels):
+            self.assertNotIn("lv_", raw_path)
+            self.assertNotIn("canvas", raw_path.lower())
 
-    def test_total_building_work_is_bounded_before_surface_rendering(self):
-        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
-        self.assertIn(
-            "buildingRecords=%u buildingRings=%u", MAP_RENDERER_SOURCE
-        )
-        self.assertIn(
-            "buildingPoints=%u heightExplicit=%u", MAP_RENDERER_SOURCE
-        )
-        self.assertIn("kMaximumRenderedBuildingPointsPerRecord", render_body)
-        self.assertIn("kMaximumRenderedBuildingRecords", render_body)
-        self.assertIn("retainNearestCandidate", render_body)
-        self.assertIn("selectNearestForRendering", render_body)
-        self.assertIn("kMaximumBuildingRenderTimeMs", render_body)
+    def test_publication_rejects_stale_frame_then_swaps_complete_buffers(self):
+        publish = function_body(MAP_RENDERER_SOURCE, "bool Maps::publishReadyFrame")
         self.assertLess(
-            render_body.index("const uint32_t buildingPassStartMs"),
-            render_body.index("for (MapBlock *block : memCache.blocks)"),
+            publish.index("renderResultStillCurrent"),
+            publish.index("std::swap(bufMapScreen, bufMapTemp)"),
         )
-        self.assertIn("projectedFootprintAreaPixels", render_body)
-        self.assertIn("if (mayExtrude && extrusionZoomEligible)", render_body)
-        self.assertIn("shouldStopBuildingWork", render_body)
-        self.assertIn("eligibleExtrusionZoom(zoom)", render_body)
-        self.assertIn("deadlineExceeded=%u", render_body)
-        self.assertIn("prepassDeadlineExceeded=%u", render_body)
-        self.assertIn("wallCandidates=%llu", render_body)
-        self.assertIn("generatedWallFaces=%llu", render_body)
-        self.assertIn("suppressedWallFaces=%llu", render_body)
-        self.assertIn("parsedRecords=%u parsedRings=%u", render_body)
-        self.assertIn("parsedPoints=%u heightExplicit=%u", render_body)
-        self.assertIn("heightClassDefault=%u", render_body)
-        self.assertIn("psramLargest=%u", render_body)
-        self.assertIn("if (!item.render)", render_body)
+        self.assertIn("rejectReadyAsStale", publish)
+        current = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::renderRequestStillCurrent"
+        )
+        self.assertIn("request.version.navigationEpoch == navigationEpoch", current)
+        self.assertIn("request.version.styleEpoch == styleEpoch", current)
+        self.assertIn("request.version.projectionEpoch == projectionEpoch", current)
+        self.assertIn("std::swap(bufMapScreenSize, bufMapTempSize)", publish)
+        self.assertIn("lv_canvas_set_buffer(canvasMap, bufMapScreen", publish)
+        self.assertIn("lv_obj_clear_flag(canvasMap, LV_OBJ_FLAG_HIDDEN)", publish)
 
-    def test_ground_roads_render_once_before_buildings(self):
-        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
-        self.assertEqual(render_body.count("for (const auto &line :"), 1)
-        self.assertLess(
-            render_body.index("////// Lines"),
-            render_body.index(
-                "buildingPassPhase = BuildingPassPhase::Draw;"
-            ),
+    def test_live_route_and_marker_share_presented_frame_transform(self):
+        foreground = function_body(MAP_RENDERER_SOURCE, "void Maps::renderLiveForeground")
+        marker = function_body(MAP_RENDERER_SOURCE, "void Maps::updatePositionOverlay")
+        frame = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::updatePresentedFrameTransform"
         )
-        self.assertNotIn(
-            "roads once above them",
-            render_body,
-        )
+        self.assertIn("RoutePresentationTransform presentation", foreground)
+        self.assertIn("visibleRenderResult.overscanPixels", foreground)
+        self.assertIn("presentedPose", foreground)
+        self.assertIn("presentFramePoint", marker)
+        self.assertIn("visibleRenderResult.overscanPixels", marker)
+        self.assertIn("lv_image_set_pivot", frame)
+        self.assertIn("screenAnchorX", frame)
+        self.assertIn("rotationDelta", frame)
+        self.assertIn("map_presentation::presentFramePoint", ROUTE_SOURCE)
 
-    def test_navigation_route_remains_above_completed_map(self):
-        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::generateVectorMap")
-        self.assertLess(
-            render_body.index("Maps::readVectorMap("),
-            render_body.index("routeOverlay.drawRoute("),
+    def test_guidance_session_accepts_route_or_maneuver_packets(self):
+        navigation_signature = function_body(
+            MAP_RENDERER_SOURCE, "uint64_t Maps::navigationSignature"
         )
+        pose = function_body(MAP_RENDERER_SOURCE, "void Maps::updatePresentedPose")
+        self.assertIn("routeOverlay.hasRoute() || hasCurrentNavigationData()", navigation_signature)
+        self.assertIn("routeActive || maneuverActive", pose)
+        self.assertIn("headingResolver.resolve", pose)
+        self.assertIn("gps.gpsData.heading < 360U", pose)
 
-    def test_building_deadline_and_allocation_failures_discard_scratch_frame(self):
-        render_body = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
-        self.assertIn("runAllocationSafe", render_body)
-        self.assertIn("buildingAllocationFailed", render_body)
-        self.assertIn("buildingDeadlineAborted", render_body)
-        self.assertIn('reason=%s', render_body)
-        self.assertIn('"allocation"', render_body)
-        self.assertIn('"deadline"', render_body)
-        self.assertIn('fallback=buildings-hidden', render_body)
-        self.assertIn("renderTimeOverflowTotal=%llu", render_body)
-        self.assertIn("projectionMs=%lu sortMs=%lu buildingDrawMs=%lu", render_body)
-        self.assertIn("psramUsed=%u psramFree=%u", render_body)
-        self.assertIn("shouldRetryWithoutBuildings", render_body)
-        self.assertIn("buildingFailureRetryCooldown.recordFailure", render_body)
-        self.assertIn("psramSamplePostCleanup", render_body)
-        self.assertGreaterEqual(render_body.count("releaseBuildingFailureWorkspace();"), 2)
-        self.assertLess(
-            render_body.rindex("releaseBuildingFailureWorkspace();"),
-            render_body.index("drawStreetLabels"),
+    def test_idle_guidance_screen_keeps_birdseye_3d_enabled(self):
+        capture = function_body(
+            MAP_RENDERER_SOURCE, "Maps::RenderContext Maps::captureRenderContext"
+        )
+        render = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::readVectorMap"
         )
         self.assertIn(
-            "projection, drawLabels, true)",
-            render_body,
+            "context.guidanceScreenActive = isMapGuidanceScreenActive()",
+            capture,
         )
-        self.assertRegex(
-            render_body,
-            r"if\s*\(\s*map_building_renderer::shouldRetryWithoutBuildings\("
-            r"\s*buildingsSuppressed,\s*buildingAllocationFailed,"
-            r"\s*buildingDeadlineAborted,\s*screenCycleInterrupted\s*\)\s*\)"
-            r"\s*\{\s*return\s+Maps::readVectorMap\("
-            r"\s*viewPort,\s*memCache,\s*canvas,\s*zoom,\s*rotation,"
-            r"\s*projection,\s*drawLabels,\s*true\s*\);\s*\}",
+        self.assertIn(
+            "buildingsVisible, context.guidanceScreenActive",
+            render,
         )
-        self.assertRegex(
-            render_body,
-            r"if \(!buildingPassCompleted\)\s*\{[\s\S]*?return false;\s*\}",
-        )
+        self.assertIn("navigationSessionActive", capture)
 
-    def test_navigation_screen_retains_destination_picker(self):
-        create_body = function_body(MAIN_SCREEN_SOURCE, "void createMainScr")
-        update_body = function_body(MAIN_SCREEN_SOURCE, "void updateNavEvent")
-        self.assertIn(
-            "createDestinationPickerContainer(navTile)", create_body
+    def test_position_only_requests_do_not_cancel_active_render(self):
+        job = (ESP32_ROOT / "lib" / "maps" / "src" / "mapRenderJob.hpp").read_text(
+            encoding="utf-8"
         )
-        self.assertIn(
-            "renderDestinationPicker(navigationDestinationPicker)", update_body
-        )
+        self.assertIn("Version::sameFrame(active_, latest_)", job)
+        self.assertIn("state_ == State::Ready", job)
+        self.assertIn("requestCancellation", job)
+        self.assertIn("gMapRenderCancellationGeneration", MAP_RENDERER_SOURCE)
+
+    def test_building_admission_is_spatial_bounded_and_allocation_only_fallback(self):
+        render = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
+        self.assertIn("map_building_admission::retainNearest", render)
+        self.assertIn("map_building_admission::select", render)
+        self.assertIn("const map_building_admission::Quotas quotas", render)
+        self.assertIn("maximumExtrudedRecords", BUILDING_ADMISSION_SOURCE)
+        self.assertIn("admissionDiagnostics.flat", render)
+        self.assertIn("buildingAllocationFailed", render)
+        self.assertIn('failure=allocation fallback=bounded-flat', render)
+        self.assertIn('fallbackDiagnostics.allocationFallback = true', render)
+        self.assertNotIn("deadline", render.lower())
+        self.assertNotIn("kMaximumBuildingRenderTimeMs", MAP_HEADER_SOURCE)
+
+    def test_route_is_not_baked_into_worker_base_frame(self):
+        render = function_body(MAP_RENDERER_SOURCE, "bool Maps::readVectorMap")
+        worker = function_body(MAP_RENDERER_SOURCE, "void Maps::renderWorkerLoop")
+        foreground = function_body(MAP_RENDERER_SOURCE, "void Maps::renderLiveForeground")
+        self.assertNotIn("drawRoute", render)
+        self.assertNotIn("drawSnapshot", worker)
+        self.assertIn("RouteOverlay::drawSnapshot", foreground)
 
     def test_main_screen_entry_defers_first_render_to_configured_screen(self):
-        load_body = function_body(LVGL_SETUP_SOURCE, "void loadMainScreen")
-        self.assertEqual(load_body.count("main_screen_entry_policy::enter("), 1)
-        self.assertEqual(load_body.count("showConfiguredDefaultMainScreen()"), 1)
-        self.assertNotIn("generateVectorMap", load_body)
-        self.assertNotIn("generateRenderMap", load_body)
-        self.assertNotIn("displayMap", load_body)
-        self.assertNotRegex(load_body, r"\bzoom\s*=\s*\d+")
+        load = function_body(LVGL_SETUP_SOURCE, "void loadMainScreen")
+        self.assertEqual(load.count("main_screen_entry_policy::enter("), 1)
+        self.assertEqual(load.count("showConfiguredDefaultMainScreen()"), 1)
+        self.assertNotIn("generateVectorMap", load)
+        self.assertNotIn("generateRenderMap", load)
+        self.assertNotIn("displayMap", load)
 
 
 if __name__ == "__main__":

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -379,6 +379,23 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertNotIn("generateRenderMap", load)
         self.assertNotIn("displayMap", load)
 
+    def test_map_profile_transition_waits_for_new_frame_publication(self):
+        show = function_body(MAIN_SCREEN_SOURCE, "static void showMainTile")
+        self.assertNotIn("mapWasVisible", show)
+        self.assertLess(
+            show.index("lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN)"),
+            show.index("mapTileTransition.begin()"),
+        )
+
+        prepare = function_body(
+            MAIN_SCREEN_SOURCE, "static bool prepareVisibleMapUpdate"
+        )
+        self.assertIn("mapTileTransition.noteFramePublished()", prepare)
+        self.assertLess(
+            prepare.index("mapTileTransition.noteFramePublished()"),
+            prepare.index("revealPendingMapTileIfReady()"),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/esp32/tools/tests/test_map_pinch_zoom.cpp
+++ b/esp32/tools/tests/test_map_pinch_zoom.cpp
@@ -622,6 +622,17 @@ int main() {
          gui_layout::centeredViewportOrigin(466, 768) +
              gui_layout::mapAnchorY(768));
 
+  // LVGL preserves CENTER alignment after lv_obj_center(). Position setters
+  // therefore take an offset from the centered origin. A fresh overscanned
+  // frame whose projected rider is at its render anchor needs offset zero,
+  // not the raw -96 px top-left origin that would apply overscan twice.
+  assert(gui_layout::centerAlignedOffsetForPoint(466, 658, 329, 233) == 0);
+  assert(gui_layout::centerAlignedOffsetForPoint(466, 558, 300, 254) == 0);
+  // As the live rider advances within the finished frame, only the projected
+  // displacement becomes the aligned offset.
+  assert(gui_layout::centerAlignedOffsetForPoint(466, 658, 405, 233) == -76);
+  assert(gui_layout::centerAlignedOffsetForPoint(466, 558, 345, 254) == -45);
+
   const auto northUpCell = map_transform::canvasWorldBounds(
       {1000.0, 2000.0}, 192.0, 192.0, 5, 0.0);
   assertNear(northUpCell.min.x, 616.0);

--- a/esp32/tools/tests/test_map_presentation.cpp
+++ b/esp32/tools/tests/test_map_presentation.cpp
@@ -1,0 +1,100 @@
+#include "../../lib/maps/src/mapPresentation.hpp"
+
+#include <cassert>
+#include <cmath>
+
+int main() {
+  using namespace map_presentation;
+
+  assert(normalizeDegrees(-1.0) == 359.0);
+  assert(std::fabs(signedHeadingDelta(359.0, 1.0) - 2.0) < 1e-9);
+  assert(std::fabs(signedHeadingDelta(1.0, 359.0) + 2.0) < 1e-9);
+
+
+  // Base pixels, route geometry, and current-position markers share one affine
+  // transform: rotate around the old projected rider, then translate that
+  // pivot to the live viewport anchor (which has overscan removed).
+  const ScreenPoint pivot{196.0, 256.0};
+  const ScreenPoint anchor{100.0, 140.0};
+  const ScreenPoint pivotPresented =
+      presentFramePoint(pivot, pivot, anchor, kPi / 2.0);
+  assert(std::fabs(pivotPresented.x - anchor.x) < 1e-9);
+  assert(std::fabs(pivotPresented.y - anchor.y) < 1e-9);
+  const ScreenPoint eastOfPivot =
+      presentFramePoint({206.0, 256.0}, pivot, anchor, kPi / 2.0);
+  assert(std::fabs(eastOfPivot.x - 100.0) < 1e-9);
+  assert(std::fabs(eastOfPivot.y - 150.0) < 1e-9);
+  const ScreenPoint translatedOnly =
+      presentFramePoint({210.0, 260.0}, pivot, anchor, 0.0);
+  assert(std::fabs(translatedOnly.x - 114.0) < 1e-9);
+  assert(std::fabs(translatedOnly.y - 144.0) < 1e-9);
+
+  HeadingResolver resolver;
+  double heading = -1.0;
+  resolver.setNavigationSession(true, 7);
+  assert(resolver.resolve(true, 358.0, true, 90.0, heading));
+  assert(heading == 358.0);
+  assert(resolver.source() == HeadingResolver::Source::Measured);
+  assert(resolver.resolve(false, -1.0, true, 2.0, heading));
+  assert(heading == 2.0);
+  assert(resolver.source() == HeadingResolver::Source::Route);
+  assert(resolver.resolve(false, -1.0, false, 0.0, heading));
+  assert(heading == 2.0);
+  assert(resolver.source() == HeadingResolver::Source::Remembered);
+
+  // A mode/session epoch change cannot inherit a stale heading and silently
+  // turn an invalid course into north-up.
+  resolver.setNavigationSession(true, 8);
+  assert(!resolver.resolve(false, -1.0, false, 0.0, heading));
+  resolver.setNavigationSession(false, 9);
+  assert(!resolver.resolve(true, 0.0, true, 90.0, heading));
+
+  Presenter::Config config;
+  config.maximumPredictionMs = 1500;
+  config.convergenceMs = 0;
+  config.maximumPredictionMeters = 20;
+  Presenter presenter(config);
+  presenter.observe({{100.0, 200.0}, 90.0, true, 10.0, 1.0, 1000},
+                    1000);
+  PresentedPose afterHalfSecond = presenter.present(1500);
+  assert(std::fabs(afterHalfSecond.position.x - 105.0) < 1e-6);
+  assert(std::fabs(afterHalfSecond.position.y - 200.0) < 1e-6);
+  PresentedPose capped = presenter.present(9000);
+  assert(std::fabs(capped.position.x - 115.0) < 1e-6);
+  assert(capped.predictionAgeMs == 1500);
+
+  // The finite prediction limit is expressed in physical metres even though
+  // Web Mercator world coordinates stretch by sec(latitude).
+  Presenter scaled(config);
+  scaled.observe({{100.0, 200.0}, 90.0, true, 20.0, 2.0, 1000}, 1000);
+  const PresentedPose scaledCapped = scaled.present(9000);
+  // The 20 metre physical cap becomes 40 world units at this local scale.
+  assert(std::fabs(scaledCapped.position.x - 140.0) < 1e-6);
+
+  // A correction converges instead of leaving disconnected dead reckoning.
+  config.convergenceMs = 400;
+  Presenter converging(config);
+  converging.observe({{0.0, 0.0}, 359.0, true, 0.0, 1.0, 0}, 0);
+  converging.observe({{10.0, 0.0}, 1.0, true, 0.0, 1.0, 1000},
+                     1000);
+  const PresentedPose halfway = converging.present(1200);
+  assert(halfway.position.x > 0.0 && halfway.position.x < 10.0);
+  assert(halfway.headingDegrees < 2.0 || halfway.headingDegrees > 358.0);
+  const PresentedPose settled = converging.present(1400);
+  assert(std::fabs(settled.position.x - 10.0) < 1e-6);
+  assert(std::fabs(settled.headingDegrees - 1.0) < 1e-6);
+
+  // A fix without a course must preserve the last valid direction rather
+  // than treating its zero-initialized heading as north-up.
+  Presenter missingCourse(config);
+  missingCourse.observe({{0.0, 0.0}, 90.0, true, 0.0, 1.0, 0}, 0);
+  missingCourse.observe({{1.0, 0.0}, 0.0, false, 0.0, 1.0, 1000}, 1000);
+  const PresentedPose missingCoursePose = missingCourse.present(1400);
+  assert(missingCoursePose.headingValid);
+  assert(std::fabs(missingCoursePose.headingDegrees - 90.0) < 1e-6);
+
+  assert(std::fabs(refreshLeadPixels(10.0, 2.0, 1200, 16.0, 32.0, 96.0) -
+                   40.0) < 1e-9);
+  assert(refreshLeadPixels(100.0, 10.0, 5000, 16.0, 32.0, 96.0) == 96.0);
+  return 0;
+}

--- a/esp32/tools/tests/test_map_presentation.cpp
+++ b/esp32/tools/tests/test_map_presentation.cpp
@@ -9,6 +9,8 @@ int main() {
   assert(normalizeDegrees(-1.0) == 359.0);
   assert(std::fabs(signedHeadingDelta(359.0, 1.0) - 2.0) < 1e-9);
   assert(std::fabs(signedHeadingDelta(1.0, 359.0) + 2.0) < 1e-9);
+  assert(std::fabs(markerRotationDegrees(90.0, 0.0) - 90.0) < 1e-9);
+  assert(std::fabs(markerRotationDegrees(90.0, -kPi / 2.0)) < 1e-9);
 
 
   // Base pixels, route geometry, and current-position markers share one affine
@@ -28,6 +30,15 @@ int main() {
       presentFramePoint({210.0, 260.0}, pivot, anchor, 0.0);
   assert(std::fabs(translatedOnly.x - 114.0) < 1e-9);
   assert(std::fabs(translatedOnly.y - 144.0) < 1e-9);
+  assert(frameCoversViewport(658.0, 658.0, 466.0, 466.0,
+                             {329.0, 329.0}, {233.0, 233.0}, 0.0, 16.0));
+  assert(frameCoversViewport(658.0, 658.0, 466.0, 466.0,
+                             {405.0, 329.0}, {233.0, 233.0}, 0.0, 16.0));
+  assert(!frameCoversViewport(658.0, 658.0, 466.0, 466.0,
+                              {420.0, 329.0}, {233.0, 233.0}, 0.0, 16.0));
+  assert(!frameCoversViewport(658.0, 658.0, 466.0, 466.0,
+                              {329.0, 329.0}, {233.0, 233.0}, kPi / 4.0,
+                              16.0));
 
   HeadingResolver resolver;
   double heading = -1.0;
@@ -41,6 +52,12 @@ int main() {
   assert(resolver.resolve(false, -1.0, false, 0.0, heading));
   assert(heading == 2.0);
   assert(resolver.source() == HeadingResolver::Source::Remembered);
+
+  // Version-10 apps encoded a missing course as zero. New firmware detects
+  // that legacy negotiation and resolves route-first instead of facing north.
+  assert(resolver.resolve(true, 0.0, true, 90.0, heading, true));
+  assert(heading == 90.0);
+  assert(resolver.source() == HeadingResolver::Source::Route);
 
   // A mode/session epoch change cannot inherit a stale heading and silently
   // turn an invalid course into north-up.
@@ -92,6 +109,31 @@ int main() {
   const PresentedPose missingCoursePose = missingCourse.present(1400);
   assert(missingCoursePose.headingValid);
   assert(std::fabs(missingCoursePose.headingDegrees - 90.0) < 1e-6);
+  missingCourse.resetHeading(1500);
+  missingCourse.observe({{2.0, 0.0}, 0.0, false, 0.0, 1.0, 1500}, 1500);
+  const PresentedPose resetMissingCourse = missingCourse.present(1900);
+  assert(!resetMissingCourse.headingValid);
+  missingCourse.observe({{3.0, 0.0}, 180.0, true, 0.0, 1.0, 2000}, 2000);
+  const PresentedPose newEpochHeading = missingCourse.present(2400);
+  assert(newEpochHeading.headingValid);
+  assert(std::fabs(newEpochHeading.headingDegrees - 180.0) < 1e-6);
+
+  // Resetting a heading epoch freezes the currently presented prediction. It
+  // must not jump back to the raw fix before the replacement heading/fix can
+  // converge.
+  Presenter headingEpoch(config);
+  headingEpoch.observe({{0.0, 0.0}, 90.0, true, 10.0, 1.0, 0}, 0);
+  const PresentedPose predictedBeforeReset = headingEpoch.present(500);
+  assert(std::fabs(predictedBeforeReset.position.x - 5.0) < 1e-6);
+  headingEpoch.resetHeading(500);
+  const PresentedPose frozenAfterReset = headingEpoch.present(500);
+  assert(!frozenAfterReset.headingValid);
+  assert(std::fabs(frozenAfterReset.position.x -
+                   predictedBeforeReset.position.x) < 1e-6);
+  headingEpoch.observe({{0.0, 0.0}, 180.0, true, 0.0, 1.0, 500}, 500);
+  const PresentedPose resetConvergenceStart = headingEpoch.present(500);
+  assert(std::fabs(resetConvergenceStart.position.x -
+                   predictedBeforeReset.position.x) < 1e-6);
 
   assert(std::fabs(refreshLeadPixels(10.0, 2.0, 1200, 16.0, 32.0, 96.0) -
                    40.0) < 1e-9);

--- a/esp32/tools/tests/test_map_render_job.cpp
+++ b/esp32/tools/tests/test_map_render_job.cpp
@@ -1,0 +1,91 @@
+#include "../../lib/maps/src/mapRenderJob.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <initializer_list>
+
+int main() {
+  using namespace map_render_job;
+
+  LatestWins jobs;
+  Version first{1, 10, 20, 30, 40, 50};
+  assert(jobs.submit(first) == first);
+  assert(jobs.beginLatest());
+  assert(jobs.state() == State::Rendering);
+  assert(jobs.checkpoint() == StopReason::None);
+
+  // A newer route revision cancels the active frame at the next bounded unit.
+  Version second{2, 11, 20, 30, 40, 50};
+  jobs.submit(second);
+  assert(jobs.checkpoint() == StopReason::Superseded);
+  jobs.cancelActive();
+  assert(jobs.diagnostics().cancelled == 1);
+
+  assert(jobs.beginLatest());
+  for (uint32_t elapsed : {120U, 450U, 900U, 1500U})
+    jobs.noteSlice(elapsed, 2000);
+  assert(!jobs.sliceBudgetExceeded());
+  assert(jobs.completeActive());
+  assert(jobs.state() == State::Ready);
+
+  Version published;
+  assert(jobs.takeReady(published));
+  assert(published == second);
+  assert(jobs.diagnostics().published == 1);
+
+  // Position-only supersession must not cancel a complete overscanned frame:
+  // the UI can present it with the live pose while the newest request waits
+  // behind the ready-surface publication.
+  Version positionOne{8, 12, 22, 30, 40, 50};
+  jobs.submit(positionOne);
+  assert(jobs.beginLatest());
+  Version positionTwo{9, 12, 22, 30, 40, 50};
+  jobs.submit(positionTwo);
+  assert(jobs.checkpoint() == StopReason::None);
+  assert(jobs.completeActive());
+  assert(jobs.state() == State::Ready);
+  assert(!jobs.beginLatest());
+  assert(jobs.takeReady(published));
+  assert(published == positionOne);
+  assert(jobs.beginLatest());
+  jobs.cancelActive();
+
+  // Completion is not permission to publish: semantic state may change before
+  // the next UI tick.
+  Version third{3, 11, 21, 30, 40, 50};
+  jobs.submit(third);
+  assert(jobs.beginLatest());
+  assert(jobs.completeActive());
+  Version fourth{4, 11, 21, 31, 40, 50};
+  jobs.submit(fourth);
+  assert(!jobs.takeReady(published));
+  assert(jobs.diagnostics().stalePublications == 1);
+
+  assert(jobs.beginLatest());
+  assert(jobs.completeActive());
+  jobs.rejectReadyAsInvariant();
+  assert(jobs.state() == State::Idle);
+  assert(jobs.diagnostics().invariantFailures == 1);
+
+  assert(jobs.beginLatest());
+  jobs.noteSlice(2501, 2000);
+  assert(jobs.sliceBudgetExceeded());
+  assert(jobs.checkpoint(true) == StopReason::Shutdown);
+  jobs.cancelActive();
+
+  // Sequence generation remains monotonic even if a caller accidentally
+  // reuses an old number.
+  const Version normalized = jobs.submit({1, 0, 0, 0, 0, 0});
+  assert(normalized.sequence == 12);
+
+  // Screen recreation invalidates active work without resetting the sequence;
+  // a newly submitted request can never collide with the cancelled token.
+  assert(jobs.beginLatest());
+  const Version invalidated = jobs.invalidate();
+  assert(invalidated.sequence == 13);
+  assert(jobs.state() == State::Idle);
+  const Version afterRecreation = jobs.submit({1, 0, 0, 0, 0, 0});
+  assert(afterRecreation.sequence == 14);
+  assert(jobs.diagnostics().cancelled >= 3);
+  return 0;
+}

--- a/esp32/tools/tests/test_map_render_job.cpp
+++ b/esp32/tools/tests/test_map_render_job.cpp
@@ -7,6 +7,13 @@
 int main() {
   using namespace map_render_job;
 
+  assert(!cancellationRequested(7, 7));
+  assert(cancellationRequested(7, 8));
+  assert(!shouldCancelWorkerOperation(false, false, 7, 7));
+  assert(shouldCancelWorkerOperation(false, false, 7, 8));
+  assert(!shouldCancelWorkerOperation(false, true, 7, 8));
+  assert(shouldCancelWorkerOperation(true, true, 7, 7));
+
   LatestWins jobs;
   Version first{1, 10, 20, 30, 40, 50};
   assert(jobs.submit(first) == first);
@@ -14,14 +21,11 @@ int main() {
   assert(jobs.state() == State::Rendering);
   assert(jobs.checkpoint() == StopReason::None);
 
-  // A newer route revision cancels the active frame at the next bounded unit.
+  // A newer route window does not cancel the active base frame because route
+  // geometry is a live foreground input.
   Version second{2, 11, 20, 30, 40, 50};
   jobs.submit(second);
-  assert(jobs.checkpoint() == StopReason::Superseded);
-  jobs.cancelActive();
-  assert(jobs.diagnostics().cancelled == 1);
-
-  assert(jobs.beginLatest());
+  assert(jobs.checkpoint() == StopReason::None);
   for (uint32_t elapsed : {120U, 450U, 900U, 1500U})
     jobs.noteSlice(elapsed, 2000);
   assert(!jobs.sliceBudgetExceeded());
@@ -30,8 +34,12 @@ int main() {
 
   Version published;
   assert(jobs.takeReady(published));
-  assert(published == second);
+  assert(published == first);
   assert(jobs.diagnostics().published == 1);
+  assert(jobs.beginLatest());
+  assert(jobs.completeActive());
+  assert(jobs.takeReady(published));
+  assert(published == second);
 
   // Position-only supersession must not cancel a complete overscanned frame:
   // the UI can present it with the live pose while the newest request waits

--- a/esp32/tools/tests/test_map_render_policy.cpp
+++ b/esp32/tools/tests/test_map_render_policy.cpp
@@ -23,7 +23,7 @@ int main() {
   assert(headingDelta(5, 355) == 10);
   assert(headingDelta(20, 200) == 180);
 
-  const Fix origin{51.5007, -0.1246, 359};
+  const Fix origin{51.5007, -0.1246, 359, true};
   assert(std::fabs(distanceMeters(origin, northOf(origin, 10.0)) - 10.0) <
          0.1);
 
@@ -33,6 +33,9 @@ int main() {
   assert(first.render);
   assert((first.reasons & reasonMask(Reason::Position)) != 0);
   scheduler.commit(first);
+  scheduler.markSubmitted(100, origin);
+  // Accepted work is a request baseline, not proof of publication.
+  assert(!scheduler.hasPendingWork());
   scheduler.markRendered(100, origin);
 
   // Sub-threshold movement never schedules a render, even after the cadence.
@@ -51,7 +54,15 @@ int main() {
   assert(dueMove.render);
   assert((dueMove.reasons & reasonMask(Reason::Position)) != 0);
   scheduler.commit(dueMove);
+  scheduler.markSubmitted(850, moved);
   scheduler.markRendered(850, moved);
+
+  // Invalid course never becomes north or triggers a heading refresh.
+  Fix invalidCourse = moved;
+  invalidCourse.headingDegrees = 0;
+  invalidCourse.headingValid = false;
+  scheduler.observe(invalidCourse);
+  assert(!scheduler.evaluate(2000, true, true).render);
 
   // Stationary course noise stays below the heading threshold, including wrap.
   Fix noisy = moved;
@@ -65,6 +76,7 @@ int main() {
   assert(thresholdHeading.render);
   assert((thresholdHeading.reasons & reasonMask(Reason::Heading)) != 0);
   scheduler.commit(thresholdHeading);
+  scheduler.markSubmitted(2000, noisy);
   scheduler.markRendered(2000, noisy);
 
   // North-up ignores heading-only changes.
@@ -86,6 +98,7 @@ int main() {
   assert((forced.reasons & reasonMask(Reason::Route)) != 0);
   assert((forced.reasons & reasonMask(Reason::Style)) != 0);
   scheduler.commit(forced);
+  scheduler.markSubmitted(3001, pannedMovement);
   scheduler.markRendered(3001, pannedMovement);
 
   scheduler.request(Reason::Zoom);
@@ -135,6 +148,7 @@ int main() {
     const Decision decision = replay.evaluate(nowMs, true, true);
     if (decision.render) {
       replay.commit(decision);
+      replay.markSubmitted(nowMs, fix);
       replay.markRendered(nowMs, fix);
       replayRenders++;
     }

--- a/esp32/tools/tests/test_map_route_geometry.cpp
+++ b/esp32/tools/tests/test_map_route_geometry.cpp
@@ -1,0 +1,35 @@
+#include "../../lib/maps/src/mapRouteGeometry.hpp"
+
+#include <cassert>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+int main() {
+  using map_transform::WorldPoint;
+  const std::vector<WorldPoint> route = {
+      {0.0, 0.0}, {10.0, 0.0}, {20.0, 0.0}, {30.0, 10.0}};
+  const WorldPoint current{15.0, 2.0};
+  const auto match = map_route_geometry::closestSegment(
+      current, route.size(), [&](size_t index) { return route[index]; });
+  assert(match.valid);
+  assert(match.index == 1);
+  assert(std::fabs(match.fraction - 0.5) < 1e-9);
+  assert(std::fabs(match.projected.x - 15.0) < 1e-9);
+  assert(std::fabs(match.projected.y) < 1e-9);
+
+  std::vector<WorldPoint> anchored;
+  const size_t emitted = map_route_geometry::emitAnchored(
+      current, route.size(), [&](size_t index) { return route[index]; },
+      [&](WorldPoint point) { anchored.push_back(point); });
+  assert(emitted == 3);
+  assert(anchored.front().x == current.x && anchored.front().y == current.y);
+  assert(anchored[1].x == 20.0 && anchored[1].y == 0.0);
+  assert(anchored[2].x == 30.0 && anchored[2].y == 10.0);
+
+  assert(!map_route_geometry::closestSegment(
+              current, 1, [&](size_t index) { return route[index]; })
+              .valid);
+  std::cout << "map route geometry tests passed\n";
+  return 0;
+}

--- a/esp32/tools/tests/test_map_route_geometry.cpp
+++ b/esp32/tools/tests/test_map_route_geometry.cpp
@@ -22,10 +22,17 @@ int main() {
   const size_t emitted = map_route_geometry::emitAnchored(
       current, route.size(), [&](size_t index) { return route[index]; },
       [&](WorldPoint point) { anchored.push_back(point); });
-  assert(emitted == 3);
+  assert(emitted == 4);
   assert(anchored.front().x == current.x && anchored.front().y == current.y);
-  assert(anchored[1].x == 20.0 && anchored[1].y == 0.0);
-  assert(anchored[2].x == 30.0 && anchored[2].y == 10.0);
+  assert(std::fabs(anchored[1].x - 15.0) < 1e-9);
+  assert(std::fabs(anchored[1].y) < 1e-9);
+  assert(anchored[2].x == 20.0 && anchored[2].y == 0.0);
+
+  // A rider fix a few metres off the route must connect to the projected
+  // route position before following the route, rather than drawing a
+  // diagonal shortcut to the next vertex.
+  assert(anchored.size() == 4);
+  assert(anchored[3].x == 30.0 && anchored[3].y == 10.0);
 
   assert(!map_route_geometry::closestSegment(
               current, 1, [&](size_t index) { return route[index]; })

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -27,6 +27,7 @@ struct TestRideData {
   double latitude = 0;
   double longitude = 0;
   uint16_t heading = 0;
+  bool headingValid = false;
 };
 
 void writeUInt16LE(uint8_t *bytes, std::size_t offset, uint16_t value) {
@@ -1100,10 +1101,12 @@ int main() {
     assert(rideData.satellites == 10);
     if (length == 8) {
       assert(rideData.heading == 99);
+      assert(!rideData.headingValid);
       assert(rideData.speed == 0);
     }
     if (length >= 10) {
       assert(rideData.heading == 270);
+      assert(rideData.headingValid);
     }
     if (length == 30) {
       assert(rideData.speed == 44);
@@ -1114,6 +1117,21 @@ int main() {
       assert(rideData.routeRemaining == 4321);
     }
   }
+
+  writeUInt16LE(gpsPacket, 8, UINT16_MAX);
+  assert(gps_position_protocol::decode(gpsPacket, 10, decoded));
+  assert(!decoded.hasHeading);
+  TestRideData invalidHeadingRide{};
+  invalidHeadingRide.heading = 123;
+  invalidHeadingRide.headingValid = true;
+  assert(gps_position_protocol::decodeAndApply(
+      gpsPacket, 10, invalidHeadingRide, &decoded));
+  assert(!invalidHeadingRide.headingValid);
+  assert(invalidHeadingRide.heading == 123);
+
+  writeUInt16LE(gpsPacket, 8, 360);
+  assert(gps_position_protocol::decode(gpsPacket, 10, decoded));
+  assert(!decoded.hasHeading);
 
   return 0;
 }

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -149,7 +149,8 @@ enum DeviceBLEProtocol {
     static let birdsEyeMapNavigationPerspectiveCapabilityMask: UInt32 = 1 << 10
     static let birdsEyeMapNavigationStrongerPerspectiveCapabilityMask: UInt32 = 1 << 11
     static let osm3DBuildingsCapabilityMask: UInt32 = 1 << 12
-    static let deviceCapabilitiesVersion: UInt8 = 10
+    static let explicitInvalidGPSHeadingCapabilityMask: UInt32 = 1 << 13
+    static let deviceCapabilitiesVersion: UInt8 = 11
     static let workoutTelemetryFrameLength = 16
     static let workoutTelemetryCoreCoalescingKey = "workout-telemetry-core"
     static let workoutTelemetryExtendedCoalescingKey =
@@ -600,6 +601,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published private(set) var supportsWorkoutTelemetry: Bool = false
     @Published private(set) var supportsStreetLabels: Bool = false
     @Published private(set) var supports3DBuildings: Bool = false
+    @Published private(set) var supportsExplicitInvalidGPSHeading: Bool = false
     @Published private(set) var powerButtonHonkConfigurationError: String?
     @Published private(set) var hasReceivedDeviceCapabilities: Bool = false
     @Published var peripheralName: String = ""
@@ -2033,7 +2035,10 @@ class BLEManager: NSObject, ObservableObject {
         let data = DeviceGPSPacketBuilder.data(
             lat: lat,
             lon: lon,
-            heading: heading,
+            heading: DeviceGPSHeadingWirePolicy.heading(
+                heading,
+                supportsExplicitInvalidHeading: supportsExplicitInvalidGPSHeading
+            ),
             speedMetersPerSecond: speedMetersPerSecond,
             altitudeMeters: altitudeMeters,
             distanceTraveledMeters: distanceTraveledMeters,
@@ -2623,6 +2628,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsDestinationPicker = false
         supportsStreetLabels = false
         supports3DBuildings = false
+        supportsExplicitInvalidGPSHeading = false
         updateWorkoutTelemetryCapability(false)
         nextDestinationCatalogTransferID = 1
         hasReceivedDeviceCapabilities = true
@@ -3372,6 +3378,7 @@ class BLEManager: NSObject, ObservableObject {
         supportsDestinationPicker = false
         supportsStreetLabels = false
         supports3DBuildings = false
+        supportsExplicitInvalidGPSHeading = false
         updateWorkoutTelemetryCapability(false)
         powerButtonHonkConfigurationError = nil
         nextDestinationCatalogTransferID = 1
@@ -5394,6 +5401,7 @@ extension BLEManager: CBPeripheralDelegate {
         supportsDestinationPicker = false
         supportsStreetLabels = false
         supports3DBuildings = false
+        supportsExplicitInvalidGPSHeading = false
         updateWorkoutTelemetryCapability(false)
         hasReceivedDeviceCapabilities = false
         hasSentScreenSettingsForConnection = false
@@ -5505,6 +5513,8 @@ extension BLEManager: CBPeripheralDelegate {
             flags & DeviceBLEProtocol.streetLabelsCapabilityMask != 0
         let has3DBuildings =
             flags & DeviceBLEProtocol.osm3DBuildingsCapabilityMask != 0
+        let hasExplicitInvalidGPSHeading =
+            flags & DeviceBLEProtocol.explicitInvalidGPSHeadingCapabilityMask != 0
         if has3DBuildings && shouldApply3DBuildingVisibilityDefault {
             shouldApply3DBuildingVisibilityDefault = false
             UserDefaults.standard.set(
@@ -5581,6 +5591,7 @@ extension BLEManager: CBPeripheralDelegate {
         supportsDestinationPicker = hasDestinationPicker
         supportsStreetLabels = hasStreetLabels
         supports3DBuildings = has3DBuildings
+        supportsExplicitInvalidGPSHeading = hasExplicitInvalidGPSHeading
         updateWorkoutTelemetryCapability(hasWorkoutTelemetry)
         if !hasPowerButtonHonkAcknowledgement {
             clearPendingPowerButtonHonkConfiguration()

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -2016,7 +2016,7 @@ class BLEManager: NSObject, ObservableObject {
     func sendGPSPosition(
         lat: Double,
         lon: Double,
-        heading: Double = 0,
+        heading: Double? = nil,
         speedMetersPerSecond: Double? = nil,
         altitudeMeters: Double? = nil,
         distanceTraveledMeters: Double? = nil,
@@ -2096,7 +2096,11 @@ class BLEManager: NSObject, ObservableObject {
                     log("GPS position not queued: write queue unavailable")
                     return
                 }
-                log(String(format: "Queued native GPS position: heading=%.0f", heading))
+                if let heading {
+                    log(String(format: "Queued native GPS position: heading=%.0f", heading))
+                } else {
+                    log("Queued native GPS position: heading=invalid")
+                }
                 return
             }
         }

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -36,6 +36,9 @@ class NavigationEngine: NSObject, ObservableObject {
     private var latestExternalGpsLocation: CLLocation?
     private var hasAcceptedLiveLocation = false
     private var lastSentGeometrySegmentIndex: Int?
+    private var routeCoordinatesCache: [CLLocationCoordinate2D] = []
+    private var routeProgressMatcher = RouteProgressMatcher()
+    private(set) var routeCoordinateExtractionCount = 0
     private var geometrySendInterval: TimeInterval = 2.0
     private var lastGeometrySendTime: Date = .distantPast
     private let geometryWindowSize: Int = 30
@@ -120,6 +123,7 @@ class NavigationEngine: NSObject, ObservableObject {
     /// Start navigation with a given route
     func startNavigation(with route: MKRoute, isTestMode: Bool = false, initialLocation: CLLocation? = nil) {
         currentRoute = route
+        cacheRouteCoordinates(from: route)
         currentStepIndex = 0
         isSimulationMode = isTestMode
         isNavigating = true
@@ -160,6 +164,7 @@ class NavigationEngine: NSObject, ObservableObject {
         guard isNavigating, !isSimulationMode else { return }
 
         currentRoute = route
+        cacheRouteCoordinates(from: route)
         navigationEpoch &+= 1
         courseResolver.reset(epoch: navigationEpoch)
         currentStepIndex = RouteStepSelection.closestNavigableStepIndex(
@@ -207,6 +212,8 @@ class NavigationEngine: NSObject, ObservableObject {
         navigationEpoch &+= 1
         courseResolver.reset(epoch: navigationEpoch)
         currentRoute = nil
+        routeCoordinatesCache.removeAll(keepingCapacity: false)
+        routeProgressMatcher.reset()
         currentStepIndex = 0
         currentSnapshot = nil
         lastManeuverStepIndex = nil
@@ -306,14 +313,15 @@ class NavigationEngine: NSObject, ObservableObject {
     
     private func interpolatePositionAlongRoute(progress: Double) -> CLLocationCoordinate2D? {
         guard let route = currentRoute else { return nil }
-        
-        let polyline = route.polyline
-        let pointCount = polyline.pointCount
+
+        // Route coordinates are immutable for a navigation epoch and already
+        // cached for live GPS matching and MAPR transmission. Reuse the same
+        // geometry for simulation so test navigation cannot introduce a
+        // separate extraction/coordinate path.
+        let points = routeCoordinatesCache
+        let pointCount = points.count
         guard pointCount > 1 else { return nil }
-        
-        var points = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
-        polyline.getCoordinates(&points, range: NSRange(location: 0, length: pointCount))
-        
+
         let targetDistance = progress * route.distance
         var currentDist = 0.0
         
@@ -672,10 +680,16 @@ class NavigationEngine: NSObject, ObservableObject {
         let routeCoordinate = convertFromMapKitRoute
             ? location.coordinate
             : CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location).coordinate
-        let routeBearing = currentRoute.flatMap {
-            RouteGeometryMath.bearingNear(
-                routeCoordinate,
-                routePoints: routeCoordinates(for: $0)
+        let routeProjection = isNavigating
+            ? routeProgressMatcher.projection(
+                to: routeCoordinate,
+                on: routeCoordinatesCache
+            )
+            : nil
+        let routeBearing = routeProjection.flatMap {
+            RouteGeometryMath.bearing(
+                for: $0,
+                routePoints: routeCoordinatesCache
             )
         }
         let heading = courseResolver.resolve(
@@ -708,9 +722,13 @@ class NavigationEngine: NSObject, ObservableObject {
 // MARK: - Route Geometry for Device Map
 
 extension NavigationEngine {
-    private func routeCoordinates(for route: MKRoute) -> [CLLocationCoordinate2D] {
+    private func cacheRouteCoordinates(from route: MKRoute) {
         let pointCount = route.polyline.pointCount
-        guard pointCount > 0 else { return [] }
+        guard pointCount > 0 else {
+            routeCoordinatesCache = []
+            routeProgressMatcher.reset()
+            return
+        }
         var points = [CLLocationCoordinate2D](
             repeating: CLLocationCoordinate2D(),
             count: pointCount
@@ -719,21 +737,33 @@ extension NavigationEngine {
             &points,
             range: NSRange(location: 0, length: pointCount)
         )
-        return points
+        routeCoordinatesCache = points
+        routeProgressMatcher.reset()
+        routeCoordinateExtractionCount += 1
     }
 
     func extractSlidingWindowGeometry(currentLocation: CLLocation) -> Data? {
-        guard let route = currentRoute else { return nil }
+        guard currentRoute != nil,
+              !routeCoordinatesCache.isEmpty,
+              let projection = routeProgressMatcher.projection(
+                to: currentLocation.coordinate,
+                on: routeCoordinatesCache
+              ) else { return nil }
+        return extractSlidingWindowGeometry(
+            currentLocation: currentLocation,
+            projection: projection
+        )
+    }
 
-        let polyline = route.polyline
-        let pointCount = polyline.pointCount
-        guard pointCount > 0 else { return nil }
-
-        let points = routeCoordinates(for: route)
+    private func extractSlidingWindowGeometry(
+        currentLocation: CLLocation,
+        projection: RouteGeometryProjection
+    ) -> Data? {
         let windowPoints = RouteGeometryMath.slidingWindow(
             riderCoordinate: currentLocation.coordinate,
-            routePoints: points,
-            maximumPointCount: geometryWindowSize
+            routePoints: routeCoordinatesCache,
+            maximumPointCount: geometryWindowSize,
+            projection: projection
         )
         guard !windowPoints.isEmpty else { return nil }
 
@@ -771,26 +801,28 @@ extension NavigationEngine {
         guard let bleManager = bleManager,
               bleManager.isConnected,
               bleManager.isNavigationReady,
-              let route = currentRoute else {
+              currentRoute != nil else {
             return
         }
 
-        let now = Date()
-        guard now.timeIntervalSince(lastGeometrySendTime) >= geometrySendInterval else { return }
-        let routePoints = routeCoordinates(for: route)
-        guard let projection = RouteGeometryMath.nearestProjection(
+        let currentTime = now()
+        guard currentTime.timeIntervalSince(lastGeometrySendTime) >= geometrySendInterval else { return }
+        guard let projection = routeProgressMatcher.projection(
             to: currentLocation.coordinate,
-            on: routePoints
+            on: routeCoordinatesCache
         ) else { return }
         guard RouteGeometryTransmissionPolicy.shouldSend(
             currentSegmentIndex: projection.segmentIndex,
             lastSentSegmentIndex: lastSentGeometrySegmentIndex,
             maximumPointCount: geometryWindowSize
         ) else { return }
-        guard let geometryData = extractSlidingWindowGeometry(currentLocation: currentLocation) else { return }
+        guard let geometryData = extractSlidingWindowGeometry(
+            currentLocation: currentLocation,
+            projection: projection
+        ) else { return }
 
         bleManager.sendRouteGeometry(geometryData)
-        lastGeometrySendTime = now
+        lastGeometrySendTime = currentTime
         lastSentGeometrySegmentIndex = projection.segmentIndex
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -35,10 +35,12 @@ class NavigationEngine: NSObject, ObservableObject {
     private var lastDeviceGpsLocation: (location: CLLocation, convertFromMapKitRoute: Bool)?
     private var latestExternalGpsLocation: CLLocation?
     private var hasAcceptedLiveLocation = false
-    private var lastSentGeometryHash: Int = 0
+    private var lastSentGeometrySegmentIndex: Int?
     private var geometrySendInterval: TimeInterval = 2.0
     private var lastGeometrySendTime: Date = .distantPast
     private let geometryWindowSize: Int = 30
+    private var navigationEpoch: UInt32 = 0
+    private var courseResolver = NavigationCourseResolver()
     private var rideStartDate: Date?
     @Published private(set) var rideDistanceMeters: CLLocationDistance = 0
     private var lastRideLocation: CLLocation?
@@ -121,6 +123,8 @@ class NavigationEngine: NSObject, ObservableObject {
         currentStepIndex = 0
         isSimulationMode = isTestMode
         isNavigating = true
+        navigationEpoch &+= 1
+        courseResolver.reset(epoch: navigationEpoch)
         
         currentSnapshot = nil
         lastManeuverStepIndex = nil
@@ -128,7 +132,7 @@ class NavigationEngine: NSObject, ObservableObject {
         sendTracker.reset()
         initialNavigationLocation = initialLocation
         hasAcceptedLiveLocation = initialLocation == nil
-        lastSentGeometryHash = 0
+        lastSentGeometrySegmentIndex = nil
         lastGeometrySendTime = .distantPast
         resetRideTelemetry(startingAt: initialLocation)
         updateNavigationSummary(route: route, remainingDistance: route.distance)
@@ -156,6 +160,8 @@ class NavigationEngine: NSObject, ObservableObject {
         guard isNavigating, !isSimulationMode else { return }
 
         currentRoute = route
+        navigationEpoch &+= 1
+        courseResolver.reset(epoch: navigationEpoch)
         currentStepIndex = RouteStepSelection.closestNavigableStepIndex(
             to: currentLocation,
             in: route
@@ -166,7 +172,7 @@ class NavigationEngine: NSObject, ObservableObject {
         sendTracker.reset()
         initialNavigationLocation = nil
         hasAcceptedLiveLocation = true
-        lastSentGeometryHash = 0
+        lastSentGeometrySegmentIndex = nil
         lastGeometrySendTime = .distantPast
 
         let remainingDistance = RouteProgress.remainingDistance(from: currentLocation, in: route) ?? route.distance
@@ -198,6 +204,8 @@ class NavigationEngine: NSObject, ObservableObject {
         stopRideTelemetryTimer()
         bleManager?.clearRouteGeometry()
         isNavigating = false
+        navigationEpoch &+= 1
+        courseResolver.reset(epoch: navigationEpoch)
         currentRoute = nil
         currentStepIndex = 0
         currentSnapshot = nil
@@ -207,7 +215,7 @@ class NavigationEngine: NSObject, ObservableObject {
         initialNavigationLocation = nil
         lastDeviceGpsLocation = nil
         hasAcceptedLiveLocation = false
-        lastSentGeometryHash = 0
+        lastSentGeometrySegmentIndex = nil
         lastGeometrySendTime = .distantPast
         routeRemainingDistance = nil
         routeRemainingTime = nil
@@ -507,7 +515,7 @@ class NavigationEngine: NSObject, ObservableObject {
     private func resendCurrentRouteGeometry() {
         guard isNavigating, let route = currentRoute, route.polyline.pointCount > 0 else { return }
 
-        lastSentGeometryHash = 0
+        lastSentGeometrySegmentIndex = nil
         lastGeometrySendTime = .distantPast
         sendRouteGeometryIfNeeded(currentLocation: routeGeometryResendLocation(for: route))
     }
@@ -661,7 +669,20 @@ class NavigationEngine: NSObject, ObservableObject {
         let wgsCoordinate = convertFromMapKitRoute
             ? CoordinateConverter.gcj02ToWGS84(coordinate: location.coordinate)
             : location.coordinate
-        let heading = location.course >= 0 ? location.course : 0
+        let routeCoordinate = convertFromMapKitRoute
+            ? location.coordinate
+            : CoordinateConverter.mapKitRouteLocation(fromGPSLocation: location).coordinate
+        let routeBearing = currentRoute.flatMap {
+            RouteGeometryMath.bearingNear(
+                routeCoordinate,
+                routePoints: routeCoordinates(for: $0)
+            )
+        }
+        let heading = courseResolver.resolve(
+            measuredCourse: location.course,
+            routeBearing: routeBearing,
+            navigationActive: isNavigating
+        )
         bleManager?.sendGPSPosition(lat: wgsCoordinate.latitude,
                                     lon: wgsCoordinate.longitude,
                                     heading: heading,
@@ -687,6 +708,20 @@ class NavigationEngine: NSObject, ObservableObject {
 // MARK: - Route Geometry for Device Map
 
 extension NavigationEngine {
+    private func routeCoordinates(for route: MKRoute) -> [CLLocationCoordinate2D] {
+        let pointCount = route.polyline.pointCount
+        guard pointCount > 0 else { return [] }
+        var points = [CLLocationCoordinate2D](
+            repeating: CLLocationCoordinate2D(),
+            count: pointCount
+        )
+        route.polyline.getCoordinates(
+            &points,
+            range: NSRange(location: 0, length: pointCount)
+        )
+        return points
+    }
+
     func extractSlidingWindowGeometry(currentLocation: CLLocation) -> Data? {
         guard let route = currentRoute else { return nil }
 
@@ -694,22 +729,12 @@ extension NavigationEngine {
         let pointCount = polyline.pointCount
         guard pointCount > 0 else { return nil }
 
-        var points = [CLLocationCoordinate2D](repeating: CLLocationCoordinate2D(), count: pointCount)
-        polyline.getCoordinates(&points, range: NSRange(location: 0, length: pointCount))
-
-        var closestIndex = 0
-        var closestDistance = Double.greatestFiniteMagnitude
-        for (index, point) in points.enumerated() {
-            let pointLocation = CLLocation(latitude: point.latitude, longitude: point.longitude)
-            let distance = currentLocation.distance(from: pointLocation)
-            if distance < closestDistance {
-                closestDistance = distance
-                closestIndex = index
-            }
-        }
-
-        let endIndex = min(closestIndex + geometryWindowSize, pointCount)
-        let windowPoints = Array(points[closestIndex..<endIndex])
+        let points = routeCoordinates(for: route)
+        let windowPoints = RouteGeometryMath.slidingWindow(
+            riderCoordinate: currentLocation.coordinate,
+            routePoints: points,
+            maximumPointCount: geometryWindowSize
+        )
         guard !windowPoints.isEmpty else { return nil }
 
         return compressRoutePoints(windowPoints)
@@ -745,19 +770,27 @@ extension NavigationEngine {
     func sendRouteGeometryIfNeeded(currentLocation: CLLocation) {
         guard let bleManager = bleManager,
               bleManager.isConnected,
-              bleManager.isNavigationReady else {
+              bleManager.isNavigationReady,
+              let route = currentRoute else {
             return
         }
 
         let now = Date()
         guard now.timeIntervalSince(lastGeometrySendTime) >= geometrySendInterval else { return }
+        let routePoints = routeCoordinates(for: route)
+        guard let projection = RouteGeometryMath.nearestProjection(
+            to: currentLocation.coordinate,
+            on: routePoints
+        ) else { return }
+        guard RouteGeometryTransmissionPolicy.shouldSend(
+            currentSegmentIndex: projection.segmentIndex,
+            lastSentSegmentIndex: lastSentGeometrySegmentIndex,
+            maximumPointCount: geometryWindowSize
+        ) else { return }
         guard let geometryData = extractSlidingWindowGeometry(currentLocation: currentLocation) else { return }
-
-        let hash = geometryData.hashValue
-        guard hash != lastSentGeometryHash else { return }
 
         bleManager.sendRouteGeometry(geometryData)
         lastGeometrySendTime = now
-        lastSentGeometryHash = hash
+        lastSentGeometrySegmentIndex = projection.segmentIndex
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -570,14 +570,212 @@ enum RouteTransportTypes {
     static let cycling = MKDirectionsTransportType(rawValue: 1 << 3)
 }
 
+
+enum NavigationHeading {
+    static func normalized(_ raw: Double?) -> Double? {
+        guard let raw, raw.isFinite, raw >= 0 else { return nil }
+        let wrapped = raw.truncatingRemainder(dividingBy: 360)
+        return wrapped >= 0 ? wrapped : wrapped + 360
+    }
+
+    static func bearing(
+        from start: CLLocationCoordinate2D,
+        to end: CLLocationCoordinate2D
+    ) -> CLLocationDirection? {
+        let lat1 = start.latitude * .pi / 180
+        let lat2 = end.latitude * .pi / 180
+        let deltaLongitude = (end.longitude - start.longitude) * .pi / 180
+        let y = sin(deltaLongitude) * cos(lat2)
+        let x = cos(lat1) * sin(lat2) -
+            sin(lat1) * cos(lat2) * cos(deltaLongitude)
+        guard abs(x) > 1e-12 || abs(y) > 1e-12 else { return nil }
+        return normalized(atan2(y, x) * 180 / .pi)
+    }
+}
+
+struct NavigationCourseResolver {
+    private(set) var navigationEpoch: UInt32 = 0
+    private(set) var lastValidCourse: CLLocationDirection?
+
+    mutating func reset(epoch: UInt32) {
+        navigationEpoch = epoch
+        lastValidCourse = nil
+    }
+
+    mutating func resolve(
+        measuredCourse: CLLocationDirection?,
+        routeBearing: CLLocationDirection?,
+        navigationActive: Bool
+    ) -> CLLocationDirection? {
+        guard navigationActive else {
+            lastValidCourse = nil
+            return NavigationHeading.normalized(measuredCourse)
+        }
+        if let measured = NavigationHeading.normalized(measuredCourse) {
+            lastValidCourse = measured
+            return measured
+        }
+        if let route = NavigationHeading.normalized(routeBearing) {
+            lastValidCourse = route
+            return route
+        }
+        return lastValidCourse
+    }
+}
+
+struct RouteGeometryProjection {
+    let segmentIndex: Int
+    let fraction: Double
+    let coordinate: CLLocationCoordinate2D
+    let distanceSquared: Double
+}
+
+enum RouteGeometryMath {
+    private static func projectedXY(
+        _ coordinate: CLLocationCoordinate2D,
+        referenceLatitude: CLLocationDegrees
+    ) -> (x: Double, y: Double) {
+        let latitudeRadians = referenceLatitude * .pi / 180
+        return (
+            coordinate.longitude * cos(latitudeRadians),
+            coordinate.latitude
+        )
+    }
+
+    static func nearestProjection(
+        to coordinate: CLLocationCoordinate2D,
+        on points: [CLLocationCoordinate2D]
+    ) -> RouteGeometryProjection? {
+        guard points.count >= 2 else { return nil }
+        let referenceLatitude = coordinate.latitude
+        let target = projectedXY(coordinate, referenceLatitude: referenceLatitude)
+        var best: RouteGeometryProjection?
+
+        for index in 0..<(points.count - 1) {
+            let start = projectedXY(points[index], referenceLatitude: referenceLatitude)
+            let end = projectedXY(points[index + 1], referenceLatitude: referenceLatitude)
+            let segmentX = end.x - start.x
+            let segmentY = end.y - start.y
+            let lengthSquared = segmentX * segmentX + segmentY * segmentY
+            guard lengthSquared > 0 else { continue }
+            let unclamped = ((target.x - start.x) * segmentX +
+                             (target.y - start.y) * segmentY) / lengthSquared
+            let fraction = min(max(unclamped, 0), 1)
+            let projectedX = start.x + segmentX * fraction
+            let projectedY = start.y + segmentY * fraction
+            let deltaX = target.x - projectedX
+            let deltaY = target.y - projectedY
+            let distanceSquared = deltaX * deltaX + deltaY * deltaY
+            let projectedCoordinate = CLLocationCoordinate2D(
+                latitude: points[index].latitude +
+                    (points[index + 1].latitude - points[index].latitude) * fraction,
+                longitude: points[index].longitude +
+                    (points[index + 1].longitude - points[index].longitude) * fraction
+            )
+            if best == nil || distanceSquared < best!.distanceSquared {
+                best = RouteGeometryProjection(
+                    segmentIndex: index,
+                    fraction: fraction,
+                    coordinate: projectedCoordinate,
+                    distanceSquared: distanceSquared
+                )
+            }
+        }
+        return best
+    }
+
+    static func bearingNear(
+        _ coordinate: CLLocationCoordinate2D,
+        routePoints: [CLLocationCoordinate2D]
+    ) -> CLLocationDirection? {
+        guard let projection = nearestProjection(to: coordinate, on: routePoints) else {
+            return nil
+        }
+        let start = routePoints[projection.segmentIndex]
+        let end = routePoints[projection.segmentIndex + 1]
+        return NavigationHeading.bearing(from: start, to: end)
+    }
+
+    /// The first point is always the live rider coordinate.  The exact route
+    /// projection follows when needed, then future route vertices.  This keeps
+    /// the device route head attached to the arrow without discarding the
+    /// route's projection space.
+    static func slidingWindow(
+        riderCoordinate: CLLocationCoordinate2D,
+        routePoints: [CLLocationCoordinate2D],
+        maximumPointCount: Int
+    ) -> [CLLocationCoordinate2D] {
+        guard maximumPointCount > 0 else { return [] }
+        guard routePoints.count >= 2,
+              let projection = nearestProjection(
+                to: riderCoordinate,
+                on: routePoints
+              ) else {
+            return [riderCoordinate]
+        }
+
+        var result = [riderCoordinate]
+        let projectedLocation = CLLocation(
+            latitude: projection.coordinate.latitude,
+            longitude: projection.coordinate.longitude
+        )
+        let riderLocation = CLLocation(
+            latitude: riderCoordinate.latitude,
+            longitude: riderCoordinate.longitude
+        )
+        if result.count < maximumPointCount,
+           riderLocation.distance(from: projectedLocation) > 0.25 {
+            result.append(projection.coordinate)
+        }
+
+        var nextIndex = projection.segmentIndex + 1
+        while nextIndex < routePoints.count && result.count < maximumPointCount {
+            let next = routePoints[nextIndex]
+            if let last = result.last {
+                let lastLocation = CLLocation(latitude: last.latitude, longitude: last.longitude)
+                let nextLocation = CLLocation(latitude: next.latitude, longitude: next.longitude)
+                if lastLocation.distance(from: nextLocation) <= 0.25 {
+                    nextIndex += 1
+                    continue
+                }
+            }
+            result.append(next)
+            nextIndex += 1
+        }
+        return result
+    }
+}
+
+enum RouteGeometryTransmissionPolicy {
+    /// Keep the already-sent route window while it still contains useful
+    /// forward geometry. The device anchors that immutable geometry at every
+    /// presented GPS pose, so retransmitting merely because the first rider
+    /// coordinate moved would only churn the firmware route revision and
+    /// starve a longer render job.
+    static func shouldSend(
+        currentSegmentIndex: Int,
+        lastSentSegmentIndex: Int?,
+        maximumPointCount: Int
+    ) -> Bool {
+        guard maximumPointCount > 0, currentSegmentIndex >= 0 else { return false }
+        guard let lastSentSegmentIndex else { return true }
+        if currentSegmentIndex < lastSentSegmentIndex {
+            return true
+        }
+        let refreshStride = max(1, maximumPointCount * 2 / 3)
+        return currentSegmentIndex - lastSentSegmentIndex >= refreshStride
+    }
+}
+
 enum DeviceGPSPacketBuilder {
+    static let invalidHeadingDegrees = UInt16.max
     static let invalidSpeedCmps = UInt16.max
     static let invalidRouteRemainingMeters = UInt32.max
 
     static func data(
         lat: Double,
         lon: Double,
-        heading: Double = 0,
+        heading: Double? = nil,
         unixTime: UInt32 = UInt32(Date().timeIntervalSince1970),
         speedMetersPerSecond: Double? = nil,
         altitudeMeters: Double? = nil,
@@ -588,7 +786,12 @@ enum DeviceGPSPacketBuilder {
         var data = Data()
         let latInt = Int32(lat * 1_000_000)
         let lonInt = Int32(lon * 1_000_000)
-        let headingDeg: UInt16 = heading >= 0 ? UInt16(min(heading, 359)) : 0
+        let headingDeg: UInt16 = {
+            guard let normalized = NavigationHeading.normalized(heading) else {
+                return invalidHeadingDegrees
+            }
+            return UInt16(normalized.rounded()) % 360
+        }()
         let speedCmps: UInt16 = {
             guard let speedMetersPerSecond, speedMetersPerSecond >= 0 else {
                 return invalidSpeedCmps

--- a/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/NavigationProtocol.swift
@@ -628,6 +628,7 @@ struct RouteGeometryProjection {
     let fraction: Double
     let coordinate: CLLocationCoordinate2D
     let distanceSquared: Double
+    let distanceMeters: CLLocationDistance
 }
 
 enum RouteGeometryMath {
@@ -644,14 +645,20 @@ enum RouteGeometryMath {
 
     static func nearestProjection(
         to coordinate: CLLocationCoordinate2D,
-        on points: [CLLocationCoordinate2D]
+        on points: [CLLocationCoordinate2D],
+        segmentRange: ClosedRange<Int>? = nil
     ) -> RouteGeometryProjection? {
         guard points.count >= 2 else { return nil }
         let referenceLatitude = coordinate.latitude
         let target = projectedXY(coordinate, referenceLatitude: referenceLatitude)
         var best: RouteGeometryProjection?
 
-        for index in 0..<(points.count - 1) {
+        let lastSegmentIndex = points.count - 2
+        let lowerBound = max(0, segmentRange?.lowerBound ?? 0)
+        let upperBound = min(lastSegmentIndex, segmentRange?.upperBound ?? lastSegmentIndex)
+        guard lowerBound <= upperBound else { return nil }
+
+        for index in lowerBound...upperBound {
             let start = projectedXY(points[index], referenceLatitude: referenceLatitude)
             let end = projectedXY(points[index + 1], referenceLatitude: referenceLatitude)
             let segmentX = end.x - start.x
@@ -673,15 +680,37 @@ enum RouteGeometryMath {
                     (points[index + 1].longitude - points[index].longitude) * fraction
             )
             if best == nil || distanceSquared < best!.distanceSquared {
+                let distanceMeters = CLLocation(
+                    latitude: coordinate.latitude,
+                    longitude: coordinate.longitude
+                ).distance(from: CLLocation(
+                    latitude: projectedCoordinate.latitude,
+                    longitude: projectedCoordinate.longitude
+                ))
                 best = RouteGeometryProjection(
                     segmentIndex: index,
                     fraction: fraction,
                     coordinate: projectedCoordinate,
-                    distanceSquared: distanceSquared
+                    distanceSquared: distanceSquared,
+                    distanceMeters: distanceMeters
                 )
             }
         }
         return best
+    }
+
+    static func bearing(
+        for projection: RouteGeometryProjection,
+        routePoints: [CLLocationCoordinate2D]
+    ) -> CLLocationDirection? {
+        guard projection.segmentIndex >= 0,
+              projection.segmentIndex + 1 < routePoints.count else {
+            return nil
+        }
+        return NavigationHeading.bearing(
+            from: routePoints[projection.segmentIndex],
+            to: routePoints[projection.segmentIndex + 1]
+        )
     }
 
     static func bearingNear(
@@ -691,42 +720,35 @@ enum RouteGeometryMath {
         guard let projection = nearestProjection(to: coordinate, on: routePoints) else {
             return nil
         }
-        let start = routePoints[projection.segmentIndex]
-        let end = routePoints[projection.segmentIndex + 1]
-        return NavigationHeading.bearing(from: start, to: end)
+        return bearing(for: projection, routePoints: routePoints)
     }
 
-    /// The first point is always the live rider coordinate.  The exact route
-    /// projection follows when needed, then future route vertices.  This keeps
-    /// the device route head attached to the arrow without discarding the
-    /// route's projection space.
+    /// The retained packet contains route geometry only: the exact projection
+    /// followed by future route vertices. The firmware prepends its *current*
+    /// presented rider pose every frame. Including the rider here would retain
+    /// a stale off-route connector until the next window refresh and could
+    /// make closest-segment heading resolution jump away from the route.
     static func slidingWindow(
         riderCoordinate: CLLocationCoordinate2D,
         routePoints: [CLLocationCoordinate2D],
-        maximumPointCount: Int
+        maximumPointCount: Int,
+        projection knownProjection: RouteGeometryProjection? = nil
     ) -> [CLLocationCoordinate2D] {
         guard maximumPointCount > 0 else { return [] }
-        guard routePoints.count >= 2,
-              let projection = nearestProjection(
-                to: riderCoordinate,
-                on: routePoints
-              ) else {
-            return [riderCoordinate]
+        guard routePoints.count >= 2 else { return [] }
+        let projection: RouteGeometryProjection
+        if let knownProjection {
+            projection = knownProjection
+        } else if let nearest = nearestProjection(
+            to: riderCoordinate,
+            on: routePoints
+        ) {
+            projection = nearest
+        } else {
+            return []
         }
 
-        var result = [riderCoordinate]
-        let projectedLocation = CLLocation(
-            latitude: projection.coordinate.latitude,
-            longitude: projection.coordinate.longitude
-        )
-        let riderLocation = CLLocation(
-            latitude: riderCoordinate.latitude,
-            longitude: riderCoordinate.longitude
-        )
-        if result.count < maximumPointCount,
-           riderLocation.distance(from: projectedLocation) > 0.25 {
-            result.append(projection.coordinate)
-        }
+        var result = [projection.coordinate]
 
         var nextIndex = projection.segmentIndex + 1
         while nextIndex < routePoints.count && result.count < maximumPointCount {
@@ -746,12 +768,70 @@ enum RouteGeometryMath {
     }
 }
 
+/// Epoch-scoped, bounded route matching. Once a rider has established forward
+/// progress, self-intersections and nearby return lanes cannot snap the match
+/// to an arbitrarily old segment. A fix far from the bounded window performs a
+/// global reacquisition, which preserves deliberate large backtracking and
+/// off-route recovery. Replacing a route must reset the matcher.
+struct RouteProgressMatcher {
+    private(set) var segmentIndex: Int?
+    let lookBehindSegments: Int
+    let lookAheadSegments: Int
+    let reacquireDistanceMeters: CLLocationDistance
+
+    init(
+        lookBehindSegments: Int = 3,
+        lookAheadSegments: Int = 48,
+        reacquireDistanceMeters: CLLocationDistance = 75
+    ) {
+        self.lookBehindSegments = max(lookBehindSegments, 0)
+        self.lookAheadSegments = max(lookAheadSegments, 1)
+        self.reacquireDistanceMeters = max(reacquireDistanceMeters, 1)
+    }
+
+    mutating func reset() {
+        segmentIndex = nil
+    }
+
+    mutating func projection(
+        to coordinate: CLLocationCoordinate2D,
+        on points: [CLLocationCoordinate2D]
+    ) -> RouteGeometryProjection? {
+        guard points.count >= 2 else {
+            segmentIndex = nil
+            return nil
+        }
+
+        if let segmentIndex {
+            let lastSegment = points.count - 2
+            let localRange = ClosedRange(
+                uncheckedBounds: (
+                    lower: max(0, segmentIndex - lookBehindSegments),
+                    upper: min(lastSegment, segmentIndex + lookAheadSegments)
+                )
+            )
+            if let local = RouteGeometryMath.nearestProjection(
+                to: coordinate,
+                on: points,
+                segmentRange: localRange
+            ), local.distanceMeters <= reacquireDistanceMeters {
+                self.segmentIndex = local.segmentIndex
+                return local
+            }
+        }
+
+        let global = RouteGeometryMath.nearestProjection(to: coordinate, on: points)
+        segmentIndex = global?.segmentIndex
+        return global
+    }
+}
+
 enum RouteGeometryTransmissionPolicy {
-    /// Keep the already-sent route window while it still contains useful
-    /// forward geometry. The device anchors that immutable geometry at every
-    /// presented GPS pose, so retransmitting merely because the first rider
-    /// coordinate moved would only churn the firmware route revision and
-    /// starve a longer render job.
+    /// Refresh when the bounded matcher advances to another segment. The
+    /// caller rate-limits this decision, so short segments are coalesced while
+    /// loops and self-intersections promptly receive a new unambiguous forward
+    /// window. Firmware treats route revisions as live-foreground input, not a
+    /// reason to cancel an in-flight 3D base render.
     static func shouldSend(
         currentSegmentIndex: Int,
         lastSentSegmentIndex: Int?,
@@ -759,11 +839,7 @@ enum RouteGeometryTransmissionPolicy {
     ) -> Bool {
         guard maximumPointCount > 0, currentSegmentIndex >= 0 else { return false }
         guard let lastSentSegmentIndex else { return true }
-        if currentSegmentIndex < lastSentSegmentIndex {
-            return true
-        }
-        let refreshStride = max(1, maximumPointCount * 2 / 3)
-        return currentSegmentIndex - lastSentSegmentIndex >= refreshStride
+        return currentSegmentIndex != lastSentSegmentIndex
     }
 }
 
@@ -818,6 +894,23 @@ enum DeviceGPSPacketBuilder {
         withUnsafeBytes(of: elapsedInt.littleEndian) { data.append(contentsOf: $0) }
         withUnsafeBytes(of: routeRemainingInt.littleEndian) { data.append(contentsOf: $0) }
         return data
+    }
+}
+
+/// Compatibility boundary for the GPS heading field. Firmware that did not
+/// advertise the explicit invalid-heading capability interprets every UInt16
+/// as a real heading, so preserve its historical zero fallback. Once bit 13
+/// is negotiated, nil can use DeviceGPSPacketBuilder.invalidHeadingDegrees and
+/// the firmware is free to resolve course from the route instead of north.
+enum DeviceGPSHeadingWirePolicy {
+    static func heading(
+        _ heading: CLLocationDirection?,
+        supportsExplicitInvalidHeading: Bool
+    ) -> CLLocationDirection? {
+        if supportsExplicitInvalidHeading {
+            return NavigationHeading.normalized(heading)
+        }
+        return NavigationHeading.normalized(heading) ?? 0
     }
 }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -314,7 +314,7 @@ final class TestBLEManager: BLEManager {
     override func sendGPSPosition(
         lat: Double,
         lon: Double,
-        heading: Double = 0,
+        heading: Double? = nil,
         speedMetersPerSecond: Double? = nil,
         altitudeMeters: Double? = nil,
         distanceTraveledMeters: Double? = nil,
@@ -595,6 +595,10 @@ struct NavigationProtocolTests {
         testDeveloperLocationOverride()
         testRideActivityPolicy()
         testDeviceGPSPacketBuilder()
+        testNavigationCourseResolver()
+        testRouteGeometryMath()
+        testRouteGeometryTransmissionPolicy()
+        testNavigationEngineUsesRouteBearingForInvalidCourse()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
         testGPSQueuePolicy()
@@ -4202,7 +4206,7 @@ struct NavigationProtocolTests {
         assertEqual(data.count, 30, "extended GPS packet has expected byte length")
         assertEqual(readInt32LE(data, offset: 0), 37_123_456, "GPS packet stores latitude microdegrees")
         assertEqual(readInt32LE(data, offset: 4), -122_654_321, "GPS packet stores longitude microdegrees")
-        assertEqual(readUInt16LE(data, offset: 8), 359, "GPS packet clamps heading")
+        assertEqual(readUInt16LE(data, offset: 8), 1, "GPS packet normalizes heading through wraparound")
         assertEqual(readUInt32LE(data, offset: 10), 1_234_567_890, "GPS packet stores Unix time")
         assertEqual(readUInt16LE(data, offset: 14), 555, "GPS packet stores speed in centimeters per second")
         assertEqual(readInt16LE(data, offset: 16), 42, "GPS packet stores altitude in meters")
@@ -4211,8 +4215,176 @@ struct NavigationProtocolTests {
         assertEqual(readUInt32LE(data, offset: 26), 9877, "GPS packet stores rounded route remaining meters")
 
         let invalidData = DeviceGPSPacketBuilder.data(lat: 0, lon: 0, unixTime: 0)
+        assertEqual(readUInt16LE(invalidData, offset: 8), DeviceGPSPacketBuilder.invalidHeadingDegrees, "missing heading uses invalid sentinel")
         assertEqual(readUInt16LE(invalidData, offset: 14), DeviceGPSPacketBuilder.invalidSpeedCmps, "missing speed uses invalid sentinel")
         assertEqual(readUInt32LE(invalidData, offset: 26), DeviceGPSPacketBuilder.invalidRouteRemainingMeters, "missing route remaining uses invalid sentinel")
+    }
+
+    static func testNavigationCourseResolver() {
+        var resolver = NavigationCourseResolver()
+        resolver.reset(epoch: 1)
+        assertEqual(
+            Int(resolver.resolve(
+                measuredCourse: 361,
+                routeBearing: 90,
+                navigationActive: true
+            ) ?? -1),
+            1,
+            "valid measured course is preferred and normalized"
+        )
+        assertEqual(
+            Int(resolver.resolve(
+                measuredCourse: -1,
+                routeBearing: 92,
+                navigationActive: true
+            ) ?? -1),
+            92,
+            "invalid measured course falls back to route bearing"
+        )
+        assertEqual(
+            Int(resolver.resolve(
+                measuredCourse: nil,
+                routeBearing: nil,
+                navigationActive: true
+            ) ?? -1),
+            92,
+            "active navigation remembers the last valid course"
+        )
+        resolver.reset(epoch: 2)
+        assert(
+            resolver.resolve(
+                measuredCourse: -1,
+                routeBearing: nil,
+                navigationActive: true
+            ) == nil,
+            "a new navigation epoch cannot inherit a stale heading"
+        )
+        assert(
+            resolver.resolve(
+                measuredCourse: -1,
+                routeBearing: 90,
+                navigationActive: false
+            ) == nil,
+            "idle mode does not accidentally activate course-up from a route"
+        )
+    }
+
+    static func testRouteGeometryMath() {
+        let route = [
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+            CLLocationCoordinate2D(latitude: 37.0, longitude: -121.999),
+            CLLocationCoordinate2D(latitude: 37.001, longitude: -121.999)
+        ]
+        let rider = CLLocationCoordinate2D(
+            latitude: 37.0001,
+            longitude: -121.9996
+        )
+        guard let projection = RouteGeometryMath.nearestProjection(
+            to: rider,
+            on: route
+        ) else {
+            assert(false, "route projection exists")
+            return
+        }
+        assertEqual(projection.segmentIndex, 0, "nearest route segment is selected")
+        assert(abs(projection.coordinate.latitude - 37.0) < 0.000001,
+               "projection lies exactly on the route")
+        let window = RouteGeometryMath.slidingWindow(
+            riderCoordinate: rider,
+            routePoints: route,
+            maximumPointCount: 4
+        )
+        assertCoordinate(
+            window[0],
+            latitude: rider.latitude,
+            longitude: rider.longitude,
+            "route window begins at the exact rider coordinate"
+        )
+        assert(window.count >= 3, "route window retains the projected route and future geometry")
+        let bearing = RouteGeometryMath.bearingNear(rider, routePoints: route)
+        assert(bearing != nil && abs((bearing ?? 0) - 90) < 1,
+               "route bearing follows the nearest eastbound segment")
+    }
+
+    static func testRouteGeometryTransmissionPolicy() {
+        assert(
+            RouteGeometryTransmissionPolicy.shouldSend(
+                currentSegmentIndex: 4,
+                lastSentSegmentIndex: nil,
+                maximumPointCount: 30
+            ),
+            "the first route window is always sent"
+        )
+        assert(
+            !RouteGeometryTransmissionPolicy.shouldSend(
+                currentSegmentIndex: 18,
+                lastSentSegmentIndex: 4,
+                maximumPointCount: 30
+            ),
+            "moving within the buffered route window does not churn route revisions"
+        )
+        assert(
+            RouteGeometryTransmissionPolicy.shouldSend(
+                currentSegmentIndex: 24,
+                lastSentSegmentIndex: 4,
+                maximumPointCount: 30
+            ),
+            "consuming two thirds of the route window requests a replacement"
+        )
+        assert(
+            RouteGeometryTransmissionPolicy.shouldSend(
+                currentSegmentIndex: 2,
+                lastSentSegmentIndex: 24,
+                maximumPointCount: 30
+            ),
+            "backtracking or a replacement route refreshes geometry"
+        )
+    }
+
+    @MainActor
+    static func testNavigationEngineUsesRouteBearingForInvalidCourse() {
+        let manager = TestBLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        let route = TestRoute(
+            instructions: "Continue",
+            coordinates: [
+                CLLocationCoordinate2D(latitude: 37.0, longitude: -122.0),
+                CLLocationCoordinate2D(latitude: 37.0, longitude: -121.99)
+            ]
+        )
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        let location = CLLocation(
+            coordinate: CLLocationCoordinate2D(latitude: 37.0, longitude: -121.999),
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: -1,
+            speed: 5,
+            timestamp: Date()
+        )
+        engine.startNavigation(with: route, initialLocation: location)
+        guard let packet = manager.sentGPSPositions.last else {
+            assert(false, "navigation sends a GPS packet")
+            return
+        }
+        let heading = readUInt16LE(packet, offset: 8)
+        assert(heading >= 89 && heading <= 91,
+               "invalid Core Location course uses route-segment bearing instead of north")
+
+        guard let geometry = engine.extractSlidingWindowGeometry(currentLocation: location) else {
+            assert(false, "navigation extracts route geometry")
+            return
+        }
+        let expected = CoordinateConverter.gcj02ToWGS84(coordinate: location.coordinate)
+        assertEqual(readInt32LE(geometry, offset: 0),
+                    Int32(expected.latitude * 1_000_000),
+                    "route geometry starts at exact current latitude")
+        assertEqual(readInt32LE(geometry, offset: 4),
+                    Int32(expected.longitude * 1_000_000),
+                    "route geometry starts at exact current longitude")
+        engine.stopNavigation()
     }
 
     static func testOfflineMapCustomBBoxRequest() {
@@ -14215,9 +14387,9 @@ struct NavigationProtocolTests {
         }
         assertCoordinate(
             replacementStart,
-            latitude: firstManeuver.latitude,
-            longitude: firstManeuver.longitude,
-            "replacement geometry starts near the rider's latest route position"
+            latitude: latest.coordinate.latitude,
+            longitude: latest.coordinate.longitude,
+            "replacement geometry starts at the rider's latest route position"
         )
         assert(
             readUInt32LE(telemetryAfterReplacement, offset: 18) >= distanceBeforeReplacement,

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -599,6 +599,7 @@ struct NavigationProtocolTests {
         testRouteGeometryMath()
         testRouteGeometryTransmissionPolicy()
         testNavigationEngineUsesRouteBearingForInvalidCourse()
+        testShanghaiNormalAndTestNavigationShareWGSDeviceSpace()
         testNavigationPacketBuilder()
         testNavigationWriteQueue()
         testGPSQueuePolicy()
@@ -4218,6 +4219,19 @@ struct NavigationProtocolTests {
         assertEqual(readUInt16LE(invalidData, offset: 8), DeviceGPSPacketBuilder.invalidHeadingDegrees, "missing heading uses invalid sentinel")
         assertEqual(readUInt16LE(invalidData, offset: 14), DeviceGPSPacketBuilder.invalidSpeedCmps, "missing speed uses invalid sentinel")
         assertEqual(readUInt32LE(invalidData, offset: 26), DeviceGPSPacketBuilder.invalidRouteRemainingMeters, "missing route remaining uses invalid sentinel")
+
+        let legacyHeading = DeviceGPSHeadingWirePolicy.heading(
+            nil,
+            supportsExplicitInvalidHeading: false
+        )
+        let modernHeading = DeviceGPSHeadingWirePolicy.heading(
+            nil,
+            supportsExplicitInvalidHeading: true
+        )
+        assertEqual(Int(legacyHeading ?? -1), 0,
+                    "legacy firmware keeps the historical missing-course zero")
+        assert(modernHeading == nil,
+               "negotiated firmware receives the explicit invalid-heading sentinel")
     }
 
     static func testNavigationCourseResolver() {
@@ -4296,14 +4310,85 @@ struct NavigationProtocolTests {
         )
         assertCoordinate(
             window[0],
-            latitude: rider.latitude,
-            longitude: rider.longitude,
-            "route window begins at the exact rider coordinate"
+            latitude: projection.coordinate.latitude,
+            longitude: projection.coordinate.longitude,
+            "route window begins at the exact route projection"
         )
-        assert(window.count >= 3, "route window retains the projected route and future geometry")
+        assert(window.count >= 2, "route window retains the projected route and future geometry")
+        assert(
+            CLLocation(latitude: window[0].latitude, longitude: window[0].longitude)
+                .distance(from: CLLocation(latitude: rider.latitude, longitude: rider.longitude)) > 1,
+            "retained route geometry does not contain a stale rider connector"
+        )
         let bearing = RouteGeometryMath.bearingNear(rider, routePoints: route)
         assert(bearing != nil && abs((bearing ?? 0) - 90) < 1,
                "route bearing follows the nearest eastbound segment")
+
+        var matcher = RouteProgressMatcher(
+            lookBehindSegments: 1,
+            lookAheadSegments: 3,
+            reacquireDistanceMeters: 50
+        )
+        let crossingRoute = [
+            CLLocationCoordinate2D(latitude: 31.2300, longitude: 121.4700),
+            CLLocationCoordinate2D(latitude: 31.2300, longitude: 121.4710),
+            CLLocationCoordinate2D(latitude: 31.2300, longitude: 121.4720),
+            CLLocationCoordinate2D(latitude: 31.2310, longitude: 121.4720),
+            CLLocationCoordinate2D(latitude: 31.2320, longitude: 121.4720),
+            CLLocationCoordinate2D(latitude: 31.2310, longitude: 121.4710),
+            CLLocationCoordinate2D(latitude: 31.2300, longitude: 121.4700),
+            CLLocationCoordinate2D(latitude: 31.2290, longitude: 121.4710),
+            CLLocationCoordinate2D(latitude: 31.2300, longitude: 121.4720)
+        ]
+        _ = matcher.projection(
+            to: CLLocationCoordinate2D(latitude: 31.2310, longitude: 121.4710),
+            on: crossingRoute
+        )
+        _ = matcher.projection(
+            to: CLLocationCoordinate2D(latitude: 31.2305, longitude: 121.4705),
+            on: crossingRoute
+        )
+        let crossing = matcher.projection(
+            to: crossingRoute[0],
+            on: crossingRoute
+        )
+        assert((crossing?.segmentIndex ?? -1) >= 4,
+               "epoch-scoped matching does not jump back to the first branch at a crossing")
+
+        matcher.reset()
+        let resetProjection = matcher.projection(to: crossingRoute[0], on: crossingRoute)
+        assertEqual(resetProjection?.segmentIndex ?? -1, 0,
+                    "route replacement resets progress and permits global matching")
+
+        let backtrackRoute = (0...11).map { index in
+            CLLocationCoordinate2D(
+                latitude: 31.2300,
+                longitude: 121.4700 + Double(index) * 0.001
+            )
+        }
+        var backtrackMatcher = RouteProgressMatcher(
+            lookBehindSegments: 1,
+            lookAheadSegments: 3,
+            reacquireDistanceMeters: 50
+        )
+        let established = backtrackMatcher.projection(
+            to: CLLocationCoordinate2D(
+                latitude: 31.2300,
+                longitude: 121.4785
+            ),
+            on: backtrackRoute
+        )
+        assertEqual(established?.segmentIndex ?? -1, 8,
+                    "matcher establishes late-route forward progress")
+        let backtracked = backtrackMatcher.projection(
+            to: CLLocationCoordinate2D(
+                latitude: 31.2300,
+                longitude: 121.4725
+            ),
+            on: backtrackRoute
+        )
+        assertEqual(backtracked?.segmentIndex ?? -1, 2,
+                    "a deliberate far backtrack escapes the bounded window and reacquires globally")
     }
 
     static func testRouteGeometryTransmissionPolicy() {
@@ -4317,19 +4402,19 @@ struct NavigationProtocolTests {
         )
         assert(
             !RouteGeometryTransmissionPolicy.shouldSend(
-                currentSegmentIndex: 18,
+                currentSegmentIndex: 4,
                 lastSentSegmentIndex: 4,
                 maximumPointCount: 30
             ),
-            "moving within the buffered route window does not churn route revisions"
+            "remaining on one segment does not churn route revisions"
         )
         assert(
             RouteGeometryTransmissionPolicy.shouldSend(
-                currentSegmentIndex: 24,
+                currentSegmentIndex: 5,
                 lastSentSegmentIndex: 4,
                 maximumPointCount: 30
             ),
-            "consuming two thirds of the route window requests a replacement"
+            "advancing one segment requests a fresh forward window"
         )
         assert(
             RouteGeometryTransmissionPolicy.shouldSend(
@@ -4378,13 +4463,109 @@ struct NavigationProtocolTests {
             return
         }
         let expected = CoordinateConverter.gcj02ToWGS84(coordinate: location.coordinate)
-        assertEqual(readInt32LE(geometry, offset: 0),
-                    Int32(expected.latitude * 1_000_000),
-                    "route geometry starts at exact current latitude")
-        assertEqual(readInt32LE(geometry, offset: 4),
-                    Int32(expected.longitude * 1_000_000),
-                    "route geometry starts at exact current longitude")
+        assert(abs(readInt32LE(geometry, offset: 0) -
+                   Int32(expected.latitude * 1_000_000)) <= 1,
+               "route geometry starts at the route projection latitude")
+        assert(abs(readInt32LE(geometry, offset: 4) -
+                   Int32(expected.longitude * 1_000_000)) <= 1,
+               "route geometry starts at the route projection longitude")
+        assertEqual(engine.routeCoordinateExtractionCount, 1,
+                    "route coordinates are extracted once per navigation epoch")
         engine.stopNavigation()
+    }
+
+    @MainActor
+    static func testShanghaiNormalAndTestNavigationShareWGSDeviceSpace() {
+        let wgsStart = CLLocationCoordinate2D(latitude: 31.2304, longitude: 121.4737)
+        let gcjStart = CoordinateConverter.wgs84ToGCJ02(coordinate: wgsStart)
+        let gcjEnd = CLLocationCoordinate2D(
+            latitude: gcjStart.latitude,
+            longitude: gcjStart.longitude + 0.001
+        )
+        let route = TestRoute(
+            instructions: "Continue east",
+            coordinates: [gcjStart, gcjEnd]
+        )
+
+        func assertAligned(
+            _ manager: TestBLEManager,
+            expectedWGS: CLLocationCoordinate2D,
+            mode: String
+        ) {
+            guard let gps = manager.sentGPSPositions.last,
+                  let geometry = manager.sentRouteGeometry.last else {
+                assert(false, "\(mode) navigation sends GPS and route geometry")
+                return
+            }
+            let gpsCoordinate = CLLocationCoordinate2D(
+                latitude: Double(readInt32LE(gps, offset: 0)) / 1_000_000,
+                longitude: Double(readInt32LE(gps, offset: 4)) / 1_000_000
+            )
+            let routeCoordinate = CLLocationCoordinate2D(
+                latitude: Double(readInt32LE(geometry, offset: 0)) / 1_000_000,
+                longitude: Double(readInt32LE(geometry, offset: 4)) / 1_000_000
+            )
+            let expectedLocation = CLLocation(
+                latitude: expectedWGS.latitude,
+                longitude: expectedWGS.longitude
+            )
+            assert(
+                CLLocation(latitude: gpsCoordinate.latitude, longitude: gpsCoordinate.longitude)
+                    .distance(from: expectedLocation) < 2,
+                "\(mode) GPS remains WGS-84 in Shanghai"
+            )
+            assert(
+                CLLocation(latitude: routeCoordinate.latitude, longitude: routeCoordinate.longitude)
+                    .distance(from: expectedLocation) < 3,
+                "\(mode) MAPR geometry is converted from MapKit GCJ-02 into the same WGS-84 space"
+            )
+            let heading = readUInt16LE(gps, offset: 8)
+            assert(heading >= 89 && heading <= 91,
+                   "\(mode) navigation follows the eastbound route instead of north")
+        }
+
+        let normalManager = TestBLEManager()
+        normalManager.isConnected = true
+        normalManager.isNavigationReady = true
+        let normalEngine = NavigationEngine()
+        normalEngine.setBLEManager(normalManager)
+        normalEngine.startNavigation(with: route)
+        let liveWGS = CLLocation(
+            coordinate: wgsStart,
+            altitude: 0,
+            horizontalAccuracy: 5,
+            verticalAccuracy: 5,
+            course: -1,
+            speed: 5,
+            timestamp: Date()
+        )
+        assert(normalEngine.processExternalLocation(liveWGS),
+               "normal Shanghai WGS fix is accepted against the MapKit route")
+        assertAligned(normalManager, expectedWGS: wgsStart, mode: "normal")
+        assertEqual(normalEngine.routeCoordinateExtractionCount, 1,
+                    "normal navigation caches the MKRoute polyline")
+        normalEngine.stopNavigation()
+
+        let testManager = TestBLEManager()
+        testManager.isConnected = true
+        testManager.isNavigationReady = true
+        let testEngine = NavigationEngine()
+        testEngine.setBLEManager(testManager)
+        testEngine.startNavigation(with: route, isTestMode: true)
+        testEngine.updateSimulationForTesting(timeInterval: 1)
+        guard let simulatedGCJ = testEngine.simulatedPosition else {
+            assert(false, "test navigation advances along the Shanghai route")
+            testEngine.stopNavigation()
+            return
+        }
+        assertAligned(
+            testManager,
+            expectedWGS: CoordinateConverter.gcj02ToWGS84(coordinate: simulatedGCJ),
+            mode: "test"
+        )
+        assertEqual(testEngine.routeCoordinateExtractionCount, 1,
+                    "test navigation uses the same cached MKRoute polyline")
+        testEngine.stopNavigation()
     }
 
     static func testOfflineMapCustomBBoxRequest() {
@@ -9465,7 +9646,8 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationPerspectiveCapabilityMask, 1 << 10, "CAP2 bit 10 advertises bird's-eye perspective")
         assertEqual(DeviceBLEProtocol.birdsEyeMapNavigationStrongerPerspectiveCapabilityMask, 1 << 11, "CAP2 bit 11 advertises stronger bird's-eye perspectives")
         assertEqual(DeviceBLEProtocol.osm3DBuildingsCapabilityMask, 1 << 12, "CAP2 bit 12 advertises OSM 3D buildings")
-        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 10, "capability version switches to CAP2 without colliding with legacy versions 7 through 9")
+        assertEqual(DeviceBLEProtocol.explicitInvalidGPSHeadingCapabilityMask, 1 << 13, "CAP2 bit 13 advertises explicit invalid GPS headings")
+        assertEqual(DeviceBLEProtocol.deviceCapabilitiesVersion, 11, "capability version negotiates explicit invalid GPS headings after CAP2 version 10")
         assertEqual(DeviceBLEProtocol.workoutTelemetryCharacteristicUUIDString,
                     "9D7B3F30-3F6A-4D1C-9F6D-1FBF0E8B1003",
                     "workout telemetry uses the dedicated 128-bit characteristic")
@@ -11096,7 +11278,7 @@ struct NavigationProtocolTests {
         assert(!manager.hasReceivedDeviceCapabilities, "malformed CAPS does not complete negotiation")
 
         let cap2 = Data(DeviceBLEProtocol.deviceCapabilitiesV2Prefix.utf8) +
-            Data([1, 0, 0x1F, 0, 0])
+            Data([1, 0, 0x3F, 0, 0])
         assert(manager.handleDeviceCapabilitiesNotification(cap2),
                "CAP2 notification should be consumed")
         assert(manager.supportsStreetLabels,
@@ -11109,6 +11291,8 @@ struct NavigationProtocolTests {
                "CAP2 bit 11 preserves stronger bird's-eye perspective support")
         assert(manager.supports3DBuildings,
                "CAP2 bit 12 enables OSM 3D-building maps and controls")
+        assert(manager.supportsExplicitInvalidGPSHeading,
+               "CAP2 bit 13 enables the explicit missing-course sentinel")
         assert(manager.hasReceivedDeviceCapabilities,
                "valid CAP2 completes capability negotiation")
 
@@ -11119,12 +11303,16 @@ struct NavigationProtocolTests {
                "CAP2 power configuration TLV is consumed")
         assert(manager.supportsStreetLabels,
                "CAP2 preserves the extended street-label capability")
+        assert(!manager.supportsExplicitInvalidGPSHeading,
+               "CAP2 version 10 firmware without bit 13 keeps legacy heading encoding")
 
         let duplicateTLV = cap2WithConfig + Data([1, 3, 1, 0, 50])
         assert(manager.handleDeviceCapabilitiesNotification(duplicateTLV),
                "malformed CAP2 is consumed for retry")
         assert(!manager.hasReceivedDeviceCapabilities,
                "duplicate CAP2 TLVs are rejected")
+        assert(!manager.supportsExplicitInvalidGPSHeading,
+               "malformed capabilities clear explicit invalid-heading support")
 
         UserDefaults.standard.removeObject(forKey: "deviceSettings.selectedSound")
         UserDefaults.standard.removeObject(forKey: "deviceSettings.soundVolumePercent")


### PR DESCRIPTION
## Summary

This is a fresh implementation from current main of the navigation-rendering fixes learned from the closed PR #199.

- Moves SD reads, vector parsing, building discovery/selection, 3D building drawing, and base-map rasterization off the LVGL/UI task into one bounded render worker.
- Keeps LVGL as the sole owner of canvas publication and presents the map, route, and arrow from one shared pose snapshot so they advance and rotate together.
- Uses a render-ahead frame plus cheap live transforms/foreground compositing between worker publications; stable ticks are signature-cached no-ops instead of repeatedly invalidating large canvases.
- Preserves deterministic 3D buildings with bounded workspaces, cancellation checkpoints, admission limits, and graceful 2D degradation under memory or time pressure.
- Keeps native GPS and route geometry in WGS-84 across BLE. GCJ-02 is presentation-only on iOS, including Shanghai test navigation.
- Refreshes the bounded route window when matched progress enters a new segment, rate-limited to avoid render churn and ambiguity at loops or self-intersections.
- Makes offline-map activation asynchronous and preserves the current published frame until a replacement is ready.
- Adds scheduler, coordinate-contract, route-window, normal-navigation, test-navigation, 3D-admission, gesture, alignment, and integration coverage.

## Root cause

The old guidance path synchronously performed expensive vector-map and 3D-building work from the UI update path. Building discovery had a short budget, but the following building selection/draw phase could continue for seconds. That starved LVGL: the blue overlay could use newer positions while the arrow and base map remained frozen until the next completed render/flush.

The fresh render-ahead implementation initially introduced a separate presentation regression. Its 658 x 658 overscan canvas remained `LV_ALIGN_CENTER`, but `lv_obj_set_pos()` values were calculated as absolute parent coordinates. LVGL interprets those values as offsets from the resolved centered origin, so the 96-pixel overscan origin was applied twice to the base canvas while the viewport-sized route foreground and marker applied it once. In course-up mode that fixed screen-space displacement rotated into world space, matching the observed east-to-north and south-to-east route offset. The presenter now converts the desired parent-space pivot target into a center-aligned style offset exactly once.

## Durable architecture

The durable invariant is strict ownership:

1. The iPhone sends native WGS-84 position, heading, and bounded WGS-84 route geometry for both normal and test navigation.
2. A single coalescing firmware worker owns all blocking map I/O and base-frame rendering.
3. LVGL never blocks on map generation and is the only task that publishes or mutates display objects.
4. Base map, route, and arrow consume one presented-pose snapshot and one frame generation.
5. The oversized base canvas stays center-aligned; presentation converts parent-space pivot targets to LVGL aligned offsets exactly once.
6. 3D work is bounded and cancellable, but remains enabled; pressure drops detail or buildings deterministically instead of blocking the UI.
7. New requests replace stale pending work while the last complete frame remains visible.

## Validation

- 188 ESP32 host tests passed in the full branch validation.
- The updated strict C++ map/presentation/render-policy/route/building/raster suites passed.
- The updated navigation integration suite passed all 17 tests, including the overscan-alignment contract.
- Portable iOS navigation, cycling, destination-callout, and saved-map test suites passed.
- Shanghai coordinate tests cover both normal navigation and test navigation, asserting WGS-84 BLE payloads and GCJ-02 presentation-only behavior.
- Clean verified Waveshare 1.75-inch build passed at commit `a249bca40a325df19a375c80582f6b9502a7d0ec`.
  - uploadEligible=1
  - RAM: 53.2% (174176 / 327680 bytes)
  - Flash: 95.2% (2995563 / 3145728 bytes)
  - firmware.bin SHA-256: `6e075776fcbbb7d71314c632d02c45554e46a999b8c460bb73d581e7099cf014`

Physical acceptance remains pending on a connected Waveshare 1.75-inch device: idle guidance, Shanghai test navigation, and real navigation with 3D buildings, heading-up orientation, aligned route/arrow/map motion, UI-gap/flush telemetry, and PSRAM telemetry. The PR remains draft until that gate is complete.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I am contributing on behalf of an organization that has authorized this contribution.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and agree that it is licensed under the repository license.
