### PR TITLE
Handle real-world OSM building relation roles

### DIFF
--- a/map-platform/backend/tests/test_map_buildings.py
+++ b/map-platform/backend/tests/test_map_buildings.py
@@ -941,8 +941,8 @@ class MapBuildingContractTests(unittest.TestCase):
                 text=True,
                 capture_output=True,
             ).stdout
-            self.assertIn("Number of ways: 3", info)
-            self.assertIn("Number of relations: 4", info)
+            self.assertIn("Number of ways: 6", info)
+            self.assertIn("Number of relations: 5", info)
 
     @unittest.skipUnless(shutil.which("osmium"), "osmium is required")
     def test_selected_preprocessing_rehydrates_output_relation_and_calibration_cells(self):

--- a/tools/OSM_Extract/scripts/extract_building_relations.py
+++ b/tools/OSM_Extract/scripts/extract_building_relations.py
@@ -77,10 +77,23 @@ class BuildingRelationHandler(osmium.SimpleHandler):
             for member in relation.members
             if member.role == "outline" and member.type in {"w", "r"}
         )
+        if not outlines:
+            outer_aliases = sorted(
+                member_key(member)
+                for member in relation.members
+                if member.role == "outer" and member.type in {"w", "r"}
+            )
+            # Some real-world type=building relations use multipolygon-style
+            # roles. A single outer is an unambiguous outline alias; multiple
+            # outers may be ring fragments or separate outlines and must keep
+            # failing closed instead of selecting an arbitrary parent.
+            if len(outer_aliases) == 1:
+                outlines = outer_aliases
         parts = sorted(
             member_key(member)
             for member in relation.members
-            if member.role == "part" and member.type in {"w", "r"}
+            if member.role in {"part", "building:part"}
+            and member.type in {"w", "r"}
         )
         if not outlines or not parts:
             if self.audit_enabled and parts and not outlines:

--- a/tools/OSM_Extract/tests/fixtures/building_relations.osm
+++ b/tools/OSM_Extract/tests/fixtures/building_relations.osm
@@ -21,7 +21,31 @@
     <nd ref="1" />
     <tag k="building" v="yes" />
   </way>
+  <way id="12" version="1">
+    <nd ref="1" />
+    <nd ref="2" />
+    <nd ref="3" />
+    <nd ref="4" />
+    <nd ref="1" />
+    <tag k="building" v="yes" />
+  </way>
   <way id="20" version="1">
+    <nd ref="1" />
+    <nd ref="2" />
+    <nd ref="3" />
+    <nd ref="4" />
+    <nd ref="1" />
+    <tag k="building:part" v="yes" />
+  </way>
+  <way id="21" version="1">
+    <nd ref="1" />
+    <nd ref="2" />
+    <nd ref="3" />
+    <nd ref="4" />
+    <nd ref="1" />
+    <tag k="building:part" v="yes" />
+  </way>
+  <way id="22" version="1">
     <nd ref="1" />
     <nd ref="2" />
     <nd ref="3" />
@@ -46,6 +70,12 @@
   </relation>
   <relation id="103" version="1">
     <member type="way" ref="10" role="outline" />
+    <tag k="type" v="building" />
+  </relation>
+  <relation id="104" version="1">
+    <member type="way" ref="12" role="outer" />
+    <member type="way" ref="21" role="part" />
+    <member type="way" ref="22" role="building:part" />
     <tag k="type" v="building" />
   </relation>
 </osm>

--- a/tools/OSM_Extract/tests/test_building_relations.py
+++ b/tools/OSM_Extract/tests/test_building_relations.py
@@ -5,12 +5,14 @@ import re
 import subprocess
 import sys
 import tempfile
+from types import SimpleNamespace
 import unittest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
 from building_calibration_cache import canonical_json  # noqa: E402
 from building_source_index import BuildingSourceIndex  # noqa: E402
 from build_building_source_index import scan_source  # noqa: E402
+from extract_building_relations import BuildingRelationHandler  # noqa: E402
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -19,6 +21,52 @@ SCRIPT = ROOT / "scripts" / "extract_building_relations.py"
 
 
 class BuildingRelationIngressTests(unittest.TestCase):
+    @staticmethod
+    def relation(relation_id, members):
+        class Tags(list):
+            def get(self, key):
+                return next((tag.v for tag in self if tag.k == key), None)
+
+        return SimpleNamespace(
+            id=relation_id,
+            tags=Tags([SimpleNamespace(k="type", v="building")]),
+            members=[SimpleNamespace(**member) for member in members],
+        )
+
+    def test_single_outer_and_building_part_roles_are_safe_aliases(self):
+        handler = BuildingRelationHandler(
+            expected_closure={"requiredRelationKeys": ["r104"]}
+        )
+        handler.relation(
+            self.relation(
+                104,
+                [
+                    {"type": "w", "ref": 12, "role": "outer"},
+                    {"type": "w", "ref": 21, "role": "part"},
+                    {"type": "w", "ref": 22, "role": "building:part"},
+                ],
+            )
+        )
+        self.assertEqual(handler.part_parents, {"w21": "w12", "w22": "w12"})
+        self.assertFalse(handler.parts_without_outline)
+
+    def test_multiple_outer_aliases_remain_without_an_explicit_parent(self):
+        handler = BuildingRelationHandler(
+            expected_closure={"requiredRelationKeys": ["r105"]}
+        )
+        handler.relation(
+            self.relation(
+                105,
+                [
+                    {"type": "w", "ref": 12, "role": "outer"},
+                    {"type": "w", "ref": 13, "role": "outer"},
+                    {"type": "w", "ref": 21, "role": "part"},
+                ],
+            )
+        )
+        self.assertFalse(handler.part_parents)
+        self.assertEqual(handler.parts_without_outline, {"w21"})
+
     def test_cli_indexes_real_osm_building_relations_deterministically(self):
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "building-relations.json"
@@ -33,20 +81,26 @@ class BuildingRelationIngressTests(unittest.TestCase):
                 json.loads(output.read_text(encoding="utf-8")),
                 {
                     "schemaVersion": 1,
-                    "partParents": {"w20": "w10"},
+                    "partParents": {
+                        "w20": "w10",
+                        "w21": "w12",
+                        "w22": "w12",
+                    },
                     "parentTags": {
                         "w10": {"type": "building"},
                         "w11": {"type": "building"},
+                        "w12": {"type": "building"},
                     },
-                    "relations": 2,
+                    "relations": 3,
                     "ambiguousParts": 1,
                 },
             )
             self.assertEqual(
                 output.read_text(encoding="utf-8"),
                 '{"ambiguousParts":1,"parentTags":{"w10":{"type":"building"},'
-                '"w11":{"type":"building"}},"partParents":{"w20":"w10"},'
-                '"relations":2,"schemaVersion":1}\n',
+                '"w11":{"type":"building"},"w12":{"type":"building"}},'
+                '"partParents":{"w20":"w10","w21":"w12","w22":"w12"},'
+                '"relations":3,"schemaVersion":1}\n',
             )
 
     def test_source_index_audit_accepts_complete_closure_and_rejects_missing_way(self):
@@ -109,7 +163,7 @@ class BuildingRelationIngressTests(unittest.TestCase):
             self.assertEqual(complete.returncode, 0, complete.stdout + complete.stderr)
             audit = json.loads(output.read_text())["closureAudit"]
             self.assertEqual(audit["relationRetryCount"], 0)
-            self.assertEqual(audit["closureRelationCount"], 3)
+            self.assertEqual(audit["closureRelationCount"], 4)
             self.assertEqual(audit["sourceSnapshotSha256"], source_sha)
 
             incomplete_fixture = root / "incomplete.osm"


### PR DESCRIPTION
## What changed

- accept `building:part` as a part-role alias in `type=building` relations
- accept a single `outer` member as an unambiguous outline alias
- keep multiple `outer` members fail-closed so no arbitrary parent is selected
- add parser, closure-audit, and real-osmium regression coverage

## Root cause and impact

The selected-scope Shanghai job failed because relation `9352659` uses one `outer` outline and both `part` and `building:part` part roles. The source-closure index correctly retained the relation, but relation ingress recognized only `outline` and `part`, so it rejected part way `672799704` as missing an explicit parent.

With this change, the exact 17.242 km² request completes locally in selected mode without relation retries. It produces 100.663 km² of aligned output from a 111.411 km² selected source scope and packages a 3.217 MB ZIP.

## Validation

- `python -m unittest discover -s tools/OSM_Extract/tests` — 109 passed
- `python -m unittest discover -s map-platform/backend/tests` — 327 passed, 1 skipped
- `python -m unittest discover -s map-platform/deploy/tests` — 37 passed
- exact Shanghai selected-scope end-to-end build — passed, valid BMAP and ZIP
