### PR TITLE
Fix BLE workout and map delivery after reconnect

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -37,11 +37,12 @@ firmware field to wrap.
 
 If iOS has cached an older GATT table and does not discover `2A6F`, `2A72`,
 `2A73`, or the workout characteristic, the app falls back to framed binary
-writes over authenticated `2A6E`. A discovered workout characteristic always
-owns workout traffic; current firmware's write-without-response transport is
-flow-controlled through CoreBluetooth and the app's correlated-pair queue.
-`WTLM` is reserved for firmware whose GATT table does not expose the dedicated
-characteristic.
+writes over authenticated `2A6E`. Current firmware exposes acknowledged and
+unacknowledged workout writes, and iOS prefers the acknowledged native route.
+For earlier firmware whose workout characteristic is unacknowledged, iOS uses
+acknowledged `WTLM` whenever `2A6E` supports responses. Native
+write-without-response remains the compatibility route when the command
+transport is also unacknowledged.
 Fallback frame prefixes:
 
 | Prefix | Payload |
@@ -317,10 +318,12 @@ Workout telemetry is iOS-to-device, RAM-only, and accepted only after the
 existing local authentication handshake. The logical native payload is exactly
 16 bytes. In an ownership-v2 session it is carried in an `S2` frame on protected
 channel `6`, for a 38-byte native wire write. Current firmware exposes the
-native characteristic as write-without-response, so iOS sends through that
-dedicated transport. The bounded queue admits each correlated core-plus-extended
-pair atomically, preserves pair ordering, coalesces obsolete state, and retries
-until the latest state converges. A cached GATT table uses this fallback:
+native characteristic with both write properties, so iOS uses acknowledged
+delivery. The bounded queue admits each correlated core-plus-extended pair
+atomically, preserves pair ordering, coalesces obsolete state, and retries until
+the latest state converges. Earlier firmware with only an unacknowledged native
+workout characteristic uses this fallback whenever the navigation
+characteristic supports acknowledged writes:
 
 ```text
 "WTLM" | 16-byte workout frame
@@ -330,9 +333,11 @@ The fallback plaintext is exactly 20 bytes before ownership-v2 protection and
 the protected fallback wire write is 42 bytes. Native and fallback payloads use
 the same parser after their authenticated channel is unwrapped. The ownership
 handshake already requires an ATT MTU large enough for either protected write.
-iOS prefers an acknowledged native workout characteristic when available,
-otherwise uses native write-without-response. It uses `WTLM` only when the
-dedicated characteristic is unavailable.
+iOS prefers an acknowledged native workout characteristic when available, then
+acknowledged `WTLM`, and uses native write-without-response only when no
+acknowledged route is available. Persistent no-response backpressure triggers a
+bounded reconnect instead of indefinitely blocking GPS, settings, and workout
+state in the shared queue.
 iOS sends no workout frames unless capability bit `7` is present, so older
 firmware continues using the existing GPS ride fields unchanged.
 

--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -76,10 +76,10 @@ BLE capability bit 7.
 - Old app + ownership-v2 firmware: authentication is intentionally rejected;
   update the app before installing the firmware.
 - New app + new firmware: the app uses the dedicated workout characteristic.
-  Current firmware's native write-without-response transport is protected by
-  CoreBluetooth flow control and the app's atomic, convergent correlated-pair
-  queue. The documented 20-byte plaintext `WTLM` fallback is retained only for
-  a cached or older GATT table without the dedicated characteristic.
+  Current firmware supports acknowledged native writes. For earlier firmware
+  with an unacknowledged workout characteristic, the app prefers acknowledged
+  `WTLM` and retains native no-response delivery only when no acknowledged route
+  exists. Persistent no-response backpressure causes a bounded reconnect.
 
 Do not advertise capability bit 7 in any firmware release that lacks the frame
 parser, RAM-only workout state, staleness handling, and Ride Stats UI.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -3306,7 +3306,8 @@ void BLENavigationServer::init(const char *deviceName) {
   // Workout frames are accepted only after the same local authentication
   // handshake as navigation traffic and remain in RAM-only telemetry state.
   pWorkoutTelemetryCharacteristic = pService->createCharacteristic(
-      WORKOUT_TELEMETRY_CHAR_UUID, NIMBLE_PROPERTY::WRITE_NR);
+      WORKOUT_TELEMETRY_CHAR_UUID,
+      NIMBLE_PROPERTY::WRITE | NIMBLE_PROPERTY::WRITE_NR);
   pWorkoutTelemetryCharacteristic->setCallbacks(
       new MyWorkoutTelemetryCharacteristicCallbacks());
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -87,10 +87,18 @@ enum WorkoutTelemetryWriteRoute: Equatable {
 enum WorkoutTelemetryWriteRouting {
     static func route(
         hasNativeWriteWithResponse: Bool,
-        hasNativeWriteWithoutResponse: Bool
+        hasNativeWriteWithoutResponse: Bool,
+        navigationExpectsWriteResponse: Bool
     ) -> WorkoutTelemetryWriteRoute {
         if hasNativeWriteWithResponse {
             return .nativeWithResponse
+        }
+        // Prefer the acknowledged fallback over a dedicated unacknowledged
+        // characteristic. Both transports share one ordered queue, so a
+        // write-without-response credit stall at the priority head would also
+        // block GPS, settings, and transfer traffic behind the workout pair.
+        if navigationExpectsWriteResponse {
+            return .navigationFallback
         }
         if hasNativeWriteWithoutResponse {
             return .nativeWithoutResponse
@@ -833,6 +841,7 @@ class BLEManager: NSObject, ObservableObject {
     private var navigationWriteWithResponseLabel: String?
     private var navigationWriteResponseTimeoutTimer: Timer?
     private var navigationWriteResponseGeneration: UInt64 = 0
+    private var navigationBackpressureStartedAt: Date?
 #if HOST_TESTING
     private var navigationWriteResponseTimeout: TimeInterval = 60
 #else
@@ -2250,7 +2259,9 @@ class BLEManager: NSObject, ObservableObject {
                 characteristic?.properties.contains(.write) == true,
             hasNativeWriteWithoutResponse:
                 testEndpoint != nil ||
-                characteristic?.properties.contains(.writeWithoutResponse) == true
+                characteristic?.properties.contains(.writeWithoutResponse) == true,
+            navigationExpectsWriteResponse:
+                navigationEndpoint.expectsWriteResponse
         )
 
         switch route {
@@ -4526,6 +4537,7 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     private func flushPendingNavigationWrites(endpoint: NavigationWriteEndpoint) {
+        var madeProgress = false
         navigationWriteQueue.flush(canSend: { [weak self] write in
             guard let self else { return false }
             let expectsWriteResponse = write.transportExpectsWriteResponse
@@ -4535,6 +4547,7 @@ class BLEManager: NSObject, ObservableObject {
             }
             return write.transportCanSend?() ?? endpoint.canSend()
         }, maxWrites: 1) { write in
+            madeProgress = true
             let expectsWriteResponse = write.transportExpectsWriteResponse
                 ?? endpoint.expectsWriteResponse
             if expectsWriteResponse {
@@ -4543,6 +4556,10 @@ class BLEManager: NSObject, ObservableObject {
             write.perform(using: endpoint.write)
             log("Sent \(write.label): \(write.data.count) bytes")
         }
+        updateNavigationBackpressureWatchdog(
+            madeProgress: madeProgress,
+            hasPendingWrites: navigationWriteQueue.count > 0
+        )
         if navigationWriteQueue.count == 0 {
             navigationFlushRetryTimer?.invalidate()
             navigationFlushRetryTimer = nil
@@ -4598,6 +4615,7 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     private func beginNavigationWriteResponseWait(for write: NavigationWrite) {
+        navigationBackpressureStartedAt = nil
         writeWithResponseInFlight = true
         navigationWriteWithResponseFailureHandler = write.onWriteFailure
         navigationWriteWithResponseLabel = write.label
@@ -4624,6 +4642,45 @@ class BLEManager: NSObject, ObservableObject {
         writeWithResponseInFlight = false
         navigationWriteWithResponseFailureHandler = nil
         navigationWriteWithResponseLabel = nil
+        navigationBackpressureStartedAt = nil
+    }
+
+    private func updateNavigationBackpressureWatchdog(
+        madeProgress: Bool,
+        hasPendingWrites: Bool
+    ) {
+        if madeProgress || !hasPendingWrites || writeWithResponseInFlight {
+            navigationBackpressureStartedAt = nil
+            return
+        }
+
+        let now = Date()
+        guard let startedAt = navigationBackpressureStartedAt else {
+            navigationBackpressureStartedAt = now
+            return
+        }
+        guard now.timeIntervalSince(startedAt) >=
+                navigationWriteResponseTimeout else {
+            return
+        }
+        recoverFromNavigationBackpressure()
+    }
+
+    private func recoverFromNavigationBackpressure() {
+        guard isNavigationReady else { return }
+        log("BLE write-without-response backpressure timed out; reconnecting")
+        navigationBackpressureStartedAt = nil
+        navigationFlushRetryTimer?.invalidate()
+        navigationFlushRetryTimer = nil
+        isNavigationReady = false
+
+        if let navigationWriteStallRecoveryForTesting {
+            navigationWriteStallRecoveryForTesting()
+            return
+        }
+        if let peripheral = connectedPeripheral {
+            centralManager.cancelPeripheralConnection(peripheral)
+        }
     }
 
     private func recoverFromNavigationWriteStall() {

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -274,16 +274,26 @@ class BikeComputerCoordinator: ObservableObject {
                     return
                 }
                 let generation = self.deviceCapabilityRefreshGeneration
-                if let location = self.locationManager.currentLocation {
-                    self.navEngine.processExternalLocation(location)
+                // @Published emits from willSet. Run readiness-guarded work on
+                // the next main turn after isNavigationReady has committed.
+                DispatchQueue.main.async { [weak self] in
+                    guard let self,
+                          self.bleManager.isNavigationReady,
+                          self.deviceCapabilityRefreshGeneration == generation
+                    else { return }
+                    if let location = self.locationManager.currentLocation {
+                        self.navEngine.processExternalLocation(location)
+                    }
+                    self.requestMapTransferStatusAfterDeviceRefresh()
+                    DeviceCapabilityRetry.scheduleInitial { [weak self] in
+                        self?.refreshDeviceCapabilities(
+                            attempt: 0,
+                            generation: generation
+                        )
+                    }
+                    self.bleManager.requestDeviceTransferStatus()
+                    self.scheduleFirmwareUpdateCheckAfterDeviceRefresh()
                 }
-                self.requestMapTransferStatusAfterDeviceRefresh()
-                DeviceCapabilityRetry.scheduleInitial { [weak self] in
-                    self?.refreshDeviceCapabilities(attempt: 0,
-                                                    generation: generation)
-                }
-                self.bleManager.requestDeviceTransferStatus()
-                self.scheduleFirmwareUpdateCheckAfterDeviceRefresh()
             }
             .store(in: &cancellables)
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -86,13 +86,20 @@ class NavigationEngine: NSObject, ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] isReady in
                 guard isReady, let self else { return }
-                self.resendCurrentDeviceGpsPosition()
-                guard self.isNavigating else {
-                    self.bleManager?.clearRouteGeometry()
-                    return
+                // @Published emits from willSet. Defer until the manager's
+                // readiness property has committed so guarded GPS/route sends
+                // do not re-read the previous false value on reconnect.
+                DispatchQueue.main.async { [weak self, weak manager] in
+                    guard let self, let manager,
+                          manager.isNavigationReady else { return }
+                    self.resendCurrentDeviceGpsPosition()
+                    guard self.isNavigating else {
+                        self.bleManager?.clearRouteGeometry()
+                        return
+                    }
+                    self.resendCurrentRouteGeometry()
+                    self.resendCurrentNavigationState()
                 }
-                self.resendCurrentRouteGeometry()
-                self.resendCurrentNavigationState()
             }
             .store(in: &cancellables)
     }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -652,6 +652,7 @@ struct NavigationProtocolTests {
         testNavigationEngineUsesDegenerateStepFallback()
         testNavigationEngineKeepsProgressAtRouteCrossing()
         testNavigationEngineResendsWhenBLEBecomesReady()
+        testNavigationEngineDefersReconnectGPSUntilReadinessCommits()
         testNavigationEngineResendsRouteGeometryNearLastLocation()
         testNavigationEngineClearsRouteGeometryOnStop()
         testNavigationEngineClearsRouteGeometryWhenReadyAndIdle()
@@ -10744,17 +10745,26 @@ struct NavigationProtocolTests {
 
         assertEqual(WorkoutTelemetryWriteRouting.route(
             hasNativeWriteWithResponse: true,
-            hasNativeWriteWithoutResponse: true
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: true
         ), .nativeWithResponse,
                     "an acknowledged native workout characteristic is preferred")
         assertEqual(WorkoutTelemetryWriteRouting.route(
             hasNativeWriteWithResponse: false,
-            hasNativeWriteWithoutResponse: true
-        ), .nativeWithoutResponse,
-                    "the dedicated workout characteristic does not inherit navigation backpressure")
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: true
+        ), .navigationFallback,
+                    "an acknowledged fallback avoids priority-lane no-response head-of-line blocking")
         assertEqual(WorkoutTelemetryWriteRouting.route(
             hasNativeWriteWithResponse: false,
-            hasNativeWriteWithoutResponse: false
+            hasNativeWriteWithoutResponse: true,
+            navigationExpectsWriteResponse: false
+        ), .nativeWithoutResponse,
+                    "native no-response remains available when the command transport is also unacknowledged")
+        assertEqual(WorkoutTelemetryWriteRouting.route(
+            hasNativeWriteWithResponse: false,
+            hasNativeWriteWithoutResponse: false,
+            navigationExpectsWriteResponse: false
         ), .navigationFallback,
                     "firmware without a dedicated workout transport uses navigation fallback")
 
@@ -12459,6 +12469,31 @@ struct NavigationProtocolTests {
                "missing acknowledged completion triggers bounded recovery")
         assert(!watchdogManager.isNavigationReady,
                "stall recovery closes the unusable navigation session")
+
+        let noResponseWatchdogManager = BLEManager()
+        noResponseWatchdogManager.isConnected = true
+        noResponseWatchdogManager.isNavigationReady = true
+        var noResponseRecoveries = 0
+        noResponseWatchdogManager.installNavigationWriteEndpoint(
+            NavigationWriteEndpoint(
+                maximumWriteLength: 20,
+                expectsWriteResponse: false,
+                canSend: { false },
+                write: { _ in
+                    assert(false, "backpressured transport must not write")
+                }
+            )
+        )
+        noResponseWatchdogManager.installNavigationWriteStallRecoveryForTesting(
+            timeout: 0.01,
+            recovery: { noResponseRecoveries += 1 }
+        )
+        assert(noResponseWatchdogManager.requestDeviceCapabilities(),
+               "no-response watchdog fixture admits the pending write")
+        assert(waitForMainLoop(timeout: 1) { noResponseRecoveries == 1 },
+               "persistent no-response backpressure triggers bounded recovery")
+        assert(!noResponseWatchdogManager.isNavigationReady,
+               "no-response recovery closes the wedged navigation session")
     }
 
     static func testBLEManagerSendsFallbackMapSettings() {
@@ -13949,6 +13984,36 @@ struct NavigationProtocolTests {
         assertEqual(fields.count, 3, "resent packet uses firmware fields")
         assertEqual(String(fields[0]), "\(NavigationIconID.left)", "resent packet keeps current icon")
         assertEqual(String(fields[2]), "Turn left onto Test Road", "resent packet keeps current instruction")
+    }
+
+    static func testNavigationEngineDefersReconnectGPSUntilReadinessCommits() {
+        let manager = BLEManager()
+        manager.isConnected = true
+        var writes: [Data] = []
+        manager.installNavigationWriteEndpoint(
+            NavigationWriteEndpoint(
+                maximumWriteLength: 64,
+                expectsWriteResponse: false,
+                canSend: { true },
+                write: { writes.append($0) }
+            )
+        )
+
+        let engine = NavigationEngine()
+        engine.setBLEManager(manager)
+        engine.processExternalLocation(
+            CLLocation(latitude: 1.305, longitude: 103.855)
+        )
+        assert(writes.isEmpty,
+               "cached GPS remains unsent before authentication readiness")
+
+        manager.isNavigationReady = true
+        assert(waitForMainLoop(timeout: 1) {
+            writes.contains { data in
+                String(data: data.prefix(4), encoding: .utf8) ==
+                    DeviceBLEProtocol.gpsPositionFallbackPrefix
+            }
+        }, "committed readiness resends cached GPS and can open the device map")
     }
 
     static func testNavigationEngineResendsRouteGeometryNearLastLocation() {


### PR DESCRIPTION
## Summary

- resend cached GPS and route state after BLE navigation readiness is fully committed
- prefer acknowledged workout telemetry writes and recover a stalled no-response queue
- advertise acknowledged writes for the firmware workout characteristic
- add regression coverage and update the BLE/workout documentation

## Root cause

The reconnect handler observed the `isNavigationReady` publisher before its backing property had committed, so synchronous map-state resends could still see the old value and be skipped. Separately, a workout write-without-response could remain at the head of the shared BLE queue while CoreBluetooth reported no write credit, blocking both workout telemetry and navigation traffic.

## Validation

- `ios-app/scripts/run-workout-contract-tests.sh`
- `ios-app/scripts/run-navigation-tests.sh`
- 79 focused firmware host tests
- C++ workout telemetry protocol and state tests
- signed iPhone and Watch builds from commit `ec836f6b`
- flashed the 1.75-inch device and installed the iPhone and Watch apps from the same commit
- physical validation: map returns after reconnect, workout data appears on the device, and the live BLE queue stays drained with zero drops
