### PR TITLE
Keep navigation smooth across missed GPS heartbeats

### DIFF
--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -120,10 +120,15 @@ invalidate nor a full 466 x 466 foreground-alpha clear. Gesture teardown clears
 those signatures, and pinch animation completion leaves the live presenter in
 sole control of the image pivot.
 
-Prediction is deliberately finite: by default it is capped at 1.5 seconds and
-30 metres, then stops instead of drifting without a fresh fix. Repeated packets
-with unchanged coordinates are still fresh observations and drive convergence.
-A new fix converges over a bounded interval rather than moving one visual layer
+Prediction is deliberately finite. Test and real navigation share one 1 Hz
+device-pose heartbeat. Presentation runs at full reported speed for 1.5
+seconds, then integrates a linear speed decay through a hard horizon at 2.5
+seconds. Distance remains capped at 30 metres. A single missed heartbeat can
+therefore remain continuous, while genuine transport loss settles
+monotonically instead of drifting forever. The accepted GPS-packet timestamp,
+not a later route-bearing update, owns freshness. Repeated GPS packets with
+unchanged coordinates are still fresh observations and drive convergence. A
+new fix converges over a bounded interval rather than moving one visual layer
 independently.
 
 ## Course-up state
@@ -206,6 +211,13 @@ capacity, not a promise that a slow render may block the UI.
 - allocation fallback; and
 - free and largest-contiguous PSRAM at completion and surface creation.
 
+The five-second `SYS` heartbeat also reports `gpsAgeMs`, capped
+`predictionAgeMs`, grace/exhausted state, exhaustion count and timestamp, plus
+the last and maximum accepted BLE GPS-packet gaps. `MAPIO: presentation` emits
+an immediate structured sample when presentation first starts or crosses the
+grace/exhausted boundaries. These fields distinguish a renderer stall from a
+missing or delayed device-pose heartbeat without changing render ownership.
+
 The declared initial UI/work-unit acceptance gate is 50 ms. Display-flush and UI
 maximum-gap telemetry remain the physical source of truth; host tests and a
 successful firmware build do not establish that gate.
@@ -214,8 +226,9 @@ successful firmware build do not establish that gate.
 
 Host tests cover semantic invalidation, position-only coalescing, stale rejection,
 invariant failure,
-bounded fake-clock slices, heading wrap/fallback, finite prediction and
-convergence, shared presentation transforms, exact route-head anchoring,
+bounded fake-clock slices, heading wrap/fallback, a missed 1 Hz heartbeat,
+decelerating finite prediction, source-timestamp freshness and convergence,
+shared presentation transforms, exact route-head anchoring,
 deterministic building admission under block-order permutations, quota
 overflow, bounded courtyard workspace, and legacy protocol behavior.
 

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -54,8 +54,21 @@ While presentation is changing, the visible frame is translated and rotated at
 UI cadence using one `PresentedPose`. The live route head, route line, and arrow
 use the same pivot, anchor, and rotation delta. Pose/frame/route/style
 signatures make stable ticks no-ops: they do not invalidate the base image or
-clear and redraw the full foreground alpha plane. Dead reckoning is finite
-(1.5 seconds and 30 metres by default) and converges to each new phone fix.
+clear and redraw the full foreground alpha plane. Test and real navigation use
+the same 1 Hz device-pose heartbeat. Dead reckoning remains at full speed for
+1.5 seconds, then linearly decelerates to a hard stop at 2.5 seconds, with a
+distance cap of 30 metres. This bridges one missed heartbeat without allowing
+unbounded motion, and all visible layers stop from the same pose when the
+horizon is exhausted. Each new phone fix converges from that shared pose.
+
+The full-speed window (1.5 seconds), hard horizon (2.5 seconds), and distance
+cap (30 metres) are static policy values from implementation commit
+`a02e24a3139d93a507cc716818ba7bcb151cf736`, based on `origin/main`
+`15d806613b680621b923b311ec30b2470fd4b349`. They apply to both
+`WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` and have no map/navigation
+fixture; they are not runtime or externally measured values. Device validation
+of the timing policy remains part of the physical gate below.
+
 The overscanned base canvas remains LVGL center-aligned; its position is an
 offset from the resolved centered origin. Presentation converts the desired
 parent-space pivot target to that aligned offset exactly once, so the 96-pixel
@@ -90,7 +103,8 @@ measured course, route bearing, or prior valid guidance frame.
 
 The focused host contracts cover worker ownership, semantic invalidation,
 position-only coalescing, shared presentation transforms, heading fallback and
-epoch reset, pre-publication overscan coverage, deterministic building
+epoch reset, one-missed-heartbeat prediction, finite transport-loss stopping,
+pre-publication overscan coverage, deterministic building
 admission, solid-roof courtyard overflow, asynchronous runtime map activation,
 and cross-version heading protocol behavior. The required physical gate is an exact
 `WAVESHARE_AMOLED_175` build followed by device navigation with an FMB v4 pack in

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -2237,19 +2237,31 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
   }
 #endif
 
+  const uint32_t gpsPacketReceivedAtMs = millis();
+  if (bleDebugStats.lastGpsPacketMs != 0) {
+    bleDebugStats.lastGpsPacketGapMs =
+        gpsPacketReceivedAtMs - bleDebugStats.lastGpsPacketMs;
+    bleDebugStats.maximumGpsPacketGapMs =
+        std::max(bleDebugStats.maximumGpsPacketGapMs,
+                 bleDebugStats.lastGpsPacketGapMs);
+  }
+  bleDebugStats.gpsPacketCount++;
+  bleDebugStats.lastGpsPacketMs = gpsPacketReceivedAtMs;
+
 #if FIRMWARE_DIAGNOSTICS
-  Serial.printf("BLE: %s GPS position received: heading=%u rtcSync=%d\n",
+  Serial.printf("BLE: %s GPS position received: heading=%u rtcSync=%d "
+                "gapMs=%lu maxGapMs=%lu\n",
                 source == nullptr ? "unknown" : source,
                 (unsigned)gps.gpsData.heading,
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-                rtcTimestampSynced
+                rtcTimestampSynced,
 #else
-                0
+                0,
 #endif
+                (unsigned long)bleDebugStats.lastGpsPacketGapMs,
+                (unsigned long)bleDebugStats.maximumGpsPacketGapMs
   );
 #endif
-  bleDebugStats.gpsPacketCount++;
-  bleDebugStats.lastGpsPacketMs = millis();
 
   if (!gpsReceivedFromApp) {
     gpsReceivedFromApp = true;
@@ -3524,7 +3536,7 @@ void BLENavigationServer::process() {
     Serial.printf("BLE Debug: up=%lus init=%d conn=%d auth=%d connects=%lu "
                   "disconnects=%lu authOK=%lu nav=%lu route=%lu gps=%lu "
                   "settings=%lu rejectAuth=%lu lastMs[c=%lu a=%lu n=%lu r=%lu "
-                  "g=%lu s=%lu rej=%lu]\n",
+                  "g=%lu s=%lu rej=%lu] gpsGapMs[last=%lu max=%lu]\n",
                   millis() / 1000, initialized, connected,
                   bleSessionAuthenticated, bleDebugStats.connectCount,
                   bleDebugStats.disconnectCount, bleDebugStats.authSuccessCount,
@@ -3537,7 +3549,9 @@ void BLENavigationServer::process() {
                   bleDebugStats.lastRoutePacketMs,
                   bleDebugStats.lastGpsPacketMs,
                   bleDebugStats.lastSettingsPacketMs,
-                  bleDebugStats.lastRejectedUnauthenticatedMs);
+                  bleDebugStats.lastRejectedUnauthenticatedMs,
+                  bleDebugStats.lastGpsPacketGapMs,
+                  bleDebugStats.maximumGpsPacketGapMs);
   }
 #else
   (void)lastLog;

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -206,6 +206,8 @@ struct BLEDebugStats {
   uint32_t lastNavPacketMs = 0;
   uint32_t lastRoutePacketMs = 0;
   uint32_t lastGpsPacketMs = 0;
+  uint32_t lastGpsPacketGapMs = 0;
+  uint32_t maximumGpsPacketGapMs = 0;
   uint32_t lastSettingsPacketMs = 0;
   uint32_t lastRejectedUnauthenticatedMs = 0;
   bool connectionParametersValid = false;

--- a/esp32/lib/maps/src/mapPresentation.hpp
+++ b/esp32/lib/maps/src/mapPresentation.hpp
@@ -109,6 +109,9 @@ struct Fix {
   // the fix lets prediction remain bounded in real metres while producing a
   // position in the exact world-coordinate space used by the map renderer.
   double worldUnitsPerMeter = 1.0;
+  // Local monotonic time when the GPS packet was accepted. This deliberately
+  // remains separate from the later UI time at which heading convergence may
+  // re-observe the same physical fix.
   uint32_t timestampMs = 0;
 };
 
@@ -117,7 +120,10 @@ struct PresentedPose {
   double headingDegrees = 0.0;
   bool headingValid = false;
   uint32_t sourceTimestampMs = 0;
+  uint32_t observationAgeMs = 0;
   uint32_t predictionAgeMs = 0;
+  bool predictionGraceActive = false;
+  bool predictionExhausted = false;
 };
 
 /**
@@ -191,7 +197,12 @@ private:
 class Presenter {
 public:
   struct Config {
-    uint32_t maximumPredictionMs = 1500;
+    // A healthy navigation session supplies a pose heartbeat every second.
+    // Keep ordinary interpolation at full speed through 1.5 seconds, then
+    // decelerate to a bounded stop at 2.5 seconds. This bridges one missed
+    // heartbeat without turning transport loss into unbounded dead reckoning.
+    uint32_t fullSpeedPredictionMs = 1500;
+    uint32_t maximumPredictionMs = 2500;
     uint32_t convergenceMs = 350;
     double maximumPredictionMeters = 30.0;
     double maximumSpeedMetersPerSecond = 35.0;
@@ -225,7 +236,6 @@ public:
     previousPresented_ = frozen;
     previousPresented_.headingDegrees = 0.0;
     previousPresented_.headingValid = false;
-    receivedAtMs_ = nowMs;
     convergenceStartMs_ = nowMs;
   }
 
@@ -250,11 +260,13 @@ public:
       previousPresented_.headingDegrees = normalized.headingDegrees;
       previousPresented_.headingValid = normalized.headingValid;
       previousPresented_.sourceTimestampMs = normalized.timestampMs;
+      previousPresented_.observationAgeMs = 0;
       previousPresented_.predictionAgeMs = 0;
+      previousPresented_.predictionGraceActive = false;
+      previousPresented_.predictionExhausted = false;
       convergenceStartMs_ = receivedAtMs;
     }
     current_ = normalized;
-    receivedAtMs_ = receivedAtMs;
     hasFix_ = true;
   }
 
@@ -264,13 +276,35 @@ public:
     if (!hasFix_)
       return {};
 
-    const uint32_t ageMs = nowMs - receivedAtMs_;
+    // Fix::timestampMs is the accepted GPS-packet time. Keep freshness tied to
+    // that source even if a later route-bearing update re-observes the same
+    // physical coordinate for heading convergence.
+    const uint32_t ageMs = nowMs - current_.timestampMs;
     const uint32_t predictionMs =
         std::min(ageMs, config_.maximumPredictionMs);
-    double distanceMeters =
-        current_.speedMetersPerSecond * predictionMs / 1000.0;
-    distanceMeters =
-        std::min(distanceMeters, config_.maximumPredictionMeters);
+    const uint32_t fullSpeedPredictionMs =
+        std::min(config_.fullSpeedPredictionMs,
+                 config_.maximumPredictionMs);
+    double effectivePredictionMs = predictionMs;
+    if (predictionMs > fullSpeedPredictionMs &&
+        config_.maximumPredictionMs > fullSpeedPredictionMs) {
+      const double graceElapsedMs =
+          static_cast<double>(predictionMs - fullSpeedPredictionMs);
+      const double graceDurationMs = static_cast<double>(
+          config_.maximumPredictionMs - fullSpeedPredictionMs);
+      // Integrate a velocity that falls linearly from 100% to 0% over the
+      // grace window. The predicted position remains monotonic and settles
+      // without the visual reversal caused by scaling total displacement.
+      effectivePredictionMs =
+          fullSpeedPredictionMs + graceElapsedMs -
+          graceElapsedMs * graceElapsedMs / (2.0 * graceDurationMs);
+    }
+    const double uncappedDistanceMeters =
+        current_.speedMetersPerSecond * effectivePredictionMs / 1000.0;
+    const double maximumPredictionMeters =
+        std::max(0.0, config_.maximumPredictionMeters);
+    const double distanceMeters =
+        std::min(uncappedDistanceMeters, maximumPredictionMeters);
     const double distance = distanceMeters * current_.worldUnitsPerMeter;
 
     WorldPoint predicted = current_.position;
@@ -308,7 +342,15 @@ public:
       pose.headingDegrees = previousPresented_.headingDegrees;
     }
     pose.sourceTimestampMs = current_.timestampMs;
+    pose.observationAgeMs = ageMs;
     pose.predictionAgeMs = predictionMs;
+    const bool timeExhausted = ageMs >= config_.maximumPredictionMs;
+    const bool distanceExhausted =
+        current_.speedMetersPerSecond > 0.0 &&
+        uncappedDistanceMeters >= maximumPredictionMeters;
+    pose.predictionExhausted = timeExhausted || distanceExhausted;
+    pose.predictionGraceActive =
+        !pose.predictionExhausted && ageMs > fullSpeedPredictionMs;
     return pose;
   }
 
@@ -317,7 +359,6 @@ private:
   bool hasFix_ = false;
   Fix current_{};
   PresentedPose previousPresented_{};
-  uint32_t receivedAtMs_ = 0;
   uint32_t convergenceStartMs_ = 0;
 };
 

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3709,6 +3709,7 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
   const bool headingValid = headingResolver.resolve(
       measuredValid, gps.gpsData.heading, routeValid, routeDegrees,
       resolvedHeading, !bleNavServer.supportsExplicitInvalidGpsHeading());
+  const BLEDebugStats bleStats = bleNavServer.getDebugStats();
 
   uint64_t gpsSignature = 1469598103934665603ULL;
   gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.latitude));
@@ -3718,8 +3719,8 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
   gpsSignature = fnvMix64(gpsSignature, doubleBits(resolvedHeading));
   // An identical coordinate is still a fresh convergence anchor. Preserve the
   // BLE packet time so dead reckoning cannot run past newly received fixes.
-  gpsSignature = fnvMix64(gpsSignature,
-                          bleNavServer.getDebugStats().lastGpsPacketMs);
+  gpsSignature = fnvMix64(gpsSignature, bleStats.lastGpsPacketMs);
+  gpsSignature = fnvMix64(gpsSignature, bleStats.gpsPacketCount);
   if (gpsSignature != lastGpsSignature || !posePresenter.hasFix()) {
     lastGpsSignature = gpsSignature;
     map_presentation::Fix fix;
@@ -3732,12 +3733,44 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
         gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
     fix.worldUnitsPerMeter =
         1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
-    fix.timestampMs = nowMs;
+    // Route-bearing changes may legitimately re-observe this fix for heading
+    // convergence, but they are not fresh GPS packets. Preserve the actual
+    // packet time so the bounded prediction horizon cannot be restarted by
+    // route traffic alone.
+    fix.timestampMs = bleStats.gpsPacketCount != 0
+                          ? bleStats.lastGpsPacketMs
+                          : nowMs;
     posePresenter.observe(fix, nowMs);
   }
   if (posePresenter.hasFix()) {
+    const bool firstPose = !hasPresentedPose;
+    const bool wasGraceActive =
+        hasPresentedPose && presentedPose.predictionGraceActive;
+    const bool wasExhausted =
+        hasPresentedPose && presentedPose.predictionExhausted;
     presentedPose = posePresenter.present(nowMs);
     hasPresentedPose = true;
+    if (presentedPose.predictionExhausted && !wasExhausted) {
+      ++predictionExhaustionCount;
+      lastPredictionExhaustedMs = nowMs;
+    }
+    if (firstPose ||
+        wasGraceActive != presentedPose.predictionGraceActive ||
+        wasExhausted != presentedPose.predictionExhausted) {
+      MAPIO_LOG(
+          "MAPIO: presentation gpsAgeMs=%lu lastGpsGapMs=%lu "
+          "maxGpsGapMs=%lu predictionAgeMs=%lu grace=%u "
+          "predictionExhausted=%u exhaustionCount=%lu "
+          "lastExhaustedMs=%lu\n",
+          (unsigned long)presentedPose.observationAgeMs,
+          (unsigned long)bleStats.lastGpsPacketGapMs,
+          (unsigned long)bleStats.maximumGpsPacketGapMs,
+          (unsigned long)presentedPose.predictionAgeMs,
+          presentedPose.predictionGraceActive ? 1U : 0U,
+          presentedPose.predictionExhausted ? 1U : 0U,
+          (unsigned long)predictionExhaustionCount,
+          (unsigned long)lastPredictionExhaustedMs);
+    }
   }
 }
 map_projection::Projection

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -397,6 +397,8 @@ private:
   map_presentation::HeadingResolver headingResolver;
   map_presentation::PresentedPose presentedPose{};
   bool hasPresentedPose = false;
+  uint32_t predictionExhaustionCount = 0;
+  uint32_t lastPredictionExhaustedMs = 0;
   uint64_t lastFramePresentationSignature = 0;
   uint64_t lastForegroundPresentationSignature = 0;
   RenderResult visibleRenderResult{};
@@ -625,6 +627,21 @@ public:
   void toggleRotationMode();
   void updateArrowColor();
   bool debugIsMapFound() const { return publishedMapFound; }
+  uint32_t debugPredictionAgeMs() const {
+    return hasPresentedPose ? presentedPose.predictionAgeMs : 0U;
+  }
+  bool debugPredictionGraceActive() const {
+    return hasPresentedPose && presentedPose.predictionGraceActive;
+  }
+  bool debugPredictionExhausted() const {
+    return hasPresentedPose && presentedPose.predictionExhausted;
+  }
+  uint32_t debugPredictionExhaustionCount() const {
+    return predictionExhaustionCount;
+  }
+  uint32_t debugLastPredictionExhaustedMs() const {
+    return lastPredictionExhaustedMs;
+  }
   size_t debugCachedBlockCount() const {
     return cachedBlockCount.load(std::memory_order_acquire);
   }

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -693,6 +693,8 @@ static void logSystemDebugHeartbeat() {
   lastLogMs = now;
 
   BLEDebugStats bleStats = bleNavServer.getDebugStats();
+  const uint32_t gpsAgeMs =
+      bleStats.gpsPacketCount != 0 ? now - bleStats.lastGpsPacketMs : 0U;
 #if (defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)) &&       \
     defined(WAVESHARE_IMU_DIAGNOSTICS)
   const waveshare_board::i2c::Stats &i2cStats = waveshare_board::i2c::stats();
@@ -741,7 +743,10 @@ static void logSystemDebugHeartbeat() {
                 "mapFlags[pos=%d redraw=%d follow=%d vector=%d zoom=%u] "
                 "ui[loop=%lu maxGapMs=%lu lvgl=%lu lastLvglMs=%lu "
                 "lvglUs=%lu/%lu flush=%lu lastFlushMs=%lu flushUs=%lu/%lu] "
-                "ble[conn=%d auth=%d nav=%lu route=%lu gps=%lu settings=%lu] "
+                "pose[gpsAgeMs=%lu predictionAgeMs=%lu grace=%d "
+                "exhausted=%d exhaustions=%lu lastExhaustedMs=%lu] "
+                "ble[conn=%d auth=%d nav=%lu route=%lu gps=%lu settings=%lu "
+                "gpsGapMs=%lu/%lu] "
                 "i2c[fail=%lu recover=%lu recovered=%lu missing=%lu] "
                 "rtc[present=%d valid=%d source=%s unix=%lld]\n",
                 (unsigned long)(now / 1000),
@@ -766,11 +771,19 @@ static void logSystemDebugHeartbeat() {
                 (unsigned long)lastDisplayFlushMs,
                 (unsigned long)lastDisplayFlushDurationUs,
                 (unsigned long)maxDisplayFlushDurationUs,
+                (unsigned long)gpsAgeMs,
+                (unsigned long)mapView.debugPredictionAgeMs(),
+                mapView.debugPredictionGraceActive(),
+                mapView.debugPredictionExhausted(),
+                (unsigned long)mapView.debugPredictionExhaustionCount(),
+                (unsigned long)mapView.debugLastPredictionExhaustedMs(),
                 bleStats.connected, bleStats.authenticated,
                 (unsigned long)bleStats.navPacketCount,
                 (unsigned long)bleStats.routePacketCount,
                 (unsigned long)bleStats.gpsPacketCount,
                 (unsigned long)bleStats.settingsPacketCount,
+                (unsigned long)bleStats.lastGpsPacketGapMs,
+                (unsigned long)bleStats.maximumGpsPacketGapMs,
                 (unsigned long)i2cStats.failedTransactions,
                 (unsigned long)i2cStats.recoveryAttempts,
                 (unsigned long)i2cStats.recoveredTransactions,
@@ -785,7 +798,10 @@ static void logSystemDebugHeartbeat() {
                 "mapFlags[pos=%d redraw=%d follow=%d vector=%d zoom=%u] "
                 "ui[loop=%lu maxGapMs=%lu lvgl=%lu lastLvglMs=%lu "
                 "lvglUs=%lu/%lu flush=%lu lastFlushMs=%lu flushUs=%lu/%lu] "
-                "ble[conn=%d auth=%d nav=%lu route=%lu gps=%lu settings=%lu]\n",
+                "pose[gpsAgeMs=%lu predictionAgeMs=%lu grace=%d "
+                "exhausted=%d exhaustions=%lu lastExhaustedMs=%lu] "
+                "ble[conn=%d auth=%d nav=%lu route=%lu gps=%lu settings=%lu "
+                "gpsGapMs=%lu/%lu]\n",
                 (unsigned long)(now / 1000),
                 (unsigned long)ESP.getFreeHeap(),
                 (unsigned long)ESP.getFreePsram(), screenName,
@@ -802,11 +818,19 @@ static void logSystemDebugHeartbeat() {
                 (unsigned long)lastLvglHandlerMs,
                 (unsigned long)lastLvglHandlerDurationUs,
                 (unsigned long)maxLvglHandlerDurationUs, 0UL, 0UL, 0UL, 0UL,
+                (unsigned long)gpsAgeMs,
+                (unsigned long)mapView.debugPredictionAgeMs(),
+                mapView.debugPredictionGraceActive(),
+                mapView.debugPredictionExhausted(),
+                (unsigned long)mapView.debugPredictionExhaustionCount(),
+                (unsigned long)mapView.debugLastPredictionExhaustedMs(),
                 bleStats.connected, bleStats.authenticated,
                 (unsigned long)bleStats.navPacketCount,
                 (unsigned long)bleStats.routePacketCount,
                 (unsigned long)bleStats.gpsPacketCount,
-                (unsigned long)bleStats.settingsPacketCount);
+                (unsigned long)bleStats.settingsPacketCount,
+                (unsigned long)bleStats.lastGpsPacketGapMs,
+                (unsigned long)bleStats.maximumGpsPacketGapMs);
 #endif
 #endif
 }

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -12,6 +12,15 @@ MAP_RENDERER_SOURCE = (
 MAP_HEADER_SOURCE = (
     ESP32_ROOT / "lib" / "maps" / "src" / "maps.hpp"
 ).read_text(encoding="utf-8")
+MAP_PRESENTATION_SOURCE = (
+    ESP32_ROOT / "lib" / "maps" / "src" / "mapPresentation.hpp"
+).read_text(encoding="utf-8")
+BLE_SOURCE = (
+    ESP32_ROOT / "lib" / "ble_navigation" / "ble_navigation.cpp"
+).read_text(encoding="utf-8")
+BLE_HEADER_SOURCE = (
+    ESP32_ROOT / "lib" / "ble_navigation" / "ble_navigation.hpp"
+).read_text(encoding="utf-8")
 BUILDING_ADMISSION_SOURCE = (
     ESP32_ROOT / "lib" / "maps" / "src" / "mapBuildingAdmission.hpp"
 ).read_text(encoding="utf-8")
@@ -171,6 +180,39 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         )
         self.assertNotIn("routeOverlay.revision()", semantics)
         self.assertIn("posePresenter.resetHeading(nowMs)", semantics)
+
+    def test_prediction_grace_is_bounded_and_reports_transport_freshness(self):
+        self.assertIn("fullSpeedPredictionMs = 1500", MAP_PRESENTATION_SOURCE)
+        self.assertIn("maximumPredictionMs = 2500", MAP_PRESENTATION_SOURCE)
+        self.assertIn("maximumPredictionMeters = 30.0", MAP_PRESENTATION_SOURCE)
+        self.assertIn("graceElapsedMs * graceElapsedMs", MAP_PRESENTATION_SOURCE)
+        self.assertIn("predictionExhausted", MAP_PRESENTATION_SOURCE)
+
+        pose = function_body(MAP_RENDERER_SOURCE, "void Maps::updatePresentedPose")
+        self.assertIn("bleStats.lastGpsPacketMs", pose)
+        self.assertIn("bleStats.gpsPacketCount", pose)
+        self.assertIn("fix.timestampMs", pose)
+        self.assertIn('"MAPIO: presentation gpsAgeMs=%lu lastGpsGapMs=%lu "', pose)
+        self.assertIn('"predictionExhausted=%u exhaustionCount=%lu "', pose)
+
+        gps_handler = function_body(BLE_SOURCE, "static void handleGpsPayload")
+        self.assertIn("lastGpsPacketGapMs", BLE_HEADER_SOURCE)
+        self.assertIn("maximumGpsPacketGapMs", BLE_HEADER_SOURCE)
+        self.assertIn(
+            "gpsPacketReceivedAtMs - bleDebugStats.lastGpsPacketMs",
+            gps_handler,
+        )
+        self.assertIn("maximumGpsPacketGapMs", gps_handler)
+
+        self.assertIn(
+            '"pose[gpsAgeMs=%lu predictionAgeMs=%lu grace=%d "',
+            MAIN_SOURCE,
+        )
+        self.assertIn(
+            '"exhausted=%d exhaustions=%lu lastExhaustedMs=%lu] "',
+            MAIN_SOURCE,
+        )
+        self.assertIn('"gpsGapMs=%lu/%lu] "', MAIN_SOURCE)
 
     def test_live_presentation_does_not_overwrite_gesture_transforms(self):
         service = function_body(

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -31,6 +31,12 @@ LVGL_SETUP_SOURCE = (
     ESP32_ROOT / "lib" / "lvgl" / "src" / "lvglSetup.cpp"
 ).read_text(encoding="utf-8")
 MAIN_SOURCE = (ESP32_ROOT / "src" / "main.cpp").read_text(encoding="utf-8")
+SCHEDULER_DOC = (
+    ESP32_ROOT.parent / "docs" / "firmware-map-render-scheduler.md"
+).read_text(encoding="utf-8")
+PSRAM_DOC = (
+    ESP32_ROOT.parent / "docs" / "firmware-map-rendering-psram.md"
+).read_text(encoding="utf-8")
 
 
 def function_body(source: str, signature: str) -> str:
@@ -213,6 +219,16 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
             MAIN_SOURCE,
         )
         self.assertIn('"gpsGapMs=%lu/%lu] "', MAIN_SOURCE)
+
+        for documentation in (SCHEDULER_DOC, PSRAM_DOC):
+            for term in (
+                "1 Hz",
+                "1.5",
+                "2.5",
+                "30 metres",
+                "missed heartbeat",
+            ):
+                self.assertIn(term, documentation)
 
     def test_live_presentation_does_not_overwrite_gesture_transforms(self):
         service = function_body(

--- a/esp32/tools/tests/test_map_presentation.cpp
+++ b/esp32/tools/tests/test_map_presentation.cpp
@@ -66,7 +66,54 @@ int main() {
   resolver.setNavigationSession(false, 9);
   assert(!resolver.resolve(true, 0.0, true, 90.0, heading));
 
+  // The default policy keeps the normal 1.5-second full-speed window, then
+  // decelerates through a 2.5-second hard horizon. A two-second gap (one
+  // missed 1 Hz heartbeat) therefore remains continuous, while longer loss
+  // settles at a finite position.
+  Presenter::Config graceConfig;
+  assert(graceConfig.fullSpeedPredictionMs == 1500);
+  assert(graceConfig.maximumPredictionMs == 2500);
+  assert(graceConfig.maximumPredictionMeters == 30.0);
+  graceConfig.convergenceMs = 0;
+  Presenter heartbeatGrace(graceConfig);
+  heartbeatGrace.observe(
+      {{100.0, 200.0}, 90.0, true, 10.0, 1.0, 1000}, 1000);
+  const PresentedPose healthyHeartbeat = heartbeatGrace.present(2000);
+  assert(std::fabs(healthyHeartbeat.position.x - 110.0) < 1e-6);
+  assert(healthyHeartbeat.observationAgeMs == 1000);
+  assert(!healthyHeartbeat.predictionGraceActive);
+  assert(!healthyHeartbeat.predictionExhausted);
+  const PresentedPose oneMissedHeartbeat = heartbeatGrace.present(3000);
+  assert(std::fabs(oneMissedHeartbeat.position.x - 118.75) < 1e-6);
+  assert(oneMissedHeartbeat.observationAgeMs == 2000);
+  assert(oneMissedHeartbeat.predictionAgeMs == 2000);
+  assert(oneMissedHeartbeat.predictionGraceActive);
+  assert(!oneMissedHeartbeat.predictionExhausted);
+  const PresentedPose graceHorizon = heartbeatGrace.present(3500);
+  assert(std::fabs(graceHorizon.position.x - 120.0) < 1e-6);
+  assert(graceHorizon.observationAgeMs == 2500);
+  assert(graceHorizon.predictionAgeMs == 2500);
+  assert(!graceHorizon.predictionGraceActive);
+  assert(graceHorizon.predictionExhausted);
+  const PresentedPose longTransportLoss = heartbeatGrace.present(9000);
+  assert(std::fabs(longTransportLoss.position.x -
+                   graceHorizon.position.x) < 1e-6);
+  assert(longTransportLoss.observationAgeMs == 8000);
+  assert(longTransportLoss.predictionAgeMs == 2500);
+  assert(longTransportLoss.predictionExhausted);
+
+  // Receiving route/heading work later must not make an old physical fix
+  // fresh. The source timestamp, not the UI observation time, owns the
+  // prediction horizon.
+  Presenter delayedObservation(graceConfig);
+  delayedObservation.observe(
+      {{0.0, 0.0}, 90.0, true, 10.0, 1.0, 1000}, 1800);
+  const PresentedPose delayedPose = delayedObservation.present(3000);
+  assert(delayedPose.observationAgeMs == 2000);
+  assert(delayedPose.predictionGraceActive);
+
   Presenter::Config config;
+  config.fullSpeedPredictionMs = 1500;
   config.maximumPredictionMs = 1500;
   config.convergenceMs = 0;
   config.maximumPredictionMeters = 20;
@@ -78,7 +125,9 @@ int main() {
   assert(std::fabs(afterHalfSecond.position.y - 200.0) < 1e-6);
   PresentedPose capped = presenter.present(9000);
   assert(std::fabs(capped.position.x - 115.0) < 1e-6);
+  assert(capped.observationAgeMs == 8000);
   assert(capped.predictionAgeMs == 1500);
+  assert(capped.predictionExhausted);
 
   // The finite prediction limit is expressed in physical metres even though
   // Web Mercator world coordinates stretch by sec(latitude).
@@ -87,6 +136,7 @@ int main() {
   const PresentedPose scaledCapped = scaled.present(9000);
   // The 20 metre physical cap becomes 40 world units at this local scale.
   assert(std::fabs(scaledCapped.position.x - 140.0) < 1e-6);
+  assert(scaledCapped.predictionExhausted);
 
   // A correction converges instead of leaving disconnected dead reckoning.
   config.convergenceMs = 400;

--- a/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/NavigationEngine.swift
@@ -50,7 +50,9 @@ class NavigationEngine: NSObject, ObservableObject {
     private var lastRideLocation: CLLocation?
     private var lastRouteRemainingMeters: CLLocationDistance?
     private var rideTelemetryTimer: Timer?
-    private let rideTelemetryRefreshInterval: TimeInterval = 1.0
+    // Test and real navigation share one device-pose heartbeat contract. The
+    // firmware grace window is sized to bridge one missed 1 Hz heartbeat.
+    private let devicePoseHeartbeatInterval: TimeInterval = 1.0
     private let now: () -> Date
     
     // Simulation state
@@ -347,7 +349,10 @@ class NavigationEngine: NSObject, ObservableObject {
         lastSimulationUpdate = Date()
         
         simulationTimer?.invalidate()
-        simulationTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+        simulationTimer = Timer.scheduledTimer(
+            withTimeInterval: devicePoseHeartbeatInterval,
+            repeats: true
+        ) { [weak self] _ in
             self?.updateSimulation()
         }
         // Add timer to RunLoop to ensure it fires in common run loop modes (including background)
@@ -619,7 +624,7 @@ class NavigationEngine: NSObject, ObservableObject {
 
     private func startRideTelemetryTimer() {
         stopRideTelemetryTimer()
-        let timer = Timer(timeInterval: rideTelemetryRefreshInterval,
+        let timer = Timer(timeInterval: devicePoseHeartbeatInterval,
                           repeats: true) { [weak self] _ in
             self?.refreshRideTelemetry()
         }


### PR DESCRIPTION
## What changed

- keep test and real navigation on one shared 1 Hz device-pose heartbeat
- predict at full reported speed for 1.5 seconds, then decelerate monotonically to a hard stop at 2.5 seconds
- cap predicted travel at 30 metres and keep the arrow, route, and map transform on the same presented pose
- base prediction freshness on the last accepted BLE GPS packet so route-bearing updates cannot extend stale motion
- add GPS-gap, prediction-grace, and prediction-exhaustion telemetry
- add host regression coverage and document the rendering/freshness contract

## Why

The previous 1.5-second prediction horizon left only about 500 ms of tolerance around the phone's 1 Hz pose heartbeat. A delayed or missed packet could therefore stop the arrow and map even while other navigation presentation appeared to advance.

The bounded grace period bridges one missed heartbeat while still stopping all visual layers together when transport genuinely disappears. Linear speed decay and the existing 30-metre cap prevent unbounded dead reckoning.

## User impact

Navigation motion remains continuous through a single delayed heartbeat. During longer GPS transport loss, the arrow, map, and route settle together instead of diverging, and serial telemetry now makes heartbeat loss distinguishable from renderer starvation.

## Validation

- 191 ESP32 Python host tests passed
- focused map-presentation and guidance integration suites passed
- portable iOS navigation test suite passed
- exact `WAVESHARE_AMOLED_175` firmware build passed with `uploadEligible=1`
- firmware build usage: 53.2% internal RAM, 95.6% application flash
- `git diff --check origin/main...HEAD` passed

Physical-device navigation validation remains pending.
