### PR TITLE
Use outdoor cycling icon for Watch complication

### DIFF
--- a/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchComplications/BikeComputerWatchComplications.swift
@@ -39,13 +39,13 @@ private struct StartRideComplicationView: View {
             case .accessoryCircular:
                 ZStack {
                     AccessoryWidgetBackground()
-                    Image(systemName: "bicycle")
+                    Image(systemName: "figure.outdoor.cycle")
                         .font(.title2)
                         .widgetAccentable()
                 }
             case .accessoryRectangular:
                 HStack(spacing: 8) {
-                    Image(systemName: "bicycle")
+                    Image(systemName: "figure.outdoor.cycle")
                         .font(.title2)
                         .widgetAccentable()
                     VStack(alignment: .leading, spacing: 1) {
@@ -57,15 +57,15 @@ private struct StartRideComplicationView: View {
                     }
                 }
             case .accessoryInline:
-                Label("Start Ride", systemImage: "bicycle")
+                Label("Start Ride", systemImage: "figure.outdoor.cycle")
             case .accessoryCorner:
-                Image(systemName: "bicycle")
+                Image(systemName: "figure.outdoor.cycle")
                     .widgetAccentable()
                     .widgetLabel {
                         Text("Start Ride")
                     }
             default:
-                Image(systemName: "bicycle")
+                Image(systemName: "figure.outdoor.cycle")
             }
         }
         .containerBackground(for: .widget) {


### PR DESCRIPTION
## Summary

- replace the Start Ride watch-face complication's `bicycle` symbol with `figure.outdoor.cycle`
- apply the symbol consistently across circular, rectangular, inline, corner, and fallback complication families

## Why

This aligns the Apple Watch face entry point with the outdoor-cycling icon already used by the iPhone Start Workout control.

## Validation

- `./ios-app/scripts/run-workout-contract-tests.sh`
- direct watchOS 10 Simulator SDK type-check of the complication and workout-launch request sources
- `git diff --check`