### PR TITLE
Preserve navigation freshness through UI stalls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
           for test in \
             test_map_render_job \
             test_map_presentation \
+            test_map_pose_input_policy \
             test_gps_input_freshness \
             test_map_building_admission \
             test_map_route_geometry \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
           for test in \
             test_map_render_job \
             test_map_presentation \
+            test_gps_input_freshness \
             test_map_building_admission \
             test_map_route_geometry \
             test_map_building_workspace; do

--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -123,13 +123,17 @@ sole control of the image pivot.
 Prediction is deliberately finite. Test and real navigation share one 1 Hz
 device-pose heartbeat. Presentation runs at full reported speed for 1.5
 seconds, then integrates a linear speed decay through a hard horizon at 2.5
-seconds. Distance remains capped at 30 metres. A single missed heartbeat can
-therefore remain continuous, while genuine transport loss settles
-monotonically instead of drifting forever. The accepted GPS-packet timestamp,
-not a later route-bearing update, owns freshness. Repeated GPS packets with
-unchanged coordinates are still fresh observations and drive convergence. A
-new fix converges over a bounded interval rather than moving one visual layer
-independently.
+seconds. Distance remains capped at 70 metres, the maximum integrated travel
+under that horizon at the supported 35 m/s speed clamp. A single missed
+heartbeat can therefore remain continuous. The one missed heartbeat policy is
+independent of speed within that clamp, while genuine transport loss settles
+monotonically instead of drifting forever. The accepted GPS-packet
+timestamp, not a later route-bearing update, owns freshness. Repeated GPS
+packets with unchanged coordinates are still fresh observations and drive
+convergence. A new fix converges over a bounded interval rather than moving one
+visual layer independently. A route-only heading refinement can rotate
+presentation but cannot redefine the positional path owned by the last
+physical fix or move an exhausted pose to a newly rotated endpoint.
 
 ## Course-up state
 
@@ -217,6 +221,10 @@ the last and maximum accepted BLE GPS-packet gaps. `MAPIO: presentation` emits
 an immediate structured sample when presentation first starts or crosses the
 grace/exhausted boundaries. These fields distinguish a renderer stall from a
 missing or delayed device-pose heartbeat without changing render ownership.
+Arrival time and cadence are captured on the authenticated NimBLE callback
+task. If the latest-state mailbox coalesces several healthy packets during a UI
+stall, their timing summary survives even though only the newest position is
+applied when the UI task resumes.
 
 The declared initial UI/work-unit acceptance gate is 50 ms. Display-flush and UI
 maximum-gap telemetry remain the physical source of truth; host tests and a
@@ -227,7 +235,9 @@ successful firmware build do not establish that gate.
 Host tests cover semantic invalidation, position-only coalescing, stale rejection,
 invariant failure,
 bounded fake-clock slices, heading wrap/fallback, a missed 1 Hz heartbeat,
-decelerating finite prediction, source-timestamp freshness and convergence,
+decelerating finite prediction across the supported speed range,
+callback-arrival freshness/coalescing, exhausted heading-only updates,
+source-timestamp freshness and convergence,
 shared presentation transforms, exact route-head anchoring,
 deterministic building admission under block-order permutations, quota
 overflow, bounded courtyard workspace, and legacy protocol behavior.

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -57,17 +57,27 @@ signatures make stable ticks no-ops: they do not invalidate the base image or
 clear and redraw the full foreground alpha plane. Test and real navigation use
 the same 1 Hz device-pose heartbeat. Dead reckoning remains at full speed for
 1.5 seconds, then linearly decelerates to a hard stop at 2.5 seconds, with a
-distance cap of 30 metres. This bridges one missed heartbeat without allowing
+distance cap of 70 metres. That cap is derived from the integrated horizon and
+the supported 35 m/s input clamp, so it cannot end the missed-heartbeat bridge
+early at a valid speed. This bridges one missed heartbeat without allowing
 unbounded motion, and all visible layers stop from the same pose when the
-horizon is exhausted. Each new phone fix converges from that shared pose.
+horizon is exhausted. Heading-only route updates can rotate presentation but
+do not redefine the positional path or interrupt convergence; each new phone
+fix converges from the shared pose.
 
 The full-speed window (1.5 seconds), hard horizon (2.5 seconds), and distance
-cap (30 metres) are static policy values from implementation commit
-`a02e24a3139d93a507cc716818ba7bcb151cf736`, based on `origin/main`
-`15d806613b680621b923b311ec30b2470fd4b349`. They apply to both
+cap (70 metres) are static defaults in `mapPresentation.hpp`. The distance cap
+equals 35 m/s multiplied by the curve's 2.0 seconds of integrated motion at
+the hard horizon. They apply to both
 `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` and have no map/navigation
 fixture; they are not runtime or externally measured values. Device validation
 of the timing policy remains part of the physical gate below.
+
+Authenticated GPS arrival time is captured before the NimBLE-to-UI mailbox.
+The mailbox keeps the newest position but retains the count, last gap, and
+maximum gap for valid packets coalesced during a UI stall. Presentation age and
+diagnostics therefore remain tied to BLE transport rather than the later UI
+drain.
 
 The overscanned base canvas remains LVGL center-aligned; its position is an
 offset from the resolved centered origin. Presentation converts the desired
@@ -103,7 +113,9 @@ measured course, route bearing, or prior valid guidance frame.
 
 The focused host contracts cover worker ownership, semantic invalidation,
 position-only coalescing, shared presentation transforms, heading fallback and
-epoch reset, one-missed-heartbeat prediction, finite transport-loss stopping,
+epoch reset, callback-arrival timing across mailbox coalescing,
+one-missed-heartbeat prediction through the supported speed range,
+heading-only updates after exhaustion, finite transport-loss stopping,
 pre-publication overscan coverage, deterministic building
 admission, solid-roof courtyard overflow, asynchronous runtime map activation,
 and cross-version heading protocol behavior. The required physical gate is an exact

--- a/docs/firmware-map-rendering-psram.md
+++ b/docs/firmware-map-rendering-psram.md
@@ -68,7 +68,9 @@ fix converges from the shared pose.
 The full-speed window (1.5 seconds), hard horizon (2.5 seconds), and distance
 cap (70 metres) are static defaults in `mapPresentation.hpp`. The distance cap
 equals 35 m/s multiplied by the curve's 2.0 seconds of integrated motion at
-the hard horizon. They apply to both
+the hard horizon. These static values were implemented in commit
+`3d12fefdb8f13544cc697c0108a3d6f805052103`, based on `origin/main`
+`836030c1bc3cf972a79e73f84e3500fd5a7f9b6a`. They apply to both
 `WAVESHARE_AMOLED_175` and `WAVESHARE_AMOLED_206` and have no map/navigation
 fixture; they are not runtime or externally measured values. Device validation
 of the timing policy remains part of the physical gate below.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -14,6 +14,7 @@
 #include "device_ownership.hpp"
 #include "ownership_button_policy.hpp"
 #include "device_screen_protocol.hpp"
+#include "gps_input_freshness.hpp"
 #include "gps_position_protocol.hpp"
 #include "map_setting_packet.hpp"
 #include "map_setting_redraw_policy.hpp"
@@ -107,6 +108,7 @@ static char pendingAuthNonce[33] = "";
 static NimBLECharacteristic *authCharacteristic = nullptr;
 static NimBLECharacteristic *mapTransferStatusCharacteristic = nullptr;
 static BLEDebugStats bleDebugStats;
+static gps_input_freshness::State gpsFreshnessState;
 static_assert(BLE_HS_CONN_HANDLE_NONE == ble_connection_policy::noConnection,
               "single-connection policy must match NimBLE's empty handle");
 static uint16_t activeConnHandle = BLE_HS_CONN_HANDLE_NONE;
@@ -654,6 +656,7 @@ struct PendingMapInput {
   bool fallback = false;
   bool pending = false;
   uint8_t *data = nullptr;
+  gps_input_freshness::ArrivalBatch gpsArrivals{};
 };
 static SemaphoreHandle_t pendingMapInputMutex = nullptr;
 static PendingMapInput pendingRouteInput;
@@ -671,6 +674,18 @@ static bool queueMapInput(PendingMapInputType type, const uint8_t *data,
     Serial.printf("BLE: rejected queued map input type=%u len=%u\n",
                   static_cast<unsigned>(type), static_cast<unsigned>(len));
     return false;
+  }
+  uint32_t gpsReceivedAtMs = 0;
+  if (type == PendingMapInputType::Gps) {
+    power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
+    if (!gps_input_freshness::acceptsPayload(data, len)) {
+      Serial.printf("BLE: Rejected %s GPS position: expected at least 8 bytes\n",
+                    source == nullptr ? "unknown" : source);
+      return false;
+    }
+    // Capture transport freshness on the authenticated NimBLE callback task,
+    // before allocation or a potentially delayed UI-task mailbox drain.
+    gpsReceivedAtMs = millis();
   }
   PendingMapInput input;
   input.type = type;
@@ -709,6 +724,10 @@ static bool queueMapInput(PendingMapInputType type, const uint8_t *data,
     return false;
   }
   PendingMapInput replaced = *slot;
+  if (type == PendingMapInputType::Gps) {
+    input.gpsArrivals = replaced.gpsArrivals;
+    input.gpsArrivals.observe(gpsReceivedAtMs);
+  }
   *slot = input;
   if (!replaced.pending) {
     pendingMapInputCount.fetch_add(1, std::memory_order_release);
@@ -2248,9 +2267,9 @@ static void handleRouteGeometryPayload(const uint8_t *data, size_t len,
     requestMapRender(map_render_policy::Reason::Route);
 }
 
-static void handleGpsPayload(const uint8_t *data, size_t len,
-                             const char *source) {
-  power_metrics::noteBlePacket(power_metrics::BlePacketClass::Gps);
+static void handleGpsPayload(
+    const uint8_t *data, size_t len, const char *source,
+    const gps_input_freshness::ArrivalBatch &arrivals) {
   gps_position_protocol::Packet packet{};
   if (!gps_position_protocol::decodeAndApply(data, len, gps.gpsData,
                                              &packet)) {
@@ -2276,16 +2295,11 @@ static void handleGpsPayload(const uint8_t *data, size_t len,
   }
 #endif
 
-  const uint32_t gpsPacketReceivedAtMs = millis();
-  if (bleDebugStats.lastGpsPacketMs != 0) {
-    bleDebugStats.lastGpsPacketGapMs =
-        gpsPacketReceivedAtMs - bleDebugStats.lastGpsPacketMs;
-    bleDebugStats.maximumGpsPacketGapMs =
-        std::max(bleDebugStats.maximumGpsPacketGapMs,
-                 bleDebugStats.lastGpsPacketGapMs);
-  }
-  bleDebugStats.gpsPacketCount++;
-  bleDebugStats.lastGpsPacketMs = gpsPacketReceivedAtMs;
+  gpsFreshnessState.accept(arrivals);
+  bleDebugStats.gpsPacketCount = gpsFreshnessState.packetCount;
+  bleDebugStats.lastGpsPacketMs = gpsFreshnessState.lastPacketMs;
+  bleDebugStats.lastGpsPacketGapMs = gpsFreshnessState.lastGapMs;
+  bleDebugStats.maximumGpsPacketGapMs = gpsFreshnessState.maximumGapMs;
 
 #if FIRMWARE_DIAGNOSTICS
   Serial.printf("BLE: %s GPS position received: heading=%u rtcSync=%d "
@@ -2729,7 +2743,7 @@ static void processPendingMapInputs() {
       handleRouteGeometryPayload(input.data, input.length, source);
       break;
     case PendingMapInputType::Gps:
-      handleGpsPayload(input.data, input.length, source);
+      handleGpsPayload(input.data, input.length, source, input.gpsArrivals);
       break;
     case PendingMapInputType::Setting:
       handleMapSettingPayload(input.data, input.length, source);

--- a/esp32/lib/ble_navigation/gps_input_freshness.hpp
+++ b/esp32/lib/ble_navigation/gps_input_freshness.hpp
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "gps_position_protocol.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+
+namespace gps_input_freshness {
+
+/** Arrival timing retained by the latest-state GPS mailbox.
+ *
+ * The payload itself may be replaced while the UI task is busy, but every
+ * valid authenticated packet still contributes to transport cadence. Keeping
+ * this summary beside the newest payload lets the UI apply only the latest fix
+ * without confusing mailbox delay with a missing BLE heartbeat.
+ */
+struct ArrivalBatch {
+  uint32_t packetCount = 0;
+  uint32_t firstPacketMs = 0;
+  uint32_t lastPacketMs = 0;
+  uint32_t lastGapMs = 0;
+  uint32_t maximumGapMs = 0;
+
+  void observe(uint32_t receivedAtMs) {
+    if (packetCount == 0) {
+      firstPacketMs = receivedAtMs;
+    } else {
+      lastGapMs = receivedAtMs - lastPacketMs;
+      maximumGapMs = std::max(maximumGapMs, lastGapMs);
+    }
+    lastPacketMs = receivedAtMs;
+    ++packetCount;
+  }
+};
+
+/** Validate at BLE ingress without mutating renderer-owned GPS state. */
+inline bool acceptsPayload(const uint8_t *data, std::size_t length) {
+  gps_position_protocol::Packet packet{};
+  return gps_position_protocol::decode(data, length, packet);
+}
+
+/** Cumulative accepted-packet timing, updated when a mailbox batch drains. */
+struct State {
+  bool hasPacket = false;
+  uint32_t packetCount = 0;
+  uint32_t lastPacketMs = 0;
+  uint32_t lastGapMs = 0;
+  uint32_t maximumGapMs = 0;
+
+  void accept(const ArrivalBatch &batch) {
+    if (batch.packetCount == 0)
+      return;
+
+    const bool hadPacket = hasPacket;
+    const uint32_t boundaryGapMs =
+        hadPacket ? batch.firstPacketMs - lastPacketMs : 0U;
+    if (hadPacket)
+      maximumGapMs = std::max(maximumGapMs, boundaryGapMs);
+    maximumGapMs = std::max(maximumGapMs, batch.maximumGapMs);
+
+    if (batch.packetCount > 1) {
+      lastGapMs = batch.lastGapMs;
+    } else {
+      lastGapMs = hadPacket ? boundaryGapMs : 0U;
+    }
+    packetCount += batch.packetCount;
+    lastPacketMs = batch.lastPacketMs;
+    hasPacket = true;
+  }
+};
+
+} // namespace gps_input_freshness

--- a/esp32/lib/maps/src/mapPoseInputPolicy.hpp
+++ b/esp32/lib/maps/src/mapPoseInputPolicy.hpp
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <cstdint>
+
+namespace map_pose_input_policy {
+
+enum class Action : uint8_t {
+  None = 0,
+  ObservePhysicalFix,
+  UpdateHeadingOnly,
+};
+
+/** Classify the latest resolved pose input without conflating route heading
+ * changes with physical GPS observations.
+ *
+ * The position signature includes accepted BLE packet identity. The complete
+ * signature additionally includes the resolved display heading. Keeping both
+ * histories here makes the production dispatch rule directly host-testable:
+ * a fresh packet must re-observe position even when its coordinates repeat,
+ * while a route-only heading change must not restart positional prediction.
+ */
+class Tracker {
+public:
+  Action classify(uint64_t positionSignature, uint64_t completeSignature,
+                  bool presenterHasFix) {
+    if (presenterHasFix && hasCompleteSignature_ &&
+        completeSignature == lastCompleteSignature_) {
+      return Action::None;
+    }
+
+    const bool physicalFixChanged =
+        !presenterHasFix || !hasPositionSignature_ ||
+        positionSignature != lastPositionSignature_;
+    lastPositionSignature_ = positionSignature;
+    lastCompleteSignature_ = completeSignature;
+    hasPositionSignature_ = true;
+    hasCompleteSignature_ = true;
+    return physicalFixChanged ? Action::ObservePhysicalFix
+                              : Action::UpdateHeadingOnly;
+  }
+
+  /** Force the current heading through the next classification without
+   * treating the unchanged physical fix as newly arrived. */
+  void invalidateHeading() { hasCompleteSignature_ = false; }
+
+private:
+  bool hasPositionSignature_ = false;
+  bool hasCompleteSignature_ = false;
+  uint64_t lastPositionSignature_ = 0;
+  uint64_t lastCompleteSignature_ = 0;
+};
+
+} // namespace map_pose_input_policy

--- a/esp32/lib/maps/src/mapPresentation.hpp
+++ b/esp32/lib/maps/src/mapPresentation.hpp
@@ -204,7 +204,11 @@ public:
     uint32_t fullSpeedPredictionMs = 1500;
     uint32_t maximumPredictionMs = 2500;
     uint32_t convergenceMs = 350;
-    double maximumPredictionMeters = 30.0;
+    // The 70 m default equals the most the 35 m/s supported-speed clamp can
+    // travel under the integrated 2.5-second horizon. The time horizon remains
+    // authoritative, so the distance guard cannot end a missed-heartbeat
+    // bridge early at a valid cycling speed.
+    double maximumPredictionMeters = 70.0;
     double maximumSpeedMetersPerSecond = 35.0;
   };
 
@@ -215,7 +219,10 @@ public:
     hasFix_ = false;
     current_ = {};
     previousPresented_ = {};
-    convergenceStartMs_ = 0;
+    predictionHeadingDegrees_ = 0.0;
+    predictionHeadingValid_ = false;
+    positionConvergenceStartMs_ = 0;
+    headingConvergenceStartMs_ = 0;
   }
 
   /** Start a new heading epoch without teleporting the presented position.
@@ -225,18 +232,20 @@ public:
     if (!hasFix_)
       return;
     // Freeze the exact pose that is currently on screen before removing its
-    // direction. Clearing current_.headingValid by itself would make
-    // present() fall back to the last raw GPS coordinate and visibly jump
-    // backwards by as much as the prediction horizon.
+    // direction. Prediction direction belongs to the physical fix, so clear it
+    // with the heading epoch and wait for the next fix before moving again.
     const PresentedPose frozen = present(nowMs);
     current_.position = frozen.position;
     current_.timestampMs = frozen.sourceTimestampMs;
     current_.headingDegrees = 0.0;
     current_.headingValid = false;
+    predictionHeadingDegrees_ = 0.0;
+    predictionHeadingValid_ = false;
     previousPresented_ = frozen;
     previousPresented_.headingDegrees = 0.0;
     previousPresented_.headingValid = false;
-    convergenceStartMs_ = nowMs;
+    positionConvergenceStartMs_ = nowMs;
+    headingConvergenceStartMs_ = nowMs;
   }
 
   void observe(const Fix &fix, uint32_t receivedAtMs) {
@@ -254,7 +263,8 @@ public:
     normalized.headingDegrees = normalizeDegrees(fix.headingDegrees);
     if (hasFix_) {
       previousPresented_ = present(receivedAtMs);
-      convergenceStartMs_ = receivedAtMs;
+      positionConvergenceStartMs_ = receivedAtMs;
+      headingConvergenceStartMs_ = receivedAtMs;
     } else {
       previousPresented_.position = normalized.position;
       previousPresented_.headingDegrees = normalized.headingDegrees;
@@ -264,10 +274,32 @@ public:
       previousPresented_.predictionAgeMs = 0;
       previousPresented_.predictionGraceActive = false;
       previousPresented_.predictionExhausted = false;
-      convergenceStartMs_ = receivedAtMs;
+      positionConvergenceStartMs_ = receivedAtMs;
+      headingConvergenceStartMs_ = receivedAtMs;
     }
     current_ = normalized;
+    predictionHeadingDegrees_ = normalized.headingDegrees;
+    predictionHeadingValid_ = normalized.headingValid;
     hasFix_ = true;
+  }
+
+  /** Update presentation direction without re-observing the physical fix.
+   *
+   * A route window can refine course while the GPS packet is unchanged. It may
+   * rotate the map and marker, but the predicted path remains owned by the last
+   * physical fix. This also preserves an in-progress position correction and
+   * prevents an exhausted endpoint from moving to a newly rotated location.
+   */
+  void updateHeading(double headingDegrees, bool headingValid,
+                     uint32_t nowMs) {
+    if (!hasFix_)
+      return;
+    const PresentedPose frozen = present(nowMs);
+    previousPresented_.headingDegrees = frozen.headingDegrees;
+    previousPresented_.headingValid = frozen.headingValid;
+    current_.headingDegrees = normalizeDegrees(headingDegrees);
+    current_.headingValid = headingValid;
+    headingConvergenceStartMs_ = nowMs;
   }
 
   bool hasFix() const { return hasFix_; }
@@ -277,28 +309,16 @@ public:
       return {};
 
     // Fix::timestampMs is the accepted GPS-packet time. Keep freshness tied to
-    // that source even if a later route-bearing update re-observes the same
-    // physical coordinate for heading convergence.
+    // that source while later route-bearing updates affect only display
+    // heading convergence.
     const uint32_t ageMs = nowMs - current_.timestampMs;
     const uint32_t predictionMs =
         std::min(ageMs, config_.maximumPredictionMs);
     const uint32_t fullSpeedPredictionMs =
         std::min(config_.fullSpeedPredictionMs,
                  config_.maximumPredictionMs);
-    double effectivePredictionMs = predictionMs;
-    if (predictionMs > fullSpeedPredictionMs &&
-        config_.maximumPredictionMs > fullSpeedPredictionMs) {
-      const double graceElapsedMs =
-          static_cast<double>(predictionMs - fullSpeedPredictionMs);
-      const double graceDurationMs = static_cast<double>(
-          config_.maximumPredictionMs - fullSpeedPredictionMs);
-      // Integrate a velocity that falls linearly from 100% to 0% over the
-      // grace window. The predicted position remains monotonic and settles
-      // without the visual reversal caused by scaling total displacement.
-      effectivePredictionMs =
-          fullSpeedPredictionMs + graceElapsedMs -
-          graceElapsedMs * graceElapsedMs / (2.0 * graceDurationMs);
-    }
+    const double effectivePredictionMs =
+        integratedPredictionMs(predictionMs, fullSpeedPredictionMs);
     const double uncappedDistanceMeters =
         current_.speedMetersPerSecond * effectivePredictionMs / 1000.0;
     const double maximumPredictionMeters =
@@ -308,33 +328,33 @@ public:
     const double distance = distanceMeters * current_.worldUnitsPerMeter;
 
     WorldPoint predicted = current_.position;
-    if (current_.headingValid && distance > 0.0) {
-      const double radians = normalizeDegrees(current_.headingDegrees) *
+    if (predictionHeadingValid_ && distance > 0.0) {
+      const double radians = normalizeDegrees(predictionHeadingDegrees_) *
                              kPi / 180.0;
       predicted.x += std::sin(radians) * distance;
       predicted.y += std::cos(radians) * distance;
     }
 
-    double blend = 1.0;
-    if (config_.convergenceMs != 0) {
-      blend = std::min(1.0, static_cast<double>(nowMs - convergenceStartMs_) /
-                                config_.convergenceMs);
-      // Smoothstep has zero slope at both ends and avoids a visible kink.
-      blend = blend * blend * (3.0 - 2.0 * blend);
-    }
+    const double positionBlend =
+        convergenceBlend(nowMs, positionConvergenceStartMs_);
+    const double headingBlend =
+        convergenceBlend(nowMs, headingConvergenceStartMs_);
 
     PresentedPose pose;
     pose.position.x = previousPresented_.position.x +
-                      (predicted.x - previousPresented_.position.x) * blend;
+                      (predicted.x - previousPresented_.position.x) *
+                          positionBlend;
     pose.position.y = previousPresented_.position.y +
-                      (predicted.y - previousPresented_.position.y) * blend;
+                      (predicted.y - previousPresented_.position.y) *
+                          positionBlend;
     pose.headingValid = current_.headingValid || previousPresented_.headingValid;
     if (current_.headingValid) {
       const double from = previousPresented_.headingValid
                               ? previousPresented_.headingDegrees
                               : current_.headingDegrees;
       pose.headingDegrees = normalizeDegrees(
-          from + signedHeadingDelta(from, current_.headingDegrees) * blend);
+          from + signedHeadingDelta(from, current_.headingDegrees) *
+                     headingBlend);
     } else if (previousPresented_.headingValid) {
       // An invalid fix carries no new direction. Keep the last valid heading
       // instead of interpolating its default zero value (north), which would
@@ -355,11 +375,40 @@ public:
   }
 
 private:
+  double convergenceBlend(uint32_t nowMs, uint32_t startedAtMs) const {
+    if (config_.convergenceMs == 0)
+      return 1.0;
+    double blend =
+        std::min(1.0, static_cast<double>(nowMs - startedAtMs) /
+                          config_.convergenceMs);
+    // Smoothstep has zero slope at both ends and avoids a visible kink.
+    return blend * blend * (3.0 - 2.0 * blend);
+  }
+
+  double integratedPredictionMs(uint32_t predictionMs,
+                                uint32_t fullSpeedPredictionMs) const {
+    if (predictionMs <= fullSpeedPredictionMs ||
+        config_.maximumPredictionMs <= fullSpeedPredictionMs) {
+      return predictionMs;
+    }
+    const double graceElapsedMs =
+        static_cast<double>(predictionMs - fullSpeedPredictionMs);
+    const double graceDurationMs = static_cast<double>(
+        config_.maximumPredictionMs - fullSpeedPredictionMs);
+    // Integrate a velocity that falls linearly from 100% to 0% over the grace
+    // window. Position remains monotonic and settles without visual reversal.
+    return fullSpeedPredictionMs + graceElapsedMs -
+           graceElapsedMs * graceElapsedMs / (2.0 * graceDurationMs);
+  }
+
   Config config_{};
   bool hasFix_ = false;
   Fix current_{};
   PresentedPose previousPresented_{};
-  uint32_t convergenceStartMs_ = 0;
+  double predictionHeadingDegrees_ = 0.0;
+  bool predictionHeadingValid_ = false;
+  uint32_t positionConvergenceStartMs_ = 0;
+  uint32_t headingConvergenceStartMs_ = 0;
 };
 
 inline double refreshLeadPixels(double speedMetersPerSecond,

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3712,17 +3712,26 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
       resolvedHeading, !bleNavServer.supportsExplicitInvalidGpsHeading());
   const BLEDebugStats bleStats = bleNavServer.getDebugStats();
 
-  uint64_t gpsSignature = 1469598103934665603ULL;
-  gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.latitude));
-  gpsSignature = fnvMix64(gpsSignature, doubleBits(gps.gpsData.longitude));
-  gpsSignature = fnvMix64(gpsSignature, gps.gpsData.speed);
+  uint64_t gpsPositionSignature = 1469598103934665603ULL;
+  gpsPositionSignature =
+      fnvMix64(gpsPositionSignature, doubleBits(gps.gpsData.latitude));
+  gpsPositionSignature =
+      fnvMix64(gpsPositionSignature, doubleBits(gps.gpsData.longitude));
+  gpsPositionSignature = fnvMix64(gpsPositionSignature, gps.gpsData.speed);
+  // Identical coordinates are still a new physical fix. Packet timing and
+  // count belong to the position signature; route-derived headings do not.
+  gpsPositionSignature =
+      fnvMix64(gpsPositionSignature, bleStats.lastGpsPacketMs);
+  gpsPositionSignature =
+      fnvMix64(gpsPositionSignature, bleStats.gpsPacketCount);
+  uint64_t gpsSignature = gpsPositionSignature;
   gpsSignature = fnvMix64(gpsSignature, headingValid ? 1U : 0U);
   gpsSignature = fnvMix64(gpsSignature, doubleBits(resolvedHeading));
-  // An identical coordinate is still a fresh convergence anchor. Preserve the
-  // BLE packet time so dead reckoning cannot run past newly received fixes.
-  gpsSignature = fnvMix64(gpsSignature, bleStats.lastGpsPacketMs);
-  gpsSignature = fnvMix64(gpsSignature, bleStats.gpsPacketCount);
   if (gpsSignature != lastGpsSignature || !posePresenter.hasFix()) {
+    const bool physicalFixChanged =
+        gpsPositionSignature != lastGpsPositionSignature ||
+        !posePresenter.hasFix();
+    lastGpsPositionSignature = gpsPositionSignature;
     lastGpsSignature = gpsSignature;
     map_presentation::Fix fix;
     fix.position = {lon2x(gps.gpsData.longitude),
@@ -3734,14 +3743,16 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
         gps.gpsData.latitude * 3.14159265358979323846 / 180.0;
     fix.worldUnitsPerMeter =
         1.0 / std::max(0.2, std::fabs(std::cos(latitudeRadians)));
-    // Route-bearing changes may legitimately re-observe this fix for heading
-    // convergence, but they are not fresh GPS packets. Preserve the actual
-    // packet time so the bounded prediction horizon cannot be restarted by
-    // route traffic alone.
+    // The accepted transport timestamp owns physical freshness. Route-bearing
+    // changes use updateHeading below and cannot re-observe this position.
     fix.timestampMs = bleStats.gpsPacketCount != 0
                           ? bleStats.lastGpsPacketMs
                           : nowMs;
-    posePresenter.observe(fix, nowMs);
+    if (physicalFixChanged) {
+      posePresenter.observe(fix, nowMs);
+    } else {
+      posePresenter.updateHeading(resolvedHeading, headingValid, nowMs);
+    }
   }
   if (posePresenter.hasFix()) {
     const bool firstPose = !hasPresentedPose;

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3642,9 +3642,9 @@ void Maps::invalidateRenderSemantics(uint32_t nowMs) {
     posePresenter.resetHeading(nowMs);
     presentedPose.headingDegrees = 0.0;
     presentedPose.headingValid = false;
-    // Re-run the latest physical fix through the new heading epoch even when
-    // its coordinate, speed, and newly resolved bearing are byte-identical.
-    lastGpsSignature = 0;
+    // Re-run display heading through the new epoch without manufacturing a
+    // fresh physical observation from the retained GPS fix.
+    poseInputTracker.invalidateHeading();
   }
 
   const uint16_t viewportHeight =
@@ -3727,12 +3727,10 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
   uint64_t gpsSignature = gpsPositionSignature;
   gpsSignature = fnvMix64(gpsSignature, headingValid ? 1U : 0U);
   gpsSignature = fnvMix64(gpsSignature, doubleBits(resolvedHeading));
-  if (gpsSignature != lastGpsSignature || !posePresenter.hasFix()) {
-    const bool physicalFixChanged =
-        gpsPositionSignature != lastGpsPositionSignature ||
-        !posePresenter.hasFix();
-    lastGpsPositionSignature = gpsPositionSignature;
-    lastGpsSignature = gpsSignature;
+  const map_pose_input_policy::Action poseInputAction =
+      poseInputTracker.classify(gpsPositionSignature, gpsSignature,
+                                posePresenter.hasFix());
+  if (poseInputAction != map_pose_input_policy::Action::None) {
     map_presentation::Fix fix;
     fix.position = {lon2x(gps.gpsData.longitude),
                     lat2y(gps.gpsData.latitude)};
@@ -3748,7 +3746,8 @@ void Maps::updatePresentedPose(uint32_t nowMs) {
     fix.timestampMs = bleStats.gpsPacketCount != 0
                           ? bleStats.lastGpsPacketMs
                           : nowMs;
-    if (physicalFixChanged) {
+    if (poseInputAction ==
+        map_pose_input_policy::Action::ObservePhysicalFix) {
       posePresenter.observe(fix, nowMs);
     } else {
       posePresenter.updateHeading(resolvedHeading, headingValid, nowMs);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -18,6 +18,7 @@
 #include "mapTransform.hpp"
 #include "map_projection.hpp"
 #include "mapPresentation.hpp"
+#include "mapPoseInputPolicy.hpp"
 #include "mapRenderJob.hpp"
 #include "mapSurface.hpp"
 #include "../../utils/src/mapDragPreview.hpp"
@@ -391,9 +392,8 @@ private:
   uint64_t lastNavigationSignature = 0;
   uint64_t lastProjectionSignature = 0;
   uint64_t lastHeadingSessionSignature = 0;
-  uint64_t lastGpsPositionSignature = 0;
-  uint64_t lastGpsSignature = 0;
   uint32_t headingSessionEpoch = 1;
+  map_pose_input_policy::Tracker poseInputTracker;
   map_presentation::Presenter posePresenter;
   map_presentation::HeadingResolver headingResolver;
   map_presentation::PresentedPose presentedPose{};

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -391,6 +391,7 @@ private:
   uint64_t lastNavigationSignature = 0;
   uint64_t lastProjectionSignature = 0;
   uint64_t lastHeadingSessionSignature = 0;
+  uint64_t lastGpsPositionSignature = 0;
   uint64_t lastGpsSignature = 0;
   uint32_t headingSessionEpoch = 1;
   map_presentation::Presenter posePresenter;

--- a/esp32/tools/tests/test_gps_input_freshness.cpp
+++ b/esp32/tools/tests/test_gps_input_freshness.cpp
@@ -1,0 +1,65 @@
+#include "../../lib/ble_navigation/gps_input_freshness.hpp"
+#include "../../lib/maps/src/mapPresentation.hpp"
+
+#include <cassert>
+#include <cstdint>
+#include <limits>
+
+int main() {
+  using namespace gps_input_freshness;
+
+  const uint8_t validPayload[8] = {};
+  const uint8_t shortPayload[7] = {};
+  assert(acceptsPayload(validPayload, sizeof(validPayload)));
+  assert(!acceptsPayload(shortPayload, sizeof(shortPayload)));
+  assert(!acceptsPayload(nullptr, 0));
+
+  // Three healthy packets may be coalesced to one latest-state payload while
+  // the UI is busy. Their transport cadence must remain 1 Hz and the latest
+  // accepted time must remain 2000 ms regardless of a much later drain.
+  ArrivalBatch coalesced;
+  coalesced.observe(0);
+  coalesced.observe(1000);
+  coalesced.observe(2000);
+  State state;
+  state.accept(coalesced);
+  assert(state.hasPacket);
+  assert(state.packetCount == 3);
+  assert(state.lastPacketMs == 2000);
+  assert(state.lastGapMs == 1000);
+  assert(state.maximumGapMs == 1000);
+
+  ArrivalBatch delayedHeartbeat;
+  delayedHeartbeat.observe(5000);
+  state.accept(delayedHeartbeat);
+  assert(state.packetCount == 4);
+  assert(state.lastPacketMs == 5000);
+  assert(state.lastGapMs == 3000);
+  assert(state.maximumGapMs == 3000);
+
+  // The presenter consumes the accepted BLE time, not the later UI drain. A
+  // latest packet accepted at 5000 and drained at 9000 is already exhausted;
+  // it does not receive another 2.5-second motion horizon at drain time.
+  map_presentation::Presenter presenter;
+  presenter.observe({{0.0, 0.0}, 90.0, true, 10.0, 1.0,
+                     state.lastPacketMs},
+                    9000);
+  const map_presentation::PresentedPose delayedDrain = presenter.present(9000);
+  assert(delayedDrain.observationAgeMs == 4000);
+  assert(delayedDrain.predictionExhausted);
+
+  // Unsigned monotonic deltas remain valid across the millis() wrap, and an
+  // accepted packet at timestamp zero is represented by count, not a sentinel.
+  ArrivalBatch beforeWrap;
+  beforeWrap.observe(std::numeric_limits<uint32_t>::max() - 500U);
+  State wrapState;
+  wrapState.accept(beforeWrap);
+  ArrivalBatch afterWrap;
+  afterWrap.observe(500U);
+  wrapState.accept(afterWrap);
+  assert(wrapState.packetCount == 2);
+  assert(wrapState.lastGapMs == 1001U);
+  assert(wrapState.maximumGapMs == 1001U);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -15,6 +15,9 @@ MAP_HEADER_SOURCE = (
 MAP_PRESENTATION_SOURCE = (
     ESP32_ROOT / "lib" / "maps" / "src" / "mapPresentation.hpp"
 ).read_text(encoding="utf-8")
+MAP_POSE_INPUT_POLICY_SOURCE = (
+    ESP32_ROOT / "lib" / "maps" / "src" / "mapPoseInputPolicy.hpp"
+).read_text(encoding="utf-8")
 BLE_SOURCE = (
     ESP32_ROOT / "lib" / "ble_navigation" / "ble_navigation.cpp"
 ).read_text(encoding="utf-8")
@@ -238,8 +241,13 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("bleStats.lastGpsPacketMs", pose)
         self.assertIn("bleStats.gpsPacketCount", pose)
         self.assertIn("fix.timestampMs", pose)
-        self.assertIn("lastGpsPositionSignature", pose)
+        self.assertIn("poseInputTracker.classify", pose)
         self.assertIn("posePresenter.updateHeading", pose)
+        self.assertIn("Action::ObservePhysicalFix", pose)
+        self.assertIn(
+            "positionSignature != lastPositionSignature_",
+            MAP_POSE_INPUT_POLICY_SOURCE,
+        )
         self.assertIn('"MAPIO: presentation gpsAgeMs=%lu lastGpsGapMs=%lu "', pose)
         self.assertIn('"predictionExhausted=%u exhaustionCount=%lu "', pose)
 

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -21,6 +21,9 @@ BLE_SOURCE = (
 BLE_HEADER_SOURCE = (
     ESP32_ROOT / "lib" / "ble_navigation" / "ble_navigation.hpp"
 ).read_text(encoding="utf-8")
+GPS_FRESHNESS_SOURCE = (
+    ESP32_ROOT / "lib" / "ble_navigation" / "gps_input_freshness.hpp"
+).read_text(encoding="utf-8")
 BUILDING_ADMISSION_SOURCE = (
     ESP32_ROOT / "lib" / "maps" / "src" / "mapBuildingAdmission.hpp"
 ).read_text(encoding="utf-8")
@@ -227,7 +230,7 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
     def test_prediction_grace_is_bounded_and_reports_transport_freshness(self):
         self.assertIn("fullSpeedPredictionMs = 1500", MAP_PRESENTATION_SOURCE)
         self.assertIn("maximumPredictionMs = 2500", MAP_PRESENTATION_SOURCE)
-        self.assertIn("maximumPredictionMeters = 30.0", MAP_PRESENTATION_SOURCE)
+        self.assertIn("maximumPredictionMeters = 70.0", MAP_PRESENTATION_SOURCE)
         self.assertIn("graceElapsedMs * graceElapsedMs", MAP_PRESENTATION_SOURCE)
         self.assertIn("predictionExhausted", MAP_PRESENTATION_SOURCE)
 
@@ -235,17 +238,20 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("bleStats.lastGpsPacketMs", pose)
         self.assertIn("bleStats.gpsPacketCount", pose)
         self.assertIn("fix.timestampMs", pose)
+        self.assertIn("lastGpsPositionSignature", pose)
+        self.assertIn("posePresenter.updateHeading", pose)
         self.assertIn('"MAPIO: presentation gpsAgeMs=%lu lastGpsGapMs=%lu "', pose)
         self.assertIn('"predictionExhausted=%u exhaustionCount=%lu "', pose)
 
+        queue = function_body(BLE_SOURCE, "static bool queueMapInput")
         gps_handler = function_body(BLE_SOURCE, "static void handleGpsPayload")
         self.assertIn("lastGpsPacketGapMs", BLE_HEADER_SOURCE)
         self.assertIn("maximumGpsPacketGapMs", BLE_HEADER_SOURCE)
-        self.assertIn(
-            "gpsPacketReceivedAtMs - bleDebugStats.lastGpsPacketMs",
-            gps_handler,
-        )
-        self.assertIn("maximumGpsPacketGapMs", gps_handler)
+        self.assertIn("gps_input_freshness::acceptsPayload", queue)
+        self.assertIn("gpsReceivedAtMs = millis()", queue)
+        self.assertIn("input.gpsArrivals.observe(gpsReceivedAtMs)", queue)
+        self.assertIn("gpsFreshnessState.accept(arrivals)", gps_handler)
+        self.assertIn("batch.firstPacketMs - lastPacketMs", GPS_FRESHNESS_SOURCE)
 
         self.assertIn(
             '"pose[gpsAgeMs=%lu predictionAgeMs=%lu grace=%d "',
@@ -262,7 +268,7 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
                 "1 Hz",
                 "1.5",
                 "2.5",
-                "30 metres",
+                "70 metres",
                 "missed heartbeat",
             ):
                 self.assertIn(term, documentation)

--- a/esp32/tools/tests/test_map_pose_input_policy.cpp
+++ b/esp32/tools/tests/test_map_pose_input_policy.cpp
@@ -1,0 +1,44 @@
+#include "../../lib/maps/src/mapPoseInputPolicy.hpp"
+
+#include <cassert>
+#include <cstdint>
+
+int main() {
+  using map_pose_input_policy::Action;
+  using map_pose_input_policy::Tracker;
+
+  Tracker tracker;
+
+  // The first input always establishes a physical presentation anchor.
+  assert(tracker.classify(100U, 1000U, false) ==
+         Action::ObservePhysicalFix);
+  assert(tracker.classify(100U, 1000U, true) == Action::None);
+
+  // A route-only heading refinement changes the complete signature but not
+  // accepted GPS packet identity, so it can rotate presentation only.
+  assert(tracker.classify(100U, 1001U, true) == Action::UpdateHeadingOnly);
+  assert(tracker.classify(100U, 1001U, true) == Action::None);
+
+  // An identical coordinate carried by a newly accepted GPS packet changes
+  // the position signature and must refresh transport age/convergence.
+  assert(tracker.classify(101U, 1002U, true) ==
+         Action::ObservePhysicalFix);
+
+  // A heading epoch reset re-resolves display direction but cannot manufacture
+  // a physical observation from the retained fix.
+  tracker.invalidateHeading();
+  assert(tracker.classify(101U, 1002U, true) == Action::UpdateHeadingOnly);
+
+  // If the presenter was independently reset, the retained signature history
+  // cannot suppress rebuilding its physical anchor.
+  assert(tracker.classify(101U, 1002U, false) ==
+         Action::ObservePhysicalFix);
+
+  // Zero is a valid hash value; explicit state, not a sentinel, owns history.
+  Tracker zeroTracker;
+  assert(zeroTracker.classify(0U, 0U, false) ==
+         Action::ObservePhysicalFix);
+  assert(zeroTracker.classify(0U, 0U, true) == Action::None);
+
+  return 0;
+}

--- a/esp32/tools/tests/test_map_presentation.cpp
+++ b/esp32/tools/tests/test_map_presentation.cpp
@@ -73,7 +73,7 @@ int main() {
   Presenter::Config graceConfig;
   assert(graceConfig.fullSpeedPredictionMs == 1500);
   assert(graceConfig.maximumPredictionMs == 2500);
-  assert(graceConfig.maximumPredictionMeters == 30.0);
+  assert(graceConfig.maximumPredictionMeters == 70.0);
   graceConfig.convergenceMs = 0;
   Presenter heartbeatGrace(graceConfig);
   heartbeatGrace.observe(
@@ -101,6 +101,74 @@ int main() {
   assert(longTransportLoss.observationAgeMs == 8000);
   assert(longTransportLoss.predictionAgeMs == 2500);
   assert(longTransportLoss.predictionExhausted);
+
+  // The default distance guard is derived from the supported 35 m/s speed and
+  // integrated horizon. A credible 20 m/s descent therefore stays continuous
+  // through one missed heartbeat and stops only at the hard time horizon.
+  Presenter highSpeedHeartbeat(graceConfig);
+  highSpeedHeartbeat.observe(
+      {{0.0, 0.0}, 90.0, true, 20.0, 1.0, 1000}, 1000);
+  const PresentedPose highSpeedMiss = highSpeedHeartbeat.present(3000);
+  assert(std::fabs(highSpeedMiss.position.x - 37.5) < 1e-6);
+  assert(highSpeedMiss.predictionGraceActive);
+  assert(!highSpeedMiss.predictionExhausted);
+  const PresentedPose highSpeedHorizon = highSpeedHeartbeat.present(3500);
+  assert(std::fabs(highSpeedHorizon.position.x - 40.0) < 1e-6);
+  assert(highSpeedHorizon.predictionExhausted);
+
+  Presenter maximumSupportedSpeed(graceConfig);
+  maximumSupportedSpeed.observe(
+      {{0.0, 0.0}, 90.0, true, 35.0, 1.0, 1000}, 1000);
+  const PresentedPose maximumSpeedMiss = maximumSupportedSpeed.present(3000);
+  assert(std::fabs(maximumSpeedMiss.position.x - 65.625) < 1e-6);
+  assert(maximumSpeedMiss.predictionGraceActive);
+  assert(!maximumSpeedMiss.predictionExhausted);
+  const PresentedPose justBeforeMaximumHorizon =
+      maximumSupportedSpeed.present(3499);
+  assert(!justBeforeMaximumHorizon.predictionExhausted);
+  const PresentedPose maximumSpeedHorizon =
+      maximumSupportedSpeed.present(3500);
+  assert(std::fabs(maximumSpeedHorizon.position.x - 70.0) < 1e-6);
+  assert(maximumSpeedHorizon.predictionExhausted);
+
+  // A route-bearing update can rotate presentation but cannot redefine the
+  // positional path owned by the last physical fix. Once stale motion is
+  // exhausted it cannot move the shared map/route/marker pose to a new endpoint.
+  Presenter::Config headingOnlyConfig;
+  Presenter headingOnly(headingOnlyConfig);
+  headingOnly.observe(
+      {{0.0, 0.0}, 90.0, true, 10.0, 1.0, 1000}, 1000);
+  const PresentedPose exhaustedEast = headingOnly.present(3500);
+  assert(std::fabs(exhaustedEast.position.x - 20.0) < 1e-6);
+  assert(std::fabs(exhaustedEast.position.y) < 1e-6);
+  assert(exhaustedEast.predictionExhausted);
+  headingOnly.updateHeading(0.0, true, 4000);
+  const PresentedPose headingChangedAtStart = headingOnly.present(4000);
+  const PresentedPose headingChangedSettled = headingOnly.present(4350);
+  for (const PresentedPose &pose :
+       {headingChangedAtStart, headingChangedSettled}) {
+    assert(std::fabs(pose.position.x - exhaustedEast.position.x) < 1e-6);
+    assert(std::fabs(pose.position.y - exhaustedEast.position.y) < 1e-6);
+    assert(pose.predictionExhausted);
+  }
+  assert(std::fabs(headingChangedSettled.headingDegrees) < 1e-6);
+
+  Presenter headingDuringPrediction(headingOnlyConfig);
+  headingDuringPrediction.observe(
+      {{0.0, 0.0}, 90.0, true, 10.0, 1.0, 1000}, 1000);
+  const PresentedPose fiveMetersEast = headingDuringPrediction.present(1500);
+  assert(std::fabs(fiveMetersEast.position.x - 5.0) < 1e-6);
+  headingDuringPrediction.updateHeading(0.0, true, 1500);
+  const PresentedPose halfwayThroughHeading =
+      headingDuringPrediction.present(1675);
+  assert(std::fabs(halfwayThroughHeading.position.x - 6.75) < 1e-6);
+  assert(std::fabs(halfwayThroughHeading.position.y) < 1e-6);
+  assert(std::fabs(halfwayThroughHeading.headingDegrees - 45.0) < 1e-6);
+  const PresentedPose continuedAlongPhysicalFix =
+      headingDuringPrediction.present(1850);
+  assert(std::fabs(continuedAlongPhysicalFix.position.x - 8.5) < 1e-6);
+  assert(std::fabs(continuedAlongPhysicalFix.position.y) < 1e-6);
+  assert(std::fabs(continuedAlongPhysicalFix.headingDegrees) < 1e-6);
 
   // Receiving route/heading work later must not make an old physical fix
   // fresh. The source timestamp, not the UI observation time, owns the


### PR DESCRIPTION
## What changed

- capture authenticated GPS arrival time on the NimBLE callback task before the UI mailbox can stall
- preserve packet count and gap timing when the latest-state mailbox coalesces multiple GPS packets
- separate physical position observations from route-only heading refinements
- keep position and heading convergence clocks independent
- derive the 70 m prediction guard from the supported 35 m/s speed clamp and the existing 2.5 s finite horizon
- add focused C++ regressions, cross-component wiring checks, CI coverage, and rendering-policy documentation

## Root cause

GPS freshness was recorded when the UI task drained its mailbox rather than when BLE accepted the packet. During a long render, this made old input appear fresh. Route-bearing updates could also re-observe the same physical fix, while the previous 30 m distance guard could end prediction before the intended time horizon at supported speeds.

Together these paths could make the marker, route overlay, and base map disagree or advance in visible jumps.

## Impact

All navigation layers continue to consume one shared presented pose. A missed 1 Hz heartbeat remains smooth across the supported speed range, genuine transport loss settles at the bounded horizon, and heading-only route updates cannot move an exhausted physical pose. The asynchronous base renderer and 3D-building pipeline remain intact.

## Validation

- 202 firmware/Python tests passed
- 6 focused C++ navigation/rendering test binaries passed
- portable iOS navigation/BLE test suite passed
- `git diff --check` passed
- fresh P0-P2 convergence review found no remaining actionable issue

Not run: physical device build or flash; the connected board model still needs to be confirmed before using the board-specific firmware workflow.