### PR TITLE
Optimize pull request CI

### DIFF
--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -27,7 +27,10 @@ FIRMWARE_CONTRACT_PATHS = {
     "docs/firmware-map-memory-diagnostics.md",
     "docs/firmware-map-render-scheduler.md",
     "docs/firmware-map-rendering-psram.md",
+}
+FIRMWARE_MANIFEST_PATHS = {
     "tools/firmware_manifest.py",
+    "tools/tests/test_firmware_manifest.py",
 }
 IOS_CONTRACT_PATHS = {
     "docs/app-store-privacy-disclosures.md",
@@ -59,13 +62,17 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
 
         if (
             path.startswith("esp32/")
-            or path.startswith("tools/tests/")
             or path in FIRMWARE_WORKFLOW_PATHS
             or path in FIRMWARE_CONTRACT_PATHS
         ):
             selected["firmware"] = True
 
         if path.startswith("ios-app/") or path in IOS_CONTRACT_PATHS:
+            selected["ios"] = True
+
+        if path in FIRMWARE_MANIFEST_PATHS:
+            # The release producer and the shipped iOS verifier share this contract.
+            selected["firmware"] = True
             selected["ios"] = True
 
         if path == ".dockerignore" or path.startswith("map-platform/"):

--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Classify changed repository paths for GitHub Actions CI routing."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+from collections.abc import Iterable, Sequence
+
+
+COMPONENTS = ("firmware", "ios", "map_backend", "osm")
+FULL_CI_PATH_PREFIXES = (".github/scripts/",)
+FULL_CI_PATHS = {".github/workflows/ci.yml"}
+FIRMWARE_WORKFLOW_PATHS = {
+    ".github/workflows/firmware-diagnostics.yml",
+    ".github/workflows/firmware-release.yml",
+    ".github/workflows/speaker-firmware.yml",
+}
+MAP_WORKFLOW_PATHS = {
+    ".github/workflows/map-platform-ci.yml",
+    ".github/workflows/map-platform-image.yml",
+}
+SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
+ZERO_SHA = "0" * 40
+
+
+def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, bool]:
+    """Return the CI components affected by a collection of Git paths."""
+
+    selected = {component: run_all for component in COMPONENTS}
+    if run_all:
+        return selected
+
+    for raw_path in paths:
+        path = raw_path
+        if not path:
+            continue
+
+        if path in FULL_CI_PATHS or path.startswith(FULL_CI_PATH_PREFIXES):
+            return {component: True for component in COMPONENTS}
+
+        if path.startswith("esp32/") or path in FIRMWARE_WORKFLOW_PATHS:
+            selected["firmware"] = True
+
+        if path.startswith("ios-app/"):
+            selected["ios"] = True
+
+        if path == ".dockerignore" or path.startswith("map-platform/"):
+            selected["map_backend"] = True
+
+        if path.startswith("tools/OSM_Extract/"):
+            # The production backend image copies the extractor into its image.
+            selected["map_backend"] = True
+            selected["osm"] = True
+
+        if path in MAP_WORKFLOW_PATHS:
+            selected["map_backend"] = True
+            selected["osm"] = True
+
+    return selected
+
+
+def select_scope(scope: str) -> dict[str, bool] | None:
+    """Return an explicit workflow-dispatch selection, or None for path routing."""
+
+    if scope == "auto":
+        return None
+    if scope == "all":
+        return {component: True for component in COMPONENTS}
+    if scope == "firmware":
+        return {
+            "firmware": True,
+            "ios": False,
+            "map_backend": False,
+            "osm": False,
+        }
+    if scope == "ios":
+        return {
+            "firmware": False,
+            "ios": True,
+            "map_backend": False,
+            "osm": False,
+        }
+    if scope == "map":
+        return {
+            "firmware": False,
+            "ios": False,
+            "map_backend": True,
+            "osm": True,
+        }
+    raise ValueError(f"unsupported CI scope: {scope}")
+
+
+def _validated_sha(value: str, label: str) -> str:
+    if not SHA_PATTERN.fullmatch(value):
+        raise ValueError(f"{label} must be a 40-character Git SHA")
+    return value.lower()
+
+
+def git_diff_command(event: str, base: str, head: str) -> Sequence[str] | None:
+    """Build the Git command that lists paths changed by a workflow event."""
+
+    if event == "workflow_dispatch":
+        return None
+
+    head_sha = _validated_sha(head, "head")
+    base_sha = _validated_sha(base, "base")
+    if event == "pull_request":
+        return (
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base_sha}...{head_sha}",
+            "--",
+        )
+    if event == "push":
+        if base_sha == ZERO_SHA:
+            return (
+                "git",
+                "diff-tree",
+                "--no-renames",
+                "--root",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "-z",
+                head_sha,
+                "--",
+            )
+        return (
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base_sha}..{head_sha}",
+            "--",
+        )
+    raise ValueError(f"unsupported GitHub event: {event}")
+
+
+def changed_paths(event: str, base: str, head: str) -> tuple[str, ...] | None:
+    """Read the changed paths for an event, or return None for a full manual run."""
+
+    command = git_diff_command(event, base, head)
+    if command is None:
+        return None
+    result = subprocess.run(command, check=True, capture_output=True)
+    return tuple(
+        entry.decode("utf-8", errors="surrogateescape")
+        for entry in result.stdout.split(b"\0")
+        if entry
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--event", required=True)
+    parser.add_argument("--base", default=ZERO_SHA)
+    parser.add_argument("--head", default=ZERO_SHA)
+    parser.add_argument(
+        "--scope",
+        choices=("auto", "all", "firmware", "ios", "map"),
+        default="auto",
+    )
+    args = parser.parse_args()
+
+    try:
+        selected = select_scope(args.scope)
+        if selected is None:
+            paths = changed_paths(args.event, args.base, args.head)
+            selected = classify_paths(paths or (), run_all=paths is None)
+    except (subprocess.CalledProcessError, ValueError) as error:
+        parser.error(str(error))
+
+    for component in COMPONENTS:
+        value = "true" if selected[component] else "false"
+        print(f"{component}={value}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -21,6 +21,23 @@ MAP_WORKFLOW_PATHS = {
     ".github/workflows/map-platform-ci.yml",
     ".github/workflows/map-platform-image.yml",
 }
+FIRMWARE_CONTRACT_PATHS = {
+    "docs/device-ownership-test-vectors.json",
+    "docs/firmware-battery-life-hardware-validation.md",
+    "docs/firmware-map-memory-diagnostics.md",
+    "docs/firmware-map-render-scheduler.md",
+    "docs/firmware-map-rendering-psram.md",
+    "tools/firmware_manifest.py",
+}
+IOS_CONTRACT_PATHS = {
+    "docs/app-store-privacy-disclosures.md",
+    "docs/device-ownership-test-vectors.json",
+    "docs/releases/watchos-workout-companion.md",
+}
+SHARED_FMB_FIXTURE_PREFIX = "test-fixtures/fmb/"
+SHARED_MAP_STREAM_FIXTURE_PATH = (
+    "map-platform/backend/tests/fixtures/map_stream_v1_golden.txt"
+)
 SHA_PATTERN = re.compile(r"^[0-9a-fA-F]{40}$")
 ZERO_SHA = "0" * 40
 
@@ -40,10 +57,15 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
         if path in FULL_CI_PATHS or path.startswith(FULL_CI_PATH_PREFIXES):
             return {component: True for component in COMPONENTS}
 
-        if path.startswith("esp32/") or path in FIRMWARE_WORKFLOW_PATHS:
+        if (
+            path.startswith("esp32/")
+            or path.startswith("tools/tests/")
+            or path in FIRMWARE_WORKFLOW_PATHS
+            or path in FIRMWARE_CONTRACT_PATHS
+        ):
             selected["firmware"] = True
 
-        if path.startswith("ios-app/"):
+        if path.startswith("ios-app/") or path in IOS_CONTRACT_PATHS:
             selected["ios"] = True
 
         if path == ".dockerignore" or path.startswith("map-platform/"):
@@ -53,6 +75,18 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
             # The production backend image copies the extractor into its image.
             selected["map_backend"] = True
             selected["osm"] = True
+
+        if path.startswith(SHARED_FMB_FIXTURE_PREFIX):
+            # Firmware, the backend, and the extractor all assert these bytes.
+            selected["firmware"] = True
+            selected["map_backend"] = True
+            selected["osm"] = True
+
+        if path == SHARED_MAP_STREAM_FIXTURE_PATH:
+            # The same signed-stream bytes are parsed by backend, iOS, and firmware.
+            selected["firmware"] = True
+            selected["ios"] = True
+            selected["map_backend"] = True
 
         if path in MAP_WORKFLOW_PATHS:
             selected["map_backend"] = True

--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -62,6 +62,7 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
 
         if (
             path.startswith("esp32/")
+            or path.startswith("tools/tests/")
             or path in FIRMWARE_WORKFLOW_PATHS
             or path in FIRMWARE_CONTRACT_PATHS
         ):

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -46,6 +46,90 @@ class ChangedComponentsTests(unittest.TestCase):
         self.assertTrue(selected["osm"])
         self.assertTrue(selected["map_backend"])
 
+    def test_shared_fmb_fixture_selects_every_consumer(self) -> None:
+        selected = changed_components.classify_paths(
+            ["test-fixtures/fmb/golden_blocks.txt"]
+        )
+
+        self.assertEqual(
+            {
+                "firmware": True,
+                "ios": False,
+                "map_backend": True,
+                "osm": True,
+            },
+            selected,
+        )
+
+    def test_shared_ownership_fixture_selects_firmware_and_ios(self) -> None:
+        selected = changed_components.classify_paths(
+            ["docs/device-ownership-test-vectors.json"]
+        )
+
+        self.assertEqual(
+            {
+                "firmware": True,
+                "ios": True,
+                "map_backend": False,
+                "osm": False,
+            },
+            selected,
+        )
+
+    def test_shared_map_stream_fixture_selects_every_consumer(self) -> None:
+        selected = changed_components.classify_paths(
+            ["map-platform/backend/tests/fixtures/map_stream_v1_golden.txt"]
+        )
+
+        self.assertEqual(
+            {
+                "firmware": True,
+                "ios": True,
+                "map_backend": True,
+                "osm": False,
+            },
+            selected,
+        )
+
+    def test_contract_documents_select_their_consumers(self) -> None:
+        firmware_contracts = (
+            "docs/firmware-battery-life-hardware-validation.md",
+            "docs/firmware-map-memory-diagnostics.md",
+            "docs/firmware-map-render-scheduler.md",
+            "docs/firmware-map-rendering-psram.md",
+        )
+        ios_contracts = (
+            "docs/app-store-privacy-disclosures.md",
+            "docs/releases/watchos-workout-companion.md",
+        )
+
+        for path in firmware_contracts:
+            with self.subTest(path=path):
+                selected = changed_components.classify_paths([path])
+                self.assertTrue(selected["firmware"])
+                self.assertFalse(selected["ios"])
+        for path in ios_contracts:
+            with self.subTest(path=path):
+                selected = changed_components.classify_paths([path])
+                self.assertTrue(selected["ios"])
+                self.assertFalse(selected["firmware"])
+
+    def test_firmware_manifest_generator_and_tests_select_firmware(self) -> None:
+        for path in (
+            "tools/firmware_manifest.py",
+            "tools/tests/test_firmware_manifest.py",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    {
+                        "firmware": True,
+                        "ios": False,
+                        "map_backend": False,
+                        "osm": False,
+                    },
+                    changed_components.classify_paths([path]),
+                )
+
     def test_ci_router_change_runs_every_component(self) -> None:
         selected = changed_components.classify_paths(
             [".github/scripts/changed_components.py"]
@@ -67,6 +151,21 @@ class ChangedComponentsTests(unittest.TestCase):
         self.assertFalse(selected["ios"])
         self.assertTrue(selected["map_backend"])
         self.assertTrue(selected["osm"])
+
+    def test_every_explicit_scope_has_the_expected_components(self) -> None:
+        self.assertIsNone(changed_components.select_scope("auto"))
+        self.assertEqual(
+            {component: True for component in changed_components.COMPONENTS},
+            changed_components.select_scope("all"),
+        )
+        for scope, component in (("firmware", "firmware"), ("ios", "ios")):
+            with self.subTest(scope=scope):
+                selected = changed_components.select_scope(scope)
+                assert selected is not None
+                self.assertTrue(selected[component])
+                self.assertEqual(1, sum(selected.values()))
+        with self.assertRaisesRegex(ValueError, "unsupported CI scope"):
+            changed_components.select_scope("unknown")
 
     def test_pull_request_uses_merge_base_diff(self) -> None:
         base = "a" * 40
@@ -105,6 +204,57 @@ class ChangedComponentsTests(unittest.TestCase):
                 "push", changed_components.ZERO_SHA, head
             ),
         )
+
+    def test_normal_push_uses_two_dot_diff(self) -> None:
+        base = "a" * 40
+        head = "b" * 40
+
+        self.assertEqual(
+            (
+                "git",
+                "diff",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                f"{base}..{head}",
+                "--",
+            ),
+            changed_components.git_diff_command("push", base, head),
+        )
+
+    def test_manual_dispatch_does_not_compute_a_git_diff(self) -> None:
+        self.assertIsNone(
+            changed_components.git_diff_command(
+                "workflow_dispatch", "not-needed", "not-needed"
+            )
+        )
+
+    def test_unsupported_event_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "unsupported GitHub event"):
+            changed_components.git_diff_command("schedule", "a" * 40, "b" * 40)
+
+    def test_workflow_and_docker_inputs_select_their_components(self) -> None:
+        firmware = changed_components.classify_paths(
+            [".github/workflows/firmware-release.yml"]
+        )
+        map_workflow = changed_components.classify_paths(
+            [".github/workflows/map-platform-image.yml"]
+        )
+        docker = changed_components.classify_paths([".dockerignore"])
+
+        self.assertEqual(
+            {
+                "firmware": True,
+                "ios": False,
+                "map_backend": False,
+                "osm": False,
+            },
+            firmware,
+        )
+        self.assertTrue(map_workflow["map_backend"])
+        self.assertTrue(map_workflow["osm"])
+        self.assertTrue(docker["map_backend"])
+        self.assertEqual(1, sum(docker.values()))
 
     def test_invalid_revision_is_rejected(self) -> None:
         with self.assertRaisesRegex(ValueError, "base must be"):

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -130,6 +130,23 @@ class ChangedComponentsTests(unittest.TestCase):
                     changed_components.classify_paths([path]),
                 )
 
+    def test_future_root_tool_tests_select_the_firmware_host_job(self) -> None:
+        for path in (
+            "tools/tests/test_future_release_tool.py",
+            "tools/tests/helpers.py",
+            "tools/tests/fixtures/manifest.json",
+        ):
+            with self.subTest(path=path):
+                self.assertEqual(
+                    {
+                        "firmware": True,
+                        "ios": False,
+                        "map_backend": False,
+                        "osm": False,
+                    },
+                    changed_components.classify_paths([path]),
+                )
+
     def test_ci_router_change_runs_every_component(self) -> None:
         selected = changed_components.classify_paths(
             [".github/scripts/changed_components.py"]

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -114,7 +114,7 @@ class ChangedComponentsTests(unittest.TestCase):
                 self.assertTrue(selected["ios"])
                 self.assertFalse(selected["firmware"])
 
-    def test_firmware_manifest_generator_and_tests_select_firmware(self) -> None:
+    def test_firmware_manifest_generator_and_tests_select_both_consumers(self) -> None:
         for path in (
             "tools/firmware_manifest.py",
             "tools/tests/test_firmware_manifest.py",
@@ -123,7 +123,7 @@ class ChangedComponentsTests(unittest.TestCase):
                 self.assertEqual(
                     {
                         "firmware": True,
-                        "ios": False,
+                        "ios": True,
                         "map_backend": False,
                         "osm": False,
                     },

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "changed_components.py"
+SPEC = importlib.util.spec_from_file_location("changed_components", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+changed_components = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(changed_components)
+
+
+class ChangedComponentsTests(unittest.TestCase):
+    def test_docs_only_change_skips_product_jobs(self) -> None:
+        self.assertEqual(
+            {
+                "firmware": False,
+                "ios": False,
+                "map_backend": False,
+                "osm": False,
+            },
+            changed_components.classify_paths(["README.md", "docs/README.md"]),
+        )
+
+    def test_each_product_tree_selects_its_jobs(self) -> None:
+        firmware = changed_components.classify_paths(["esp32/src/main.cpp"])
+        ios = changed_components.classify_paths(["ios-app/BikeComputer/App.swift"])
+        backend = changed_components.classify_paths(
+            ["map-platform/backend/map_platform/api.py"]
+        )
+
+        self.assertTrue(firmware["firmware"])
+        self.assertFalse(firmware["ios"])
+        self.assertTrue(ios["ios"])
+        self.assertFalse(ios["firmware"])
+        self.assertTrue(backend["map_backend"])
+        self.assertFalse(backend["osm"])
+
+    def test_osm_changes_also_validate_the_backend_image(self) -> None:
+        selected = changed_components.classify_paths(
+            ["tools/OSM_Extract/scripts/extract_features.py"]
+        )
+
+        self.assertTrue(selected["osm"])
+        self.assertTrue(selected["map_backend"])
+
+    def test_ci_router_change_runs_every_component(self) -> None:
+        selected = changed_components.classify_paths(
+            [".github/scripts/changed_components.py"]
+        )
+
+        self.assertTrue(all(selected.values()))
+
+    def test_manual_dispatch_runs_every_component(self) -> None:
+        selected = changed_components.classify_paths([], run_all=True)
+
+        self.assertTrue(all(selected.values()))
+
+    def test_map_scope_runs_only_map_components(self) -> None:
+        selected = changed_components.select_scope("map")
+
+        self.assertIsNotNone(selected)
+        assert selected is not None
+        self.assertFalse(selected["firmware"])
+        self.assertFalse(selected["ios"])
+        self.assertTrue(selected["map_backend"])
+        self.assertTrue(selected["osm"])
+
+    def test_pull_request_uses_merge_base_diff(self) -> None:
+        base = "a" * 40
+        head = "b" * 40
+
+        self.assertEqual(
+            (
+                "git",
+                "diff",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                f"{base}...{head}",
+                "--",
+            ),
+            changed_components.git_diff_command("pull_request", base, head),
+        )
+
+    def test_new_ref_push_uses_root_diff(self) -> None:
+        head = "b" * 40
+
+        self.assertEqual(
+            (
+                "git",
+                "diff-tree",
+                "--no-renames",
+                "--root",
+                "--no-commit-id",
+                "--name-only",
+                "-r",
+                "-z",
+                head,
+                "--",
+            ),
+            changed_components.git_diff_command(
+                "push", changed_components.ZERO_SHA, head
+            ),
+        )
+
+    def test_invalid_revision_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "base must be"):
+            changed_components.git_diff_command("push", "main", "b" * 40)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+CORE_FIRMWARE_TARGETS = {
+    "WAVESHARE_AMOLED_175",
+    "WAVESHARE_AMOLED_175_PRODUCTION",
+    "WAVESHARE_AMOLED_206",
+    "WAVESHARE_AMOLED_206_PRODUCTION",
+}
+DIAGNOSTIC_FIRMWARE_TARGETS = {
+    "WAVESHARE_AMOLED_175_MAPIO_DIAGNOSTICS",
+    "WAVESHARE_AMOLED_175_POWER_METRICS",
+    "WAVESHARE_AMOLED_175_LIGHT_SLEEP",
+    "WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS",
+    "WAVESHARE_AMOLED_206_DISPLAY_TEST",
+    "WAVESHARE_AMOLED_206_POWER_METRICS",
+    "WAVESHARE_AMOLED_206_LIGHT_SLEEP",
+}
+
+
+def workflow_source(filename: str) -> str:
+    return (WORKFLOW_ROOT / filename).read_text(encoding="utf-8")
+
+
+def matrix_targets(source: str) -> set[str]:
+    return set(
+        re.findall(r"^\s+- (WAVESHARE_AMOLED_[A-Z0-9_]+)$", source, re.MULTILINE)
+    )
+
+
+class WorkflowPolicyTests(unittest.TestCase):
+    def test_default_and_diagnostic_firmware_matrices_stay_separate(self) -> None:
+        default_targets = matrix_targets(workflow_source("ci.yml"))
+        diagnostic_targets = matrix_targets(
+            workflow_source("firmware-diagnostics.yml")
+        )
+
+        self.assertEqual(CORE_FIRMWARE_TARGETS, default_targets)
+        self.assertEqual(DIAGNOSTIC_FIRMWARE_TARGETS, diagnostic_targets)
+
+    def test_feature_branch_pushes_do_not_duplicate_pull_request_ci(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        self.assertIn("  push:\n    branches:\n      - main\n", general_ci)
+        self.assertIn("  pull_request:\n", general_ci)
+        self.assertIn("  cancel-in-progress: true\n", general_ci)
+
+    def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
+        for workflow in (
+            "ci.yml",
+            "firmware-diagnostics.yml",
+            "firmware-release.yml",
+            "speaker-firmware.yml",
+        ):
+            with self.subTest(workflow=workflow):
+                source = workflow_source(workflow)
+                self.assertIn("uses: actions/cache@v6", source)
+                self.assertIn(".pio/open-bike-build/downloads", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -109,6 +109,16 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("Merge only after **CI Gate**", agent_instructions)
         self.assertNotIn("Merge only after **Map Backend**", agent_instructions)
 
+    def test_host_tests_keep_a_clean_firmware_build_environment(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        host_job = general_ci.split("\n  esp32-host:\n", 1)[1].split(
+            "\n  map-platform:\n", 1
+        )[0]
+
+        self.assertNotIn("actions/setup-python", host_job)
+        self.assertIn("python3-cryptography", host_job)
+        self.assertIn("python3 -m unittest discover -s tools/tests", host_job)
+
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
         for workflow in (
             "ci.yml",

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -37,6 +37,41 @@ def workflow_source(filename: str) -> str:
     return (WORKFLOW_ROOT / filename).read_text(encoding="utf-8")
 
 
+def workflow_sources() -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (path.name, path.read_text(encoding="utf-8"))
+        for path in sorted(WORKFLOW_ROOT.glob("*.yml"))
+    )
+
+
+def firmware_builder_lines(source: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip()
+        for line in source.splitlines()
+        if "build_firmware.py" in line and not line.lstrip().startswith("#")
+    )
+
+
+def mapping_block(source: str, key: str, *, indent: int) -> str:
+    lines = source.splitlines()
+    marker = f"{' ' * indent}{key}:"
+    try:
+        start = lines.index(marker)
+    except ValueError as error:
+        raise AssertionError(f"missing YAML mapping key: {key}") from error
+
+    end = len(lines)
+    for index in range(start + 1, len(lines)):
+        line = lines[index]
+        if not line.strip() or line.lstrip().startswith("#"):
+            continue
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent <= indent:
+            end = index
+            break
+    return "\n".join(lines[start:end])
+
+
 def matrix_targets(source: str) -> set[str]:
     return set(
         re.findall(r"^\s+- (WAVESHARE_AMOLED_[A-Z0-9_]+)$", source, re.MULTILINE)
@@ -111,45 +146,60 @@ class WorkflowPolicyTests(unittest.TestCase):
 
     def test_host_tests_keep_a_clean_firmware_build_environment(self) -> None:
         general_ci = workflow_source("ci.yml")
-        host_job = general_ci.split("\n  esp32-host:\n", 1)[1].split(
-            "\n  map-platform:\n", 1
-        )[0]
+        host_job = mapping_block(general_ci, "esp32-host", indent=2)
 
         self.assertNotIn("actions/setup-python", host_job)
         self.assertIn("python3-cryptography", host_job)
         self.assertIn("python3 -m unittest discover -s tools/tests", host_job)
 
-    def test_every_setup_python_firmware_builder_clears_library_overrides(
-        self,
-    ) -> None:
-        for workflow in (
-            "ci.yml",
-            "firmware-diagnostics.yml",
-            "firmware-release.yml",
-            "speaker-firmware.yml",
-        ):
-            with self.subTest(workflow=workflow):
-                commands = re.findall(
-                    r"^\s+run: (.+build_firmware\.py.+)$",
-                    workflow_source(workflow),
-                    re.MULTILINE,
-                )
-                self.assertTrue(commands)
-                for command in commands:
+    def test_host_job_mapping_stops_at_the_next_peer(self) -> None:
+        source = (
+            "jobs:\n"
+            "  esp32-host:\n"
+            "    steps:\n"
+            "      - run: python3 -m unittest\n"
+            "  unrelated:\n"
+            "    uses: actions/setup-python@v7\n"
+        )
+
+        host_job = mapping_block(source, "esp32-host", indent=2)
+
+        self.assertIn("python3 -m unittest", host_job)
+        self.assertNotIn("actions/setup-python", host_job)
+
+    def test_builder_scanner_includes_block_scalar_commands(self) -> None:
+        source = (
+            "steps:\n"
+            "  - run: |\n"
+            "      python tools/build_firmware.py WAVESHARE_AMOLED_175\n"
+        )
+
+        self.assertEqual(
+            ("python tools/build_firmware.py WAVESHARE_AMOLED_175",),
+            firmware_builder_lines(source),
+        )
+
+    def test_every_firmware_builder_clears_library_overrides(self) -> None:
+        builder_count = 0
+        for workflow, source in workflow_sources():
+            for command in firmware_builder_lines(source):
+                builder_count += 1
+                with self.subTest(workflow=workflow, command=command):
                     self.assertIn(
                         "env -u LD_LIBRARY_PATH python tools/build_firmware.py",
                         command,
                     )
+        self.assertGreater(builder_count, 0)
 
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
-        for workflow in (
-            "ci.yml",
-            "firmware-diagnostics.yml",
-            "firmware-release.yml",
-            "speaker-firmware.yml",
-        ):
+        builder_workflows = tuple(
+            (workflow, source)
+            for workflow, source in workflow_sources()
+            if firmware_builder_lines(source)
+        )
+        self.assertTrue(builder_workflows)
+        for workflow, source in builder_workflows:
             with self.subTest(workflow=workflow):
-                source = workflow_source(workflow)
                 self.assertIn("uses: actions/cache@v6", source)
                 self.assertIn(".pio/open-bike-build/downloads", source)
 

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -37,10 +38,14 @@ def workflow_source(filename: str) -> str:
     return (WORKFLOW_ROOT / filename).read_text(encoding="utf-8")
 
 
-def workflow_sources() -> tuple[tuple[str, str], ...]:
+def workflow_paths(root: Path = WORKFLOW_ROOT) -> tuple[Path, ...]:
+    return tuple(sorted((*root.glob("*.yml"), *root.glob("*.yaml"))))
+
+
+def workflow_sources(root: Path = WORKFLOW_ROOT) -> tuple[tuple[str, str], ...]:
     return tuple(
         (path.name, path.read_text(encoding="utf-8"))
-        for path in sorted(WORKFLOW_ROOT.glob("*.yml"))
+        for path in workflow_paths(root)
     )
 
 
@@ -70,6 +75,37 @@ def mapping_block(source: str, key: str, *, indent: int) -> str:
             end = index
             break
     return "\n".join(lines[start:end])
+
+
+def child_mapping_blocks(
+    source: str, parent_key: str, *, indent: int
+) -> tuple[tuple[str, str], ...]:
+    parent_lines = mapping_block(source, parent_key, indent=indent).splitlines()
+    child_indent = indent + 2
+    children: list[tuple[str, int]] = []
+    for index, line in enumerate(parent_lines[1:], start=1):
+        line_indent = len(line) - len(line.lstrip())
+        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):", line.strip())
+        if line_indent == child_indent and match:
+            children.append((match.group(1), index))
+
+    blocks = []
+    for child_index, (key, start) in enumerate(children):
+        end = (
+            children[child_index + 1][1]
+            if child_index + 1 < len(children)
+            else len(parent_lines)
+        )
+        blocks.append((key, "\n".join(parent_lines[start:end])))
+    return tuple(blocks)
+
+
+def firmware_builder_jobs(source: str) -> tuple[tuple[str, str], ...]:
+    return tuple(
+        (job, block)
+        for job, block in child_mapping_blocks(source, "jobs", indent=0)
+        if firmware_builder_lines(block)
+    )
 
 
 def matrix_targets(source: str) -> set[str]:
@@ -179,29 +215,60 @@ class WorkflowPolicyTests(unittest.TestCase):
             firmware_builder_lines(source),
         )
 
+    def test_workflow_discovery_includes_yml_and_yaml(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            for filename in ("builder.yml", "release.yaml", "ignored.txt"):
+                (root / filename).write_text("name: test\n", encoding="utf-8")
+
+            self.assertEqual(
+                ("builder.yml", "release.yaml"),
+                tuple(path.name for path in workflow_paths(root)),
+            )
+
+    def test_builder_cache_association_stays_job_scoped(self) -> None:
+        source = (
+            "jobs:\n"
+            "  cached-non-builder:\n"
+            "    steps:\n"
+            "      - uses: actions/cache@v6\n"
+            "  uncached-builder:\n"
+            "    steps:\n"
+            "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+        )
+
+        self.assertEqual(
+            (("uncached-builder", mapping_block(source, "uncached-builder", indent=2)),),
+            firmware_builder_jobs(source),
+        )
+        self.assertNotIn("actions/cache", firmware_builder_jobs(source)[0][1])
+
     def test_every_firmware_builder_clears_library_overrides(self) -> None:
         builder_count = 0
         for workflow, source in workflow_sources():
-            for command in firmware_builder_lines(source):
-                builder_count += 1
-                with self.subTest(workflow=workflow, command=command):
-                    self.assertIn(
-                        "env -u LD_LIBRARY_PATH python tools/build_firmware.py",
-                        command,
-                    )
+            for job, block in firmware_builder_jobs(source):
+                for command in firmware_builder_lines(block):
+                    builder_count += 1
+                    with self.subTest(
+                        workflow=workflow, job=job, command=command
+                    ):
+                        self.assertIn(
+                            "env -u LD_LIBRARY_PATH python tools/build_firmware.py",
+                            command,
+                        )
         self.assertGreater(builder_count, 0)
 
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
-        builder_workflows = tuple(
-            (workflow, source)
+        builder_jobs = tuple(
+            (workflow, job, block)
             for workflow, source in workflow_sources()
-            if firmware_builder_lines(source)
+            for job, block in firmware_builder_jobs(source)
         )
-        self.assertTrue(builder_workflows)
-        for workflow, source in builder_workflows:
-            with self.subTest(workflow=workflow):
-                self.assertIn("uses: actions/cache@v6", source)
-                self.assertIn(".pio/open-bike-build/downloads", source)
+        self.assertTrue(builder_jobs)
+        for workflow, job, block in builder_jobs:
+            with self.subTest(workflow=workflow, job=job):
+                self.assertIn("uses: actions/cache@v6", block)
+                self.assertIn(".pio/open-bike-build/downloads", block)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -32,6 +32,12 @@ SHARED_CONTRACT_PATHS = {
     "docs/firmware-map-rendering-psram.md",
     "docs/releases/watchos-workout-companion.md",
 }
+JOB_KEY_PATTERN = re.compile(
+    r'(?:"(?P<double>[A-Za-z_][A-Za-z0-9_-]*)"|'
+    r"'(?P<single>[A-Za-z_][A-Za-z0-9_-]*)'|"
+    r"(?P<plain>[A-Za-z_][A-Za-z0-9_-]*)):"
+    r"\s*(?:&[A-Za-z_][A-Za-z0-9_-]*\s*)?(?:#.*)?"
+)
 
 
 def workflow_source(filename: str) -> str:
@@ -85,9 +91,9 @@ def child_mapping_blocks(
     children: list[tuple[str, int]] = []
     for index, line in enumerate(parent_lines[1:], start=1):
         line_indent = len(line) - len(line.lstrip())
-        match = re.fullmatch(r"([A-Za-z_][A-Za-z0-9_-]*):", line.strip())
+        match = JOB_KEY_PATTERN.fullmatch(line.strip())
         if line_indent == child_indent and match:
-            children.append((match.group(1), index))
+            children.append((next(group for group in match.groups() if group), index))
 
     blocks = []
     for child_index, (key, start) in enumerate(children):
@@ -115,6 +121,51 @@ def matrix_targets(source: str) -> set[str]:
 
 
 class WorkflowPolicyTests(unittest.TestCase):
+    def assert_firmware_builders_clear_library_overrides(
+        self, root: Path = WORKFLOW_ROOT
+    ) -> None:
+        builder_count = 0
+        violations = []
+        for workflow, source in workflow_sources(root):
+            for job, block in firmware_builder_jobs(source):
+                for command in firmware_builder_lines(block):
+                    builder_count += 1
+                    if (
+                        "env -u LD_LIBRARY_PATH python tools/build_firmware.py"
+                        not in command
+                    ):
+                        violations.append(
+                            f"{workflow}:{job}: unsafe builder command: {command}"
+                        )
+        self.assertGreater(builder_count, 0)
+        self.assertEqual((), tuple(violations))
+
+    def assert_firmware_builders_reuse_verified_downloads(
+        self, root: Path = WORKFLOW_ROOT
+    ) -> None:
+        builder_jobs = tuple(
+            (workflow, job, block)
+            for workflow, source in workflow_sources(root)
+            for job, block in firmware_builder_jobs(source)
+        )
+        self.assertTrue(builder_jobs)
+        violations = []
+        for workflow, job, block in builder_jobs:
+            has_cache = re.search(
+                r"(?m)^\s+(?:-\s+)?uses:\s*actions/cache@v6\s*(?:#.*)?$",
+                block,
+            )
+            has_download_path = re.search(
+                r"(?m)^\s+path:\s*(?:esp32/)?\.pio/open-bike-build/downloads"
+                r"\s*(?:#.*)?$",
+                block,
+            )
+            if not has_cache or not has_download_path:
+                violations.append(
+                    f"{workflow}:{job}: missing active verified-download cache"
+                )
+        self.assertEqual((), tuple(violations))
+
     def test_default_and_diagnostic_firmware_matrices_stay_separate(self) -> None:
         default_targets = matrix_targets(workflow_source("ci.yml"))
         diagnostic_targets = matrix_targets(
@@ -243,32 +294,82 @@ class WorkflowPolicyTests(unittest.TestCase):
         )
         self.assertNotIn("actions/cache", firmware_builder_jobs(source)[0][1])
 
+    def test_quoted_and_commented_job_keys_cannot_hide_unsafe_builders(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "safe.yml").write_text(
+                "jobs:\n"
+                "  safe:\n"
+                "    steps:\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py SAFE\n",
+                encoding="utf-8",
+            )
+            (root / "fifth.yaml").write_text(
+                "jobs:\n"
+                '  "fifth-builder": # valid YAML comment\n'
+                "    steps:\n"
+                "      - run: python tools/build_firmware.py UNSAFE\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(AssertionError):
+                self.assert_firmware_builders_clear_library_overrides(root)
+
+    def test_commented_peer_keys_cannot_lend_cache_to_builder(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "builder.yaml").write_text(
+                "jobs:\n"
+                "  uncached-builder:\n"
+                "    steps:\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+                "  unrelated: # valid YAML comment\n"
+                "    steps:\n"
+                "      - uses: actions/cache@v6\n"
+                "        with:\n"
+                "          path: .pio/open-bike-build/downloads\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(AssertionError):
+                self.assert_firmware_builders_reuse_verified_downloads(root)
+
+    def test_anchored_job_keys_cannot_hide_unsafe_builders(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "builder.yml").write_text(
+                "jobs:\n"
+                "  anchored-builder: &firmware_job\n"
+                "    steps:\n"
+                "      - run: python tools/build_firmware.py UNSAFE\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(AssertionError):
+                self.assert_firmware_builders_clear_library_overrides(root)
+
+    def test_commented_cache_lines_cannot_satisfy_builder_policy(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "builder.yml").write_text(
+                "jobs:\n"
+                "  uncached-builder:\n"
+                "    steps:\n"
+                "      # - uses: actions/cache@v6\n"
+                "      #   with:\n"
+                "      #     path: .pio/open-bike-build/downloads\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaises(AssertionError):
+                self.assert_firmware_builders_reuse_verified_downloads(root)
+
     def test_every_firmware_builder_clears_library_overrides(self) -> None:
-        builder_count = 0
-        for workflow, source in workflow_sources():
-            for job, block in firmware_builder_jobs(source):
-                for command in firmware_builder_lines(block):
-                    builder_count += 1
-                    with self.subTest(
-                        workflow=workflow, job=job, command=command
-                    ):
-                        self.assertIn(
-                            "env -u LD_LIBRARY_PATH python tools/build_firmware.py",
-                            command,
-                        )
-        self.assertGreater(builder_count, 0)
+        self.assert_firmware_builders_clear_library_overrides()
 
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
-        builder_jobs = tuple(
-            (workflow, job, block)
-            for workflow, source in workflow_sources()
-            for job, block in firmware_builder_jobs(source)
-        )
-        self.assertTrue(builder_jobs)
-        for workflow, job, block in builder_jobs:
-            with self.subTest(workflow=workflow, job=job):
-                self.assertIn("uses: actions/cache@v6", block)
-                self.assertIn(".pio/open-bike-build/downloads", block)
+        self.assert_firmware_builders_reuse_verified_downloads()
 
 
 if __name__ == "__main__":

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -106,6 +106,61 @@ def child_mapping_blocks(
     return tuple(blocks)
 
 
+def sequence_mapping_blocks(
+    source: str, parent_key: str, *, indent: int
+) -> tuple[str, ...]:
+    parent_lines = mapping_block(source, parent_key, indent=indent).splitlines()
+    item_indent = indent + 2
+    item_starts = []
+    for index, line in enumerate(parent_lines[1:], start=1):
+        line_indent = len(line) - len(line.lstrip())
+        if line_indent == item_indent and line.lstrip().startswith("-"):
+            item_starts.append(index)
+
+    blocks = []
+    property_indent = item_indent + 2
+    for item_index, start in enumerate(item_starts):
+        end = (
+            item_starts[item_index + 1]
+            if item_index + 1 < len(item_starts)
+            else len(parent_lines)
+        )
+        raw_lines = parent_lines[start:end]
+        first_match = re.fullmatch(rf"\s{{{item_indent}}}-\s*(.*)", raw_lines[0])
+        if not first_match:
+            continue
+        normalized = [first_match.group(1)]
+        for line in raw_lines[1:]:
+            normalized.append(
+                line[property_indent:]
+                if line.startswith(" " * property_indent)
+                else line
+            )
+        blocks.append("\n".join(normalized))
+    return tuple(blocks)
+
+
+def is_verified_download_cache_step(step: str) -> bool:
+    if not re.search(
+        r"(?m)^uses:\s*actions/cache@v6\s*(?:#.*)?$",
+        step,
+    ):
+        return False
+    if re.search(r"(?m)^if:", step):
+        return False
+    try:
+        with_block = mapping_block(step, "with", indent=0)
+    except AssertionError:
+        return False
+    return bool(
+        re.search(
+            r"(?m)^\s{2}path:\s*(?:esp32/)?\.pio/open-bike-build/downloads"
+            r"\s*(?:#.*)?$",
+            with_block,
+        )
+    )
+
+
 def firmware_builder_jobs(source: str) -> tuple[tuple[str, str], ...]:
     return tuple(
         (job, block)
@@ -151,16 +206,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertTrue(builder_jobs)
         violations = []
         for workflow, job, block in builder_jobs:
-            has_cache = re.search(
-                r"(?m)^\s+(?:-\s+)?uses:\s*actions/cache@v6\s*(?:#.*)?$",
-                block,
-            )
-            has_download_path = re.search(
-                r"(?m)^\s+path:\s*(?:esp32/)?\.pio/open-bike-build/downloads"
-                r"\s*(?:#.*)?$",
-                block,
-            )
-            if not has_cache or not has_download_path:
+            steps = sequence_mapping_blocks(block, "steps", indent=4)
+            if not any(is_verified_download_cache_step(step) for step in steps):
                 violations.append(
                     f"{workflow}:{job}: missing active verified-download cache"
                 )
@@ -364,6 +411,57 @@ class WorkflowPolicyTests(unittest.TestCase):
 
             with self.assertRaises(AssertionError):
                 self.assert_firmware_builders_reuse_verified_downloads(root)
+
+    def test_unrelated_yaml_fields_cannot_satisfy_builder_cache_policy(self) -> None:
+        mutations = {
+            "job-env.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    env:\n"
+                "      uses: actions/cache@v6\n"
+                "      path: .pio/open-bike-build/downloads\n"
+                "    steps:\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+            ),
+            "disabled-cache.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - uses: actions/cache@v6\n"
+                "        if: ${{ false }}\n"
+                "        with:\n"
+                "          path: .pio/open-bike-build/downloads\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+            ),
+            "split-cache.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - uses: actions/cache@v6\n"
+                "        with:\n"
+                "          path: /tmp/unrelated\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+                "        env:\n"
+                "          path: .pio/open-bike-build/downloads\n"
+            ),
+            "block-scalar.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          echo 'uses: actions/cache@v6'\n"
+                "          echo 'path: .pio/open-bike-build/downloads'\n"
+                "          env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+            ),
+        }
+        for filename, source in mutations.items():
+            with self.subTest(filename=filename):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    (root / filename).write_text(source, encoding="utf-8")
+
+                    with self.assertRaises(AssertionError):
+                        self.assert_firmware_builders_reuse_verified_downloads(root)
 
     def test_every_firmware_builder_clears_library_overrides(self) -> None:
         self.assert_firmware_builders_clear_library_overrides()

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -103,6 +103,12 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('      - "tools/firmware_manifest.py"', general_ci)
         self.assertIn('      - "tools/tests/**"', general_ci)
 
+    def test_promotion_contract_requires_the_aggregate_gate(self) -> None:
+        agent_instructions = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertIn("Merge only after **CI Gate**", agent_instructions)
+        self.assertNotIn("Merge only after **Map Backend**", agent_instructions)
+
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
         for workflow in (
             "ci.yml",

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -119,6 +119,28 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("python3-cryptography", host_job)
         self.assertIn("python3 -m unittest discover -s tools/tests", host_job)
 
+    def test_every_setup_python_firmware_builder_clears_library_overrides(
+        self,
+    ) -> None:
+        for workflow in (
+            "ci.yml",
+            "firmware-diagnostics.yml",
+            "firmware-release.yml",
+            "speaker-firmware.yml",
+        ):
+            with self.subTest(workflow=workflow):
+                commands = re.findall(
+                    r"^\s+run: (.+build_firmware\.py.+)$",
+                    workflow_source(workflow),
+                    re.MULTILINE,
+                )
+                self.assertTrue(commands)
+                for command in commands:
+                    self.assertIn(
+                        "env -u LD_LIBRARY_PATH python tools/build_firmware.py",
+                        command,
+                    )
+
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
         for workflow in (
             "ci.yml",

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -22,6 +22,15 @@ DIAGNOSTIC_FIRMWARE_TARGETS = {
     "WAVESHARE_AMOLED_206_POWER_METRICS",
     "WAVESHARE_AMOLED_206_LIGHT_SLEEP",
 }
+SHARED_CONTRACT_PATHS = {
+    "docs/app-store-privacy-disclosures.md",
+    "docs/device-ownership-test-vectors.json",
+    "docs/firmware-battery-life-hardware-validation.md",
+    "docs/firmware-map-memory-diagnostics.md",
+    "docs/firmware-map-render-scheduler.md",
+    "docs/firmware-map-rendering-psram.md",
+    "docs/releases/watchos-workout-companion.md",
+}
 
 
 def workflow_source(filename: str) -> str:
@@ -50,6 +59,49 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("  push:\n    branches:\n      - main\n", general_ci)
         self.assertIn("  pull_request:\n", general_ci)
         self.assertIn("  cancel-in-progress: true\n", general_ci)
+
+    def test_concurrency_separates_events_and_manual_scopes(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        self.assertIn("github.event_name", general_ci)
+        self.assertIn("inputs.scope || 'auto'", general_ci)
+
+    def test_partial_manual_runs_do_not_publish_the_protected_gate(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        self.assertIn("Manual CI Gate", general_ci)
+        self.assertIn("refs/heads/deploy/map-platform-production", general_ci)
+        self.assertIn("Validate the protected partial gate scope", general_ci)
+        self.assertIn("':(exclude)map-platform/deploy/compose.yaml'", general_ci)
+
+    def test_release_tags_use_one_gated_validation_orchestrator(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        diagnostic_ci = workflow_source("firmware-diagnostics.yml")
+        release = workflow_source("firmware-release.yml")
+
+        self.assertIn("  workflow_call:\n", general_ci)
+        self.assertIn("github.ref_type == 'tag'", general_ci)
+        self.assertNotIn('      - "v*"', general_ci)
+        self.assertIn("  workflow_call:\n", diagnostic_ci)
+        self.assertNotIn('      - "v*"', diagnostic_ci)
+        self.assertIn('      - "v*"', release)
+        self.assertIn("uses: ./.github/workflows/ci.yml", release)
+        self.assertIn(
+            "uses: ./.github/workflows/firmware-diagnostics.yml", release
+        )
+        self.assertIn("      - build\n      - diagnostics\n      - validate\n", release)
+        self.assertIn("  attestations: read\n", release)
+        self.assertIn("  packages: read\n", release)
+
+    def test_main_push_filter_includes_shared_contract_inputs(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        for path in SHARED_CONTRACT_PATHS:
+            with self.subTest(path=path):
+                self.assertIn(f'      - "{path}"', general_ci)
+        self.assertIn('      - "test-fixtures/fmb/**"', general_ci)
+        self.assertIn('      - "tools/firmware_manifest.py"', general_ci)
+        self.assertIn('      - "tools/tests/**"', general_ci)
 
     def test_every_firmware_builder_reuses_verified_downloads(self) -> None:
         for workflow in (

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -38,6 +38,9 @@ JOB_KEY_PATTERN = re.compile(
     r"(?P<plain>[A-Za-z_][A-Za-z0-9_-]*)):"
     r"\s*(?:&[A-Za-z_][A-Za-z0-9_-]*\s*)?(?:#.*)?"
 )
+CLEAN_BUILDER_PATTERN = re.compile(
+    r"(?:run:\s*)?env -u LD_LIBRARY_PATH python tools/build_firmware\.py\s+.+"
+)
 
 
 def workflow_source(filename: str) -> str:
@@ -169,6 +172,14 @@ def firmware_builder_jobs(source: str) -> tuple[tuple[str, str], ...]:
     )
 
 
+def firmware_builder_steps(job_block: str) -> tuple[str, ...]:
+    return tuple(
+        step
+        for step in sequence_mapping_blocks(job_block, "steps", indent=4)
+        if firmware_builder_lines(step)
+    )
+
+
 def matrix_targets(source: str) -> set[str]:
     return set(
         re.findall(r"^\s+- (WAVESHARE_AMOLED_[A-Z0-9_]+)$", source, re.MULTILINE)
@@ -182,16 +193,38 @@ class WorkflowPolicyTests(unittest.TestCase):
         builder_count = 0
         violations = []
         for workflow, source in workflow_sources(root):
-            for job, block in firmware_builder_jobs(source):
-                for command in firmware_builder_lines(block):
-                    builder_count += 1
-                    if (
-                        "env -u LD_LIBRARY_PATH python tools/build_firmware.py"
-                        not in command
-                    ):
+            jobs = firmware_builder_jobs(source)
+            all_commands = firmware_builder_lines(source)
+            job_commands = tuple(
+                command
+                for _, block in jobs
+                for command in firmware_builder_lines(block)
+            )
+            builder_count += len(all_commands)
+            if sorted(all_commands) != sorted(job_commands):
+                violations.append(
+                    f"{workflow}: builder command exists outside a recognized job"
+                )
+            for job, block in jobs:
+                steps = firmware_builder_steps(block)
+                block_commands = firmware_builder_lines(block)
+                step_commands = tuple(
+                    command for step in steps for command in firmware_builder_lines(step)
+                )
+                if sorted(block_commands) != sorted(step_commands):
+                    violations.append(
+                        f"{workflow}:{job}: builder command exists outside a run step"
+                    )
+                for step in steps:
+                    if re.search(r"(?m)^if:", step):
                         violations.append(
-                            f"{workflow}:{job}: unsafe builder command: {command}"
+                            f"{workflow}:{job}: builder step is conditional"
                         )
+                    for command in firmware_builder_lines(step):
+                        if not CLEAN_BUILDER_PATTERN.fullmatch(command):
+                            violations.append(
+                                f"{workflow}:{job}: unsafe builder command: {command}"
+                            )
         self.assertGreater(builder_count, 0)
         self.assertEqual((), tuple(violations))
 
@@ -207,9 +240,23 @@ class WorkflowPolicyTests(unittest.TestCase):
         violations = []
         for workflow, job, block in builder_jobs:
             steps = sequence_mapping_blocks(block, "steps", indent=4)
-            if not any(is_verified_download_cache_step(step) for step in steps):
+            cache_indices = tuple(
+                index
+                for index, step in enumerate(steps)
+                if is_verified_download_cache_step(step)
+            )
+            builder_indices = tuple(
+                index
+                for index, step in enumerate(steps)
+                if firmware_builder_lines(step)
+            )
+            if not builder_indices or not all(
+                any(cache_index < builder_index for cache_index in cache_indices)
+                for builder_index in builder_indices
+            ):
                 violations.append(
-                    f"{workflow}:{job}: missing active verified-download cache"
+                    f"{workflow}:{job}: missing active verified-download cache "
+                    "before builder step"
                 )
         self.assertEqual((), tuple(violations))
 
@@ -453,6 +500,15 @@ class WorkflowPolicyTests(unittest.TestCase):
                 "          echo 'path: .pio/open-bike-build/downloads'\n"
                 "          env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
             ),
+            "late-cache.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+                "      - uses: actions/cache@v6\n"
+                "        with:\n"
+                "          path: .pio/open-bike-build/downloads\n"
+            ),
         }
         for filename, source in mutations.items():
             with self.subTest(filename=filename):
@@ -462,6 +518,55 @@ class WorkflowPolicyTests(unittest.TestCase):
 
                     with self.assertRaises(AssertionError):
                         self.assert_firmware_builders_reuse_verified_downloads(root)
+
+    def test_builder_policy_requires_an_active_exact_run_command(self) -> None:
+        mutations = {
+            "job-env.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    env:\n"
+                "      NOTE: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+                "    steps:\n"
+                "      - uses: actions/cache@v6\n"
+                "        with:\n"
+                "          path: .pio/open-bike-build/downloads\n"
+            ),
+            "echo.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - run: echo env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+            ),
+            "disabled.yml": (
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - run: env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n"
+                "        if: ${{ false }}\n"
+            ),
+        }
+        for filename, source in mutations.items():
+            with self.subTest(filename=filename):
+                with tempfile.TemporaryDirectory() as temporary_directory:
+                    root = Path(temporary_directory)
+                    (root / filename).write_text(source, encoding="utf-8")
+
+                    with self.assertRaises(AssertionError):
+                        self.assert_firmware_builders_clear_library_overrides(root)
+
+    def test_block_scalar_builder_is_bound_to_its_run_step(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            (root / "builder.yml").write_text(
+                "jobs:\n"
+                "  builder:\n"
+                "    steps:\n"
+                "      - run: |\n"
+                "          env -u LD_LIBRARY_PATH python tools/build_firmware.py TEST\n",
+                encoding="utf-8",
+            )
+
+            self.assert_firmware_builders_clear_library_overrides(root)
 
     def test_every_firmware_builder_clears_library_overrides(self) -> None:
         self.assert_firmware_builders_clear_library_overrides()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,16 +209,12 @@ jobs:
         working-directory: esp32
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
-        with:
-          python-version: "3.12"
       - name: Install host crypto dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libmbedtls-dev
-          python -m pip install --upgrade cryptography
+          sudo apt-get install -y libmbedtls-dev python3-cryptography
       - name: Firmware manifest tests
-        run: python -m unittest discover -s tools/tests
+        run: python3 -m unittest discover -s tools/tests
         working-directory: ${{ github.workspace }}
       - name: GUI layout host tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,13 @@
 name: CI
 
 on:
+  workflow_call:
+    inputs:
+      scope:
+        description: CI component to run
+        required: false
+        default: all
+        type: string
   push:
     branches:
       - main
@@ -13,9 +20,19 @@ on:
       - ".github/workflows/map-platform-ci.yml"
       - ".github/workflows/map-platform-image.yml"
       - ".github/workflows/speaker-firmware.yml"
+      - "docs/app-store-privacy-disclosures.md"
+      - "docs/device-ownership-test-vectors.json"
+      - "docs/firmware-battery-life-hardware-validation.md"
+      - "docs/firmware-map-memory-diagnostics.md"
+      - "docs/firmware-map-render-scheduler.md"
+      - "docs/firmware-map-rendering-psram.md"
+      - "docs/releases/watchos-workout-companion.md"
       - "esp32/**"
       - "ios-app/**"
       - "map-platform/**"
+      - "test-fixtures/fmb/**"
+      - "tools/firmware_manifest.py"
+      - "tools/tests/**"
       - "tools/OSM_Extract/**"
   pull_request:
   workflow_dispatch:
@@ -35,7 +52,9 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: >-
+    ${{ github.workflow }}-${{ github.event_name }}-${{
+    github.event.pull_request.number || github.ref }}-${{ inputs.scope || 'auto' }}
   cancel-in-progress: true
 
 jobs:
@@ -53,11 +72,29 @@ jobs:
           fetch-depth: 0
       - name: Test CI component routing
         run: python3 -m unittest discover -s .github/scripts/tests
+      - name: Validate the protected partial gate scope
+        if: >-
+          github.event_name == 'workflow_dispatch' && inputs.scope == 'map' &&
+          github.ref == 'refs/heads/deploy/map-platform-production'
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          default_ref="origin/${DEFAULT_BRANCH}"
+          if ! git diff --quiet "$default_ref...$GITHUB_SHA" -- \
+            . ':(exclude)map-platform/deploy/compose.yaml'; then
+            echo "::error::Protected map-only CI contains changes outside the production lock"
+            exit 1
+          fi
+          if git diff --quiet "$default_ref...$GITHUB_SHA" -- \
+            map-platform/deploy/compose.yaml; then
+            echo "::error::Protected map-only CI does not change the production lock"
+            exit 1
+          fi
       - id: components
         name: Select changed components
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
-          CI_SCOPE: ${{ inputs.scope || 'auto' }}
+          CI_SCOPE: ${{ github.ref_type == 'tag' && 'all' || inputs.scope || 'auto' }}
           EVENT_NAME: ${{ github.event_name }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: >-
@@ -172,8 +209,17 @@ jobs:
         working-directory: esp32
     steps:
       - uses: actions/checkout@v7
-      - name: Install host crypto dependency
-        run: sudo apt-get update && sudo apt-get install -y libmbedtls-dev
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Install host crypto dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libmbedtls-dev
+          python -m pip install --upgrade cryptography
+      - name: Firmware manifest tests
+        run: python -m unittest discover -s tools/tests
+        working-directory: ${{ github.workspace }}
       - name: GUI layout host tests
         run: |
           PYTHONPATH=tools python -m unittest \
@@ -543,7 +589,11 @@ jobs:
       run_osm: ${{ needs.changes.outputs.osm == 'true' }}
 
   gate:
-    name: CI Gate
+    name: >-
+      ${{ (github.event_name != 'workflow_dispatch' || inputs.scope == 'all' ||
+      (inputs.scope == 'map' && github.ref ==
+      'refs/heads/deploy/map-platform-production')) && 'CI Gate' ||
+      format('Manual CI Gate ({0})', inputs.scope) }}
     needs:
       - changes
       - esp32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,36 +2,98 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+    paths:
+      - ".dockerignore"
+      - ".github/scripts/**"
+      - ".github/workflows/ci.yml"
+      - ".github/workflows/firmware-diagnostics.yml"
+      - ".github/workflows/firmware-release.yml"
+      - ".github/workflows/map-platform-ci.yml"
+      - ".github/workflows/map-platform-image.yml"
+      - ".github/workflows/speaker-firmware.yml"
+      - "esp32/**"
+      - "ios-app/**"
+      - "map-platform/**"
+      - "tools/OSM_Extract/**"
   pull_request:
   workflow_dispatch:
+    inputs:
+      scope:
+        description: CI component to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - firmware
+          - ios
+          - map
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Select CI components
+    runs-on: ubuntu-latest
+    outputs:
+      firmware: ${{ steps.components.outputs.firmware }}
+      ios: ${{ steps.components.outputs.ios }}
+      map_backend: ${{ steps.components.outputs.map_backend }}
+      osm: ${{ steps.components.outputs.osm }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Test CI component routing
+        run: python3 -m unittest discover -s .github/scripts/tests
+      - id: components
+        name: Select changed components
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
+          CI_SCOPE: ${{ inputs.scope || 'auto' }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: >-
+          python3 .github/scripts/changed_components.py
+          --event "$EVENT_NAME"
+          --base "$BASE_SHA"
+          --head "$HEAD_SHA"
+          --scope "$CI_SCOPE"
+          >> "$GITHUB_OUTPUT"
+
   esp32:
     name: ESP32 (${{ matrix.target }})
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         target:
           - WAVESHARE_AMOLED_175
-          - WAVESHARE_AMOLED_175_MAPIO_DIAGNOSTICS
-          - WAVESHARE_AMOLED_175_POWER_METRICS
-          - WAVESHARE_AMOLED_175_LIGHT_SLEEP
           - WAVESHARE_AMOLED_175_PRODUCTION
           - WAVESHARE_AMOLED_206
-          - WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS
-          - WAVESHARE_AMOLED_206_DISPLAY_TEST
-          - WAVESHARE_AMOLED_206_POWER_METRICS
-          - WAVESHARE_AMOLED_206_LIGHT_SLEEP
           - WAVESHARE_AMOLED_206_PRODUCTION
     defaults:
       run:
         working-directory: esp32
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - name: Restore pinned PlatformIO downloads
+        uses: actions/cache@v6
+        with:
+          path: esp32/.pio/open-bike-build/downloads
+          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
@@ -39,9 +101,11 @@ jobs:
 
   ios:
     name: iOS
+    needs: changes
+    if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Test generated app build identity
         run: python3 -m unittest discover -s scripts/tests
         working-directory: ios-app
@@ -100,12 +164,14 @@ jobs:
 
   esp32-host:
     name: ESP32 Host Tests
+    needs: changes
+    if: needs.changes.outputs.firmware == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: esp32
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Install host crypto dependency
         run: sudo apt-get update && sudo apt-get install -y libmbedtls-dev
       - name: GUI layout host tests
@@ -460,3 +526,73 @@ jobs:
             -lm \
             -o /tmp/test_es8311_recovery
           /tmp/test_es8311_recovery
+
+  map-platform:
+    name: Map Platform
+    needs: changes
+    if: >-
+      needs.changes.outputs.map_backend == 'true' ||
+      needs.changes.outputs.osm == 'true'
+    permissions:
+      attestations: read
+      contents: read
+      packages: read
+    uses: ./.github/workflows/map-platform-ci.yml
+    with:
+      run_backend: ${{ needs.changes.outputs.map_backend == 'true' }}
+      run_osm: ${{ needs.changes.outputs.osm == 'true' }}
+
+  gate:
+    name: CI Gate
+    needs:
+      - changes
+      - esp32
+      - esp32-host
+      - ios
+      - map-platform
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require every selected component
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          ESP32_RESULT: ${{ needs.esp32.result }}
+          FIRMWARE_CHANGED: ${{ needs.changes.outputs.firmware }}
+          HOST_RESULT: ${{ needs.esp32-host.result }}
+          IOS_CHANGED: ${{ needs.changes.outputs.ios }}
+          IOS_RESULT: ${{ needs.ios.result }}
+          MAP_BACKEND_CHANGED: ${{ needs.changes.outputs.map_backend }}
+          MAP_RESULT: ${{ needs.map-platform.result }}
+          OSM_CHANGED: ${{ needs.changes.outputs.osm }}
+        run: |
+          require_result() {
+            label="$1"
+            actual="$2"
+            expected="$3"
+            if test "$actual" != "$expected"; then
+              echo "::error::${label} result was ${actual}; expected ${expected}"
+              exit 1
+            fi
+          }
+
+          require_result "CI component selection" "$CHANGES_RESULT" success
+
+          if test "$FIRMWARE_CHANGED" = true; then
+            require_result "ESP32 builds" "$ESP32_RESULT" success
+            require_result "ESP32 host tests" "$HOST_RESULT" success
+          else
+            require_result "ESP32 builds" "$ESP32_RESULT" skipped
+            require_result "ESP32 host tests" "$HOST_RESULT" skipped
+          fi
+
+          if test "$IOS_CHANGED" = true; then
+            require_result "iOS" "$IOS_RESULT" success
+          else
+            require_result "iOS" "$IOS_RESULT" skipped
+          fi
+
+          if test "$MAP_BACKEND_CHANGED" = true || test "$OSM_CHANGED" = true; then
+            require_result "Map Platform" "$MAP_RESULT" success
+          else
+            require_result "Map Platform" "$MAP_RESULT" skipped
+          fi

--- a/.github/workflows/firmware-diagnostics.yml
+++ b/.github/workflows/firmware-diagnostics.yml
@@ -1,0 +1,46 @@
+name: Firmware Diagnostic Builds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "17 3 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  esp32-diagnostics:
+    name: ESP32 Diagnostic (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - WAVESHARE_AMOLED_175_MAPIO_DIAGNOSTICS
+          - WAVESHARE_AMOLED_175_POWER_METRICS
+          - WAVESHARE_AMOLED_175_LIGHT_SLEEP
+          - WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS
+          - WAVESHARE_AMOLED_206_DISPLAY_TEST
+          - WAVESHARE_AMOLED_206_POWER_METRICS
+          - WAVESHARE_AMOLED_206_LIGHT_SLEEP
+    defaults:
+      run:
+        working-directory: esp32
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      - name: Restore pinned PlatformIO downloads
+        uses: actions/cache@v6
+        with:
+          path: esp32/.pio/open-bike-build/downloads
+          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
+      - name: Install PlatformIO
+        run: python -m pip install --upgrade platformio
+      - name: Build diagnostic firmware
+        run: env -u LD_LIBRARY_PATH python tools/build_firmware.py "${{ matrix.target }}"

--- a/.github/workflows/firmware-diagnostics.yml
+++ b/.github/workflows/firmware-diagnostics.yml
@@ -1,6 +1,7 @@
 name: Firmware Diagnostic Builds
 
 on:
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: "17 3 * * 1"

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -26,10 +26,15 @@ jobs:
       run:
         working-directory: esp32
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - name: Restore pinned PlatformIO downloads
+        uses: actions/cache@v6
+        with:
+          path: esp32/.pio/open-bike-build/downloads
+          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build firmware
@@ -56,8 +61,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY: ${{ secrets.FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install manifest dependencies

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -6,11 +6,23 @@ on:
       - "v*"
 
 permissions:
+  attestations: read
   contents: write
+  packages: read
   pages: write
   id-token: write
 
 jobs:
+  validate:
+    name: Validate release CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      scope: all
+
+  diagnostics:
+    name: Validate diagnostic firmware
+    uses: ./.github/workflows/firmware-diagnostics.yml
+
   build:
     name: Build ${{ matrix.target }}
     runs-on: ubuntu-latest
@@ -53,7 +65,10 @@ jobs:
   publish:
     name: Publish Firmware
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - build
+      - diagnostics
+      - validate
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/map-platform-ci.yml
+++ b/.github/workflows/map-platform-ci.yml
@@ -12,6 +12,17 @@ on:
         required: true
         type: boolean
   workflow_dispatch:
+    inputs:
+      run_backend:
+        description: Validate the backend, deployment, and production image
+        required: true
+        default: true
+        type: boolean
+      run_osm:
+        description: Validate the OSM extraction toolchain
+        required: true
+        default: true
+        type: boolean
 
 permissions:
   contents: read
@@ -19,7 +30,7 @@ permissions:
 jobs:
   osm:
     name: OSM Pipeline
-    if: github.event_name != 'workflow_call' || inputs.run_osm
+    if: inputs.run_osm
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -72,7 +83,7 @@ jobs:
 
   backend:
     name: Map Backend
-    if: github.event_name != 'workflow_call' || inputs.run_backend
+    if: inputs.run_backend
     runs-on: ubuntu-latest
     permissions:
       attestations: read

--- a/.github/workflows/map-platform-ci.yml
+++ b/.github/workflows/map-platform-ci.yml
@@ -1,20 +1,16 @@
 name: Map Platform CI
 
 on:
-  push:
-    paths:
-      - ".dockerignore"
-      - ".github/workflows/map-platform-ci.yml"
-      - ".github/workflows/map-platform-image.yml"
-      - "map-platform/backend/**"
-      - "map-platform/config/map-stream-hardware-gate.json"
-      - "map-platform/config/map-stream-rollout-approvals.json"
-      - "map-platform/config/map-stream-trust.json"
-      - "map-platform/deploy/**"
-      - "tools/OSM_Extract/**"
-  # Keep the Map Backend check present on every pull request because repository
-  # protection requires that status. Push builds remain path-filtered.
-  pull_request:
+  workflow_call:
+    inputs:
+      run_backend:
+        description: Validate the backend, deployment, and production image
+        required: true
+        type: boolean
+      run_osm:
+        description: Validate the OSM extraction toolchain
+        required: true
+        type: boolean
   workflow_dispatch:
 
 permissions:
@@ -23,13 +19,14 @@ permissions:
 jobs:
   osm:
     name: OSM Pipeline
+    if: github.event_name != 'workflow_call' || inputs.run_osm
     runs-on: ubuntu-latest
     defaults:
       run:
         working-directory: tools/OSM_Extract
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - name: Install validation dependencies
@@ -75,6 +72,7 @@ jobs:
 
   backend:
     name: Map Backend
+    if: github.event_name != 'workflow_call' || inputs.run_backend
     runs-on: ubuntu-latest
     permissions:
       attestations: read
@@ -84,8 +82,8 @@ jobs:
       run:
         working-directory: map-platform/backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
       - uses: docker/setup-buildx-action@v3

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -2,6 +2,8 @@ name: Map Platform Image
 
 on:
   push:
+    branches:
+      - main
     paths:
       - ".dockerignore"
       - ".github/workflows/map-platform-image.yml"
@@ -48,7 +50,7 @@ jobs:
     outputs:
       image_digest: ${{ steps.image.outputs.digest }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -126,7 +128,7 @@ jobs:
       packages: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -414,8 +416,9 @@ jobs:
           fi
 
           # GITHUB_TOKEN-authored pushes and pull requests do not trigger new
-          # workflow runs. Dispatch map-platform CI explicitly for the
-          # promotion commit.
-          gh workflow run map-platform-ci.yml \
+          # workflow runs. Dispatch the map-only aggregate CI gate explicitly
+          # for the promotion commit.
+          gh workflow run ci.yml \
             --repo "$GITHUB_REPOSITORY" \
-            --ref "$PROMOTION_BRANCH"
+            --ref "$PROMOTION_BRANCH" \
+            -f scope=map

--- a/.github/workflows/speaker-firmware.yml
+++ b/.github/workflows/speaker-firmware.yml
@@ -29,4 +29,4 @@ jobs:
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build speaker firmware
-        run: python tools/build_firmware.py "${{ matrix.target }}"
+        run: env -u LD_LIBRARY_PATH python tools/build_firmware.py "${{ matrix.target }}"

--- a/.github/workflows/speaker-firmware.yml
+++ b/.github/workflows/speaker-firmware.yml
@@ -17,10 +17,15 @@ jobs:
       run:
         working-directory: esp32
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.12"
+      - name: Restore pinned PlatformIO downloads
+        uses: actions/cache@v6
+        with:
+          path: esp32/.pio/open-bike-build/downloads
+          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
       - name: Install PlatformIO
         run: python -m pip install --upgrade platformio
       - name: Build speaker firmware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,7 +285,7 @@ For changes under `map-platform/backend/` or other image inputs listed in
    the generated `deploy/map-platform-production` pull request. Production is
    defined by the immutable digest pins in `map-platform/deploy/compose.yaml`.
 3. If the promotion moves the signed worker, complete the worker/hardware gates
-   in `docs/map-stream-rollout-runbook.md`. Merge only after **Map Backend** CI
+   in `docs/map-stream-rollout-runbook.md`. Merge only after **CI Gate**
    passes; the manifest merge triggers the production deployment.
 4. Verify the deployment and `/healthz`. Roll back through a pull request that
    restores the complete previous Compose lock, including both image anchors

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -136,11 +136,12 @@ transfer, RF, wake-cycle, and overnight checks remain part of the final matrix.
 ## Automatic light-sleep experiment
 
 `WAVESHARE_AMOLED_175_LIGHT_SLEEP` and
-`WAVESHARE_AMOLED_206_LIGHT_SLEEP` are dedicated, CI-built validation profiles.
-They inherit power metrics, enable FreeRTOS tickless idle, and request automatic
-light sleep while retaining the 80-240 MHz DFS range. Ordinary, metrics-only,
-and production profiles continue to compile with tickless idle off and never
-request automatic light sleep.
+`WAVESHARE_AMOLED_206_LIGHT_SLEEP` are dedicated validation profiles built by
+the weekly/manual **Firmware Diagnostic Builds** workflow. They inherit power
+metrics, enable FreeRTOS tickless idle, and request automatic light sleep while
+retaining the 80-240 MHz DFS range. Ordinary, metrics-only, and production
+profiles continue to compile with tickless idle off and never request automatic
+light sleep.
 
 The experiment creates named `ESP_PM_NO_LIGHT_SLEEP` locks for startup,
 display/rotation/QSPI, map rendering, storage/GPX access, transfer and map

--- a/docs/firmware-battery-life-hardware-validation.md
+++ b/docs/firmware-battery-life-hardware-validation.md
@@ -137,11 +137,12 @@ transfer, RF, wake-cycle, and overnight checks remain part of the final matrix.
 
 `WAVESHARE_AMOLED_175_LIGHT_SLEEP` and
 `WAVESHARE_AMOLED_206_LIGHT_SLEEP` are dedicated validation profiles built by
-the weekly/manual **Firmware Diagnostic Builds** workflow. They inherit power
-metrics, enable FreeRTOS tickless idle, and request automatic light sleep while
-retaining the 80-240 MHz DFS range. Ordinary, metrics-only, and production
-profiles continue to compile with tickless idle off and never request automatic
-light sleep.
+the weekly, release-validation, and manual **Firmware Diagnostic Builds**
+workflow.
+They inherit power metrics, enable FreeRTOS tickless idle, and request automatic
+light sleep while retaining the 80-240 MHz DFS range. Ordinary, metrics-only,
+and production profiles continue to compile with tickless idle off and never
+request automatic light sleep.
 
 The experiment creates named `ESP_PM_NO_LIGHT_SLEEP` locks for startup,
 display/rotation/QSPI, map rendering, storage/GPX access, transfer and map

--- a/docs/firmware-build-profiles.md
+++ b/docs/firmware-build-profiles.md
@@ -17,8 +17,9 @@ target:
   is only a transient hint, so the profile also uses throttled, PM-locked frame
   sampling from tickless task deadlines. On 2.06-inch hardware, GPIO interrupt
   control remains in IRAM so each low-level live interrupt can mask itself
-  until its source is released. The profile is built in CI but is never
-  selected by the release workflow.
+  until its source is released. The profile is built by the weekly/manual
+  **Firmware Diagnostic Builds** workflow but is never selected by the release
+  workflow.
 - `*_PRODUCTION` compiles with `CORE_DEBUG_LEVEL=0`, leaves `DEBUG` undefined,
   and sets `FIRMWARE_DIAGNOSTICS=0`. It does not start USB CDC at application
   boot and does not wait for a serial host. GitHub firmware releases use these

--- a/docs/firmware-build-profiles.md
+++ b/docs/firmware-build-profiles.md
@@ -17,9 +17,9 @@ target:
   is only a transient hint, so the profile also uses throttled, PM-locked frame
   sampling from tickless task deadlines. On 2.06-inch hardware, GPIO interrupt
   control remains in IRAM so each low-level live interrupt can mask itself
-  until its source is released. The profile is built by the weekly/manual
-  **Firmware Diagnostic Builds** workflow but is never selected by the release
-  workflow.
+  until its source is released. The profile is built by the weekly,
+  release-validation, and manual **Firmware Diagnostic Builds** workflow but is
+  never selected by the release workflow.
 - `*_PRODUCTION` compiles with `CORE_DEBUG_LEVEL=0`, leaves `DEBUG` undefined,
   and sets `FIRMWARE_DIAGNOSTICS=0`. It does not start USB CDC at application
   boot and does not wait for a serial host. GitHub firmware releases use these

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -25,8 +25,9 @@ responsive. Power saving is therefore layered:
 - Disconnected deep sleep is enabled according to the user's timeout setting.
 - Automatic light sleep and FreeRTOS tickless idle are **not** enabled in
   ordinary or production builds.
-- The `*_LIGHT_SLEEP` profiles are built in CI for continued validation but are
-  never selected by the firmware release workflow.
+- The `*_LIGHT_SLEEP` profiles are built by the weekly/manual **Firmware
+  Diagnostic Builds** workflow for continued validation, but are never selected
+  by the firmware release workflow.
 - The Phase 9 light-sleep interaction gate has passed on the available
   1.75-inch board. The 2.06-inch path is build-tested only.
 - No battery-life percentage or runtime improvement has been measured yet.
@@ -268,7 +269,7 @@ Each board has four profile classes:
 | --- | --- | --- | --- | --- | --- |
 | `WAVESHARE_AMOLED_175` / `206` | Yes | No | No | Low-rate developer diagnostics; USB CDC at boot | No |
 | `*_POWER_METRICS` | Yes | No | No | Structured `PWRMET` and optional timing pulse | No |
-| `*_LIGHT_SLEEP` | Yes | Yes | Yes | `PWRMET`, wake capture, and PM-lock telemetry | No; CI validation only |
+| `*_LIGHT_SLEEP` | Yes | Yes | Yes | `PWRMET`, wake capture, and PM-lock telemetry | No; scheduled/manual validation only |
 | `*_PRODUCTION` | Yes | No | No | Disabled; USB CDC not started at application boot | Yes |
 
 Production retains native USB hardware support for ROM download recovery, but

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -25,9 +25,9 @@ responsive. Power saving is therefore layered:
 - Disconnected deep sleep is enabled according to the user's timeout setting.
 - Automatic light sleep and FreeRTOS tickless idle are **not** enabled in
   ordinary or production builds.
-- The `*_LIGHT_SLEEP` profiles are built by the weekly/manual **Firmware
-  Diagnostic Builds** workflow for continued validation, but are never selected
-  by the firmware release workflow.
+- The `*_LIGHT_SLEEP` profiles are built by the weekly, release-validation, and
+  manual **Firmware Diagnostic Builds** workflow for continued validation, but
+  are never selected by the firmware release workflow.
 - The Phase 9 light-sleep interaction gate has passed on the available
   1.75-inch board. The 2.06-inch path is build-tested only.
 - No battery-life percentage or runtime improvement has been measured yet.

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -161,16 +161,28 @@ for section in config.sections():
         )
 
 ci_workflow = (repo_root / ".github/workflows/ci.yml").read_text()
+diagnostic_workflow = (
+    repo_root / ".github/workflows/firmware-diagnostics.yml"
+).read_text()
 speaker_workflow = (
     repo_root / ".github/workflows/speaker-firmware.yml"
 ).read_text()
 assert "python tools/build_firmware.py" in ci_workflow
+assert "python tools/build_firmware.py" in diagnostic_workflow
+assert "workflow_dispatch:" in diagnostic_workflow
+assert "workflow_call:" in diagnostic_workflow
+assert "schedule:" in diagnostic_workflow
+assert "pull_request:" not in diagnostic_workflow
+assert '      - "v*"' not in diagnostic_workflow
+assert "branches:" not in diagnostic_workflow
 assert "workflow_dispatch:" in speaker_workflow
 assert "push:" not in speaker_workflow
 assert "pull_request:" not in speaker_workflow
 assert "python tools/build_firmware.py" in speaker_workflow
 for environment in light_sleep_profiles:
-    assert environment.removeprefix("env:") in ci_workflow
+    profile = environment.removeprefix("env:")
+    assert profile not in ci_workflow
+    assert profile in diagnostic_workflow
 
 battery_validation = (
     repo_root / "docs/firmware-battery-life-hardware-validation.md"
@@ -183,7 +195,9 @@ display_probe_profile = "env:WAVESHARE_AMOLED_206_DISPLAY_TEST"
 assert config.get(display_probe_profile, "extends") == "env:WAVESHARE_AMOLED_206"
 display_probe_flags = config.get(display_probe_profile, "build_flags")
 assert "-DWAVESHARE_DISPLAY_PROBE=1" in display_probe_flags
-assert display_probe_profile.removeprefix("env:") in ci_workflow
+display_probe = display_probe_profile.removeprefix("env:")
+assert display_probe not in ci_workflow
+assert display_probe in diagnostic_workflow
 
 speaker_source = (project_dir / "speaker_honk_test.cpp").read_text()
 speaker_implementation = (project_dir / "lib/speaker/speaker.cpp").read_text()

--- a/map-platform/deploy/README.md
+++ b/map-platform/deploy/README.md
@@ -19,7 +19,7 @@ Protect `main` with a ruleset or classic branch protection that:
 
 - requires changes to arrive through a pull request (zero required approvals is
   acceptable for a solo-maintainer repository),
-- requires the `Map Backend` status check before merge, and
+- requires the `CI Gate` status check before merge, and
 - requires branches to be up to date before merging, and
 - blocks force pushes and branch deletion.
 
@@ -27,9 +27,11 @@ This is the repository-side deployment admission control: without it, a direct
 push could change the watched production Compose without passing pull-request
 CI.
 
-`Map Platform CI` owns the `Map Backend` and `OSM Pipeline` checks. It runs on
-every pull request so the required `Map Backend` status is always reported;
-push runs are limited to map-platform paths.
+The top-level `CI` workflow reports the stable `CI Gate` check on every pull
+request. It selects changed components and calls `Map Platform CI` only when
+backend, deployment, image, or OSM inputs changed. Backend image validation also
+runs for OSM changes because the production image copies the extractor. A
+manual `Map Platform CI` dispatch still runs both map jobs for targeted use.
 
 ## One-time Coolify configuration
 
@@ -114,11 +116,11 @@ the exact pinned image. A promotion-only merge does not start another image
 build, so the workflow cannot loop.
 
 GitHub suppresses workflow events caused by `GITHUB_TOKEN`, so the promotion
-job explicitly dispatches `map-platform-ci.yml` for the promotion commit after
-opening or refreshing the pull request. The dedicated workflow runs only the
-map backend and OSM checks, keeping unrelated firmware and iOS CI changes out
-of the image-promotion path while retaining the least-privileged repository
-token.
+job explicitly dispatches `ci.yml` with `scope=map` for the promotion commit
+after opening or refreshing the pull request. That produces the required
+aggregate gate while running only the map backend and OSM checks, keeping
+unrelated firmware and iOS CI changes out of the image-promotion path while
+retaining the least-privileged repository token.
 
 Validate the lock locally with:
 

--- a/map-platform/deploy/tests/test_ci_workflow_split.py
+++ b/map-platform/deploy/tests/test_ci_workflow_split.py
@@ -29,11 +29,20 @@ class CIWorkflowSplitTests(unittest.TestCase):
         map_ci = workflow_source("map-platform-ci.yml")
 
         self.assertIn("  pull_request:\n", general_ci)
-        self.assertIn("    name: CI Gate\n", general_ci)
+        self.assertIn("  gate:\n", general_ci)
+        self.assertIn("&& 'CI Gate' ||", general_ci)
         self.assertIn("uses: ./.github/workflows/map-platform-ci.yml", general_ci)
         self.assertIn("  workflow_call:\n", map_ci)
         self.assertNotIn("  pull_request:\n", map_ci)
         self.assertNotIn("  push:\n", map_ci)
+
+    def test_reusable_map_jobs_follow_inputs_and_manual_defaults_run_both(self) -> None:
+        map_ci = workflow_source("map-platform-ci.yml")
+
+        self.assertIn("    if: inputs.run_backend\n", map_ci)
+        self.assertIn("    if: inputs.run_osm\n", map_ci)
+        self.assertNotIn("github.event_name != 'workflow_call'", map_ci)
+        self.assertEqual(map_ci.count("        default: true\n"), 2)
 
     def test_image_promotion_watches_and_dispatches_dedicated_ci(self) -> None:
         image_workflow = workflow_source("map-platform-image.yml")

--- a/map-platform/deploy/tests/test_ci_workflow_split.py
+++ b/map-platform/deploy/tests/test_ci_workflow_split.py
@@ -24,14 +24,16 @@ class CIWorkflowSplitTests(unittest.TestCase):
         self.assertIn("    name: Map Backend\n", map_ci)
         self.assertIn("    name: OSM Pipeline\n", map_ci)
 
-    def test_required_map_backend_check_runs_on_every_pull_request(self) -> None:
+    def test_pull_requests_route_map_jobs_through_the_aggregate_gate(self) -> None:
+        general_ci = workflow_source("ci.yml")
         map_ci = workflow_source("map-platform-ci.yml")
-        pull_request_config = map_ci.split("  pull_request:\n", 1)[1].split(
-            "  workflow_dispatch:\n", 1
-        )[0]
 
-        self.assertEqual("", pull_request_config)
-        self.assertIn("  push:\n    paths:\n", map_ci)
+        self.assertIn("  pull_request:\n", general_ci)
+        self.assertIn("    name: CI Gate\n", general_ci)
+        self.assertIn("uses: ./.github/workflows/map-platform-ci.yml", general_ci)
+        self.assertIn("  workflow_call:\n", map_ci)
+        self.assertNotIn("  pull_request:\n", map_ci)
+        self.assertNotIn("  push:\n", map_ci)
 
     def test_image_promotion_watches_and_dispatches_dedicated_ci(self) -> None:
         image_workflow = workflow_source("map-platform-image.yml")
@@ -42,8 +44,14 @@ class CIWorkflowSplitTests(unittest.TestCase):
             "python3 map-platform/deploy/export_pending_compose.py",
             image_workflow,
         )
-        self.assertIn("gh workflow run map-platform-ci.yml", image_workflow)
-        self.assertNotIn("gh workflow run ci.yml", image_workflow)
+        self.assertIn("gh workflow run ci.yml", image_workflow)
+        self.assertIn("-f scope=map", image_workflow)
+        self.assertNotIn("gh workflow run map-platform-ci.yml", image_workflow)
+
+    def test_image_publishing_is_automatic_only_on_main(self) -> None:
+        image_workflow = workflow_source("map-platform-image.yml")
+
+        self.assertIn("  push:\n    branches:\n      - main\n", image_workflow)
 
 
 if __name__ == "__main__":

--- a/tools/tests/test_firmware_manifest.py
+++ b/tools/tests/test_firmware_manifest.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import argparse
+import base64
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "firmware_manifest.py"
+SPEC = importlib.util.spec_from_file_location("firmware_manifest", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+firmware_manifest = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = firmware_manifest
+SPEC.loader.exec_module(firmware_manifest)
+
+
+class FirmwareManifestTests(unittest.TestCase):
+    def test_canonical_payload_requires_and_orders_signed_fields(self) -> None:
+        manifest = {
+            field: index
+            for index, field in enumerate(reversed(firmware_manifest.SIGNATURE_FIELDS))
+        }
+
+        payload = firmware_manifest.canonical_payload(manifest).decode("utf-8")
+
+        self.assertEqual(
+            "".join(
+                f"{field}={manifest[field]}\n"
+                for field in firmware_manifest.SIGNATURE_FIELDS
+            ),
+            payload,
+        )
+        del manifest["sha256"]
+        with self.assertRaisesRegex(ValueError, "manifest is missing sha256"):
+            firmware_manifest.canonical_payload(manifest)
+
+    def test_write_manifest_hashes_and_signs_release_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            firmware = root / "firmware.bin"
+            firmware.write_bytes(b"open-bike-firmware")
+            platformio_ini = root / "platformio.ini"
+            platformio_ini.write_text(
+                "[common]\nversion = 2.3.4\nrevision = 57\n",
+                encoding="utf-8",
+            )
+            output = root / "public" / "manifest.json"
+            private_scalar = (1).to_bytes(32, byteorder="big")
+            private_key_base64 = base64.b64encode(private_scalar).decode("ascii")
+            args = argparse.Namespace(
+                firmware=firmware,
+                target="WAVESHARE_AMOLED_175",
+                repository="owner/repository",
+                git_sha="0123456789ab",
+                private_key_base64=private_key_base64,
+                output=output,
+                platformio_ini=platformio_ini,
+                version=None,
+                build=None,
+                tag="v2.3.4",
+                asset_name=None,
+                min_updater_protocol=2,
+            )
+
+            firmware_manifest.write_manifest(args)
+
+            manifest = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual("2.3.4", manifest["version"])
+            self.assertEqual(57, manifest["build"])
+            self.assertEqual(len(b"open-bike-firmware"), manifest["size"])
+            self.assertEqual(
+                "https://github.com/owner/repository/releases/download/"
+                "v2.3.4/WAVESHARE_AMOLED_175.bin",
+                manifest["url"],
+            )
+            public_key = ec.derive_private_key(1, ec.SECP256R1()).public_key()
+            public_key.verify(
+                base64.b64decode(manifest["signature"], validate=True),
+                firmware_manifest.canonical_payload(manifest),
+                ec.ECDSA(hashes.SHA256()),
+            )
+
+    def test_signing_rejects_a_zero_private_scalar(self) -> None:
+        manifest = {
+            field: index
+            for index, field in enumerate(firmware_manifest.SIGNATURE_FIELDS)
+        }
+        zero_scalar = base64.b64encode(bytes(32)).decode("ascii")
+
+        with self.assertRaisesRegex(ValueError, "greater than zero"):
+            firmware_manifest.sign_manifest(manifest, zero_scalar)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/tests/test_firmware_manifest.py
+++ b/tools/tests/test_firmware_manifest.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-import argparse
 import base64
+import hashlib
 import importlib.util
 import json
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -24,28 +25,41 @@ SPEC.loader.exec_module(firmware_manifest)
 class FirmwareManifestTests(unittest.TestCase):
     def test_canonical_payload_requires_and_orders_signed_fields(self) -> None:
         manifest = {
-            field: index
-            for index, field in enumerate(reversed(firmware_manifest.SIGNATURE_FIELDS))
+            "schemaVersion": 1,
+            "target": "WAVESHARE_AMOLED_175",
+            "version": "2.3.4",
+            "build": 57,
+            "gitSha": "0123456789ab",
+            "size": 18,
+            "sha256": "abc123",
+            "url": "https://example.invalid/firmware.bin",
+            "minUpdaterProtocol": 1,
         }
 
         payload = firmware_manifest.canonical_payload(manifest).decode("utf-8")
 
         self.assertEqual(
-            "".join(
-                f"{field}={manifest[field]}\n"
-                for field in firmware_manifest.SIGNATURE_FIELDS
-            ),
+            "schemaVersion=1\n"
+            "target=WAVESHARE_AMOLED_175\n"
+            "version=2.3.4\n"
+            "build=57\n"
+            "gitSha=0123456789ab\n"
+            "size=18\n"
+            "sha256=abc123\n"
+            "url=https://example.invalid/firmware.bin\n"
+            "minUpdaterProtocol=1\n",
             payload,
         )
         del manifest["sha256"]
         with self.assertRaisesRegex(ValueError, "manifest is missing sha256"):
             firmware_manifest.canonical_payload(manifest)
 
-    def test_write_manifest_hashes_and_signs_release_metadata(self) -> None:
+    def test_release_cli_emits_complete_hash_and_signature_contract(self) -> None:
         with tempfile.TemporaryDirectory() as temporary_directory:
             root = Path(temporary_directory)
             firmware = root / "firmware.bin"
-            firmware.write_bytes(b"open-bike-firmware")
+            firmware_bytes = b"open-bike-firmware"
+            firmware.write_bytes(firmware_bytes)
             platformio_ini = root / "platformio.ini"
             platformio_ini.write_text(
                 "[common]\nversion = 2.3.4\nrevision = 57\n",
@@ -54,48 +68,72 @@ class FirmwareManifestTests(unittest.TestCase):
             output = root / "public" / "manifest.json"
             private_scalar = (1).to_bytes(32, byteorder="big")
             private_key_base64 = base64.b64encode(private_scalar).decode("ascii")
-            args = argparse.Namespace(
-                firmware=firmware,
-                target="WAVESHARE_AMOLED_175",
-                repository="owner/repository",
-                git_sha="0123456789ab",
-                private_key_base64=private_key_base64,
-                output=output,
-                platformio_ini=platformio_ini,
-                version=None,
-                build=None,
-                tag="v2.3.4",
-                asset_name=None,
-                min_updater_protocol=2,
+            subprocess.run(
+                (
+                    sys.executable,
+                    str(SCRIPT),
+                    "--firmware",
+                    str(firmware),
+                    "--target",
+                    "WAVESHARE_AMOLED_175",
+                    "--repository",
+                    "owner/repository",
+                    "--tag",
+                    "v2.3.4",
+                    "--git-sha",
+                    "0123456789ab",
+                    "--private-key-base64",
+                    private_key_base64,
+                    "--output",
+                    str(output),
+                    "--platformio-ini",
+                    str(platformio_ini),
+                ),
+                check=True,
             )
-
-            firmware_manifest.write_manifest(args)
 
             manifest = json.loads(output.read_text(encoding="utf-8"))
-            self.assertEqual("2.3.4", manifest["version"])
-            self.assertEqual(57, manifest["build"])
-            self.assertEqual(len(b"open-bike-firmware"), manifest["size"])
             self.assertEqual(
-                "https://github.com/owner/repository/releases/download/"
-                "v2.3.4/WAVESHARE_AMOLED_175.bin",
-                manifest["url"],
+                {
+                    "schemaVersion": 1,
+                    "target": "WAVESHARE_AMOLED_175",
+                    "version": "2.3.4",
+                    "build": 57,
+                    "gitSha": "0123456789ab",
+                    "size": len(firmware_bytes),
+                    "sha256": hashlib.sha256(firmware_bytes).hexdigest(),
+                    "url": (
+                        "https://github.com/owner/repository/releases/download/"
+                        "v2.3.4/WAVESHARE_AMOLED_175.bin"
+                    ),
+                    "minUpdaterProtocol": 1,
+                },
+                {key: value for key, value in manifest.items() if key != "signature"},
             )
+            expected_payload = (
+                "schemaVersion=1\n"
+                "target=WAVESHARE_AMOLED_175\n"
+                "version=2.3.4\n"
+                "build=57\n"
+                "gitSha=0123456789ab\n"
+                f"size={len(firmware_bytes)}\n"
+                f"sha256={hashlib.sha256(firmware_bytes).hexdigest()}\n"
+                "url=https://github.com/owner/repository/releases/download/"
+                "v2.3.4/WAVESHARE_AMOLED_175.bin\n"
+                "minUpdaterProtocol=1\n"
+            ).encode("utf-8")
             public_key = ec.derive_private_key(1, ec.SECP256R1()).public_key()
             public_key.verify(
                 base64.b64decode(manifest["signature"], validate=True),
-                firmware_manifest.canonical_payload(manifest),
+                expected_payload,
                 ec.ECDSA(hashes.SHA256()),
             )
 
     def test_signing_rejects_a_zero_private_scalar(self) -> None:
-        manifest = {
-            field: index
-            for index, field in enumerate(firmware_manifest.SIGNATURE_FIELDS)
-        }
         zero_scalar = base64.b64encode(bytes(32)).decode("ascii")
 
         with self.assertRaisesRegex(ValueError, "greater than zero"):
-            firmware_manifest.sign_manifest(manifest, zero_scalar)
+            firmware_manifest.sign_manifest({}, zero_scalar)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Route pull request CI by changed component and expose one stable `CI Gate` check.
- Keep the four core firmware profiles on pull requests; move seven diagnostic profiles to weekly/manual runs while preserving them as required release validation.
- Avoid duplicate feature-branch push runs, cancel superseded runs, and cache verified PlatformIO archives.
- Run map validation through the aggregate workflow, restrict automatic map images to `main`, and preserve automated promotion PR validation with a guarded map-only dispatch.
- Make the firmware release workflow wait for full CI and diagnostic firmware validation before publishing assets or Pages manifests.
- Add policy, classifier, release-path, and manifest-signing tests so the workflow split cannot silently regress.

## Why

The previous setup ran the full firmware matrix for every pull request and also ran overlapping workflows on both feature-branch pushes and pull request events. That consumed substantially more Actions time than the change required while still leaving branch protection without a stable aggregate check.

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- `python3 -m unittest discover -s .github/scripts/tests` (41 tests)
- `python3 -m unittest discover -s map-platform/deploy/tests` (39 tests)
- Ubuntu 24.04: `python3 -m unittest discover -s tools/tests` (3 manifest tests)
- `PYTHONPATH=tools python -m unittest discover -s tools/tests` from `esp32/` (202 tests)
- `git diff --check`

## Follow-up after merge

Configure the `main` ruleset to require `CI Gate`. The repository currently has no branch protection or rulesets; this should be done after merge so GitHub has first observed the new check on `main`.
