### PR TITLE
Add explicit local firmware device nicknames

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -238,6 +238,7 @@ jobs:
             tools.tests.test_refresh_firmware_runtime \
             tools.tests.test_capture_boot \
             tools.tests.test_resolve_upload_port \
+            tools.tests.test_device_registry \
             tools.tests.test_map_guidance_integration \
             tools.tests.test_map_memory_diagnostics
           g++ -std=c++17 \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,12 @@ state, artifacts, and flash plan. Dirty builds may consume an entry but never
 publish or upload. Cross-worktree core sharing is disabled until artifacts pass
 the documented relocatability gate.
 
+Optional device nicknames are stored outside Git with
+`tools/device_registry.py`. `--device-name NAME` must resolve to one enrolled
+board family and stable serial, and the environment must match that family.
+This shorthand never guesses a board or replaces the required connected-model
+confirmation immediately before flashing.
+
 After the locked runtime handoff, a clean pioarduino installation first
 converts content-pinned tool wrappers into the
 host compiler/runtime packages, then compiles a custom core against a generated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,19 @@ before reporting a physical installation as complete. Pass the same stable
 hardware identity to `tools/capture_boot.py --device-serial ...`; this prevents
 boot verification from following a different board after USB re-enumeration.
 
+Optional local nicknames map only to an explicitly enrolled board family and
+stable USB serial. Real serials live outside Git:
+
+```sh
+python3 tools/device_registry.py add desk-175 WAVESHARE_AMOLED_175 SERIAL
+python3 tools/device_registry.py list
+python3 tools/build_firmware.py WAVESHARE_AMOLED_175 --device-name desk-175
+```
+
+A nickname does not select the only attached board, infer a model, or grant
+flash approval. Confirm the connected physical model immediately before any
+flash as usual.
+
 Ordinary contributors consume accepted runtime locks only. Maintainers use the
 manual **Firmware runtime refresh candidate** workflow as the first bootstrap
 check, then must produce and review both-host offline replay, dependency graphs,

--- a/esp32/README.md
+++ b/esp32/README.md
@@ -75,6 +75,18 @@ are attached. The helper resolves that serial immediately before flashing and
 waits up to 60 seconds for it to appear; use `--device-timeout` to change the
 wait. `--upload-port` remains available when stable serial metadata is not.
 
+You may explicitly enroll a nickname without committing a serial:
+
+```sh
+python3 tools/device_registry.py add desk-206 WAVESHARE_AMOLED_206 SERIAL
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206 --device-name desk-206
+```
+
+The registry uses the macOS user Application Support directory or Linux XDG
+config directory, requires private non-symlink storage, and rejects nickname,
+serial, or board-family ambiguity before building. It does not replace the
+required physical model confirmation immediately before flashing.
+
 If the verified build succeeded but the upload failed because the selected
 device disappeared, entered the wrong USB mode, or needed a cable reconnect,
 retry the same attested build without compiling again:

--- a/esp32/tools/build_firmware.py
+++ b/esp32/tools/build_firmware.py
@@ -45,6 +45,12 @@ from firmware_build_identity import (
     git_commit_source_date_epoch,
     git_head_identity,
 )
+from device_registry import (
+    DeviceEntry,
+    DeviceRegistryError,
+    environment_matches_family,
+    resolve_device_name,
+)
 from firmware_runtime import (
     FirmwareRuntimeError,
     PROVENANCE_ENV,
@@ -210,6 +216,7 @@ def _resolved_device_port(
     device_serial: str,
     timeout_seconds: float,
     *,
+    device_entry: DeviceEntry | None = None,
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
 ) -> str:
     """Resolve a stable USB hardware serial using the attested private Python."""
@@ -294,8 +301,14 @@ def _resolved_device_port(
     pid = resolved.get("pid")
     description = resolved.get("description")
     usb_identity = f" vid={vid!s} pid={pid!s} description={description!r}"
+    details = ""
+    if device_entry is not None:
+        details = (
+            f" nickname={device_entry.nickname}"
+            f" boardFamily={device_entry.board_family}"
+        )
     print(
-        f"FIRMWARE_UPLOAD_DEVICE serial={actual_serial}"
+        f"FIRMWARE_UPLOAD_DEVICE{details} serial={actual_serial}"
         f" port={port}{usb_identity}",
         flush=True,
     )
@@ -1826,6 +1839,7 @@ def upload_firmware(
     upload_port: str | None = None,
     *,
     device_serial: str | None = None,
+    device_entry: DeviceEntry | None = None,
     device_timeout: float = 60.0,
     runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
     resolver_runner: Callable[..., subprocess.CompletedProcess] = subprocess.run,
@@ -1891,6 +1905,7 @@ def upload_firmware(
                     manifest,
                     device_serial,
                     device_timeout,
+                    device_entry=device_entry,
                     runner=resolver_runner,
                 )
             if resolved_port is None:
@@ -1947,6 +1962,18 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
             "USB hardware serial"
         ),
     )
+    upload_selector.add_argument(
+        "--device-name",
+        help=(
+            "resolve an explicitly enrolled nickname to its board family and "
+            "stable USB serial"
+        ),
+    )
+    parser.add_argument(
+        "--device-registry",
+        type=Path,
+        help="override the platform user-config registry path (primarily for tests)",
+    )
     parser.add_argument(
         "--device-timeout",
         type=float,
@@ -1971,7 +1998,6 @@ def main(
     raw_arguments = tuple(sys.argv[1:] if argv is None else argv)
     args = _parse_args(raw_arguments)
     try:
-        device_serial = args.device_serial
         try:
             runtime = runtime_handoff(raw_arguments, args.project_dir.resolve())
             pio_command = (
@@ -1981,12 +2007,25 @@ def main(
             )
         except FirmwareRuntimeError as error:
             raise BuildError(str(error)) from error
+        device_entry = None
+        device_serial = args.device_serial
+        if args.device_name is not None:
+            try:
+                device_entry = resolve_device_name(args.device_name, args.device_registry)
+            except DeviceRegistryError as error:
+                raise BuildError(str(error)) from error
+            if not environment_matches_family(args.environment, device_entry.board_family):
+                raise BuildError(
+                    f"device {device_entry.nickname!r} is enrolled as "
+                    f"{device_entry.board_family}, not {args.environment}"
+                )
+            device_serial = device_entry.serial
         if args.upload_only and args.upload_port is None and device_serial is None:
             raise BuildError(
-                "--upload-only requires --upload-port or --device-serial"
+                "--upload-only requires --upload-port or --device-serial/--device-name"
             )
         if device_serial is None and args.device_timeout != 60.0:
-            raise BuildError("--device-timeout requires --device-serial")
+            raise BuildError("--device-timeout requires --device-serial or --device-name")
         if not math.isfinite(args.device_timeout) or args.device_timeout < 0:
             raise BuildError("device timeout must be a finite nonnegative value")
         if not args.upload_only:
@@ -1996,6 +2035,8 @@ def main(
                 "device_serial": device_serial,
                 "device_timeout": args.device_timeout,
             }
+            if device_entry is not None:
+                upload_options["device_entry"] = device_entry
             upload_firmware(
                 args.project_dir,
                 args.environment,

--- a/esp32/tools/device-registry.example.json
+++ b/esp32/tools/device-registry.example.json
@@ -1,0 +1,12 @@
+{
+  "devices": [
+    {
+      "boardFamily": "WAVESHARE_AMOLED_175",
+      "nickname": "desk-175",
+      "note": "Example only; never commit a real serial",
+      "serialNumber": "EXAMPLE-SERIAL",
+      "updatedAt": "2026-08-10T00:00:00Z"
+    }
+  ],
+  "schema": 1
+}

--- a/esp32/tools/device-registry.schema.json
+++ b/esp32/tools/device-registry.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/seichris/open-bike-computer/esp32/tools/device-registry.schema.json",
+  "additionalProperties": false,
+  "properties": {
+    "devices": {
+      "items": {
+        "additionalProperties": false,
+        "properties": {
+          "boardFamily": {
+            "enum": ["WAVESHARE_AMOLED_175", "WAVESHARE_AMOLED_206"]
+          },
+          "nickname": {"pattern": "^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$", "type": "string"},
+          "note": {"maxLength": 256, "minLength": 1, "type": "string"},
+          "serialNumber": {"pattern": "^[A-Za-z0-9][A-Za-z0-9._:-]{0,254}$", "type": "string"},
+          "updatedAt": {"format": "date-time", "type": "string"}
+        },
+        "required": ["nickname", "boardFamily", "serialNumber", "updatedAt"],
+        "type": "object"
+      },
+      "type": "array"
+    },
+    "schema": {"const": 1}
+  },
+  "required": ["schema", "devices"],
+  "type": "object"
+}

--- a/esp32/tools/device_registry.py
+++ b/esp32/tools/device_registry.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Manage the local, explicit Waveshare device-name registry."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import stat
+import sys
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Sequence
+
+
+SCHEMA = 1
+BOARD_FAMILIES = frozenset(
+    {"WAVESHARE_AMOLED_175", "WAVESHARE_AMOLED_206"}
+)
+NICKNAME_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+SERIAL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{0,254}$")
+MAX_REGISTRY_BYTES = 1024 * 1024
+TIMESTAMP_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,6})?Z$"
+)
+
+
+class DeviceRegistryError(RuntimeError):
+    """Raised when a registry or requested mutation is unsafe or invalid."""
+
+
+@dataclass(frozen=True)
+class DeviceEntry:
+    nickname: str
+    board_family: str
+    serial: str
+    note: str | None
+    updated_at: str
+
+    def as_json(self) -> dict[str, object]:
+        value: dict[str, object] = {
+            "nickname": self.nickname,
+            "boardFamily": self.board_family,
+            "serialNumber": self.serial,
+            "updatedAt": self.updated_at,
+        }
+        if self.note is not None:
+            value["note"] = self.note
+        return value
+
+
+def default_registry_path() -> Path:
+    if sys.platform == "darwin":
+        return Path.home() / "Library/Application Support/OpenBikeComputer/devices.json"
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    # XDG_CONFIG_HOME is valid only as an absolute path. Ignoring a relative
+    # value prevents a registry containing real serials from landing in the
+    # current checkout by accident.
+    root = (
+        Path(config_home)
+        if config_home and Path(config_home).is_absolute()
+        else Path.home() / ".config"
+    )
+    return root / "open-bike-computer/devices.json"
+
+
+def _absolute_without_resolving(path: Path) -> Path:
+    return Path(os.path.abspath(path.expanduser()))
+
+
+def _validate_registry_parent(path: Path) -> None:
+    parent = path.parent
+    current = parent
+    while True:
+        if os.path.lexists(current) and current.is_symlink():
+            raise DeviceRegistryError(
+                f"device registry path contains a symlinked directory: {current}"
+            )
+        if current == current.parent:
+            break
+        current = current.parent
+    if not parent.is_dir():
+        raise DeviceRegistryError(
+            f"device registry parent is not a directory: {parent}"
+        )
+    info = parent.stat()
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        raise DeviceRegistryError(
+            f"device registry directory has the wrong owner: {parent}"
+        )
+    if stat.S_IMODE(info.st_mode) & 0o022:
+        raise DeviceRegistryError(
+            f"device registry directory is writable by another user: {parent}"
+        )
+
+
+def _prepare_registry_parent(path: Path) -> None:
+    parent = path.parent
+    missing: list[Path] = []
+    current = parent
+    while not os.path.lexists(current):
+        missing.append(current)
+        if current == current.parent:
+            break
+        current = current.parent
+    while True:
+        if os.path.lexists(current):
+            info = current.lstat()
+            if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+                raise DeviceRegistryError(
+                    f"device registry path contains an unsafe directory: {current}"
+                )
+        if current == current.parent:
+            break
+        current = current.parent
+    for directory in reversed(missing):
+        try:
+            directory.mkdir(mode=0o700)
+        except FileExistsError:
+            pass
+        info = directory.lstat()
+        if stat.S_ISLNK(info.st_mode) or not stat.S_ISDIR(info.st_mode):
+            raise DeviceRegistryError(
+                f"device registry path contains an unsafe directory: {directory}"
+            )
+        if hasattr(os, "getuid") and info.st_uid != os.getuid():
+            raise DeviceRegistryError(
+                f"device registry directory has the wrong owner: {directory}"
+            )
+        if stat.S_IMODE(info.st_mode) & 0o022:
+            raise DeviceRegistryError(
+                f"device registry directory is writable by another user: {directory}"
+            )
+    _validate_registry_parent(path)
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    result: dict[str, object] = {}
+    for key, value in pairs:
+        if key in result:
+            raise DeviceRegistryError(f"duplicate JSON key: {key}")
+        result[key] = value
+    return result
+
+
+def _normalize_nickname(value: str) -> str:
+    nickname = value.strip()
+    if not NICKNAME_PATTERN.fullmatch(nickname):
+        raise DeviceRegistryError(
+            "nickname must be 1-64 ASCII letters, digits, dots, underscores, or hyphens"
+        )
+    return nickname
+
+
+def normalize_serial(value: str) -> str:
+    serial = value.strip().upper()
+    if not SERIAL_PATTERN.fullmatch(serial):
+        raise DeviceRegistryError("stable USB serial is empty or malformed")
+    return serial
+
+
+def _validate_note(value: object) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip() or len(value) > 256:
+        raise DeviceRegistryError("note must be a nonempty string of at most 256 characters")
+    note = value.strip()
+    if not note.isprintable() or "\0" in note:
+        raise DeviceRegistryError("note contains unsupported characters")
+    return note
+
+
+def _validate_timestamp(value: object) -> str:
+    if not isinstance(value, str) or TIMESTAMP_PATTERN.fullmatch(value) is None:
+        raise DeviceRegistryError("updatedAt must be an ISO-8601 UTC timestamp")
+    try:
+        datetime.fromisoformat(value[:-1] + "+00:00")
+    except ValueError as error:
+        raise DeviceRegistryError("updatedAt must be an ISO-8601 UTC timestamp") from error
+    return value
+
+
+def _entry_from_json(value: object) -> DeviceEntry:
+    if not isinstance(value, dict):
+        raise DeviceRegistryError("each device entry must be an object")
+    allowed = {"nickname", "boardFamily", "serialNumber", "note", "updatedAt"}
+    required = {"nickname", "boardFamily", "serialNumber", "updatedAt"}
+    if set(value) - allowed or not required <= set(value):
+        raise DeviceRegistryError("device entry has missing or unexpected fields")
+    nickname_value = value["nickname"]
+    family = value["boardFamily"]
+    serial_value = value["serialNumber"]
+    if not isinstance(nickname_value, str) or not isinstance(serial_value, str):
+        raise DeviceRegistryError("nickname and serialNumber must be strings")
+    if not isinstance(family, str) or family not in BOARD_FAMILIES:
+        raise DeviceRegistryError("device boardFamily is unsupported")
+    nickname = _normalize_nickname(nickname_value)
+    serial = normalize_serial(serial_value)
+    note = _validate_note(value.get("note"))
+    if nickname_value != nickname or serial_value != serial:
+        raise DeviceRegistryError(
+            "device nickname or stable USB serial is not canonical"
+        )
+    if "note" in value and value["note"] != note:
+        raise DeviceRegistryError("device note is not canonical")
+    return DeviceEntry(
+        nickname=nickname,
+        board_family=family,
+        serial=serial,
+        note=note,
+        updated_at=_validate_timestamp(value["updatedAt"]),
+    )
+
+
+def _validate_entries(values: object) -> tuple[DeviceEntry, ...]:
+    if not isinstance(values, list):
+        raise DeviceRegistryError("devices must be an array")
+    entries = tuple(_entry_from_json(value) for value in values)
+    names: set[str] = set()
+    serials: set[str] = set()
+    for entry in entries:
+        name_key = entry.nickname.casefold()
+        serial_key = entry.serial.casefold()
+        if name_key in names:
+            raise DeviceRegistryError(f"duplicate device nickname: {entry.nickname}")
+        if serial_key in serials:
+            raise DeviceRegistryError(f"duplicate stable USB serial: {entry.serial}")
+        names.add(name_key)
+        serials.add(serial_key)
+    return entries
+
+
+def load_registry(path: Path | None = None, *, missing_ok: bool = True) -> tuple[DeviceEntry, ...]:
+    path = _absolute_without_resolving(path or default_registry_path())
+    if not os.path.lexists(path):
+        if missing_ok:
+            return ()
+        raise DeviceRegistryError(f"device registry does not exist: {path}")
+    info = path.lstat()
+    if stat.S_ISLNK(info.st_mode) or not stat.S_ISREG(info.st_mode):
+        raise DeviceRegistryError(f"device registry is not a regular non-symlink file: {path}")
+    if info.st_nlink != 1:
+        raise DeviceRegistryError(f"device registry must not be hard-linked: {path}")
+    if stat.S_IMODE(info.st_mode) != 0o600:
+        raise DeviceRegistryError(f"device registry permissions must be 0600: {path}")
+    if hasattr(os, "getuid") and info.st_uid != os.getuid():
+        raise DeviceRegistryError(f"device registry has the wrong owner: {path}")
+    if info.st_size > MAX_REGISTRY_BYTES:
+        raise DeviceRegistryError(f"device registry exceeds {MAX_REGISTRY_BYTES} bytes")
+    _validate_registry_parent(path)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        value = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise DeviceRegistryError(f"could not read device registry: {error}") from error
+    if not isinstance(value, dict) or set(value) != {"schema", "devices"}:
+        raise DeviceRegistryError("device registry has missing or unexpected fields")
+    if value["schema"] != SCHEMA or isinstance(value["schema"], bool):
+        raise DeviceRegistryError("unsupported device registry schema")
+    return _validate_entries(value["devices"])
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _write_registry(path: Path, entries: Sequence[DeviceEntry]) -> None:
+    path = _absolute_without_resolving(path)
+    if os.path.lexists(path) and (path.is_symlink() or not path.is_file()):
+        raise DeviceRegistryError(f"refusing unsafe device registry path: {path}")
+    _prepare_registry_parent(path)
+    value = {"schema": SCHEMA, "devices": [entry.as_json() for entry in entries]}
+    temporary_name: str | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(value, stream, sort_keys=True, separators=(",", ":"))
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        if os.path.lexists(path) and path.is_symlink():
+            raise DeviceRegistryError(f"refusing symlink device registry: {path}")
+        _validate_registry_parent(path)
+        os.replace(temporary_name, path)
+        temporary_name = None
+        os.chmod(path, 0o600, follow_symlinks=False)
+        if hasattr(os, "O_DIRECTORY"):
+            directory_fd = os.open(path.parent, os.O_RDONLY | os.O_DIRECTORY)
+            try:
+                os.fsync(directory_fd)
+            finally:
+                os.close(directory_fd)
+    except OSError as error:
+        raise DeviceRegistryError(f"could not update device registry: {error}") from error
+    finally:
+        if temporary_name is not None:
+            try:
+                Path(temporary_name).unlink()
+            except OSError:
+                pass
+
+
+def resolve_device_name(name: str, path: Path | None = None) -> DeviceEntry:
+    requested = _normalize_nickname(name).casefold()
+    matches = [
+        entry
+        for entry in load_registry(path, missing_ok=False)
+        if entry.nickname.casefold() == requested
+    ]
+    if len(matches) != 1:
+        raise DeviceRegistryError(f"unknown or ambiguous device nickname: {name}")
+    return matches[0]
+
+
+def environment_matches_family(environment: str, family: str) -> bool:
+    return environment == family or environment.startswith(family + "_")
+
+
+def _print_entry(entry: DeviceEntry, path: Path) -> None:
+    print(
+        json.dumps(
+            {"schema": SCHEMA, "path": str(path), "device": entry.as_json()},
+            sort_keys=True,
+        )
+    )
+
+
+def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--registry", type=Path, default=default_registry_path())
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("list")
+    show = commands.add_parser("show")
+    show.add_argument("nickname")
+    add = commands.add_parser("add")
+    add.add_argument("nickname")
+    add.add_argument("board_family", choices=sorted(BOARD_FAMILIES))
+    add.add_argument("serial")
+    add.add_argument("--note")
+    rename = commands.add_parser("rename")
+    rename.add_argument("nickname")
+    rename.add_argument("new_nickname")
+    remove = commands.add_parser("remove")
+    remove.add_argument("nickname")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parse_args(argv)
+    path = _absolute_without_resolving(args.registry)
+    try:
+        entries = list(load_registry(path))
+        if args.command == "list":
+            print(
+                json.dumps(
+                    {
+                        "schema": SCHEMA,
+                        "path": str(path),
+                        "devices": [entry.as_json() for entry in entries],
+                    },
+                    sort_keys=True,
+                )
+            )
+            return 0
+        if args.command == "show":
+            _print_entry(resolve_device_name(args.nickname, path), path)
+            return 0
+        if args.command == "add":
+            nickname = _normalize_nickname(args.nickname)
+            serial = normalize_serial(args.serial)
+            if any(entry.nickname.casefold() == nickname.casefold() for entry in entries):
+                raise DeviceRegistryError(f"device nickname already exists: {nickname}")
+            if any(entry.serial.casefold() == serial.casefold() for entry in entries):
+                raise DeviceRegistryError(f"stable USB serial already exists: {serial}")
+            changed = DeviceEntry(
+                nickname,
+                args.board_family,
+                serial,
+                _validate_note(args.note),
+                _utc_now(),
+            )
+            entries.append(changed)
+        elif args.command == "rename":
+            current = resolve_device_name(args.nickname, path)
+            nickname = _normalize_nickname(args.new_nickname)
+            if any(
+                entry.nickname.casefold() == nickname.casefold()
+                and entry != current
+                for entry in entries
+            ):
+                raise DeviceRegistryError(f"device nickname already exists: {nickname}")
+            changed = DeviceEntry(
+                nickname,
+                current.board_family,
+                current.serial,
+                current.note,
+                _utc_now(),
+            )
+            entries = [changed if entry == current else entry for entry in entries]
+        elif args.command == "remove":
+            changed = resolve_device_name(args.nickname, path)
+            entries = [entry for entry in entries if entry != changed]
+        else:
+            raise AssertionError("unhandled registry command")
+        entries.sort(key=lambda entry: entry.nickname.casefold())
+        _write_registry(path, entries)
+        _print_entry(changed, path)
+        return 0
+    except DeviceRegistryError as error:
+        print(f"Device registry failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/esp32/tools/resolve_upload_port.py
+++ b/esp32/tools/resolve_upload_port.py
@@ -10,7 +10,14 @@ import sys
 import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Protocol
+
+from device_registry import (
+    DeviceRegistryError,
+    default_registry_path,
+    resolve_device_name,
+)
 
 
 class DeviceResolutionError(RuntimeError):
@@ -124,7 +131,10 @@ def resolve_device_port(
 
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--device-serial", required=True)
+    selector = parser.add_mutually_exclusive_group(required=True)
+    selector.add_argument("--device-serial")
+    selector.add_argument("--device-name")
+    parser.add_argument("--device-registry", type=Path, default=default_registry_path())
     parser.add_argument("--timeout", type=float, default=60.0)
     return parser.parse_args(argv)
 
@@ -132,11 +142,22 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 def main(argv: Sequence[str] | None = None) -> int:
     args = _parse_args(argv)
     try:
-        resolved = resolve_device_port(args.device_serial, args.timeout)
-    except DeviceResolutionError as error:
+        entry = None
+        serial = args.device_serial
+        if args.device_name is not None:
+            entry = resolve_device_name(args.device_name, args.device_registry)
+            serial = entry.serial
+        if serial is None:
+            raise AssertionError("validated selector did not resolve")
+        resolved = resolve_device_port(serial, args.timeout)
+    except (DeviceResolutionError, DeviceRegistryError) as error:
         print(f"Device resolution failed: {error}", file=sys.stderr)
         return 1
-    print(json.dumps(resolved.as_json(), sort_keys=True))
+    result = resolved.as_json()
+    if entry is not None:
+        result["nickname"] = entry.nickname
+        result["boardFamily"] = entry.board_family
+    print(json.dumps(result, sort_keys=True))
     return 0
 
 

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -1657,6 +1657,86 @@ build_src_filter =
         mocked_upload.assert_not_called()
         self.assertIn("requires --upload-port or --device-serial", errors.getvalue())
 
+    def test_cli_device_name_rejects_family_mismatch_before_build(self):
+        registry = (self.project_dir / "devices.json").resolve()
+        registry.write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "devices": [
+                        {
+                            "nickname": "desk-206",
+                            "boardFamily": "WAVESHARE_AMOLED_206",
+                            "serialNumber": "SERIAL-206",
+                            "updatedAt": "2026-08-10T00:00:00Z",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        registry.chmod(0o600)
+        errors = StringIO()
+        handoffs = []
+        with patch("build_firmware.build_firmware") as mocked_build, patch(
+            "build_firmware.upload_firmware"
+        ) as mocked_upload, redirect_stderr(errors):
+            result = main(
+                [
+                    self.environment,
+                    "--project-dir", str(self.project_dir),
+                    "--device-name", "desk-206",
+                    "--device-registry", str(registry),
+                ],
+                runtime_handoff=lambda argv, project: handoffs.append(
+                    (argv, project)
+                ),
+            )
+        self.assertEqual(result, 1)
+        self.assertEqual(len(handoffs), 1)
+        mocked_build.assert_not_called()
+        mocked_upload.assert_not_called()
+        self.assertIn("enrolled as WAVESHARE_AMOLED_206", errors.getvalue())
+
+    def test_cli_device_name_passes_enrolled_serial_and_context_to_upload(self):
+        registry = (self.project_dir / "devices.json").resolve()
+        registry.write_text(
+            json.dumps(
+                {
+                    "schema": 1,
+                    "devices": [
+                        {
+                            "nickname": "desk-175",
+                            "boardFamily": "WAVESHARE_AMOLED_175",
+                            "serialNumber": "SERIAL-175",
+                            "updatedAt": "2026-08-10T00:00:00Z",
+                        }
+                    ],
+                }
+            ),
+            encoding="utf-8",
+        )
+        registry.chmod(0o600)
+        with patch("build_firmware.build_firmware") as mocked_build, patch(
+            "build_firmware.upload_firmware"
+        ) as mocked_upload:
+            result = main(
+                [
+                    self.environment,
+                    "--project-dir", str(self.project_dir),
+                    "--device-name", "desk-175",
+                    "--device-registry", str(registry),
+                ],
+                runtime_handoff=lambda _argv, _project: None,
+            )
+        self.assertEqual(result, 0)
+        mocked_build.assert_called_once()
+        upload_arguments = mocked_upload.call_args
+        self.assertEqual(upload_arguments.kwargs["device_serial"], "SERIAL-175")
+        self.assertEqual(
+            upload_arguments.kwargs["device_entry"].nickname, "desk-175"
+        )
+
     def test_upload_device_serial_binds_the_resolved_port(self):
         core = self.write_core_attestation()
         defaults = self.project_dir / "sdkconfig.defaults"

--- a/esp32/tools/tests/test_device_registry.py
+++ b/esp32/tools/tests/test_device_registry.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import unittest
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from device_registry import (
+    DeviceRegistryError,
+    default_registry_path,
+    environment_matches_family,
+    load_registry,
+    main,
+    resolve_device_name,
+)
+
+
+class DeviceRegistryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.path = Path(self.temporary.name).resolve() / "config/devices.json"
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def run_cli(self, *arguments: str) -> tuple[int, str, str]:
+        output = StringIO()
+        error = StringIO()
+        with redirect_stdout(output), redirect_stderr(error):
+            status = main(("--registry", str(self.path), *arguments))
+        return status, output.getvalue(), error.getvalue()
+
+    def test_add_list_show_rename_and_remove_are_atomic_and_private(self) -> None:
+        status, output, _ = self.run_cli(
+            "add", "desk-175", "WAVESHARE_AMOLED_175", "abc-123", "--note", "desk"
+        )
+        self.assertEqual(status, 0)
+        self.assertEqual(self.path.stat().st_mode & 0o777, 0o600)
+        self.assertFalse(any(self.path.parent.glob(".devices.json.*")))
+        changed = json.loads(output)
+        self.assertEqual(changed["device"]["serialNumber"], "ABC-123")
+        self.assertEqual(resolve_device_name("DESK-175", self.path).nickname, "desk-175")
+
+        status, _, _ = self.run_cli("rename", "desk-175", "road-175")
+        self.assertEqual(status, 0)
+        self.assertEqual(resolve_device_name("road-175", self.path).serial, "ABC-123")
+
+        status, output, _ = self.run_cli("list")
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(output)["devices"][0]["nickname"], "road-175")
+
+        status, output, _ = self.run_cli("remove", "road-175")
+        self.assertEqual(status, 0)
+        self.assertEqual(json.loads(output)["device"]["nickname"], "road-175")
+        self.assertEqual(load_registry(self.path), ())
+
+    def test_rejects_casefold_duplicate_names_and_serials(self) -> None:
+        self.assertEqual(
+            self.run_cli("add", "Desk", "WAVESHARE_AMOLED_175", "serial-1")[0], 0
+        )
+        self.assertEqual(
+            self.run_cli("add", "desk", "WAVESHARE_AMOLED_206", "serial-2")[0], 1
+        )
+        self.assertEqual(
+            self.run_cli("add", "other", "WAVESHARE_AMOLED_206", "SERIAL-1")[0], 1
+        )
+
+    def test_interrupted_update_preserves_the_previous_registry(self) -> None:
+        self.assertEqual(
+            self.run_cli(
+                "add", "desk", "WAVESHARE_AMOLED_175", "serial-1"
+            )[0],
+            0,
+        )
+        before = self.path.read_bytes()
+        with patch(
+            "device_registry.os.replace",
+            side_effect=OSError("injected replacement failure"),
+        ):
+            status, _, error = self.run_cli("rename", "desk", "road")
+        self.assertEqual(status, 1)
+        self.assertIn("could not update", error)
+        self.assertEqual(self.path.read_bytes(), before)
+        self.assertFalse(any(self.path.parent.glob(".devices.json.*")))
+
+    def test_rejects_duplicate_json_keys_and_unknown_schema(self) -> None:
+        self.path.parent.mkdir(parents=True)
+        self.path.write_text('{"schema":1,"schema":1,"devices":[]}\n', encoding="utf-8")
+        self.path.chmod(0o600)
+        with self.assertRaisesRegex(DeviceRegistryError, "duplicate JSON key"):
+            load_registry(self.path)
+        self.path.write_text('{"schema":2,"devices":[]}\n', encoding="utf-8")
+        with self.assertRaisesRegex(DeviceRegistryError, "unsupported.*schema"):
+            load_registry(self.path)
+
+    def test_rejects_noncanonical_entries_and_non_timestamp_dates(self) -> None:
+        self.path.parent.mkdir(parents=True)
+        for field, value in (
+            ("nickname", " desk"),
+            ("serialNumber", "serial-1"),
+            ("note", " padded "),
+            ("updatedAt", "2026-08-10Z"),
+        ):
+            with self.subTest(field=field):
+                entry = {
+                    "nickname": "desk",
+                    "boardFamily": "WAVESHARE_AMOLED_175",
+                    "serialNumber": "SERIAL-1",
+                    "note": "desk",
+                    "updatedAt": "2026-08-10T00:00:00Z",
+                }
+                entry[field] = value
+                self.path.write_text(
+                    json.dumps({"schema": 1, "devices": [entry]}) + "\n",
+                    encoding="utf-8",
+                )
+                self.path.chmod(0o600)
+                with self.assertRaises(DeviceRegistryError):
+                    load_registry(self.path)
+
+    def test_rejects_symlink_and_unsafe_permissions(self) -> None:
+        external = Path(self.temporary.name) / "external.json"
+        external.write_text('{"schema":1,"devices":[]}\n', encoding="utf-8")
+        external.chmod(0o600)
+        self.path.parent.mkdir(parents=True)
+        self.path.symlink_to(external)
+        with self.assertRaisesRegex(DeviceRegistryError, "non-symlink"):
+            load_registry(self.path)
+        self.path.unlink()
+        self.path.write_text('{"schema":1,"devices":[]}\n', encoding="utf-8")
+        self.path.chmod(0o644)
+        with self.assertRaisesRegex(DeviceRegistryError, "permissions"):
+            load_registry(self.path)
+        self.path.chmod(0o400)
+        with self.assertRaisesRegex(DeviceRegistryError, "permissions"):
+            load_registry(self.path)
+
+    def test_rejects_hard_linked_registry(self) -> None:
+        external = Path(self.temporary.name) / "external.json"
+        external.write_text('{"schema":1,"devices":[]}\n', encoding="utf-8")
+        external.chmod(0o600)
+        self.path.parent.mkdir(parents=True)
+        os.link(external, self.path)
+        with self.assertRaisesRegex(DeviceRegistryError, "hard-linked"):
+            load_registry(self.path)
+
+    def test_relative_xdg_config_home_cannot_place_registry_in_checkout(self) -> None:
+        with (
+            patch("device_registry.sys.platform", "linux"),
+            patch("device_registry.Path.home", return_value=Path("/safe/home")),
+            patch.dict(os.environ, {"XDG_CONFIG_HOME": "relative-config"}),
+        ):
+            self.assertEqual(
+                default_registry_path(),
+                Path("/safe/home/.config/open-bike-computer/devices.json"),
+            )
+
+    def test_rejects_symlinked_parent_and_wrong_owner(self) -> None:
+        real_parent = Path(self.temporary.name).resolve() / "real-config"
+        real_parent.mkdir()
+        linked_parent = Path(self.temporary.name).resolve() / "linked-config"
+        linked_parent.symlink_to(real_parent, target_is_directory=True)
+        linked_registry = linked_parent / "devices.json"
+        linked_registry.write_text('{"schema":1,"devices":[]}\n', encoding="utf-8")
+        linked_registry.chmod(0o600)
+        with self.assertRaisesRegex(DeviceRegistryError, "symlinked directory"):
+            load_registry(linked_registry)
+
+        nested_registry = linked_parent / "new/config/devices.json"
+        status, _, error = self.run_cli(
+            "--registry",
+            str(nested_registry),
+            "add",
+            "desk",
+            "WAVESHARE_AMOLED_175",
+            "SERIAL-1",
+        )
+        self.assertEqual(status, 1)
+        self.assertIn("unsafe directory", error)
+        self.assertFalse((real_parent / "new").exists())
+
+        self.path.parent.mkdir(parents=True)
+        self.path.write_text('{"schema":1,"devices":[]}\n', encoding="utf-8")
+        self.path.chmod(0o600)
+        if hasattr(os, "getuid"):
+            with patch("device_registry.os.getuid", return_value=os.getuid() + 1):
+                with self.assertRaisesRegex(DeviceRegistryError, "wrong owner"):
+                    load_registry(self.path)
+
+    def test_family_matching_accepts_profiles_but_not_other_board(self) -> None:
+        self.assertTrue(
+            environment_matches_family(
+                "WAVESHARE_AMOLED_175_PRODUCTION", "WAVESHARE_AMOLED_175"
+            )
+        )
+        self.assertFalse(
+            environment_matches_family(
+                "WAVESHARE_AMOLED_206", "WAVESHARE_AMOLED_175"
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/esp32/tools/tests/test_resolve_upload_port.py
+++ b/esp32/tools/tests/test_resolve_upload_port.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
 
 import json
+import tempfile
 import unittest
 from contextlib import redirect_stderr, redirect_stdout
 from io import StringIO
 from types import SimpleNamespace
+from pathlib import Path
 from unittest.mock import patch
 
 from resolve_upload_port import (
@@ -110,6 +112,42 @@ class ResolveUploadPortTests(unittest.TestCase):
 
         self.assertEqual(result, 1)
         self.assertIn("not connected", errors.getvalue())
+
+    def test_cli_resolves_explicit_registry_name_and_reports_family(self):
+        with tempfile.TemporaryDirectory() as directory:
+            registry = (Path(directory) / "devices.json").resolve()
+            registry.write_text(
+                json.dumps(
+                    {
+                        "schema": 1,
+                        "devices": [
+                            {
+                                "nickname": "desk-175",
+                                "boardFamily": "WAVESHARE_AMOLED_175",
+                                "serialNumber": "SERIAL",
+                                "updatedAt": "2026-08-10T00:00:00Z",
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+            registry.chmod(0o600)
+            output = StringIO()
+            with patch(
+                "resolve_upload_port.resolve_device_port",
+                return_value=resolve_device_port(
+                    "serial", 0,
+                    list_ports_provider=lambda: [port("/dev/cu.named", "serial")],
+                ),
+            ), redirect_stdout(output):
+                result = main(
+                    ["--device-name", "desk-175", "--device-registry", str(registry)]
+                )
+        self.assertEqual(result, 0)
+        payload = json.loads(output.getvalue())
+        self.assertEqual(payload["nickname"], "desk-175")
+        self.assertEqual(payload["boardFamily"], "WAVESHARE_AMOLED_175")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a versioned local firmware device-name registry with strict schema, canonical values, and duplicate validation
- resolve `--device-name` to one enrolled board family and stable USB serial before build or upload
- reject board-family mismatches after the locked runtime handoff and before firmware compilation or upload
- use owner-checked 0600 atomic persistence, symlink-safe parent creation, and file/directory fsync
- print nickname, family, serial, VID:PID, description, and resolved transient port without auto-enrollment, auto-selection, or board guessing
- preserve the required immediate physical-model confirmation before flashing

## Dependency order

This PR is stacked directly on #231 so the repository-owned runtime lands before the custom-core cache identity and the device registry lands after both. Its review diff relative to #231 remains limited to the registry scope.

## Validation

- focused registry/runtime/core suite — 181 tests passed in 16.923 s
- `python3 -m unittest discover -s .github/scripts/tests` — 42 workflow-policy tests passed
- registry, resolver, family-mismatch, atomic interruption, canonical schema, unsafe permission, wrong-owner, and nested-parent symlink cases pass
- CI run [31484248523](https://github.com/seichris/open-bike-computer/actions/runs/31484248523) passed all 10 jobs at head `f874f6c9546418dcf558dbf364a63447d4875ffb`
- live local enrollment succeeded for nickname `waveshare-175`, family `WAVESHARE_AMOLED_175`, stable serial `28:84:85:3B:68:60`
- `python3 tools/device_registry.py show waveshare-175` resolved the exact enrolled family and stable serial
- `python3 tools/build_firmware.py WAVESHARE_AMOLED_206 --device-name waveshare-175 --upload-only` failed closed before device access: `device waveshare-175 is enrolled as WAVESHARE_AMOLED_175, not WAVESHARE_AMOLED_206`
- combined runtime/cache/registry/SD integration at `dc0e0d1fa175f7b388ff6fdbc8a6ab6a23a4aea9` passed clean and immediate warm locked-runtime builds:
  - clean cache miss: total 686.189 s, custom core 294.124 s
  - warm cache hit: total 178.009 s, custom core 0 s
  - both builds reproduced BIN `474d1b7153ca9f4387e7389967f0ac87f4f480c92bc691e51ccc0271db42772b`, ELF `70f85d13ed86fb6905defef059aa9694bd53394dd680d3df75238a82abe71f94`, flash plan `21e1f5a9febf2046b0fa4866dfbf13447aa517d3ccfe3a5ad17c0adcb77dc242`, core input key `ebfba52fef13fd1ce94aaa4a7c828e89030b5786fac52021bfdfa241139d3d8f`, and core attestation `910158118fd0388cf6fb3183e8549c00c7c0fdb1c360015c0d4bf25c5855b067`
  - both reported `uploadEligible=1` under runtime lock `firmware-runtime-2026-08-10-1`
- `git diff --check`

## Hardware validation

The user explicitly confirmed the 1.75-inch flash. Immediately before upload, `waveshare-175` resolved to family `WAVESHARE_AMOLED_175`, stable serial `28:84:85:3B:68:60`, VID:PID `303A:1001`, and the live transient port. The attested upload-only path completed successfully and emitted matching device and upload provenance for integration Git `dc0e0d1fa175f7b388ff6fdbc8a6ab6a23a4aea9`, BIN `474d1b7153ca9f4387e7389967f0ac87f4f480c92bc691e51ccc0271db42772b`, ELF `70f85d13ed86fb6905defef059aa9694bd53394dd680d3df75238a82abe71f94`, and flash plan `21e1f5a9febf2046b0fa4866dfbf13447aa517d3ccfe3a5ad17c0adcb77dc242`; every flashed region passed esptool hash verification. Independent post-upload boot capture confirmed the exact target/profile/Git identity, schema-1 PMIC read-only/current-preserved evidence, and a ready stage. The registry hardware gate is complete.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.