### PR TITLE
Avoid Xcode 26.6 command-line build deadlock

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,7 +266,11 @@ for that stronger claim.
 
 ### iOS app
 
-Open `ios-app/BikeComputer/BikeComputer.xcodeproj`. Run the portable Swift
+Open `ios-app/BikeComputer/BikeComputer.xcodeproj` only when GUI-specific setup
+or debugging is required. For command-line builds, use
+`ios-app/scripts/xcodebuild-cli.sh` with normal `xcodebuild` arguments. Do not
+call `xcodebuild` directly on Xcode 26.6; its verbose clang discovery probe can
+deadlock inside `SWBBuildService` on this Mac. Run the portable Swift
 navigation/BLE tests with:
 
 ```sh
@@ -278,7 +282,7 @@ The CI build shape is:
 
 ```sh
 cd ios-app
-xcodebuild -project BikeComputer/BikeComputer.xcodeproj \
+./scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj \
   -scheme BikeComputer -destination 'generic/platform=iOS' \
   CODE_SIGNING_ALLOWED=NO build
 ```

--- a/ios-app/README.md
+++ b/ios-app/README.md
@@ -1,6 +1,7 @@
 # BikeComputer for iPhone and Apple Watch
 
-Open `BikeComputer/BikeComputer.xcodeproj` in Xcode.
+The Xcode project is `BikeComputer/BikeComputer.xcodeproj`. Routine builds do
+not require opening Xcode; use the command-line entry point below.
 
 ## Requirements
 
@@ -12,6 +13,38 @@ Open `BikeComputer/BikeComputer.xcodeproj` in Xcode.
   cannot be accepted from Simulator results alone.
 - The Watch must be worn and unlocked for setup and normal workout collection.
   Enable Developer Mode on both devices for Xcode installation and debugging.
+
+## Command-line Xcode builds
+
+Use the repository's `xcodebuild` entry point instead of opening Xcode for
+routine builds:
+
+```sh
+scripts/xcodebuild-cli.sh \
+  -project BikeComputer/BikeComputer.xcodeproj \
+  -scheme BikeComputer \
+  -configuration Debug \
+  -destination 'generic/platform=iOS' \
+  CODE_SIGNING_ALLOWED=NO \
+  build
+```
+
+The entry point works around a build-service deadlock observed with Xcode 26.6
+in the verbose Apple clang discovery probe. It changes only that `/dev/null`
+probe; normal compiler and linker invocations continue to use the selected
+Xcode toolchain.
+
+For a connected iPhone, replace the generic destination and unsigned setting:
+
+```sh
+scripts/xcodebuild-cli.sh \
+  -project BikeComputer/BikeComputer.xcodeproj \
+  -scheme BikeComputer \
+  -configuration Debug \
+  -destination 'id=<iPhone UDID>' \
+  -allowProvisioningUpdates \
+  build
+```
 
 ## First run
 

--- a/ios-app/scripts/xcode-clang-wrapper.sh
+++ b/ios-app/scripts/xcode-clang-wrapper.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+developer_dir="${DEVELOPER_DIR:-$(xcode-select -p)}"
+real_clang="$developer_dir/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang"
+
+if [[ ! -x "$real_clang" ]]; then
+    echo "Apple clang not found at $real_clang" >&2
+    exit 69
+fi
+
+has_preprocess=false
+has_macro_dump=false
+has_null_input=false
+
+for arg in "$@"; do
+    case "$arg" in
+        -E)
+            has_preprocess=true
+            ;;
+        -dM)
+            has_macro_dump=true
+            ;;
+        /dev/null)
+            has_null_input=true
+            ;;
+    esac
+done
+
+# Xcode 26.6's build service has been observed deadlocking while capturing the
+# verbose output from its compiler-discovery probe. Removing only -v keeps the
+# macro output Xcode consumes while avoiding the blocked stderr pipe. Real
+# compilation and linking invocations are forwarded byte-for-byte to Apple clang.
+if $has_preprocess && $has_macro_dump && $has_null_input; then
+    filtered_args=()
+    for arg in "$@"; do
+        if [[ "$arg" != "-v" ]]; then
+            filtered_args+=("$arg")
+        fi
+    done
+    exec "$real_clang" "${filtered_args[@]}"
+fi
+
+exec "$real_clang" "$@"

--- a/ios-app/scripts/xcodebuild-cli.sh
+++ b/ios-app/scripts/xcodebuild-cli.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+xcodebuild_path="${XCODEBUILD_PATH:-$(xcrun --find xcodebuild)}"
+clang_wrapper="$script_dir/xcode-clang-wrapper.sh"
+
+if [[ ! -x "$clang_wrapper" ]]; then
+    echo "Clang wrapper is not executable: $clang_wrapper" >&2
+    exit 69
+fi
+
+# CC is a build-setting override. Callers can still replace it by passing a
+# later CC=/path argument explicitly.
+exec "$xcodebuild_path" CC="$clang_wrapper" "$@"


### PR DESCRIPTION
## Summary

- add a repository-local `xcodebuild` entry point for reliable command-line iPhone and Watch builds
- add a transparent Clang wrapper that removes `-v` only from Xcode's exact `-E -dM /dev/null` compiler-discovery probe
- document the command-line workflow and the narrow Xcode 26.6 workaround

## Root cause

With Xcode 26.6, `SWBBuildService` can deadlock while capturing the verbose Clang macro-discovery probe. The Clang process remains blocked writing verbose output while the build service is idle. The same hang occurs with code signing disabled and in detached builds, so it is unrelated to signing or terminal lifetime.

## Impact

Routine CLI builds can complete without opening the Xcode app. Normal compilation and linking arguments remain unchanged; only the discovery probe loses verbose output.

## Privacy audit

The PR contains four public text files only: two documentation updates and two shell scripts. The diff contains no local user paths, device identifiers, credentials, tokens, private keys, provisioning profiles, personal email addresses, or binary files.

## Validation

- clean unsigned four-target iPhone/Watch build on commit `046c10deb88d80d5a0ba3ddd3481a3cd274b29f9`: `BUILD SUCCEEDED`
- `bash -n` passed for both scripts
- ordinary `clang --version` behavior matches the real compiler
- macro-discovery output is byte-identical to the real compiler
- `git diff --check origin/main...HEAD` passed
