### PR TITLE
Pre-render map screens for faster firmware switching

### DIFF
--- a/docs/firmware-map-render-scheduler.md
+++ b/docs/firmware-map-render-scheduler.md
@@ -97,6 +97,15 @@ and projection semantics. During a direct transition between those profiles,
 the shared canvas is concealed against the neutral screen background until a
 new worker publication for the destination profile arrives; the prior
 profile's already-published frame is never accepted as transition completion.
+While a non-map main screen is visible, the UI predicts the next enabled
+map-backed screen in the configured cycle and submits that destination profile
+to the same low-priority worker. The worker reuses the existing hidden back
+buffer, so this adds no persistent frame allocation. A BOOT press publishes a
+ready frame with the ordinary semantic and viewport-coverage checks. An
+unfinished current preparation continues without being restarted, while a
+stale or failed preparation falls back to the normal destination-screen
+request. Transition logs report the press-to-visible duration and whether
+render-ahead was available for physical validation.
 The oversized base object stays LVGL center-aligned. Its style position is an
 offset from the centered origin, not an absolute parent coordinate; the
 presenter explicitly converts the desired parent-space pivot target to that

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -81,6 +81,10 @@ static lv_obj_t *mapGuidanceArrow;
 static lv_obj_t *mapGuidanceDistance;
 static lv_obj_t *mapGuidanceCycleStrip;
 static map_tile_transition::State mapTileTransition;
+static uint32_t mapTileTransitionStartedMs = 0;
+static bool mapTileTransitionUsedRenderAhead = false;
+static bool mapRenderAheadPending = false;
+static tileName mapRenderAheadTile = MAP;
 struct DestinationRowContext {
   uint32_t generation = 0;
   uint16_t token = 0;
@@ -538,16 +542,27 @@ bool shouldInterruptMapRenderForScreenCycle() {
 #endif
 }
 
-const ScreenMapRenderSettings &currentMapStyleSettings() {
+static const ScreenMapRenderSettings &mapStyleSettingsForTile(tileName tile) {
   return map_profile_protocol::select(mapRenderSettings.mapStyle,
                                       mapRenderSettings.mapNavigationStyle,
-                                      isMapGuidanceScreenActive());
+                                      tile == MAP_GUIDANCE);
+}
+
+const ScreenMapRenderSettings &currentMapStyleSettings() {
+  return mapStyleSettingsForTile(static_cast<tileName>(activeTile));
 }
 
 static void tapCycleScreenEvent(lv_event_t *event);
 static void mapGuidanceOverlayTapEvent(lv_event_t *event);
 static void updateMapGuidanceOverlay();
 static void revealPendingMapTileIfReady();
+
+static void acceptPublishedMapFrame(uint32_t nowMs) {
+  mapTileTransition.noteFramePublished();
+  (void)mapView.takeFramePublication();
+  mapRenderScheduler.markRendered(nowMs, currentMapFix());
+  revealPendingMapTileIfReady();
+}
 
 static int16_t mapInteractionAnchorX() {
   return gui_layout::mapScreenAnchorX(TFT_WIDTH, mapView.mapScrWidth);
@@ -684,6 +699,28 @@ static tileName nextEnabledTile(tileName current) {
   return configuredDefaultTile();
 }
 
+static bool nextEnabledMapBackedTile(tileName current, tileName &next) {
+  const uint8_t currentScreen = deviceScreenForTile(current);
+  uint8_t currentIndex = 0;
+  for (uint8_t index = 0; index < DEVICE_SCREEN_COUNT; index++) {
+    if (DEVICE_SCREEN_CYCLE_ORDER[index] == currentScreen) {
+      currentIndex = index;
+      break;
+    }
+  }
+
+  for (uint8_t offset = 1; offset <= DEVICE_SCREEN_COUNT; offset++) {
+    const uint8_t screen = DEVICE_SCREEN_CYCLE_ORDER[
+        (currentIndex + offset) % DEVICE_SCREEN_COUNT];
+    const tileName candidate = tileForDeviceScreen(screen);
+    if (isScreenEnabled(candidate) && isMapBackedTile(candidate)) {
+      next = candidate;
+      return true;
+    }
+  }
+  return false;
+}
+
 static bool isGuidanceNavigating() {
   return routeOverlay.hasRoute() || hasCurrentNavigationData();
 }
@@ -715,8 +752,8 @@ static void setNavigationDistanceLabel(lv_obj_t *label,
   setLabelTextIfChanged(label, text);
 }
 
-static void applyMapRotationForActiveTile() {
-  if (activeTile == MAP_GUIDANCE) {
+static void applyMapRotationForTile(tileName tile) {
+  if (tile == MAP_GUIDANCE) {
     const Maps::RotationMode desiredMode =
         isGuidanceNavigating() ? Maps::ROT_COURSE_UP : Maps::ROT_NORTH_UP;
     if (mapView.rotationMode != desiredMode) {
@@ -732,7 +769,7 @@ static void applyMapRotationForActiveTile() {
     return;
   }
 
-  if (activeTile != MAP) {
+  if (tile != MAP) {
     return;
   }
 
@@ -750,6 +787,45 @@ static void applyMapRotationForActiveTile() {
     requestMapRender(map_render_policy::Reason::Style);
     log_i("Creating Map: Syncing rotation to North Up (from settings)");
   }
+}
+
+static void prepareNextMapScreenRenderAhead(tileName current) {
+  if (isMapBackedTile(current) || !mapSet.vectorMap ||
+      !mapView.hasMapCanvas()) {
+    mapRenderAheadPending = false;
+    return;
+  }
+
+  tileName target = MAP;
+  if (!nextEnabledMapBackedTile(current, target)) {
+    mapRenderAheadPending = false;
+    return;
+  }
+  if (mapRenderAheadPending && mapRenderAheadTile == target) {
+    return;
+  }
+
+  // The visible screen is already a lightweight LVGL tile. Prepare the next
+  // map profile on the low-priority worker now, using the existing hidden back
+  // buffer, so a later BOOT press only needs the bounded pointer publication.
+  applyMapRotationForTile(target);
+  const ScreenMapRenderSettings &style = mapStyleSettingsForTile(target);
+  const uint32_t nowMs = millis();
+  if (!mapView.prepareVectorMapForScreen(style.zoomLevel,
+                                         target == MAP_GUIDANCE)) {
+    mapRenderAheadPending = false;
+    return;
+  }
+
+  mapView.isPosMoved = false;
+  mapView.redrawMap = false;
+  noteMapRenderReasons(
+      map_render_policy::reasonMask(map_render_policy::Reason::Screen));
+  mapRenderScheduler.markSubmitted(nowMs, currentMapFix());
+  mapRenderAheadPending = true;
+  mapRenderAheadTile = target;
+  log_i("UI: render-ahead requested for %s screen",
+        target == MAP_GUIDANCE ? "map guidance" : "map");
 }
 
 static uint16_t mapGuidanceOverlayHeight() {
@@ -1071,7 +1147,7 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
 #ifdef ENABLE_COMPASS
   heading = compass.getHeading();
 #endif
-  applyMapRotationForActiveTile();
+  applyMapRotationForTile(static_cast<tileName>(activeTile));
 
   // Publication, pose interpolation, front-frame translation, live route, and
   // marker work are all bounded LVGL-owner operations and run at display
@@ -1079,16 +1155,21 @@ static bool prepareVisibleMapUpdate(uint32_t nowMs) {
   const bool framePublished = mapView.serviceRenderPipeline(nowMs);
   mapView.updatePositionOverlay();
   if (framePublished) {
-    mapTileTransition.noteFramePublished();
-    (void)mapView.takeFramePublication();
-    mapRenderScheduler.markRendered(nowMs, currentMapFix());
-    revealPendingMapTileIfReady();
+    acceptPublishedMapFrame(nowMs);
   }
   if (mapView.takeRenderFailure()) {
     mapRenderScheduler.markInterrupted();
     noteMapRenderReasons(mapRenderScheduler.pendingForcedReasons());
     mapView.isPosMoved = true;
     mapView.redrawMap = true;
+  }
+  if (!framePublished && mapTileTransition.pending &&
+      !mapView.isPosMoved && !mapView.redrawMap &&
+      !mapView.hasPendingRenderForCurrentScreen()) {
+    // A render-ahead result can become stale between its off-screen build and
+    // this screen entry. Fall back to the normal latest-state request instead
+    // of leaving the previous non-map tile visible indefinitely.
+    requestMapRender(map_render_policy::Reason::Screen);
   }
 
   bool navigationOverlayChanged = false;
@@ -1848,10 +1929,46 @@ static void showMainTile(tileName tile) {
     // profile remains visible briefly while the replacement renders.
     lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
     mapTileTransition.begin();
+    mapTileTransitionStartedMs = millis();
+    mapTileTransitionUsedRenderAhead =
+        mapRenderAheadPending && mapRenderAheadTile == tile;
     zoom = currentMapStyleSettings().zoomLevel;
-    requestMapRender(map_render_policy::Reason::Screen);
+    if (tile == MAP_GUIDANCE) {
+      mapView.followGps = true;
+    }
+    applyMapRotationForTile(tile);
+
+    bool framePublished = false;
+    bool renderPending = false;
+    if (mapRenderAheadPending && mapRenderAheadTile == tile) {
+      const uint32_t nowMs = millis();
+      framePublished = mapView.serviceRenderPipeline(nowMs);
+      if (framePublished) {
+        // Publication validates current profile semantics and viewport
+        // coverage. Clear the old intake flags so the prepared frame can be
+        // revealed now; ordinary source tracking can schedule a later refresh.
+        mapView.isPosMoved = false;
+        mapView.redrawMap = false;
+        acceptPublishedMapFrame(nowMs);
+        log_i("UI: render-ahead frame published on BOOT press");
+      } else {
+        renderPending = mapView.hasPendingRenderForCurrentScreen();
+        if (renderPending) {
+          // Keep the worker's back buffer intact instead of replacing the
+          // already-correct request with a duplicate screen-cycle request.
+          mapView.isPosMoved = false;
+          mapView.redrawMap = false;
+        }
+      }
+    }
+    mapRenderAheadPending = false;
+    if (!framePublished && !renderPending) {
+      requestMapRender(map_render_policy::Reason::Screen);
+    }
   } else {
     mapTileTransition.cancel();
+    mapTileTransitionStartedMs = 0;
+    mapTileTransitionUsedRenderAhead = false;
     lv_obj_add_flag(mapTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(navTile, LV_OBJ_FLAG_HIDDEN);
     lv_obj_add_flag(rideStatsTile, LV_OBJ_FLAG_HIDDEN);
@@ -1861,8 +1978,6 @@ static void showMainTile(tileName tile) {
   switch (tile) {
   case MAP_GUIDANCE:
     uiChangeTracker.mark(ui_update_policy::Source::Navigation);
-    mapView.followGps = true;
-    applyMapRotationForActiveTile();
     updateMapGuidanceOverlay();
     (void)uiChangeTracker.take(ui_update_policy::Source::Navigation);
     lv_obj_send_event(mapTile, LV_EVENT_VALUE_CHANGED, NULL);
@@ -1904,6 +2019,10 @@ static void showMainTile(tileName tile) {
     log_i("UI: switched to map screen");
     break;
   }
+
+  if (!isMapBackedTile(tile)) {
+    prepareNextMapScreenRenderAhead(tile);
+  }
 }
 
 static void revealPendingMapTileIfReady() {
@@ -1926,6 +2045,12 @@ static void revealPendingMapTileIfReady() {
     lv_obj_add_flag(mapGuidanceOverlay, LV_OBJ_FLAG_HIDDEN);
   }
 
+  const uint32_t visibleAtMs = millis();
+  log_i("UI: map transition visible after %lu ms renderAhead=%u",
+        static_cast<unsigned long>(visibleAtMs - mapTileTransitionStartedMs),
+        mapTileTransitionUsedRenderAhead ? 1U : 0U);
+  mapTileTransitionStartedMs = 0;
+  mapTileTransitionUsedRenderAhead = false;
   mapTileTransition.complete();
 }
 

--- a/esp32/lib/maps/src/maps.cpp
+++ b/esp32/lib/maps/src/maps.cpp
@@ -3435,25 +3435,35 @@ bool Maps::readVectorMap(
 }
 
 Maps::RenderContext Maps::captureRenderContext(uint32_t nowMs) {
+  return captureRenderContextForScreen(
+      nowMs, isMapScreenActive() || isMapGuidanceScreenActive(),
+      isMapGuidanceScreenActive());
+}
+
+Maps::RenderContext Maps::captureRenderContextForScreen(
+    uint32_t nowMs, bool mapVisible, bool guidanceScreenActive) {
   RenderContext context;
-  context.style = currentMapStyleSettings();
+  context.style = map_profile_protocol::select(
+      mapRenderSettings.mapStyle, mapRenderSettings.mapNavigationStyle,
+      guidanceScreenActive);
   context.measuredGpsWorld = {lon2x(gps.gpsData.longitude),
                               lat2y(gps.gpsData.latitude)};
   if (nowMs != 0)
-    updatePresentedPose(nowMs);
+    updatePresentedPoseForScreen(nowMs, mapVisible);
   context.presentedWorld = hasPresentedPose
                                ? map_transform::WorldPoint{
                                      presentedPose.position.x,
                                      presentedPose.position.y}
                                : context.measuredGpsWorld;
-  context.guidanceScreenActive = isMapGuidanceScreenActive();
+  context.guidanceScreenActive = guidanceScreenActive;
   context.navigationSessionActive =
       routeOverlay.hasRoute() || hasCurrentNavigationData();
-  context.followPosition = followGps || isMapGuidanceScreenActive();
+  context.followPosition = followGps || guidanceScreenActive;
   context.showCurrentPosition = isCurrentPositionVisible(mapRenderSettings);
   context.buildings3DEnabled =
       mapRenderSettings.mapNavigation3DBuildingsEnabled;
-  context.markerScale = currentMarkerScale();
+  context.markerScale = static_cast<uint8_t>(std::min(
+      std::max(static_cast<int>(context.style.positionMarkerScale), 1), 5));
   context.birdsEyePerspective =
       mapRenderSettings.mapNavigationBirdsEyePerspective;
   return context;
@@ -3565,7 +3575,8 @@ uint64_t Maps::styleSignature(const ScreenMapRenderSettings &style) const {
   return hash;
 }
 
-uint64_t Maps::navigationSignature() const {
+uint64_t
+Maps::navigationSignatureForScreen(bool guidanceScreenActive) const {
   // Only state that changes the base-frame contract belongs here. Maneuver
   // text/distance remains a lightweight LVGL overlay and must not cancel an
   // expensive base render every time its packet advances.
@@ -3573,7 +3584,7 @@ uint64_t Maps::navigationSignature() const {
   const bool guidanceSession =
       routeOverlay.hasRoute() || hasCurrentNavigationData();
   hash = fnvMix64(hash, guidanceSession ? 1U : 0U);
-  hash = fnvMix64(hash, isMapGuidanceScreenActive() ? 1U : 0U);
+  hash = fnvMix64(hash, guidanceScreenActive ? 1U : 0U);
   hash = fnvMix64(hash, static_cast<uint8_t>(rotationMode));
   return hash;
 }
@@ -3593,8 +3604,19 @@ uint64_t Maps::projectionSignature(uint8_t requestedZoom,
 }
 
 void Maps::invalidateRenderSemantics(uint32_t nowMs) {
+  invalidateRenderSemanticsForScreen(
+      nowMs, zoom, isMapScreenActive() || isMapGuidanceScreenActive(),
+      isMapGuidanceScreenActive());
+}
+
+void Maps::invalidateRenderSemanticsForScreen(uint32_t nowMs,
+                                              uint8_t requestedZoom,
+                                              bool mapVisible,
+                                              bool guidanceScreenActive) {
   bool semanticChanged = false;
-  const ScreenMapRenderSettings &style = currentMapStyleSettings();
+  const ScreenMapRenderSettings &style = map_profile_protocol::select(
+      mapRenderSettings.mapStyle, mapRenderSettings.mapNavigationStyle,
+      guidanceScreenActive);
   const uint64_t currentStyle = styleSignature(style);
   if (lastStyleSignature == 0) {
     lastStyleSignature = currentStyle;
@@ -3606,7 +3628,8 @@ void Maps::invalidateRenderSemantics(uint32_t nowMs) {
     semanticChanged = true;
   }
 
-  const uint64_t currentNavigation = navigationSignature();
+  const uint64_t currentNavigation =
+      navigationSignatureForScreen(guidanceScreenActive);
   if (lastNavigationSignature == 0) {
     lastNavigationSignature = currentNavigation;
   } else if (lastNavigationSignature != currentNavigation) {
@@ -3623,12 +3646,11 @@ void Maps::invalidateRenderSemantics(uint32_t nowMs) {
   // rider jump back to the last raw GPS coordinate. A newly received route
   // bearing still replaces remembered heading through resolve().
   uint64_t headingSession = 1469598103934665603ULL;
-  const bool mapVisible = isMapScreenActive() || isMapGuidanceScreenActive();
   const bool routeActive = routeOverlay.hasRoute();
   const bool maneuverActive = hasCurrentNavigationData();
   headingSession = fnvMix64(headingSession, mapVisible ? 1U : 0U);
-  headingSession = fnvMix64(headingSession,
-                            isMapGuidanceScreenActive() ? 1U : 0U);
+  headingSession =
+      fnvMix64(headingSession, guidanceScreenActive ? 1U : 0U);
   headingSession = fnvMix64(
       headingSession, (routeActive || maneuverActive) ? 1U : 0U);
   headingSession = fnvMix64(headingSession,
@@ -3650,10 +3672,10 @@ void Maps::invalidateRenderSemantics(uint32_t nowMs) {
   const uint16_t viewportHeight =
       mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
   const bool birdsEye = navigation_content_mode::usesMapGuidanceBirdsEye(
-      isMapGuidanceScreenActive(),
+      guidanceScreenActive,
       mapRenderSettings.mapNavigationBirdsEyeEnabled);
   const uint64_t currentProjection = projectionSignature(
-      zoom, mapScrWidth, viewportHeight, birdsEye,
+      requestedZoom, mapScrWidth, viewportHeight, birdsEye,
       mapRenderSettings.mapNavigationBirdsEyePerspective);
   if (lastProjectionSignature == 0) {
     lastProjectionSignature = currentProjection;
@@ -3685,9 +3707,13 @@ void Maps::cancelActiveRenderWork() {
 }
 
 void Maps::updatePresentedPose(uint32_t nowMs) {
+  updatePresentedPoseForScreen(
+      nowMs, isMapScreenActive() || isMapGuidanceScreenActive());
+}
+
+void Maps::updatePresentedPoseForScreen(uint32_t nowMs, bool mapVisible) {
   const bool routeActive = routeOverlay.hasRoute();
   const bool maneuverActive = hasCurrentNavigationData();
-  const bool mapVisible = isMapScreenActive() || isMapGuidanceScreenActive();
   // The session is explicit and screen-scoped. A route window or a maneuver
   // snapshot is independently sufficient to make guidance course-up valid.
   const bool sessionActive =
@@ -3809,8 +3835,19 @@ Maps::makeRequestProjection(const RenderRequest &request) const {
 
 bool Maps::buildRenderRequest(uint8_t requestedZoom, uint32_t nowMs,
                               RenderRequest &request) {
-  invalidateRenderSemantics(nowMs);
-  updatePresentedPose(nowMs);
+  return buildRenderRequestForScreen(
+      requestedZoom, nowMs,
+      isMapScreenActive() || isMapGuidanceScreenActive(),
+      isMapGuidanceScreenActive(), request);
+}
+
+bool Maps::buildRenderRequestForScreen(uint8_t requestedZoom, uint32_t nowMs,
+                                       bool mapVisible,
+                                       bool guidanceScreenActive,
+                                       RenderRequest &request) {
+  invalidateRenderSemanticsForScreen(nowMs, requestedZoom, mapVisible,
+                                     guidanceScreenActive);
+  updatePresentedPoseForScreen(nowMs, mapVisible);
 
   const uint16_t viewportHeight =
       mapSet.mapFullScreen ? mapScrFull : mapScrHeight;
@@ -3831,11 +3868,13 @@ bool Maps::buildRenderRequest(uint8_t requestedZoom, uint32_t nowMs,
                                   LV_COLOR_FORMAT_RGB565) /
       sizeof(uint16_t);
   request.birdsEye = navigation_content_mode::usesMapGuidanceBirdsEye(
-      isMapGuidanceScreenActive(),
+      guidanceScreenActive,
       mapRenderSettings.mapNavigationBirdsEyeEnabled);
-  request.context = captureRenderContext(nowMs);
+  request.context = captureRenderContextForScreen(
+      nowMs, mapVisible, guidanceScreenActive);
   request.styleSignature = styleSignature(request.context.style);
-  request.navigationSignature = navigationSignature();
+  request.navigationSignature =
+      navigationSignatureForScreen(guidanceScreenActive);
   request.projectionSignature = projectionSignature(
       request.zoom, request.viewportWidth, request.viewportHeight,
       request.birdsEye, request.context.birdsEyePerspective);
@@ -3972,16 +4011,21 @@ bool Maps::takeWorkerRequest(RenderRequest &request) {
 }
 
 bool Maps::renderRequestStillCurrent(const RenderRequest &request) const {
+  const bool guidanceScreenActive = isMapGuidanceScreenActive();
+  const ScreenMapRenderSettings &style = map_profile_protocol::select(
+      mapRenderSettings.mapStyle, mapRenderSettings.mapNavigationStyle,
+      guidanceScreenActive);
   return request.version.navigationEpoch == navigationEpoch &&
          request.version.styleEpoch == styleEpoch &&
          request.version.mapEpoch == mapEpoch &&
          request.version.projectionEpoch == projectionEpoch &&
-         request.styleSignature == styleSignature(currentMapStyleSettings()) &&
-         request.navigationSignature == navigationSignature() &&
+         request.styleSignature == styleSignature(style) &&
+         request.navigationSignature ==
+             navigationSignatureForScreen(guidanceScreenActive) &&
          request.projectionSignature == projectionSignature(
              request.zoom, request.viewportWidth, request.viewportHeight,
              navigation_content_mode::usesMapGuidanceBirdsEye(
-                 isMapGuidanceScreenActive(),
+                 guidanceScreenActive,
                  mapRenderSettings.mapNavigationBirdsEyeEnabled),
              mapRenderSettings.mapNavigationBirdsEyePerspective);
 }
@@ -4701,6 +4745,27 @@ bool Maps::serviceRenderPipeline(uint32_t nowMs) {
   updatePresentedFrameTransform();
   renderLiveForeground();
   return published;
+}
+
+bool Maps::hasPendingRenderForCurrentScreen() const {
+  if (renderStateMutex == nullptr)
+    return false;
+  if (xSemaphoreTake(renderStateMutex, 0) != pdTRUE) {
+    // The worker holds this mutex only around short state transitions. Treat a
+    // transient miss as pending so a BOOT press cannot supersede a render-ahead
+    // frame at the instant it becomes ready.
+    return true;
+  }
+
+  const map_render_job::State state = renderJobs.state();
+  const bool queued = latestRenderRequestValid &&
+                      (state == map_render_job::State::Rendering ||
+                       state == map_render_job::State::Ready ||
+                       renderJobs.hasRequestNewerThan(lastTakenRenderSequence));
+  const bool current =
+      queued && renderRequestStillCurrent(latestRenderRequest);
+  xSemaphoreGive(renderStateMutex);
+  return current;
 }
 
 bool Maps::takeFramePublication() {
@@ -7050,6 +7115,24 @@ bool Maps::generateVectorMap(uint8_t requestedZoom) {
     // state, not an allocation/render failure and must never become north-up.
     // Return false so the UI scheduler does not mark a request as submitted or
     // clear the dirty state when no immutable job was actually queued.
+    return false;
+  }
+  return submitRenderRequest(request);
+}
+
+bool Maps::prepareVectorMapForScreen(uint8_t requestedZoom,
+                                     bool guidanceScreenActive) {
+  (void)recoverRenderWorkerIfNeeded();
+  if (canvasMap == nullptr || canvasMapTemp == nullptr ||
+      renderWorkerTaskHandle == nullptr) {
+    return false;
+  }
+
+  mapTileSize = vectorMapTileSize;
+  zoomLevel = map_transform::clampRuntimeZoom(requestedZoom);
+  RenderRequest request;
+  if (!buildRenderRequestForScreen(zoomLevel, millis(), true,
+                                   guidanceScreenActive, request)) {
     return false;
   }
   return submitRenderRequest(request);

--- a/esp32/lib/maps/src/maps.hpp
+++ b/esp32/lib/maps/src/maps.hpp
@@ -325,6 +325,9 @@ private:
                         lv_obj_t *canvas, uint8_t zoom, double rotation,
                         const ScreenMapRenderSettings &style);
   RenderContext captureRenderContext(uint32_t nowMs = 0);
+  RenderContext captureRenderContextForScreen(uint32_t nowMs,
+                                              bool mapVisible,
+                                              bool guidanceScreenActive);
   static void renderWorkerTaskThunk(void *argument);
   void renderWorkerLoop();
   struct VectorMapActivationRequest {
@@ -346,6 +349,10 @@ private:
   bool recoverRenderWorkerIfNeeded();
   bool buildRenderRequest(uint8_t zoom, uint32_t nowMs,
                           RenderRequest &request);
+  bool buildRenderRequestForScreen(uint8_t zoom, uint32_t nowMs,
+                                   bool mapVisible,
+                                   bool guidanceScreenActive,
+                                   RenderRequest &request);
   bool submitRenderRequest(const RenderRequest &request);
   void cancelActiveRenderWork();
   bool takeWorkerRequest(RenderRequest &request);
@@ -353,12 +360,16 @@ private:
   bool renderRequestStillCurrent(const RenderRequest &request) const;
   bool renderResultStillCurrent(const RenderResult &result) const;
   void updatePresentedPose(uint32_t nowMs);
+  void updatePresentedPoseForScreen(uint32_t nowMs, bool mapVisible);
   void updatePresentedFrameTransform();
   void renderLiveForeground();
   void invalidateRenderSemantics(uint32_t nowMs);
+  void invalidateRenderSemanticsForScreen(uint32_t nowMs, uint8_t zoom,
+                                          bool mapVisible,
+                                          bool guidanceScreenActive);
   bool presentationGestureOwnsTransforms() const;
   uint64_t styleSignature(const ScreenMapRenderSettings &style) const;
-  uint64_t navigationSignature() const;
+  uint64_t navigationSignatureForScreen(bool guidanceScreenActive) const;
   uint64_t projectionSignature(uint8_t zoom, uint16_t viewportWidth,
                                uint16_t viewportHeight, bool birdsEye,
                                uint8_t perspective) const;
@@ -565,7 +576,9 @@ public:
   void createMapScrSprites();
   void generateRenderMap(uint8_t zoom);
   bool generateVectorMap(uint8_t zoom);
+  bool prepareVectorMapForScreen(uint8_t zoom, bool guidanceScreenActive);
   bool serviceRenderPipeline(uint32_t nowMs);
+  bool hasPendingRenderForCurrentScreen() const;
   bool takeFramePublication();
   bool takeRenderFailure();
   bool hasPublishedMapFrame() const { return publishedMapFrame; }

--- a/esp32/tools/tests/test_map_guidance_integration.py
+++ b/esp32/tools/tests/test_map_guidance_integration.py
@@ -220,15 +220,17 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
 
     def test_guidance_session_accepts_route_or_maneuver_packets(self):
         navigation_signature = function_body(
-            MAP_RENDERER_SOURCE, "uint64_t Maps::navigationSignature"
+            MAP_RENDERER_SOURCE, "Maps::navigationSignatureForScreen"
         )
-        pose = function_body(MAP_RENDERER_SOURCE, "void Maps::updatePresentedPose")
+        pose = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::updatePresentedPoseForScreen"
+        )
         self.assertIn("routeOverlay.hasRoute() || hasCurrentNavigationData()", navigation_signature)
         self.assertIn("routeActive || maneuverActive", pose)
         self.assertIn("headingResolver.resolve", pose)
         self.assertIn("gps.gpsData.heading < 360U", pose)
         semantics = function_body(
-            MAP_RENDERER_SOURCE, "void Maps::invalidateRenderSemantics"
+            MAP_RENDERER_SOURCE, "void Maps::invalidateRenderSemanticsForScreen"
         )
         self.assertNotIn("routeOverlay.revision()", semantics)
         self.assertIn("posePresenter.resetHeading(nowMs)", semantics)
@@ -240,7 +242,9 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         self.assertIn("graceElapsedMs * graceElapsedMs", MAP_PRESENTATION_SOURCE)
         self.assertIn("predictionExhausted", MAP_PRESENTATION_SOURCE)
 
-        pose = function_body(MAP_RENDERER_SOURCE, "void Maps::updatePresentedPose")
+        pose = function_body(
+            MAP_RENDERER_SOURCE, "void Maps::updatePresentedPoseForScreen"
+        )
         self.assertIn("bleStats.lastGpsPacketMs", pose)
         self.assertIn("bleStats.gpsPacketCount", pose)
         self.assertIn("fix.timestampMs", pose)
@@ -340,16 +344,17 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
 
     def test_idle_guidance_screen_keeps_birdseye_3d_enabled(self):
         capture = function_body(
-            MAP_RENDERER_SOURCE, "Maps::RenderContext Maps::captureRenderContext"
+            MAP_RENDERER_SOURCE,
+            "Maps::RenderContext Maps::captureRenderContextForScreen",
         )
         render = function_body(
             MAP_RENDERER_SOURCE, "bool Maps::readVectorMap"
         )
         request = function_body(
-            MAP_RENDERER_SOURCE, "bool Maps::buildRenderRequest"
+            MAP_RENDERER_SOURCE, "bool Maps::buildRenderRequestForScreen"
         )
         self.assertIn(
-            "context.guidanceScreenActive = isMapGuidanceScreenActive()",
+            "context.guidanceScreenActive = guidanceScreenActive",
             capture,
         )
         self.assertIn(
@@ -539,11 +544,68 @@ class MapGuidanceIntegrationTests(unittest.TestCase):
         prepare = function_body(
             MAIN_SCREEN_SOURCE, "static bool prepareVisibleMapUpdate"
         )
-        self.assertIn("mapTileTransition.noteFramePublished()", prepare)
-        self.assertLess(
-            prepare.index("mapTileTransition.noteFramePublished()"),
-            prepare.index("revealPendingMapTileIfReady()"),
+        self.assertIn("acceptPublishedMapFrame(nowMs)", prepare)
+        accept = function_body(
+            MAIN_SCREEN_SOURCE, "static void acceptPublishedMapFrame"
         )
+        self.assertIn("mapTileTransition.noteFramePublished()", accept)
+        self.assertLess(
+            accept.index("mapTileTransition.noteFramePublished()"),
+            accept.index("revealPendingMapTileIfReady()"),
+        )
+
+    def test_non_map_screens_render_ahead_without_overwriting_ready_frame(self):
+        show = function_body(MAIN_SCREEN_SOURCE, "static void showMainTile")
+        self.assertIn("prepareNextMapScreenRenderAhead(tile);", show)
+        self.assertLess(
+            show.index("mapView.serviceRenderPipeline(nowMs)"),
+            show.index("requestMapRender(map_render_policy::Reason::Screen)"),
+        )
+        self.assertIn("mapView.hasPendingRenderForCurrentScreen()", show)
+
+        render_ahead = function_body(
+            MAIN_SCREEN_SOURCE, "static void prepareNextMapScreenRenderAhead"
+        )
+        self.assertIn("mapView.prepareVectorMapForScreen", render_ahead)
+        self.assertIn("mapView.isPosMoved = false", render_ahead)
+        self.assertIn("mapView.redrawMap = false", render_ahead)
+        self.assertIn("noteMapRenderReasons", render_ahead)
+
+        renderer_prepare = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::prepareVectorMapForScreen"
+        )
+        self.assertIn("buildRenderRequestForScreen", renderer_prepare)
+        self.assertIn("submitRenderRequest(request)", renderer_prepare)
+        for forbidden in (
+            "heap_caps_malloc",
+            "ensureMapScreenBuffer",
+            "ensureMapTempBuffer",
+            "readVectorMap",
+            "lv_canvas_set_buffer",
+        ):
+            self.assertNotIn(forbidden, renderer_prepare)
+
+        pending = function_body(
+            MAP_RENDERER_SOURCE,
+            "bool Maps::hasPendingRenderForCurrentScreen",
+        )
+        self.assertIn("renderRequestStillCurrent(latestRenderRequest)", pending)
+
+    def test_render_ahead_captures_destination_profile_semantics(self):
+        build = function_body(
+            MAP_RENDERER_SOURCE, "bool Maps::buildRenderRequestForScreen"
+        )
+        self.assertIn("guidanceScreenActive", build)
+        self.assertIn("captureRenderContextForScreen", build)
+        self.assertIn("navigationSignatureForScreen", build)
+        self.assertIn("request.birdsEye", build)
+
+    def test_map_transition_logs_render_ahead_latency(self):
+        reveal = function_body(
+            MAIN_SCREEN_SOURCE, "static void revealPendingMapTileIfReady() {"
+        )
+        self.assertIn("map transition visible after %lu ms", reveal)
+        self.assertIn("mapTileTransitionUsedRenderAhead", reveal)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- pre-render the next enabled map-backed screen while a lightweight screen is visible
- reuse the existing render worker and back buffer, without adding another persistent framebuffer
- publish a ready destination frame immediately on BOOT and log the transition timing

## Root cause

BOOT input already wakes the UI immediately. Map-backed transitions deliberately keep the shared canvas hidden until a frame matching the destination profile is published, but rendering previously started only after entering that screen. That made the button feel delayed even though input handling was prompt.

## Impact

Map and Map + Navigation screens can become visible immediately when render-ahead is ready. Unfinished current preparation continues without restarting; stale or failed work safely falls back to the existing foreground render path.

## Validation

- rebased onto `main` at `81aeb0c46b793ae5e392c99de7c3265fe4ed3aee`
- `PYTHONPATH=tools python3 -m unittest ...`: 217 tests passed
- 1.75-inch GUI layout host binary passed
- 2.06-inch GUI layout host binary passed
- `env -u LD_LIBRARY_PATH python3 tools/build_firmware.py WAVESHARE_AMOLED_175` passed
  - RAM: 84,520 / 327,680 bytes (25.8%)
  - Flash: 3,054,883 / 3,145,728 bytes (97.1%)
  - build provenance: `uploadEligible=1`, commit `5fb1c95a6ccd3cdfd897f786a803e4117cb11d23`
  - firmware SHA-256: `7bc6e809baca398214a6e0fd4c687a406954bc01c749666a10f739bfc291f55b`
  - flash-plan SHA-256: `db2a5574fa71a06fb92cb418202885549af23d6a64b8c45851b7b89a54bb1645`
- all selected GitHub CI checks passed, including all four ESP32 target builds and ESP32 host tests
- `git diff --check` passed

Physical timing validation is pending. The next step is to flash the confirmed `WAVESHARE_AMOLED_175` device and inspect `UI: map transition visible after ... renderAhead=...` logs.
