### PR TITLE
Reorganize device screen UI settings

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -91,7 +91,9 @@ struct SettingsView: View {
                 }
 
                 MainFirmwareUpdateSection(manager: firmwareUpdateManager)
-                DeviceScreensSettingsSection()
+                DeviceScreensSettingsSection(
+                    offlineMapManager: offlineMapManager
+                )
                 SavedMapsSettingsSection(
                     manager: offlineMapManager,
                     focusedPackFilename: $focusedSavedMapFilename
@@ -140,14 +142,6 @@ struct SettingsView: View {
                         )
                     } label: {
                         Label("Ride Detection", systemImage: "figure.outdoor.cycle")
-                    }
-
-                    NavigationLink {
-                        UICustomizationSettingsView(
-                            offlineMapManager: offlineMapManager
-                        )
-                    } label: {
-                        Label("UI Customization", systemImage: "slider.horizontal.3")
                     }
 
                     NavigationLink {
@@ -1073,15 +1067,53 @@ private struct FirmwareUpdateSettingsSection: View {
 
 private struct DeviceScreensSettingsSection: View {
     @EnvironmentObject private var bleManager: BLEManager
+    let offlineMapManager: OfflineMapManager
 
     var body: some View {
-        Section(header: Text("Device Screens")) {
+        Section(
+            header: Text("Device Screens"),
+            footer: Text(mapStyleFooter)
+        ) {
             ForEach(bleManager.availableDeviceScreens) { screen in
-                Toggle(screen.title, isOn: Binding(
-                    get: { bleManager.isDeviceScreenEnabled(screen) },
-                    set: { bleManager.setDeviceScreen(screen, enabled: $0) }
-                ))
-                .disabled(bleManager.isOnlyEnabledDeviceScreen(screen))
+                HStack(spacing: 8) {
+                    Text(screen.title)
+                    Spacer()
+
+                    if let styleScreen = mapStyleScreen(for: screen) {
+                        NavigationLink {
+                            MapStyleSettingsView(
+                                screen: styleScreen,
+                                offlineMapManager: offlineMapManager
+                            )
+                        } label: {
+                            Image(systemName: "gearshape")
+                                .frame(width: 44, height: 44)
+                                .contentShape(Rectangle())
+                        }
+                        .buttonStyle(.borderless)
+                        .accessibilityLabel(
+                            mapStyleAccessibilityLabel(for: screen)
+                        )
+                    }
+
+                    Toggle(
+                        screen.title,
+                        isOn: Binding(
+                            get: {
+                                bleManager.isDeviceScreenEnabled(screen)
+                            },
+                            set: {
+                                bleManager.setDeviceScreen(
+                                    screen,
+                                    enabled: $0
+                                )
+                            }
+                        )
+                    )
+                    .labelsHidden()
+                    .accessibilityLabel("\(screen.title) screen")
+                    .disabled(bleManager.isOnlyEnabledDeviceScreen(screen))
+                }
             }
 
             Picker("Default Screen", selection: Binding(
@@ -1099,59 +1131,59 @@ private struct DeviceScreensSettingsSection: View {
         .disabled(!bleManager.supportsDeviceSettings ||
                   !bleManager.hasReceivedDeviceCapabilities)
     }
-}
 
-private struct UICustomizationSettingsView: View {
-    @EnvironmentObject private var bleManager: BLEManager
-    @ObservedObject var offlineMapManager: OfflineMapManager
-
-    private var screenStylesFooter: String {
+    private var mapStyleFooter: String {
         if !bleManager.hasReceivedDeviceCapabilities {
             return "Checking whether the connected firmware supports independent map styles."
         }
         if bleManager.supportsIndependentMapProfiles {
-            return "Configure map appearance independently for each device screen."
+            return "Use the gear buttons to configure Map and Map + Navigation independently."
         }
-        return "This firmware uses one shared style for both map screens. Update the firmware to configure them independently."
+        return "This firmware uses one shared style for Map and Map + Navigation. Either gear opens the shared Map Screens settings."
     }
 
-    var body: some View {
-        Form {
-            Section(header: Text("Screen Styles"), footer: Text(screenStylesFooter)) {
-                NavigationLink {
-                    MapStyleSettingsView(
-                        screen: .map,
-                        offlineMapManager: offlineMapManager
-                    )
-                } label: {
-                    Label(bleManager.supportsIndependentMapProfiles ? "Map" : "Map Screens",
-                          systemImage: "map")
-                }
-
-                if bleManager.supportsIndependentMapProfiles {
-                    NavigationLink {
-                        MapStyleSettingsView(
-                            screen: .mapPlusNavigation,
-                            offlineMapManager: offlineMapManager
-                        )
-                    } label: {
-                        Label("Map + Navigation", systemImage: "location.north.line")
-                    }
-                }
-            }
-            .disabled(!bleManager.supportsDeviceSettings ||
-                      !bleManager.hasReceivedDeviceCapabilities)
-
-            Section(header: Text("Navigation Overlays"), footer: Text("Show or hide live navigation layers drawn above both map screens.")) {
-                Toggle("Route Line", isOn: $bleManager.showRouteOverlay)
-                    .onChange(of: bleManager.showRouteOverlay) { _ in bleManager.sendVisibilityMask() }
-                Toggle("Current Position", isOn: $bleManager.showCurrentPosition)
-                    .onChange(of: bleManager.showCurrentPosition) { _ in bleManager.sendVisibilityMask() }
-            }
-            .disabled(!bleManager.supportsDeviceSettings)
+    private func mapStyleAccessibilityLabel(for screen: DeviceScreen) -> String {
+        if !bleManager.supportsIndependentMapProfiles {
+            return "Shared Map Screens UI settings, affects Map and Map + Navigation"
         }
-        .navigationTitle("UI Customization")
-        .navigationBarTitleDisplayMode(.inline)
+        return "\(screen.title) UI settings"
+    }
+
+    private func mapStyleScreen(for screen: DeviceScreen) -> MapStyleScreen? {
+        switch screen {
+        case .map:
+            return .map
+        case .mapPlusNavigation:
+            return bleManager.supportsIndependentMapProfiles
+                ? .mapPlusNavigation
+                : .map
+        case .navigation, .rideStats, .batteryStatus:
+            return nil
+        }
+    }
+}
+
+private struct NavigationOverlaysSettingsSection: View {
+    @EnvironmentObject private var bleManager: BLEManager
+
+    var body: some View {
+        Section {
+            Toggle("Route Line", isOn: $bleManager.showRouteOverlay)
+                .onChange(of: bleManager.showRouteOverlay) { _ in
+                    bleManager.sendVisibilityMask()
+                }
+            Toggle("Current Position", isOn: $bleManager.showCurrentPosition)
+                .onChange(of: bleManager.showCurrentPosition) { _ in
+                    bleManager.sendVisibilityMask()
+                }
+        } header: {
+            Text("Navigation Overlays")
+        } footer: {
+            Text(
+                "Show or hide live navigation layers drawn above both map screens."
+            )
+        }
+        .disabled(!bleManager.supportsDeviceSettings)
     }
 }
 
@@ -2343,6 +2375,8 @@ private struct DeveloperSettingsView: View {
                     }
                 }
             }
+
+            NavigationOverlaysSettingsSection()
         }
         .navigationTitle("Developer Settings")
         .navigationBarTitleDisplayMode(.inline)

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1075,9 +1075,8 @@ private struct DeviceScreensSettingsSection: View {
             footer: Text(mapStyleFooter)
         ) {
             ForEach(bleManager.availableDeviceScreens) { screen in
-                HStack(spacing: 8) {
+                HStack(spacing: 4) {
                     Text(screen.title)
-                    Spacer()
 
                     if let styleScreen = mapStyleScreen(for: screen) {
                         NavigationLink {
@@ -1087,7 +1086,11 @@ private struct DeviceScreensSettingsSection: View {
                             )
                         } label: {
                             Image(systemName: "gearshape")
-                                .frame(width: 44, height: 44)
+                                .frame(
+                                    width: 44,
+                                    height: 44,
+                                    alignment: .leading
+                                )
                                 .contentShape(Rectangle())
                         }
                         .buttonStyle(.borderless)
@@ -1095,6 +1098,8 @@ private struct DeviceScreensSettingsSection: View {
                             mapStyleAccessibilityLabel(for: screen)
                         )
                     }
+
+                    Spacer()
 
                     Toggle(
                         screen.title,

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8057,15 +8057,24 @@ struct NavigationProtocolTests {
         let overlaySection = String(source[overlaySectionStart..<mapStyleStart])
 
         assert(
-            deviceSection.contains("Image(systemName: \"gearshape\")") &&
-                deviceSection.contains(".frame(width: 44, height: 44)") &&
+            deviceSection.contains("HStack(spacing: 4)") &&
+                deviceSection.contains("Image(systemName: \"gearshape\")") &&
+                deviceSection.contains(
+                    "width: 44,\n" +
+                        "                                    height: 44,\n" +
+                        "                                    alignment: .leading"
+                ) &&
                 deviceSection.contains(".contentShape(Rectangle())") &&
                 deviceSection.contains(".buttonStyle(.borderless)") &&
                 deviceSection.contains(".labelsHidden()"),
-            "map-screen rows keep distinct accessible gear and toggle controls"
+            "map-screen rows keep a close-leading accessible gear and trailing toggle"
         )
-        guard let gearCondition = deviceSection.range(
-            of: "if let styleScreen = mapStyleScreen(for: screen)"
+        guard let rowText = deviceSection.range(
+            of: "Text(screen.title)"
+        ),
+        let gearCondition = deviceSection.range(
+            of: "if let styleScreen = mapStyleScreen(for: screen)",
+            range: rowText.upperBound..<deviceSection.endIndex
         ),
         let gearDestination = deviceSection.range(
             of: "MapStyleSettingsView(",
@@ -8079,9 +8088,13 @@ struct NavigationProtocolTests {
             of: "Image(systemName: \"gearshape\")",
             range: destinationBinding.upperBound..<deviceSection.endIndex
         ),
+        let trailingSpacer = deviceSection.range(
+            of: "Spacer()",
+            range: gearImage.upperBound..<deviceSection.endIndex
+        ),
         let screenToggle = deviceSection.range(
             of: "Toggle(",
-            range: gearImage.upperBound..<deviceSection.endIndex
+            range: trailingSpacer.upperBound..<deviceSection.endIndex
         ),
         let screenGetter = deviceSection.range(
             of: "bleManager.isDeviceScreenEnabled(screen)",
@@ -8110,16 +8123,18 @@ struct NavigationProtocolTests {
             return
         }
         assert(
-            gearCondition.lowerBound < gearDestination.lowerBound &&
+            rowText.lowerBound < gearCondition.lowerBound &&
+                gearCondition.lowerBound < gearDestination.lowerBound &&
                 gearDestination.lowerBound < destinationBinding.lowerBound &&
                 destinationBinding.lowerBound < gearImage.lowerBound &&
-                gearImage.lowerBound < screenToggle.lowerBound &&
+                gearImage.lowerBound < trailingSpacer.lowerBound &&
+                trailingSpacer.lowerBound < screenToggle.lowerBound &&
                 screenToggle.lowerBound < screenGetter.lowerBound &&
                 screenGetter.lowerBound < screenSetter.lowerBound &&
                 screenSetter.lowerBound < setterScreen.lowerBound &&
                 setterScreen.lowerBound < setterValue.lowerBound &&
                 setterValue.lowerBound < lastScreenGuard.lowerBound,
-            "each map gear precedes an independent toggle wired to the same screen"
+            "each map gear sits beside its label before the trailing screen toggle"
         )
         assert(
             deviceSection.contains("case .map:\n            return .map") &&

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -728,6 +728,7 @@ struct NavigationProtocolTests {
         testOfflineMapManagerRepairsGeneratedPackDefaults()
         testOfflineMapManagerRenamesCachedPack()
         testSavedMapRenameViewWiring()
+        testDeviceScreenUISettingsWiring()
         testSavedRouteNamingAndViewWiring()
         testOfflineMapManagerRestoresLastTransferIdentity()
         testOfflineMapManagerReconcilesInterruptedActivation()
@@ -8020,6 +8021,156 @@ struct NavigationProtocolTests {
                 managerSource.contains("catch is CancellationError") &&
                 managerSource.contains("OfflineMapPackCompatibilityArchive.remove("),
             "preview ZIPs retain resumable background upload through a sanitized archive"
+        )
+    }
+
+    static func testDeviceScreenUISettingsWiring() {
+        let sourceURL = URL(fileURLWithPath:
+            "ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift"
+        )
+        guard let source = try? String(contentsOf: sourceURL, encoding: .utf8) else {
+            assert(false, "settings view source should be available to the integration test")
+            return
+        }
+
+        assert(
+            !source.contains("UICustomizationSettingsView") &&
+                !source.contains("UI Customization"),
+            "Settings removes the standalone UI Customization destination"
+        )
+
+        guard let deviceSectionStart = source.range(
+            of: "private struct DeviceScreensSettingsSection"
+        )?.lowerBound,
+        let overlaySectionStart = source.range(
+            of: "private struct NavigationOverlaysSettingsSection",
+            range: deviceSectionStart..<source.endIndex
+        )?.lowerBound,
+        let mapStyleStart = source.range(
+            of: "private enum MapStyleScreen",
+            range: overlaySectionStart..<source.endIndex
+        )?.lowerBound else {
+            assert(false, "device-screen settings source boundaries should be present")
+            return
+        }
+        let deviceSection = String(source[deviceSectionStart..<overlaySectionStart])
+        let overlaySection = String(source[overlaySectionStart..<mapStyleStart])
+
+        assert(
+            deviceSection.contains("Image(systemName: \"gearshape\")") &&
+                deviceSection.contains(".frame(width: 44, height: 44)") &&
+                deviceSection.contains(".contentShape(Rectangle())") &&
+                deviceSection.contains(".buttonStyle(.borderless)") &&
+                deviceSection.contains(".labelsHidden()"),
+            "map-screen rows keep distinct accessible gear and toggle controls"
+        )
+        guard let gearCondition = deviceSection.range(
+            of: "if let styleScreen = mapStyleScreen(for: screen)"
+        ),
+        let gearDestination = deviceSection.range(
+            of: "MapStyleSettingsView(",
+            range: gearCondition.upperBound..<deviceSection.endIndex
+        ),
+        let destinationBinding = deviceSection.range(
+            of: "screen: styleScreen",
+            range: gearDestination.upperBound..<deviceSection.endIndex
+        ),
+        let gearImage = deviceSection.range(
+            of: "Image(systemName: \"gearshape\")",
+            range: destinationBinding.upperBound..<deviceSection.endIndex
+        ),
+        let screenToggle = deviceSection.range(
+            of: "Toggle(",
+            range: gearImage.upperBound..<deviceSection.endIndex
+        ),
+        let screenGetter = deviceSection.range(
+            of: "bleManager.isDeviceScreenEnabled(screen)",
+            range: screenToggle.upperBound..<deviceSection.endIndex
+        ),
+        let screenSetter = deviceSection.range(
+            of: "bleManager.setDeviceScreen(",
+            range: screenGetter.upperBound..<deviceSection.endIndex
+        ),
+        let setterScreen = deviceSection.range(
+            of: "screen,",
+            range: screenSetter.upperBound..<deviceSection.endIndex
+        ),
+        let setterValue = deviceSection.range(
+            of: "enabled: $0",
+            range: setterScreen.upperBound..<deviceSection.endIndex
+        ),
+        let lastScreenGuard = deviceSection.range(
+            of: ".disabled(bleManager.isOnlyEnabledDeviceScreen(screen))",
+            range: setterValue.upperBound..<deviceSection.endIndex
+        ) else {
+            assert(
+                false,
+                "each row should keep its routed gear, screen-specific toggle, and last-screen guard"
+            )
+            return
+        }
+        assert(
+            gearCondition.lowerBound < gearDestination.lowerBound &&
+                gearDestination.lowerBound < destinationBinding.lowerBound &&
+                destinationBinding.lowerBound < gearImage.lowerBound &&
+                gearImage.lowerBound < screenToggle.lowerBound &&
+                screenToggle.lowerBound < screenGetter.lowerBound &&
+                screenGetter.lowerBound < screenSetter.lowerBound &&
+                screenSetter.lowerBound < setterScreen.lowerBound &&
+                setterScreen.lowerBound < setterValue.lowerBound &&
+                setterValue.lowerBound < lastScreenGuard.lowerBound,
+            "each map gear precedes an independent toggle wired to the same screen"
+        )
+        assert(
+            deviceSection.contains("case .map:\n            return .map") &&
+                deviceSection.contains("case .mapPlusNavigation:") &&
+                deviceSection.contains("? .mapPlusNavigation\n                : .map") &&
+                deviceSection.contains(
+                    "case .navigation, .rideStats, .batteryStatus:\n            return nil"
+                ),
+            "only Map rows receive gears and legacy firmware opens the shared map profile"
+        )
+        assert(
+            deviceSection.contains(
+                "This firmware uses one shared style for Map and Map + Navigation."
+            ) &&
+                deviceSection.contains(
+                    "Shared Map Screens UI settings, affects Map and Map + Navigation"
+                ),
+            "legacy shared-profile behavior is visible and accurately announced"
+        )
+
+        guard let developerStart = source.range(
+            of: "private struct DeveloperSettingsView"
+        )?.lowerBound else {
+            assert(false, "developer settings source boundary should be present")
+            return
+        }
+        let developerSource = String(source[developerStart...])
+        assert(
+            developerSource.contains(
+                "NavigationOverlaysSettingsSection()\n        }\n        .navigationTitle(\"Developer Settings\")"
+            ),
+            "Navigation Overlays is the final Developer Settings form section"
+        )
+        assert(
+            overlaySection.contains(
+                "Toggle(\"Route Line\", isOn: $bleManager.showRouteOverlay)\n" +
+                    "                .onChange(of: bleManager.showRouteOverlay) { _ in\n" +
+                    "                    bleManager.sendVisibilityMask()"
+            ) &&
+                overlaySection.contains(
+                    "Toggle(\"Current Position\", isOn: $bleManager.showCurrentPosition)\n" +
+                        "                .onChange(of: bleManager.showCurrentPosition) { _ in\n" +
+                        "                    bleManager.sendVisibilityMask()"
+                ) &&
+                overlaySection.components(
+                    separatedBy: "bleManager.sendVisibilityMask()"
+                ).count - 1 == 2 &&
+                overlaySection.contains(
+                    ".disabled(!bleManager.supportsDeviceSettings)"
+                ),
+            "Navigation Overlays retains both BLE callbacks and its capability guard"
         )
     }
 


### PR DESCRIPTION
## Summary

- move Navigation Overlays out of UI Customization and make it the final section in Developer Settings
- add dedicated gear controls beside the Map + Navigation and Map screen toggles
- route each gear to its matching UI settings while keeping the toggle action independent
- preserve the shared Map Screens editor and explanatory accessibility copy for legacy firmware
- remove the standalone UI Customization destination
- add focused mutation-sensitive regression coverage for destination routing, toggle wiring, overlay callbacks, accessibility, and section placement

## Why

Map appearance settings now live next to the device screens they configure, while developer-only navigation overlay controls are grouped with the rest of Developer Settings. This removes an unnecessary intermediate settings page and makes the relationship between a screen toggle and its UI configuration explicit.

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `./ios-app/scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`
- deep review-fix loop completed with no remaining P0/P1/P2 findings
- negative mutations verified the regression test fails for a hard-coded map destination, a hard-coded screen toggle target, and a missing overlay visibility callback

## Remaining manual check

- no separate Simulator/device tap or Accessibility Inspector pass was performed