### PR TITLE
Prepare firmware 0.3.3 release

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.3.2
-revision = 91
+version = 0.3.3
+revision = 92
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
## Summary

- bump firmware version from `0.3.2` to `0.3.3`
- bump firmware revision from `91` to `92`

This gives the post-#244 release artifacts a new on-device identity before creating the immutable `v0.3.3` release.

## Validation

- `git diff --check`
- parsed `esp32/platformio.ini` and asserted version `0.3.3`, revision `92`
- firmware production profile contract check

The release-manifest unit modules are covered by PR CI. Their repository-pinned signing wheels target the Linux release runner, so the exact-hash install intentionally does not accept this macOS Python wheel.
