### PR TITLE
Fix firmware release caller permissions

### DIFF
--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -319,7 +319,10 @@ class WorkflowPolicyTests(unittest.TestCase):
             "uses: ./.github/workflows/firmware-diagnostics.yml", release
         )
         self.assertIn("      - build\n      - diagnostics\n      - validate\n", release)
-        self.assertIn("permissions:\n  contents: read\n", release)
+        release_permissions = mapping_block(release, "permissions", indent=0)
+        self.assertIn("  attestations: read", release_permissions)
+        self.assertIn("  contents: read", release_permissions)
+        self.assertIn("  packages: read", release_permissions)
         publish_job = mapping_block(release, "publish", indent=2)
         self.assertIn("contents: write", publish_job)
         self.assertIn("pages: write", publish_job)

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -6,7 +6,9 @@ on:
       - "v*"
 
 permissions:
+  attestations: read
   contents: read
+  packages: read
 
 jobs:
   validate:


### PR DESCRIPTION
## Summary

- grant the firmware-release caller the read-only attestation and package permissions required by its reusable full-CI workflow
- make the workflow-policy test require all three caller permissions

## Root cause

The first `v0.3.3` run failed during workflow validation before any job started. `firmware-release.yml` called `ci.yml`, whose nested map-platform job requests `attestations: read` and `packages: read`, while the caller allowed both as `none`.

No release or release asset was created. The existing `v0.3.3` tag remains unchanged at `7b5aef0d3cb085a62a52994105e1b6ba42ed0470`.

## Validation

- `python3 -m unittest discover -s .github/scripts/tests` (49 tests)
- `git diff --check`
