### PR TITLE
Show app version in Settings

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -150,6 +150,11 @@ struct SettingsView: View {
                         Label("Hardware Customization", systemImage: "dial.low")
                     }
 
+                    SettingsValueRow(
+                        title: "App Version",
+                        value: appVersionText
+                    )
+
                     NavigationLink {
                         DeveloperSettingsView(
                             offlineMapManager: offlineMapManager,
@@ -178,6 +183,26 @@ struct SettingsView: View {
             }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+
+    private var appVersionText: String {
+        let version = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String
+        let build = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String
+
+        switch (version, build) {
+        case let (version?, build?):
+            return "\(version) (\(build))"
+        case let (version?, nil):
+            return version
+        case let (nil, build?):
+            return build
+        case (nil, nil):
+            return "Unknown"
         }
     }
 


### PR DESCRIPTION
## Summary

- show the installed iOS app version directly above Developer Settings
- include both the marketing version and build number from the app bundle
- fall back gracefully if either bundle value is unavailable

## Why

This makes it easy to identify the exact installed build when troubleshooting or comparing development and App Store installations.

## User impact

The Settings screen now displays the current app identity in the form `1.3 (10)` without requiring navigation into developer tools.

## Validation

- `git diff --check`
- `xcodebuild -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -configuration Debug -destination 'generic/platform=iOS Simulator' -derivedDataPath /tmp/open-bike-version-pr-derived CODE_SIGNING_ALLOWED=NO build`
- verified the built app bundle reports `CFBundleShortVersionString = 1.3` and `CFBundleVersion = 10`