### PR TITLE
Show actionable map scope errors

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -877,9 +877,15 @@ enum OfflineMapJobPoller {
         fetch: @escaping (String) async throws -> OfflineMapJob,
         sleep: @escaping (UInt64) async throws -> Void,
         onUpdate: @escaping (OfflineMapJob) -> Void,
-        onRetry: @escaping () -> Void
+        onRetry: @escaping () -> Void,
+        legacyFailedGraceSeconds: TimeInterval = 30,
+        monotonicNow: @escaping () -> TimeInterval = {
+            ProcessInfo.processInfo.systemUptime
+        }
     ) async throws -> OfflineMapJob {
         var consecutiveFailures = 0
+        var legacyFailedAttempt: Int?
+        var legacyFailedDeadline: TimeInterval?
         while !Task.isCancelled {
             let job: OfflineMapJob
             do {
@@ -897,9 +903,39 @@ enum OfflineMapJobPoller {
                 continue
             }
 
+            if job.status != "failed" {
+                legacyFailedAttempt = nil
+                legacyFailedDeadline = nil
+            }
+            if job.mayBeLegacyRetryTransition,
+               let attempt = job.attempts {
+                // Older workers briefly persisted FAILED before QUEUED. Confirm
+                // this ambiguous state for a bounded grace window so rolling
+                // deployments do not discard a job the server is retrying.
+                // Inline-worker failures remain terminal when the window ends.
+                let observedAt = monotonicNow()
+                if legacyFailedAttempt != attempt || legacyFailedDeadline == nil {
+                    legacyFailedAttempt = attempt
+                    legacyFailedDeadline = observedAt + max(
+                        0,
+                        legacyFailedGraceSeconds
+                    )
+                }
+                if let deadline = legacyFailedDeadline, observedAt < deadline {
+                    try await sleep(pollIntervalNanoseconds)
+                    continue
+                }
+            }
+
             onUpdate(job)
             if job.status == "ready", job.mapId != nil {
                 return job
+            }
+            if job.status == "cancelled" {
+                throw OfflineMapPlatformError.mapJobCancelled
+            }
+            if job.status == "expired" {
+                throw OfflineMapPlatformError.mapJobExpired
             }
             if job.isTerminal {
                 throw OfflineMapPlatformError.mapJobFailed(

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -902,9 +902,9 @@ enum OfflineMapJobPoller {
                 return job
             }
             if job.isTerminal {
-                throw OfflineMapPlatformError.serverStatus(
-                    409,
-                    job.error ?? "Map job ended with status \(job.status)"
+                throw OfflineMapPlatformError.mapJobFailed(
+                    code: job.errorCode,
+                    message: job.error ?? "Map job ended with status \(job.status)"
                 )
             }
             try await sleep(pollIntervalNanoseconds)

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -977,10 +977,24 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
         case .unsupportedRendererTarget(_, _, let message):
             return message
         case .mapJobFailed(let code, let message):
-            if code == "building_scope_exceeded" {
+            switch code {
+            case "building_scope_exceeded":
                 return "This selection is too large for 3D buildings. Choose a smaller area and try again. The processing limit includes the required buffer, and water inside the selection counts."
+            case "building_source_snapshot_changed":
+                return "Map data changed while your map was being built. Retry the same area."
+            case "source_cache_unavailable":
+                return "Map data for this area is temporarily unavailable. Try again later."
+            case "building_relation_incomplete":
+                return "Some buildings could not be included completely. Adjust the selected area slightly and try again."
+            case "building_calibration_unavailable":
+                return "3D building data could not be prepared. Try again later."
+            case "building_scope_policy_invalid":
+                return "The map service is temporarily misconfigured. Try again later."
+            case "map_build_failed":
+                return "We couldn't build this map after several attempts. Try again. If it keeps failing, report the problem."
+            default:
+                return "Map generation failed: \(message)"
             }
-            return "Map generation failed: \(message)"
         case .serverStatus(let status, let body):
             return "Map server returned \(status): \(body)"
         }

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -297,6 +297,7 @@ struct OfflineMapJob: Decodable, Equatable {
     let status: String
     let createdAt: String?
     let error: String?
+    let errorCode: String?
     let mapId: String?
     let packPath: String?
     let geometry: OfflineMapJobGeometry?
@@ -940,6 +941,7 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
         supportedRendererFormatVersions: [Int],
         message: String
     )
+    case mapJobFailed(code: String?, message: String)
     case serverStatus(Int, String)
 
     var errorDescription: String? {
@@ -974,6 +976,11 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
             return "Map server returned an invalid response"
         case .unsupportedRendererTarget(_, _, let message):
             return message
+        case .mapJobFailed(let code, let message):
+            if code == "building_scope_exceeded" {
+                return "This selection is too large for 3D buildings. Choose a smaller area and try again. The processing limit includes the required buffer, and water inside the selection counts."
+            }
+            return "Map generation failed: \(message)"
         case .serverStatus(let status, let body):
             return "Map server returned \(status): \(body)"
         }

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -296,8 +296,11 @@ struct OfflineMapJob: Decodable, Equatable {
     let jobId: String
     let status: String
     let createdAt: String?
+    let updatedAt: String?
     let error: String?
     let errorCode: String?
+    let attempts: Int?
+    let maxAttempts: Int?
     let mapId: String?
     let packPath: String?
     let geometry: OfflineMapJobGeometry?
@@ -315,7 +318,12 @@ struct OfflineMapJob: Decodable, Equatable {
     let lastDownloadedAt: String?
 
     var isTerminal: Bool {
-        ["ready", "failed", "expired", "cancelled"].contains(status)
+        return ["ready", "failed", "expired", "cancelled"].contains(status)
+    }
+
+    var mayBeLegacyRetryTransition: Bool {
+        guard status == "failed", let attempts, let maxAttempts else { return false }
+        return attempts >= 0 && maxAttempts > 0 && attempts < maxAttempts
     }
 }
 
@@ -442,15 +450,47 @@ enum OfflineMapJobRecoverySelector {
     static func select(
         jobs: [OfflineMapJob],
         clientInstallationId: String,
-        excludedJobIds: Set<String> = []
+        excludedJobIds: Set<String> = [],
+        legacyFailedGraceSeconds: TimeInterval = 30,
+        now: Date = Date()
     ) -> OfflineMapJob? {
         jobs
             .filter { job in
                 guard job.clientInstallationId == clientInstallationId else { return false }
                 guard !excludedJobIds.contains(job.jobId) else { return false }
-                return job.status == "ready" ? job.mapId != nil : !job.isTerminal
+                return job.status == "ready"
+                    ? job.mapId != nil
+                    : !job.isTerminal || isRecentLegacyRetryTransition(
+                        job,
+                        graceSeconds: legacyFailedGraceSeconds,
+                        now: now
+                    )
             }
             .max { ($0.createdAt ?? "") < ($1.createdAt ?? "") }
+    }
+
+    private static func isRecentLegacyRetryTransition(
+        _ job: OfflineMapJob,
+        graceSeconds: TimeInterval,
+        now: Date
+    ) -> Bool {
+        guard job.mayBeLegacyRetryTransition,
+              let updatedAt = job.updatedAt,
+              let updated = serverDate(updatedAt) else {
+            return false
+        }
+        let age = now.timeIntervalSince(updated)
+        return age >= 0 && age < graceSeconds
+    }
+
+    private static func serverDate(_ value: String) -> Date? {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: value) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.date(from: value)
     }
 }
 
@@ -766,7 +806,21 @@ struct OfflineMapPreparationEstimatePresentation: Equatable {
         let title = job.status == "queued"
             ? "Estimated Preparation"
             : "Estimated Remaining"
+        if job.status == "queued", job.errorCode != nil {
+            return Self(
+                title: title,
+                value: "Re-estimating after retry…"
+            )
+        }
         if let estimate = job.preparationEstimate {
+            if let jobAttempt = job.attempts,
+               let estimateAttempt = estimate.attempt,
+               jobAttempt != estimateAttempt {
+                return Self(
+                    title: title,
+                    value: "Re-estimating after retry…"
+                )
+            }
             if let range = estimate.validRemainingRange {
                 return Self(
                     title: title,
@@ -941,6 +995,8 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
         supportedRendererFormatVersions: [Int],
         message: String
     )
+    case mapJobCancelled
+    case mapJobExpired
     case mapJobFailed(code: String?, message: String)
     case serverStatus(Int, String)
 
@@ -976,7 +1032,11 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
             return "Map server returned an invalid response"
         case .unsupportedRendererTarget(_, _, let message):
             return message
-        case .mapJobFailed(let code, let message):
+        case .mapJobCancelled:
+            return "This map download was cancelled. Start a new download when you're ready."
+        case .mapJobExpired:
+            return "This map download expired. Start a new download to build it again."
+        case .mapJobFailed(let code, _):
             switch code {
             case "building_scope_exceeded":
                 return "This selection is too large for 3D buildings. Choose a smaller area and try again. The processing limit includes the required buffer, and water inside the selection counts."
@@ -992,8 +1052,16 @@ nonisolated enum OfflineMapPlatformError: LocalizedError {
                 return "The map service is temporarily misconfigured. Try again later."
             case "map_build_failed":
                 return "We couldn't build this map after several attempts. Try again. If it keeps failing, report the problem."
+            case "map_stream_format_invalid":
+                return "The generated map data was invalid. Try again. If it keeps failing, report the problem."
+            case "map_stream_build_failed":
+                return "The map file could not be prepared. Try again later."
+            case "map_stream_signing_failed":
+                return "The map file could not be secured for download. Try again later."
+            case "artifact_storage_failed":
+                return "The finished map could not be stored for download. Try again later."
             default:
-                return "Map generation failed: \(message)"
+                return "We couldn't build this map. Try again. If it keeps failing, report the problem."
             }
         case .serverStatus(let status, let body):
             return "Map server returned \(status): \(body)"

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -722,6 +722,7 @@ struct NavigationProtocolTests {
         await testOfflineMapPollerOutlivesLegacyAttemptLimit()
         await testOfflineMapPollerRetriesTransientFailure()
         await testOfflineMapPollerStopsOnTerminalAndCancellation()
+        testOfflineMapJobFailureMessages()
         testOfflineMapCreateJobURLRequest()
         testOfflineMapListJobsURLRequest()
         testOfflineMapInventoryMutationURLRequests()
@@ -7623,6 +7624,34 @@ struct NavigationProtocolTests {
             // Expected.
         } catch {
             assert(false, "cancelled polling should preserve CancellationError")
+        }
+    }
+
+    static func testOfflineMapJobFailureMessages() {
+        let internalDiagnostic = "internal details; jobId=failed-job; /private/server/path"
+        let expectations = [
+            ("building_scope_exceeded", "Choose a smaller area"),
+            ("building_source_snapshot_changed", "Retry the same area"),
+            ("source_cache_unavailable", "temporarily unavailable"),
+            ("building_relation_incomplete", "Adjust the selected area slightly"),
+            ("building_calibration_unavailable", "3D building data could not be prepared"),
+            ("building_scope_policy_invalid", "temporarily misconfigured"),
+            ("map_build_failed", "after several attempts"),
+        ]
+
+        for (code, recoveryText) in expectations {
+            let displayMessage = OfflineMapPlatformError
+                .mapJobFailed(code: code, message: internalDiagnostic)
+                .localizedDescription
+            assert(
+                displayMessage.contains(recoveryText),
+                "\(code) provides actionable recovery guidance"
+            )
+            assert(
+                !displayMessage.contains("jobId=") &&
+                    !displayMessage.contains("/private/server/path"),
+                "\(code) hides internal diagnostics from the user"
+            )
         }
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -7571,7 +7571,11 @@ struct NavigationProtocolTests {
 
     @MainActor
     static func testOfflineMapPollerStopsOnTerminalAndCancellation() async {
-        guard let failed = offlineMapJob(status: "failed", error: "conversion failed"),
+        guard let failed = offlineMapJob(
+            status: "failed",
+            error: "selected building scope exceeds policy; jobId=failed-job",
+            errorCode: "building_scope_exceeded"
+        ),
               let running = offlineMapJob(status: "converting_features") else {
             assert(false, "terminal poller test jobs should decode")
             return
@@ -7587,9 +7591,20 @@ struct NavigationProtocolTests {
                 onRetry: {}
             )
             assert(false, "terminal map job should throw")
-        } catch OfflineMapPlatformError.serverStatus(let status, let body) {
-            assertEqual(status, 409, "terminal map job uses conflict status")
-            assert(body.contains("conversion failed"), "terminal map job preserves server error")
+        } catch OfflineMapPlatformError.mapJobFailed(let code, let message) {
+            assertEqual(code, "building_scope_exceeded", "terminal map job preserves typed server code")
+            assert(message.contains("selected building scope"), "terminal map job preserves diagnostic detail")
+            let displayMessage = OfflineMapPlatformError
+                .mapJobFailed(code: code, message: message)
+                .localizedDescription
+            assert(
+                displayMessage.contains("Choose a smaller area"),
+                "building scope failure provides an actionable recovery"
+            )
+            assert(
+                !displayMessage.contains("jobId="),
+                "building scope failure hides internal diagnostics from the user"
+            )
         } catch {
             assert(false, "terminal map job should use platform error")
         }
@@ -7616,6 +7631,7 @@ struct NavigationProtocolTests {
         status: String,
         mapId: String? = nil,
         error: String? = nil,
+        errorCode: String? = nil,
         createdAt: String? = nil,
         clientInstallationId: String? = nil,
         clientRequestId: String? = nil,
@@ -7624,6 +7640,7 @@ struct NavigationProtocolTests {
         var payload: [String: Any] = ["jobId": jobId ?? "job-\(status)", "status": status]
         if let mapId { payload["mapId"] = mapId }
         if let error { payload["error"] = error }
+        if let errorCode { payload["errorCode"] = errorCode }
         if let createdAt { payload["createdAt"] = createdAt }
         if let clientInstallationId { payload["clientInstallationId"] = clientInstallationId }
         if let clientRequestId { payload["clientRequestId"] = clientRequestId }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -5660,6 +5660,37 @@ struct NavigationProtocolTests {
             "Re-estimating after retry…",
             "retry pending state has explicit copy"
         )
+        let retryWithStaleAvailableEstimate = decode(
+            """
+            {
+              "jobId": "estimate-retry-stale",
+              "status": "queued",
+              "attempts": 2,
+              "createdAt": "2026-08-10T00:00:00Z",
+              "preparationEstimate": {
+                "schemaVersion": 1,
+                "modelVersion": "map-preparation-v1",
+                "revision": 4,
+                "state": "available",
+                "generatedAt": "2026-08-10T01:00:00Z",
+                "attempt": 1,
+                "basedOnPhase": "building_complexity",
+                "confidence": "medium",
+                "remaining": {"lowerSeconds": 60, "upperSeconds": 120},
+                "basis": ["baseline_profile"],
+                "sampleCount": 24
+              }
+            }
+            """
+        )
+        assertEqual(
+            OfflineMapPreparationEstimatePresentation.presentation(
+                for: retryWithStaleAvailableEstimate,
+                now: now
+            )?.value,
+            "Re-estimating after retry…",
+            "newly claimed retry suppresses the previous attempt's stale estimate"
+        )
         let malformed = decode(
             """
             {
@@ -6004,6 +6035,40 @@ struct NavigationProtocolTests {
             excludedJobIds: ["job-regenerated", "job-running", "job-cached-old"]
         )
         assertEqual(none, nil, "terminal and ready-without-map jobs are not recoverable")
+
+        guard let legacyRetry = offlineMapJob(
+            jobId: "job-legacy-retry",
+            status: "failed",
+            errorCode: "map_build_failed",
+            attempts: 1,
+            maxAttempts: 3,
+            createdAt: "2026-07-12T09:00:00Z",
+            updatedAt: "2026-07-12T09:00:00Z",
+            clientInstallationId: "installation-mine"
+        ) else {
+            assert(false, "legacy retry recovery fixture should decode")
+            return
+        }
+        let legacySelection = OfflineMapJobRecoverySelector.select(
+            jobs: [legacyRetry],
+            clientInstallationId: "installation-mine",
+            now: Date(timeIntervalSince1970: 1_783_846_805)
+        )
+        assertEqual(
+            legacySelection?.jobId,
+            "job-legacy-retry",
+            "recovery discovers an old worker's transient failed-to-queued job"
+        )
+        let staleLegacySelection = OfflineMapJobRecoverySelector.select(
+            jobs: [legacyRetry],
+            clientInstallationId: "installation-mine",
+            now: Date(timeIntervalSince1970: 1_783_846_840)
+        )
+        assertEqual(
+            staleLegacySelection,
+            nil,
+            "recovery does not repeatedly adopt a permanent legacy-shaped failure"
+        )
 
     }
 
@@ -7577,10 +7642,85 @@ struct NavigationProtocolTests {
             error: "selected building scope exceeds policy; jobId=failed-job",
             errorCode: "building_scope_exceeded"
         ),
-              let running = offlineMapJob(status: "converting_features") else {
+              let running = offlineMapJob(status: "converting_features"),
+              let exhausted = offlineMapJob(
+                status: "failed",
+                error: "worker failed; jobId=exhausted-job",
+                errorCode: "map_build_failed"
+              ),
+              let cancelled = offlineMapJob(status: "cancelled"),
+              let expired = offlineMapJob(status: "expired"),
+              let legacyRetryFailure = offlineMapJob(
+                status: "failed",
+                error: "temporary worker failure; jobId=legacy-retry-job",
+                errorCode: "map_build_failed",
+                attempts: 1,
+                maxAttempts: 3
+              ),
+              let queued = offlineMapJob(status: "queued", attempts: 1, maxAttempts: 3),
+              let ready = offlineMapJob(status: "ready", mapId: "map-ready") else {
             assert(false, "terminal poller test jobs should decode")
             return
         }
+
+        var legacyRetryFetchCount = 0
+        let legacyRetryResult = try? await OfflineMapJobPoller.waitForReady(
+            jobId: "legacy-retry-job",
+            pollIntervalNanoseconds: 0,
+            fetch: { _ in
+                legacyRetryFetchCount += 1
+                switch legacyRetryFetchCount {
+                case 1...3: return legacyRetryFailure
+                case 4: return queued
+                default: return ready
+                }
+            },
+            sleep: { _ in },
+            onUpdate: { _ in },
+            onRetry: {}
+        )
+        assertEqual(
+            legacyRetryResult?.mapId,
+            "map-ready",
+            "poller tolerates the old worker's transient failed-to-queued transition"
+        )
+        assertEqual(
+            legacyRetryFetchCount,
+            5,
+            "poller tolerates repeated legacy failures within the bounded grace window"
+        )
+
+        var inlineFailureFetchCount = 0
+        var inlineFailureClock: TimeInterval = 0
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "inline-failed-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in
+                    inlineFailureFetchCount += 1
+                    return legacyRetryFailure
+                },
+                sleep: { _ in },
+                onUpdate: { _ in },
+                onRetry: {},
+                legacyFailedGraceSeconds: 1,
+                monotonicNow: {
+                    defer { inlineFailureClock += 2 }
+                    return inlineFailureClock
+                }
+            )
+            assert(false, "repeated legacy-shaped failure should be terminal")
+        } catch OfflineMapPlatformError.mapJobFailed {
+            assertEqual(
+                inlineFailureFetchCount,
+                2,
+                "inline failure stops when the compatibility grace window ends"
+            )
+        } catch {
+            assert(false, "repeated legacy-shaped failure should use platform error")
+        }
+
+        assert(exhausted.isTerminal, "a failed final attempt is terminal")
 
         do {
             _ = try await OfflineMapJobPoller.waitForReady(
@@ -7612,6 +7752,62 @@ struct NavigationProtocolTests {
 
         do {
             _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "exhausted-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in exhausted },
+                sleep: { _ in },
+                onUpdate: { _ in },
+                onRetry: {}
+            )
+            assert(false, "exhausted map job should throw")
+        } catch OfflineMapPlatformError.mapJobFailed(let code, _) {
+            assertEqual(code, "map_build_failed", "exhausted map job preserves its stable code")
+        } catch {
+            assert(false, "exhausted map job should use platform error")
+        }
+
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "cancelled-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in cancelled },
+                sleep: { _ in },
+                onUpdate: { _ in },
+                onRetry: {}
+            )
+            assert(false, "cancelled map job should throw")
+        } catch OfflineMapPlatformError.mapJobCancelled {
+            assert(
+                OfflineMapPlatformError.mapJobCancelled.localizedDescription
+                    .contains("was cancelled"),
+                "cancelled map job explains what happened"
+            )
+        } catch {
+            assert(false, "cancelled map job should use its typed platform error")
+        }
+
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
+                jobId: "expired-job",
+                pollIntervalNanoseconds: 0,
+                fetch: { _ in expired },
+                sleep: { _ in },
+                onUpdate: { _ in },
+                onRetry: {}
+            )
+            assert(false, "expired map job should throw")
+        } catch OfflineMapPlatformError.mapJobExpired {
+            assert(
+                OfflineMapPlatformError.mapJobExpired.localizedDescription
+                    .contains("Start a new download"),
+                "expired map job provides the recovery action"
+            )
+        } catch {
+            assert(false, "expired map job should use its typed platform error")
+        }
+
+        do {
+            _ = try await OfflineMapJobPoller.waitForReady(
                 jobId: "cancel-job",
                 pollIntervalNanoseconds: 0,
                 fetch: { _ in running },
@@ -7629,7 +7825,7 @@ struct NavigationProtocolTests {
 
     static func testOfflineMapJobFailureMessages() {
         let internalDiagnostic = "internal details; jobId=failed-job; /private/server/path"
-        let expectations = [
+        let expectations: [(String?, String)] = [
             ("building_scope_exceeded", "Choose a smaller area"),
             ("building_source_snapshot_changed", "Retry the same area"),
             ("source_cache_unavailable", "temporarily unavailable"),
@@ -7637,20 +7833,27 @@ struct NavigationProtocolTests {
             ("building_calibration_unavailable", "3D building data could not be prepared"),
             ("building_scope_policy_invalid", "temporarily misconfigured"),
             ("map_build_failed", "after several attempts"),
+            ("map_stream_format_invalid", "generated map data was invalid"),
+            ("map_stream_build_failed", "could not be prepared"),
+            ("map_stream_signing_failed", "secured for download"),
+            ("artifact_storage_failed", "stored for download"),
+            ("future_failure_code", "couldn't build this map"),
+            (nil, "couldn't build this map"),
         ]
 
         for (code, recoveryText) in expectations {
+            let codeLabel = code ?? "missing code"
             let displayMessage = OfflineMapPlatformError
                 .mapJobFailed(code: code, message: internalDiagnostic)
                 .localizedDescription
             assert(
                 displayMessage.contains(recoveryText),
-                "\(code) provides actionable recovery guidance"
+                "\(codeLabel) provides actionable recovery guidance"
             )
             assert(
                 !displayMessage.contains("jobId=") &&
                     !displayMessage.contains("/private/server/path"),
-                "\(code) hides internal diagnostics from the user"
+                "\(codeLabel) hides internal diagnostics from the user"
             )
         }
     }
@@ -7661,7 +7864,10 @@ struct NavigationProtocolTests {
         mapId: String? = nil,
         error: String? = nil,
         errorCode: String? = nil,
+        attempts: Int? = nil,
+        maxAttempts: Int? = nil,
         createdAt: String? = nil,
+        updatedAt: String? = nil,
         clientInstallationId: String? = nil,
         clientRequestId: String? = nil,
         installOnDevice: Bool? = nil
@@ -7670,7 +7876,10 @@ struct NavigationProtocolTests {
         if let mapId { payload["mapId"] = mapId }
         if let error { payload["error"] = error }
         if let errorCode { payload["errorCode"] = errorCode }
+        if let attempts { payload["attempts"] = attempts }
+        if let maxAttempts { payload["maxAttempts"] = maxAttempts }
         if let createdAt { payload["createdAt"] = createdAt }
+        if let updatedAt { payload["updatedAt"] = updatedAt }
         if let clientInstallationId { payload["clientInstallationId"] = clientInstallationId }
         if let clientRequestId { payload["clientRequestId"] = clientRequestId }
         if let installOnDevice { payload["installOnDevice"] = installOnDevice }

--- a/map-platform/backend/map_platform/jobs.py
+++ b/map-platform/backend/map_platform/jobs.py
@@ -542,13 +542,14 @@ class JobStore:
                 preview_geometry=None,
             )
         if event or previous_status != status:
-            job.events.append(
-                {
-                    "at": job.updated_at,
-                    "status": status.value,
-                    "message": event or f"entered {status.value}",
-                }
-            )
+            job_event = {
+                "at": job.updated_at,
+                "status": status.value,
+                "message": event or f"entered {status.value}",
+            }
+            if error_code is not None:
+                job_event["errorCode"] = error_code
+            job.events.append(job_event)
         self.save(job)
         return job
 
@@ -1333,6 +1334,7 @@ class JobStore:
                 job.job_id,
                 JobStatus.FAILED,
                 error="maximum retry attempts exceeded",
+                error_code="map_build_failed",
                 finished=True,
             )
         job.status = JobStatus.VALIDATING

--- a/map-platform/backend/map_platform/monitoring.py
+++ b/map-platform/backend/map_platform/monitoring.py
@@ -987,6 +987,8 @@ def build_map_job_monitoring_event(
     }
     if job.reuse_strategy is not None:
         event["reuseStrategy"] = job.reuse_strategy
+    if job.error_code is not None:
+        event["errorCode"] = job.error_code
     if isinstance(job.preparation_estimate, dict):
         estimate = job.preparation_estimate
         event["preparationEstimate"] = {

--- a/map-platform/backend/map_platform/worker.py
+++ b/map-platform/backend/map_platform/worker.py
@@ -416,41 +416,35 @@ class MapWorker:
                     monitoring_event=monitoring_event,
                 )
             error_message, error_code = safe_build_failure(job, exc)
-            failed = self.store.update_status_unless_cancelled(
+            retrying = job.attempts < job.max_attempts
+            completed = self.store.update_status_unless_cancelled(
                 job.job_id,
-                JobStatus.FAILED,
+                JobStatus.QUEUED if retrying else JobStatus.FAILED,
                 error=error_message,
                 error_code=error_code,
                 worker_id=self.worker_id,
-                event=error_message,
-                finished=True,
+                event="queued for retry" if retrying else error_message,
+                finished=not retrying,
             )
             monitoring_event = self._monitoring_event(
-                failed,
+                completed,
                 attempt_started_at,
                 outcome="failed",
-                persist=failed.attempts >= failed.max_attempts,
+                persist=not retrying,
             )
-            if failed.attempts < failed.max_attempts:
+            if retrying:
                 if self.estimate_coordinator is not None:
                     self.estimate_coordinator.publish_pending_retry(
                         job.job_id,
                         worker_id=self.worker_id,
                     )
-                failed = self.store.update_status_unless_cancelled(
-                    job.job_id,
-                    JobStatus.QUEUED,
-                    error=error_message,
-                    error_code=error_code,
-                    worker_id=self.worker_id,
-                    event="queued for retry",
-                )
+                    completed = self.store.get(job.job_id)
             elif isinstance(self.pipeline, MapBuildPipeline) and self.pipeline.artifact_store is not None:
                 self.store.queue_terminal_pending_artifacts(job.job_id)
-                failed = self.store.get(job.job_id)
+                completed = self.store.get(job.job_id)
             return WorkerResult(
                 worker_id=self.worker_id,
-                job=failed,
+                job=completed,
                 processed=True,
                 monitoring_event=monitoring_event,
             )
@@ -491,6 +485,8 @@ class MapWorker:
                 "outcome": outcome,
                 "attempt": job.attempts,
             }
+            if job.error_code is not None:
+                event["errorCode"] = job.error_code
         event["monitoringPersisted"] = monitoring_persisted
         return event
 

--- a/map-platform/backend/tests/test_worker.py
+++ b/map-platform/backend/tests/test_worker.py
@@ -48,6 +48,21 @@ class FakePipeline:
         return "map-123", pack_path
 
 
+class BlockingRetryEstimateCoordinator:
+    def __init__(self):
+        self.started = threading.Event()
+        self.release = threading.Event()
+
+    def publish(self, *args, **kwargs):
+        return None
+
+    def publish_pending_retry(self, job_id, *, worker_id):
+        del job_id, worker_id
+        self.started.set()
+        if not self.release.wait(timeout=2):
+            raise TimeoutError("test retry estimate publication was not released")
+
+
 class CancellingPipeline:
     def __init__(self, service):
         self.service = service
@@ -426,6 +441,46 @@ class WorkerTests(unittest.TestCase):
             self.assertIsNone(first.job.to_dict()["progress"])
             self.assertEqual(first.job.to_dict()["errorCode"], "map_build_failed")
             self.assertEqual(first_queued_event["message"], "queued for retry")
+            self.assertEqual(first_queued_event["errorCode"], "map_build_failed")
+            completed_retry_event = next(
+                event
+                for event in loaded.events
+                if event["message"] == "queued for retry"
+            )
+            self.assertEqual(completed_retry_event["errorCode"], "map_build_failed")
+
+    def test_retryable_failure_is_never_observable_as_terminal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job(
+                {"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]}
+            )
+            coordinator = BlockingRetryEstimateCoordinator()
+            worker = MapWorker(
+                store,
+                FakePipeline(failures=1),
+                worker_id="worker-retry-state",
+                estimate_coordinator=coordinator,
+            )
+            results = []
+            thread = threading.Thread(target=lambda: results.append(worker.run_next()))
+            thread.start()
+            try:
+                self.assertTrue(coordinator.started.wait(timeout=2))
+                observed = store.get(job.job_id)
+                self.assertEqual(observed.status, JobStatus.QUEUED)
+                self.assertIsNone(observed.finished_at)
+                self.assertEqual(observed.error_code, "map_build_failed")
+                self.assertFalse(
+                    any(event["status"] == "failed" for event in observed.events)
+                )
+            finally:
+                coordinator.release.set()
+                thread.join(timeout=2)
+            self.assertFalse(thread.is_alive())
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0].job.status, JobStatus.QUEUED)
 
     def test_monitoring_skips_retryable_attempt_until_job_finishes(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -444,6 +499,7 @@ class WorkerTests(unittest.TestCase):
 
             first = worker.run_next()
             self.assertFalse(first.monitoring_event["monitoringPersisted"])
+            self.assertEqual(first.monitoring_event["errorCode"], "map_build_failed")
             self.assertEqual(monitoring.summary()["runs"]["count"], 0)
 
             second = worker.run_next()
@@ -469,6 +525,35 @@ class WorkerTests(unittest.TestCase):
 
             self.assertFalse(result.monitoring_event["monitoringPersisted"])
             monitoring.record_job.assert_called_once()
+
+    def test_monitoring_fallback_preserves_retry_error_code(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job(
+                {"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]}
+            )
+            job.error_code = "map_build_failed"
+            worker = MapWorker(
+                store,
+                FakePipeline(),
+                worker_id="worker-monitoring-fallback",
+                monitoring_store=Mock(),
+            )
+
+            with patch(
+                "map_platform.worker.build_map_job_monitoring_event",
+                side_effect=ValueError("malformed optional telemetry"),
+            ):
+                event = worker._monitoring_event(
+                    job,
+                    job.created_at,
+                    outcome="failed",
+                    persist=False,
+                )
+
+            self.assertEqual(event["errorCode"], "map_build_failed")
+            self.assertFalse(event["monitoringPersisted"])
 
     def test_worker_ignores_cancelled_job(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -1682,6 +1767,7 @@ class WorkerTests(unittest.TestCase):
                 store.claim_next("worker-replacement", interrupted_job_stale_seconds=0)
             )
             self.assertEqual(store.get(job.job_id).status, JobStatus.FAILED)
+            self.assertEqual(store.get(job.job_id).error_code, "map_build_failed")
             self.assertEqual(store.cleanup_artifact_garbage(artifact_store), 1)
             recovered = store.get(job.job_id)
             self.assertEqual(recovered.pending_artifact_keys, [])


### PR DESCRIPTION
## What changed

- Decode the map job's typed `errorCode` from the backend.
- Preserve typed job failures through the polling layer instead of converting every terminal job into a generic HTTP-style 409.
- Show recovery-oriented messages for every map-job failure code currently emitted by the backend:
  - `building_scope_exceeded`: choose a smaller area, with buffer/water context.
  - `building_source_snapshot_changed`: retry the same area.
  - `source_cache_unavailable`: try again later.
  - `building_relation_incomplete`: adjust the selected area slightly.
  - `building_calibration_unavailable`: try again later.
  - `building_scope_policy_invalid`: explain that the service is temporarily misconfigured.
  - `map_build_failed`: retry and report the problem if it persists.
- Keep internal diagnostics such as job IDs and server paths out of these user-visible messages.
- Add regression coverage for the typed failure and display-message mappings.

## Why

The backend already returns stable error codes, but the iOS client discarded them and showed raw server messages. This made known, recoverable problems look like opaque server failures and could expose internal diagnostics.

## User impact

Bicino now explains what the rider can do next for known map-download failures, while retaining a generic fallback for unknown future error codes.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- Signed Debug device build with `xcodebuild` for generic iOS
- `codesign --verify --deep --strict`
- Verified the Dev package still embeds `maps-dev.8o.vc`
