### PR TITLE
Canonicalize attested firmware flash offsets

### DIFF
--- a/esp32/tools/generated_sdkconfig.py
+++ b/esp32/tools/generated_sdkconfig.py
@@ -1835,7 +1835,7 @@ def _validated_flash_plan(
                 raise GeneratedSdkconfigError(
                     "verified PlatformIO flash plan contains an invalid image offset"
                 ) from error
-            normalized_offset_token = offset_token
+            normalized_offset_token = hex(offset)
         if offset < 0 or offset > 0xFFFFFFFF or offset in offsets:
             raise GeneratedSdkconfigError(
                 "verified PlatformIO flash plan contains a duplicate or out-of-range "

--- a/esp32/tools/tests/test_build_firmware.py
+++ b/esp32/tools/tests/test_build_firmware.py
@@ -1240,6 +1240,37 @@ build_src_filter =
         self.assertNotIn("nobuild", command)
         self.assertNotIn("upload", command)
 
+    def test_attestation_canonicalizes_platformio_flash_offsets(self):
+        core = self.write_core_attestation().resolve()
+        defaults = self.project_dir / "sdkconfig.defaults"
+        defaults.write_text(GENERATED_CONFIG, encoding="utf-8")
+        self.write_firmware()
+        plan_path = (
+            self.project_dir
+            / ".pio/build"
+            / self.environment
+            / FLASH_PLAN_FILENAME
+        )
+        plan = json.loads(plan_path.read_text(encoding="utf-8"))
+        plan["images"][0]["offset"] = "0x0000"
+        image_tail = [
+            value
+            for image in plan["images"]
+            for value in (image["offset"], image["path"])
+        ]
+        plan["command"][-len(image_tail) :] = image_tail
+        plan_path.write_text(json.dumps(plan) + "\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"PLATFORMIO_CORE_DIR": str(core)}):
+            manifest_path = record_generated_sdkconfig_defaults(
+                self.project_dir, self.environment
+            )
+
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+        flash_plan = manifest["flashPlan"]
+        self.assertEqual(flash_plan["images"][0]["offset"], "0x0")
+        self.assertEqual(flash_plan["command"][-8], "0x0")
+
     def test_attestation_rejects_platformio_app_offset_mismatch(self):
         core = self.write_core_attestation()
         defaults = self.project_dir / "sdkconfig.defaults"


### PR DESCRIPTION
## Summary

- canonicalize every verified PlatformIO flash offset before storing the attested flash plan
- add an end-to-end regression for the padded `0x0000` form emitted by the production toolchain
- keep the factory-release verifier strict about one canonical schema representation

## Root cause

The production PlatformIO toolchain emits the bootloader offset as `0x0000`. The verified build manifest preserved that spelling, while the factory-release signer correctly requires canonical `0x0`, so release publication failed before creating a draft release.

## Validation

- 72 firmware helper tests
- 11 factory packaging tests
- 43 generated SDK/config tests
- 15 factory release manifest tests
- 27 workflow policy tests
- Python compile and `git diff --check`
