### PR TITLE
Use read-only app for immutable release preflight

### DIFF
--- a/.github/actions/require-immutable-releases/action.yml
+++ b/.github/actions/require-immutable-releases/action.yml
@@ -1,0 +1,33 @@
+name: Require immutable GitHub releases
+description: Fail before publication unless GitHub reports immutable releases enabled
+
+inputs:
+  app-id:
+    description: GitHub App ID for the repository-scoped Administration-read preflight
+    required: true
+  private-key:
+    description: Private key for the repository-scoped Administration-read GitHub App
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Mint repository-scoped preflight token
+      id: preflight-token
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+      with:
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
+        owner: ${{ github.repository_owner }}
+        repositories: ${{ github.event.repository.name }}
+        permission-administration: read
+    - name: Require immutable releases before publication
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.preflight-token.outputs.token }}
+      run: |
+        set -euo pipefail
+        if [ "$(gh api -H "X-GitHub-Api-Version: 2026-03-10" "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq .enabled)" != true ]; then
+          echo "Repository immutable releases must be enabled before publication" >&2
+          exit 1
+        fi

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -329,6 +329,13 @@ class WorkflowPolicyTests(unittest.TestCase):
 
     def test_release_publishes_signed_factory_flash_bundles(self) -> None:
         release = workflow_source("firmware-release.yml")
+        immutable_preflight = (
+            REPO_ROOT
+            / ".github"
+            / "actions"
+            / "require-immutable-releases"
+            / "action.yml"
+        ).read_text(encoding="utf-8")
 
         self.assertIn("--factory-output-dir dist", release)
         self.assertNotIn("tools/package_factory_firmware.py", release)
@@ -344,9 +351,20 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("--draft", release)
         self.assertIn("tools/verify_github_release_assets.py", release)
         self.assertIn("already exists; refusing to replace assets", release)
-        self.assertIn("immutable-releases", release)
+        self.assertIn(
+            "uses: ./.github/actions/require-immutable-releases", release
+        )
         self.assertIn("--require-immutable", release)
         self.assertIn("X-GitHub-Api-Version: 2026-03-10", release)
+        self.assertIn(
+            "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+            immutable_preflight,
+        )
+        self.assertIn("permission-administration: read", immutable_preflight)
+        self.assertIn(
+            "repositories: ${{ github.event.repository.name }}", immutable_preflight
+        )
+        self.assertIn("/immutable-releases", immutable_preflight)
         self.assertIn("--require-hashes --only-binary=:all: --no-deps", release)
         self.assertIn("tools/firmware-signing-requirements.txt", release)
         self.assertNotIn("pip install --upgrade cryptography", release)
@@ -427,7 +445,9 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("verify-staged", publish)
         self.assertIn("tools/verify_github_release_assets.py", publish)
         self.assertIn("already exists; refusing to replace it", publish)
-        self.assertIn("immutable-releases", publish)
+        self.assertIn(
+            "uses: ./.github/actions/require-immutable-releases", publish
+        )
         self.assertIn("--require-immutable", publish)
         self.assertIn("Runtime tag ${release_tag} already exists", publish)
         self.assertIn("runtime release tag does not bind", publish)

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -125,13 +125,14 @@ jobs:
               --private-key-base64 "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" \
               --output "release-assets/${target}.factory-release.json"
           done
+      - name: Require immutable releases
+        uses: ./.github/actions/require-immutable-releases
+        with:
+          app-id: ${{ vars.FIRMWARE_RELEASE_PREFLIGHT_APP_ID }}
+          private-key: ${{ secrets.FIRMWARE_RELEASE_PREFLIGHT_APP_PRIVATE_KEY }}
       - name: Publish GitHub release assets
         run: |
           set -euo pipefail
-          if [ "$(gh api -H "X-GitHub-Api-Version: 2026-03-10" "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq .enabled)" != true ]; then
-            echo "Repository immutable releases must be enabled before publication" >&2
-            exit 1
-          fi
           if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
             echo "Release ${GITHUB_REF_NAME} already exists; refusing to replace assets" >&2
             exit 1

--- a/.github/workflows/firmware-runtime-publish.yml
+++ b/.github/workflows/firmware-runtime-publish.yml
@@ -142,13 +142,14 @@ jobs:
             tools/firmware_runtime_publication.py verify-staged \
             --asset-dir "${RUNNER_TEMP}/runtime-publication/assets" \
             --manifest "${RUNNER_TEMP}/runtime-publication/publication-manifest.json"
+      - name: Require immutable releases
+        uses: ./.github/actions/require-immutable-releases
+        with:
+          app-id: ${{ vars.FIRMWARE_RELEASE_PREFLIGHT_APP_ID }}
+          private-key: ${{ secrets.FIRMWARE_RELEASE_PREFLIGHT_APP_PRIVATE_KEY }}
       - name: Create, verify, and publish a unique prerelease
         run: |
           set -euo pipefail
-          if [ "$(gh api -H "X-GitHub-Api-Version: 2026-03-10" "repos/${GITHUB_REPOSITORY}/immutable-releases" --jq .enabled)" != true ]; then
-            echo "Repository immutable releases must be enabled before publication" >&2
-            exit 1
-          fi
           publication_manifest="${RUNNER_TEMP}/runtime-publication/publication-manifest.json"
           release_tag="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["releaseTag"])' "${publication_manifest}")"
           generator_commit="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["generatorCommit"])' "${publication_manifest}")"

--- a/docs/firmware-runtime-maintenance.md
+++ b/docs/firmware-runtime-maintenance.md
@@ -29,9 +29,13 @@ normal build updates the accepted closure.
 5. Approve the `firmware-runtime-publication` environment only after human
    review. Configure that GitHub environment with required reviewers before the
    next refresh. Only the post-approval job receives `contents: write`.
-6. Enable GitHub repository immutable releases before publication. The
-   publisher fails before creating a release unless that repository setting is
-   active.
+6. Enable GitHub repository immutable releases before publication. Configure
+   the `FIRMWARE_RELEASE_PREFLIGHT_APP_ID` repository variable and
+   `FIRMWARE_RELEASE_PREFLIGHT_APP_PRIVATE_KEY` repository secret for a GitHub
+   App installed only on this repository with `Administration: read`. The
+   publisher mints a short-lived, repository-scoped token and fails before
+   creating a release unless GitHub reports that the setting is active. Its
+   normal `GITHUB_TOKEN` retains only the separate publication permissions.
 7. The publisher requires the Git tag to be absent, creates a draft prerelease
    and a lightweight tag at the exact reviewed generator commit, proves that
    binding, uploads the exact create-only 11-asset set without `--clobber`, and verifies
@@ -45,9 +49,10 @@ normal build updates the accepted closure.
    alone never changes ordinary builds.
 
 Create-only publication and server-side immutable releases are both mandatory.
-The repository currently has to be configured once by an administrator before
-the next runtime or product release; this workflow never weakens the repository
-setting or silently falls back to a mutable release.
+The repository setting and narrowly scoped preflight GitHub App are one-time
+administrator configuration for runtime and product releases. A missing App
+configuration, failed preflight, mutable published release, or changed asset
+fails the workflow; it never silently falls back to mutable publication.
 
 ## Performance and rollback
 

--- a/docs/plans/pioarduino-wheelhouse-hardening.md
+++ b/docs/plans/pioarduino-wheelhouse-hardening.md
@@ -621,10 +621,12 @@ lock automatically.
 The current release
 [`firmware-runtime-2026-08-10-1`](https://github.com/seichris/open-bike-computer/releases/tag/firmware-runtime-2026-08-10-1)
 is a public prerelease with 11 server-digested assets. At this revision, GitHub
-reports `immutable: false`. Local content verification still fails closed if an
-asset changes. The implemented publishers therefore refuse to create the next
-runtime or product release until an administrator enables the repository's
-immutable-release control.
+reports that legacy release as `immutable: false`; enabling the repository
+control does not retroactively freeze it. Local content verification still
+fails closed if an asset changes. New runtime and product publishers require a
+repository-scoped, `Administration: read` GitHub App to verify the enabled
+control before creating a release, then require `immutable: true` after
+publication.
 
 ## Implemented focused maintenance work
 
@@ -642,10 +644,12 @@ no live resolver or automatic lock update.
    only after environment approval.
    The publisher also rejects any pre-existing release tag and proves the new
    lightweight tag resolves to the exact reviewed generator commit.
-3. Both runtime and product-release publication require repository immutable
-   releases before creating anything, upload without `--clobber`, verify the
-   draft inventory before publication, then require `immutable: true` and
-   reverify every server-reported size/SHA-256 for the retained receipt.
+3. Both runtime and product-release publication use a short-lived token from a
+   single-repository, `Administration: read` GitHub App to require immutable
+   releases before creating anything. They upload without `--clobber`, verify
+   the draft inventory before publication, then require `immutable: true` and
+   reverify every server-reported size/SHA-256 for the retained receipt. The
+   built-in publication token never receives repository-administration access.
 4. One strict tracked `publication-v1.json` owns the prospective lock-set ID and
    release tag. Changing it is an ordinary review commit; there is no `latest`
    selector.
@@ -926,11 +930,12 @@ medians: 4,636 ms for `linux-x86_64-cp313` on `ubuntu-24.04` and 2,197 ms for
 
 Only these external or deliberately broader decisions remain:
 
-1. **Repository controls:** GitHub currently reports immutable releases as
-   disabled. An administrator must enable them before the next runtime or
-   product release. The publisher intentionally fails before creating a
-   release until this is done. The `firmware-runtime-publication` environment
-   must likewise be configured with required human reviewers before use.
+1. **Repository controls:** GitHub immutable releases are enabled. Maintainers
+   must retain the single-repository preflight GitHub App with only
+   `Administration: read`, its Actions variable/secret, and required human
+   reviewers on the `firmware-runtime-publication` environment. Publishers
+   fail before creating a release if the App or setting is unavailable and
+   fail again unless the published release is reported immutable.
 2. **Additional host targets:** add none until a concrete supported-developer
    or release requirement pays for native generation and continuing CI.
 3. **Initial host bootstrap trust:** keep it explicit in the mandatory claim;


### PR DESCRIPTION
## What changed

- mint a short-lived GitHub App installation token scoped to this repository with only `Administration: read`
- use that token for the immutable-release setting preflight in both product and runtime publishers
- retain the built-in `GITHUB_TOKEN` for the separate create-only publication path
- keep draft asset verification and the authoritative post-publication `immutable: true` receipt gate
- update workflow policy tests and maintenance/architecture documentation

## Why

The immutable-release settings endpoint requires repository Administration read permission, which the built-in Actions token cannot request. Both publishers therefore failed with HTTP 403 before creating a release even though immutable releases were enabled.

Using a dedicated read-only GitHub App preserves the pre-publication fail-closed check without storing a broad personal token or granting administration access to the release-writing token.

## Validation

- `python3 .github/scripts/tests/test_workflow_policy.py` (27 tests)
- YAML parsing for the composite action and both changed workflows
- `python3 -m py_compile .github/scripts/tests/test_workflow_policy.py`
- explicit assertions for pre-publication ordering and the sole `Administration: read` permission
- `git diff --check`
