### PR TITLE
Fix immutable firmware release recovery

### DIFF
--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -351,6 +351,8 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("--draft", release)
         self.assertIn("tools/verify_github_release_assets.py", release)
         self.assertIn("already exists; refusing to replace assets", release)
+        self.assertIn('"repos/${GITHUB_REPOSITORY}/releases/${release_id}"', release)
+        self.assertIn("expected exactly one matching draft release", release)
         self.assertIn(
             "uses: ./.github/actions/require-immutable-releases", release
         )
@@ -368,6 +370,25 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("--require-hashes --only-binary=:all: --no-deps", release)
         self.assertIn("tools/firmware-signing-requirements.txt", release)
         self.assertNotIn("pip install --upgrade cryptography", release)
+
+    def test_release_pages_recovery_accepts_only_attested_immutable_assets(self) -> None:
+        release = workflow_source("firmware-release.yml")
+        recovery = mapping_block(release, "recover-pages", indent=2)
+
+        self.assertIn("  workflow_dispatch:\n", release)
+        self.assertIn("if: github.event_name == 'workflow_dispatch'", recovery)
+        self.assertIn("attestations: read", recovery)
+        self.assertIn("contents: read", recovery)
+        self.assertNotIn("contents: write", recovery)
+        self.assertIn("must run from the default branch", recovery)
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", recovery)
+        self.assertNotIn("ref: ${{ inputs.release_tag }}", recovery)
+        self.assertIn("--require-immutable", recovery)
+        self.assertIn('gh release verify "${RELEASE_TAG}"', recovery)
+        self.assertIn('gh release verify-asset "${RELEASE_TAG}"', recovery)
+        self.assertIn("actions/upload-pages-artifact@v3", recovery)
+        self.assertIn("actions/deploy-pages@v4", recovery)
+        self.assertNotIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", recovery)
 
     def test_production_ci_extracts_and_checks_factory_bundles(self) -> None:
         general_ci = workflow_source("ci.yml")

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Immutable firmware release tag whose OTA manifests should be redeployed
+        required: true
+        type: string
 
 permissions:
   attestations: read
@@ -13,16 +19,19 @@ permissions:
 jobs:
   validate:
     name: Validate release CI
+    if: github.event_name == 'push'
     uses: ./.github/workflows/ci.yml
     with:
       scope: all
 
   diagnostics:
     name: Validate diagnostic firmware
+    if: github.event_name == 'push'
     uses: ./.github/workflows/firmware-diagnostics.yml
 
   build:
     name: Build ${{ matrix.target }}
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -57,6 +66,7 @@ jobs:
 
   publish:
     name: Publish Firmware
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     needs:
       - build
@@ -143,8 +153,17 @@ jobs:
             --title "${GITHUB_REF_NAME}" \
             --generate-notes
           gh release upload "${GITHUB_REF_NAME}" release-assets/*
+          release_id="$(
+            gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
+              jq -er --arg tag "${GITHUB_REF_NAME}" '
+                [.[] | select(.tag_name == $tag and .draft == true)] |
+                if length == 1 then .[0].id
+                else error("expected exactly one matching draft release")
+                end
+              '
+          )"
           gh api -H "X-GitHub-Api-Version: 2026-03-10" \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            "repos/${GITHUB_REPOSITORY}/releases/${release_id}" \
             > "${RUNNER_TEMP}/release.json"
           python tools/verify_github_release_assets.py \
             --release-json "${RUNNER_TEMP}/release.json" \
@@ -162,6 +181,78 @@ jobs:
         with:
           name: firmware-release-publication-receipt
           path: ${{ runner.temp }}/publication-receipt.json
+          if-no-files-found: error
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: public
+      - id: deployment
+        uses: actions/deploy-pages@v4
+
+  recover-pages:
+    name: Recover Firmware OTA Pages
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      attestations: read
+      contents: read
+      id-token: write
+      pages: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      RELEASE_TAG: ${{ inputs.release_tag }}
+    steps:
+      - name: Validate recovery tag
+        run: |
+          set -euo pipefail
+          if [ "${GITHUB_REF}" != "refs/heads/${{ github.event.repository.default_branch }}" ]; then
+            echo "Firmware Pages recovery must run from the default branch" >&2
+            exit 1
+          fi
+          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([.-][A-Za-z0-9][A-Za-z0-9.-]*)?$ ]]; then
+            echo "Invalid firmware release tag: ${RELEASE_TAG}" >&2
+            exit 1
+          fi
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 1
+      - name: Verify immutable release and stage exact OTA manifests
+        run: |
+          set -euo pipefail
+          mkdir -p release-assets public/firmware
+          gh release download "${RELEASE_TAG}" --dir release-assets
+          gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            > "${RUNNER_TEMP}/release.json"
+          python3 tools/verify_github_release_assets.py \
+            --release-json "${RUNNER_TEMP}/release.json" \
+            --asset-dir release-assets \
+            --require-immutable \
+            --output "${RUNNER_TEMP}/recovery-receipt.json"
+          gh release verify "${RELEASE_TAG}"
+          for asset in release-assets/*; do
+            gh release verify-asset "${RELEASE_TAG}" "${asset}"
+          done
+          for target in WAVESHARE_AMOLED_175 WAVESHARE_AMOLED_206; do
+            manifest="release-assets/${target}.manifest.json"
+            if [ ! -f "${manifest}" ]; then
+              echo "Missing OTA manifest: ${manifest}" >&2
+              exit 1
+            fi
+            mkdir -p "public/firmware/${target}"
+            cp "${manifest}" "public/firmware/${target}/manifest.json"
+          done
+          if [ "$(find public -type f | wc -l)" -ne 2 ]; then
+            echo "Recovery payload must contain exactly two OTA manifests" >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-release-recovery-receipt-${{ inputs.release_tag }}
+          path: ${{ runner.temp }}/recovery-receipt.json
           if-no-files-found: error
       - uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/firmware-factory-release.md
+++ b/docs/firmware-factory-release.md
@@ -129,3 +129,14 @@ release to be immutable and re-verifies the exact asset inventory before
 retaining its receipt. An existing release tag or asset, disabled immutable
 release setting, or mutable published release is a hard failure; recovery uses
 a new tag rather than `--clobber`.
+
+If publication succeeds but the same job stops before GitHub Pages deployment,
+run **Firmware Release** manually from the default branch with the immutable
+release tag in `release_tag`. This recovery path never signs, rebuilds,
+uploads, edits, or replaces release assets. It downloads the complete
+published inventory,
+requires the repository verifier and GitHub release attestation to accept the
+immutable release, verifies every downloaded asset against that attestation,
+and deploys only the two exact signed OTA manifests. A mutable, incomplete, or
+unattested release fails closed. This manual path is for OTA Pages recovery
+only; failed or partial asset publication still requires a new release tag.


### PR DESCRIPTION
## Summary
- verify draft releases by numeric release ID before publication
- add a manual, default-branch-only OTA Pages recovery path for already immutable GitHub-attested releases
- document the recovery boundary and lock it with workflow policy tests

## Why
The v0.3.3-release.3 job uploaded all ten draft assets, then the tag lookup endpoint returned 404 because draft releases are not addressable through that endpoint. The verified draft was safely published, but Pages deployment was skipped.

## Security boundary
Recovery has contents read only, never receives the signing key, never rebuilds or modifies release assets, requires repository immutable verification plus GitHub release and per-asset attestations, and deploys only the two exact signed OTA manifests.

## Validation
- 50 workflow-policy tests
- 3 GitHub release asset verifier tests
- 3 firmware manifest tests
- 15 factory release manifest tests
- YAML syntax and git diff checks