### PR TITLE
Make Bicino settings promo full width

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -58,6 +58,33 @@ nonisolated enum RideActivityPolicy {
     }
 }
 
+nonisolated enum LocationAuthorizationRemediation: Equatable {
+    case requestInApp
+    case openSettings
+    case none
+}
+
+nonisolated enum LocationAuthorizationRemediationPolicy {
+    static func action(
+        for status: CLAuthorizationStatus
+    ) -> LocationAuthorizationRemediation {
+        switch status {
+        case .notDetermined:
+            .requestInApp
+        case .restricted, .denied:
+            .openSettings
+        case .authorizedAlways:
+            .none
+#if !os(macOS)
+        case .authorizedWhenInUse:
+            .none
+#endif
+        @unknown default:
+            .openSettings
+        }
+    }
+}
+
 nonisolated enum RideIdleTimerController {
     static func update(
         isNavigating: Bool,

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceOwnership.swift
@@ -514,7 +514,7 @@ enum BikeComputerSettingsDiscoveryLifecyclePolicy {
 enum BikeComputerSettingsPresentationPolicy {
     static func settingsLinkTitle(knownDeviceCount: Int) -> String {
         if knownDeviceCount == 0 {
-            return "Add a Bicino Bike Computer!"
+            return "Connect a Bicino Bike Computer!"
         }
         return knownDeviceCount > 1
             ? "My Bike Computers"

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
@@ -66,12 +66,28 @@ struct OfflineMapOnboardingView: View {
     private var artwork: some View {
         switch step {
         case .welcome:
-            Image("BicinoLogo")
-                .resizable()
-                .scaledToFit()
-                .foregroundStyle(Color.bicinoBrandRed)
-                .frame(width: 88, height: 64)
-                .accessibilityLabel("Bicino")
+            VStack(spacing: 14) {
+                Image("BicinoOneSettingsPromo")
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 170)
+                    .clipped()
+                    .clipShape(
+                        RoundedRectangle(
+                            cornerRadius: 14,
+                            style: .continuous
+                        )
+                    )
+                    .accessibilityHidden(true)
+
+                Image("BicinoLogo")
+                    .resizable()
+                    .scaledToFit()
+                    .foregroundStyle(Color.bicinoBrandRed)
+                    .frame(width: 88, height: 64)
+                    .accessibilityLabel("Bicino")
+            }
 
         case .download:
             Image(systemName: "map.circle")

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -84,11 +84,7 @@ struct SettingsView: View {
 
                 if !locationAuthorized {
                     Section {
-                        Button {
-                            if let url = URL(string: UIApplication.openSettingsURLString) {
-                                openURL(url)
-                            }
-                        } label: {
+                        Button(action: remediateLocationAuthorization) {
                             Label("Enable Location Access", systemImage: "location")
                         }
                     } footer: {
@@ -235,6 +231,22 @@ struct SettingsView: View {
     private var locationAuthorized: Bool {
         locationAuthorizationStatus == .authorizedAlways ||
             locationAuthorizationStatus == .authorizedWhenInUse
+    }
+
+    private func remediateLocationAuthorization() {
+        switch LocationAuthorizationRemediationPolicy.action(
+            for: locationAuthorizationStatus
+        ) {
+        case .requestInApp:
+            onRequestLocationAuthorization()
+        case .openSettings:
+            guard let url = URL(string: UIApplication.openSettingsURLString) else {
+                return
+            }
+            openURL(url)
+        case .none:
+            break
+        }
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -77,8 +77,6 @@ struct SettingsView: View {
         NavigationView {
             Form {
                 if shouldPromoteBikeComputerSettings {
-                    BicinoOneStoreSection()
-
                     Section {
                         bikeComputerSettingsLink
                     }
@@ -181,6 +179,11 @@ struct SettingsView: View {
                     .listRowBackground(Color.clear)
                 }
             }
+            .safeAreaInset(edge: .top, spacing: 0) {
+                if shouldPromoteBikeComputerSettings {
+                    BicinoOneStoreHero()
+                }
+            }
             .navigationTitle("Settings")
             .navigationBarTitleDisplayMode(.inline)
         }
@@ -235,45 +238,41 @@ struct SettingsView: View {
     }
 }
 
-private struct BicinoOneStoreSection: View {
+private struct BicinoOneStoreHero: View {
     private static let storeURL = URL(string: "https://bicino.com")!
 
     var body: some View {
-        Section {
-            Link(destination: Self.storeURL) {
-                VStack(alignment: .leading, spacing: 12) {
-                    Image("BicinoOneSettingsPromo")
-                        .resizable()
-                        .scaledToFill()
-                        .frame(maxWidth: .infinity)
-                        .frame(height: 180)
-                        .clipped()
-                        .clipShape(RoundedRectangle(cornerRadius: 10))
+        Link(destination: Self.storeURL) {
+            VStack(alignment: .leading, spacing: 0) {
+                Image("BicinoOneSettingsPromo")
+                    .resizable()
+                    .scaledToFill()
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 200)
+                    .clipped()
 
-                    HStack(alignment: .firstTextBaseline, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 3) {
-                            Text("Get your Bicino One")
-                                .font(.headline)
-                            Text("Plan on your iPhone. Ride with Bicino One.")
-                                .font(.footnote)
-                                .foregroundStyle(.secondary)
-                        }
+                HStack(alignment: .firstTextBaseline, spacing: 12) {
+                    Text("Get your Bicino One")
+                        .font(.headline)
 
-                        Spacer(minLength: 8)
+                    Spacer(minLength: 8)
 
-                        Image(systemName: "arrow.up.right")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.secondary)
-                    }
+                    Image(systemName: "arrow.up.right")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.secondary)
                 }
-                .padding(.vertical, 4)
-                .contentShape(Rectangle())
+                .padding(.horizontal, 20)
+                .padding(.vertical, 12)
             }
-            .buttonStyle(.plain)
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel("Get your Bicino One")
-            .accessibilityHint("Opens bicino.com")
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+        .foregroundStyle(.primary)
+        .background(Color(uiColor: .systemGroupedBackground))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Get your Bicino One")
+        .accessibilityHint("Opens bicino.com")
     }
 }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -13120,7 +13120,7 @@ struct NavigationProtocolTests {
             BikeComputerSettingsPresentationPolicy.settingsLinkTitle(
                 knownDeviceCount: 0
             ),
-            "Add a Bicino Bike Computer!",
+            "Connect a Bicino Bike Computer!",
             "empty settings presents a clear add-device action"
         )
         assertEqual(

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -605,6 +605,7 @@ struct NavigationProtocolTests {
         testRouteTransportTypes()
         testMapTrackingPolicy()
         testDeveloperLocationOverride()
+        testLocationAuthorizationRemediationPolicy()
         testRideActivityPolicy()
         testRideDetectionLocationStatusResolver()
         testDeviceGPSPacketBuilder()
@@ -17065,6 +17066,42 @@ struct NavigationProtocolTests {
         assertEqual(overridden.horizontalAccuracy, 4, "override should preserve accuracy")
         assertEqual(overridden.course, 72, "override should preserve course")
         assertEqual(overridden.speed, 8, "override should preserve speed")
+    }
+
+    static func testLocationAuthorizationRemediationPolicy() {
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.action(
+                for: .notDetermined
+            ),
+            .requestInApp,
+            "first-use location access presents the native permission prompt"
+        )
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.action(for: .denied),
+            .openSettings,
+            "denied location access directs the user to Apple Settings"
+        )
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.action(for: .restricted),
+            .openSettings,
+            "restricted location access directs the user to Apple Settings"
+        )
+#if !os(macOS)
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.action(
+                for: .authorizedWhenInUse
+            ),
+            .none,
+            "authorized location access needs no remediation"
+        )
+#endif
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.action(
+                for: .authorizedAlways
+            ),
+            .none,
+            "always-authorized location access needs no remediation"
+        )
     }
 
     static func testNavigationEngineIgnoresLiveLocationFarFromRouteStart() {


### PR DESCRIPTION
## Summary
- move the zero-device Bicino One promo above the Settings form as a full-width header
- remove the rounded settings-row treatment
- remove “Plan on your iPhone. Ride with Bicino One.”
- keep the Bicino One image and headline linked to bicino.com

## Verification
- simulator Debug build (`BikeComputer` scheme)
- `./scripts/run-navigation-tests.sh`
- `git diff --check`