### PR TITLE
Optimize CI component routing

### DIFF
--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Classify changed repository paths for GitHub Actions CI routing."""
+"""Classify changed paths into the minimum safe GitHub Actions CI jobs."""
 
 from __future__ import annotations
 
@@ -9,9 +9,13 @@ import subprocess
 from collections.abc import Iterable, Sequence
 
 
-COMPONENTS = ("firmware", "ios", "map_backend", "osm")
-FULL_CI_PATH_PREFIXES = (".github/scripts/",)
-FULL_CI_PATHS = {".github/workflows/ci.yml"}
+COMPONENTS = ("firmware_build", "firmware_host", "ios", "map_backend", "osm")
+FULL_CI_PATHS = {
+    ".github/scripts/changed_components.py",
+    ".github/workflows/ci.yml",
+}
+FIRMWARE_HOST_ONLY_PATH_PREFIXES = ("esp32/tools/tests/",)
+FIRMWARE_HOST_PATH_PREFIXES = (".github/actions/require-immutable-releases/",)
 FIRMWARE_WORKFLOW_PATHS = {
     ".github/workflows/firmware-diagnostics.yml",
     ".github/workflows/firmware-release.yml",
@@ -68,24 +72,32 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
         if not path:
             continue
 
-        if path in FULL_CI_PATHS or path.startswith(FULL_CI_PATH_PREFIXES):
+        if path in FULL_CI_PATHS:
             return {component: True for component in COMPONENTS}
 
+        if path.startswith("esp32/"):
+            selected["firmware_host"] = True
+            if (
+                not path.startswith(FIRMWARE_HOST_ONLY_PATH_PREFIXES)
+                and not path.endswith(".md")
+            ):
+                selected["firmware_build"] = True
+
         if (
-            path.startswith("esp32/")
-            or path.startswith("tools/tests/")
+            path.startswith("tools/tests/")
+            or path.startswith(FIRMWARE_HOST_PATH_PREFIXES)
             or path in FIRMWARE_WORKFLOW_PATHS
             or path in FIRMWARE_CONTRACT_PATHS
             or path in FIRMWARE_RELEASE_TOOL_PATHS
         ):
-            selected["firmware"] = True
+            selected["firmware_host"] = True
 
         if path.startswith("ios-app/") or path in IOS_CONTRACT_PATHS:
             selected["ios"] = True
 
         if path in FIRMWARE_MANIFEST_PATHS:
             # The release producer and the shipped iOS verifier share this contract.
-            selected["firmware"] = True
+            selected["firmware_host"] = True
             selected["ios"] = True
 
         if path == ".dockerignore" or path.startswith("map-platform/"):
@@ -98,13 +110,13 @@ def classify_paths(paths: Iterable[str], *, run_all: bool = False) -> dict[str, 
 
         if path.startswith(SHARED_FMB_FIXTURE_PREFIX):
             # Firmware, the backend, and the extractor all assert these bytes.
-            selected["firmware"] = True
+            selected["firmware_host"] = True
             selected["map_backend"] = True
             selected["osm"] = True
 
         if path == SHARED_MAP_STREAM_FIXTURE_PATH:
             # The same signed-stream bytes are parsed by backend, iOS, and firmware.
-            selected["firmware"] = True
+            selected["firmware_host"] = True
             selected["ios"] = True
             selected["map_backend"] = True
 
@@ -124,21 +136,24 @@ def select_scope(scope: str) -> dict[str, bool] | None:
         return {component: True for component in COMPONENTS}
     if scope == "firmware":
         return {
-            "firmware": True,
+            "firmware_build": True,
+            "firmware_host": True,
             "ios": False,
             "map_backend": False,
             "osm": False,
         }
     if scope == "ios":
         return {
-            "firmware": False,
+            "firmware_build": False,
+            "firmware_host": False,
             "ios": True,
             "map_backend": False,
             "osm": False,
         }
     if scope == "map":
         return {
-            "firmware": False,
+            "firmware_build": False,
+            "firmware_host": False,
             "ios": False,
             "map_backend": True,
             "osm": True,

--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -4,12 +4,23 @@
 from __future__ import annotations
 
 import argparse
+import json
 import re
 import subprocess
 from collections.abc import Iterable, Sequence
 
 
 COMPONENTS = ("firmware_build", "firmware_host", "ios", "map_backend", "osm")
+FIRMWARE_TARGETS = {
+    "175": (
+        "WAVESHARE_AMOLED_175",
+        "WAVESHARE_AMOLED_175_PRODUCTION",
+    ),
+    "206": (
+        "WAVESHARE_AMOLED_206",
+        "WAVESHARE_AMOLED_206_PRODUCTION",
+    ),
+}
 FULL_CI_PATHS = {
     ".github/scripts/changed_components.py",
     ".github/workflows/ci.yml",
@@ -161,6 +172,17 @@ def select_scope(scope: str) -> dict[str, bool] | None:
     raise ValueError(f"unsupported CI scope: {scope}")
 
 
+def select_firmware_targets(hardware: str) -> tuple[str, ...]:
+    """Return the explicitly selected core firmware build environments."""
+
+    if hardware == "all":
+        return FIRMWARE_TARGETS["175"] + FIRMWARE_TARGETS["206"]
+    try:
+        return FIRMWARE_TARGETS[hardware]
+    except KeyError as error:
+        raise ValueError(f"unsupported firmware hardware: {hardware}") from error
+
+
 def _validated_sha(value: str, label: str) -> str:
     if not SHA_PATTERN.fullmatch(value):
         raise ValueError(f"{label} must be a 40-character Git SHA")
@@ -235,6 +257,11 @@ def main() -> int:
         choices=("auto", "all", "firmware", "ios", "map"),
         default="auto",
     )
+    parser.add_argument(
+        "--firmware-hardware",
+        choices=("175", "206", "all"),
+        default="175",
+    )
     args = parser.parse_args()
 
     try:
@@ -248,6 +275,11 @@ def main() -> int:
     for component in COMPONENTS:
         value = "true" if selected[component] else "false"
         print(f"{component}={value}")
+    firmware_targets = json.dumps(
+        select_firmware_targets(args.firmware_hardware),
+        separators=(",", ":"),
+    )
+    print(f"firmware_targets={firmware_targets}")
     return 0
 
 

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -16,7 +16,8 @@ class ChangedComponentsTests(unittest.TestCase):
     def test_docs_only_change_skips_product_jobs(self) -> None:
         self.assertEqual(
             {
-                "firmware": False,
+                "firmware_build": False,
+                "firmware_host": False,
                 "ios": False,
                 "map_backend": False,
                 "osm": False,
@@ -31,12 +32,28 @@ class ChangedComponentsTests(unittest.TestCase):
             ["map-platform/backend/map_platform/api.py"]
         )
 
-        self.assertTrue(firmware["firmware"])
+        self.assertTrue(firmware["firmware_build"])
+        self.assertTrue(firmware["firmware_host"])
         self.assertFalse(firmware["ios"])
         self.assertTrue(ios["ios"])
-        self.assertFalse(ios["firmware"])
+        self.assertFalse(ios["firmware_build"])
+        self.assertFalse(ios["firmware_host"])
         self.assertTrue(backend["map_backend"])
         self.assertFalse(backend["osm"])
+
+    def test_firmware_host_only_inputs_skip_board_builds(self) -> None:
+        for path in (
+            "esp32/README.md",
+            "esp32/tools/tests/test_build_firmware.py",
+            "tools/tests/test_future_release_tool.py",
+            ".github/actions/require-immutable-releases/action.yml",
+            ".github/workflows/firmware-release.yml",
+            "docs/firmware-build-provenance.md",
+        ):
+            with self.subTest(path=path):
+                selected = changed_components.classify_paths([path])
+                self.assertFalse(selected["firmware_build"])
+                self.assertTrue(selected["firmware_host"])
 
     def test_osm_changes_also_validate_the_backend_image(self) -> None:
         selected = changed_components.classify_paths(
@@ -53,7 +70,8 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertEqual(
             {
-                "firmware": True,
+                "firmware_build": False,
+                "firmware_host": True,
                 "ios": False,
                 "map_backend": True,
                 "osm": True,
@@ -68,7 +86,8 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertEqual(
             {
-                "firmware": True,
+                "firmware_build": False,
+                "firmware_host": True,
                 "ios": True,
                 "map_backend": False,
                 "osm": False,
@@ -83,7 +102,8 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertEqual(
             {
-                "firmware": True,
+                "firmware_build": False,
+                "firmware_host": True,
                 "ios": True,
                 "map_backend": True,
                 "osm": False,
@@ -109,13 +129,15 @@ class ChangedComponentsTests(unittest.TestCase):
         for path in firmware_contracts:
             with self.subTest(path=path):
                 selected = changed_components.classify_paths([path])
-                self.assertTrue(selected["firmware"])
+                self.assertFalse(selected["firmware_build"])
+                self.assertTrue(selected["firmware_host"])
                 self.assertFalse(selected["ios"])
         for path in ios_contracts:
             with self.subTest(path=path):
                 selected = changed_components.classify_paths([path])
                 self.assertTrue(selected["ios"])
-                self.assertFalse(selected["firmware"])
+                self.assertFalse(selected["firmware_build"])
+                self.assertFalse(selected["firmware_host"])
 
     def test_firmware_manifest_generator_and_tests_select_both_consumers(self) -> None:
         for path in (
@@ -125,7 +147,8 @@ class ChangedComponentsTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(
                     {
-                        "firmware": True,
+                        "firmware_build": False,
+                        "firmware_host": True,
                         "ios": True,
                         "map_backend": False,
                         "osm": False,
@@ -142,7 +165,8 @@ class ChangedComponentsTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(
                     {
-                        "firmware": True,
+                        "firmware_build": False,
+                        "firmware_host": True,
                         "ios": False,
                         "map_backend": False,
                         "osm": False,
@@ -158,7 +182,8 @@ class ChangedComponentsTests(unittest.TestCase):
         ):
             with self.subTest(path=path):
                 selected = changed_components.classify_paths([path])
-                self.assertTrue(selected["firmware"])
+                self.assertFalse(selected["firmware_build"])
+                self.assertTrue(selected["firmware_host"])
                 self.assertFalse(selected["ios"])
 
     def test_future_root_tool_tests_select_the_firmware_host_job(self) -> None:
@@ -170,7 +195,8 @@ class ChangedComponentsTests(unittest.TestCase):
             with self.subTest(path=path):
                 self.assertEqual(
                     {
-                        "firmware": True,
+                        "firmware_build": False,
+                        "firmware_host": True,
                         "ios": False,
                         "map_backend": False,
                         "osm": False,
@@ -185,6 +211,13 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertTrue(all(selected.values()))
 
+    def test_ci_policy_test_change_runs_in_the_selector_only(self) -> None:
+        selected = changed_components.classify_paths(
+            [".github/scripts/tests/test_workflow_policy.py"]
+        )
+
+        self.assertFalse(any(selected.values()))
+
     def test_manual_dispatch_runs_every_component(self) -> None:
         selected = changed_components.classify_paths([], run_all=True)
 
@@ -195,7 +228,8 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertIsNotNone(selected)
         assert selected is not None
-        self.assertFalse(selected["firmware"])
+        self.assertFalse(selected["firmware_build"])
+        self.assertFalse(selected["firmware_host"])
         self.assertFalse(selected["ios"])
         self.assertTrue(selected["map_backend"])
         self.assertTrue(selected["osm"])
@@ -206,12 +240,16 @@ class ChangedComponentsTests(unittest.TestCase):
             {component: True for component in changed_components.COMPONENTS},
             changed_components.select_scope("all"),
         )
-        for scope, component in (("firmware", "firmware"), ("ios", "ios")):
-            with self.subTest(scope=scope):
-                selected = changed_components.select_scope(scope)
-                assert selected is not None
-                self.assertTrue(selected[component])
-                self.assertEqual(1, sum(selected.values()))
+        firmware = changed_components.select_scope("firmware")
+        assert firmware is not None
+        self.assertTrue(firmware["firmware_build"])
+        self.assertTrue(firmware["firmware_host"])
+        self.assertEqual(2, sum(firmware.values()))
+
+        ios = changed_components.select_scope("ios")
+        assert ios is not None
+        self.assertTrue(ios["ios"])
+        self.assertEqual(1, sum(ios.values()))
         with self.assertRaisesRegex(ValueError, "unsupported CI scope"):
             changed_components.select_scope("unknown")
 
@@ -292,7 +330,8 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertEqual(
             {
-                "firmware": True,
+                "firmware_build": False,
+                "firmware_host": True,
                 "ios": False,
                 "map_backend": False,
                 "osm": False,

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -223,6 +223,31 @@ class ChangedComponentsTests(unittest.TestCase):
 
         self.assertTrue(all(selected.values()))
 
+    def test_firmware_hardware_selection_is_explicit(self) -> None:
+        targets_175 = (
+            "WAVESHARE_AMOLED_175",
+            "WAVESHARE_AMOLED_175_PRODUCTION",
+        )
+        targets_206 = (
+            "WAVESHARE_AMOLED_206",
+            "WAVESHARE_AMOLED_206_PRODUCTION",
+        )
+
+        self.assertEqual(
+            targets_175,
+            changed_components.select_firmware_targets("175"),
+        )
+        self.assertEqual(
+            targets_206,
+            changed_components.select_firmware_targets("206"),
+        )
+        self.assertEqual(
+            targets_175 + targets_206,
+            changed_components.select_firmware_targets("all"),
+        )
+        with self.assertRaisesRegex(ValueError, "unsupported firmware hardware"):
+            changed_components.select_firmware_targets("unknown")
+
     def test_map_scope_runs_only_map_components(self) -> None:
         selected = changed_components.select_scope("map")
 

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -274,12 +274,22 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertEqual((), tuple(violations))
 
     def test_default_and_diagnostic_firmware_matrices_stay_separate(self) -> None:
-        default_targets = matrix_targets(workflow_source("ci.yml"))
+        general_ci = workflow_source("ci.yml")
+        router = (REPO_ROOT / ".github/scripts/changed_components.py").read_text(
+            encoding="utf-8"
+        )
         diagnostic_targets = matrix_targets(
             workflow_source("firmware-diagnostics.yml")
         )
 
-        self.assertEqual(CORE_FIRMWARE_TARGETS, default_targets)
+        self.assertEqual(set(), matrix_targets(general_ci))
+        self.assertIn(
+            "target: ${{ fromJSON(needs.changes.outputs.firmware_targets) }}",
+            general_ci,
+        )
+        for target in CORE_FIRMWARE_TARGETS:
+            with self.subTest(target=target):
+                self.assertIn(f'"{target}"', router)
         self.assertEqual(DIAGNOSTIC_FIRMWARE_TARGETS, diagnostic_targets)
 
     def test_feature_branch_pushes_do_not_duplicate_pull_request_ci(self) -> None:
@@ -294,6 +304,7 @@ class WorkflowPolicyTests(unittest.TestCase):
 
         self.assertIn("github.event_name", general_ci)
         self.assertIn("inputs.scope || 'auto'", general_ci)
+        self.assertIn("inputs.firmware_hardware || '175'", general_ci)
 
     def test_firmware_build_and_host_routing_stay_independent(self) -> None:
         general_ci = workflow_source("ci.yml")
@@ -311,6 +322,10 @@ class WorkflowPolicyTests(unittest.TestCase):
             changes,
         )
         self.assertIn(
+            "firmware_targets: ${{ steps.components.outputs.firmware_targets }}",
+            changes,
+        )
+        self.assertIn(
             "if: needs.changes.outputs.firmware_build == 'true'",
             esp32,
         )
@@ -320,6 +335,18 @@ class WorkflowPolicyTests(unittest.TestCase):
         )
         self.assertIn("FIRMWARE_BUILD_CHANGED", gate)
         self.assertIn("FIRMWARE_HOST_CHANGED", gate)
+
+    def test_206_firmware_ci_is_explicitly_dispatched(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        instructions = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+
+        self.assertEqual(2, general_ci.count('default: "175"'))
+        self.assertIn('          - "206"', general_ci)
+        self.assertIn("--firmware-hardware \"$FIRMWARE_HARDWARE\"", general_ci)
+        self.assertIn("gh workflow run ci.yml", instructions)
+        self.assertIn("firmware_hardware=206", instructions)
+        self.assertIn("previous_run_id", instructions)
+        self.assertIn("gh run watch", instructions)
 
     def test_partial_manual_runs_do_not_publish_the_protected_gate(self) -> None:
         general_ci = workflow_source("ci.yml")
@@ -341,6 +368,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn('      - "v*"', diagnostic_ci)
         self.assertIn('      - "v*"', release)
         self.assertIn("uses: ./.github/workflows/ci.yml", release)
+        self.assertIn("firmware_hardware: all", release)
         self.assertIn(
             "uses: ./.github/workflows/firmware-diagnostics.yml", release
         )

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -295,6 +295,32 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("github.event_name", general_ci)
         self.assertIn("inputs.scope || 'auto'", general_ci)
 
+    def test_firmware_build_and_host_routing_stay_independent(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        changes = mapping_block(general_ci, "changes", indent=2)
+        esp32 = mapping_block(general_ci, "esp32", indent=2)
+        host = mapping_block(general_ci, "esp32-host", indent=2)
+        gate = mapping_block(general_ci, "gate", indent=2)
+
+        self.assertIn(
+            "firmware_build: ${{ steps.components.outputs.firmware_build }}",
+            changes,
+        )
+        self.assertIn(
+            "firmware_host: ${{ steps.components.outputs.firmware_host }}",
+            changes,
+        )
+        self.assertIn(
+            "if: needs.changes.outputs.firmware_build == 'true'",
+            esp32,
+        )
+        self.assertIn(
+            "if: needs.changes.outputs.firmware_host == 'true'",
+            host,
+        )
+        self.assertIn("FIRMWARE_BUILD_CHANGED", gate)
+        self.assertIn("FIRMWARE_HOST_CHANGED", gate)
+
     def test_partial_manual_runs_do_not_publish_the_protected_gate(self) -> None:
         general_ci = workflow_source("ci.yml")
 
@@ -406,6 +432,7 @@ class WorkflowPolicyTests(unittest.TestCase):
         for path in SHARED_CONTRACT_PATHS:
             with self.subTest(path=path):
                 self.assertIn(f'      - "{path}"', general_ci)
+        self.assertIn('      - ".github/actions/**"', general_ci)
         self.assertIn('      - "test-fixtures/fmb/**"', general_ci)
         self.assertIn('      - "tools/firmware_manifest.py"', general_ci)
         self.assertIn('      - "tools/firmware-signing-requirements.txt"', general_ci)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
         required: false
         default: all
         type: string
+      firmware_hardware:
+        description: Firmware hardware families to build
+        required: false
+        default: "175"
+        type: string
   push:
     branches:
       - main
@@ -57,6 +62,15 @@ on:
           - firmware
           - ios
           - map
+      firmware_hardware:
+        description: Firmware hardware families to build
+        required: true
+        default: "175"
+        type: choice
+        options:
+          - "175"
+          - "206"
+          - all
 
 permissions:
   contents: read
@@ -64,7 +78,8 @@ permissions:
 concurrency:
   group: >-
     ${{ github.workflow }}-${{ github.event_name }}-${{
-    github.event.pull_request.number || github.ref }}-${{ inputs.scope || 'auto' }}
+    github.event.pull_request.number || github.ref }}-${{ inputs.scope || 'auto' }}-${{
+    inputs.firmware_hardware || '175' }}
   cancel-in-progress: true
 
 jobs:
@@ -74,6 +89,7 @@ jobs:
     outputs:
       firmware_build: ${{ steps.components.outputs.firmware_build }}
       firmware_host: ${{ steps.components.outputs.firmware_host }}
+      firmware_targets: ${{ steps.components.outputs.firmware_targets }}
       ios: ${{ steps.components.outputs.ios }}
       map_backend: ${{ steps.components.outputs.map_backend }}
       osm: ${{ steps.components.outputs.osm }}
@@ -107,6 +123,7 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
           CI_SCOPE: ${{ github.ref_type == 'tag' && 'all' || inputs.scope || 'auto' }}
           EVENT_NAME: ${{ github.event_name }}
+          FIRMWARE_HARDWARE: ${{ inputs.firmware_hardware || '175' }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         run: >-
           python3 .github/scripts/changed_components.py
@@ -114,6 +131,7 @@ jobs:
           --base "$BASE_SHA"
           --head "$HEAD_SHA"
           --scope "$CI_SCOPE"
+          --firmware-hardware "$FIRMWARE_HARDWARE"
           >> "$GITHUB_OUTPUT"
 
   esp32:
@@ -124,11 +142,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - WAVESHARE_AMOLED_175
-          - WAVESHARE_AMOLED_175_PRODUCTION
-          - WAVESHARE_AMOLED_206
-          - WAVESHARE_AMOLED_206_PRODUCTION
+        target: ${{ fromJSON(needs.changes.outputs.firmware_targets) }}
     defaults:
       run:
         working-directory: esp32

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - main
     paths:
       - ".dockerignore"
+      - ".github/actions/**"
       - ".github/scripts/**"
       - ".github/workflows/ci.yml"
       - ".github/workflows/firmware-diagnostics.yml"
@@ -71,7 +72,8 @@ jobs:
     name: Select CI components
     runs-on: ubuntu-latest
     outputs:
-      firmware: ${{ steps.components.outputs.firmware }}
+      firmware_build: ${{ steps.components.outputs.firmware_build }}
+      firmware_host: ${{ steps.components.outputs.firmware_host }}
       ios: ${{ steps.components.outputs.ios }}
       map_backend: ${{ steps.components.outputs.map_backend }}
       osm: ${{ steps.components.outputs.osm }}
@@ -117,7 +119,7 @@ jobs:
   esp32:
     name: ESP32 (${{ matrix.target }})
     needs: changes
-    if: needs.changes.outputs.firmware == 'true'
+    if: needs.changes.outputs.firmware_build == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -261,7 +263,7 @@ jobs:
   esp32-host:
     name: ESP32 Host Tests
     needs: changes
-    if: needs.changes.outputs.firmware == 'true'
+    if: needs.changes.outputs.firmware_host == 'true'
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -712,7 +714,8 @@ jobs:
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
           ESP32_RESULT: ${{ needs.esp32.result }}
-          FIRMWARE_CHANGED: ${{ needs.changes.outputs.firmware }}
+          FIRMWARE_BUILD_CHANGED: ${{ needs.changes.outputs.firmware_build }}
+          FIRMWARE_HOST_CHANGED: ${{ needs.changes.outputs.firmware_host }}
           HOST_RESULT: ${{ needs.esp32-host.result }}
           IOS_CHANGED: ${{ needs.changes.outputs.ios }}
           IOS_RESULT: ${{ needs.ios.result }}
@@ -732,11 +735,15 @@ jobs:
 
           require_result "CI component selection" "$CHANGES_RESULT" success
 
-          if test "$FIRMWARE_CHANGED" = true; then
+          if test "$FIRMWARE_BUILD_CHANGED" = true; then
             require_result "ESP32 builds" "$ESP32_RESULT" success
-            require_result "ESP32 host tests" "$HOST_RESULT" success
           else
             require_result "ESP32 builds" "$ESP32_RESULT" skipped
+          fi
+
+          if test "$FIRMWARE_HOST_CHANGED" = true; then
+            require_result "ESP32 host tests" "$HOST_RESULT" success
+          else
             require_result "ESP32 host tests" "$HOST_RESULT" skipped
           fi
 

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -23,6 +23,7 @@ jobs:
     uses: ./.github/workflows/ci.yml
     with:
       scope: all
+      firmware_hardware: all
 
   diagnostics:
     name: Validate diagnostic firmware

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -265,6 +265,43 @@ embedded Git/profile identity; it does not contain those SHA-256 values or prove
 on-device byte equality. Flash readback or a runtime image digest is required
 for that stronger claim.
 
+### GitHub firmware CI
+
+Automatic pull-request and `main` CI intentionally build only the 1.75-inch
+ordinary and production firmware profiles. The aggregate gate therefore does
+not prove that 2.06-inch firmware compiles.
+
+When the user explicitly asks in a Codex task to run 2.06 CI, dispatch the
+manual firmware scope for the current branch and wait for the exact run:
+
+```sh
+branch="$(git branch --show-current)"
+previous_run_id="$(gh run list --workflow ci.yml --branch "$branch" \
+  --event workflow_dispatch --limit 1 --json databaseId \
+  --jq '.[0].databaseId // empty')"
+gh workflow run ci.yml --ref "$branch" \
+  -f scope=firmware \
+  -f firmware_hardware=206
+for attempt in {1..30}; do
+  run_id="$(gh run list --workflow ci.yml --branch "$branch" \
+    --event workflow_dispatch --limit 1 --json databaseId \
+    --jq '.[0].databaseId // empty')"
+  if [[ -n "$run_id" && "$run_id" != "$previous_run_id" ]]; then
+    break
+  fi
+  sleep 2
+done
+[[ -n "$run_id" && "$run_id" != "$previous_run_id" ]]
+gh run watch "$run_id" --exit-status
+```
+
+Use `firmware_hardware=all` only when the user requests both boards or when a
+release/full-qualification workflow requires them. A manual 2.06 CI run builds
+both `WAVESHARE_AMOLED_206` and `WAVESHARE_AMOLED_206_PRODUCTION`; it does not
+flash or otherwise touch a physical device. Report 2.06 validation only after
+the dispatched run completes successfully. Tagged firmware releases always
+request `all` and continue to qualify both board families.
+
 ### Firmware release and factory-image qualification
 
 When firmware is requested from current or latest GitHub `main`, fetch


### PR DESCRIPTION
## Summary

- split firmware routing into compiled board builds and lightweight host/contract validation
- make automatic pull-request and `main` firmware CI build only the 1.75-inch ordinary and production profiles
- add explicit manual firmware selectors for `175`, `206`, and `all`
- keep tagged firmware releases on `all`, so releases still qualify both hardware families
- stop CI policy tests, release workflows, documentation, and test-only changes from launching unrelated firmware, iOS, and map jobs
- make the aggregate CI gate validate firmware builds and host tests independently

## Manual 2.06 validation

When a Codex task explicitly asks to run 2.06 CI, the repository instructions dispatch `ci.yml` for the current branch with:

```sh
gh workflow run ci.yml --ref "$branch" \
  -f scope=firmware \
  -f firmware_hardware=206
```

The instructions then identify the new workflow-dispatch run and wait for it with `gh run watch --exit-status`. This builds both `WAVESHARE_AMOLED_206` and `WAVESHARE_AMOLED_206_PRODUCTION`; it does not flash a physical device.

## Why

The previous router treated every firmware-adjacent change as a full four-board build and every `.github/scripts/**` change as affecting every product. In practice, the 2.06 profiles are rarely needed for ordinary PR validation and can be requested explicitly when a change needs them.

Replaying 30 recent runs that used the current CI policy estimates these changes would avoid 656 of 1,170 rounded runner minutes (about 56%):

- 508 firmware-build minutes
- 113 iOS minutes
- 35 map minutes

The opt-in 2.06 policy accounts for 140 of those firmware minutes beyond the component-routing savings.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 python3 -m unittest discover -s .github/scripts/tests` — 55 tests passed
- `actionlint` 1.7.12
- explicit router checks for `175`, `206`, and `all`
- `git diff --check`
