### PR TITLE
Show active device maps in Saved Maps

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -1304,6 +1304,15 @@ Status responses should include:
   distinguishes regenerated packs that intentionally reuse a stable map ID.
 - `activeManifestReceipt`: SHA-256 identity of the exact installed manifest;
   the app binds the following label-health fields to this receipt.
+- `activeMapDisplayName`: optional, bounded UTF-8 display name read from the
+  installed manifest. Invalid or missing presentation metadata is omitted and
+  does not invalidate an otherwise usable map.
+- `activeMapBoundsE7`: optional four-integer array in
+  `[minLongitude, minLatitude, maxLongitude, maxLatitude]` order, with each
+  coordinate scaled by `10^7`. Firmware normalizes legacy decimal `bounds`
+  manifests to this representation. The app validates these bounds and uses
+  them to generate a local preview; preview image bytes are never sent over
+  BLE.
 - `activeRendererFormat`: the installed renderer target format (`1` legacy,
   `2` FMB v3 + FMA1 street labels, `3` FMB v4 + FMA1 + OSM buildings).
 - `labelProfileVersion`: `1` for the current target-2/3 label profile, otherwise

--- a/docs/plans/device-map-presence-implementation-plan.md
+++ b/docs/plans/device-map-presence-implementation-plan.md
@@ -4,8 +4,10 @@
 
 This plan was authored from freshly fetched `origin/main` at
 `95880ff88ba96b01abf714c13ad2107ed3110535` on 2026-08-17. It is an
-implementation contract, not a claim that the feature has been implemented or
-shipped.
+implementation contract for the accompanying branch, not a claim that the
+feature has shipped. The software changes and automated coverage are
+implemented on this branch; the cloned-SD physical-device acceptance check
+remains a release validation step.
 
 The feature makes the iOS **Saved Maps** section reflect the map that is
 currently active on the connected bike computer even when the corresponding

--- a/docs/plans/device-map-presence-implementation-plan.md
+++ b/docs/plans/device-map-presence-implementation-plan.md
@@ -1,0 +1,521 @@
+# Device-Reported Saved Map Presence Implementation Plan
+
+## Status and scope
+
+This plan was authored from freshly fetched `origin/main` at
+`95880ff88ba96b01abf714c13ad2107ed3110535` on 2026-08-17. It is an
+implementation contract, not a claim that the feature has been implemented or
+shipped.
+
+The feature makes the iOS **Saved Maps** section reflect the map that is
+currently active on the connected bike computer even when the corresponding
+map pack is not cached on that iPhone. The primary acceptance case is a cloned
+SD card moved into another bike computer and connected to a different iPhone.
+
+This is deliberately an active-map feature, not a multi-map library. Firmware
+continues to select one usable map through `/VECTMAP/active-map.json`; inactive,
+rollback, staging, and orphaned folders are not presented as user-selectable
+maps.
+
+## Outcome
+
+The Saved Maps list becomes the union of:
+
+1. map packs cached by the Bicino app on this iPhone; and
+2. the active map descriptor reported by the currently authenticated bike
+   computer.
+
+Each row shows two independent location indicators:
+
+- an iPhone symbol showing whether the exact map artifact is saved locally;
+- a filled round bike-computer symbol containing a lowercase `b`, showing
+  whether that exact map artifact is active on the device.
+
+A device-only map receives the same style of map preview as an iPhone-cached
+map. The iPhone generates that preview from trusted, bounded geographic
+metadata; firmware does not send PNG bytes over BLE.
+
+## Current main-branch behavior
+
+### iPhone saved-map inventory
+
+`OfflineMapManager.refreshCachedPacks()` enumerates only `.bmap` and `.zip`
+files under the iPhone cache directory `OfflineMapPacks`. `SettingsView` then
+renders one `DownloadedMapRow` for each `cachedPackURL`. A map that exists only
+on the SD card therefore cannot create a Saved Maps row.
+
+The current row contains:
+
+- the locally resolved preview;
+- an editable local display name;
+- a gray upload icon when the local pack is not active on the device;
+- a green checkmark when local map and active device session match; and
+- a trash action that removes only the iPhone copy.
+
+### Device-reported state
+
+The existing authenticated `MSTS`/`MSTC` map-transfer status already reports:
+
+- `sdPresent`;
+- `activeMapId`;
+- `activeSessionId`;
+- `activeManifestReceipt`;
+- renderer/label metadata; and
+- activation progress and errors.
+
+`BLEManager` parses those fields, and `OfflineMapManager.isCachedPackInstalled`
+uses the map ID plus the content/session identity to avoid claiming that a
+regenerated pack for the same area is already installed.
+
+The status does not currently expose the active map's display name or bounds.
+The iOS app also has no row model for a map without a local pack URL.
+
+### Installed manifest metadata
+
+The signed map manifests already contain the required presentation metadata:
+
+- `displayName`;
+- `bounds` in ZIP manifests;
+- normalized `boundsE7` in Bike Map Stream manifests; and
+- optional preview data intended for local pack presentation.
+
+Current firmware validates and stores the installed manifest but ignores
+`displayName`, `bounds`, and `boundsE7` in its `MapManifest` model. The feature
+can therefore be implemented without changing map generation or transferring
+preview images from the SD card.
+
+## Product contract
+
+### Presence states and icons
+
+| Exact artifact state | iPhone indicator | Bike-computer indicator | Primary interaction |
+| --- | --- | --- | --- |
+| Cached only on this iPhone | Blue `iphone` symbol | Gray filled circle with white lowercase `b` and a small upload badge | Tap the `b` button to transfer |
+| Active only on the connected device | Gray `iphone` symbol | Green filled circle with white lowercase `b` and a small check badge | Status only |
+| Cached on this iPhone and active on the device | Blue `iphone` symbol | Green filled circle with white lowercase `b` and a small check badge | Tapping the `b` button may retain the existing “Already on Device” explanation |
+| Upload in progress | Blue `iphone` symbol | Gray/blue `b` circle with a progress ring | Existing pause/resume behavior remains authoritative |
+
+The lowercase `b` stays visible in every device state. Badges and accessibility
+labels carry meaning in addition to color.
+
+Recommended visual metrics for the device indicator:
+
+- preserve the current 32 x 32-point button target;
+- render a 26-28-point filled circle;
+- center a white semibold lowercase `b` using Dynamic Type-safe sizing;
+- use the current success green for the active state;
+- use `secondary`/neutral gray for the inactive state;
+- place the upload or check badge at the lower trailing edge without covering
+  the `b`; and
+- preserve adequate contrast in light and dark appearance.
+
+The iPhone indicator is informational and is not a download-from-device
+button. A gray iPhone means the app does not possess the map pack.
+
+Accessibility labels must describe the complete state, for example:
+
+- `Saved on this iPhone`;
+- `Not saved on this iPhone`;
+- `Active on bike computer`; and
+- `Transfer <map name> to bike computer`.
+
+### Row behavior
+
+- The active device row sorts first.
+- A device-only row is not renameable because changing the iPhone label would
+  not rename the signed map metadata on the SD card.
+- A device-only row has no trash button. Remote deletion is outside this
+  feature.
+- A merged phone-and-device row keeps the existing local rename behavior and
+  prefers the iPhone's user-defined name for presentation.
+- Deleting the local copy from a merged row leaves a device-only row visible
+  while the device remains connected. The existing confirmation must continue
+  to state that the map on the bike computer remains.
+- The `Download a new Map` action remains unchanged.
+- Replace the misleading empty-state copy `0 maps downloaded yet` with
+  `No offline maps yet` when neither a local nor live device map is available.
+
+### Connection and freshness
+
+Device presence is live, connection-scoped state:
+
+- publish a device-only row only after a complete authenticated map-status
+  response has been parsed;
+- clear the live descriptor on disconnect, local forget, authentication reset,
+  SD removal, or a later valid status with no active map;
+- never leave a green device indicator based only on stale persisted state;
+- keep local rows visible while disconnected, with the neutral gray `b`
+  transfer state disabled until navigation BLE is ready; and
+- request a fresh map status through the existing status request after the
+  connection becomes navigation-ready.
+
+A future feature may show a clearly labeled “last seen” map, but this plan does
+not persist live device presence as current truth.
+
+## Identity and merge rules
+
+`mapId` identifies a logical area, not necessarily one generated artifact.
+Rows must therefore merge only when content identity is proven.
+
+Use this matching order:
+
+1. compare the active `sessionId` with the local signed manifest receipt,
+   expected active session, or last transferred session already accepted by
+   `isCachedPackInstalled`;
+2. for legacy ZIP packs, derive the existing manifest-based transfer session
+   identity and compare it with `activeSessionId`;
+3. if firmware reports an active map ID but no session identity, show a
+   conservative device-only row rather than marking an arbitrary same-area
+   local pack active.
+
+If a local pack and device map share `mapId` but not content identity, show
+them as distinct rows. This avoids a false “on both” state and preserves the
+user's ability to upload the newer/different iPhone copy.
+
+Define a pure, host-testable model such as:
+
+```swift
+struct DeviceActiveMapDescriptor: Equatable, Sendable {
+    let mapID: String
+    let sessionID: String?
+    let manifestReceipt: String?
+    let displayName: String?
+    let bounds: OfflineMapPreviewBounds?
+}
+
+struct SavedMapListItem: Identifiable, Equatable {
+    let identity: SavedMapContentIdentity
+    let localPackURL: URL?
+    let activeDeviceMap: DeviceActiveMapDescriptor?
+    let displayName: String
+}
+```
+
+The exact names may change during implementation, but identity resolution and
+row merging must remain independent of SwiftUI rendering.
+
+## BLE status extension
+
+Extend the existing map-transfer status additively; do not add a BLE UUID or a
+second status command.
+
+When presentation metadata is valid, firmware adds:
+
+```json
+{
+  "activeMapId": "custom-map-6354c43431",
+  "activeSessionId": "<content identity>",
+  "activeMapDisplayName": "Shanghai and Suzhou",
+  "activeMapBoundsE7": [1209000000, 307000000, 1219500000, 315500000]
+}
+```
+
+Requirements:
+
+- retain every existing status field and meaning;
+- continue using authenticated `MSTS` when it fits and authenticated `MSTC`
+  chunks otherwise;
+- never place `preview.dataBase64` or other image data in BLE status;
+- bound and JSON-escape the display name before serialization;
+- validate four bounds coordinates, longitude/latitude ranges, and strict
+  minimum/maximum ordering;
+- prefer `boundsE7`; accept and safely convert legacy finite `bounds` values;
+- omit invalid optional presentation metadata without hiding an otherwise
+  valid active map; and
+- keep the serialized response below the existing 255-chunk ceiling under the
+  minimum supported authenticated chunk payload.
+
+Older iOS builds ignore the additive fields. New iOS builds continue to work
+with older firmware by falling back to `activeMapId`, a generated display name,
+and the generic map placeholder when name or bounds are absent.
+
+## Firmware implementation
+
+### Presentation metadata parsing
+
+Add bounded optional presentation fields to the map-transfer domain rather
+than parsing arbitrary manifest JSON directly in `ble_navigation.cpp`.
+
+Recommended changes:
+
+1. Add a small `MapPresentationMetadata` value to
+   `esp32/lib/map_transfer/map_transfer.hpp` or a focused adjacent header.
+2. Extend the installed-manifest reader in
+   `esp32/lib/map_transfer/map_transfer.cpp` to parse `displayName`,
+   `boundsE7`, and legacy `bounds` as optional presentation data.
+3. Treat malformed presentation data as unavailable, not as a reason to reject
+   a map that passes the existing renderer/file integrity checks.
+4. Expose one read-only `readActiveMapPresentation(...)` operation that binds
+   presentation data to the same active root selected by `active-map.json`.
+5. Reuse a pure JSON-serialization helper for the new status fields so host
+   tests can cover escaping, bounds, omission, and size behavior without
+   compiling NimBLE/LVGL globals.
+
+The reader must not enumerate `/VECTMAP/.maps`, staging directories, or rollback
+roots. Only the map selected by the validated active-map record is surfaced.
+
+### Status publication
+
+Update `esp32/lib/ble_navigation/ble_navigation.cpp` to append the optional
+name and E7 bounds to `mapTransferStatusJson()`. Preserve the current status
+chunk transfer-ID behavior: identical response bodies reuse their transfer ID,
+and a changed active descriptor produces a new transfer ID.
+
+If SD metadata changes while connected, the next explicit or lifecycle status
+request must replace the entire iOS descriptor atomically. Partial chunks must
+never publish a half-updated row.
+
+## iOS implementation
+
+### Atomic active-map descriptor
+
+Add a single published `DeviceActiveMapDescriptor?` to `BLEManager` and build
+it only after the complete `MSTS` body or all `MSTC` chunks have parsed.
+
+The parser must:
+
+- validate map ID and optional session/receipt lengths;
+- decode `activeMapBoundsE7` using the same geographic invariants as
+  `OfflineMapPreviewBounds`;
+- trim or reject empty display names;
+- publish `nil` when `activeMapId` is absent or invalid;
+- clear the descriptor wherever existing map-transfer active fields are reset;
+  and
+- preserve current published fields for transfer, activation, label, and
+  compatibility consumers.
+
+Keep descriptor assignment logically atomic even if legacy scalar properties
+remain for existing callers.
+
+### Merged Saved Maps model
+
+Move Saved Maps row construction out of the direct
+`ForEach(manager.cachedPackURLs)` path. Add a pure builder that accepts:
+
+- the ordered local pack URLs and their derived identities/metadata; and
+- the current optional `DeviceActiveMapDescriptor`.
+
+It returns `SavedMapListItem` values with the active device item first, exact
+matches merged, and remaining local packs in their current modification order.
+
+Refactor `isCachedPackInstalled` to share the same identity matcher rather than
+maintaining two definitions of “same artifact.” Existing transfer recovery and
+activation decisions must continue to use content identity, not display name
+or bounds.
+
+### Device-only previews
+
+Reuse `OfflineMapSnapshotPreviewRenderer` for a device-only descriptor with
+valid bounds:
+
+1. immediately publish the existing lightweight bounds fallback;
+2. request the MapKit snapshot asynchronously;
+3. validate meaningful visual variation as existing local snapshots do;
+4. cache the PNG under an identity-derived filename in a dedicated
+   `DeviceMapPreviews` cache directory; and
+5. replace the fallback only if the descriptor/task token is still current.
+
+Do not synthesize a fake artifact URL or place device-only previews beside
+local `.bmap`/`.zip` files. Use a distinct cache API keyed by the normalized
+map/session identity. Bound the cache by count or age so SD swaps do not create
+unbounded files.
+
+When bounds are unavailable, invalid, or MapKit fails, display the existing
+generic map placeholder. Lack of a preview must not hide the row.
+
+### SwiftUI row
+
+Refactor `DownloadedMapRow` into a row that accepts `SavedMapListItem` rather
+than requiring a local `packURL`.
+
+Add focused components:
+
+- `PhoneMapPresenceIcon`, backed by the SF Symbol `iphone`; and
+- `BikeComputerMapPresenceButton`, drawn as a filled circle containing a
+  lowercase `b` with optional upload/check/progress treatment.
+
+Preserve the current upload enablement conditions, background upload resume
+behavior, installed confirmation, rename commit behavior, and local delete
+confirmation. Gate controls by the row's actual capabilities:
+
+- rename and trash require `localPackURL`;
+- upload requires `localPackURL` and a nonmatching device identity;
+- a device-only row exposes no action that implies downloading the map back to
+  the iPhone; and
+- the active device indicator remains visible when there is no local pack.
+
+## Compatibility and failure behavior
+
+| Situation | Required behavior |
+| --- | --- |
+| New iOS + new firmware + cloned current SD | Device-only row, gray phone, green `b`, manifest name, generated preview |
+| New iOS + older firmware with active ID/session | Device-only row, gray phone, green `b`, ID-derived name, placeholder preview |
+| New iOS + older firmware with active ID but no session | Conservative device-only row; do not merge with same-area local pack |
+| Old iOS + new firmware | Existing Saved Maps behavior; additive fields ignored |
+| Missing or invalid active manifest | No phantom device-only row; retain valid local rows |
+| Valid active map with malformed optional name/bounds | Device-only row with safe fallback name/preview |
+| SD removed after connection | Fresh status clears the device descriptor and green `b` state |
+| Incomplete/lost `MSTC` response | Keep the previous complete descriptor until a complete replacement or connection reset; never publish partial data |
+| Same map ID, different sessions | Separate device-active and local rows |
+| MapKit unavailable/offline | Bounds fallback or generic map placeholder; row remains usable |
+
+## Expected file changes
+
+Firmware and protocol:
+
+- `esp32/lib/map_transfer/map_transfer.hpp`
+- `esp32/lib/map_transfer/map_transfer.cpp`
+- `esp32/lib/ble_navigation/ble_navigation.cpp`
+- a small host-testable status/presentation helper if needed
+- `esp32/tools/tests/test_map_transfer.cpp`
+- `esp32/tools/tests/test_map_transfer_status_chunk_session.cpp` or a focused
+  new status-payload test
+- `docs/ble-protocol.md`
+
+iOS:
+
+- `ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift`
+- `ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift`
+- `ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift`
+- optionally a focused
+  `ios-app/BikeComputer/BikeComputer/Models/SavedMapPresence.swift`
+- the Xcode project and host-test source list if a new Swift file is introduced
+- `ios-app/BikeComputerTests/NavigationProtocolTests.swift`
+- `ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift`
+
+The map-platform generator should require no production change because current
+manifests already contain display name and bounds. Add or adjust backend tests
+only if implementation exposes a missing contract in archive/stream manifest
+normalization.
+
+## Implementation sequence
+
+1. **Extract and test active presentation metadata in firmware.** Add
+   best-effort name/bounds parsing bound to the validated active map root.
+2. **Extend authenticated map status.** Serialize optional presentation fields,
+   document them, and verify direct and chunked transport size behavior.
+3. **Parse an atomic device descriptor on iOS.** Cover full, missing, malformed,
+   chunked, retransmitted, and reset payloads.
+4. **Build the pure merged-row model.** Reuse exact session/receipt matching and
+   cover every local/device combination before changing SwiftUI.
+5. **Add device-only preview loading and caching.** Reuse the existing snapshot,
+   validation, cancellation, and stale-result protections.
+6. **Replace row status controls with phone and round-`b` indicators.** Preserve
+   upload, rename, delete, progress, and accessibility behavior.
+7. **Run host, app, firmware-build, and physical cloned-SD acceptance gates.**
+
+## Verification plan
+
+### Firmware host tests
+
+Add coverage for:
+
+- stream `boundsE7` and legacy `bounds` parsing;
+- coordinate range/order rejection;
+- display-name escaping, empty values, control characters, and size bounds;
+- valid active map with absent/malformed optional presentation metadata;
+- selection of only the `active-map.json` root;
+- unchanged core manifest validation and installed receipt behavior;
+- additive JSON fields and omission behavior;
+- direct `MSTS` versus chunked `MSTC` behavior; and
+- status bodies remaining within the chunk-count ceiling.
+
+Run at minimum the CI-equivalent map-transfer and status host tests, including
+`test_map_transfer` and `test_map_transfer_status_chunk_session`, with
+`-Wall -Wextra -Werror` for any new pure helper.
+
+### iOS host and Catalyst tests
+
+Add coverage for:
+
+- parsing the new descriptor from direct and chunked status;
+- clearing it on a status without an active map and on disconnect/reset;
+- no publication from incomplete chunks;
+- local-only, device-only, exact merged, same-ID/different-session, and empty
+  list construction;
+- active-first stable ordering;
+- device-only preview fallback, MapKit replacement, disk restoration, cache
+  invalidation, and stale async completion;
+- absence of rename/delete/upload actions when no local pack exists;
+- local deletion converting a merged row into device-only; and
+- accessibility labels for both indicators.
+
+Run:
+
+```sh
+cd ios-app
+./scripts/run-navigation-tests.sh
+```
+
+Then build the complete iOS app through `scripts/xcodebuild-cli.sh` using an
+isolated DerivedData directory and no code signing, matching the repository CI
+configuration.
+
+### Firmware builds
+
+Build both supported production targets through the repository-owned firmware
+runtime:
+
+```sh
+cd esp32
+python3 tools/build_firmware.py WAVESHARE_AMOLED_175_PRODUCTION
+python3 tools/build_firmware.py WAVESHARE_AMOLED_206_PRODUCTION
+```
+
+No firmware flash is part of implementation until the connected physical
+device is identified and explicit pre-flash confirmation is obtained.
+
+### Physical cloned-SD acceptance
+
+Use a verified exact clone containing the hidden active stream state,
+`active-map.json`, and its ready/receipt files.
+
+1. Start with an iPhone/app installation that has no matching local map pack.
+2. Insert the cloned SD card into the identified compatible Bicino device.
+3. Boot and confirm SD mount, active map selection, and normal map rendering.
+4. Connect and authenticate the other iPhone.
+5. Open Saved Maps and confirm the active map appears first.
+6. Confirm the iPhone symbol is gray and the round lowercase-`b` icon is green.
+7. Confirm the manifest-derived display name appears.
+8. Confirm the bounds fallback appears promptly and the MapKit snapshot replaces
+   it when available.
+9. Reboot/reconnect and confirm the same identity and preview are restored.
+10. Remove or swap the SD card, request fresh status, and confirm the green
+    device presence is not retained incorrectly.
+11. Download the exact same artifact to the iPhone and confirm the row merges to
+    blue iPhone plus green `b` without duplication.
+12. Test a same-map-ID but different-session local pack and confirm it does not
+    receive a false active state.
+
+## Acceptance criteria
+
+The implementation is complete only when all of the following are true:
+
+- A current cloned SD map appears in Saved Maps on a different, otherwise
+  empty iPhone after an authenticated connection.
+- The row accurately distinguishes phone absence from device-active presence.
+- The bike-computer indicator is a filled round icon with a lowercase `b`, gray
+  when inactive/uploadable and green when active.
+- A device-only map receives a bounds-derived preview without transferring PNG
+  data over BLE.
+- Exact local/device identities merge; same-area different artifacts do not.
+- Device-only rows cannot be renamed, locally deleted, or mistaken for an
+  iPhone download.
+- Existing local map download, rename, preview, upload/resume, installed
+  confirmation, and delete behavior remains intact.
+- Old firmware and old iOS compatibility behavior remains safe.
+- Firmware host tests, iOS helper/Catalyst tests, complete iOS build, and both
+  firmware production builds pass.
+- Physical cloned-SD behavior is verified on an identified device after the
+  required flash approval and boot validation.
+
+## Explicit non-goals
+
+- Enumerating every folder or rollback artifact on the SD card.
+- Turning the bike computer into a selectable multi-map library.
+- Copying a map pack from the bike computer back to the iPhone.
+- Sending preview PNG bytes over BLE.
+- Renaming or deleting device-only maps.
+- Changing map generation, map activation, rollback, or pruning semantics.
+- Adding a new BLE service or characteristic.
+- Persisting stale device presence as if it were live.

--- a/docs/plans/device-map-presence-implementation-plan.md
+++ b/docs/plans/device-map-presence-implementation-plan.md
@@ -27,15 +27,16 @@ The Saved Maps list becomes the union of:
 2. the active map descriptor reported by the currently authenticated bike
    computer.
 
-Each row shows two independent location indicators:
-
-- an iPhone symbol showing whether the exact map artifact is saved locally;
-- a filled round bike-computer symbol containing a lowercase `b`, showing
-  whether that exact map artifact is active on the device.
+Each row reuses the existing saved-map state indicator: a round upload arrow
+when a local map can be sent to the device, or a green check when the exact map
+is active. No separate phone or bike-computer symbol is shown. A local trash
+button indicates that the map is cached on the iPhone; its absence identifies a
+device-only row.
 
 A device-only map receives the same style of map preview as an iPhone-cached
 map. The iPhone generates that preview from trusted, bounded geographic
-metadata; firmware does not send PNG bytes over BLE.
+metadata; firmware does not send PNG bytes over BLE. Tapping an available
+thumbnail opens that rendered preview in a modal.
 
 ## Current main-branch behavior
 
@@ -90,29 +91,21 @@ preview images from the SD card.
 
 ### Presence states and icons
 
-| Exact artifact state | iPhone indicator | Bike-computer indicator | Primary interaction |
+| Exact artifact state | State indicator | Local delete button | Primary interaction |
 | --- | --- | --- | --- |
-| Cached only on this iPhone | Blue `iphone` symbol | Gray filled circle with white lowercase `b` and a small upload badge | Tap the `b` button to transfer |
-| Active only on the connected device | Gray `iphone` symbol | Green filled circle with white lowercase `b` and a small check badge | Status only |
-| Cached on this iPhone and active on the device | Blue `iphone` symbol | Green filled circle with white lowercase `b` and a small check badge | Tapping the `b` button may retain the existing “Already on Device” explanation |
-| Upload in progress | Blue `iphone` symbol | Gray/blue `b` circle with a progress ring | Existing pause/resume behavior remains authoritative |
+| Cached only on this iPhone | Existing round `arrow.up.circle` | Visible | Tap the arrow to transfer |
+| Active only on the connected device | Existing green `checkmark.circle.fill` | Hidden | Status only |
+| Cached on this iPhone and active on the device | Existing green `checkmark.circle.fill` | Visible | Tapping the check may retain the existing “Already on Device” explanation |
+| Upload in progress | Existing upload progress/resume treatment | Visible | Existing pause/resume behavior remains authoritative |
 
-The lowercase `b` stays visible in every device state. Badges and accessibility
-labels carry meaning in addition to color.
+Do not show a separate iPhone or bike-computer symbol. The state indicator is
+the same regardless of where the row originated. The local trash button is the
+visual distinction between a local row and a device-only row, while
+accessibility text states explicitly when the map is not saved on the iPhone.
 
-Recommended visual metrics for the device indicator:
-
-- preserve the current 32 x 32-point button target;
-- render a 26-28-point filled circle;
-- center a white semibold lowercase `b` using Dynamic Type-safe sizing;
-- use the current success green for the active state;
-- use `secondary`/neutral gray for the inactive state;
-- place the upload or check badge at the lower trailing edge without covering
-  the `b`; and
-- preserve adequate contrast in light and dark appearance.
-
-The iPhone indicator is informational and is not a download-from-device
-button. A gray iPhone means the app does not possess the map pack.
+Inactive device packs remain outside this active-map-only protocol. If a future
+device inventory exposes them, use the same round upload/activation arrow and
+omit the local trash button.
 
 Accessibility labels must describe the complete state, for example:
 
@@ -330,11 +323,8 @@ generic map placeholder. Lack of a preview must not hide the row.
 Refactor `DownloadedMapRow` into a row that accepts `SavedMapListItem` rather
 than requiring a local `packURL`.
 
-Add focused components:
-
-- `PhoneMapPresenceIcon`, backed by the SF Symbol `iphone`; and
-- `BikeComputerMapPresenceButton`, drawn as a filled circle containing a
-  lowercase `b` with optional upload/check/progress treatment.
+Use the existing upload and installed-state SF Symbols directly in the saved
+map row; no origin-specific icon component is needed.
 
 Preserve the current upload enablement conditions, background upload resume
 behavior, installed confirmation, rename commit behavior, and local delete
@@ -346,17 +336,23 @@ confirmation. Gate controls by the row's actual capabilities:
   the iPhone; and
 - the active device indicator remains visible when there is no local pack.
 
+Make the rendered thumbnail a plain button whenever a preview is available.
+Capture the displayed image at tap time and present it scaled to fit in a modal
+with the map display name, a Close action, and an accessibility label that
+describes the preview action. A still-loading placeholder must not open an
+empty modal.
+
 ## Compatibility and failure behavior
 
 | Situation | Required behavior |
 | --- | --- |
-| New iOS + new firmware + cloned current SD | Device-only row, gray phone, green `b`, manifest name, generated preview |
-| New iOS + older firmware with active ID/session | Device-only row, gray phone, green `b`, ID-derived name, placeholder preview |
+| New iOS + new firmware + cloned current SD | Device-only row, green check, no trash, manifest name, generated preview |
+| New iOS + older firmware with active ID/session | Device-only row, green check, no trash, ID-derived name, placeholder preview |
 | New iOS + older firmware with active ID but no session | Conservative device-only row; do not merge with same-area local pack |
 | Old iOS + new firmware | Existing Saved Maps behavior; additive fields ignored |
 | Missing or invalid active manifest | No phantom device-only row; retain valid local rows |
 | Valid active map with malformed optional name/bounds | Device-only row with safe fallback name/preview |
-| SD removed after connection | Fresh status clears the device descriptor and green `b` state |
+| SD removed after connection | Fresh status clears the device descriptor and active green-check state |
 | Incomplete/lost `MSTC` response | Keep the previous complete descriptor until a complete replacement or connection reset; never publish partial data |
 | Same map ID, different sessions | Separate device-active and local rows |
 | MapKit unavailable/offline | Bounds fallback or generic map placeholder; row remains usable |
@@ -477,15 +473,17 @@ Use a verified exact clone containing the hidden active stream state,
 3. Boot and confirm SD mount, active map selection, and normal map rendering.
 4. Connect and authenticate the other iPhone.
 5. Open Saved Maps and confirm the active map appears first.
-6. Confirm the iPhone symbol is gray and the round lowercase-`b` icon is green.
+6. Confirm the active green check is shown, there is no iPhone icon, and there
+   is no local trash action.
 7. Confirm the manifest-derived display name appears.
 8. Confirm the bounds fallback appears promptly and the MapKit snapshot replaces
-   it when available.
+   it when available, then tap the thumbnail and confirm the preview opens in a
+   modal.
 9. Reboot/reconnect and confirm the same identity and preview are restored.
 10. Remove or swap the SD card, request fresh status, and confirm the green
     device presence is not retained incorrectly.
-11. Download the exact same artifact to the iPhone and confirm the row merges to
-    blue iPhone plus green `b` without duplication.
+11. Download the exact same artifact to the iPhone and confirm the row remains a
+    single green-check row and gains the local trash action.
 12. Test a same-map-ID but different-session local pack and confirm it does not
     receive a false active state.
 
@@ -495,11 +493,14 @@ The implementation is complete only when all of the following are true:
 
 - A current cloned SD map appears in Saved Maps on a different, otherwise
   empty iPhone after an authenticated connection.
-- The row accurately distinguishes phone absence from device-active presence.
-- The bike-computer indicator is a filled round icon with a lowercase `b`, gray
-  when inactive/uploadable and green when active.
+- The row accurately distinguishes phone absence from device-active presence
+  through the local trash action and an explicit accessibility hint.
+- The state indicator is the existing round arrow when inactive/uploadable and
+  the existing green check when active, regardless of row origin.
 - A device-only map receives a bounds-derived preview without transferring PNG
   data over BLE.
+- Tapping an available Saved Maps thumbnail opens the displayed preview in an
+  accessible, dismissible modal; a loading placeholder does not open one.
 - Exact local/device identities merge; same-area different artifacts do not.
 - Device-only rows cannot be renamed, locally deleted, or mistaken for an
   iPhone download.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1497,88 +1497,145 @@ static std::string jsonEscape(const std::string &value) {
   return out;
 }
 
-static std::string mapTransferStatusJson() {
-  struct ActivePresentationCache {
-    bool available = false;
-    std::string mapId;
-    std::string sessionId;
-    std::string root;
-    std::string manifestReceipt;
-    std::string signedManifestReceipt;
-    map_transfer::MapPresentationMetadata presentation;
-    map_transfer::MapPresentationRevision revision;
+struct ActivePresentationCache {
+  bool available = false;
+  std::string mapId;
+  std::string sessionId;
+  std::string root;
+  std::string manifestReceipt;
+  std::string signedManifestReceipt;
+  map_transfer::MapPresentationMetadata presentation;
+  map_transfer::MapPresentationRevision revision;
 
-    bool matches(
-        const map_transfer::ActiveMapSelection &selection,
-        const map_transfer::MapPresentationRevision &sourceRevision) const {
-      return available && mapId == selection.mapId &&
-             sessionId == selection.sessionId && root == selection.root &&
-             manifestReceipt == selection.manifestReceipt &&
-             signedManifestReceipt == selection.signedManifestReceipt &&
-             revision.bytes == sourceRevision.bytes &&
-             revision.modifiedSeconds == sourceRevision.modifiedSeconds &&
-             revision.inode == sourceRevision.inode;
-    }
+  bool matches(
+      const map_transfer::ActiveMapSelection &selection,
+      const map_transfer::MapPresentationRevision &sourceRevision) const {
+    return available && mapId == selection.mapId &&
+           sessionId == selection.sessionId && root == selection.root &&
+           manifestReceipt == selection.manifestReceipt &&
+           signedManifestReceipt == selection.signedManifestReceipt &&
+           revision.bytes == sourceRevision.bytes &&
+           revision.modifiedSeconds == sourceRevision.modifiedSeconds &&
+           revision.inode == sourceRevision.inode;
+  }
 
-    void store(const map_transfer::ActiveMapSelection &selection,
-               const map_transfer::MapPresentationMetadata &value,
-               const map_transfer::MapPresentationRevision &sourceRevision) {
-      available = true;
-      mapId = selection.mapId;
-      sessionId = selection.sessionId;
-      root = selection.root;
-      manifestReceipt = selection.manifestReceipt;
-      signedManifestReceipt = selection.signedManifestReceipt;
-      presentation = value;
-      revision = sourceRevision;
-    }
-  };
-  static ActivePresentationCache activePresentationCache;
+  void clear() {
+    available = false;
+    mapId.clear();
+    sessionId.clear();
+    root.clear();
+    manifestReceipt.clear();
+    signedManifestReceipt.clear();
+    presentation = map_transfer::MapPresentationMetadata();
+    revision = map_transfer::MapPresentationRevision();
+  }
 
-  map_transfer::HttpTransferStatus transferStatus = mapTransferHttp.status();
+  void store(const map_transfer::ActiveMapSelection &selection,
+             const map_transfer::MapPresentationMetadata &value,
+             const map_transfer::MapPresentationRevision &sourceRevision) {
+    available = true;
+    mapId = selection.mapId;
+    sessionId = selection.sessionId;
+    root = selection.root;
+    manifestReceipt = selection.manifestReceipt;
+    signedManifestReceipt = selection.signedManifestReceipt;
+    presentation = value;
+    revision = sourceRevision;
+  }
+};
+
+struct ActiveMapStatusSnapshot {
+  bool available = false;
+  std::string errorCode;
   map_transfer::ActiveMapSelection activeMap;
+  map_transfer::MapPresentationMetadata presentation;
+};
+
+// Keep filesystem/manifest work out of the JSON composition frame. The
+// Arduino loop task has an 8 KiB stack and the VFS stat path is deep enough
+// that combining both phases can trip its stack canary on a status request.
+__attribute__((noinline)) static const ActiveMapStatusSnapshot &
+readActiveMapStatusSnapshot() {
+  static ActivePresentationCache activePresentationCache;
+  static ActiveMapStatusSnapshot snapshot;
+
   map_transfer::MapTransferInstaller installer("/sdcard");
+  map_transfer::ActiveMapSelection activeMap;
   map_transfer::InstallStatus activeStatus =
       installer.readActiveMap(activeMap);
+  if (!activeStatus.ok) {
+    activePresentationCache.clear();
+    snapshot.available = false;
+    snapshot.errorCode = activeStatus.code;
+    return snapshot;
+  }
+
   map_transfer::MapPresentationMetadata activePresentation;
   map_transfer::InstallStatus activePresentationStatus;
-  if (activeStatus.ok) {
-    map_transfer::MapPresentationRevision activePresentationRevision;
-    const bool hasPresentationRevision =
-        installer.readActiveMapPresentationRevision(
-            activeMap, activePresentationRevision);
-    if (hasPresentationRevision && activePresentationCache.matches(
-                                       activeMap,
-                                       activePresentationRevision)) {
-      activePresentation = activePresentationCache.presentation;
-      activePresentationStatus = {true, "ok", ""};
-    } else {
-      activePresentationCache = ActivePresentationCache();
-      const map_transfer::ActiveMapSelection requestedActiveMap = activeMap;
-      activePresentationStatus = installer.readActiveMapPresentation(
-          activeMap, activePresentation);
-      if (activePresentationStatus.ok) {
-        map_transfer::MapPresentationRevision presentedRevision;
-        if (installer.readActiveMapPresentationRevision(
-                activeMap, presentedRevision) &&
-            activeMap.mapId == requestedActiveMap.mapId &&
-            activeMap.sessionId == requestedActiveMap.sessionId &&
-            activeMap.root == requestedActiveMap.root &&
-            activeMap.manifestReceipt == requestedActiveMap.manifestReceipt &&
-            activeMap.signedManifestReceipt ==
-                requestedActiveMap.signedManifestReceipt &&
-            activePresentationRevision.bytes == presentedRevision.bytes &&
-            activePresentationRevision.modifiedSeconds ==
-                presentedRevision.modifiedSeconds &&
-            activePresentationRevision.inode == presentedRevision.inode) {
-          activePresentationCache.store(activeMap, activePresentation,
-                                        presentedRevision);
-        }
+  map_transfer::MapPresentationRevision activePresentationRevision;
+  const bool hasPresentationRevision =
+      installer.readActiveMapPresentationRevision(
+          activeMap, activePresentationRevision);
+  if (hasPresentationRevision && activePresentationCache.matches(
+                                     activeMap,
+                                     activePresentationRevision)) {
+    activePresentation = activePresentationCache.presentation;
+    activePresentationStatus = {true, "ok", ""};
+  } else {
+    activePresentationCache.clear();
+    snapshot.activeMap = activeMap;
+    activePresentationStatus = installer.readActiveMapPresentation(
+        activeMap, activePresentation);
+    if (activePresentationStatus.ok) {
+      map_transfer::MapPresentationRevision presentedRevision;
+      if (installer.readActiveMapPresentationRevision(
+              activeMap, presentedRevision) &&
+          activeMap.mapId == snapshot.activeMap.mapId &&
+          activeMap.sessionId == snapshot.activeMap.sessionId &&
+          activeMap.root == snapshot.activeMap.root &&
+          activeMap.manifestReceipt == snapshot.activeMap.manifestReceipt &&
+          activeMap.signedManifestReceipt ==
+              snapshot.activeMap.signedManifestReceipt &&
+          activePresentationRevision.bytes == presentedRevision.bytes &&
+          activePresentationRevision.modifiedSeconds ==
+              presentedRevision.modifiedSeconds &&
+          activePresentationRevision.inode == presentedRevision.inode) {
+        activePresentationCache.store(activeMap, activePresentation,
+                                      presentedRevision);
       }
     }
-  } else {
-    activePresentationCache = ActivePresentationCache();
   }
+
+  if (!activePresentationStatus.ok) {
+    snapshot.available = false;
+    snapshot.errorCode = activePresentationStatus.code;
+    return snapshot;
+  }
+
+  snapshot.available = true;
+  snapshot.errorCode.clear();
+  snapshot.activeMap = activeMap;
+  snapshot.presentation = activePresentation;
+  return snapshot;
+}
+
+static void appendActiveMapPresentationStatus(
+    std::string &body,
+    const map_transfer::MapPresentationMetadata &activePresentation) {
+  map_transfer_status_protocol::ActiveMapPresentation presentation;
+  presentation.displayName = activePresentation.displayName;
+  presentation.boundsE7 = activePresentation.boundsE7;
+  presentation.hasBoundsE7 = activePresentation.hasBoundsE7;
+  map_transfer_status_protocol::appendActiveMapPresentation(body,
+                                                            presentation);
+}
+
+// Do not let link-time optimization merge this back into the filesystem phase.
+__attribute__((noinline)) static std::string composeMapTransferStatusJson(
+    const ActiveMapStatusSnapshot &activeMapStatus) {
+  map_transfer::HttpTransferStatus transferStatus = mapTransferHttp.status();
+  const map_transfer::ActiveMapSelection &activeMap =
+      activeMapStatus.activeMap;
   const bool streamSupported = mapTransferHttp.streamInstallSupported();
 
   std::string body = std::string("{\"configured\":") +
@@ -1628,7 +1685,7 @@ static std::string mapTransferStatusJson() {
     body += ",\"hotspotFallbackReason\":\"" +
             jsonEscape(transferStatus.hotspotFallbackReason) + "\"";
   }
-  if (activeStatus.ok && activePresentationStatus.ok) {
+  if (activeMapStatus.available) {
     body += ",\"activeMapId\":\"" + jsonEscape(activeMap.mapId) + "\"";
     if (!activeMap.sessionId.empty()) {
       body += ",\"activeSessionId\":\"" +
@@ -1638,12 +1695,7 @@ static std::string mapTransferStatusJson() {
       body += ",\"activeManifestReceipt\":\"" +
               jsonEscape(activeMap.manifestReceipt) + "\"";
     }
-    map_transfer_status_protocol::ActiveMapPresentation presentation;
-    presentation.displayName = activePresentation.displayName;
-    presentation.boundsE7 = activePresentation.boundsE7;
-    presentation.hasBoundsE7 = activePresentation.hasBoundsE7;
-    map_transfer_status_protocol::appendActiveMapPresentation(body,
-                                                              presentation);
+    appendActiveMapPresentationStatus(body, activeMapStatus.presentation);
     if (activeMap.target.formatVersion != 0) {
       body += ",\"activeRendererFormat\":" +
               std::to_string(activeMap.target.formatVersion) +
@@ -1664,9 +1716,8 @@ static std::string mapTransferStatusJson() {
                   : "false";
     }
   } else {
-    const map_transfer::InstallStatus &failure =
-        activeStatus.ok ? activePresentationStatus : activeStatus;
-    body += ",\"activeError\":{\"code\":\"" + jsonEscape(failure.code) +
+    body += ",\"activeError\":{\"code\":\"" +
+            jsonEscape(activeMapStatus.errorCode) +
             "\"}";
   }
 
@@ -1680,6 +1731,10 @@ static std::string mapTransferStatusJson() {
 
   body += "}";
   return body;
+}
+
+static std::string mapTransferStatusJson() {
+  return composeMapTransferStatusJson(readActiveMapStatusSnapshot());
 }
 
 static std::string genericTransferStatusJson() {

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1498,6 +1498,43 @@ static std::string jsonEscape(const std::string &value) {
 }
 
 static std::string mapTransferStatusJson() {
+  struct ActivePresentationCache {
+    bool available = false;
+    std::string mapId;
+    std::string sessionId;
+    std::string root;
+    std::string manifestReceipt;
+    std::string signedManifestReceipt;
+    map_transfer::MapPresentationMetadata presentation;
+    map_transfer::MapPresentationRevision revision;
+
+    bool matches(
+        const map_transfer::ActiveMapSelection &selection,
+        const map_transfer::MapPresentationRevision &sourceRevision) const {
+      return available && mapId == selection.mapId &&
+             sessionId == selection.sessionId && root == selection.root &&
+             manifestReceipt == selection.manifestReceipt &&
+             signedManifestReceipt == selection.signedManifestReceipt &&
+             revision.bytes == sourceRevision.bytes &&
+             revision.modifiedSeconds == sourceRevision.modifiedSeconds &&
+             revision.inode == sourceRevision.inode;
+    }
+
+    void store(const map_transfer::ActiveMapSelection &selection,
+               const map_transfer::MapPresentationMetadata &value,
+               const map_transfer::MapPresentationRevision &sourceRevision) {
+      available = true;
+      mapId = selection.mapId;
+      sessionId = selection.sessionId;
+      root = selection.root;
+      manifestReceipt = selection.manifestReceipt;
+      signedManifestReceipt = selection.signedManifestReceipt;
+      presentation = value;
+      revision = sourceRevision;
+    }
+  };
+  static ActivePresentationCache activePresentationCache;
+
   map_transfer::HttpTransferStatus transferStatus = mapTransferHttp.status();
   map_transfer::ActiveMapSelection activeMap;
   map_transfer::MapTransferInstaller installer("/sdcard");
@@ -1506,8 +1543,41 @@ static std::string mapTransferStatusJson() {
   map_transfer::MapPresentationMetadata activePresentation;
   map_transfer::InstallStatus activePresentationStatus;
   if (activeStatus.ok) {
-    activePresentationStatus =
-        installer.readActiveMapPresentation(activePresentation);
+    map_transfer::MapPresentationRevision activePresentationRevision;
+    const bool hasPresentationRevision =
+        installer.readActiveMapPresentationRevision(
+            activeMap, activePresentationRevision);
+    if (hasPresentationRevision && activePresentationCache.matches(
+                                       activeMap,
+                                       activePresentationRevision)) {
+      activePresentation = activePresentationCache.presentation;
+      activePresentationStatus = {true, "ok", ""};
+    } else {
+      activePresentationCache = ActivePresentationCache();
+      const map_transfer::ActiveMapSelection requestedActiveMap = activeMap;
+      activePresentationStatus = installer.readActiveMapPresentation(
+          activeMap, activePresentation);
+      if (activePresentationStatus.ok) {
+        map_transfer::MapPresentationRevision presentedRevision;
+        if (installer.readActiveMapPresentationRevision(
+                activeMap, presentedRevision) &&
+            activeMap.mapId == requestedActiveMap.mapId &&
+            activeMap.sessionId == requestedActiveMap.sessionId &&
+            activeMap.root == requestedActiveMap.root &&
+            activeMap.manifestReceipt == requestedActiveMap.manifestReceipt &&
+            activeMap.signedManifestReceipt ==
+                requestedActiveMap.signedManifestReceipt &&
+            activePresentationRevision.bytes == presentedRevision.bytes &&
+            activePresentationRevision.modifiedSeconds ==
+                presentedRevision.modifiedSeconds &&
+            activePresentationRevision.inode == presentedRevision.inode) {
+          activePresentationCache.store(activeMap, activePresentation,
+                                        presentedRevision);
+        }
+      }
+    }
+  } else {
+    activePresentationCache = ActivePresentationCache();
   }
   const bool streamSupported = mapTransferHttp.streamInstallSupported();
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -1503,6 +1503,12 @@ static std::string mapTransferStatusJson() {
   map_transfer::MapTransferInstaller installer("/sdcard");
   map_transfer::InstallStatus activeStatus =
       installer.readActiveMap(activeMap);
+  map_transfer::MapPresentationMetadata activePresentation;
+  map_transfer::InstallStatus activePresentationStatus;
+  if (activeStatus.ok) {
+    activePresentationStatus =
+        installer.readActiveMapPresentation(activePresentation);
+  }
   const bool streamSupported = mapTransferHttp.streamInstallSupported();
 
   std::string body = std::string("{\"configured\":") +
@@ -1552,7 +1558,7 @@ static std::string mapTransferStatusJson() {
     body += ",\"hotspotFallbackReason\":\"" +
             jsonEscape(transferStatus.hotspotFallbackReason) + "\"";
   }
-  if (activeStatus.ok) {
+  if (activeStatus.ok && activePresentationStatus.ok) {
     body += ",\"activeMapId\":\"" + jsonEscape(activeMap.mapId) + "\"";
     if (!activeMap.sessionId.empty()) {
       body += ",\"activeSessionId\":\"" +
@@ -1562,6 +1568,12 @@ static std::string mapTransferStatusJson() {
       body += ",\"activeManifestReceipt\":\"" +
               jsonEscape(activeMap.manifestReceipt) + "\"";
     }
+    map_transfer_status_protocol::ActiveMapPresentation presentation;
+    presentation.displayName = activePresentation.displayName;
+    presentation.boundsE7 = activePresentation.boundsE7;
+    presentation.hasBoundsE7 = activePresentation.hasBoundsE7;
+    map_transfer_status_protocol::appendActiveMapPresentation(body,
+                                                              presentation);
     if (activeMap.target.formatVersion != 0) {
       body += ",\"activeRendererFormat\":" +
               std::to_string(activeMap.target.formatVersion) +
@@ -1582,7 +1594,9 @@ static std::string mapTransferStatusJson() {
                   : "false";
     }
   } else {
-    body += ",\"activeError\":{\"code\":\"" + jsonEscape(activeStatus.code) +
+    const map_transfer::InstallStatus &failure =
+        activeStatus.ok ? activePresentationStatus : activeStatus;
+    body += ",\"activeError\":{\"code\":\"" + jsonEscape(failure.code) +
             "\"}";
   }
 

--- a/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
+++ b/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
@@ -1,10 +1,73 @@
 #pragma once
 
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <string>
 
 namespace map_transfer_status_protocol {
+
+struct ActiveMapPresentation {
+  std::string displayName;
+  std::array<int32_t, 4> boundsE7 = {};
+  bool hasBoundsE7 = false;
+};
+
+inline std::string jsonEscape(const std::string &value) {
+  static constexpr char kHex[] = "0123456789abcdef";
+  std::string output;
+  output.reserve(value.size() + 8);
+  for (const unsigned char character : value) {
+    switch (character) {
+    case '"':
+      output += "\\\"";
+      break;
+    case '\\':
+      output += "\\\\";
+      break;
+    case '\b':
+      output += "\\b";
+      break;
+    case '\f':
+      output += "\\f";
+      break;
+    case '\n':
+      output += "\\n";
+      break;
+    case '\r':
+      output += "\\r";
+      break;
+    case '\t':
+      output += "\\t";
+      break;
+    default:
+      if (character < 0x20) {
+        output += "\\u00";
+        output.push_back(kHex[character >> 4]);
+        output.push_back(kHex[character & 0x0f]);
+      } else {
+        output.push_back(static_cast<char>(character));
+      }
+      break;
+    }
+  }
+  return output;
+}
+
+inline void appendActiveMapPresentation(std::string &body,
+                                        const ActiveMapPresentation &value) {
+  if (!value.displayName.empty()) {
+    body += ",\"activeMapDisplayName\":\"" +
+            jsonEscape(value.displayName) + "\"";
+  }
+  if (value.hasBoundsE7) {
+    body += ",\"activeMapBoundsE7\":[" +
+            std::to_string(value.boundsE7[0]) + "," +
+            std::to_string(value.boundsE7[1]) + "," +
+            std::to_string(value.boundsE7[2]) + "," +
+            std::to_string(value.boundsE7[3]) + "]";
+  }
+}
 
 // ATT notifications reserve three bytes for the protocol header. Each
 // authenticated notification then adds a 22-byte envelope, and chunked map

--- a/esp32/lib/map_transfer/map_transfer.cpp
+++ b/esp32/lib/map_transfer/map_transfer.cpp
@@ -207,6 +207,8 @@ static bool validUtf8(const std::string &value) {
     const uint8_t second = static_cast<uint8_t>(value[index + 1]);
     if (second < secondMinimum || second > secondMaximum)
       return false;
+    if (first == 0xc2 && second >= 0x80 && second <= 0x9f)
+      return false;
     for (size_t offset = 2; offset <= continuationCount; ++offset) {
       const uint8_t continuation =
           static_cast<uint8_t>(value[index + offset]);
@@ -261,7 +263,7 @@ static std::string jsonPresentationStringValue(const std::string &json,
                  ? output
                  : std::string();
     }
-    if (character < 0x20)
+    if (character < 0x20 || character == 0x7f)
       return "";
     if (character != '\\') {
       output.push_back(static_cast<char>(character));
@@ -273,7 +275,8 @@ static std::string jsonPresentationStringValue(const std::string &json,
         output.push_back(escaped);
       } else if (escaped == 'u') {
         uint16_t first = 0;
-        if (!readUnicodeEscape(json, cursor, first) || first < 0x20)
+        if (!readUnicodeEscape(json, cursor, first) || first < 0x20 ||
+            (first >= 0x7f && first <= 0x9f))
           return "";
         uint32_t codePoint = first;
         if (first >= 0xd800 && first <= 0xdbff) {
@@ -2587,16 +2590,70 @@ MapTransferInstaller::readActiveManifest(MapManifest &manifest) const {
 }
 
 InstallStatus MapTransferInstaller::readActiveMapPresentation(
+    ActiveMapSelection &selection,
     MapPresentationMetadata &presentation) const {
+  selection = ActiveMapSelection();
   presentation = MapPresentationMetadata();
+  const InstallStatus active = readActiveMap(selection);
+  if (!active.ok)
+    return active;
+  if (!safeActiveRoot(selection.root) || !activeRootExists(selection.root))
+    return fail("installed_root", "installed map root is missing");
+  std::string manifestText;
+  if (!readTextFile(joinPath(joinPath(storageRoot_, selection.root),
+                             kInstalledManifestFile),
+                    manifestText, kMaxManifestBytes)) {
+    return fail("installed_manifest", "installed map manifest is missing");
+  }
+  if (jsonStringValue(manifestText, "mapId") != selection.mapId) {
+    return fail("installed_manifest_identity",
+                "installed map manifest does not match active map ID");
+  }
+  if (!selection.manifestReceipt.empty()) {
+    const std::string receipt = sha256Hex(
+        reinterpret_cast<const uint8_t *>(manifestText.data()),
+        manifestText.size());
+    std::string expectedReceipt = selection.manifestReceipt;
+    std::transform(expectedReceipt.begin(), expectedReceipt.end(),
+                   expectedReceipt.begin(), ::tolower);
+    if (receipt != expectedReceipt) {
+      return fail("installed_manifest_receipt",
+                  "installed map manifest does not match active selection");
+    }
+    presentation.displayName =
+        jsonPresentationStringValue(manifestText, "displayName");
+    presentation.hasBoundsE7 =
+        jsonPresentationBoundsE7(manifestText, presentation.boundsE7);
+    return {true, "ok", ""};
+  }
   MapManifest manifest;
-  const InstallStatus status = readActiveManifest(manifest);
+  const InstallStatus status = validateManifestText(manifestText, manifest);
   if (!status.ok)
     return status;
   presentation.displayName = manifest.displayName;
   presentation.boundsE7 = manifest.boundsE7;
   presentation.hasBoundsE7 = manifest.hasBoundsE7;
   return status;
+}
+
+bool MapTransferInstaller::readActiveMapPresentationRevision(
+    const ActiveMapSelection &selection,
+    MapPresentationRevision &revision) const {
+  revision = MapPresentationRevision();
+  if (!safeActiveRoot(selection.root))
+    return false;
+  struct stat info = {};
+  const std::string path = joinPath(
+      joinPath(storageRoot_, selection.root), kInstalledManifestFile);
+  if (::stat(path.c_str(), &info) != 0 || !S_ISREG(info.st_mode) ||
+      info.st_size <= 0 ||
+      static_cast<uint64_t>(info.st_size) > kMaxManifestBytes) {
+    return false;
+  }
+  revision.bytes = static_cast<uint64_t>(info.st_size);
+  revision.modifiedSeconds = static_cast<int64_t>(info.st_mtime);
+  revision.inode = static_cast<uint64_t>(info.st_ino);
+  return true;
 }
 
 bool MapTransferInstaller::pruneStagingSessions(

--- a/esp32/lib/map_transfer/map_transfer.cpp
+++ b/esp32/lib/map_transfer/map_transfer.cpp
@@ -7,7 +7,9 @@
 #include <array>
 #include <cctype>
 #include <cerrno>
+#include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <dirent.h>
 #include <fcntl.h>
@@ -133,6 +135,252 @@ static std::string jsonStringValue(const std::string &json,
     out.push_back(c);
   }
   return "";
+}
+
+static int hexValue(char value) {
+  if (value >= '0' && value <= '9')
+    return value - '0';
+  if (value >= 'a' && value <= 'f')
+    return value - 'a' + 10;
+  if (value >= 'A' && value <= 'F')
+    return value - 'A' + 10;
+  return -1;
+}
+
+static bool appendUtf8(uint32_t codePoint, std::string &output) {
+  if (codePoint <= 0x7f) {
+    output.push_back(static_cast<char>(codePoint));
+  } else if (codePoint <= 0x7ff) {
+    output.push_back(static_cast<char>(0xc0 | (codePoint >> 6)));
+    output.push_back(static_cast<char>(0x80 | (codePoint & 0x3f)));
+  } else if (codePoint <= 0xffff) {
+    if (codePoint >= 0xd800 && codePoint <= 0xdfff)
+      return false;
+    output.push_back(static_cast<char>(0xe0 | (codePoint >> 12)));
+    output.push_back(static_cast<char>(0x80 | ((codePoint >> 6) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | (codePoint & 0x3f)));
+  } else if (codePoint <= 0x10ffff) {
+    output.push_back(static_cast<char>(0xf0 | (codePoint >> 18)));
+    output.push_back(static_cast<char>(0x80 | ((codePoint >> 12) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | ((codePoint >> 6) & 0x3f)));
+    output.push_back(static_cast<char>(0x80 | (codePoint & 0x3f)));
+  } else {
+    return false;
+  }
+  return true;
+}
+
+static bool validUtf8(const std::string &value) {
+  for (size_t index = 0; index < value.size();) {
+    const uint8_t first = static_cast<uint8_t>(value[index]);
+    size_t continuationCount = 0;
+    uint8_t secondMinimum = 0x80;
+    uint8_t secondMaximum = 0xbf;
+    if (first <= 0x7f) {
+      index++;
+      continue;
+    } else if (first >= 0xc2 && first <= 0xdf) {
+      continuationCount = 1;
+    } else if (first == 0xe0) {
+      continuationCount = 2;
+      secondMinimum = 0xa0;
+    } else if (first >= 0xe1 && first <= 0xec) {
+      continuationCount = 2;
+    } else if (first == 0xed) {
+      continuationCount = 2;
+      secondMaximum = 0x9f;
+    } else if (first >= 0xee && first <= 0xef) {
+      continuationCount = 2;
+    } else if (first == 0xf0) {
+      continuationCount = 3;
+      secondMinimum = 0x90;
+    } else if (first >= 0xf1 && first <= 0xf3) {
+      continuationCount = 3;
+    } else if (first == 0xf4) {
+      continuationCount = 3;
+      secondMaximum = 0x8f;
+    } else {
+      return false;
+    }
+    if (index + continuationCount >= value.size())
+      return false;
+    const uint8_t second = static_cast<uint8_t>(value[index + 1]);
+    if (second < secondMinimum || second > secondMaximum)
+      return false;
+    for (size_t offset = 2; offset <= continuationCount; ++offset) {
+      const uint8_t continuation =
+          static_cast<uint8_t>(value[index + offset]);
+      if (continuation < 0x80 || continuation > 0xbf)
+        return false;
+    }
+    index += continuationCount + 1;
+  }
+  return true;
+}
+
+static bool readUnicodeEscape(const std::string &json, size_t &cursor,
+                              uint16_t &value) {
+  if (cursor + 4 > json.size())
+    return false;
+  value = 0;
+  for (size_t index = 0; index < 4; ++index) {
+    const int digit = hexValue(json[cursor + index]);
+    if (digit < 0)
+      return false;
+    value = static_cast<uint16_t>((value << 4) | digit);
+  }
+  cursor += 4;
+  return true;
+}
+
+static std::string jsonPresentationStringValue(const std::string &json,
+                                               const std::string &key) {
+  constexpr size_t kMaximumDisplayNameBytes = 240;
+  const std::string needle = "\"" + key + "\"";
+  size_t cursor = json.find(needle);
+  if (cursor == std::string::npos)
+    return "";
+  cursor = json.find(':', cursor + needle.size());
+  if (cursor == std::string::npos)
+    return "";
+  cursor++;
+  while (cursor < json.size() &&
+         std::isspace(static_cast<unsigned char>(json[cursor])) != 0)
+    cursor++;
+  if (cursor >= json.size() || json[cursor++] != '"')
+    return "";
+
+  std::string output;
+  output.reserve(80);
+  while (cursor < json.size()) {
+    const unsigned char character =
+        static_cast<unsigned char>(json[cursor++]);
+    if (character == '"') {
+      return !output.empty() && output.size() <= kMaximumDisplayNameBytes &&
+                     validUtf8(output)
+                 ? output
+                 : std::string();
+    }
+    if (character < 0x20)
+      return "";
+    if (character != '\\') {
+      output.push_back(static_cast<char>(character));
+    } else {
+      if (cursor >= json.size())
+        return "";
+      const char escaped = json[cursor++];
+      if (escaped == '"' || escaped == '\\' || escaped == '/') {
+        output.push_back(escaped);
+      } else if (escaped == 'u') {
+        uint16_t first = 0;
+        if (!readUnicodeEscape(json, cursor, first) || first < 0x20)
+          return "";
+        uint32_t codePoint = first;
+        if (first >= 0xd800 && first <= 0xdbff) {
+          if (cursor + 2 > json.size() || json[cursor] != '\\' ||
+              json[cursor + 1] != 'u')
+            return "";
+          cursor += 2;
+          uint16_t second = 0;
+          if (!readUnicodeEscape(json, cursor, second) || second < 0xdc00 ||
+              second > 0xdfff)
+            return "";
+          codePoint = 0x10000u +
+                      ((static_cast<uint32_t>(first) - 0xd800u) << 10) +
+                      (static_cast<uint32_t>(second) - 0xdc00u);
+        } else if (first >= 0xdc00 && first <= 0xdfff) {
+          return "";
+        }
+        if (!appendUtf8(codePoint, output))
+          return "";
+      } else {
+        // Escaped controls are not valid display-name content.
+        return "";
+      }
+    }
+    if (output.size() > kMaximumDisplayNameBytes)
+      return "";
+  }
+  return "";
+}
+
+static bool jsonNumberArray4(const std::string &json, const std::string &key,
+                             std::array<double, 4> &values, bool &found) {
+  found = false;
+  const std::string needle = "\"" + key + "\"";
+  size_t cursor = json.find(needle);
+  if (cursor == std::string::npos)
+    return false;
+  found = true;
+  cursor = json.find(':', cursor + needle.size());
+  if (cursor == std::string::npos)
+    return false;
+  cursor++;
+  while (cursor < json.size() &&
+         std::isspace(static_cast<unsigned char>(json[cursor])) != 0)
+    cursor++;
+  if (cursor >= json.size() || json[cursor++] != '[')
+    return false;
+  for (size_t index = 0; index < values.size(); ++index) {
+    while (cursor < json.size() &&
+           std::isspace(static_cast<unsigned char>(json[cursor])) != 0)
+      cursor++;
+    if (cursor >= json.size())
+      return false;
+    errno = 0;
+    char *end = nullptr;
+    const char *start = json.c_str() + cursor;
+    const double parsed = std::strtod(start, &end);
+    if (end == start || errno == ERANGE || !std::isfinite(parsed))
+      return false;
+    cursor = static_cast<size_t>(end - json.c_str());
+    values[index] = parsed;
+    while (cursor < json.size() &&
+           std::isspace(static_cast<unsigned char>(json[cursor])) != 0)
+      cursor++;
+    const char expected = index + 1 == values.size() ? ']' : ',';
+    if (cursor >= json.size() || json[cursor++] != expected)
+      return false;
+  }
+  return true;
+}
+
+static bool boundsE7Valid(const std::array<int32_t, 4> &bounds) {
+  return bounds[0] >= -1800000000 && bounds[0] <= 1800000000 &&
+         bounds[2] >= -1800000000 && bounds[2] <= 1800000000 &&
+         bounds[1] >= -900000000 && bounds[1] <= 900000000 &&
+         bounds[3] >= -900000000 && bounds[3] <= 900000000 &&
+         bounds[0] < bounds[2] && bounds[1] < bounds[3];
+}
+
+static bool jsonPresentationBoundsE7(const std::string &json,
+                                     std::array<int32_t, 4> &bounds) {
+  std::array<double, 4> values = {};
+  bool found = false;
+  if (jsonNumberArray4(json, "boundsE7", values, found)) {
+    for (size_t index = 0; index < values.size(); ++index) {
+      if (values[index] != std::trunc(values[index]) ||
+          values[index] < std::numeric_limits<int32_t>::min() ||
+          values[index] > std::numeric_limits<int32_t>::max())
+        return false;
+      bounds[index] = static_cast<int32_t>(values[index]);
+    }
+    return boundsE7Valid(bounds);
+  }
+  if (found)
+    return false;
+
+  if (!jsonNumberArray4(json, "bounds", values, found))
+    return false;
+  for (size_t index = 0; index < values.size(); ++index) {
+    const double scaled = values[index] * 10000000.0;
+    if (!std::isfinite(scaled) ||
+        scaled < std::numeric_limits<int32_t>::min() ||
+        scaled > std::numeric_limits<int32_t>::max())
+      return false;
+    bounds[index] = static_cast<int32_t>(std::llround(scaled));
+  }
+  return boundsE7Valid(bounds);
 }
 
 static uint64_t jsonUintValue(const std::string &json, const std::string &key) {
@@ -672,6 +920,10 @@ MapTransferInstaller::validateManifestText(const std::string &manifestText,
   manifest.schemaVersion =
       static_cast<uint32_t>(jsonUintValue(manifestText, "schemaVersion"));
   manifest.mapId = jsonStringValue(manifestText, "mapId");
+  manifest.displayName =
+      jsonPresentationStringValue(manifestText, "displayName");
+  manifest.hasBoundsE7 =
+      jsonPresentationBoundsE7(manifestText, manifest.boundsE7);
   manifest.renderer = jsonStringValue(manifestText, "renderer");
   manifest.formatVersion =
       static_cast<uint32_t>(jsonUintValue(manifestText, "formatVersion"));
@@ -2332,6 +2584,19 @@ MapTransferInstaller::readActiveManifest(MapManifest &manifest) const {
   if (!active.ok)
     return active;
   return readInstalledManifest(selection.root, manifest);
+}
+
+InstallStatus MapTransferInstaller::readActiveMapPresentation(
+    MapPresentationMetadata &presentation) const {
+  presentation = MapPresentationMetadata();
+  MapManifest manifest;
+  const InstallStatus status = readActiveManifest(manifest);
+  if (!status.ok)
+    return status;
+  presentation.displayName = manifest.displayName;
+  presentation.boundsE7 = manifest.boundsE7;
+  presentation.hasBoundsE7 = manifest.hasBoundsE7;
+  return status;
 }
 
 bool MapTransferInstaller::pruneStagingSessions(

--- a/esp32/lib/map_transfer/map_transfer.hpp
+++ b/esp32/lib/map_transfer/map_transfer.hpp
@@ -16,9 +16,18 @@ struct ManifestFile {
   uint64_t bytes = 0;
 };
 
+struct MapPresentationMetadata {
+  std::string displayName;
+  std::array<int32_t, 4> boundsE7 = {};
+  bool hasBoundsE7 = false;
+};
+
 struct MapManifest {
   uint32_t schemaVersion = 0;
   std::string mapId;
+  std::string displayName;
+  std::array<int32_t, 4> boundsE7 = {};
+  bool hasBoundsE7 = false;
   std::string renderer;
   uint32_t formatVersion = 0;
   uint32_t labelProfileVersion = 0;
@@ -168,6 +177,8 @@ public:
   bool hasInterruptedActivation() const;
   InstallStatus readActiveMap(ActiveMapSelection &selection) const;
   InstallStatus readActiveManifest(MapManifest &manifest) const;
+  InstallStatus
+  readActiveMapPresentation(MapPresentationMetadata &presentation) const;
   InstallStatus readActiveMapId(std::string &mapId) const;
   InstallStatus rollbackActiveMap(const std::string &sessionId) const;
   InstallStatus discardIncompleteStreamMap(

--- a/esp32/lib/map_transfer/map_transfer.hpp
+++ b/esp32/lib/map_transfer/map_transfer.hpp
@@ -22,6 +22,12 @@ struct MapPresentationMetadata {
   bool hasBoundsE7 = false;
 };
 
+struct MapPresentationRevision {
+  uint64_t bytes = 0;
+  int64_t modifiedSeconds = 0;
+  uint64_t inode = 0;
+};
+
 struct MapManifest {
   uint32_t schemaVersion = 0;
   std::string mapId;
@@ -177,8 +183,12 @@ public:
   bool hasInterruptedActivation() const;
   InstallStatus readActiveMap(ActiveMapSelection &selection) const;
   InstallStatus readActiveManifest(MapManifest &manifest) const;
-  InstallStatus
-  readActiveMapPresentation(MapPresentationMetadata &presentation) const;
+  InstallStatus readActiveMapPresentation(
+      ActiveMapSelection &selection,
+      MapPresentationMetadata &presentation) const;
+  bool readActiveMapPresentationRevision(
+      const ActiveMapSelection &selection,
+      MapPresentationRevision &revision) const;
   InstallStatus readActiveMapId(std::string &mapId) const;
   InstallStatus rollbackActiveMap(const std::string &sessionId) const;
   InstallStatus discardIncompleteStreamMap(

--- a/esp32/tools/tests/test_map_transfer.cpp
+++ b/esp32/tools/tests/test_map_transfer.cpp
@@ -426,6 +426,65 @@ static void testRejectsUnsafeManifestPath() {
   assert(status.code == "manifest_path");
 }
 
+static std::string presentationManifest(const std::string &metadata) {
+  return "{\"schemaVersion\":1,\"mapId\":\"map-1\"," + metadata +
+         "\"files\":[{\"path\":\"VECTMAP/map-1/+0000+0000/1.fmb\","
+         "\"bytes\":1,\"sha256\":\"" + std::string(64, '0') +
+         "\"}]}";
+}
+
+static void testParsesOptionalActiveMapPresentationMetadata() {
+  MapTransferInstaller installer("/tmp/root");
+  MapManifest manifest;
+
+  auto status = installer.validateManifestText(
+      presentationManifest(
+          "\"displayName\":\"Shànghǎi 🚲\","
+          "\"boundsE7\":[1209000000,307000000,1219500000,315500000],"),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName == "Shànghǎi 🚲");
+  assert(manifest.hasBoundsE7);
+  assert((manifest.boundsE7 ==
+          std::array<int32_t, 4>{1209000000, 307000000, 1219500000,
+                                 315500000}));
+
+  status = installer.validateManifestText(
+      presentationManifest(
+          "\"displayName\":\"S\\u00e3o Paulo \\ud83d\\udeb2\","
+          "\"bounds\":[-46.83,-24.01,-46.36,-23.35],"),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName == "São Paulo 🚲");
+  assert(manifest.hasBoundsE7);
+  assert((manifest.boundsE7 ==
+          std::array<int32_t, 4>{-468300000, -240100000, -463600000,
+                                 -233500000}));
+}
+
+static void testIgnoresInvalidOptionalActiveMapPresentationMetadata() {
+  MapTransferInstaller installer("/tmp/root");
+  MapManifest manifest;
+
+  auto status = installer.validateManifestText(
+      presentationManifest(
+          "\"displayName\":\"line\\nbreak\","
+          "\"boundsE7\":[1210000000,310000000,1200000000,320000000],"),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName.empty());
+  assert(!manifest.hasBoundsE7);
+
+  const std::string oversizedName(241, 'x');
+  status = installer.validateManifestText(
+      presentationManifest("\"displayName\":\"" + oversizedName +
+                           "\",\"bounds\":[-181,-20,-180,-10],"),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName.empty());
+  assert(!manifest.hasBoundsE7);
+}
+
 static void testRejectsMalformedActiveTargetMetadata() {
   const std::string root = tempRoot();
   assert(::system((std::string("mkdir -p ") + root + "/VECTMAP").c_str()) ==
@@ -480,7 +539,10 @@ static void testValidatesStagedMapAndActivates() {
   writeFile(stagedDir + "/123_456.fmb", blockData);
   writeFile(stagedDir + "/123_456.fmp", previewData);
   const std::string manifestText =
-      "{\"schemaVersion\":1,\"mapId\":\"map-1\",\"files\":["
+      "{\"schemaVersion\":1,\"mapId\":\"map-1\","
+      "\"displayName\":\"Active Map\","
+      "\"boundsE7\":[1209000000,307000000,1219500000,315500000],"
+      "\"files\":["
       "{\"path\":\"VECTMAP/map-1/+0032+0008/123_456.fmb\",\"bytes\":" +
       std::to_string(blockData.size()) +
       ","
@@ -521,6 +583,13 @@ static void testValidatesStagedMapAndActivates() {
   assert(selection.target.renderer == "esp32-fmb");
   assert(selection.target.formatVersion == 1);
   assert(selection.previousRoot.empty());
+  map_transfer::MapPresentationMetadata presentation;
+  assert(installer.readActiveMapPresentation(presentation).ok);
+  assert(presentation.displayName == "Active Map");
+  assert(presentation.hasBoundsE7);
+  assert((presentation.boundsE7 ==
+          std::array<int32_t, 4>{1209000000, 307000000, 1219500000,
+                                 315500000}));
   assert(!exists(root + "/VECTMAP/.staging/" + session));
   assert(!exists(root + "/VECTMAP/.activation-transaction.json"));
 
@@ -533,6 +602,8 @@ static void testValidatesStagedMapAndActivates() {
   assert(cleared.ok);
   assert(cleared.code == "active_cleared");
   assert(installer.readActiveMap(selection).code == "active_missing");
+  assert(installer.readActiveMapPresentation(presentation).code ==
+         "active_missing");
 }
 
 static void testActivationSwitchesPointerAndRetainsPreviousVersion() {
@@ -1285,6 +1356,8 @@ int main() {
   testTargetThreeBuildingContractValidation();
   testActivationStateTracksAttemptsAndCompactStatus();
   testRejectsUnsafeManifestPath();
+  testParsesOptionalActiveMapPresentationMetadata();
+  testIgnoresInvalidOptionalActiveMapPresentationMetadata();
   testRejectsMalformedActiveTargetMetadata();
   testRejectsPathOutsideMapNamespace();
   testRejectsMapBlockOutsideRendererBudget();

--- a/esp32/tools/tests/test_map_transfer.cpp
+++ b/esp32/tools/tests/test_map_transfer.cpp
@@ -460,6 +460,13 @@ static void testParsesOptionalActiveMapPresentationMetadata() {
   assert((manifest.boundsE7 ==
           std::array<int32_t, 4>{-468300000, -240100000, -463600000,
                                  -233500000}));
+
+  const std::string maximumName(240, 'x');
+  status = installer.validateManifestText(
+      presentationManifest("\"displayName\":\"" + maximumName + "\","),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName == maximumName);
 }
 
 static void testIgnoresInvalidOptionalActiveMapPresentationMetadata() {
@@ -483,6 +490,56 @@ static void testIgnoresInvalidOptionalActiveMapPresentationMetadata() {
   assert(status.ok);
   assert(manifest.displayName.empty());
   assert(!manifest.hasBoundsE7);
+
+  status = installer.validateManifestText(
+      presentationManifest(
+          "\"displayName\":\"ride\\u0085name\","
+          "\"boundsE7\":[1200000000,300000000,1210000000,310000000],"),
+      manifest);
+  assert(status.ok);
+  assert(manifest.displayName.empty());
+  assert(manifest.hasBoundsE7);
+}
+
+static void testBindsActivePresentationToManifestReceipt() {
+  const std::string root = tempRoot();
+  const std::string installedRoot =
+      root + "/VECTMAP/.maps/signed-session";
+  assert(::system((std::string("mkdir -p ") + installedRoot).c_str()) == 0);
+  const std::string manifestText = presentationManifest(
+      "\"displayName\":\"Signed Map\","
+      "\"boundsE7\":[1209000000,307000000,1219500000,315500000],");
+  writeFile(installedRoot + "/.manifest.json", manifestText);
+  writeFile(
+      root + "/VECTMAP/active-map.json",
+      "{\"mapId\":\"map-1\",\"sessionId\":\"signed-session\","
+      "\"root\":\"/VECTMAP/.maps/signed-session\","
+      "\"renderer\":\"esp32-fmb\",\"formatVersion\":1,"
+      "\"labelProfileVersion\":0,\"labelLanguages\":[],"
+      "\"internationalFallback\":\"\",\"manifestReceipt\":\"" +
+          sha(manifestText) +
+          "\",\"signedManifestReceipt\":\"" + std::string(64, 'a') +
+          "\"}\n");
+
+  MapTransferInstaller installer(root);
+  ActiveMapSelection selection;
+  map_transfer::MapPresentationMetadata presentation;
+  assert(installer.readActiveMapPresentation(selection, presentation).ok);
+  assert(presentation.displayName == "Signed Map");
+  map_transfer::MapPresentationRevision revision;
+  assert(installer.readActiveMapPresentationRevision(selection, revision));
+  assert(revision.bytes == manifestText.size());
+
+  const std::string modifiedManifest = presentationManifest(
+      "\"displayName\":\"Modified Map\","
+      "\"boundsE7\":[100000000,100000000,200000000,200000000],");
+  writeFile(installedRoot + "/.manifest.json", modifiedManifest);
+  const auto status =
+      installer.readActiveMapPresentation(selection, presentation);
+  assert(!status.ok);
+  assert(status.code == "installed_manifest_receipt");
+  assert(::unlink((installedRoot + "/.manifest.json").c_str()) == 0);
+  assert(!installer.readActiveMapPresentationRevision(selection, revision));
 }
 
 static void testRejectsMalformedActiveTargetMetadata() {
@@ -584,7 +641,12 @@ static void testValidatesStagedMapAndActivates() {
   assert(selection.target.formatVersion == 1);
   assert(selection.previousRoot.empty());
   map_transfer::MapPresentationMetadata presentation;
-  assert(installer.readActiveMapPresentation(presentation).ok);
+  ActiveMapSelection presentedSelection;
+  assert(installer.readActiveMapPresentation(presentedSelection, presentation)
+             .ok);
+  assert(presentedSelection.mapId == selection.mapId);
+  assert(presentedSelection.sessionId == selection.sessionId);
+  assert(presentedSelection.root == selection.root);
   assert(presentation.displayName == "Active Map");
   assert(presentation.hasBoundsE7);
   assert((presentation.boundsE7 ==
@@ -602,8 +664,8 @@ static void testValidatesStagedMapAndActivates() {
   assert(cleared.ok);
   assert(cleared.code == "active_cleared");
   assert(installer.readActiveMap(selection).code == "active_missing");
-  assert(installer.readActiveMapPresentation(presentation).code ==
-         "active_missing");
+  assert(installer.readActiveMapPresentation(presentedSelection, presentation)
+             .code == "active_missing");
 }
 
 static void testActivationSwitchesPointerAndRetainsPreviousVersion() {
@@ -1358,6 +1420,7 @@ int main() {
   testRejectsUnsafeManifestPath();
   testParsesOptionalActiveMapPresentationMetadata();
   testIgnoresInvalidOptionalActiveMapPresentationMetadata();
+  testBindsActivePresentationToManifestReceipt();
   testRejectsMalformedActiveTargetMetadata();
   testRejectsPathOutsideMapNamespace();
   testRejectsMapBlockOutsideRendererBudget();

--- a/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
+++ b/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
@@ -4,6 +4,33 @@
 #include <iostream>
 
 int main() {
+  std::string statusBody = "{\"status\":\"idle\"";
+  map_transfer_status_protocol::ActiveMapPresentation presentation;
+  presentation.displayName = "Chris's \"Bike\"";
+  presentation.boundsE7 = {-468300000, -240100000, -463600000, -233500000};
+  presentation.hasBoundsE7 = true;
+  map_transfer_status_protocol::appendActiveMapPresentation(statusBody,
+                                                            presentation);
+  assert(statusBody ==
+         "{\"status\":\"idle\",\"activeMapDisplayName\":"
+         "\"Chris's \\\"Bike\\\"\",\"activeMapBoundsE7\":"
+         "[-468300000,-240100000,-463600000,-233500000]");
+
+  const std::string unchanged = statusBody;
+  map_transfer_status_protocol::appendActiveMapPresentation(
+      statusBody, map_transfer_status_protocol::ActiveMapPresentation());
+  assert(statusBody == unchanged);
+
+  map_transfer_status_protocol::ActiveMapPresentation maximumPresentation;
+  maximumPresentation.displayName = std::string(240, 'x');
+  maximumPresentation.boundsE7 = {-1800000000, -900000000, 1800000000,
+                                  900000000};
+  maximumPresentation.hasBoundsE7 = true;
+  std::string maximumBody = "{}";
+  map_transfer_status_protocol::appendActiveMapPresentation(
+      maximumBody, maximumPresentation);
+  assert(maximumBody.size() <= 13U * 255U);
+
   assert(map_transfer_status_protocol::chunkPayloadBytes(23) == 0);
   assert(map_transfer_status_protocol::chunkPayloadBytes(32) == 0);
   assert(map_transfer_status_protocol::chunkPayloadBytes(33) == 1);

--- a/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
+++ b/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
@@ -22,14 +22,39 @@ int main() {
   assert(statusBody == unchanged);
 
   map_transfer_status_protocol::ActiveMapPresentation maximumPresentation;
-  maximumPresentation.displayName = std::string(240, 'x');
+  maximumPresentation.displayName = std::string(240, '\\');
   maximumPresentation.boundsE7 = {-1800000000, -900000000, 1800000000,
                                   900000000};
   maximumPresentation.hasBoundsE7 = true;
-  std::string maximumBody = "{}";
+  std::string maximumBody =
+      "{\"configured\":true,\"enabled\":true,\"port\":65535,"
+      "\"firmwareVersion\":\"2026.08.17-production\","
+      "\"firmwareBuild\":4294967295,"
+      "\"firmwareGitSha\":\"0123456789abcdef0123456789abcdef01234567\","
+      "\"protocols\":[1,2],\"streamFormatVersions\":[1],"
+      "\"streamTrust\":[\"production-key=" +
+      std::string(64, 'a') +
+      "\"],\"sdPresent\":true,\"mapFound\":true,"
+      "\"mapBlocks\":4294967295,"
+      "\"baseUrl\":\"http://255.255.255.255:65535\","
+      "\"apSsid\":\"BikeComputer-Transfer-123456789\","
+      "\"networkTransport\":\"hotspot\","
+      "\"networkSsid\":\"12345678901234567890123456789012\","
+      "\"hotspotFallback\":true,"
+      "\"hotspotFallbackReason\":\"endpoint_unreachable\","
+      "\"activeMapId\":\"" +
+      std::string(80, 'm') + "\",\"activeSessionId\":\"" +
+      std::string(80, 's') + "\",\"activeManifestReceipt\":\"" +
+      std::string(64, 'b') + "\"}";
   map_transfer_status_protocol::appendActiveMapPresentation(
       maximumBody, maximumPresentation);
-  assert(maximumBody.size() <= 13U * 255U);
+  const size_t minimumMtuChunkBytes =
+      map_transfer_status_protocol::chunkPayloadBytes(45);
+  assert(minimumMtuChunkBytes == 13U);
+  const size_t maximumBodyChunkCount =
+      (maximumBody.size() + minimumMtuChunkBytes - 1U) /
+      minimumMtuChunkBytes;
+  assert(maximumBodyChunkCount <= 255U);
 
   assert(map_transfer_status_protocol::chunkPayloadBytes(23) == 0);
   assert(map_transfer_status_protocol::chunkPayloadBytes(32) == 0);

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -27,7 +27,27 @@ nonisolated struct DeviceActiveMapDescriptor: Equatable, Sendable {
     }
 
     var previewFilename: String {
-        "\(mapID)--\(stableIdentity).png"
+        let boundsIdentity = bounds.map { value in
+            [
+                value.minLongitude,
+                value.minLatitude,
+                value.maxLongitude,
+                value.maxLatitude,
+            ]
+            .map { String($0.bitPattern, radix: 16) }
+            .joined(separator: ",")
+        } ?? ""
+        let identity = [
+            mapID,
+            sessionID ?? "",
+            manifestReceipt ?? "",
+            displayName ?? "",
+            boundsIdentity,
+        ].joined(separator: "\u{0}")
+        let digest = SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
+        return "device-map-\(digest).png"
     }
 
     init?(
@@ -54,22 +74,32 @@ nonisolated struct DeviceActiveMapDescriptor: Equatable, Sendable {
         guard let mapID = statusObject["activeMapId"] as? String else {
             return nil
         }
-        let bounds: [Int]? = (statusObject["activeMapBoundsE7"] as? [NSNumber])?.compactMap {
-            let value = $0.doubleValue
-            guard value.isFinite,
-                  value.rounded(.towardZero) == value,
-                  value >= Double(Int32.min),
-                  value <= Double(Int32.max) else {
-                return nil
+        let bounds: [Int]? = (statusObject["activeMapBoundsE7"] as? [Any]).flatMap {
+            guard $0.count == 4 else { return nil }
+            var values: [Int] = []
+            values.reserveCapacity(4)
+            for item in $0 {
+                guard let number = item as? NSNumber,
+                      CFGetTypeID(number) != CFBooleanGetTypeID() else {
+                    return nil
+                }
+                let value = number.doubleValue
+                guard value.isFinite,
+                      value.rounded(.towardZero) == value,
+                      value >= Double(Int32.min),
+                      value <= Double(Int32.max) else {
+                    return nil
+                }
+                values.append(Int(value))
             }
-            return Int(value)
+            return values
         }
         self.init(
             mapID: mapID,
             sessionID: statusObject["activeSessionId"] as? String,
             manifestReceipt: statusObject["activeManifestReceipt"] as? String,
             displayName: statusObject["activeMapDisplayName"] as? String,
-            boundsE7: bounds?.count == 4 ? bounds : nil
+            boundsE7: bounds
         )
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -15,6 +15,115 @@ import Security
 import UIKit
 #endif
 
+nonisolated struct DeviceActiveMapDescriptor: Equatable, Sendable {
+    let mapID: String
+    let sessionID: String?
+    let manifestReceipt: String?
+    let displayName: String?
+    let bounds: OfflineMapPreviewBounds?
+
+    var stableIdentity: String {
+        sessionID ?? manifestReceipt ?? mapID
+    }
+
+    var previewFilename: String {
+        "\(mapID)--\(stableIdentity).png"
+    }
+
+    init?(
+        mapID: String,
+        sessionID: String? = nil,
+        manifestReceipt: String? = nil,
+        displayName: String? = nil,
+        boundsE7: [Int]? = nil
+    ) {
+        guard Self.isSafeMapID(mapID) else { return nil }
+        self.mapID = mapID
+        self.sessionID = sessionID.flatMap(Self.validSessionID)
+        self.manifestReceipt = manifestReceipt.flatMap(Self.validReceipt)
+        self.displayName = displayName.flatMap(Self.validDisplayName)
+        self.bounds = boundsE7.flatMap { values in
+            guard values.count == 4 else { return nil }
+            return OfflineMapPreviewBounds(
+                coordinates: values.map { Double($0) / 10_000_000 }
+            )
+        }
+    }
+
+    init?(statusObject: [String: Any]) {
+        guard let mapID = statusObject["activeMapId"] as? String else {
+            return nil
+        }
+        let bounds: [Int]? = (statusObject["activeMapBoundsE7"] as? [NSNumber])?.compactMap {
+            let value = $0.doubleValue
+            guard value.isFinite,
+                  value.rounded(.towardZero) == value,
+                  value >= Double(Int32.min),
+                  value <= Double(Int32.max) else {
+                return nil
+            }
+            return Int(value)
+        }
+        self.init(
+            mapID: mapID,
+            sessionID: statusObject["activeSessionId"] as? String,
+            manifestReceipt: statusObject["activeManifestReceipt"] as? String,
+            displayName: statusObject["activeMapDisplayName"] as? String,
+            boundsE7: bounds?.count == 4 ? bounds : nil
+        )
+    }
+
+    private static func isSafeMapID(_ value: String) -> Bool {
+        guard !value.isEmpty,
+              value.utf8.count <= 64,
+              value != ".",
+              value != ".." else {
+            return false
+        }
+        return value.utf8.allSatisfy(isSafeIdentifierByte)
+    }
+
+    private static func validSessionID(_ value: String) -> String? {
+        guard !value.isEmpty,
+              value.utf8.count <= 80,
+              value.first != ".",
+              !value.contains(".."),
+              value.utf8.allSatisfy(isSafeIdentifierByte) else {
+            return nil
+        }
+        return value
+    }
+
+    private static func validReceipt(_ value: String) -> String? {
+        guard value.utf8.count == 64,
+              value.utf8.allSatisfy({ byte in
+                  (48...57).contains(byte) || (65...70).contains(byte) ||
+                      (97...102).contains(byte)
+              }) else {
+            return nil
+        }
+        return value.lowercased()
+    }
+
+    private static func validDisplayName(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.count <= 80,
+              trimmed.utf8.count <= 240,
+              trimmed.unicodeScalars.allSatisfy({
+                  !CharacterSet.controlCharacters.contains($0)
+              }) else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func isSafeIdentifierByte(_ byte: UInt8) -> Bool {
+        (48...57).contains(byte) || (65...90).contains(byte) ||
+            (97...122).contains(byte) || byte == 45 || byte == 46 || byte == 95
+    }
+}
+
 struct NavigationWriteEndpoint {
     let maximumWriteLength: Int
     let expectsWriteResponse: Bool
@@ -698,6 +807,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var mapTransferAccessPointSSID: String?
     @Published var mapTransferActiveMapId: String = ""
     @Published var mapTransferActiveSessionId: String = ""
+    @Published private(set) var activeDeviceMap: DeviceActiveMapDescriptor?
     @Published private(set) var activeMapManifestReceipt: String = ""
     @Published private(set) var activeMapRendererFormat: Int?
     @Published private(set) var activeMapLabelProfileVersion: Int?
@@ -4728,6 +4838,7 @@ class BLEManager: NSObject, ObservableObject {
         mapTransferAccessPointSSID = nil
         mapTransferActiveMapId = ""
         mapTransferActiveSessionId = ""
+        activeDeviceMap = nil
         activeMapManifestReceipt = ""
         activeMapRendererFormat = nil
         activeMapLabelProfileVersion = nil
@@ -7746,6 +7857,7 @@ extension BLEManager: CBPeripheralDelegate {
         mapTransferActiveMapId = object["activeMapId"] as? String ?? ""
         mapTransferActiveSessionId = object["activeSessionId"] as? String ?? ""
         activeMapManifestReceipt = object["activeManifestReceipt"] as? String ?? ""
+        activeDeviceMap = DeviceActiveMapDescriptor(statusObject: object)
         activeMapRendererFormat =
             (object["activeRendererFormat"] as? NSNumber)?.intValue
         activeMapLabelProfileVersion =

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -354,7 +354,7 @@ nonisolated enum SavedMapSnapshotPreviewStore {
         }
     }
 
-    private static func isValidPNG(_ data: Data) -> Bool {
+    static func isValidPNG(_ data: Data) -> Bool {
         guard (33...maximumImageBytes).contains(data.count),
               data.starts(with: pngSignature),
               uint32BE(data, at: 8) == 13,
@@ -371,6 +371,104 @@ nonisolated enum SavedMapSnapshotPreviewStore {
             UInt32(data[offset + 1]) << 16 |
             UInt32(data[offset + 2]) << 8 |
             UInt32(data[offset + 3])
+    }
+}
+
+nonisolated enum DeviceMapSnapshotPreviewStore {
+    private static let maximumEntryCount = 16
+    private static let maximumEntryAge: TimeInterval = 30 * 24 * 60 * 60
+
+    static func imageData(
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) -> Data? {
+        let url = imageURL(for: descriptor, in: cacheRoot)
+        guard let values = try? url.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey]
+        ),
+        values.isRegularFile == true,
+        let fileSize = values.fileSize,
+        (33...SavedMapSnapshotPreviewStore.maximumImageBytes).contains(fileSize),
+        let data = try? Data(contentsOf: url),
+        SavedMapSnapshotPreviewStore.isValidPNG(data) else {
+            return nil
+        }
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: url.path
+        )
+        return data
+    }
+
+    static func save(
+        _ data: Data,
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) throws {
+        guard SavedMapSnapshotPreviewStore.isValidPNG(data) else {
+            throw OfflineMapPlatformError.invalidPack(
+                "device map snapshot preview is not a valid PNG"
+            )
+        }
+        let directory = previewDirectory(in: cacheRoot)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        try data.write(
+            to: imageURL(for: descriptor, in: cacheRoot),
+            options: .atomic
+        )
+        prune(directory: directory)
+    }
+
+    static func imageURL(
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) -> URL {
+        previewDirectory(in: cacheRoot)
+            .appendingPathComponent(descriptor.previewFilename, isDirectory: false)
+    }
+
+    private static func previewDirectory(in cacheRoot: URL) -> URL {
+        cacheRoot.appendingPathComponent("DeviceMapPreviews", isDirectory: true)
+    }
+
+    private static func prune(directory: URL, now: Date = Date()) {
+        guard var entries = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey,
+                .isRegularFileKey,
+            ],
+            options: [.skipsHiddenFiles]
+        ) else {
+            return
+        }
+        entries = entries.filter { url in
+            let values = try? url.resourceValues(
+                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+            )
+            return values?.isRegularFile == true &&
+                url.pathExtension.lowercased() == "png"
+        }
+        entries.sort { lhs, rhs in
+            let lhsDate = (try? lhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            let rhsDate = (try? rhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            return lhsDate > rhsDate
+        }
+        for (index, url) in entries.enumerated() {
+            let date = (try? url.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            if index >= maximumEntryCount || now.timeIntervalSince(date) > maximumEntryAge {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
 }
 
@@ -1446,6 +1544,24 @@ nonisolated struct OfflineMapActivityCounter {
     }
 }
 
+nonisolated struct SavedMapLocalRecord: Equatable, Sendable {
+    let packURL: URL
+    let mapID: String
+    let acceptedSessionIDs: Set<String>
+    let displayName: String
+}
+
+nonisolated struct SavedMapListItem: Identifiable, Equatable, Sendable {
+    let id: String
+    let localRecord: SavedMapLocalRecord?
+    let deviceMap: DeviceActiveMapDescriptor?
+    let displayName: String
+
+    var packURL: URL? { localRecord?.packURL }
+    var isOnIPhone: Bool { localRecord != nil }
+    var isActiveOnDevice: Bool { deviceMap != nil }
+}
+
 @MainActor
 final class OfflineMapManager: ObservableObject {
     typealias PackDownloadOperation = (
@@ -1471,6 +1587,7 @@ final class OfflineMapManager: ObservableObject {
     @Published private(set) var downloadURL: URL?
     @Published private(set) var downloadedPackURL: URL?
     @Published private(set) var cachedPackURLs: [URL] = []
+    @Published private(set) var cachedMapRecords: [SavedMapLocalRecord] = []
     @Published private(set) var downloadProgress: Double = 0
     @Published private(set) var downloadByteProgress: OfflineMapByteProgress?
     @Published private(set) var transferProgress: Double = 0
@@ -1545,6 +1662,7 @@ final class OfflineMapManager: ObservableObject {
     private var unavailablePackPreviews: Set<String> = []
     private var previewLoadTasks: [String: Task<Void, Never>] = [:]
     private let previewLoadRegistry = OfflineMapPreviewLoadRegistry()
+    private var currentActiveDeviceMap: DeviceActiveMapDescriptor?
 #endif
 
     init(
@@ -1939,6 +2057,15 @@ final class OfflineMapManager: ObservableObject {
         )
     }
 
+    func mapUploadProgress(for packURL: URL) -> Double? {
+        guard savedMapID(for: packURL) == lastTransferMapId,
+              lastTransferOutcome == "uploading" || hasActiveBackgroundUpload,
+              !isPausedMapUpload(packURL) else {
+            return nil
+        }
+        return min(0.99, max(0.02, transferProgress))
+    }
+
     private func startCachedPackTransfer(
         at packURL: URL,
         bleManager: BLEManager,
@@ -2005,7 +2132,86 @@ final class OfflineMapManager: ObservableObject {
         )
     }
 
+    func savedMapListItems(
+        activeDeviceMap: DeviceActiveMapDescriptor?
+    ) -> [SavedMapListItem] {
+        var remainingRecords = cachedMapRecords
+        var items: [SavedMapListItem] = []
+
+        if let activeDeviceMap {
+            let matchingIndex = activeDeviceMap.sessionID.flatMap { sessionID in
+                remainingRecords.firstIndex { record in
+                    record.mapID == activeDeviceMap.mapID &&
+                        record.acceptedSessionIDs.contains(sessionID)
+                }
+            }
+            if let matchingIndex {
+                let record = remainingRecords.remove(at: matchingIndex)
+                items.append(
+                    SavedMapListItem(
+                        id: "local:\(record.packURL.standardizedFileURL.path)",
+                        localRecord: record,
+                        deviceMap: activeDeviceMap,
+                        displayName: record.displayName
+                    )
+                )
+            } else {
+                items.append(
+                    SavedMapListItem(
+                        id: "device:\(activeDeviceMap.mapID):\(activeDeviceMap.stableIdentity)",
+                        localRecord: nil,
+                        deviceMap: activeDeviceMap,
+                        displayName: SavedMapDisplayNamePolicy.resolve(
+                            artifactDisplayName: activeDeviceMap.displayName,
+                            sourceRegionName: nil,
+                            mapID: activeDeviceMap.mapID
+                        )
+                    )
+                )
+            }
+        }
+
+        items.append(contentsOf: remainingRecords.map { record in
+            SavedMapListItem(
+                id: "local:\(record.packURL.standardizedFileURL.path)",
+                localRecord: record,
+                deviceMap: nil,
+                displayName: record.displayName
+            )
+        })
+        return items
+    }
+
 #if canImport(UIKit)
+    func updateActiveDeviceMap(_ descriptor: DeviceActiveMapDescriptor?) {
+        guard descriptor != currentActiveDeviceMap else { return }
+        if let currentActiveDeviceMap {
+            let key = devicePreviewCacheKey(for: currentActiveDeviceMap)
+            previewLoadRegistry.invalidate(key)
+            previewLoadTasks.removeValue(forKey: key)?.cancel()
+            packPreviewImages.removeValue(forKey: key)
+            unavailablePackPreviews.remove(key)
+        }
+        currentActiveDeviceMap = descriptor
+    }
+
+    func previewImage(for item: SavedMapListItem) -> UIImage? {
+        if let packURL = item.packURL {
+            return previewImage(forCachedPack: packURL)
+        }
+        guard let descriptor = item.deviceMap else { return nil }
+        return packPreviewImages[devicePreviewCacheKey(for: descriptor)]
+    }
+
+    func loadPreviewIfNeeded(for item: SavedMapListItem) {
+        if let packURL = item.packURL {
+            loadPreviewIfNeeded(forCachedPack: packURL)
+            return
+        }
+        guard let descriptor = item.deviceMap else { return }
+        loadDevicePreviewIfNeeded(for: descriptor)
+    }
+
     func previewImage(forCachedPack packURL: URL) -> UIImage? {
         packPreviewImages[previewCacheKey(for: packURL)]
     }
@@ -2125,6 +2331,85 @@ final class OfflineMapManager: ObservableObject {
         }
         return image
     }
+
+    private func loadDevicePreviewIfNeeded(
+        for descriptor: DeviceActiveMapDescriptor
+    ) {
+        if currentActiveDeviceMap != descriptor {
+            updateActiveDeviceMap(descriptor)
+        }
+        let key = devicePreviewCacheKey(for: descriptor)
+        guard packPreviewImages[key] == nil,
+              !unavailablePackPreviews.contains(key),
+              previewLoadTasks[key] == nil else {
+            return
+        }
+        if let bounds = descriptor.bounds {
+            packPreviewImages[key] = OfflineMapFallbackPreviewRenderer.image(
+                for: bounds
+            )
+        }
+        guard let cacheRoot = try? cachedPackDirectory() else {
+            unavailablePackPreviews.insert(key)
+            return
+        }
+        let token = previewLoadRegistry.begin(for: key)
+        previewLoadTasks[key] = Task { [weak self] in
+            let storedData = await Task.detached(priority: .utility) {
+                DeviceMapSnapshotPreviewStore.imageData(
+                    for: descriptor,
+                    in: cacheRoot
+                )
+            }.value
+            guard let self,
+                  self.previewLoadRegistry.isCurrent(token, for: key),
+                  !Task.isCancelled,
+                  self.currentActiveDeviceMap == descriptor else {
+                return
+            }
+            if let storedImage = self.usableSnapshotImage(from: storedData) {
+                _ = self.previewLoadRegistry.finishIfCurrent(token, for: key)
+                self.previewLoadTasks.removeValue(forKey: key)
+                self.packPreviewImages[key] = storedImage
+                return
+            }
+            guard let bounds = descriptor.bounds else {
+                _ = self.previewLoadRegistry.finishIfCurrent(token, for: key)
+                self.previewLoadTasks.removeValue(forKey: key)
+                self.unavailablePackPreviews.insert(key)
+                return
+            }
+
+            let generatedData: Data?
+            do {
+                generatedData = try await self.mapSnapshot(bounds)
+            } catch is CancellationError {
+                if self.previewLoadRegistry.finishIfCurrent(token, for: key) {
+                    self.previewLoadTasks.removeValue(forKey: key)
+                }
+                return
+            } catch {
+                generatedData = nil
+            }
+            guard self.previewLoadRegistry.finishIfCurrent(token, for: key) else {
+                return
+            }
+            self.previewLoadTasks.removeValue(forKey: key)
+            guard !Task.isCancelled,
+                  self.currentActiveDeviceMap == descriptor else {
+                return
+            }
+            if let generatedData,
+               let image = self.usableSnapshotImage(from: generatedData) {
+                try? DeviceMapSnapshotPreviewStore.save(
+                    generatedData,
+                    for: descriptor,
+                    in: cacheRoot
+                )
+                self.packPreviewImages[key] = image
+            }
+        }
+    }
 #endif
 
     @discardableResult
@@ -2141,6 +2426,7 @@ final class OfflineMapManager: ObservableObject {
         }
         persistPackDisplayNames()
         syncSavedMapInventory(packURL)
+        refreshCachedPacks()
         return displayName
     }
 
@@ -2155,30 +2441,10 @@ final class OfflineMapManager: ObservableObject {
         // Older firmware does not expose the content-derived session, so it
         // cannot prove that a regenerated same-area pack is already installed.
         guard !activeSessionId.isEmpty else { return false }
-        if let metadata = SavedMapArtifactMetadataStore.load(for: packURL),
-           metadata.primaryArtifact?.isBikeMapStream == true,
-           let signedReceipt = metadata.primaryArtifact?.signedManifestReceipt,
-           !signedReceipt.isEmpty {
-            let acceptedSessions = [
-                signedReceipt,
-                metadata.expectedActiveSessionID,
-                metadata.lastTransferSessionID,
-            ].compactMap { value in
-                value?.isEmpty == false ? value : nil
-            }
-            return acceptedSessions.contains(activeSessionId)
-        }
-        guard let archive = try? OfflineMapPackArchive(url: packURL),
-              let manifest = try? archive.manifest(),
-              let mapId = manifest.mapId,
-              let manifestEntry = archive.manifestEntry,
-              let manifestData = try? archive.data(for: manifestEntry) else {
-            return false
-        }
-        return MapTransferSessionIdentity.make(
-            mapId: mapId,
-            manifestData: manifestData
-        ) == activeSessionId
+        return acceptedActiveSessionIDs(
+            for: packURL,
+            mapID: activeMapId
+        ).contains(activeSessionId)
     }
 
     var lastTransferDescription: String? {
@@ -4478,7 +4744,12 @@ final class OfflineMapManager: ObservableObject {
                 return lhsDate > rhsDate
             }
 #if canImport(UIKit)
-            let activePreviewKeys = Set(packURLs.map(previewCacheKey))
+            var activePreviewKeys = Set(packURLs.map(previewCacheKey))
+            if let currentActiveDeviceMap {
+                activePreviewKeys.insert(
+                    devicePreviewCacheKey(for: currentActiveDeviceMap)
+                )
+            }
             for key in Array(packPreviewImages.keys) where !activePreviewKeys.contains(key) {
                 packPreviewImages.removeValue(forKey: key)
             }
@@ -4489,6 +4760,7 @@ final class OfflineMapManager: ObservableObject {
             unavailablePackPreviews.formIntersection(activePreviewKeys)
 #endif
             cacheDefaultDisplayNames(for: packURLs)
+            cachedMapRecords = packURLs.map(cachedMapRecord)
             cachedPackURLs = packURLs
         } catch {
 #if canImport(UIKit)
@@ -4501,12 +4773,19 @@ final class OfflineMapManager: ObservableObject {
             unavailablePackPreviews.removeAll()
 #endif
             cachedPackURLs = []
+            cachedMapRecords = []
         }
     }
 
 #if canImport(UIKit)
     private func previewCacheKey(for packURL: URL) -> String {
         packURL.standardizedFileURL.path
+    }
+
+    private func devicePreviewCacheKey(
+        for descriptor: DeviceActiveMapDescriptor
+    ) -> String {
+        "device:\(descriptor.previewFilename)"
     }
 
     private func invalidateCachedPreview(for packURL: URL) {
@@ -4581,6 +4860,48 @@ final class OfflineMapManager: ObservableObject {
     private func savedMapID(for packURL: URL) -> String {
         SavedMapArtifactMetadataStore.load(for: packURL)?.mapID ??
             packURL.deletingPathExtension().lastPathComponent
+    }
+
+    private func cachedMapRecord(for packURL: URL) -> SavedMapLocalRecord {
+        let mapID = savedMapID(for: packURL)
+        return SavedMapLocalRecord(
+            packURL: packURL,
+            mapID: mapID,
+            acceptedSessionIDs: acceptedActiveSessionIDs(
+                for: packURL,
+                mapID: mapID
+            ),
+            displayName: displayName(forCachedPack: packURL)
+        )
+    }
+
+    private func acceptedActiveSessionIDs(
+        for packURL: URL,
+        mapID: String
+    ) -> Set<String> {
+        if let metadata = SavedMapArtifactMetadataStore.load(for: packURL),
+           metadata.primaryArtifact?.isBikeMapStream == true,
+           let signedReceipt = metadata.primaryArtifact?.signedManifestReceipt,
+           !signedReceipt.isEmpty {
+            return Set([
+                signedReceipt,
+                metadata.expectedActiveSessionID,
+                metadata.lastTransferSessionID,
+            ].compactMap { value in
+                value?.isEmpty == false ? value : nil
+            })
+        }
+        guard let archive = try? OfflineMapPackArchive(url: packURL),
+              let manifest = try? archive.manifest(),
+              manifest.mapId == mapID,
+              let manifestEntry = archive.manifestEntry,
+              let manifestData = try? archive.data(for: manifestEntry) else {
+            return []
+        }
+        return [MapTransferSessionIdentity.make(
+            mapId: mapID,
+            manifestData: manifestData
+        )]
     }
 
     private func transferIdentity(for packURL: URL) throws -> (mapID: String, sessionID: String) {

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -441,7 +441,7 @@ nonisolated enum DeviceMapSnapshotPreviewStore {
                 .contentModificationDateKey,
                 .isRegularFileKey,
             ],
-            options: [.skipsHiddenFiles]
+            options: []
         ) else {
             return
         }
@@ -4600,7 +4600,7 @@ final class OfflineMapManager: ObservableObject {
         }
     }
 
-    private func updateSavedMapTransferMetadata(
+    func updateSavedMapTransferMetadata(
         mapID: String,
         protocolVersion: Int?,
         streamFormatVersion: Int?,
@@ -4611,6 +4611,11 @@ final class OfflineMapManager: ObservableObject {
         for fileExtension in ["bmap", "zip"] {
             let url = directory.appendingPathComponent("\(mapID).\(fileExtension)")
             guard var metadata = SavedMapArtifactMetadataStore.load(for: url) else { continue }
+            let mergeIdentityChanged =
+                metadata.lastTransferProtocol != protocolVersion ||
+                metadata.lastTransferSessionID != sessionID ||
+                metadata.expectedActiveMapID != mapID ||
+                metadata.expectedActiveSessionID != sessionID
             metadata.lastTransferProtocol = protocolVersion
             metadata.lastTransferStreamFormat = streamFormatVersion
             metadata.lastTransferSessionID = sessionID
@@ -4618,7 +4623,19 @@ final class OfflineMapManager: ObservableObject {
             metadata.expectedActiveSessionID = sessionID
             metadata.lastTransferOutcome = outcome
             try? SavedMapArtifactMetadataStore.save(metadata, for: url)
+            if mergeIdentityChanged {
+                refreshCachedMapRecord(for: url)
+            }
         }
+    }
+
+    func refreshCachedMapRecord(for packURL: URL) {
+        guard let index = cachedMapRecords.firstIndex(where: {
+            $0.packURL.standardizedFileURL == packURL.standardizedFileURL
+        }) else {
+            return
+        }
+        cachedMapRecords[index] = cachedMapRecord(for: packURL)
     }
 
     private func updateSavedMapDeviceState(

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -1280,6 +1280,9 @@ nonisolated struct MapTransferDeviceStatus: Decodable, Equatable {
     let enabled: Bool?
     let activeMapId: String?
     let activeSessionId: String?
+    var activeManifestReceipt: String? = nil
+    var activeMapDisplayName: String? = nil
+    var activeMapBoundsE7: [Int]? = nil
     let activation: Activation?
     let protocols: [Int]?
     let streamFormatVersions: [Int]?

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -879,7 +879,6 @@ private struct SavedMapRow: View {
         let displayName = item.displayName
         let packURL = item.packURL
         let isPausedUpload = packURL.map(manager.isPausedMapUpload) ?? false
-        let uploadProgress = packURL.flatMap(manager.mapUploadProgress)
 
         HStack(spacing: 12) {
             SavedMapThumbnail(
@@ -944,15 +943,6 @@ private struct SavedMapRow: View {
                     focusedPackFilename = nil
                 }
 
-            Image(systemName: "iphone")
-                .foregroundStyle(item.isOnIPhone ? Color.blue : Color.secondary)
-                .frame(width: 28, height: 32)
-                .accessibilityLabel(
-                    item.isOnIPhone
-                        ? "\(displayName) is saved on this iPhone"
-                        : "\(displayName) is not saved on this iPhone"
-                )
-
             if item.isActiveOnDevice {
                 if item.isOnIPhone {
                     Button {
@@ -960,18 +950,26 @@ private struct SavedMapRow: View {
                         focusedPackFilename = nil
                         isShowingInstalledConfirmation = true
                     } label: {
-                        BikeComputerMapStatusIcon(
-                            state: .active
-                        )
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .frame(width: 32, height: 32)
                     }
                     .buttonStyle(.borderless)
                     .accessibilityLabel("\(displayName) is active on the Bike Computer")
                     .accessibilityHint("Shows the installed map status")
                 } else {
-                    BikeComputerMapStatusIcon(
-                        state: .active
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .frame(width: 32, height: 32)
+
+                        IPhoneDownloadStatusIcon()
+                    }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel(
+                        "\(displayName) is active on the Bike Computer " +
+                            "and is not saved on this iPhone"
                     )
-                    .accessibilityLabel("\(displayName) is active on the Bike Computer")
                 }
             } else if let packURL {
                 Button {
@@ -979,11 +977,12 @@ private struct SavedMapRow: View {
                     focusedPackFilename = nil
                     manager.transferCachedPack(at: packURL, bleManager: bleManager)
                 } label: {
-                    BikeComputerMapStatusIcon(
-                        state: isPausedUpload
-                            ? .paused
-                            : uploadProgress.map { .uploading($0) } ?? .available
+                    Image(
+                        systemName: isPausedUpload
+                            ? "arrow.clockwise.circle"
+                            : "arrow.up.circle"
                     )
+                        .frame(width: 32, height: 32)
                 }
                 .buttonStyle(.borderless)
                 .disabled(
@@ -1047,71 +1046,21 @@ private struct SavedMapRow: View {
     }
 }
 
-private struct BikeComputerMapStatusIcon: View {
-    enum State: Equatable {
-        case active
-        case available
-        case paused
-        case uploading(Double)
-
-        var color: Color {
-            switch self {
-            case .active:
-                return .green
-            case .uploading:
-                return .blue
-            case .available, .paused:
-                return .secondary
-            }
-        }
-
-        var badgeSystemName: String {
-            switch self {
-            case .active:
-                return "checkmark.circle.fill"
-            case .available:
-                return "arrow.up.circle.fill"
-            case .paused:
-                return "arrow.clockwise.circle.fill"
-            case .uploading:
-                return "arrow.up.circle.fill"
-            }
-        }
-    }
-
-    let state: State
-
+private struct IPhoneDownloadStatusIcon: View {
     var body: some View {
         ZStack(alignment: .bottomTrailing) {
-            Circle()
-                .fill(state.color)
-                .frame(width: 28, height: 28)
-                .overlay {
-                    Text("b")
-                        .font(.system(size: 17, weight: .bold, design: .rounded))
-                        .foregroundStyle(.white)
-                        .offset(y: -0.5)
-                }
+            Image(systemName: "iphone")
+                .font(.system(size: 24, weight: .regular))
+                .foregroundStyle(.secondary)
 
-            if case let .uploading(progress) = state {
-                Circle()
-                    .trim(from: 0, to: progress)
-                    .stroke(
-                        Color.blue,
-                        style: StrokeStyle(lineWidth: 2, lineCap: .round)
-                    )
-                    .rotationEffect(.degrees(-90))
-                    .frame(width: 32, height: 32)
-            }
-
-            Image(systemName: state.badgeSystemName)
-                .font(.system(size: 11, weight: .semibold))
+            Image(systemName: "arrow.down.circle.fill")
+                .font(.system(size: 12, weight: .semibold))
                 .symbolRenderingMode(.palette)
-                .foregroundStyle(.white, state.color)
+                .foregroundStyle(.white, Color.blue)
                 .background(Circle().fill(Color(uiColor: .systemBackground)))
-                .offset(x: 3, y: 3)
+                .offset(x: 4, y: 3)
         }
-        .frame(width: 34, height: 34)
+        .frame(width: 32, height: 32)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -874,15 +874,33 @@ private struct SavedMapRow: View {
     let onCommitRename: (SavedMapRenameCommit) -> Void
     @State private var isShowingInstalledConfirmation = false
     @State private var isShowingDeleteConfirmation = false
+    @State private var presentedPreview: SavedMapPreviewPresentation?
 
     var body: some View {
         let displayName = item.displayName
         let packURL = item.packURL
         let isPausedUpload = packURL.map(manager.isPausedMapUpload) ?? false
+        let previewImage = manager.previewImage(for: item)
 
         HStack(spacing: 12) {
-            SavedMapThumbnail(
-                image: manager.previewImage(for: item)
+            Button {
+                guard let previewImage else { return }
+                finishRenaming()
+                focusedPackFilename = nil
+                presentedPreview = SavedMapPreviewPresentation(
+                    displayName: displayName,
+                    image: previewImage
+                )
+            } label: {
+                SavedMapThumbnail(image: previewImage)
+            }
+            .buttonStyle(.plain)
+            .disabled(previewImage == nil)
+            .accessibilityLabel("Show preview for \(displayName)")
+            .accessibilityHint(
+                previewImage == nil
+                    ? "Preview is loading"
+                    : "Opens the map preview"
             )
             .task(id: item.id) {
                 manager.loadPreviewIfNeeded(for: item)
@@ -944,33 +962,22 @@ private struct SavedMapRow: View {
                 }
 
             if item.isActiveOnDevice {
-                if item.isOnIPhone {
-                    Button {
-                        finishRenaming()
-                        focusedPackFilename = nil
-                        isShowingInstalledConfirmation = true
-                    } label: {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                            .frame(width: 32, height: 32)
-                    }
-                    .buttonStyle(.borderless)
-                    .accessibilityLabel("\(displayName) is active on the Bike Computer")
-                    .accessibilityHint("Shows the installed map status")
-                } else {
-                    HStack(spacing: 4) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .foregroundColor(.green)
-                            .frame(width: 32, height: 32)
-
-                        IPhoneDownloadStatusIcon()
-                    }
-                    .accessibilityElement(children: .ignore)
-                    .accessibilityLabel(
-                        "\(displayName) is active on the Bike Computer " +
-                            "and is not saved on this iPhone"
-                    )
+                Button {
+                    finishRenaming()
+                    focusedPackFilename = nil
+                    isShowingInstalledConfirmation = true
+                } label: {
+                    Image(systemName: "checkmark.circle.fill")
+                        .foregroundColor(.green)
+                        .frame(width: 32, height: 32)
                 }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("\(displayName) is active on the Bike Computer")
+                .accessibilityHint(
+                    item.isOnIPhone
+                        ? "Shows the installed map status"
+                        : "This map is not saved on this iPhone"
+                )
             } else if let packURL {
                 Button {
                     finishRenaming()
@@ -1037,6 +1044,10 @@ private struct SavedMapRow: View {
                     "A copy already installed on the Bike Computer remains there."
             )
         }
+        .sheet(item: $presentedPreview) { preview in
+            SavedMapPreviewSheet(preview: preview)
+                .presentationDetents([.large])
+        }
     }
 
     private func finishRenaming() {
@@ -1046,21 +1057,34 @@ private struct SavedMapRow: View {
     }
 }
 
-private struct IPhoneDownloadStatusIcon: View {
-    var body: some View {
-        ZStack(alignment: .bottomTrailing) {
-            Image(systemName: "iphone")
-                .font(.system(size: 24, weight: .regular))
-                .foregroundStyle(.secondary)
+private struct SavedMapPreviewPresentation: Identifiable {
+    let id = UUID()
+    let displayName: String
+    let image: UIImage
+}
 
-            Image(systemName: "arrow.down.circle.fill")
-                .font(.system(size: 12, weight: .semibold))
-                .symbolRenderingMode(.palette)
-                .foregroundStyle(.white, Color.blue)
-                .background(Circle().fill(Color(uiColor: .systemBackground)))
-                .offset(x: 4, y: 3)
+private struct SavedMapPreviewSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    let preview: SavedMapPreviewPresentation
+
+    var body: some View {
+        NavigationView {
+            Image(uiImage: preview.image)
+                .resizable()
+                .scaledToFit()
+                .padding()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(Color(uiColor: .systemBackground))
+                .navigationTitle(preview.displayName)
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("Close") {
+                            dismiss()
+                        }
+                    }
+                }
         }
-        .frame(width: 32, height: 32)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -774,15 +774,18 @@ private struct SavedMapsSettingsSection: View {
     @State private var renameInteraction = SavedMapRenameInteraction()
 
     var body: some View {
+        let savedMaps = manager.savedMapListItems(
+            activeDeviceMap: bleManager.activeDeviceMap
+        )
         Section(header: Text("Saved Maps")) {
-            if manager.cachedPackURLs.isEmpty {
-                Text("0 maps downloaded yet")
+            if savedMaps.isEmpty {
+                Text("No saved maps yet")
                     .foregroundColor(.secondary)
             } else {
-                ForEach(manager.cachedPackURLs, id: \.self) { packURL in
-                    DownloadedMapRow(
+                ForEach(savedMaps) { item in
+                    SavedMapRow(
                         manager: manager,
-                        packURL: packURL,
+                        item: item,
                         focusedPackFilename: $focusedPackFilename,
                         renameInteraction: $renameInteraction,
                         onCommitRename: commitRename
@@ -813,7 +816,11 @@ private struct SavedMapsSettingsSection: View {
             }
         }
         .onAppear {
+            manager.updateActiveDeviceMap(bleManager.activeDeviceMap)
             manager.reconcileLastTransfer(bleManager: bleManager)
+        }
+        .onChange(of: bleManager.activeDeviceMap) { descriptor in
+            manager.updateActiveDeviceMap(descriptor)
         }
         .onChange(of: bleManager.mapTransferActiveMapId) { _ in
             manager.reconcileLastTransfer(bleManager: bleManager)
@@ -858,10 +865,10 @@ private struct SavedMapsSettingsSection: View {
     }
 }
 
-private struct DownloadedMapRow: View {
+private struct SavedMapRow: View {
     @EnvironmentObject private var bleManager: BLEManager
     @ObservedObject var manager: OfflineMapManager
-    let packURL: URL
+    let item: SavedMapListItem
     @FocusState.Binding var focusedPackFilename: String?
     @Binding var renameInteraction: SavedMapRenameInteraction
     let onCommitRename: (SavedMapRenameCommit) -> Void
@@ -869,23 +876,21 @@ private struct DownloadedMapRow: View {
     @State private var isShowingDeleteConfirmation = false
 
     var body: some View {
-        let displayName = manager.displayName(forCachedPack: packURL)
-        let isInstalled = manager.isCachedPackInstalled(
-            packURL,
-            activeMapId: bleManager.mapTransferActiveMapId,
-            activeSessionId: bleManager.mapTransferActiveSessionId
-        )
-        let isPausedUpload = manager.isPausedMapUpload(packURL)
+        let displayName = item.displayName
+        let packURL = item.packURL
+        let isPausedUpload = packURL.map(manager.isPausedMapUpload) ?? false
+        let uploadProgress = packURL.flatMap(manager.mapUploadProgress)
 
         HStack(spacing: 12) {
             SavedMapThumbnail(
-                image: manager.previewImage(forCachedPack: packURL)
+                image: manager.previewImage(for: item)
             )
-            .task(id: packURL) {
-                manager.loadPreviewIfNeeded(forCachedPack: packURL)
+            .task(id: item.id) {
+                manager.loadPreviewIfNeeded(for: item)
             }
 
-            if renameInteraction.editingFilename == packURL.lastPathComponent {
+            if let packURL,
+               renameInteraction.editingFilename == packURL.lastPathComponent {
                 TextField(
                     "Map name",
                     text: Binding(
@@ -905,7 +910,7 @@ private struct DownloadedMapRow: View {
                     })
                     .accessibilityLabel("Map name")
                     .layoutPriority(1)
-            } else {
+            } else if let packURL {
                 Button {
                     if let commit = renameInteraction.begin(
                         filename: packURL.lastPathComponent,
@@ -926,6 +931,11 @@ private struct DownloadedMapRow: View {
                 .accessibilityLabel("Rename \(displayName)")
                 .accessibilityHint("Edits this saved map name")
                 .layoutPriority(1)
+            } else {
+                Text(displayName)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .layoutPriority(1)
             }
 
             Spacer()
@@ -934,31 +944,46 @@ private struct DownloadedMapRow: View {
                     focusedPackFilename = nil
                 }
 
-            if isInstalled {
-                Button {
-                    finishRenaming()
-                    focusedPackFilename = nil
-                    isShowingInstalledConfirmation = true
-                } label: {
-                    Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
-                        .frame(width: 32, height: 32)
+            Image(systemName: "iphone")
+                .foregroundStyle(item.isOnIPhone ? Color.blue : Color.secondary)
+                .frame(width: 28, height: 32)
+                .accessibilityLabel(
+                    item.isOnIPhone
+                        ? "\(displayName) is saved on this iPhone"
+                        : "\(displayName) is not saved on this iPhone"
+                )
+
+            if item.isActiveOnDevice {
+                if item.isOnIPhone {
+                    Button {
+                        finishRenaming()
+                        focusedPackFilename = nil
+                        isShowingInstalledConfirmation = true
+                    } label: {
+                        BikeComputerMapStatusIcon(
+                            state: .active
+                        )
+                    }
+                    .buttonStyle(.borderless)
+                    .accessibilityLabel("\(displayName) is active on the Bike Computer")
+                    .accessibilityHint("Shows the installed map status")
+                } else {
+                    BikeComputerMapStatusIcon(
+                        state: .active
+                    )
+                    .accessibilityLabel("\(displayName) is active on the Bike Computer")
                 }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("\(displayName) is installed on device")
-                .accessibilityHint("Shows the installed map status")
-            } else {
+            } else if let packURL {
                 Button {
                     finishRenaming()
                     focusedPackFilename = nil
                     manager.transferCachedPack(at: packURL, bleManager: bleManager)
                 } label: {
-                    Image(
-                        systemName: isPausedUpload
-                            ? "arrow.clockwise.circle"
-                            : "arrow.up.circle"
+                    BikeComputerMapStatusIcon(
+                        state: isPausedUpload
+                            ? .paused
+                            : uploadProgress.map { .uploading($0) } ?? .available
                     )
-                        .frame(width: 32, height: 32)
                 }
                 .buttonStyle(.borderless)
                 .disabled(
@@ -973,17 +998,23 @@ private struct DownloadedMapRow: View {
                 )
             }
 
-            Button(role: .destructive) {
-                finishRenaming()
-                focusedPackFilename = nil
-                isShowingDeleteConfirmation = true
-            } label: {
-                Image(systemName: "trash")
+            if packURL != nil {
+                Button(role: .destructive) {
+                    finishRenaming()
+                    focusedPackFilename = nil
+                    isShowingDeleteConfirmation = true
+                } label: {
+                    Image(systemName: "trash")
+                        .frame(width: 32, height: 32)
+                }
+                .buttonStyle(.borderless)
+                .disabled(manager.isBusy || manager.hasActiveBackgroundUpload)
+                .accessibilityLabel("Delete \(displayName)")
+            } else {
+                Color.clear
                     .frame(width: 32, height: 32)
+                    .accessibilityHidden(true)
             }
-            .buttonStyle(.borderless)
-            .disabled(manager.isBusy || manager.hasActiveBackgroundUpload)
-            .accessibilityLabel("Delete \(displayName)")
         }
         .alert("Already on Device", isPresented: $isShowingInstalledConfirmation) {
             Button("OK", role: .cancel) {}
@@ -996,7 +1027,9 @@ private struct DownloadedMapRow: View {
             titleVisibility: .visible
         ) {
             Button("Delete", role: .destructive) {
-                manager.deleteCachedPack(at: packURL)
+                if let packURL {
+                    manager.deleteCachedPack(at: packURL)
+                }
             }
             Button("Cancel", role: .cancel) { }
         } message: {
@@ -1011,6 +1044,74 @@ private struct DownloadedMapRow: View {
         if let commit = renameInteraction.finish() {
             onCommitRename(commit)
         }
+    }
+}
+
+private struct BikeComputerMapStatusIcon: View {
+    enum State: Equatable {
+        case active
+        case available
+        case paused
+        case uploading(Double)
+
+        var color: Color {
+            switch self {
+            case .active:
+                return .green
+            case .uploading:
+                return .blue
+            case .available, .paused:
+                return .secondary
+            }
+        }
+
+        var badgeSystemName: String {
+            switch self {
+            case .active:
+                return "checkmark.circle.fill"
+            case .available:
+                return "arrow.up.circle.fill"
+            case .paused:
+                return "arrow.clockwise.circle.fill"
+            case .uploading:
+                return "arrow.up.circle.fill"
+            }
+        }
+    }
+
+    let state: State
+
+    var body: some View {
+        ZStack(alignment: .bottomTrailing) {
+            Circle()
+                .fill(state.color)
+                .frame(width: 28, height: 28)
+                .overlay {
+                    Text("b")
+                        .font(.system(size: 17, weight: .bold, design: .rounded))
+                        .foregroundStyle(.white)
+                        .offset(y: -0.5)
+                }
+
+            if case let .uploading(progress) = state {
+                Circle()
+                    .trim(from: 0, to: progress)
+                    .stroke(
+                        Color.blue,
+                        style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                    )
+                    .rotationEffect(.degrees(-90))
+                    .frame(width: 32, height: 32)
+            }
+
+            Image(systemName: state.badgeSystemName)
+                .font(.system(size: 11, weight: .semibold))
+                .symbolRenderingMode(.palette)
+                .foregroundStyle(.white, state.color)
+                .background(Circle().fill(Color(uiColor: .systemBackground)))
+                .offset(x: 3, y: 3)
+        }
+        .frame(width: 34, height: 34)
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -144,11 +144,6 @@ struct SettingsView: View {
                         Label("Hardware Customization", systemImage: "dial.low")
                     }
 
-                    SettingsValueRow(
-                        title: "App Version",
-                        value: appVersionText
-                    )
-
                     NavigationLink {
                         DeveloperSettingsView(
                             offlineMapManager: offlineMapManager,
@@ -205,26 +200,6 @@ struct SettingsView: View {
                 ),
                 systemImage: "bicycle"
             )
-        }
-    }
-
-    private var appVersionText: String {
-        let version = Bundle.main.object(
-            forInfoDictionaryKey: "CFBundleShortVersionString"
-        ) as? String
-        let build = Bundle.main.object(
-            forInfoDictionaryKey: "CFBundleVersion"
-        ) as? String
-
-        switch (version, build) {
-        case let (version?, build?):
-            return "\(version) (\(build))"
-        case let (version?, nil):
-            return version
-        case let (nil, build?):
-            return build
-        case (nil, nil):
-            return "Unknown"
         }
     }
 
@@ -2556,6 +2531,13 @@ private struct DeveloperSettingsView: View {
                 }
             }
 
+            Section(header: Text("App")) {
+                SettingsValueRow(
+                    title: "App Version",
+                    value: appVersionText
+                )
+            }
+
             NavigationOverlaysSettingsSection()
         }
         .navigationTitle("Developer Settings")
@@ -2585,6 +2567,26 @@ private struct DeveloperSettingsView: View {
         }
 
         return "Connected"
+    }
+
+    private var appVersionText: String {
+        let version = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleShortVersionString"
+        ) as? String
+        let build = Bundle.main.object(
+            forInfoDictionaryKey: "CFBundleVersion"
+        ) as? String
+
+        switch (version, build) {
+        case let (version?, build?):
+            return "\(version) (\(build))"
+        case let (version?, nil):
+            return version
+        case let (nil, build?):
+            return build
+        case (nil, nil):
+            return "Unknown"
+        }
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -779,7 +779,7 @@ private struct SavedMapsSettingsSection: View {
         )
         Section(header: Text("Saved Maps")) {
             if savedMaps.isEmpty {
-                Text("No saved maps yet")
+                Text("No offline maps yet")
                     .foregroundColor(.secondary)
             } else {
                 ForEach(savedMaps) { item in

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8257,21 +8257,21 @@ struct NavigationProtocolTests {
         )
         assert(
             source.contains("if item.isActiveOnDevice {") &&
-                source.contains("if item.isOnIPhone {") &&
                 source.contains("Image(systemName: \"checkmark.circle.fill\")") &&
-                source.contains("IPhoneDownloadStatusIcon()") &&
                 source.contains("? \"arrow.clockwise.circle\"") &&
                 source.contains(": \"arrow.up.circle\"") &&
+                !source.contains("IPhoneDownloadStatusIcon") &&
+                !source.contains("Image(systemName: \"iphone\")") &&
                 !source.contains("BikeComputerMapStatusIcon") &&
                 !source.contains("Text(\"b\")"),
-            "saved maps use the agreed iPhone-only, device-only, and shared icons"
+            "saved maps use the same active check and inactive upload icons regardless of origin"
         )
         assert(
             source.contains("Text(\"No offline maps yet\")"),
             "Saved Maps uses the agreed empty-state copy"
         )
         assert(
-            source.contains("and is not saved on this iPhone") &&
+            source.contains("This map is not saved on this iPhone") &&
                 source.contains("is active on the Bike Computer") &&
                 source.contains("Transfer \\(displayName) to device"),
             "saved-map presence indicators expose accessible state labels"
@@ -8297,10 +8297,18 @@ struct NavigationProtocolTests {
         )
         assert(
             source.contains("SavedMapThumbnail(") &&
-                source.contains("manager.previewImage(for: item)") &&
+                source.contains("let previewImage = manager.previewImage(for: item)") &&
                 source.contains("manager.loadPreviewIfNeeded(for: item)") &&
                 source.contains(".frame(width: 52, height: 36)"),
             "each saved map shows a fixed-size preview before its editable name"
+        )
+        assert(
+            source.contains("presentedPreview = SavedMapPreviewPresentation(") &&
+                source.contains(".sheet(item: $presentedPreview)") &&
+                source.contains("SavedMapPreviewSheet(preview: preview)") &&
+                source.contains(".accessibilityLabel(\"Show preview for \\(displayName)\")") &&
+                source.contains("Button(\"Close\")"),
+            "tapping an available saved-map thumbnail opens an accessible preview modal"
         )
         assert(
             source.contains("manager.savedMapListItems(") &&

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8256,22 +8256,25 @@ struct NavigationProtocolTests {
             "Saved Maps omits redundant device and transfer summary rows"
         )
         assert(
-            source.contains("Image(systemName: \"iphone\")") &&
-                source.contains("Text(\"b\")") &&
-                source.contains("state: .active") &&
-                source.contains("uploadProgress.map { .uploading($0) } ?? .available"),
-            "each saved map shows distinct iPhone and Bike Computer presence icons"
+            source.contains("if item.isActiveOnDevice {") &&
+                source.contains("if item.isOnIPhone {") &&
+                source.contains("Image(systemName: \"checkmark.circle.fill\")") &&
+                source.contains("IPhoneDownloadStatusIcon()") &&
+                source.contains("? \"arrow.clockwise.circle\"") &&
+                source.contains(": \"arrow.up.circle\"") &&
+                !source.contains("BikeComputerMapStatusIcon") &&
+                !source.contains("Text(\"b\")"),
+            "saved maps use the agreed iPhone-only, device-only, and shared icons"
         )
         assert(
             source.contains("Text(\"No offline maps yet\")"),
             "Saved Maps uses the agreed empty-state copy"
         )
         assert(
-            source.contains("is saved on this iPhone") &&
-                source.contains("is not saved on this iPhone") &&
+            source.contains("and is not saved on this iPhone") &&
                 source.contains("is active on the Bike Computer") &&
                 source.contains("Transfer \\(displayName) to device"),
-            "both saved-map presence indicators expose accessible state labels"
+            "saved-map presence indicators expose accessible state labels"
         )
         assert(
             source.contains("manager.resumePausedMapUpload(bleManager: bleManager)") &&

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -744,6 +744,7 @@ struct NavigationProtocolTests {
         await testOfflineMapCompatibilityArchiveCancellation()
         await testOfflineMapArchiveValidationCancellation()
         testCachedMapInstalledIdentityUsesManifestSession()
+        testSavedMapInventoryMergesOnlyExactDeviceContent()
         testOfflineMapManifestDecoding()
         testMapTransferUploadURLEncodesPlusPathComponents()
         testMapTransferOutcomePolicy()
@@ -8255,11 +8256,11 @@ struct NavigationProtocolTests {
             "Saved Maps omits redundant device and transfer summary rows"
         )
         assert(
-            source.contains("if isInstalled {") &&
-                source.contains("Image(systemName: \"checkmark.circle.fill\")") &&
-                source.contains("\"arrow.clockwise.circle\"") &&
-                source.contains("\"arrow.up.circle\""),
-            "each saved map shows installed status, resume, or upload as exclusive actions"
+            source.contains("Image(systemName: \"iphone\")") &&
+                source.contains("Text(\"b\")") &&
+                source.contains("state: .active") &&
+                source.contains("uploadProgress.map { .uploading($0) } ?? .available"),
+            "each saved map shows distinct iPhone and Bike Computer presence icons"
         )
         assert(
             source.contains("manager.resumePausedMapUpload(bleManager: bleManager)") &&
@@ -8282,10 +8283,16 @@ struct NavigationProtocolTests {
         )
         assert(
             source.contains("SavedMapThumbnail(") &&
-                source.contains("manager.previewImage(forCachedPack: packURL)") &&
-                source.contains("manager.loadPreviewIfNeeded(forCachedPack: packURL)") &&
+                source.contains("manager.previewImage(for: item)") &&
+                source.contains("manager.loadPreviewIfNeeded(for: item)") &&
                 source.contains(".frame(width: 52, height: 36)"),
             "each saved map shows a fixed-size preview before its editable name"
+        )
+        assert(
+            source.contains("manager.savedMapListItems(") &&
+                source.contains("activeDeviceMap: bleManager.activeDeviceMap") &&
+                source.contains("manager.updateActiveDeviceMap(descriptor)"),
+            "Saved Maps includes and tracks the connected Bike Computer inventory"
         )
         let managerSourceURL = URL(fileURLWithPath:
             "ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift"
@@ -9155,6 +9162,69 @@ struct NavigationProtocolTests {
         )
     }
 
+    @MainActor
+    static func testSavedMapInventoryMergesOnlyExactDeviceContent() {
+        let cacheDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("saved-map-inventory-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: cacheDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: cacheDirectory) }
+
+        let manifestData = Data("""
+        {"schemaVersion":1,"mapId":"map-1","displayName":"Phone Map"}
+        """.utf8)
+        let packURL = cacheDirectory.appendingPathComponent("map-1.zip")
+        try? makeStoredZip(entries: [
+            ("manifest.json", manifestData),
+            ("VECTMAP/map-1/+0032+0008/123_456.fmb", Data("map-block".utf8)),
+        ]).write(to: packURL)
+        let suite = "saved-map-inventory-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let manager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory
+        )
+        let exactSession = MapTransferSessionIdentity.make(
+            mapId: "map-1",
+            manifestData: manifestData
+        )
+        let exactDevice = DeviceActiveMapDescriptor(
+            mapID: "map-1",
+            sessionID: exactSession,
+            displayName: "Device Name",
+            boundsE7: [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000]
+        )!
+
+        var items = manager.savedMapListItems(activeDeviceMap: exactDevice)
+        assertEqual(items.count, 1, "the exact device and iPhone map collapse into one row")
+        assert(items[0].isOnIPhone && items[0].isActiveOnDevice,
+               "the merged row exposes both presence states")
+        assertEqual(items[0].displayName, "Phone Map",
+                    "a local saved name wins when exact content is merged")
+
+        let regeneratedDevice = DeviceActiveMapDescriptor(
+            mapID: "map-1",
+            sessionID: "different-session",
+            displayName: "Cloned SD Map",
+            boundsE7: [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000]
+        )!
+        items = manager.savedMapListItems(activeDeviceMap: regeneratedDevice)
+        assertEqual(items.count, 2,
+                    "same map ID with different content stays as separate device and phone rows")
+        assert(!items[0].isOnIPhone && items[0].isActiveOnDevice,
+               "device-only content sorts first and is not claimed by the iPhone")
+        assert(items[1].isOnIPhone && !items[1].isActiveOnDevice,
+               "the local regenerated map remains uploadable")
+
+        items = manager.savedMapListItems(activeDeviceMap: nil)
+        assertEqual(items.count, 1, "disconnect removes live device-only inventory")
+        assert(items[0].isOnIPhone && !items[0].isActiveOnDevice,
+               "disconnect preserves the iPhone cache without stale device presence")
+    }
+
     static func testOfflineMapManifestDecoding() {
         let url = URL(fileURLWithPath: NSTemporaryDirectory())
             .appendingPathComponent("offline-map-manifest-test-\(UUID().uuidString).zip")
@@ -9789,6 +9859,9 @@ struct NavigationProtocolTests {
           "enabled": true,
           "activeMapId": "old-map",
           "activeSessionId": "old-map-session",
+          "activeManifestReceipt": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "activeMapDisplayName": "Old Map",
+          "activeMapBoundsE7": [1037500000, 12400000, 1039300000, 13700000],
           "activation": {
             "status": "failed",
             "sequence": 9,
@@ -9814,6 +9887,13 @@ struct NavigationProtocolTests {
         assertEqual(status.activation?.error?.code, "file_sha256", "status exposes activation error code")
         assertEqual(status.activation?.error?.message, "sha mismatch for VECTMAP/new-map/1.fmb", "status exposes activation error message")
         assertEqual(status.activeSessionId, "old-map-session", "status exposes durable active session identity")
+        assertEqual(status.activeManifestReceipt, String(repeating: "a", count: 64),
+                    "HTTP status exposes the active manifest receipt")
+        assertEqual(status.activeMapDisplayName, "Old Map",
+                    "HTTP status exposes the active display name")
+        assertEqual(status.activeMapBoundsE7,
+                    [1_037_500_000, 12_400_000, 1_039_300_000, 13_700_000],
+                    "HTTP status exposes normalized preview bounds")
     }
 
     static func testFirmwareManifestDecodingAndHash() {
@@ -15496,7 +15576,7 @@ struct NavigationProtocolTests {
     static func testBLEManagerParsesMapTransferStatus() {
         let manager = BLEManager()
         let json = """
-        {"configured":true,"enabled":true,"port":8080,"baseUrl":"http://192.168.4.20:8080","sdPresent":true,"mapFound":false,"mapBlocks":0,"activeMapId":"kyoto-v1","activeSessionId":"kyoto-v1-session","activeManifestReceipt":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","activeRendererFormat":2,"labelProfileVersion":1,"labelLanguages":["ja","en"],"fontAssetHealthy":true,"activation":{"status":"activating","sequence":12,"sessionId":"tokyo-v2","mapId":"tokyo-v2","step":1,"steps":5,"progress":6},"lastError":{"code":"previous","message":"previous upload failed"}}
+        {"configured":true,"enabled":true,"port":8080,"baseUrl":"http://192.168.4.20:8080","sdPresent":true,"mapFound":false,"mapBlocks":0,"activeMapId":"kyoto-v1","activeSessionId":"kyoto-v1-session","activeManifestReceipt":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","activeMapDisplayName":"Kyoto Hills","activeMapBoundsE7":[1356000000,349000000,1360000000,352000000],"activeRendererFormat":2,"labelProfileVersion":1,"labelLanguages":["ja","en"],"fontAssetHealthy":true,"activation":{"status":"activating","sequence":12,"sessionId":"tokyo-v2","mapId":"tokyo-v2","step":1,"steps":5,"progress":6},"lastError":{"code":"previous","message":"previous upload failed"}}
         """
         let packet = Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(json.utf8)
 
@@ -15508,6 +15588,12 @@ struct NavigationProtocolTests {
         assertEqual(manager.activeMapManifestReceipt,
                     String(repeating: "a", count: 64),
                     "status parser associates label health with the active receipt")
+        assertEqual(manager.activeDeviceMap?.mapID, "kyoto-v1",
+                    "status parser publishes a device map descriptor")
+        assertEqual(manager.activeDeviceMap?.displayName, "Kyoto Hills",
+                    "device map descriptor exposes its manifest display name")
+        assertEqual(manager.activeDeviceMap?.bounds?.minLongitude, 135.6,
+                    "device map descriptor converts integer preview bounds")
         assertEqual(manager.activeMapRendererFormat, 2,
                     "status parser exposes active renderer target")
         assertEqual(manager.activeMapLabelProfileVersion, 1,
@@ -15527,6 +15613,24 @@ struct NavigationProtocolTests {
         assertEqual(manager.deviceMapFoundForCurrentLocation, false, "status parser exposes current map coverage")
         assertEqual(manager.deviceMapBlockCount, 0, "status parser exposes current map block count")
         assertEqual(manager.mapTransferLastError, "previous: previous upload failed", "status parser exposes last transfer error")
+
+        let legacyPacket = Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
+            "{\"enabled\":true,\"activeMapId\":\"legacy-map\"}".utf8
+        )
+        assert(manager.handleMapTransferStatusNotification(legacyPacket),
+               "legacy map status should remain supported")
+        assertEqual(manager.activeDeviceMap?.mapID, "legacy-map",
+                    "older firmware still creates a conservative device-only descriptor")
+        assertEqual(manager.activeDeviceMap?.sessionID, nil,
+                    "older firmware without a session cannot merge with a local pack")
+
+        let missingActivePacket = Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
+            "{\"enabled\":true,\"activeError\":{\"code\":\"installed_manifest\"}}".utf8
+        )
+        assert(manager.handleMapTransferStatusNotification(missingActivePacket),
+               "active-map error status should be consumed")
+        assertEqual(manager.activeDeviceMap, nil,
+                    "a complete status without an active map clears device inventory")
     }
 
     static func testBLEManagerReassemblesChunkedMapTransferStatus() {
@@ -15559,6 +15663,12 @@ struct NavigationProtocolTests {
 
     static func testBLEManagerCompletesRetransmittedChunkedMapTransferStatus() {
         let manager = BLEManager()
+        let previousBody = Data(
+            "{\"enabled\":true,\"activeMapId\":\"previous-map\",\"activeSessionId\":\"previous-session\"}".utf8
+        )
+        assert(manager.handleMapTransferStatusNotification(
+            Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + previousBody
+        ), "a previous complete map status should seed the live descriptor")
         let body = Data("""
         {"enabled":false,"activeMapId":"shanghai-v2","activeSessionId":"session-v2","activeRendererFormat":2,"labelProfileVersion":1,"labelLanguages":["zh-Hans","en"],"fontAssetHealthy":true,"activation":{"status":"installed","sequence":10,"sessionId":"session-v2","mapId":"shanghai-v2","step":3,"steps":3,"progress":100}}
         """.utf8)
@@ -15579,8 +15689,10 @@ struct NavigationProtocolTests {
             assert(manager.handleMapTransferStatusNotification(frame(index: index)),
                    "first lossy status response should retain received chunks")
         }
-        assertEqual(manager.mapTransferActiveMapId, "",
-                    "an incomplete response must not publish partial state")
+        assertEqual(manager.mapTransferActiveMapId, "previous-map",
+                    "an incomplete response must retain the previous complete state")
+        assertEqual(manager.activeDeviceMap?.sessionID, "previous-session",
+                    "an incomplete response must retain complete device inventory")
 
         for index in UInt8(0)..<chunkCount {
             assert(manager.handleMapTransferStatusNotification(frame(index: index)),

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8487,6 +8487,14 @@ struct NavigationProtocolTests {
             return
         }
         let developerSource = String(source[developerStart...])
+        let rootSettingsSource = String(source[..<developerStart])
+        assert(
+            !rootSettingsSource.contains("title: \"App Version\"") &&
+                developerSource.contains("Section(header: Text(\"App\"))") &&
+                developerSource.contains("title: \"App Version\"") &&
+                developerSource.contains("value: appVersionText"),
+            "App Version appears only in Developer Settings"
+        )
         assert(
             developerSource.contains(
                 "NavigationOverlaysSettingsSection()\n        }\n        .navigationTitle(\"Developer Settings\")"

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -8263,6 +8263,17 @@ struct NavigationProtocolTests {
             "each saved map shows distinct iPhone and Bike Computer presence icons"
         )
         assert(
+            source.contains("Text(\"No offline maps yet\")"),
+            "Saved Maps uses the agreed empty-state copy"
+        )
+        assert(
+            source.contains("is saved on this iPhone") &&
+                source.contains("is not saved on this iPhone") &&
+                source.contains("is active on the Bike Computer") &&
+                source.contains("Transfer \\(displayName) to device"),
+            "both saved-map presence indicators expose accessible state labels"
+        )
+        assert(
             source.contains("manager.resumePausedMapUpload(bleManager: bleManager)") &&
                 source.contains("Map upload paused. Tap to resume."),
             "the paused status row resumes the matching map transfer"
@@ -9223,6 +9234,93 @@ struct NavigationProtocolTests {
         assertEqual(items.count, 1, "disconnect removes live device-only inventory")
         assert(items[0].isOnIPhone && !items[0].isActiveOnDevice,
                "disconnect preserves the iPhone cache without stale device presence")
+
+        manager.deleteCachedPack(at: packURL)
+        items = manager.savedMapListItems(activeDeviceMap: exactDevice)
+        assertEqual(items.count, 1,
+                    "deleting the iPhone copy keeps the active device map visible")
+        assert(!items[0].isOnIPhone && items[0].isActiveOnDevice,
+               "local deletion converts a merged row into device-only inventory")
+        assert(manager.savedMapListItems(activeDeviceMap: nil).isEmpty,
+               "no local or connected-device map produces an empty inventory")
+
+        let streamCacheDirectory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(
+                "saved-stream-inventory-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        try? FileManager.default.createDirectory(
+            at: streamCacheDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: streamCacheDirectory) }
+        let streamURL = streamCacheDirectory.appendingPathComponent("stream-map.bmap")
+        try? Data([1, 2, 3, 4]).write(to: streamURL)
+        let signedReceipt = String(repeating: "d", count: 64)
+        let streamArtifact = OfflineMapArtifact(
+            format: OfflineMapArtifact.bikeMapStreamFormat,
+            mediaType: "application/vnd.openbikecomputer.map-stream",
+            filename: streamURL.lastPathComponent,
+            objectKey: "maps/stream-map.bmap",
+            bytes: 4,
+            sha256: String(repeating: "a", count: 64),
+            manifestReceipt: String(repeating: "b", count: 64),
+            signedManifestReceipt: signedReceipt
+        )
+        let streamMetadata = SavedMapArtifactMetadata(
+            schemaVersion: SavedMapArtifactMetadata.currentSchemaVersion,
+            mapID: "stream-map",
+            displayName: "Stream Map",
+            localArtifactFilename: streamURL.lastPathComponent,
+            streamFormatVersion: 1,
+            rendererFormatVersion: 2,
+            jobID: nil,
+            serverURLString: nil,
+            clientInstallationID: nil,
+            primaryArtifact: streamArtifact,
+            legacyArtifact: nil,
+            lastTransferProtocol: nil,
+            lastTransferStreamFormat: nil,
+            lastTransferSessionID: nil,
+            lastBackgroundTaskID: nil,
+            lastDeviceSequence: nil,
+            lastDeviceState: nil,
+            lastDeviceStep: nil,
+            lastDeviceStepCount: nil,
+            lastDeviceProgress: nil,
+            expectedActiveMapID: nil,
+            expectedActiveSessionID: nil,
+            lastTransferOutcome: nil
+        )
+        try? SavedMapArtifactMetadataStore.save(streamMetadata, for: streamURL)
+        let streamManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: streamCacheDirectory
+        )
+        let legacySession = "stream-map-legacy-session"
+        let legacyDevice = DeviceActiveMapDescriptor(
+            mapID: "stream-map",
+            sessionID: legacySession
+        )!
+        assertEqual(
+            streamManager.savedMapListItems(activeDeviceMap: legacyDevice).count,
+            2,
+            "a stream pack does not claim an unknown legacy fallback session"
+        )
+        streamManager.updateSavedMapTransferMetadata(
+            mapID: "stream-map",
+            protocolVersion: 1,
+            streamFormatVersion: nil,
+            sessionID: legacySession,
+            outcome: "installed"
+        )
+        let refreshedItems = streamManager.savedMapListItems(
+            activeDeviceMap: legacyDevice
+        )
+        assertEqual(refreshedItems.count, 1,
+                    "recorded legacy transfer identity refreshes the live inventory")
+        assert(refreshedItems[0].isOnIPhone && refreshedItems[0].isActiveOnDevice,
+               "protocol-v1 fallback installation merges without an app relaunch")
     }
 
     static func testOfflineMapManifestDecoding() {
@@ -15624,6 +15722,68 @@ struct NavigationProtocolTests {
         assertEqual(manager.activeDeviceMap?.sessionID, nil,
                     "older firmware without a session cannot merge with a local pack")
 
+        let malformedPresentationPacket =
+            Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
+                """
+                {"enabled":true,"activeMapId":"safe-map","activeSessionId":"safe-session","activeMapDisplayName":42,"activeMapBoundsE7":[1219500000,315500000,1209000000,307000000]}
+                """.utf8
+            )
+        assert(manager.handleMapTransferStatusNotification(malformedPresentationPacket),
+               "malformed optional map presentation should not reject the status")
+        assertEqual(manager.activeDeviceMap?.mapID, "safe-map",
+                    "valid active identity survives malformed optional presentation")
+        assertEqual(manager.activeDeviceMap?.displayName, nil,
+                    "malformed optional display name is omitted")
+        assertEqual(manager.activeDeviceMap?.bounds, nil,
+                    "reversed optional preview bounds are omitted")
+
+        let booleanBoundsPacket =
+            Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
+                """
+                {"enabled":true,"activeMapId":"safe-map","activeMapBoundsE7":[false,false,true,true]}
+                """.utf8
+            )
+        assert(manager.handleMapTransferStatusNotification(booleanBoundsPacket),
+               "boolean optional bounds should not reject the status")
+        assertEqual(manager.activeDeviceMap?.bounds, nil,
+                    "JSON booleans are not accepted as integer coordinates")
+
+        let oversizedBoundsPacket =
+            Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
+                """
+                {"enabled":true,"activeMapId":"safe-map","activeMapBoundsE7":[100000000,100000000,200000000,200000000,2147483648]}
+                """.utf8
+            )
+        assert(manager.handleMapTransferStatusNotification(oversizedBoundsPacket),
+               "oversized optional bounds should not reject the status")
+        assertEqual(manager.activeDeviceMap?.bounds, nil,
+                    "invalid extra coordinates cannot be compacted into a valid bounds array")
+
+        let collisionA = DeviceActiveMapDescriptor(
+            mapID: "a--b",
+            sessionID: "c",
+            boundsE7: [100000000, 100000000, 200000000, 200000000]
+        )!
+        let collisionB = DeviceActiveMapDescriptor(
+            mapID: "a",
+            sessionID: "b--c",
+            boundsE7: [100000000, 100000000, 200000000, 200000000]
+        )!
+        assert(collisionA.previewFilename != collisionB.previewFilename,
+               "preview cache filenames bind unambiguous map and session identities")
+        let legacyBoundsA = DeviceActiveMapDescriptor(
+            mapID: ".legacy-map",
+            boundsE7: [100000000, 100000000, 200000000, 200000000]
+        )!
+        let legacyBoundsB = DeviceActiveMapDescriptor(
+            mapID: ".legacy-map",
+            boundsE7: [300000000, 300000000, 400000000, 400000000]
+        )!
+        assert(legacyBoundsA.previewFilename != legacyBoundsB.previewFilename,
+               "sessionless preview identity includes presentation metadata")
+        assert(legacyBoundsA.previewFilename.hasPrefix("device-map-"),
+               "valid dot-prefixed map IDs cannot create hidden preview files")
+
         let missingActivePacket = Data(DeviceBLEProtocol.mapTransferStatusPrefix.utf8) + Data(
             "{\"enabled\":true,\"activeError\":{\"code\":\"installed_manifest\"}}".utf8
         )
@@ -15636,7 +15796,7 @@ struct NavigationProtocolTests {
     static func testBLEManagerReassemblesChunkedMapTransferStatus() {
         let manager = BLEManager()
         let body = Data("""
-        {"enabled":true,"baseUrl":"http://192.168.4.20:8080","activeMapId":"custom-map","activeSessionId":"custom-map-session","activation":{"status":"installed","sequence":9,"sessionId":"custom-map-session"}}
+        {"enabled":true,"baseUrl":"http://192.168.4.20:8080","activeMapId":"custom-map","activeSessionId":"custom-map-session","activeMapDisplayName":"Custom Map","activeMapBoundsE7":[1209000000,307000000,1219500000,315500000],"activation":{"status":"installed","sequence":9,"sessionId":"custom-map-session"}}
         """.utf8)
         let chunkSize = 13
         let chunkCount = UInt8((body.count + chunkSize - 1) / chunkSize)
@@ -15655,6 +15815,10 @@ struct NavigationProtocolTests {
                     "chunk reassembly exposes active map")
         assertEqual(manager.mapTransferActiveSessionId, "custom-map-session",
                     "chunk reassembly exposes durable active session")
+        assertEqual(manager.activeDeviceMap?.displayName, "Custom Map",
+                    "chunk reassembly publishes the device map display name")
+        assertEqual(manager.activeDeviceMap?.bounds?.maxLatitude, 31.55,
+                    "chunk reassembly publishes the device map preview bounds")
         assertEqual(manager.mapTransferActivationStatus, "installed",
                     "chunk reassembly exposes activation state")
         assertEqual(manager.mapTransferActivationSequence, 9,

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -860,6 +860,76 @@ struct SavedMapPreviewCatalystTests {
             fail("disconnect should clear live device-only preview state")
         }
 
+        let sessionlessDescriptorA = DeviceActiveMapDescriptor(
+            mapID: "legacy-map",
+            boundsE7: [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000]
+        )!
+        let sessionlessDescriptorB = DeviceActiveMapDescriptor(
+            mapID: "legacy-map",
+            boundsE7: [1_000_000_000, 200_000_000, 1_010_000_000, 210_000_000]
+        )!
+        do {
+            try DeviceMapSnapshotPreviewStore.save(
+                snapshotPNG,
+                for: sessionlessDescriptorA,
+                in: cacheDirectory
+            )
+        } catch {
+            fail("sessionless device preview should persist: \(error)")
+        }
+        guard DeviceMapSnapshotPreviewStore.imageURL(
+            for: sessionlessDescriptorA,
+            in: cacheDirectory
+        ) != DeviceMapSnapshotPreviewStore.imageURL(
+            for: sessionlessDescriptorB,
+            in: cacheDirectory
+        ), DeviceMapSnapshotPreviewStore.imageData(
+            for: sessionlessDescriptorB,
+            in: cacheDirectory
+        ) == nil else {
+            fail("sessionless descriptors with different bounds must not share previews")
+        }
+
+        let pruneCacheDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "device-preview-prune-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: pruneCacheDirectory) }
+        for index in 0..<18 {
+            let descriptor = DeviceActiveMapDescriptor(
+                mapID: ".map-\(index)",
+                sessionID: "session-\(index)",
+                boundsE7: [
+                    1_000_000_000 + index,
+                    200_000_000,
+                    1_010_000_000 + index,
+                    210_000_000,
+                ]
+            )!
+            do {
+                try DeviceMapSnapshotPreviewStore.save(
+                    snapshotPNG,
+                    for: descriptor,
+                    in: pruneCacheDirectory
+                )
+            } catch {
+                fail("bounded device preview cache should save entry \(index): \(error)")
+            }
+        }
+        let prunedEntries = (try? FileManager.default.contentsOfDirectory(
+            at: pruneCacheDirectory.appendingPathComponent(
+                "DeviceMapPreviews",
+                isDirectory: true
+            ),
+            includingPropertiesForKeys: nil,
+            options: []
+        ))?.filter { $0.pathExtension.lowercased() == "png" } ?? []
+        guard prunedEntries.count <= 16,
+              prunedEntries.allSatisfy({ !$0.lastPathComponent.hasPrefix(".") }) else {
+            fail("device preview cache should prune dot-prefixed map identities")
+        }
+
         let northWestCoordinate = CLLocationCoordinate2D(
             latitude: expectedBounds.maxLatitude,
             longitude: expectedBounds.minLongitude

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -778,6 +778,88 @@ struct SavedMapPreviewCatalystTests {
             fail("a late snapshot must not persist after its map was deleted")
         }
 
+        let deviceDescriptor = DeviceActiveMapDescriptor(
+            mapID: "cloned-sd-map",
+            sessionID: "cloned-sd-session",
+            displayName: "Cloned SD Map",
+            boundsE7: [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000]
+        )!
+        var deviceSnapshotGenerationCount = 0
+        let devicePreviewManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { bounds in
+                guard bounds == expectedBounds else {
+                    fail("device-only preview should use its reported bounds")
+                }
+                deviceSnapshotGenerationCount += 1
+                return snapshotPNG
+            }
+        )
+        devicePreviewManager.updateActiveDeviceMap(deviceDescriptor)
+        guard let deviceItem = devicePreviewManager.savedMapListItems(
+            activeDeviceMap: deviceDescriptor
+        ).first(where: { $0.deviceMap?.mapID == deviceDescriptor.mapID }) else {
+            fail("device-only map should appear in the merged saved-map inventory")
+        }
+        devicePreviewManager.loadPreviewIfNeeded(for: deviceItem)
+        let devicePreviewDeadline = Date().addingTimeInterval(3)
+        while (!imageMatchesPNG(
+            devicePreviewManager.previewImage(for: deviceItem),
+            data: snapshotPNG
+        ) || DeviceMapSnapshotPreviewStore.imageData(
+            for: deviceDescriptor,
+            in: cacheDirectory
+        ) != snapshotPNG) && Date() < devicePreviewDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard deviceSnapshotGenerationCount == 1,
+              imageMatchesPNG(
+                  devicePreviewManager.previewImage(for: deviceItem),
+                  data: snapshotPNG
+              ),
+              DeviceMapSnapshotPreviewStore.imageData(
+                  for: deviceDescriptor,
+                  in: cacheDirectory
+              ) == snapshotPNG else {
+            fail("device-only map should generate and persist its MapKit preview")
+        }
+
+        var restoredDeviceGenerationCount = 0
+        let restoredDevicePreviewManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in
+                restoredDeviceGenerationCount += 1
+                return nil
+            }
+        )
+        restoredDevicePreviewManager.updateActiveDeviceMap(deviceDescriptor)
+        guard let restoredDeviceItem = restoredDevicePreviewManager.savedMapListItems(
+            activeDeviceMap: deviceDescriptor
+        ).first(where: { $0.deviceMap?.mapID == deviceDescriptor.mapID }) else {
+            fail("restored device-only map should remain visible")
+        }
+        restoredDevicePreviewManager.loadPreviewIfNeeded(for: restoredDeviceItem)
+        let restoredDeviceDeadline = Date().addingTimeInterval(3)
+        while !imageMatchesPNG(
+            restoredDevicePreviewManager.previewImage(for: restoredDeviceItem),
+            data: snapshotPNG
+        ) && Date() < restoredDeviceDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard restoredDeviceGenerationCount == 0,
+              imageMatchesPNG(
+                  restoredDevicePreviewManager.previewImage(for: restoredDeviceItem),
+                  data: snapshotPNG
+              ) else {
+            fail("device preview cache should survive relaunch without another snapshot")
+        }
+        restoredDevicePreviewManager.updateActiveDeviceMap(nil)
+        guard restoredDevicePreviewManager.previewImage(for: restoredDeviceItem) == nil else {
+            fail("disconnect should clear live device-only preview state")
+        }
+
         let northWestCoordinate = CLLocationCoordinate2D(
             latitude: expectedBounds.maxLatitude,
             longitude: expectedBounds.minLongitude

--- a/map-platform/backend/map_platform/jobs.py
+++ b/map-platform/backend/map_platform/jobs.py
@@ -1944,7 +1944,12 @@ def _normalize_user_label(value: Any) -> str:
         raise ValueError("displayName must not be empty")
     if len(label) > 80:
         raise ValueError("displayName must be at most 80 characters")
-    if any(ord(character) < 32 or ord(character) == 127 for character in label):
+    if len(label.encode("utf-8")) > 240:
+        raise ValueError("displayName must be at most 240 UTF-8 bytes")
+    if any(
+        ord(character) < 32 or 127 <= ord(character) <= 159
+        for character in label
+    ):
         raise ValueError("displayName must not contain control characters")
     return label
 

--- a/map-platform/backend/tests/test_sources_jobs.py
+++ b/map-platform/backend/tests/test_sources_jobs.py
@@ -414,6 +414,10 @@ class SourceAndJobTests(unittest.TestCase):
                 service.create_job({**base, "target": {"renderer": "unknown"}})
             with self.assertRaisesRegex(ValueError, "displayName must be at most"):
                 service.create_job({**base, "displayName": "x" * 81})
+            with self.assertRaisesRegex(ValueError, "240 UTF-8 bytes"):
+                service.create_job({**base, "displayName": "🚲" * 61})
+            with self.assertRaisesRegex(ValueError, "control characters"):
+                service.create_job({**base, "displayName": "ride\u0085name"})
 
             job = service.create_job(
                 {


### PR DESCRIPTION
## Summary

- report the active installed map display name and normalized bounds from firmware over the existing chunked map-status response
- model Saved Maps as the union of iPhone-cached packs and the connected bike computer active map, merging only when exact session identity is proven
- show separate iPhone and filled round lowercase-b presence icons, with device-only rows rendered as status-only inventory
- generate and cache device-only map previews locally from reported bounds; no preview PNG bytes travel over BLE
- document the protocol extension and keep the physical cloned-SD acceptance procedure in the implementation plan

## Deep-review hardening

- cache and receipt-bind active-map presentation reads so status polling does not repeatedly scan large manifests or mix presentation data across active-map changes
- reject protocol-unsafe display names consistently in firmware and the map platform, including UTF-8 byte-length and control-character boundaries
- give generated previews collision-resistant identities and prune hidden stale cache files
- preserve protocol-v1 transfer identity updates in existing cached-map records and strictly validate reported bounds

## Verification

- `./ios-app/scripts/run-navigation-tests.sh`
- full unsigned iOS Release build through `ios-app/scripts/xcodebuild-cli.sh`
- focused firmware host tests with `-std=c++17 -Wall -Wextra -Werror`
- `python3 -m unittest tests.test_sources_jobs` (23 tests)
- `python3 tools/build_firmware.py WAVESHARE_AMOLED_175_PRODUCTION`
- `python3 tools/build_firmware.py WAVESHARE_AMOLED_206_PRODUCTION`
- `git diff --check`

## Remaining physical validation

No bike computer was accessed or flashed. The cloned-SD workflow, reboot/reconnect behavior, exact-artifact merge, and same-map-ID/different-session split remain explicit pre-release device checks in the plan.
