### PR TITLE
Fix App Store location permission flow

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -263,7 +263,8 @@ struct ContentView: View {
                         manager: offlineMapManager,
                         step: onboardingStep,
                         location: coordinator.currentLocation,
-                        isLocationAuthorized: coordinator.isLocationAuthorized,
+                        locationAuthorizationStatus:
+                            coordinator.locationAuthorizationStatus,
                         onRequestLocation: {
                             coordinator.requestLocationAuthorization()
                         },

--- a/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CurrentLocationManager.swift
@@ -83,6 +83,25 @@ nonisolated enum LocationAuthorizationRemediationPolicy {
             .openSettings
         }
     }
+
+    static func buttonTitle(
+        for status: CLAuthorizationStatus
+    ) -> String? {
+        switch action(for: status) {
+        case .requestInApp:
+            "Continue"
+        case .openSettings:
+            "Open iPhone Settings"
+        case .none:
+            nil
+        }
+    }
+
+    static func allowsDismissal(
+        for status: CLAuthorizationStatus
+    ) -> Bool {
+        action(for: status) != .requestInApp
+    }
 }
 
 nonisolated enum RideIdleTimerController {
@@ -371,8 +390,8 @@ class CurrentLocationManager: NSObject, ObservableObject, CLLocationManagerDeleg
             )
         }
 #endif
-        // First-run onboarding owns the permission prompt so the user can read
-        // the rationale or skip location before iOS asks for access.
+        // User-initiated feature flows own the permission request so the native
+        // prompt appears in context and the user's response remains authoritative.
     }
     
     func requestLocation() {

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapOnboardingView.swift
@@ -13,7 +13,7 @@ struct OfflineMapOnboardingView: View {
     @ObservedObject var manager: OfflineMapManager
     let step: OfflineMapOnboardingStep
     let location: CLLocation?
-    let isLocationAuthorized: Bool
+    let locationAuthorizationStatus: CLAuthorizationStatus
     let onRequestLocation: () -> Void
     let onChooseArea: () -> Void
     let onClose: () -> Void
@@ -23,13 +23,15 @@ struct OfflineMapOnboardingView: View {
     var body: some View {
         VStack(spacing: 0) {
             HStack {
-                Button(action: onClose) {
-                    Image(systemName: "xmark")
-                        .font(.headline)
-                        .frame(width: 36, height: 36)
+                if allowsClose {
+                    Button(action: onClose) {
+                        Image(systemName: "xmark")
+                            .font(.headline)
+                            .frame(width: 36, height: 36)
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Close")
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("Close")
 
                 Spacer()
             }
@@ -41,7 +43,7 @@ struct OfflineMapOnboardingView: View {
                     .font(.title2.weight(.semibold))
                     .multilineTextAlignment(.center)
 
-                Text(step.message)
+                Text(step.message(for: locationAuthorizationAction))
                     .font(.body)
                     .foregroundColor(.secondary)
                     .multilineTextAlignment(.center)
@@ -115,7 +117,7 @@ struct OfflineMapOnboardingView: View {
                         .font(.caption)
                         .foregroundColor(.secondary)
                         .multilineTextAlignment(.center)
-                } else if !isLocationAuthorized {
+                } else if locationAuthorizationAction != .none {
                     locationActions
                 } else if location == nil {
                     ProgressView()
@@ -141,23 +143,43 @@ struct OfflineMapOnboardingView: View {
     }
 
     private var locationActions: some View {
-        VStack(spacing: 10) {
-            Button(action: onRequestLocation) {
-                Label("Enable Location", systemImage: "location")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.borderedProminent)
-
-            Button {
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    openURL(url)
+        Group {
+            switch locationAuthorizationAction {
+            case .requestInApp:
+                Button(action: onRequestLocation) {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
                 }
-            } label: {
-                Text("Open iPhone Settings")
-                    .frame(maxWidth: .infinity)
+                .buttonStyle(.borderedProminent)
+
+            case .openSettings:
+                Button {
+                    if let url = URL(string: UIApplication.openSettingsURLString) {
+                        openURL(url)
+                    }
+                } label: {
+                    Text("Open iPhone Settings")
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.borderedProminent)
+
+            case .none:
+                EmptyView()
             }
-            .buttonStyle(.bordered)
         }
+    }
+
+    private var locationAuthorizationAction: LocationAuthorizationRemediation {
+        LocationAuthorizationRemediationPolicy.action(
+            for: locationAuthorizationStatus
+        )
+    }
+
+    private var allowsClose: Bool {
+        step != .download ||
+            LocationAuthorizationRemediationPolicy.allowsDismissal(
+                for: locationAuthorizationStatus
+            )
     }
 }
 
@@ -171,12 +193,21 @@ private extension OfflineMapOnboardingStep {
         }
     }
 
-    var message: String {
+    func message(
+        for locationAuthorizationAction: LocationAuthorizationRemediation
+    ) -> String {
         switch self {
         case .welcome:
             return "Plan your rides, connect your Bicino One, or turn your iPhone into a cycling computer."
         case .download:
-            return "Choose an area to download to your Bike Computer."
+            switch locationAuthorizationAction {
+            case .requestInApp:
+                return "Bicino uses your current location to prepare the right offline map for your Bike Computer."
+            case .openSettings:
+                return "Location access is needed to prepare a map for your current area. You can grant access in iPhone Settings."
+            case .none:
+                return "Choose an area to download to your Bike Computer."
+            }
         }
     }
 }

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -85,7 +85,13 @@ struct SettingsView: View {
                 if !locationAuthorized {
                     Section {
                         Button(action: remediateLocationAuthorization) {
-                            Label("Enable Location Access", systemImage: "location")
+                            Label(
+                                LocationAuthorizationRemediationPolicy
+                                    .buttonTitle(
+                                        for: locationAuthorizationStatus
+                                    ) ?? "Location Access",
+                                systemImage: "location"
+                            )
                         }
                     } footer: {
                         Text("Location access is needed to download the map for your current area.")
@@ -316,15 +322,14 @@ private struct RideDetectionSettingsView: View {
 
                 if store.settings.startMode != .off &&
                     !store.hasAcknowledgedLocationUse {
-                    Button("Enable iPhone GPS for Detection") {
+                    Button("Use iPhone GPS for Detection") {
                         showLocationUseWarning = true
                     }
                     .alert(
                         "Use iPhone GPS for Ride Detection?",
                         isPresented: $showLocationUseWarning
                     ) {
-                        Button("Not Now", role: .cancel) {}
-                        Button("Enable") {
+                        Button("Continue") {
                             store.acknowledgeLocationUse()
                             if authorizationStatus == .notDetermined {
                                 onRequestLocationAuthorization()
@@ -351,7 +356,9 @@ private struct RideDetectionSettingsView: View {
                         }
                     } label: {
                         Label(
-                            "Enable Location Access",
+                            LocationAuthorizationRemediationPolicy
+                                .buttonTitle(for: authorizationStatus)
+                                ?? "Location Access",
                             systemImage: "location"
                         )
                     }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -17372,14 +17372,43 @@ struct NavigationProtocolTests {
             "first-use location access presents the native permission prompt"
         )
         assertEqual(
+            LocationAuthorizationRemediationPolicy.buttonTitle(
+                for: .notDetermined
+            ),
+            "Continue",
+            "first-use permission copy does not imply that access is already granted"
+        )
+        assert(
+            !LocationAuthorizationRemediationPolicy.allowsDismissal(
+                for: .notDetermined
+            ),
+            "the pre-permission explanation cannot defer the native prompt"
+        )
+        assertEqual(
             LocationAuthorizationRemediationPolicy.action(for: .denied),
             .openSettings,
             "denied location access directs the user to Apple Settings"
         )
         assertEqual(
+            LocationAuthorizationRemediationPolicy.buttonTitle(for: .denied),
+            "Open iPhone Settings",
+            "denied access clearly identifies the post-decision remediation"
+        )
+        assert(
+            LocationAuthorizationRemediationPolicy.allowsDismissal(for: .denied),
+            "post-denial remediation remains optional"
+        )
+        assertEqual(
             LocationAuthorizationRemediationPolicy.action(for: .restricted),
             .openSettings,
             "restricted location access directs the user to Apple Settings"
+        )
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.buttonTitle(
+                for: .restricted
+            ),
+            "Open iPhone Settings",
+            "restricted access uses the post-decision settings action"
         )
 #if !os(macOS)
         assertEqual(
@@ -17388,6 +17417,13 @@ struct NavigationProtocolTests {
             ),
             .none,
             "authorized location access needs no remediation"
+        )
+        assertEqual(
+            LocationAuthorizationRemediationPolicy.buttonTitle(
+                for: .authorizedWhenInUse
+            ),
+            nil,
+            "authorized access does not show a permission action"
         )
 #endif
         assertEqual(


### PR DESCRIPTION
## Summary

- make first-time location explanations advance through a single **Continue** action with no close, skip, or Settings shortcut
- offer **Open iPhone Settings** only after location access is denied or restricted
- remove the cancellable location pre-alert from ride-detection setup
- add regression coverage for the authorization-state policy and user-facing actions

## Why

App Review rejected Bicino 1.3 (12) under Guideline 5.1.1(iv). The reviewed location flow could direct a fresh user to Settings before the native permission request, used an “Enable Location” action in custom UI, and allowed the request to be deferred from the explanation.

The root cause was treating every non-authorized Core Location state as the same UI state instead of distinguishing `.notDetermined` from `.denied` and `.restricted`.

## User impact

The native iOS permission prompt remains the authoritative first-time decision. Users who already declined can still choose to grant access later through iPhone Settings, while unrelated welcome and workout controls remain dismissible.

## Validation

- `cd ios-app && ./scripts/run-navigation-tests.sh`
- `cd ios-app && ./scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build`
- `git diff --check`

The navigation/location test suite passed and the unsigned iPhone/Watch app container build completed with `BUILD SUCCEEDED`. No physical device was used.