### PR TITLE
Use region-neutral App Store links

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ A sleek, Garmin-mounted bike computer.
 🧭 Ride stats and turn-by-turn directions on your bike computer.\
 📡 Connect your power meter and cadence sensor.
 
-[![Download Bike Computer 2.0 on the App Store](https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83)](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349)
+[![Download Bike Computer 2.0 on the App Store](https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83)](https://geo.itunes.apple.com/app/id6788977349)
 
 ## Get started
 
 1. **Buy your bike computer including Garmin mount at [bicino.com](https://bicino.com)** or get a generic [Waveshare 1.75"](https://www.waveshare.com/esp32-s3-touch-amoled-1.75.htm?sku=31262), or a [Waveshare 2.06"](https://www.waveshare.com/esp32-s3-touch-amoled-2.06.htm).
-2. **Download** [**the Bicino iPhone and Apple Watch app**](https://apps.apple.com/us/app/bike-computer-2-0/id6788977349) and pair your bike computer.
+2. **Download** [**the Bicino iPhone and Apple Watch app**](https://geo.itunes.apple.com/app/id6788977349) and pair your bike computer.
 3. **Ride.** Track your workout and check your live ride statistics on your bike computer.
 
 ## Contributing


### PR DESCRIPTION
## What changed
- Replace the fixed US App Store URL in the download badge with Apple’s region-neutral geo resolver.
- Replace the fixed US URL in the Getting Started download step with the same resolver.

## Why
The geo resolver selects the visitor’s storefront while preserving the exact Bike Computer 2.0 product page, so the link works across regions and hands off to the App Store on iPhone.

## Validation
- Desktop browser: resolves to the Bike Computer 2.0 product page.
- iPhone user-agent: hands off to the App Store URL for Bike Computer 2.0.
- `git diff --check` passes.