### PR TITLE
Improve Watch terminal cleanup recovery UX

### DIFF
--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchWorkoutManager.swift
@@ -23,6 +23,13 @@ enum WatchWorkoutFinishRequestError: Equatable {
     case segmentConfirmationPending
 }
 
+enum WatchWorkoutCleanupState: Equatable {
+    case none
+    case delivering
+    case retrying
+    case retryRequired
+}
+
 enum WatchWorkoutSegmentError: Equatable {
     case unavailable
     case healthKitWriteFailed
@@ -299,6 +306,8 @@ typealias WatchSegmentEventOperation = @MainActor (
 
 @MainActor
 final class WatchWorkoutManager: NSObject, ObservableObject {
+    private static let maxTerminalCleanupRetryAttempts = 3
+
     private enum RideDetectionMirrorKey {
         static let payload = "rideDetection.watchMirror.v1"
         static let generation = "rideDetection.watchMirrorGeneration.v1"
@@ -363,6 +372,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     @Published private(set) var finishRequestError: WatchWorkoutFinishRequestError? = nil
     @Published private(set) var isTerminalArchivePending = false
     @Published private(set) var isTerminalPublicationPending = false
+    @Published private(set) var isTerminalMirrorDeliveryPending = false
+    @Published private(set) var isStartFailureMirrorDeliveryPending = false
+    @Published private(set) var isTerminalCleanupRetrying = false
     @Published private(set) var maximumHeartRateBPM: Int
     @Published private(set) var rideDetectionSettings: RideDetectionSettings
     @Published private(set) var rideDetectionSettingsGeneration: UInt32
@@ -425,6 +437,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     )?
     private let mirrorRetryDelay: TimeInterval
     private let mirrorShutdownDeliveryTimeout: TimeInterval
+    private let terminalCleanupRetryDelay: TimeInterval
     private var cancellables: Set<AnyCancellable> = []
 
     private var session: HKWorkoutSession?
@@ -493,8 +506,8 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
     private var manualTransitionOverrideTimeoutTask: Task<Void, Never>?
     private var lastProcessedManualTransitionRequestAt = Date.distantPast
     private var remoteSegmentControlContext: RemoteSegmentControlContext?
-    private var isTerminalMirrorDeliveryPending = false
-    private var isStartFailureMirrorDeliveryPending = false
+    private var terminalCleanupRetryTask: Task<Void, Never>?
+    private var terminalCleanupRetryAttemptCount = 0
     private var shutdownMirrorFailureRetryCount = 0
     private var pendingWorkoutConfiguration: HKWorkoutConfiguration?
     private var hasPendingComplicationStartRequest = false
@@ -565,6 +578,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             mirrorShutdownEndSession: nil,
             mirrorRetryDelay: 5,
             mirrorShutdownDeliveryTimeout: 10,
+            terminalCleanupRetryDelay: 1,
             initializeOnLaunch: !isAppStoreScreenshotPreview
         )
 #if DEBUG
@@ -628,6 +642,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             (@MainActor (HKWorkoutSession) -> Void)? = nil,
         mirrorRetryDelay: TimeInterval = 5,
         mirrorShutdownDeliveryTimeout: TimeInterval = 10,
+        terminalCleanupRetryDelay: TimeInterval = 1,
         initializeOnLaunch: Bool = true,
         heartRateZoneDefaults: UserDefaults = .standard
     ) {
@@ -684,6 +699,9 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         self.injectedMirrorShutdownEndSession = mirrorShutdownEndSession
         self.mirrorRetryDelay = mirrorRetryDelay
         self.mirrorShutdownDeliveryTimeout = mirrorShutdownDeliveryTimeout
+        self.terminalCleanupRetryDelay = terminalCleanupRetryDelay.isFinite
+            ? min(max(0, terminalCleanupRetryDelay), 60)
+            : 1
         self.locationAuthorizationState = routeRecorder.authorizationState
         super.init()
 
@@ -739,6 +757,7 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         finalizationTask?.cancel()
         mirrorRetryTask?.cancel()
         mirrorShutdownWatchdogTask?.cancel()
+        terminalCleanupRetryTask?.cancel()
         complicationStartTask?.cancel()
         authorizationRefreshTask?.cancel()
         segmentOperationTask?.cancel()
@@ -760,6 +779,53 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         return recoveryStore.recoveredIdentity?.sessionToken
             ?? identity?.sessionToken
     }
+
+    var isTerminalCleanupDeliveryInFlight: Bool {
+        isTerminalMirrorDeliveryPending
+            || isStartFailureMirrorDeliveryPending
+            || (session != nil
+                && (isTerminalPublicationPending || isTerminalArchivePending))
+    }
+
+    private var hasDetachedRecoveryCleanup: Bool {
+        guard session == nil else { return false }
+        return recoveryStore.recoveredIdentity?.finishRequest?.disposition
+                == .discard
+            || recoveryStore.recoveredIdentity?.finishRequest?.phase
+                == .workoutSaved
+            || reconciledSavedWorkout != nil
+    }
+
+    private var hasDurableTerminalCleanupRetry: Bool {
+        guard session == nil,
+              !isTerminalCleanupDeliveryInFlight else {
+            return false
+        }
+        return isTerminalPublicationPending
+            || isTerminalArchivePending
+    }
+
+    var isTerminalCleanupRetryRequired: Bool {
+        guard !isTerminalCleanupDeliveryInFlight,
+              !isTerminalCleanupRetrying else {
+            return false
+        }
+        return hasDurableTerminalCleanupRetry || hasDetachedRecoveryCleanup
+    }
+
+    var terminalCleanupState: WatchWorkoutCleanupState {
+        if isTerminalCleanupDeliveryInFlight {
+            return .delivering
+        }
+        if isTerminalCleanupRetrying {
+            return .retrying
+        }
+        if isTerminalCleanupRetryRequired {
+            return .retryRequired
+        }
+        return .none
+    }
+
     var isAwaitingDetachedSessionCleanup: Bool {
         if isTerminalPublicationPending
             || isTerminalMirrorDeliveryPending
@@ -1304,8 +1370,29 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         clearMetrics()
     }
 
+    func retryPendingTerminalCleanupIfPossible() {
+        guard hasDurableTerminalCleanupRetry else { return }
+        if terminalCleanupRetryTask == nil,
+           terminalCleanupRetryAttemptCount
+                >= Self.maxTerminalCleanupRetryAttempts {
+            terminalCleanupRetryAttemptCount = 0
+        }
+        scheduleTerminalCleanupRetryIfNeeded()
+    }
+
     func retryDetachedSessionCleanup() {
-        guard isAwaitingDetachedSessionCleanup else { return }
+        guard hasDurableTerminalCleanupRetry || hasDetachedRecoveryCleanup else {
+            return
+        }
+        cancelTerminalCleanupRetry(resetAttemptCount: true)
+        guard hasDurableTerminalCleanupRetry else {
+            handleActiveWorkoutRecovery()
+            return
+        }
+        runTerminalCleanupRetryAttempt()
+    }
+
+    private func performTerminalCleanupRetry() {
         if isTerminalPublicationPending {
             retryTerminalPublicationAndArchive()
             return
@@ -1329,6 +1416,62 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
             return
         }
         handleActiveWorkoutRecovery()
+    }
+
+    private func scheduleTerminalCleanupRetryIfNeeded() {
+        guard hasDurableTerminalCleanupRetry,
+              !isTerminalCleanupRetrying,
+              terminalCleanupRetryTask == nil,
+              terminalCleanupRetryAttemptCount
+                < Self.maxTerminalCleanupRetryAttempts else {
+            return
+        }
+        let nextAttempt = terminalCleanupRetryAttemptCount + 1
+        let delay = min(
+            terminalCleanupRetryDelay
+                * pow(2, Double(max(0, nextAttempt - 1))),
+            30
+        )
+        isTerminalCleanupRetrying = true
+        terminalCleanupRetryTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(
+                    nanoseconds: UInt64(max(0, delay) * 1_000_000_000)
+                )
+            } catch {
+                return
+            }
+            guard let self else { return }
+            self.terminalCleanupRetryTask = nil
+            self.runTerminalCleanupRetryAttempt()
+        }
+    }
+
+    private func runTerminalCleanupRetryAttempt() {
+        terminalCleanupRetryTask = nil
+        guard hasDurableTerminalCleanupRetry else {
+            isTerminalCleanupRetrying = false
+            terminalCleanupRetryAttemptCount = 0
+            return
+        }
+        terminalCleanupRetryAttemptCount += 1
+        isTerminalCleanupRetrying = true
+        performTerminalCleanupRetry()
+        isTerminalCleanupRetrying = false
+        if hasDurableTerminalCleanupRetry {
+            scheduleTerminalCleanupRetryIfNeeded()
+        } else {
+            terminalCleanupRetryAttemptCount = 0
+        }
+    }
+
+    private func cancelTerminalCleanupRetry(resetAttemptCount: Bool) {
+        terminalCleanupRetryTask?.cancel()
+        terminalCleanupRetryTask = nil
+        isTerminalCleanupRetrying = false
+        if resetAttemptCount {
+            terminalCleanupRetryAttemptCount = 0
+        }
     }
 
     private func startRecoveryLoopIfNeeded() {
@@ -3482,9 +3625,11 @@ final class WatchWorkoutManager: NSObject, ObservableObject {
         remoteSegmentControlContext = nil
         segmentAccumulator = WorkoutSegmentAccumulator()
         handleAttachedSessionRelease()
+        scheduleTerminalCleanupRetryIfNeeded()
     }
 
     private func clearActiveObjects() {
+        cancelTerminalCleanupRetry(resetAttemptCount: true)
         resetMirrorTransport()
         session = nil
         builder = nil

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchWorkoutRootView.swift
@@ -39,7 +39,7 @@ struct WatchWorkoutRootView: View {
                           manager.state == .ended {
                     WorkoutSummaryView(
                         summary: summary,
-                        isAwaitingSessionCleanup: manager.isAwaitingDetachedSessionCleanup,
+                        cleanupState: manager.terminalCleanupState,
                         onRetryCleanup: manager.retryDetachedSessionCleanup,
                         onDone: manager.dismissSummary
                     )
@@ -55,10 +55,12 @@ struct WatchWorkoutRootView: View {
             }
         }
         .onAppear {
+            manager.retryPendingTerminalCleanupIfPossible()
             manager.refreshAuthorizationIfNeeded()
         }
         .onChange(of: scenePhase) { _, newValue in
             guard newValue == .active else { return }
+            manager.retryPendingTerminalCleanupIfPossible()
             manager.refreshAuthorizationIfNeeded()
         }
     }

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutSummaryView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WorkoutSummaryView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct WorkoutSummaryView: View {
     let summary: WatchWorkoutSummary
-    let isAwaitingSessionCleanup: Bool
+    let cleanupState: WatchWorkoutCleanupState
     let onRetryCleanup: () -> Void
     let onDone: () -> Void
 
@@ -48,14 +48,27 @@ struct WorkoutSummaryView: View {
                         .multilineTextAlignment(.center)
                 }
 
-                if isAwaitingSessionCleanup {
+                switch cleanupState {
+                case .delivering:
+                    ProgressView()
+                    Text("Finishing workout cleanup before another ride can start.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                case .retrying:
+                    ProgressView()
+                    Text("Retrying workout recovery before another ride can start.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                case .retryRequired:
                     Text("Finishing workout recovery before another ride can start.")
                         .font(.caption2)
                         .foregroundStyle(.secondary)
                         .multilineTextAlignment(.center)
                     Button("Retry Recovery", action: onRetryCleanup)
                         .tint(.orange)
-                } else {
+                case .none:
                     Button("Done", action: onDone)
                         .tint(.blue)
                 }

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -7051,6 +7051,124 @@ final class WatchWorkoutManagerTests: XCTestCase {
         XCTAssertEqual(manager.terminalCleanupState, .none)
     }
 
+    func testTerminalPublicationFailureAutomaticallyRetriesBeforeArchive()
+        async throws
+    {
+        for disposition in [WorkoutFinishDisposition.save, .discard] {
+            let persistence = ToggleRecoveryPersistence()
+            let recoveryStore = WatchWorkoutRecoveryStore(
+                persistence: persistence
+            )
+            let identity = try recoveryStore.begin(startDate: Date())
+            let endedAt = identity.startDate.addingTimeInterval(30)
+            try recoveryStore.markFinishing(
+                disposition: disposition,
+                requestedAt: endedAt
+            )
+            if disposition == .save {
+                try recoveryStore.markCollectionEnded()
+                try recoveryStore.markFinishAttempted()
+                try recoveryStore.markWorkoutSaved()
+            }
+            let manager = WatchWorkoutManager(
+                healthStore: HKHealthStore(),
+                routeRecorder: WatchRouteRecorder(),
+                recoveryStore: recoveryStore,
+                terminalCleanupRetryDelay: 0.01,
+                initializeOnLaunch: false
+            )
+            XCTAssertTrue(
+                manager.restoreDetachedFinalizationLifecycle(
+                    from: try XCTUnwrap(recoveryStore.recoveredIdentity)
+                )
+            )
+
+            persistence.failOnSaveCall = persistence.saveCallCount + 1
+            let summary = WatchWorkoutSummary(
+                outcome: disposition == .save ? .saved : .discarded,
+                endedAt: endedAt,
+                duration: 30,
+                distanceMeters: nil,
+                activeEnergyKilocalories: nil,
+                averageHeartRate: nil,
+                routeStatus: .unavailable
+            )
+            if disposition == .save {
+                manager.completeConfirmedSave(summary: summary, savedAt: endedAt)
+            } else {
+                manager.completeConfirmedDiscard(
+                    summary: summary,
+                    discardedAt: endedAt
+                )
+            }
+            XCTAssertTrue(manager.isTerminalPublicationPending)
+            XCTAssertEqual(manager.terminalCleanupState, .retrying)
+
+            persistence.failOnSaveCall = nil
+            try await waitUntil {
+                !manager.isTerminalPublicationPending
+                    && recoveryStore.recoveredIdentity == nil
+            }
+            XCTAssertEqual(
+                recoveryStore.terminalTombstone(
+                    externalUUID: identity.sessionID.uuidString
+                )?.disposition,
+                disposition
+            )
+            XCTAssertEqual(manager.terminalCleanupState, .none)
+        }
+    }
+
+    func testTerminalCleanupRetryStopsAtBoundAndLeavesManualRecovery()
+        async throws
+    {
+        let persistence = ToggleRecoveryPersistence()
+        let recoveryStore = WatchWorkoutRecoveryStore(persistence: persistence)
+        let identity = try recoveryStore.begin(startDate: Date())
+        let endedAt = identity.startDate.addingTimeInterval(30)
+        try recoveryStore.markFinishing(
+            disposition: .discard,
+            requestedAt: endedAt
+        )
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            terminalCleanupRetryDelay: 0.001,
+            initializeOnLaunch: false
+        )
+        XCTAssertTrue(
+            manager.restoreDetachedFinalizationLifecycle(
+                from: try XCTUnwrap(recoveryStore.recoveredIdentity)
+            )
+        )
+
+        persistence.failsSave = true
+        manager.completeConfirmedDiscard(
+            summary: WatchWorkoutSummary(
+                outcome: .discarded,
+                endedAt: endedAt,
+                duration: 30,
+                distanceMeters: nil,
+                activeEnergyKilocalories: nil,
+                averageHeartRate: nil,
+                routeStatus: .unavailable
+            ),
+            discardedAt: endedAt
+        )
+        try await waitUntil {
+            manager.terminalCleanupState == .retryRequired
+        }
+        XCTAssertTrue(manager.isTerminalPublicationPending)
+        XCTAssertTrue(manager.isTerminalCleanupRetryRequired)
+
+        persistence.failsSave = false
+        manager.retryDetachedSessionCleanup()
+        XCTAssertFalse(manager.isTerminalPublicationPending)
+        XCTAssertNil(recoveryStore.recoveredIdentity)
+        XCTAssertEqual(manager.terminalCleanupState, .none)
+    }
+
     func testTerminalEnvelopeFailureBlocksArchiveUntilPublicationRetry() throws {
         for disposition in [WorkoutFinishDisposition.save, .discard] {
             let persistence = ToggleRecoveryPersistence()

--- a/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
+++ b/ios-app/BikeComputer/BikeComputerWatchTests/WatchWorkoutManagerTests.swift
@@ -1,3 +1,4 @@
+import Combine
 import CoreLocation
 import HealthKit
 import WatchConnectivity
@@ -2351,9 +2352,24 @@ final class WatchWorkoutManagerTests: XCTestCase {
             await Task.yield()
             XCTAssertTrue(runtime.manager.publishMirrorSnapshotForTesting())
             XCTAssertTrue(runtime.manager.mirrorSendIsInFlightForTesting)
+            var observedMirrorDeliveryStates: [Bool] = []
+            var mirrorDeliveryObservation: AnyCancellable?
+            if !startFailure {
+                mirrorDeliveryObservation = runtime.manager
+                    .$isTerminalMirrorDeliveryPending
+                    .sink { observedMirrorDeliveryStates.append($0) }
+            }
             runtime.manager.markMirrorShutdownDeliveryPendingForTesting(
                 startFailure: startFailure
             )
+            if !startFailure {
+                XCTAssertEqual(
+                    runtime.manager.terminalCleanupState,
+                    .delivering
+                )
+                runtime.manager.retryDetachedSessionCleanup()
+                XCTAssertTrue(runtime.manager.isTerminalMirrorDeliveryPending)
+            }
             XCTAssertEqual(probe.sentData.count, 2)
             let shutdownEnvelope = try WorkoutContractCodec.decode(
                 XCTUnwrap(probe.sentData.last)
@@ -2377,6 +2393,12 @@ final class WatchWorkoutManagerTests: XCTestCase {
             XCTAssertEqual(probe.endSessionCallCount, 1)
             XCTAssertFalse(runtime.manager.hasAttachedSessionForTesting)
             XCTAssertFalse(runtime.manager.isAwaitingDetachedSessionCleanup)
+            if !startFailure {
+                XCTAssertTrue(observedMirrorDeliveryStates.contains(true))
+                XCTAssertTrue(observedMirrorDeliveryStates.contains(false))
+                XCTAssertEqual(runtime.manager.terminalCleanupState, .none)
+            }
+            _ = mirrorDeliveryObservation
         }
     }
 
@@ -6973,6 +6995,60 @@ final class WatchWorkoutManagerTests: XCTestCase {
                 disposition
             )
         }
+    }
+
+    func testTerminalArchiveFailureAutomaticallyRetriesAfterRuntimeRelease()
+        async throws
+    {
+        let persistence = ToggleRecoveryPersistence()
+        let recoveryStore = WatchWorkoutRecoveryStore(persistence: persistence)
+        let identity = try recoveryStore.begin(startDate: Date())
+        let endedAt = identity.startDate.addingTimeInterval(30)
+        try recoveryStore.markFinishing(
+            disposition: .discard,
+            requestedAt: endedAt
+        )
+        let manager = WatchWorkoutManager(
+            healthStore: HKHealthStore(),
+            routeRecorder: WatchRouteRecorder(),
+            recoveryStore: recoveryStore,
+            terminalCleanupRetryDelay: 0.01,
+            initializeOnLaunch: false
+        )
+        XCTAssertTrue(
+            manager.restoreDetachedFinalizationLifecycle(
+                from: try XCTUnwrap(recoveryStore.recoveredIdentity)
+            )
+        )
+
+        persistence.failOnSaveCall = persistence.saveCallCount + 2
+        manager.completeConfirmedDiscard(
+            summary: WatchWorkoutSummary(
+                outcome: .discarded,
+                endedAt: endedAt,
+                duration: 30,
+                distanceMeters: nil,
+                activeEnergyKilocalories: nil,
+                averageHeartRate: nil,
+                routeStatus: .unavailable
+            ),
+            discardedAt: endedAt
+        )
+        XCTAssertTrue(manager.isTerminalArchivePending)
+        XCTAssertEqual(manager.terminalCleanupState, .retrying)
+
+        persistence.failOnSaveCall = nil
+        try await waitUntil {
+            !manager.isTerminalArchivePending
+                && recoveryStore.recoveredIdentity == nil
+        }
+        XCTAssertEqual(
+            recoveryStore.terminalTombstone(
+                externalUUID: identity.sessionID.uuidString
+            )?.disposition,
+            .discard
+        )
+        XCTAssertEqual(manager.terminalCleanupState, .none)
     }
 
     func testTerminalEnvelopeFailureBlocksArchiveUntilPublicationRetry() throws {


### PR DESCRIPTION
## Summary

- Distinguish normal terminal mirror delivery from cleanup that actually needs rider intervention.
- Automatically retry durable terminal publication/archive cleanup with bounded exponential backoff.
- Keep the safety gate in place until terminal cleanup is durable, while preserving manual recovery after automatic attempts are exhausted.

## Why

The Watch summary treated mirror transport that was still completing as the same state as a durable cleanup failure, so riders saw `Retry Recovery` during ordinary discard shutdown. The recovery flags were also not observable to SwiftUI, and terminal publication/archive failures could wait indefinitely for a manual retry.

## Validation

- `xcodebuild ... -scheme BikeComputerWatch -destination 'generic/platform=watchOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- Full `WorkoutContractWatchTests` bundle on the watchOS simulator
- `git diff --check`
