### PR TITLE
Tighten saved map previews

### DIFF
--- a/map-platform/backend/map_platform/manifest.py
+++ b/map-platform/backend/map_platform/manifest.py
@@ -187,7 +187,7 @@ def build_manifest(
     map_id = job.map_id or stable_map_id(job)
     files = collect_map_files(map_root, map_id)
     preview_bytes = render_boundary_preview(
-        job.source_region.preview_geometry or job.geometry.geometry,
+        job.geometry.geometry,
         job.geometry.bounds,
     )
     preview_path = map_root / DEFAULT_PREVIEW_PATH

--- a/map-platform/backend/map_platform/pipeline.py
+++ b/map-platform/backend/map_platform/pipeline.py
@@ -2565,7 +2565,7 @@ class MapBuildPipeline:
     def _freeze_preview_identity(self, job: MapJob) -> str:
         preview_sha256 = hashlib.sha256(
             render_boundary_preview(
-                job.source_region.preview_geometry or job.geometry.geometry,
+                job.geometry.geometry,
                 job.geometry.bounds,
             )
         ).hexdigest()

--- a/map-platform/backend/map_platform/reuse.py
+++ b/map-platform/backend/map_platform/reuse.py
@@ -155,7 +155,7 @@ def reuse_keys(
     if preview_sha256 is None:
         preview_sha256 = hashlib.sha256(
             render_boundary_preview(
-                job.source_region.preview_geometry or job.geometry.geometry,
+                job.geometry.geometry,
                 job.geometry.bounds,
             )
         ).hexdigest()

--- a/map-platform/backend/tests/test_manifest.py
+++ b/map-platform/backend/tests/test_manifest.py
@@ -192,7 +192,7 @@ class ManifestTests(unittest.TestCase):
             with zipfile.ZipFile(archive) as zip_archive:
                 self.assertNotIn("preview.png", zip_archive.namelist())
 
-    def test_preview_uses_source_boundary_and_requested_bounds_fallback(self):
+    def test_preview_uses_requested_geometry_and_bounds_fallback(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             job = fake_job()
@@ -250,7 +250,28 @@ class ManifestTests(unittest.TestCase):
             source_data = base64.b64decode(source_manifest["preview"]["dataBase64"])
             self.assertEqual(
                 source_data,
+                render_boundary_preview(requested_geometry, job.geometry.bounds),
+            )
+            self.assertNotEqual(
+                source_data,
                 render_boundary_preview(source_geometry, job.geometry.bounds),
+            )
+
+            bbox_job = fake_job()
+            bbox_job.map_id = stable_map_id(bbox_job)
+            bbox_job.source_region = SourceRegion(
+                id=bbox_job.source_region.id,
+                provider=bbox_job.source_region.provider,
+                name=bbox_job.source_region.name,
+                url=bbox_job.source_region.url,
+                bounds=bbox_job.source_region.bounds,
+                preview_geometry=source_geometry,
+            )
+            bbox_manifest = build_manifest(bbox_job, root, PipelineMetadata())
+            bbox_data = base64.b64decode(bbox_manifest["preview"]["dataBase64"])
+            self.assertEqual(
+                bbox_data,
+                render_boundary_preview(None, bbox_job.geometry.bounds),
             )
 
     def test_map_id_includes_custom_polygon_geometry(self):

--- a/map-platform/backend/tests/test_reuse.py
+++ b/map-platform/backend/tests/test_reuse.py
@@ -199,7 +199,7 @@ class MapReuseTests(unittest.TestCase):
                 producer_image_digest=PRODUCER_IMAGE,
             )
             self.assertEqual(first_keys.compatibility, preview_keys.compatibility)
-            self.assertNotEqual(first_keys.exact, preview_keys.exact)
+            self.assertEqual(first_keys.exact, preview_keys.exact)
             first.source_region = replace(
                 first.source_region,
                 name="Renamed source",
@@ -915,7 +915,7 @@ class MapReuseTests(unittest.TestCase):
                 result.build_compatibility_key, leased_keys.compatibility
             )
 
-    def test_exact_reuse_key_changes_when_resolved_preview_changes(self):
+    def test_exact_reuse_key_ignores_resolved_source_preview_changes(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             source_without_preview = replace(self.source, preview_geometry=None)
@@ -973,8 +973,8 @@ class MapReuseTests(unittest.TestCase):
             ).run_next()
 
             self.assertEqual(result.job.status, JobStatus.READY)
-            self.assertIsNone(result.job.reuse_strategy)
-            self.assertEqual(pipeline.full_build_calls, 1)
+            self.assertEqual(result.job.reuse_strategy, "exact")
+            self.assertEqual(pipeline.full_build_calls, 0)
 
     def test_subset_rejects_a_corrupt_selected_block(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

- Render saved-map `preview.png` from the requested map geometry or requested bounds.
- Stop using the entire Geofabrik/source-region outline for a small map cutout.
- Keep preview artifact identities aligned with the new framing so source-region outline changes do not invalidate or alter reuse decisions.
- Add coverage for custom geometry, bbox fallback, and source-preview changes.

## Why

Saved-map thumbnails could be framed at the source dataset scale instead of the requested map area. A small download therefore looked like a tiny region cut from a zoomed-out map.

The preview now fits the actual requested geometry, with the existing renderer padding, so saved-map previews stay focused on the area or route the user selected.

## Validation

- `python -m unittest discover -s tests` from `map-platform/backend` (375 tests passed)
- `python -m py_compile` for the changed backend modules
- `git diff --check`
