### PR TITLE
Prepare App Store 1.4 release

### DIFF
--- a/docs/releases/watchos-workout-companion.md
+++ b/docs/releases/watchos-workout-companion.md
@@ -1,7 +1,7 @@
 # Watch workout companion release notes
 
-Release candidate: **1.3 (10)**. App Store version 1.2 is already distributed,
-and App Store Connect already contains builds through 9, so both the marketing
+Release candidate: **1.4 (14)**. App Store version 1.3 is already distributed,
+and App Store Connect already contains builds through 13, so both the marketing
 version and build number advance for this release.
 
 ## App Store What's New

--- a/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
+++ b/ios-app/BikeComputer/BikeComputer.xcodeproj/project.pbxproj
@@ -804,7 +804,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -821,7 +821,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_IOS_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -848,7 +848,7 @@
 				CODE_SIGN_ALLOW_ENTITLEMENTS_MODIFICATION = YES;
 				CODE_SIGN_ENTITLEMENTS = BikeComputer/BikeComputer.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -865,7 +865,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_IOS_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -889,7 +889,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = BikeComputerWatch/BikeComputerWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -899,7 +899,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_WATCH_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -921,7 +921,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = BikeComputerWatch/BikeComputerWatch.entitlements;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -931,7 +931,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_WATCH_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -953,7 +953,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
@@ -963,7 +963,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_WATCH_COMPLICATION_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -984,7 +984,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerWatchComplications/Info.plist;
@@ -994,7 +994,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_WATCH_COMPLICATION_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = watchos;
@@ -1016,7 +1016,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
@@ -1027,7 +1027,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_LIVE_ACTIVITY_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1050,7 +1050,7 @@
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 10;
+				CURRENT_PROJECT_VERSION = 14;
 				DEVELOPMENT_TEAM = 4H5PK8686H;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = BikeComputerLiveActivity/Info.plist;
@@ -1061,7 +1061,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3;
+				MARKETING_VERSION = 1.4;
 				PRODUCT_BUNDLE_IDENTIFIER = "$(BICINO_LIVE_ACTIVITY_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/ios-app/scripts/tests/test_workout_release_assets.py
+++ b/ios-app/scripts/tests/test_workout_release_assets.py
@@ -95,6 +95,14 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
             / "releases"
             / "watchos-workout-companion.md"
         ).read_text()
+        release_candidate = re.search(
+            r"Release candidate: \*\*(?P<version>[^ ]+) \((?P<build>\d+)\)\*\*",
+            release_notes,
+        )
+        self.assertIsNotNone(release_candidate)
+        assert release_candidate is not None
+        expected_version = release_candidate.group("version")
+        expected_build = release_candidate.group("build")
 
         development = load_xcconfig(
             IOS_PROJECT / "Configuration" / "Development.xcconfig"
@@ -165,13 +173,16 @@ class WorkoutReleaseAssetsTests(unittest.TestCase):
                 with self.subTest(
                     target=target_name, configuration=configuration_name
                 ):
-                    self.assertIn("CURRENT_PROJECT_VERSION = 10;", settings)
-                    self.assertIn("MARKETING_VERSION = 1.3;", settings)
+                    self.assertIn(
+                        f"CURRENT_PROJECT_VERSION = {expected_build};", settings
+                    )
+                    self.assertIn(
+                        f"MARKETING_VERSION = {expected_version};", settings
+                    )
                     self.assertIn(
                         f'PRODUCT_BUNDLE_IDENTIFIER = "$({variable})";',
                         settings,
                     )
-        self.assertIn("Release candidate: **1.3 (10)**", release_notes)
 
     def test_privacy_policy_is_reachable_and_covers_release_obligations(self):
         shared_policy = (


### PR DESCRIPTION
## What changed

- Bump the production iOS, watchOS, complications, and Live Activity targets to marketing version `1.4`.
- Set the next App Store build number to `14` across the app family.

## Why

This creates the App Store version needed to publish the refreshed Bicino listing assets.

## Validation

- `ios-app/scripts/run-navigation-tests.sh`
- Release archive from this commit with Xcode 26.6
- Manual App Store export with the installed production profiles
- Exported IPA metadata: `LetItRide.BikeComputer`, version `1.4`, build `14`
- `codesign --verify --deep --strict` passed on the exported app
