### PR TITLE
Add automatic display-off setting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,14 @@ jobs:
       - uses: actions/checkout@v7
       - name: Install host crypto dependencies
         run: |
+          for source in /etc/apt/sources.list /etc/apt/sources.list.d/*.list /etc/apt/sources.list.d/*.sources; do
+            if [ -f "$source" ]; then
+              sudo sed -i \
+                -e 's|http://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                -e 's|https://azure.archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' \
+                "$source"
+            fi
+          done
           sudo apt-get update
           sudo apt-get install -y libmbedtls-dev python3-cryptography
       - name: Firmware manifest tests

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -769,6 +769,7 @@ Current setting IDs:
 | `33` | Map + Navigation street-label size | Same values as ID `29` |
 | `34` | Map + Navigation street-label orientation | Same values as ID `30` |
 | `35` | Map + Navigation 3D buildings | `0` flat footprints, `1` LoD1 walls and roofs in the bird's-eye Map + Navigation view; defaults to enabled and is persisted as `nav3DBuild` |
+| `36` | Automatic display off | `0` disabled, `1` enabled; defaults to enabled and is persisted as `automaticDisplayOff`. When enabled, the connected display dims after 15 seconds and turns off after 45 seconds without meaningful activity, except for navigation, workout, transfer, or attention holds. |
 
 In a dense scene, firmware reserves its bounded extrusion workspace from the
 nearest eligible buildings outward, preserves global back-to-front drawing,

--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -769,7 +769,7 @@ Current setting IDs:
 | `33` | Map + Navigation street-label size | Same values as ID `29` |
 | `34` | Map + Navigation street-label orientation | Same values as ID `30` |
 | `35` | Map + Navigation 3D buildings | `0` flat footprints, `1` LoD1 walls and roofs in the bird's-eye Map + Navigation view; defaults to enabled and is persisted as `nav3DBuild` |
-| `36` | Automatic display off | `0` disabled, `1` enabled; defaults to enabled and is persisted as `automaticDisplayOff`. When enabled, the connected display dims after 15 seconds and turns off after 45 seconds without meaningful activity, except for navigation, workout, transfer, or attention holds. |
+| `36` | Automatic display off | `0` disabled, `1` enabled; defaults to enabled and is persisted as `autoDisplayOff`. When enabled, the connected display dims after 15 seconds and turns off after 45 seconds without meaningful activity, except for navigation, workout, transfer, or attention holds. |
 
 In a dense scene, firmware reserves its bounded extrusion workspace from the
 nearest eligible buildings outward, preserves global back-to-front drawing,
@@ -1006,6 +1006,10 @@ ride-detection physical gates pass. Firmware sets bit `16` only in
 `DEVICE_REMOTE_DEBUG=1` builds after the debug HTTP/input service initializes.
 Firmware sets bit `18` only when `FIRMWARE_DIAGNOSTICS=1`; production builds
 therefore expose neither the snapshot nor experimental profile control.
+Bit `19` reports connected-display automatic-inactivity support (setting ID
+`36`). GFX firmware advertises it in `CAP2`; iOS enables the toggle and sends
+ID `36` only after this bit is received, so legacy firmware with the generic
+settings characteristic never receives an unsupported setting.
 Bits `0...7` retain their legacy meanings above. TLV type `1` carries the
 persisted PWR honk configuration as
 exactly three bytes (`Enabled`, `SoundID`, `VolumePercent`). Types are unique;
@@ -1133,6 +1137,11 @@ Firmware without that bit is never offered renderer target 3 and never receives
 the new setting. The setting has no effect unless Buildings is visible, Map +
 Navigation is using bird's-eye projection, and an FMB v4 block supplies
 building records.
+
+ID `36` is sent only after a valid `CAP2` response advertises bit `19`.
+Firmware without that bit is never offered the Automatic Display Off toggle;
+the setting remains app-local until a compatible connected display is
+negotiated.
 
 ## Destination Picker
 

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -83,6 +83,11 @@ The user's active brightness is stored in NVS under namespace
 `deviceSettings`, key `brightnessPct`. It is clamped to 5–100%, restored after
 reboot and display wake, and capped at 20% while dimmed.
 
+Automatic connected-display inactivity is controlled by BLE setting `36` and is
+stored in NVS under `deviceSettings`, key `automaticDisplayOff`. It defaults to
+enabled. When disabled, the connected display remains active outside the
+navigation, workout, transfer, and attention holds.
+
 Navigation, workout, transfer, and attention states deliberately hold the
 display awake:
 

--- a/docs/firmware-power-management.md
+++ b/docs/firmware-power-management.md
@@ -84,7 +84,7 @@ The user's active brightness is stored in NVS under namespace
 reboot and display wake, and capped at 20% while dimmed.
 
 Automatic connected-display inactivity is controlled by BLE setting `36` and is
-stored in NVS under `deviceSettings`, key `automaticDisplayOff`. It defaults to
+stored in NVS under `deviceSettings`, key `autoDisplayOff`. It defaults to
 enabled. When disabled, the connected display remains active outside the
 navigation, workout, transfer, and attention holds.
 

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -2326,6 +2326,10 @@ static void notifyDeviceCapabilities(NimBLECharacteristic *pChar,
         device_capabilities_protocol::BIRDS_EYE_PERSPECTIVE_FEATURE |
         device_capabilities_protocol::BIRDS_EYE_STRONGER_PERSPECTIVE_FEATURE |
         device_capabilities_protocol::OSM_3D_BUILDINGS_FEATURE;
+#ifdef USE_ARDUINO_GFX
+    featureFlags |=
+        device_capabilities_protocol::AUTOMATIC_DISPLAY_OFF_FEATURE;
+#endif
     if (clientVersion >= device_capabilities_protocol::
                              EXPLICIT_INVALID_GPS_HEADING_CLIENT_VERSION) {
       featureFlags |= device_capabilities_protocol::
@@ -3085,7 +3089,8 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
       return;
     }
 #ifdef USE_ARDUINO_GFX
-    if (!displayPowerManager.requestAutomaticDisplayOff(settingValue == 1)) {
+    if (!display_power::applyAutomaticDisplayOffSetting(displayPowerManager,
+                                                        settingValue)) {
       Serial.printf("BLE Settings: automatic display-off persistence failed from %s\n",
                     source == nullptr ? "unknown" : source);
       return;

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -37,6 +37,7 @@
 #include "../maps/src/maps.hpp"
 #include "../device_transfer/device_transfer_http.hpp"
 #include "../device_debug/device_debug_http.hpp"
+#include "../display_power/display_power_policy.hpp"
 #ifdef USE_ARDUINO_GFX
 #include "../display_power/display_power.hpp"
 #endif
@@ -3074,6 +3075,25 @@ static void handleMapSetting(uint8_t settingId, int32_t settingValue,
 #endif
 #else
     Serial.println("BLE Settings: brightness unsupported on this target");
+#endif
+    return;
+  case display_power::kAutomaticDisplayOffSettingID:
+    if (!display_power::isBooleanSettingValue(settingValue)) {
+      Serial.printf("BLE Settings: rejected automatic display-off value %ld from %s\n",
+                    (long)settingValue,
+                    source == nullptr ? "unknown" : source);
+      return;
+    }
+#ifdef USE_ARDUINO_GFX
+    if (!displayPowerManager.requestAutomaticDisplayOff(settingValue == 1)) {
+      Serial.printf("BLE Settings: automatic display-off persistence failed from %s\n",
+                    source == nullptr ? "unknown" : source);
+      return;
+    }
+    Serial.printf("BLE Settings: automaticDisplayOff = %s (saved)\n",
+                  settingValue == 1 ? "on" : "off");
+#else
+    Serial.println("BLE Settings: automatic display-off unsupported on this target");
 #endif
     return;
   case 13: {

--- a/esp32/lib/ble_navigation/ble_navigation.hpp
+++ b/esp32/lib/ble_navigation/ble_navigation.hpp
@@ -40,7 +40,8 @@ struct NavigationData {
  * 23-24 carry the connected phone's transient battery percentage and charging
  * state. IDs 25-26 control the Map + Navigation bird's-eye projection and
  * perspective. IDs 27-34 configure street labels for Map and Map + Navigation,
- * and ID 35 controls OSM 3D buildings in bird's-eye navigation.
+ * and ID 35 controls OSM 3D buildings in bird's-eye navigation. ID 36
+ * controls automatic connected-display inactivity.
  * Legacy ID 4 is ignored because display rotation is selected by the hardware
  * target.
  */

--- a/esp32/lib/ble_navigation/device_capabilities_protocol.hpp
+++ b/esp32/lib/ble_navigation/device_capabilities_protocol.hpp
@@ -27,6 +27,8 @@ constexpr uint32_t RIDE_AUTOMATION_V2_FEATURE = 1UL << 15;
 constexpr uint32_t REMOTE_DEVICE_DEBUG_FEATURE = 1UL << 16;
 constexpr uint32_t GPS_POSITION_QUALITY_V1_FEATURE = 1UL << 17;
 constexpr uint32_t RENDERER_DIAGNOSTICS_FEATURE = 1UL << 18;
+// Connected-display inactivity control (setting ID 36).
+constexpr uint32_t AUTOMATIC_DISPLAY_OFF_FEATURE = 1UL << 19;
 constexpr uint8_t POWER_BUTTON_CONFIG_TLV = 1;
 constexpr size_t POWER_BUTTON_CONFIG_BYTES = 3;
 constexpr size_t CAP2_BASE_BYTES = 9;

--- a/esp32/lib/display_power/display_inactivity_policy.hpp
+++ b/esp32/lib/display_power/display_inactivity_policy.hpp
@@ -38,6 +38,7 @@ constexpr bool shouldPollTouchWhileDisplayInactive(Mode currentMode,
 struct Context {
   bool navigating = false;
   bool workoutActive = false;
+  bool automaticDisplayOffEnabled = true;
   bool transferActive = false;
   bool attentionActive = false;
 };
@@ -100,6 +101,7 @@ public:
     initialized_ = true;
     lastMeaningfulActivityMs_ = nowMs;
     heldAwake_ = false;
+    automaticDisplayOffEnabled_ = true;
     mode_ = Mode::Active;
   }
 
@@ -114,6 +116,14 @@ public:
   Update update(uint32_t nowMs, const Context &context) {
     if (!initialized_) {
       begin(nowMs);
+    }
+
+    if (automaticDisplayOffEnabled_ != context.automaticDisplayOffEnabled) {
+      // Changing this preference is itself a meaningful boundary. Start a
+      // fresh idle interval so enabling automatic display-off never applies
+      // the time spent with the preference disabled retroactively.
+      automaticDisplayOffEnabled_ = context.automaticDisplayOffEnabled;
+      lastMeaningfulActivityMs_ = nowMs;
     }
 
     const bool heldAwake =
@@ -132,6 +142,8 @@ public:
       requested = Mode::Transfer;
     } else if (context.navigating || context.workoutActive ||
                context.attentionActive) {
+      requested = Mode::Active;
+    } else if (!context.automaticDisplayOffEnabled) {
       requested = Mode::Active;
     } else {
       const uint32_t idleMs = elapsedMs(nowMs, lastMeaningfulActivityMs_);
@@ -160,6 +172,7 @@ public:
 private:
   bool initialized_ = false;
   bool heldAwake_ = false;
+  bool automaticDisplayOffEnabled_ = true;
   uint32_t lastMeaningfulActivityMs_ = 0;
   Mode mode_ = Mode::Active;
 };

--- a/esp32/lib/display_power/display_power.cpp
+++ b/esp32/lib/display_power/display_power.cpp
@@ -13,6 +13,7 @@ namespace {
 
 constexpr char kPreferencesNamespace[] = "deviceSettings";
 constexpr char kBrightnessKey[] = "brightnessPct";
+constexpr char kAutomaticDisplayOffKey[] = "automaticDisplayOff";
 
 } // namespace
 
@@ -39,11 +40,20 @@ bool DisplayPowerManager::begin() {
   Preferences preferences;
   bool hasSavedValue = false;
   uint8_t savedValue = display_power::kDefaultBrightnessPercent;
+  bool hasSavedAutomaticDisplayOff = false;
+  bool automaticDisplayOff =
+      display_power::kDefaultAutomaticDisplayOffEnabled;
   if (preferences.begin(kPreferencesNamespace, false)) {
     hasSavedValue = preferences.isKey(kBrightnessKey);
     if (hasSavedValue) {
       savedValue = preferences.getUChar(
           kBrightnessKey, display_power::kDefaultBrightnessPercent);
+    }
+    hasSavedAutomaticDisplayOff = preferences.isKey(kAutomaticDisplayOffKey);
+    if (hasSavedAutomaticDisplayOff) {
+      automaticDisplayOff = preferences.getBool(
+          kAutomaticDisplayOffKey,
+          display_power::kDefaultAutomaticDisplayOffEnabled);
     }
     preferences.end();
   } else {
@@ -53,6 +63,8 @@ bool DisplayPowerManager::begin() {
   policy_.restoreSavedBrightness(hasSavedValue, savedValue);
   savedBrightnessPersisted_ =
       hasSavedValue && display_power::isBrightnessPercentInRange(savedValue);
+  automaticDisplayOffEnabled_ = automaticDisplayOff;
+  automaticDisplayOffPersisted_ = hasSavedAutomaticDisplayOff;
   initialized_ = true;
   return true;
 }
@@ -88,6 +100,41 @@ bool DisplayPowerManager::requestUserBrightness(int32_t requestedPercent) {
 
   if (!persisted) {
     Serial.println("DisplayPower: failed to persist brightness");
+  } else {
+    ui_scheduler::notify(ui_scheduler::WakeReason::Display);
+  }
+  return persisted;
+}
+
+bool DisplayPowerManager::requestAutomaticDisplayOff(bool enabled) {
+  if (!initialized_ && !begin()) {
+    return false;
+  }
+  if (!lock()) {
+    return false;
+  }
+
+  if (automaticDisplayOffPersisted_ &&
+      automaticDisplayOffEnabled_ == enabled) {
+    unlock();
+    return true;
+  }
+
+  Preferences preferences;
+  const bool opened = preferences.begin(kPreferencesNamespace, false);
+  const bool persisted =
+      opened && preferences.putBool(kAutomaticDisplayOffKey, enabled) == 1;
+  if (opened) {
+    preferences.end();
+  }
+  if (persisted) {
+    automaticDisplayOffEnabled_ = enabled;
+    automaticDisplayOffPersisted_ = true;
+  }
+  unlock();
+
+  if (!persisted) {
+    Serial.println("DisplayPower: failed to persist automatic display-off setting");
   } else {
     ui_scheduler::notify(ui_scheduler::WakeReason::Display);
   }
@@ -132,6 +179,15 @@ uint8_t DisplayPowerManager::effectiveBrightnessPercent() const {
     return display_power::kDefaultBrightnessPercent;
   }
   const uint8_t value = policy_.effectiveBrightnessPercent();
+  unlock();
+  return value;
+}
+
+bool DisplayPowerManager::automaticDisplayOffEnabled() const {
+  if (!lock()) {
+    return display_power::kDefaultAutomaticDisplayOffEnabled;
+  }
+  const bool value = automaticDisplayOffEnabled_;
   unlock();
   return value;
 }

--- a/esp32/lib/display_power/display_power.cpp
+++ b/esp32/lib/display_power/display_power.cpp
@@ -1,4 +1,5 @@
 #include "display_power.hpp"
+#include "display_power_preferences.hpp"
 
 #include "../panel/WAVESHARE_AMOLED_175.hpp"
 #include "../power_management/power_management.hpp"
@@ -11,9 +12,7 @@
 
 namespace {
 
-constexpr char kPreferencesNamespace[] = "deviceSettings";
 constexpr char kBrightnessKey[] = "brightnessPct";
-constexpr char kAutomaticDisplayOffKey[] = "automaticDisplayOff";
 
 } // namespace
 
@@ -43,18 +42,14 @@ bool DisplayPowerManager::begin() {
   bool hasSavedAutomaticDisplayOff = false;
   bool automaticDisplayOff =
       display_power::kDefaultAutomaticDisplayOffEnabled;
-  if (preferences.begin(kPreferencesNamespace, false)) {
+  if (display_power::beginDeviceSettingsPreferences(preferences)) {
     hasSavedValue = preferences.isKey(kBrightnessKey);
     if (hasSavedValue) {
       savedValue = preferences.getUChar(
           kBrightnessKey, display_power::kDefaultBrightnessPercent);
     }
-    hasSavedAutomaticDisplayOff = preferences.isKey(kAutomaticDisplayOffKey);
-    if (hasSavedAutomaticDisplayOff) {
-      automaticDisplayOff = preferences.getBool(
-          kAutomaticDisplayOffKey,
-          display_power::kDefaultAutomaticDisplayOffEnabled);
-    }
+    automaticDisplayOff = display_power::loadAutomaticDisplayOff(
+        preferences, hasSavedAutomaticDisplayOff);
     preferences.end();
   } else {
     Serial.println("DisplayPower: failed to open device settings NVS");
@@ -86,7 +81,8 @@ bool DisplayPowerManager::requestUserBrightness(int32_t requestedPercent) {
   }
 
   Preferences preferences;
-  const bool opened = preferences.begin(kPreferencesNamespace, false);
+  const bool opened =
+      display_power::beginDeviceSettingsPreferences(preferences);
   const bool persisted =
       opened && preferences.putUChar(kBrightnessKey, normalized) == 1;
   if (opened) {
@@ -121,9 +117,10 @@ bool DisplayPowerManager::requestAutomaticDisplayOff(bool enabled) {
   }
 
   Preferences preferences;
-  const bool opened = preferences.begin(kPreferencesNamespace, false);
+  const bool opened =
+      display_power::beginDeviceSettingsPreferences(preferences);
   const bool persisted =
-      opened && preferences.putBool(kAutomaticDisplayOffKey, enabled) == 1;
+      opened && display_power::persistAutomaticDisplayOff(preferences, enabled);
   if (opened) {
     preferences.end();
   }

--- a/esp32/lib/display_power/display_power.hpp
+++ b/esp32/lib/display_power/display_power.hpp
@@ -10,11 +10,13 @@ class DisplayPowerManager {
 public:
   bool begin();
   bool requestUserBrightness(int32_t requestedPercent);
+  bool requestAutomaticDisplayOff(bool enabled);
   void requestState(display_power::State state);
 
   display_power::State state() const;
   uint8_t savedBrightnessPercent() const;
   uint8_t effectiveBrightnessPercent() const;
+  bool automaticDisplayOffEnabled() const;
 
   bool initializePanel();
   bool applyPendingPanelChange();
@@ -28,6 +30,9 @@ private:
   mutable SemaphoreHandle_t mutex_ = nullptr;
   display_power::Policy policy_;
   bool savedBrightnessPersisted_ = false;
+  bool automaticDisplayOffEnabled_ =
+      display_power::kDefaultAutomaticDisplayOffEnabled;
+  bool automaticDisplayOffPersisted_ = false;
   bool initialized_ = false;
 };
 

--- a/esp32/lib/display_power/display_power_policy.hpp
+++ b/esp32/lib/display_power/display_power_policy.hpp
@@ -4,10 +4,16 @@
 
 namespace display_power {
 
+constexpr uint8_t kAutomaticDisplayOffSettingID = 36;
+constexpr bool kDefaultAutomaticDisplayOffEnabled = true;
 constexpr uint8_t kMinimumBrightnessPercent = 5;
 constexpr uint8_t kMaximumBrightnessPercent = 100;
 constexpr uint8_t kDefaultBrightnessPercent = 100;
 constexpr uint8_t kDefaultDimmedBrightnessPercent = 20;
+
+constexpr bool isBooleanSettingValue(int32_t value) {
+  return value == 0 || value == 1;
+}
 
 constexpr bool isBrightnessPercentInRange(int32_t value) {
   return value >= kMinimumBrightnessPercent &&

--- a/esp32/lib/display_power/display_power_policy.hpp
+++ b/esp32/lib/display_power/display_power_policy.hpp
@@ -6,6 +6,10 @@ namespace display_power {
 
 constexpr uint8_t kAutomaticDisplayOffSettingID = 36;
 constexpr bool kDefaultAutomaticDisplayOffEnabled = true;
+// ESP32 NVS keys are limited to 15 characters (excluding the terminator).
+constexpr char kAutomaticDisplayOffPreferencesKey[] = "autoDisplayOff";
+static_assert(sizeof(kAutomaticDisplayOffPreferencesKey) - 1 <= 15,
+              "automatic display-off NVS key exceeds the ESP32 limit");
 constexpr uint8_t kMinimumBrightnessPercent = 5;
 constexpr uint8_t kMaximumBrightnessPercent = 100;
 constexpr uint8_t kDefaultBrightnessPercent = 100;
@@ -13,6 +17,12 @@ constexpr uint8_t kDefaultDimmedBrightnessPercent = 20;
 
 constexpr bool isBooleanSettingValue(int32_t value) {
   return value == 0 || value == 1;
+}
+
+template <typename Manager>
+bool applyAutomaticDisplayOffSetting(Manager &manager, int32_t value) {
+  return isBooleanSettingValue(value) &&
+         manager.requestAutomaticDisplayOff(value == 1);
 }
 
 constexpr bool isBrightnessPercentInRange(int32_t value) {

--- a/esp32/lib/display_power/display_power_preferences.hpp
+++ b/esp32/lib/display_power/display_power_preferences.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "display_power_policy.hpp"
+
+namespace display_power {
+
+constexpr char kDeviceSettingsPreferencesNamespace[] = "deviceSettings";
+
+template <typename PreferencesType>
+bool beginDeviceSettingsPreferences(PreferencesType &preferences) {
+  return preferences.begin(kDeviceSettingsPreferencesNamespace, false);
+}
+
+template <typename PreferencesType>
+bool loadAutomaticDisplayOff(PreferencesType &preferences,
+                             bool &hasSavedValue) {
+  hasSavedValue = preferences.isKey(kAutomaticDisplayOffPreferencesKey);
+  return hasSavedValue
+             ? preferences.getBool(kAutomaticDisplayOffPreferencesKey,
+                                   kDefaultAutomaticDisplayOffEnabled)
+             : kDefaultAutomaticDisplayOffEnabled;
+}
+
+template <typename PreferencesType>
+bool persistAutomaticDisplayOff(PreferencesType &preferences, bool enabled) {
+  return preferences.putBool(kAutomaticDisplayOffPreferencesKey, enabled) ==
+         1;
+}
+
+} // namespace display_power

--- a/esp32/src/main.cpp
+++ b/esp32/src/main.cpp
@@ -841,6 +841,8 @@ static display_inactivity::Update updateDisplayInactivityPolicy(
   context.workoutActive =
       bleStats.connected && bleStats.authenticated &&
       workout_telemetry_runtime::isWorkoutActive();
+  context.automaticDisplayOffEnabled =
+      displayPowerManager.automaticDisplayOffEnabled();
   context.transferActive =
       (signals.transferEnabled && signals.transferMode != "debug") ||
       signals.activationRunning;

--- a/esp32/tools/tests/test_device_capabilities_protocol.cpp
+++ b/esp32/tools/tests/test_device_capabilities_protocol.cpp
@@ -46,6 +46,9 @@ int main() {
                 16);
   static_assert(device_capabilities_protocol::RENDERER_DIAGNOSTICS_FEATURE ==
                 (1UL << 18));
+  static_assert(
+      device_capabilities_protocol::AUTOMATIC_DISPLAY_OFF_FEATURE ==
+      (1UL << 19));
   uint8_t output[device_capabilities_protocol::CAP2_MAX_BYTES]{};
   const uint8_t power[] = {1, 4, 80};
   const size_t size = device_capabilities_protocol::encodeCap2(
@@ -103,6 +106,15 @@ int main() {
   assert(rendererDiagnosticsSize == sizeof(expectedRendererDiagnostics));
   for (size_t index = 0; index < rendererDiagnosticsSize; ++index)
     assert(output[index] == expectedRendererDiagnostics[index]);
+  const size_t automaticDisplayOffSize =
+      device_capabilities_protocol::encodeCap2(
+          device_capabilities_protocol::AUTOMATIC_DISPLAY_OFF_FEATURE, nullptr,
+          false, output, sizeof(output));
+  const uint8_t expectedAutomaticDisplayOff[] = {
+      'C', 'A', 'P', '2', 1, 0x00, 0x00, 0x08, 0x00};
+  assert(automaticDisplayOffSize == sizeof(expectedAutomaticDisplayOff));
+  for (size_t index = 0; index < automaticDisplayOffSize; ++index)
+    assert(output[index] == expectedAutomaticDisplayOff[index]);
   std::cout << "device capabilities protocol tests passed\n";
   return 0;
 }

--- a/esp32/tools/tests/test_display_inactivity_policy.cpp
+++ b/esp32/tools/tests/test_display_inactivity_policy.cpp
@@ -126,6 +126,19 @@ int main() {
   assert(automaticOffDisabled.update(345'000, noAutomaticOff).current ==
          Mode::DisplayOff);
 
+  Policy disableFromDisplayOff;
+  disableFromDisplayOff.begin(0);
+  assert(disableFromDisplayOff.update(45'000, {}).current ==
+         Mode::DisplayOff);
+  Context automaticOffNowDisabled;
+  automaticOffNowDisabled.automaticDisplayOffEnabled = false;
+  const auto disabledUpdate =
+      disableFromDisplayOff.update(45'001, automaticOffNowDisabled);
+  assert(disabledUpdate.current == Mode::Active);
+  assert(disabledUpdate.displayWakeRequired);
+  assert(!disableFromDisplayOff.update(45'002, automaticOffNowDisabled)
+              .displayWakeRequired);
+
   Policy transfer;
   transfer.begin(0);
   Context transferring;

--- a/esp32/tools/tests/test_display_inactivity_policy.cpp
+++ b/esp32/tools/tests/test_display_inactivity_policy.cpp
@@ -110,6 +110,22 @@ int main() {
   assert(workout.update(315'000, {}).current == Mode::Dimmed);
   assert(workout.update(345'000, {}).current == Mode::DisplayOff);
 
+  Policy automaticOffDisabled;
+  automaticOffDisabled.begin(0);
+  Context noAutomaticOff;
+  noAutomaticOff.automaticDisplayOffEnabled = false;
+  assert(automaticOffDisabled.update(100'000, noAutomaticOff).current ==
+         Mode::Active);
+  assert(automaticOffDisabled.update(200'000, noAutomaticOff).current ==
+         Mode::Active);
+  noAutomaticOff.automaticDisplayOffEnabled = true;
+  assert(automaticOffDisabled.update(300'000, noAutomaticOff).current ==
+         Mode::Active);
+  assert(automaticOffDisabled.update(315'000, noAutomaticOff).current ==
+         Mode::Dimmed);
+  assert(automaticOffDisabled.update(345'000, noAutomaticOff).current ==
+         Mode::DisplayOff);
+
   Policy transfer;
   transfer.begin(0);
   Context transferring;

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -1,10 +1,65 @@
 #include "../../lib/display_power/display_power_policy.hpp"
+#include "../../lib/display_power/display_power_preferences.hpp"
 #include "../../lib/ble_navigation/map_setting_packet.hpp"
 #include "../../lib/ble_navigation/map_setting_redraw_policy.hpp"
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <initializer_list>
+
+struct FakePreferences {
+  bool hasValue = false;
+  bool value = false;
+  bool opened = false;
+  bool readOnly = true;
+  const char *lastKey = nullptr;
+
+  bool begin(const char *name, bool nextReadOnly) {
+    assert(std::strcmp(name,
+                       display_power::kDeviceSettingsPreferencesNamespace) ==
+           0);
+    opened = true;
+    readOnly = nextReadOnly;
+    return true;
+  }
+
+  bool isKey(const char *key) {
+    lastKey = key;
+    assert(std::strcmp(key,
+                       display_power::kAutomaticDisplayOffPreferencesKey) ==
+           0);
+    return hasValue;
+  }
+  bool getBool(const char *key, bool fallback) {
+    lastKey = key;
+    assert(std::strcmp(key,
+                       display_power::kAutomaticDisplayOffPreferencesKey) ==
+           0);
+    return hasValue ? value : fallback;
+  }
+  size_t putBool(const char *key, bool nextValue) {
+    lastKey = key;
+    assert(std::strcmp(key,
+                       display_power::kAutomaticDisplayOffPreferencesKey) ==
+           0);
+    hasValue = true;
+    value = nextValue;
+    return 1;
+  }
+};
+
+struct FakeDisplayPowerManager {
+  int requestCount = 0;
+  bool enabled = true;
+
+  bool requestAutomaticDisplayOff(bool nextEnabled) {
+    ++requestCount;
+    enabled = nextEnabled;
+    return true;
+  }
+};
 
 int main() {
   using display_power::PanelUpdate;
@@ -13,10 +68,35 @@ int main() {
 
   static_assert(display_power::kAutomaticDisplayOffSettingID == 36);
   static_assert(display_power::kDefaultAutomaticDisplayOffEnabled);
+  static_assert(sizeof(display_power::kAutomaticDisplayOffPreferencesKey) - 1 <=
+                15);
+  static_assert(sizeof(display_power::kDeviceSettingsPreferencesNamespace) - 1 <=
+                15);
   static_assert(display_power::isBooleanSettingValue(0));
   static_assert(display_power::isBooleanSettingValue(1));
   static_assert(!display_power::isBooleanSettingValue(-1));
   static_assert(!display_power::isBooleanSettingValue(2));
+
+  FakePreferences preferences;
+  assert(display_power::beginDeviceSettingsPreferences(preferences));
+  assert(preferences.opened);
+  assert(!preferences.readOnly);
+  bool hasSavedAutomaticDisplayOff = false;
+  assert(display_power::loadAutomaticDisplayOff(
+             preferences, hasSavedAutomaticDisplayOff) ==
+         display_power::kDefaultAutomaticDisplayOffEnabled);
+  assert(!hasSavedAutomaticDisplayOff);
+  assert(display_power::persistAutomaticDisplayOff(preferences, false));
+  assert(!display_power::loadAutomaticDisplayOff(
+      preferences, hasSavedAutomaticDisplayOff));
+  assert(hasSavedAutomaticDisplayOff);
+
+  FakeDisplayPowerManager manager;
+  assert(!display_power::applyAutomaticDisplayOffSetting(manager, 2));
+  assert(manager.requestCount == 0);
+  assert(display_power::applyAutomaticDisplayOffSetting(manager, 0));
+  assert(manager.requestCount == 1);
+  assert(!manager.enabled);
 
   static_assert(!display_power::isBrightnessPercentInRange(4));
   static_assert(display_power::isBrightnessPercentInRange(5));

--- a/esp32/tools/tests/test_display_power_policy.cpp
+++ b/esp32/tools/tests/test_display_power_policy.cpp
@@ -11,6 +11,13 @@ int main() {
   using display_power::Policy;
   using display_power::State;
 
+  static_assert(display_power::kAutomaticDisplayOffSettingID == 36);
+  static_assert(display_power::kDefaultAutomaticDisplayOffEnabled);
+  static_assert(display_power::isBooleanSettingValue(0));
+  static_assert(display_power::isBooleanSettingValue(1));
+  static_assert(!display_power::isBooleanSettingValue(-1));
+  static_assert(!display_power::isBooleanSettingValue(2));
+
   static_assert(!display_power::isBrightnessPercentInRange(4));
   static_assert(display_power::isBrightnessPercentInRange(5));
   static_assert(display_power::isBrightnessPercentInRange(100));

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -353,6 +353,7 @@ enum DeviceBLEProtocol {
     static let mapPlusNavigationLabelTextSizeSettingID: UInt8 = 33
     static let mapPlusNavigationLabelOrientationSettingID: UInt8 = 34
     static let mapPlusNavigation3DBuildingsSettingID: UInt8 = 35
+    static let automaticDisplayOffSettingID: UInt8 = 36
     static let currentScreenMaskMarker: Int32 = 1 << 30
     static let defaultMapStreetLabelsEnabled = true
     static let defaultMapPlusNavigationStreetLabelsEnabled = false
@@ -918,6 +919,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var enabledDeviceScreensMask: Int = DeviceScreen.allScreensMask
     @Published var defaultDeviceScreen: DeviceScreen = .mapPlusNavigation
     @Published var deviceBrightnessPercent: Double = 100
+    @Published var automaticDisplayOffEnabled: Bool = true
     @Published var disconnectedSleepTimeout: DisconnectedSleepTimeout = .twoMinutes
     @Published var selectedDeviceSound: DeviceSound = .defaultSelection
     @Published var deviceSoundVolumePercent: Double = DeviceSound.defaultVolumePercent
@@ -1196,6 +1198,7 @@ class BLEManager: NSObject, ObservableObject {
         static let defaultDeviceScreenMigrated = "deviceSettings.defaultScreen.mapPlusNavigationDefault.v1"
         static let batteryStatusScreenMigrated = "deviceSettings.enabledScreensMask.batteryStatus.v1"
         static let deviceBrightnessPercent = "deviceSettings.brightnessPercent"
+        static let automaticDisplayOffEnabled = "deviceSettings.automaticDisplayOffEnabled"
         static let disconnectedSleepTimeoutSeconds = "deviceSettings.disconnectedSleepTimeoutSeconds"
         static let watchControllerIDsByDevice =
             "deviceSettings.watchControllerIDsByDevice.v1"
@@ -1426,6 +1429,9 @@ class BLEManager: NSObject, ObservableObject {
         deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
             defaults.object(forKey: SettingsKeys.deviceBrightnessPercent) as? Double ?? 100
         )
+        automaticDisplayOffEnabled = defaults.object(
+            forKey: SettingsKeys.automaticDisplayOffEnabled
+        ) as? Bool ?? true
         disconnectedSleepTimeout = DisconnectedSleepTimeout.normalized(
             rawValue: defaults.object(forKey: SettingsKeys.disconnectedSleepTimeoutSeconds) as? Int ?? DisconnectedSleepTimeout.twoMinutes.rawValue
         )
@@ -1709,6 +1715,7 @@ class BLEManager: NSObject, ObservableObject {
             deviceBrightnessPercent
         )
         defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
+        defaults.set(automaticDisplayOffEnabled, forKey: SettingsKeys.automaticDisplayOffEnabled)
         defaults.set(disconnectedSleepTimeout.rawValue, forKey: SettingsKeys.disconnectedSleepTimeoutSeconds)
         defaults.set(Int(selectedDeviceSound.rawValue), forKey: SettingsKeys.selectedDeviceSound)
         deviceSoundVolumePercent = DeviceSound.normalizedVolumePercent(deviceSoundVolumePercent)
@@ -3889,6 +3896,8 @@ class BLEManager: NSObject, ObservableObject {
             deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
                 Double(value)
             )
+        } else if id == DeviceBLEProtocol.automaticDisplayOffSettingID {
+            automaticDisplayOffEnabled = value != 0
         }
         if hasReceivedDeviceCapabilities,
            !supportsIndependentMapProfiles,
@@ -3926,6 +3935,8 @@ class BLEManager: NSObject, ObservableObject {
         let deviceValue: Int32
         if id == DeviceBLEProtocol.brightnessSettingID {
             deviceValue = Int32(deviceBrightnessPercent)
+        } else if id == DeviceBLEProtocol.automaticDisplayOffSettingID {
+            deviceValue = value == 0 ? 0 : 1
         } else if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID {
             let maximum = supportsBirdsEyeMapNavigationStrongerPerspective
                 ? MapNavigationBirdsEyePerspective.maximum.rawValue
@@ -6227,6 +6238,10 @@ class BLEManager: NSObject, ObservableObject {
         sendSetting(
             id: DeviceBLEProtocol.brightnessSettingID,
             value: Int32(deviceBrightnessPercent)
+        )
+        sendSetting(
+            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+            value: automaticDisplayOffEnabled ? 1 : 0
         )
         sendSetting(
             id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -310,6 +310,7 @@ enum DeviceBLEProtocol {
     static let remoteDeviceDebugCapabilityMask: UInt32 = 1 << 16
     static let gpsPositionQualityV1CapabilityMask: UInt32 = 1 << 17
     static let rendererDiagnosticsCapabilityMask: UInt32 = 1 << 18
+    static let automaticDisplayOffCapabilityMask: UInt32 = 1 << 19
     static let deviceCapabilitiesVersion: UInt8 = 16
     static let workoutTelemetryFrameLength = 16
     static let workoutTelemetryOriginFrameLength = 28
@@ -320,6 +321,8 @@ enum DeviceBLEProtocol {
         "workout-telemetry-origin"
     static let navigationSnapshotCoalescingKey = "navigation-snapshot"
     static let gpsPositionCoalescingKey = "gps-position"
+    static let automaticDisplayOffSettingCoalescingKey =
+        "automatic-display-off-setting"
     // Large enough for the worst schema-v1 three-favorite catalog at the
     // minimum BLE write length, without retaining a long stale GPS backlog.
     static let fallbackWriteQueueCapacity = 64
@@ -790,6 +793,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var isConnected: Bool = false
     @Published var isNavigationReady: Bool = false
     @Published var supportsDeviceSettings: Bool = false
+    @Published private(set) var supportsAutomaticDisplayOff: Bool = false
     @Published var supportsDeviceSounds: Bool = false
     @Published var supportsPowerButtonHonk: Bool = false
     @Published var supportsPowerButtonHonkAcknowledgement: Bool = false
@@ -1130,6 +1134,7 @@ class BLEManager: NSObject, ObservableObject {
     private var hasSentMapProfileForConnection = false
     private var hasSentMapNavigationProfileForConnection = false
     private var hasSentScreenSettingsForConnection = false
+    private var hasSentAutomaticDisplayOffForConnection = false
     private var isSendingNegotiatedMapProfiles = false
     private var lastSentPhoneBatteryPercent: Int32?
     private var lastSentPhoneBatteryCharging: Bool?
@@ -3890,8 +3895,9 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     /// Persist and send a runtime map setting to ESP32 when supported.
+    @discardableResult
     func sendSetting(id: UInt8, value: Int32,
-                     synchronizeLegacyProfile: Bool = true) {
+                     synchronizeLegacyProfile: Bool = true) -> Bool {
         if id == DeviceBLEProtocol.brightnessSettingID {
             deviceBrightnessPercent = DeviceBLEProtocol.normalizedBrightnessPercent(
                 Double(value)
@@ -3907,30 +3913,35 @@ class BLEManager: NSObject, ObservableObject {
             synchronizeMapPlusNavigationProfileWithMap(for: id)
         }
         saveSettings()
+        if id == DeviceBLEProtocol.automaticDisplayOffSettingID,
+           (!hasReceivedDeviceCapabilities || !supportsAutomaticDisplayOff) {
+            log("Automatic display-off setting not sent: connected firmware does not advertise support")
+            return false
+        }
         if Self.isIndependentMapProfileSetting(id),
            (!hasReceivedDeviceCapabilities || !supportsIndependentMapProfiles) {
             log("Independent map setting id=\(id) not sent: connected firmware does not advertise support")
-            return
+            return false
         }
         if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyeViewSettingID,
-           (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigation) {
+            (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigation) {
             log("Bird's-eye map setting not sent: connected firmware does not advertise support")
-            return
+            return false
         }
         if id == DeviceBLEProtocol.mapPlusNavigationBirdsEyePerspectiveSettingID,
-           (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigationPerspective) {
+            (!hasReceivedDeviceCapabilities || !supportsBirdsEyeMapNavigationPerspective) {
             log("Bird's-eye perspective setting not sent: connected firmware does not advertise support")
-            return
+            return false
         }
         if id == DeviceBLEProtocol.mapPlusNavigation3DBuildingsSettingID,
-           (!hasReceivedDeviceCapabilities || !supports3DBuildings) {
+            (!hasReceivedDeviceCapabilities || !supports3DBuildings) {
             log("3D buildings setting not sent: connected firmware does not advertise support")
-            return
+            return false
         }
         if Self.isStreetLabelSetting(id),
            (!hasReceivedDeviceCapabilities || !supportsStreetLabels) {
             log("Street-label setting id=\(id) not sent: connected firmware does not advertise support")
-            return
+            return false
         }
         let deviceValue: Int32
         if id == DeviceBLEProtocol.brightnessSettingID {
@@ -3951,8 +3962,12 @@ class BLEManager: NSObject, ObservableObject {
         }
         guard sendSettingPacket(id: id, value: deviceValue, label: "setting id=\(id)") else {
             log("Settings characteristic unsupported; saved local setting id=\(id), value=\(value)")
-            return
+            return false
         }
+        if id == DeviceBLEProtocol.automaticDisplayOffSettingID {
+            hasSentAutomaticDisplayOffForConnection = true
+        }
+        return true
     }
 
     func sendStreetLabelDensity(for screen: DeviceScreen) {
@@ -3991,16 +4006,37 @@ class BLEManager: NSObject, ObservableObject {
         var fallback = Data(DeviceBLEProtocol.settingsFallbackPrefix.utf8)
         fallback.append(data)
 
+        let coalescingKey = id == DeviceBLEProtocol.automaticDisplayOffSettingID
+            ? DeviceBLEProtocol.automaticDisplayOffSettingCoalescingKey
+            : nil
+        let onDrop: (() -> Void)? = id == DeviceBLEProtocol.automaticDisplayOffSettingID
+            ? { [weak self] in
+                guard let self else { return }
+                self.hasSentAutomaticDisplayOffForConnection = false
+                self.log("Automatic display-off setting was dropped before transmission")
+            }
+            : nil
+
         return DevicePacketRouting.sendPreferredThenFallback(
             preferred: {
-                sendNativeMapTransferPacket(data, label: label)
+                sendNativeMapTransferPacket(
+                    data,
+                    label: label,
+                    coalescingKey: coalescingKey,
+                    onDrop: onDrop
+                )
             },
             fallback: {
                 guard fallback.count <= (navigationWriteEndpoint?.maximumWriteLength ?? 0) else {
                     log("Cannot send \(label): write limit exceeded")
                     return false
                 }
-                return sendFallbackMapPacket(fallback, label: label)
+                return sendFallbackMapPacket(
+                    fallback,
+                    label: label,
+                    coalescingKey: coalescingKey,
+                    onDrop: onDrop
+                )
             }
         )
     }
@@ -4170,6 +4206,7 @@ class BLEManager: NSObject, ObservableObject {
 
     func useDeviceCapabilitiesFallback() {
         guard isConnected, isNavigationReady, !hasReceivedDeviceCapabilities else { return }
+        supportsAutomaticDisplayOff = false
         supportsIndependentMapProfiles = false
         supportsExtendedMapVisibility = false
         supportsBirdsEyeMapNavigation = false
@@ -4340,6 +4377,7 @@ class BLEManager: NSObject, ObservableObject {
     }
 
     private func sendScreenSettingsAfterCapabilityNegotiation() {
+        sendAutomaticDisplayOffSettingAfterCapabilityNegotiation()
         guard supportsDeviceSettings,
               hasReceivedDeviceCapabilities,
               !hasSentScreenSettingsForConnection else {
@@ -4351,6 +4389,19 @@ class BLEManager: NSObject, ObservableObject {
         if supportsBatteryStatusScreen {
             sendPhoneBatteryStatus(force: true)
         }
+    }
+
+    private func sendAutomaticDisplayOffSettingAfterCapabilityNegotiation() {
+        guard supportsDeviceSettings,
+              hasReceivedDeviceCapabilities,
+              supportsAutomaticDisplayOff,
+              !hasSentAutomaticDisplayOffForConnection else {
+            return
+        }
+        _ = sendSetting(
+            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+            value: automaticDisplayOffEnabled ? 1 : 0
+        )
     }
 
     @discardableResult
@@ -4965,6 +5016,7 @@ class BLEManager: NSObject, ObservableObject {
         isConnected = false
         isConnecting = false
         supportsDeviceSettings = false
+        supportsAutomaticDisplayOff = false
         connectedPeripheral = nil
         connectedDeviceID = nil
         navigationCharacteristic = nil
@@ -5062,6 +5114,7 @@ class BLEManager: NSObject, ObservableObject {
         firmwareUpdateTotalBytes = 0
         firmwareUpdateLastError = nil
         supportsDeviceSounds = false
+        supportsAutomaticDisplayOff = false
         supportsPowerButtonHonk = false
         supportsPowerButtonHonkAcknowledgement = false
         supportsIndependentMapProfiles = false
@@ -5096,6 +5149,7 @@ class BLEManager: NSObject, ObservableObject {
         hasSentMapProfileForConnection = false
         hasSentMapNavigationProfileForConnection = false
         hasSentScreenSettingsForConnection = false
+        hasSentAutomaticDisplayOffForConnection = false
         isSendingNegotiatedMapProfiles = false
         clearPendingPowerButtonHonkConfiguration()
     }
@@ -5159,6 +5213,26 @@ class BLEManager: NSObject, ObservableObject {
             maxCount: maxCount,
             priorityMaxCount: priorityMaxCount
         )
+    }
+
+    @discardableResult
+    func enqueueProtectedNavigationWriteForTesting(_ data: Data) -> Bool {
+        guard let endpoint = navigationWriteEndpoint else { return false }
+        return enqueueNavigationWrite(
+            data,
+            endpoint: endpoint,
+            label: "test protected transfer",
+            writeClass: .transfer,
+            atomically: true,
+            transportWrite: endpoint.write,
+            transportCanSend: endpoint.canSend,
+            transportExpectsWriteResponse: endpoint.expectsWriteResponse
+        )
+    }
+
+    func flushPendingNavigationWritesForTesting() {
+        guard let endpoint = navigationWriteEndpoint else { return }
+        flushPendingNavigationWrites(endpoint: endpoint)
     }
 
     func installNavigationWriteStallRecoveryForTesting(
@@ -6239,10 +6313,7 @@ class BLEManager: NSObject, ObservableObject {
             id: DeviceBLEProtocol.brightnessSettingID,
             value: Int32(deviceBrightnessPercent)
         )
-        sendSetting(
-            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
-            value: automaticDisplayOffEnabled ? 1 : 0
-        )
+        sendAutomaticDisplayOffSettingAfterCapabilityNegotiation()
         sendSetting(
             id: DeviceBLEProtocol.disconnectedSleepTimeoutSettingID,
             value: disconnectedSleepTimeout.settingValue
@@ -6432,7 +6503,8 @@ class BLEManager: NSObject, ObservableObject {
         label: String,
         writeClass: NavigationWriteClass = .settingsControl,
         coalescingKey: String? = nil,
-        prioritized: Bool = false
+        prioritized: Bool = false,
+        onDrop: (() -> Void)? = nil
     ) -> Bool {
         guard isConnected,
               isNavigationReady,
@@ -6474,7 +6546,8 @@ class BLEManager: NSObject, ObservableObject {
                     ? !self.writeWithResponseInFlight
                     : peripheral.canSendWriteWithoutResponse
             },
-            transportExpectsWriteResponse: expectsWriteResponse
+            transportExpectsWriteResponse: expectsWriteResponse,
+            onDrop: onDrop
         ) else { return false }
         log("Queued native \(label): \(data.count) bytes")
         return true
@@ -6529,6 +6602,15 @@ class BLEManager: NSObject, ObservableObject {
         } else if Date().timeIntervalSince(lastNavigationQueuePendingLogAt) >= 1 {
             log("Navigation write queue pending: \(navigationWriteQueue.count)")
             lastNavigationQueuePendingLogAt = Date()
+        }
+        if madeProgress,
+           hasReceivedDeviceCapabilities,
+           supportsDeviceSettings,
+           supportsAutomaticDisplayOff,
+           !hasSentAutomaticDisplayOffForConnection {
+            DispatchQueue.main.async { [weak self] in
+                self?.sendAutomaticDisplayOffSettingAfterCapabilityNegotiation()
+            }
         }
     }
 
@@ -7067,6 +7149,7 @@ extension BLEManager: CBCentralManagerDelegate {
         isConnected = false
         isConnecting = false
         supportsDeviceSettings = false
+        supportsAutomaticDisplayOff = false
         hardwareLabel = ""
         deviceInformation.removeAll()
         connectedPeripheral = nil
@@ -7529,6 +7612,7 @@ extension BLEManager: CBPeripheralDelegate {
 
     private func rejectDeviceCapabilities(_ message: String) {
         supportsDeviceSounds = false
+        supportsAutomaticDisplayOff = false
         supportsPowerButtonHonk = false
         supportsPowerButtonHonkAcknowledgement = false
         supportsIndependentMapProfiles = false
@@ -7555,6 +7639,7 @@ extension BLEManager: CBPeripheralDelegate {
         updateWorkoutTelemetryCapability(false)
         hasReceivedDeviceCapabilities = false
         hasSentScreenSettingsForConnection = false
+        hasSentAutomaticDisplayOffForConnection = false
         hasSentMapProfileForConnection = false
         hasSentMapNavigationProfileForConnection = false
         clearPendingPowerButtonHonkConfiguration()
@@ -7675,6 +7760,8 @@ extension BLEManager: CBPeripheralDelegate {
             flags & DeviceBLEProtocol.gpsPositionQualityV1CapabilityMask != 0
         let hasRendererDiagnostics =
             flags & DeviceBLEProtocol.rendererDiagnosticsCapabilityMask != 0
+        let hasAutomaticDisplayOff =
+            flags & DeviceBLEProtocol.automaticDisplayOffCapabilityMask != 0
         if has3DBuildings && shouldApply3DBuildingVisibilityDefault {
             shouldApply3DBuildingVisibilityDefault = false
             UserDefaults.standard.set(
@@ -7738,7 +7825,12 @@ extension BLEManager: CBPeripheralDelegate {
             supportsBatteryStatusScreen != hasBatteryStatusScreen {
             hasSentScreenSettingsForConnection = false
         }
+        if hasReceivedDeviceCapabilities &&
+            supportsAutomaticDisplayOff != hasAutomaticDisplayOff {
+            hasSentAutomaticDisplayOffForConnection = false
+        }
         supportsDeviceSounds = hasDeviceSounds
+        supportsAutomaticDisplayOff = hasAutomaticDisplayOff
         supportsPowerButtonHonk = hasPowerButtonHonk
         supportsPowerButtonHonkAcknowledgement = hasPowerButtonHonkAcknowledgement
         supportsIndependentMapProfiles = hasIndependentMapProfiles

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1869,7 +1869,7 @@ private struct HardwareCustomizationSettingsView: View {
         Form {
             Section(
                 header: Text("Device Brightness"),
-                footer: Text("When enabled, the display dims after 15 seconds and turns off after 45 seconds unless navigation or a workout is active.")
+                footer: Text("When enabled, the display dims after 15 seconds and turns off after 45 seconds unless navigation, workout, transfer, or attention activity is active.")
             ) {
                 VStack(alignment: .leading) {
                     HStack {
@@ -1891,6 +1891,7 @@ private struct HardwareCustomizationSettingsView: View {
                             value: newValue ? 1 : 0
                         )
                     }
+                    .disabled(!bleManager.supportsAutomaticDisplayOff)
             }
             .disabled(!bleManager.supportsDeviceSettings)
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1867,7 +1867,10 @@ private struct HardwareCustomizationSettingsView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Device Brightness")) {
+            Section(
+                header: Text("Device Brightness"),
+                footer: Text("When enabled, the display dims after 15 seconds and turns off after 45 seconds unless navigation or a workout is active.")
+            ) {
                 VStack(alignment: .leading) {
                     HStack {
                         Text("Brightness")
@@ -1880,6 +1883,14 @@ private struct HardwareCustomizationSettingsView: View {
                             bleManager.sendSetting(id: DeviceBLEProtocol.brightnessSettingID, value: Int32(newValue))
                         }
                 }
+
+                Toggle("Automatic Display Off", isOn: $bleManager.automaticDisplayOffEnabled)
+                    .onChange(of: bleManager.automaticDisplayOffEnabled) { newValue in
+                        bleManager.sendSetting(
+                            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+                            value: newValue ? 1 : 0
+                        )
+                    }
             }
             .disabled(!bleManager.supportsDeviceSettings)
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -659,7 +659,10 @@ struct NavigationProtocolTests {
         testBLEManagerParsesDeviceTransferStatus()
         testBLEManagerSendsBrightnessFallbackSetting()
         testBLEManagerResendsBrightnessAfterAuthentication()
+        testBLEManagerGatesAutomaticDisplayOffForLegacyFirmware()
+        testBLEManagerSendsAutomaticDisplayOffAfterCapabilityNegotiation()
         testBLEManagerSendsAutomaticDisplayOffSetting()
+        testBLEManagerRetriesAutomaticDisplayOffAfterQueuePressure()
         testBLEManagerSendsDisconnectedSleepTimeoutSetting()
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
@@ -10477,6 +10480,21 @@ struct NavigationProtocolTests {
         assertEqual(protectedWrites, [Data([1]), Data([2]), Data([3])],
                     "later queue pressure cannot fragment an accepted atomic message")
 
+        var protectedSettingQueue = NavigationWriteQueue(maxCount: 1)
+        assert(protectedSettingQueue.enqueueAtomically([
+            NavigationWrite(data: Data([5]), label: "protected-transfer")
+        ]), "a protected transfer can occupy the bounded queue")
+        assert(!protectedSettingQueue.enqueueCoalescing(
+            NavigationWrite(
+                data: Data([6]),
+                label: "automatic-display-off",
+                coalescingKey: DeviceBLEProtocol.automaticDisplayOffSettingCoalescingKey
+            ),
+            prioritized: false
+        ), "automatic display-off rejects a full protected queue instead of reporting success")
+        assertEqual(protectedSettingQueue.count, 1,
+                    "a rejected automatic display-off write preserves the protected transfer")
+
         var rejectedCoalescingDropCount = 0
         var fullProtectedCoalescingQueue = NavigationWriteQueue(maxCount: 2)
         assert(fullProtectedCoalescingQueue.enqueueAtomically([
@@ -16289,11 +16307,20 @@ struct NavigationProtocolTests {
     static func testBLEManagerResendsBrightnessAfterAuthentication() {
         let defaults = UserDefaults.standard
         defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+        defaults.removeObject(forKey: "deviceSettings.automaticDisplayOffEnabled")
 
         let manager = BLEManager()
         manager.isConnected = true
         manager.isNavigationReady = true
+        manager.supportsDeviceSettings = true
         manager.deviceBrightnessPercent = 70
+        manager.automaticDisplayOffEnabled = false
+        assert(manager.handleDeviceCapabilitiesNotification(
+            Data(DeviceBLEProtocol.deviceCapabilitiesV2Prefix.utf8) +
+                Data([1, 0, 0, 8, 0])
+        ), "automatic display-off capability response should be consumed")
+        assert(manager.supportsAutomaticDisplayOff,
+               "CAP2 bit 19 enables automatic display-off")
 
         var sentPackets: [Data] = []
         manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
@@ -16319,7 +16346,96 @@ struct NavigationProtocolTests {
             | (Int32(valueBytes[3]) << 24)
         assertEqual(value, 70,
                     "authenticated reconnect restores the saved brightness")
+        let automaticDisplayOffPackets = sentPackets.filter {
+            $0.count == 9 &&
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.settingsFallbackPrefix &&
+            $0[4] == DeviceBLEProtocol.automaticDisplayOffSettingID
+        }
+        assertEqual(automaticDisplayOffPackets.count, 1,
+                    "authenticated reconnect sends automatic display-off exactly once")
+        assertEqual(readInt32LE(automaticDisplayOffPackets[0], offset: 5), 0,
+                    "authenticated reconnect restores disabled automatic display-off")
         defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+        defaults.removeObject(forKey: "deviceSettings.automaticDisplayOffEnabled")
+    }
+
+    static func testBLEManagerGatesAutomaticDisplayOffForLegacyFirmware() {
+        let defaults = UserDefaults.standard
+        let key = "deviceSettings.automaticDisplayOffEnabled"
+        defaults.removeObject(forKey: key)
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        assert(manager.handleDeviceCapabilitiesNotification(
+            Data(DeviceBLEProtocol.deviceCapabilitiesPrefix.utf8) + Data([0])
+        ), "legacy capability response should be consumed")
+        assert(!manager.supportsAutomaticDisplayOff,
+               "legacy firmware does not advertise automatic display-off")
+        manager.supportsDeviceSettings = true
+        manager.automaticDisplayOffEnabled = false
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        assert(!manager.sendSetting(
+            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+            value: 0
+        ), "legacy firmware rejects unsupported automatic display-off writes")
+        assert(sentPackets.isEmpty,
+               "legacy firmware receives no automatic display-off packet")
+        defaults.removeObject(forKey: key)
+    }
+
+    static func testBLEManagerSendsAutomaticDisplayOffAfterCapabilityNegotiation() {
+        let defaults = UserDefaults.standard
+        let key = "deviceSettings.automaticDisplayOffEnabled"
+        defaults.removeObject(forKey: key)
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.supportsDeviceSettings = true
+        manager.automaticDisplayOffEnabled = false
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        let capability = Data(DeviceBLEProtocol.deviceCapabilitiesV2Prefix.utf8) +
+            Data([1, 0, 0, 8, 0])
+        assert(manager.handleDeviceCapabilitiesNotification(capability),
+               "CAP2 capability response should be consumed")
+        let automaticDisplayOffPackets = sentPackets.filter {
+            $0.count == 9 &&
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.settingsFallbackPrefix &&
+            $0[4] == DeviceBLEProtocol.automaticDisplayOffSettingID
+        }
+        assertEqual(automaticDisplayOffPackets.count, 1,
+                    "capability negotiation sends automatic display-off exactly once")
+        assertEqual(readInt32LE(automaticDisplayOffPackets[0], offset: 5), 0,
+                    "capability negotiation sends the saved disabled value")
+
+        assert(manager.handleDeviceCapabilitiesNotification(capability),
+               "duplicate CAP2 capability response should be consumed")
+        let duplicatePackets = sentPackets.filter {
+            $0.count == 9 &&
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.settingsFallbackPrefix &&
+            $0[4] == DeviceBLEProtocol.automaticDisplayOffSettingID
+        }
+        assertEqual(duplicatePackets.count, 1,
+                    "duplicate capability responses do not resend automatic display-off")
+        defaults.removeObject(forKey: key)
     }
 
     static func testBLEManagerSendsAutomaticDisplayOffSetting() {
@@ -16330,9 +16446,16 @@ struct NavigationProtocolTests {
         let manager = BLEManager()
         manager.isConnected = true
         manager.isNavigationReady = true
+        manager.supportsDeviceSettings = true
         assert(manager.automaticDisplayOffEnabled,
                "automatic display-off defaults to enabled")
         manager.automaticDisplayOffEnabled = false
+        assert(manager.handleDeviceCapabilitiesNotification(
+            Data(DeviceBLEProtocol.deviceCapabilitiesV2Prefix.utf8) +
+                Data([1, 0, 0, 8, 0])
+        ), "automatic display-off capability response should be consumed")
+        assert(manager.supportsAutomaticDisplayOff,
+               "CAP2 bit 19 enables automatic display-off")
 
         var sentPackets: [Data] = []
         manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
@@ -16357,6 +16480,57 @@ struct NavigationProtocolTests {
         let reloaded = BLEManager()
         assert(!reloaded.automaticDisplayOffEnabled,
                "automatic display-off preference persists")
+        defaults.removeObject(forKey: key)
+    }
+
+    static func testBLEManagerRetriesAutomaticDisplayOffAfterQueuePressure() {
+        let defaults = UserDefaults.standard
+        let key = "deviceSettings.automaticDisplayOffEnabled"
+        defaults.removeObject(forKey: key)
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        manager.supportsDeviceSettings = true
+        manager.automaticDisplayOffEnabled = false
+
+        assert(manager.handleDeviceCapabilitiesNotification(
+            Data(DeviceBLEProtocol.deviceCapabilitiesV2Prefix.utf8) +
+                Data([1, 0, 0, 8, 0])
+        ), "automatic display-off capability response should be consumed")
+
+        var canSend = false
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { canSend },
+            write: { sentPackets.append($0) }
+        ))
+        manager.installNavigationWriteQueueForTesting(maxCount: 1)
+
+        assert(manager.enqueueProtectedNavigationWriteForTesting(Data([0xA1])),
+               "a protected transfer should occupy the test queue")
+        assert(!manager.sendSetting(
+            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+            value: 0
+        ), "automatic display-off reports queue rejection when no slot is available")
+        assert(sentPackets.isEmpty,
+               "queue pressure must not report an unsent automatic display-off packet")
+
+        canSend = true
+        manager.flushPendingNavigationWritesForTesting()
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        let automaticDisplayOffPackets = sentPackets.filter {
+            $0.count == 9 &&
+            String(data: $0.prefix(4), encoding: .utf8) ==
+                DeviceBLEProtocol.settingsFallbackPrefix &&
+            $0[4] == DeviceBLEProtocol.automaticDisplayOffSettingID
+        }
+        assertEqual(automaticDisplayOffPackets.count, 1,
+                    "automatic display-off retries after protected queue traffic drains")
+        assertEqual(readInt32LE(automaticDisplayOffPackets[0], offset: 5), 0,
+                    "the retried automatic display-off packet preserves the saved value")
         defaults.removeObject(forKey: key)
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -659,6 +659,7 @@ struct NavigationProtocolTests {
         testBLEManagerParsesDeviceTransferStatus()
         testBLEManagerSendsBrightnessFallbackSetting()
         testBLEManagerResendsBrightnessAfterAuthentication()
+        testBLEManagerSendsAutomaticDisplayOffSetting()
         testBLEManagerSendsDisconnectedSleepTimeoutSetting()
         testBLEManagerSendsDeviceScreenSettings()
         testBLEManagerPersistsNewMapSettings()
@@ -11240,6 +11241,7 @@ struct NavigationProtocolTests {
         assertEqual(DeviceBLEProtocol.mapPlusNavigationLabelTextSizeSettingID, 33, "Map + Navigation street-label size uses setting ID 33")
         assertEqual(DeviceBLEProtocol.mapPlusNavigationLabelOrientationSettingID, 34, "Map + Navigation street-label orientation uses setting ID 34")
         assertEqual(DeviceBLEProtocol.mapPlusNavigation3DBuildingsSettingID, 35, "Map + Navigation 3D buildings use setting ID 35")
+        assertEqual(DeviceBLEProtocol.automaticDisplayOffSettingID, 36, "automatic display-off uses firmware setting ID 36")
         assertEqual(DeviceBLEProtocol.defaultMapStreetLabelsEnabled, true, "Map street labels default to enabled")
         assertEqual(DeviceBLEProtocol.defaultMapPlusNavigationStreetLabelsEnabled, false, "Map + Navigation street labels default to disabled")
         assertEqual(DeviceBLEProtocol.defaultStreetLabelDensity, 2, "street labels default to Balanced density")
@@ -16318,6 +16320,44 @@ struct NavigationProtocolTests {
         assertEqual(value, 70,
                     "authenticated reconnect restores the saved brightness")
         defaults.removeObject(forKey: "deviceSettings.brightnessPercent")
+    }
+
+    static func testBLEManagerSendsAutomaticDisplayOffSetting() {
+        let defaults = UserDefaults.standard
+        let key = "deviceSettings.automaticDisplayOffEnabled"
+        defaults.removeObject(forKey: key)
+
+        let manager = BLEManager()
+        manager.isConnected = true
+        manager.isNavigationReady = true
+        assert(manager.automaticDisplayOffEnabled,
+               "automatic display-off defaults to enabled")
+        manager.automaticDisplayOffEnabled = false
+
+        var sentPackets: [Data] = []
+        manager.installNavigationWriteEndpoint(NavigationWriteEndpoint(
+            maximumWriteLength: 20,
+            canSend: { true },
+            write: { sentPackets.append($0) }
+        ))
+
+        manager.sendSetting(
+            id: DeviceBLEProtocol.automaticDisplayOffSettingID,
+            value: 0
+        )
+
+        assertEqual(sentPackets.count, 1,
+                    "automatic display-off should send one fallback packet")
+        assertEqual(sentPackets[0][4],
+                    DeviceBLEProtocol.automaticDisplayOffSettingID,
+                    "automatic display-off uses setting ID 36")
+        assertEqual(readInt32LE(sentPackets[0], offset: 5), 0,
+                    "automatic display-off sends the disabled value")
+
+        let reloaded = BLEManager()
+        assert(!reloaded.automaticDisplayOffEnabled,
+               "automatic display-off preference persists")
+        defaults.removeObject(forKey: key)
     }
 
     static func testBLEManagerSendsDeviceScreenSettings() {


### PR DESCRIPTION
## What changed

Adds an **Automatic Display Off** toggle under Hardware Customization → Device Brightness.

When enabled (the default), the connected display dims after 15 seconds and turns off after 45 seconds without meaningful activity. Navigation and workout states keep the display active; existing transfer and attention holds remain unchanged. Turning the toggle off keeps the display active outside those holds.

The setting is persisted locally in iOS, sent over BLE as setting ID 36, and persisted on the device in NVS.

## Validation

- Firmware host tests:
  - `test_display_power_policy.cpp`
  - `test_display_inactivity_policy.cpp`
- `ios-app/scripts/run-navigation-tests.sh`
- iOS Debug build with code signing disabled
- Verified `WAVESHARE_AMOLED_175` firmware build via `tools/build_firmware.py`

No hardware was flashed.