### PR TITLE
Show aggregate map generation progress

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -306,6 +306,7 @@ struct OfflineMapJob: Decodable, Equatable {
     let geometry: OfflineMapJobGeometry?
     let sourceRegion: OfflineMapSourceRegion?
     let progress: OfflineMapJobProgress?
+    let buildingProgress: OfflineMapBuildingProgress?
     let clientInstallationId: String?
     let clientRequestId: String?
     let installOnDevice: Bool?
@@ -324,6 +325,50 @@ struct OfflineMapJob: Decodable, Equatable {
     var mayBeLegacyRetryTransition: Bool {
         guard status == "failed", let attempts, let maxAttempts else { return false }
         return attempts >= 0 && maxAttempts > 0 && attempts < maxAttempts
+    }
+}
+
+/// Durable whole-job progress from the chunk coordinator.
+///
+/// `progress` remains the phase-local detail shown below the overall bar. The
+/// coordinator's block receipts are the stable denominator for the overall
+/// percentage; chunk counts are supporting diagnostics because chunks can
+/// contain different numbers of output blocks.
+struct OfflineMapBuildingProgress: Decodable, Equatable {
+    let completedBlocks: Int?
+    let totalBlocks: Int?
+    let readyChunks: Int?
+    let totalChunks: Int?
+    let activeChunks: Int?
+    let indeterminate: Bool?
+
+    var fraction: Double? {
+        guard indeterminate != true,
+              let completedBlocks,
+              let totalBlocks,
+              totalBlocks > 0 else {
+            return nil
+        }
+        return min(max(Double(completedBlocks) / Double(totalBlocks), 0), 1)
+    }
+
+    var percentage: Int? {
+        guard let fraction else { return nil }
+        return Int((fraction * 100).rounded())
+    }
+
+    var detail: String {
+        var parts: [String] = []
+        if let completedBlocks, let totalBlocks, totalBlocks > 0 {
+            parts.append("\(completedBlocks) of \(totalBlocks) map blocks")
+        }
+        if let readyChunks, let totalChunks, totalChunks > 0 {
+            parts.append("\(readyChunks) of \(totalChunks) chunks ready")
+        }
+        if let activeChunks, activeChunks > 0 {
+            parts.append("\(activeChunks) active")
+        }
+        return parts.isEmpty ? "Planning map chunks" : parts.joined(separator: " · ")
     }
 }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -673,6 +673,28 @@ private struct DownloadingMapsSettingsSection: View {
                 StatusValueRow(status: "Checking device activation", isBusy: false)
             }
 
+            if let overallGenerationProgress {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Overall Generation")
+                        Spacer()
+                        if let percentage = overallGenerationProgress.percentage {
+                            Text("\(percentage)%")
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                    if let fraction = overallGenerationProgress.fraction {
+                        ProgressView(value: fraction)
+                    } else {
+                        ProgressView()
+                    }
+                    Text(overallGenerationProgress.detail)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                .accessibilityElement(children: .combine)
+            }
+
             if let generationProgress {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
@@ -749,6 +771,11 @@ private struct DownloadingMapsSettingsSection: View {
     private var generationProgress: OfflineMapJobProgress? {
         guard manager.currentJob?.status == "converting_features" else { return nil }
         return manager.currentJob?.progress
+    }
+
+    private var overallGenerationProgress: OfflineMapBuildingProgress? {
+        guard manager.currentJob?.status == "converting_features" else { return nil }
+        return manager.currentJob?.buildingProgress
     }
 }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -5733,6 +5733,14 @@ struct NavigationProtocolTests {
             {
               "jobId": "job-progress",
               "status": "converting_features",
+              "buildingProgress": {
+                "completedBlocks": 231,
+                "totalBlocks": 266,
+                "readyChunks": 7,
+                "totalChunks": 8,
+                "activeChunks": 1,
+                "indeterminate": false
+              },
               "progress": {
                 "phase": "building_preprocessing",
                 "unit": "calibration_cells",
@@ -5759,6 +5767,18 @@ struct NavigationProtocolTests {
         assertEqual(progress.percentage, 40, "map progress calculates phase percentage")
         assert(abs(progress.fraction - 0.79) < 0.000001, "map progress calculates fraction")
         assertEqual(progress.detail, "Preparing deterministic building heights", "map progress explains preprocessing")
+
+        guard let buildingProgress = job.buildingProgress else {
+            assert(false, "aggregate building progress should decode")
+            return
+        }
+        assertEqual(buildingProgress.percentage, 87, "aggregate progress uses completed blocks")
+        assert(abs((buildingProgress.fraction ?? 0) - (231.0 / 266.0)) < 0.000001, "aggregate progress calculates block fraction")
+        assertEqual(
+            buildingProgress.detail,
+            "231 of 266 map blocks · 7 of 8 chunks ready · 1 active",
+            "aggregate progress explains block and chunk completion"
+        )
     }
 
     static func testOfflineMapJobProgressAbsentFallback() {
@@ -5768,6 +5788,7 @@ struct NavigationProtocolTests {
             return
         }
         assertEqual(job.progress, nil, "legacy server response keeps indeterminate progress fallback")
+        assertEqual(job.buildingProgress, nil, "legacy server response keeps aggregate progress optional")
     }
 
     static func testOfflineMapJobPersistence() {


### PR DESCRIPTION
## Summary

- Decode the backend buildingProgress aggregate counters in the iOS map-job model.
- Add an Overall Generation row above the existing phase-local Generation Progress row.
- Use completed map blocks for the overall percentage and show ready/active chunk counts as supporting detail.
- Keep legacy responses compatible by making aggregate progress optional.

The existing backend already publishes buildingProgress with receipt-backed block and chunk counters; no backend or production configuration change is included.

## Verification

- cd ios-app && ./scripts/run-navigation-tests.sh — passed (NavigationProtocolTests, Cycling sensor tests, DestinationCalloutLayoutTests, SavedMapPreviewCatalystTests).
- ./ios-app/scripts/xcodebuild-cli.sh -project ios-app/BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination generic/platform=iOS -derivedDataPath /tmp/bicino-progress-derived.PxBlzB CODE_SIGNING_ALLOWED=NO build — BUILD SUCCEEDED.
- git diff --check — clean.

## UI behavior

For a planned chunked job, the new row shows an overall block-based percentage such as 87%, with detail like “231 of 266 map blocks · 7 of 8 chunks ready · 1 active”. The existing Generation Progress row continues to show the current phase-local work (for example, relation closure or block encoding). Before aggregate counters exist, the overall row remains absent rather than presenting a fabricated weighted percentage.

No production, hardware, or physical-device action was taken.
