### PR TITLE
Bound production worker memory for chunked maps

### DIFF
--- a/map-platform/deploy/README.md
+++ b/map-platform/deploy/README.md
@@ -63,6 +63,13 @@ promotion. The policy-aware API ignores them. Remove them only after `/healthz`
 reports both `deploymentChannel` and `generationProfilePolicySha256` from the
 promoted control plane.
 
+Keep `MAP_PLATFORM_WORKER_MEMORY_LIMIT` at the reviewed `12g` default (or a
+separately reviewed lower value). The production Compose lock applies it as a
+real worker cgroup limit; the chunk coordinator refuses to claim target-3 work
+when that limit is absent or malformed. Keep
+`MAP_PLATFORM_WORKER_MAX_CONCURRENT_TASKS=1` until retained resource evidence
+supports a higher value.
+
 The initial worker lock points at the image already running successfully in
 production. Its control-plane lock contains the same backend revision currently
 deployed from `main`, so changing the Compose location does not introduce a new

--- a/map-platform/deploy/compose.yaml
+++ b/map-platform/deploy/compose.yaml
@@ -86,6 +86,10 @@ services:
 
   map-platform-worker:
     image: *map-platform-worker-image
+    # Chunk admission requires a real cgroup memory ceiling. Keep the
+    # production default aligned with the reviewed 12 GiB validation cap;
+    # operators may lower it only with a corresponding resource review.
+    mem_limit: ${MAP_PLATFORM_WORKER_MEMORY_LIMIT:-12g}
     command: ["map-platform", "worker-loop", "--idle-sleep-seconds", "10"]
     environment:
       MAP_PLATFORM_REPO_ROOT: /app

--- a/map-platform/deploy/tests/test_deployment_channels.py
+++ b/map-platform/deploy/tests/test_deployment_channels.py
@@ -25,6 +25,18 @@ class DeploymentChannelComposeTests(unittest.TestCase):
         self.assertIn("MAP_PLATFORM_BUILDING_TARGET3_ENABLED", api_environment)
         self.assertIn("MAP_PLATFORM_BUILDING_TARGET3_ALLOWLIST", api_environment)
 
+    def test_production_worker_has_an_explicit_chunk_memory_ceiling(self):
+        compose = (DEPLOY_DIR / "compose.yaml").read_text(encoding="utf-8")
+        worker_environment = compose.split("  map-platform-worker:", 1)[1].split(
+            "  map-platform-maintenance:", 1
+        )[0]
+
+        self.assertIn(
+            "mem_limit: ${MAP_PLATFORM_WORKER_MEMORY_LIMIT:-12g}",
+            worker_environment,
+        )
+        self.assertIn("MAP_PLATFORM_WORKER_MEMORY_LIMIT_BYTES", worker_environment)
+
 
 class PreparationEstimateComposeTests(unittest.TestCase):
     _SERVICES = (


### PR DESCRIPTION
## Summary
- enforce a real 12 GiB cgroup memory ceiling for the production map worker
- document the chunk-admission and concurrency-one deployment gate
- add a compose regression test

## Why
The production target-3 canary reached the implemented `chunked_allowlist` path but the worker had no configured/cgroup memory limit, so it correctly refused to claim chunked work. This keeps production on the existing selected path until the tested lock is promoted.

## Verification
- `python3 -m unittest discover -s map-platform/deploy/tests -p 'test_deployment_channels.py' -v`
- `python3 map-platform/deploy/update_image.py map-platform/deploy/compose.yaml --check`
- `MAP_PLATFORM_DOWNLOAD_SECRET=ci-download-secret MAP_PLATFORM_INSTALLATION_SECRET=ci-installation-secret-32-bytes-minimum MAP_PLATFORM_TRUSTED_PROXY_CIDRS=172.16.0.0/12 MAP_PLATFORM_WORKER_MEMORY_LIMIT=12g docker compose -f map-platform/deploy/compose.yaml config`
