### PR TITLE
Handle unoutlined building-part relations in target-3 extraction

### DIFF
--- a/tools/OSM_Extract/scripts/extract_building_relations.py
+++ b/tools/OSM_Extract/scripts/extract_building_relations.py
@@ -141,20 +141,49 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         qualified_relations = {
             relation_key
             for relation_key, parts in self.incomplete_relation_parts.items()
-            if len(parts) == 1
-            and parts[0].startswith("w")
-            and self.way_tags.get(parts[0], {}).get("building")
-            not in (None, "", "no")
+            if parts
+            and all(
+                part.startswith("w")
+                and (
+                    self.way_tags.get(part, {}).get("building")
+                    not in (None, "", "no")
+                    or self.way_tags.get(part, {}).get("building:part")
+                    not in (None, "", "no")
+                )
+                for part in parts
+            )
         }
+        relation_part_counts: dict[str, int] = {}
+        for parts in self.incomplete_relation_parts.values():
+            for part in parts:
+                relation_part_counts[part] = relation_part_counts.get(part, 0) + 1
         unsafe_parts = {
             part
             for relation_key, parts in self.incomplete_relation_parts.items()
             if relation_key not in qualified_relations
             for part in parts
         }
+        unsafe_parts.update(
+            part
+            for part, count in relation_part_counts.items()
+            if count != 1 or part in self.part_parents
+        )
+        safe_relations = {
+            relation_key
+            for relation_key in qualified_relations
+            if all(
+                part not in unsafe_parts
+                for part in self.incomplete_relation_parts[relation_key]
+            )
+        }
+        # A relation without an outline is safe to normalize only when every
+        # direct way is an explicit building/part feature and none of its
+        # members participates in another relation association. This keeps
+        # malformed or ambiguous nesting fail-closed while accepting common
+        # OSM building relations whose parts collectively are the footprint.
         self.standalone_part_keys = {
             part
-            for relation_key in qualified_relations
+            for relation_key in safe_relations
             for part in self.incomplete_relation_parts[relation_key]
             if part not in unsafe_parts
         }

--- a/tools/OSM_Extract/tests/test_building_relations.py
+++ b/tools/OSM_Extract/tests/test_building_relations.py
@@ -155,6 +155,40 @@ class BuildingRelationIngressTests(unittest.TestCase):
         self.assertEqual(handler.standalone_part_keys, {"w30"})
         self.assertFalse(handler.parts_without_outline)
 
+    def test_unoutlined_building_relation_with_explicit_parts_is_retained_standalone(self):
+        handler = BuildingRelationHandler(
+            expected_closure={
+                "requiredRelationKeys": ["r108"],
+                "requiredWayKeys": ["w31", "w32"],
+            }
+        )
+
+        class Tags(list):
+            def get(self, key):
+                return next((tag.v for tag in self if tag.k == key), None)
+
+        for way_id in (31, 32):
+            handler.way(
+                SimpleNamespace(
+                    id=way_id,
+                    nodes=[],
+                    tags=Tags([SimpleNamespace(k="building:part", v="yes")]),
+                )
+            )
+        handler.relation(
+            self.relation(
+                108,
+                [
+                    {"type": "w", "ref": 31, "role": "part"},
+                    {"type": "w", "ref": 32, "role": "part"},
+                ],
+            )
+        )
+        handler.finalize()
+
+        self.assertEqual(handler.standalone_part_keys, {"w31", "w32"})
+        self.assertFalse(handler.parts_without_outline)
+
     def test_cli_indexes_real_osm_building_relations_deterministically(self):
         with tempfile.TemporaryDirectory() as tmp:
             output = Path(tmp) / "building-relations.json"


### PR DESCRIPTION
## Summary
- normalize unambiguous `type=building` relations whose direct members are all explicit building/part ways and no outline member exists
- preserve fail-closed behavior for shared, ambiguous, or otherwise malformed parts
- add regression coverage for multi-part standalone normalization

## Production evidence
The production target-3 canary on the chunked worker reached feature conversion and failed on Singapore relation `r14346906`, which has five direct `building:part` ways and no outline. Each part carries its own building metadata; rejecting the entire map prevents target-3 artifact generation for this ordinary OSM pattern.

## Verification
- `/tmp/open-bike-map-venv-current/bin/python -m unittest discover -s tools/OSM_Extract/tests -p 'test_building_relations.py' -v`
- `/tmp/open-bike-map-venv-current/bin/python -m unittest discover -s tools/OSM_Extract/tests -p 'test_building_pipeline.py' -v`
- `cd map-platform/backend && /tmp/open-bike-map-venv-current/bin/python -m unittest discover -s tests -p 'test_map_buildings.py' -v`
- `cd map-platform/backend && /tmp/open-bike-map-venv-current/bin/python -m unittest discover -s tests -p 'test_map_stream*.py' -v`
