### PR TITLE
Enable production target-3 map stream rollout

### DIFF
--- a/map-platform/backend/tests/test_api.py
+++ b/map-platform/backend/tests/test_api.py
@@ -484,9 +484,8 @@ class MapJobRunAPITests(unittest.TestCase):
         enabled = self.client.post("/v1/map-jobs", json=payload)
         self.assertEqual(enabled.status_code, 200)
 
-    def test_target_three_returns_typed_fallback_and_honors_allowlist(self):
-        allowed = self.client.post("/v1/installations").json()
-        blocked = self.client.post("/v1/installations").json()
+    def test_target_three_is_globally_available_after_production_promotion(self):
+        credential = self.client.post("/v1/installations").json()
         payload = {
             "mode": "custom_bbox",
             "bbox": [103.75, 1.24, 103.93, 1.37],
@@ -500,70 +499,18 @@ class MapJobRunAPITests(unittest.TestCase):
                 "preferredLanguages": ["en"],
                 "internationalFallback": "en",
             },
-            "clientInstallationId": blocked["clientInstallationId"],
-            "clientRequestId": "request-target3-blocked",
+            "clientInstallationId": credential["clientInstallationId"],
+            "clientRequestId": "request-target3-global",
         }
-        disabled_response = self.client.post(
+        response = self.client.post(
             "/v1/map-jobs",
-            headers={"X-Installation-Token": blocked["clientInstallationToken"]},
+            headers={"X-Installation-Token": credential["clientInstallationToken"]},
             json=payload,
         )
-        self.assertEqual(disabled_response.status_code, 400)
+        self.assertEqual(response.status_code, 200)
         self.assertEqual(
-            disabled_response.json()["detail"],
-            {
-                "code": "unsupported_renderer_target",
-                "message": "renderer format 3 generation is not available for this installation",
-                "requestedRendererFormatVersion": 3,
-                "supportedRendererFormatVersions": [2, 1],
-            },
-        )
-
-        with patch.dict(
-            os.environ,
-            {
-                "MAP_PLATFORM_BUILDING_TARGET3_ALLOWLIST": allowed[
-                    "clientInstallationId"
-                ],
-            },
-            clear=False,
-        ):
-            client = TestClient(create_app())
-            try:
-                blocked_response = client.post(
-                    "/v1/map-jobs",
-                    headers={"X-Installation-Token": blocked["clientInstallationToken"]},
-                    json=payload,
-                )
-                allowed_payload = {
-                    **payload,
-                    "clientInstallationId": allowed["clientInstallationId"],
-                    "clientRequestId": "request-target3-allowed",
-                }
-                allowed_response = client.post(
-                    "/v1/map-jobs",
-                    headers={"X-Installation-Token": allowed["clientInstallationToken"]},
-                    json=allowed_payload,
-                )
-            finally:
-                client.close()
-
-        self.assertEqual(blocked_response.status_code, 400)
-        self.assertEqual(
-            blocked_response.json()["detail"],
-            {
-                "code": "unsupported_renderer_target",
-                "message": "renderer format 3 generation is not available for this installation",
-                "requestedRendererFormatVersion": 3,
-                "supportedRendererFormatVersions": [2, 1],
-            },
-        )
-        self.assertEqual(allowed_response.status_code, 200)
-        allowed_job = self.client.app.state.job_store.get(
-            allowed_response.json()["jobId"]
-        )
-        self.assertEqual(
-            allowed_job.request["target"]["rendererFormatVersion"],
+            self.client.app.state.job_store.get(response.json()["jobId"])
+            .request["target"]["rendererFormatVersion"],
             3,
         )
 
@@ -593,7 +540,7 @@ class MapJobRunAPITests(unittest.TestCase):
                 profile["rendererFormatVersion"]
                 for profile in payload["generationProfiles"]
             ],
-            [2, 1],
+            [3, 2, 1],
         )
 
         with patch.dict(

--- a/map-platform/backend/tests/test_generation_profiles.py
+++ b/map-platform/backend/tests/test_generation_profiles.py
@@ -36,7 +36,7 @@ class GenerationProfilePolicyTests(unittest.TestCase):
                 profile.renderer_format_version
                 for profile in policy.available_profiles("production")
             ],
-            [2, 1],
+            [3, 2, 1],
         )
         self.assertEqual(
             [

--- a/map-platform/config/generation-profile-policy-v1.json
+++ b/map-platform/config/generation-profile-policy-v1.json
@@ -34,11 +34,10 @@
     "production": {
       "globalProfiles": [
         "legacy-vector-v1",
-        "street-labels-v1"
-      ],
-      "canaryProfiles": [
+        "street-labels-v1",
         "buildings-3d-v1"
-      ]
+      ],
+      "canaryProfiles": []
     }
   }
 }

--- a/map-platform/config/map-stream-rollout-approvals.json
+++ b/map-platform/config/map-stream-rollout-approvals.json
@@ -26,6 +26,32 @@
           "publicKeySha256": "ac8a2852fd7b608219d9c477f16aef3afecada504abbc5dedbe3c9c0e0b35c8b"
         }
       ]
+    },
+    {
+      "promotionId": "msr-20260821-target3-full",
+      "candidateGitSha": "4601abf6df57310f12b36ad682a5b2946c627c5d",
+      "producerBuildSha256": "7ba338050c792411be3025a57039e5317ffe2d691ec1b15728840ca6bfd2f601",
+      "workerImageDigest": "sha256:ccee49f00672002c5d7656c8d04ffc3326b9aec1ad75cdaa43a310c2db59f1c3",
+      "firmwareVersion": "0.3.3",
+      "firmwareBuild": 92,
+      "firmwareGitSha": "a3a77873311e5bb4074e01d7edef14d6457f1598",
+      "iosBuild": "15",
+      "iosGitSha": "a3a77873311e5bb4074e01d7edef14d6457f1598",
+      "iosBuildSha256": "2cea4736338da664bbec9c823732d39b4f9eb4f1e4709f2246e2bd0249d91bff",
+      "reportSha256": "ed724b7b1e7c0ae950feb0d98c3b2dd5c1f886d81b93bac67e7c3cd06edd18fb",
+      "requirementsSha256": "05e65f81f161d27bfd3f32f28fda42a5ca8519632d95846c6791b57a30dd08ae",
+      "approvedAt": "2026-08-21T10:43:36Z",
+      "approvedBy": "seichris",
+      "targets": [
+        "WAVESHARE_AMOLED_175",
+        "WAVESHARE_AMOLED_206"
+      ],
+      "signingKeys": [
+        {
+          "keyId": "map-prod-2026-07",
+          "publicKeySha256": "ac8a2852fd7b608219d9c477f16aef3afecada504abbc5dedbe3c9c0e0b35c8b"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary
- enable production generation profile format 3 globally
- add exact worker/image/client/signing approval for promotion `msr-20260821-target3-full`
- update API and profile tests for global target-3 availability

## Evidence
- production worker digest `sha256:ccee49f00672002c5d7656c8d04ffc3326b9aec1ad75cdaa43a310c2db59f1c3`
- backend-only target-3 canary produced and cryptographically verified a signed stream artifact
- no iPhone or physical firmware testing performed; optional hardware matrix is explicitly empty and residual risk is documented

The merge will trigger the immutable control-plane image promotion workflow; Coolify remains unchanged until that digest-pinned promotion is merged.