### PR TITLE
Prepare firmware 0.3.4 release

### DIFF
--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -15,8 +15,8 @@ default_envs = WAVESHARE_AMOLED_175
 [common]
 platform = espressif32@6.9.0
 framework = arduino
-version = 0.3.3
-revision = 92
+version = 0.3.4
+revision = 93
 monitor_speed = 115200
 ;monitor_rts = 0
 ;monitor_dtr = 0


### PR DESCRIPTION
## Summary

- bump firmware version from `0.3.3` to `0.3.4`
- bump firmware revision from `92` to `93`

This gives the merged ride-diagnostics firmware a new on-device and immutable-release identity before publishing `v0.3.4`.

## Validation

- parsed `esp32/platformio.ini` and asserted version `0.3.4`, revision `93`
- firmware production-profile contract test passed
- `git diff --check` passed

## Release qualification

Firmware-bearing commit `1e279f40d1d90e53af9025f367d6eee62e9316c5` was attested, hash-verified, flashed to the identified WAVESHARE_AMOLED_175, and confirmed working with the iPhone. The 2.06 target and the complete two-board fault/resource matrix remain CI-qualified rather than physically qualified in this run; at maintainer direction, that residual risk is accepted for the `v0.3.4` release.
