### PR TITLE
Give oversized diagnostic builds a larger app partition

### DIFF
--- a/esp32/partitions_remote_debug.csv
+++ b/esp32/partitions_remote_debug.csv
@@ -1,8 +1,8 @@
-# Remote-debug images include the renderer/input service and need more than an
-# ordinary 3 MiB OTA slot. They are development-only, USB-flashed images, so a
-# single 6 MiB app slot preserves the ordinary profile's FFat start at
-# 0x610000. Switching profiles therefore cannot relocate or format fallback
-# map/diagnostic data.
+# Large diagnostic images include extra renderer, input, or timing code and can
+# exceed an ordinary 3 MiB OTA slot. They are development-only, USB-flashed
+# images, so a single 6 MiB app slot preserves the ordinary profile's FFat
+# start at 0x610000. Switching profiles therefore cannot relocate or format
+# fallback map/diagnostic data.
 # Name,   Type, SubType, Offset, Size, Flags
 nvs,      data, nvs,     ,      0x5000,
 otadata,  data, ota,     ,      0x2000,

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -363,6 +363,7 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_175_MAPIO_DIAGNOSTICS]
 extends = env:WAVESHARE_AMOLED_175
+board_build.partitions = partitions_remote_debug.csv
 build_flags =
   ${env:WAVESHARE_AMOLED_175.build_flags}
   -DWAVESHARE_MAPIO_TIMING_LOG=1
@@ -454,6 +455,7 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS]
 extends = env:WAVESHARE_AMOLED_206
+board_build.partitions = partitions_remote_debug.csv
 build_flags =
   ${env:WAVESHARE_AMOLED_206.build_flags}
   -DWAVESHARE_MAPIO_TIMING_LOG=1

--- a/esp32/platformio.ini
+++ b/esp32/platformio.ini
@@ -310,6 +310,7 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_175_POWER_METRICS]
 extends = env:WAVESHARE_AMOLED_175
+board_build.partitions = partitions_remote_debug.csv
 build_flags =
   ${env:WAVESHARE_AMOLED_175.build_flags}
   -DPOWER_METRICS=1
@@ -409,6 +410,7 @@ build_flags =
 
 [env:WAVESHARE_AMOLED_206_POWER_METRICS]
 extends = env:WAVESHARE_AMOLED_206
+board_build.partitions = partitions_remote_debug.csv
 build_flags =
   ${env:WAVESHARE_AMOLED_206.build_flags}
   -DPOWER_METRICS=1

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -142,6 +142,21 @@ for environment, (base, target) in remote_debug_profiles.items():
     assert f"${{{base}.build_flags}}" in flags
     assert "-DDEVICE_REMOTE_DEBUG=1" in flags
 
+large_diagnostic_profiles = (
+    *remote_debug_profiles,
+    "env:WAVESHARE_AMOLED_175_MAPIO_DIAGNOSTICS",
+    "env:WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS",
+    "env:WAVESHARE_AMOLED_175_POWER_METRICS",
+    "env:WAVESHARE_AMOLED_206_POWER_METRICS",
+    "env:WAVESHARE_AMOLED_175_LIGHT_SLEEP",
+    "env:WAVESHARE_AMOLED_206_LIGHT_SLEEP",
+)
+for environment in large_diagnostic_profiles:
+    assert (
+        inherited_option(environment, "board_build.partitions")
+        == "partitions_remote_debug.csv"
+    )
+
 light_sleep_profiles = {
     "env:WAVESHARE_AMOLED_175_LIGHT_SLEEP": (
         "env:WAVESHARE_AMOLED_175_POWER_METRICS",

--- a/esp32/tools/tests/test_map_memory_diagnostics.py
+++ b/esp32/tools/tests/test_map_memory_diagnostics.py
@@ -55,6 +55,12 @@ class MapMemoryDiagnosticsTests(unittest.TestCase):
             "WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS",
         ):
             self.assertIn(f"[env:{profile}]", PLATFORMIO_SOURCE)
+            section = PLATFORMIO_SOURCE.split(f"[env:{profile}]", 1)[1].split(
+                "\n[", 1
+            )[0]
+            self.assertIn(
+                "board_build.partitions = partitions_remote_debug.csv", section
+            )
         self.assertGreaterEqual(
             PLATFORMIO_SOURCE.count("-DWAVESHARE_MAPIO_TIMING_LOG=1"), 2
         )


### PR DESCRIPTION
## Summary

- give MAPIO, power-metrics, and light-sleep diagnostic profiles the existing 6 MiB diagnostic app partition on both boards
- preserve the ordinary profile's FFat start at `0x610000`
- assert direct and inherited partition selection in profile regression tests

## Release blocker

The completed `v0.3.4` release run found five diagnostic images over the ordinary 3,145,728-byte application partition:

- 1.75 light sleep: 3,153,627 bytes
- 2.06 light sleep: 3,150,091 bytes
- 1.75 MAPIO: 3,151,275 bytes
- 2.06 MAPIO: 3,146,767 bytes
- 1.75 power metrics: 3,147,895 bytes

These are development-only USB-flashed diagnostic images. The existing single-app diagnostic layout provides 6,291,456 bytes while retaining the ordinary profile's fallback-storage boundary. The locally rebuilt 2.06 MAPIO image verifies at 50.0% of that slot.

## Verification

- `python3 esp32/tools/tests/test_map_memory_diagnostics.py`
- `python3 esp32/tools/tests/test_firmware_profile_config.py`
- `env -u LD_LIBRARY_PATH python3 esp32/tools/build_firmware.py WAVESHARE_AMOLED_206_MAPIO_DIAGNOSTICS`
- `git diff --check`

Failed release run: https://github.com/seichris/open-bike-computer/actions/runs/32691341672
