### PR TITLE
Allow map uploads during server processing

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -1592,6 +1592,8 @@ final class OfflineMapManager: ObservableObject {
     @Published private(set) var downloadByteProgress: OfflineMapByteProgress?
     @Published private(set) var transferProgress: Double = 0
     @Published private(set) var isBusy = false
+    @Published private(set) var isMapJobProcessing = false
+    @Published private(set) var isDeviceTransferBusy = false
     @Published private(set) var hasActiveBackgroundUpload = false
     @Published private(set) var isServerRecoveryCheckPending = false
     @Published private(set) var isMapAreaSelectionActive = false
@@ -1969,6 +1971,7 @@ final class OfflineMapManager: ObservableObject {
         mapJobTask?.cancel()
         mapJobTask = nil
         mapJobTaskID = nil
+        isMapJobProcessing = false
         clearPersistedJob(markHandled: true)
         currentJob = nil
         downloadURL = nil
@@ -2021,13 +2024,11 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func transferDownloadedPack(bleManager: BLEManager) {
-        Task {
-            await runBusy {
-                guard let packURL = self.downloadedPackURL else {
-                    throw OfflineMapPlatformError.missingDownloadURL
-                }
-                try await self.transferPack(at: packURL, bleManager: bleManager)
+        startDeviceTransfer { manager in
+            guard let packURL = manager.downloadedPackURL else {
+                throw OfflineMapPlatformError.missingDownloadURL
             }
+            try await manager.transferPack(at: packURL, bleManager: bleManager)
         }
     }
 
@@ -2076,14 +2077,12 @@ final class OfflineMapManager: ObservableObject {
         bleManager: BLEManager,
         resumePausedUpload: Bool
     ) {
-        Task {
-            await runBusy {
-                try await self.transferPack(
-                    at: packURL,
-                    bleManager: bleManager,
-                    resumePausedUpload: resumePausedUpload
-                )
-            }
+        startDeviceTransfer { manager in
+            try await manager.transferPack(
+                at: packURL,
+                bleManager: bleManager,
+                resumePausedUpload: resumePausedUpload
+            )
         }
     }
 
@@ -2622,6 +2621,7 @@ final class OfflineMapManager: ObservableObject {
         guard mapJobTask == nil else { return }
         let taskID = UUID()
         mapJobTaskID = taskID
+        isMapJobProcessing = true
         mapJobTask = Task { [weak self] in
             guard let self else { return }
             await runBusy {
@@ -2630,6 +2630,7 @@ final class OfflineMapManager: ObservableObject {
             if mapJobTaskID == taskID {
                 mapJobTask = nil
                 mapJobTaskID = nil
+                isMapJobProcessing = false
             }
         }
     }
@@ -3502,7 +3503,27 @@ final class OfflineMapManager: ObservableObject {
         guard let packURL = downloadedPackURL else {
             throw OfflineMapPlatformError.missingDownloadURL
         }
+        while isDeviceTransferBusy || hasActiveBackgroundUpload {
+            try Task.checkCancellation()
+            try await Task.sleep(nanoseconds: 100_000_000)
+        }
+        isDeviceTransferBusy = true
+        defer { isDeviceTransferBusy = false }
         try await transferPack(at: packURL, bleManager: bleManager)
+    }
+
+    private func startDeviceTransfer(
+        _ operation: @MainActor @escaping (OfflineMapManager) async throws -> Void
+    ) {
+        guard !isDeviceTransferBusy else { return }
+        isDeviceTransferBusy = true
+        Task { [weak self] in
+            guard let self else { return }
+            defer { self.isDeviceTransferBusy = false }
+            await self.runBusy {
+                try await operation(self)
+            }
+        }
     }
 
     private func transferPack(

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -731,6 +731,20 @@ nonisolated enum PausedMapUploadResumePolicy {
     }
 }
 
+nonisolated enum SavedMapDeviceTransferPolicy {
+    // Server-side preparation is independent; only device-side conflicts block transfer.
+    static func canStart(
+        isDeviceTransferBusy: Bool,
+        hasActiveBackgroundUpload: Bool,
+        isPausedUpload: Bool,
+        isNavigationReady: Bool
+    ) -> Bool {
+        !isDeviceTransferBusy &&
+            (isPausedUpload || !hasActiveBackgroundUpload) &&
+            isNavigationReady
+    }
+}
+
 struct OfflineMapJobGeometry: Decodable, Equatable {
     let mode: String
     let bounds: [Double]

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
@@ -126,7 +126,7 @@ struct OfflineMapsView: View {
                 Button(action: { manager.transferDownloadedPack(bleManager: bleManager) }) {
                     Label("Upload to Device", systemImage: "sdcard")
                 }
-                .disabled(manager.isBusy || !bleManager.isNavigationReady || manager.downloadedPackURL == nil)
+                .disabled(!canTransferDownloadedPack)
 
                 if manager.transferProgress > 0 && manager.transferProgress < 1 {
                     ProgressView(value: manager.transferProgress)
@@ -148,6 +148,16 @@ struct OfflineMapsView: View {
         }
         .navigationTitle("Offline Maps")
         .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var canTransferDownloadedPack: Bool {
+        guard let packURL = manager.downloadedPackURL else { return false }
+        return SavedMapDeviceTransferPolicy.canStart(
+            isDeviceTransferBusy: manager.isDeviceTransferBusy,
+            hasActiveBackgroundUpload: manager.hasActiveBackgroundUpload,
+            isPausedUpload: manager.isPausedMapUpload(packURL),
+            isNavigationReady: bleManager.isNavigationReady
+        )
     }
 
     private static func byteText(_ bytes: Int64) -> String {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -671,7 +671,14 @@ private struct DownloadingMapsSettingsSection: View {
                     .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .disabled(manager.isBusy || !bleManager.isNavigationReady)
+                .disabled(
+                    !SavedMapDeviceTransferPolicy.canStart(
+                        isDeviceTransferBusy: manager.isDeviceTransferBusy,
+                        hasActiveBackgroundUpload: manager.hasActiveBackgroundUpload,
+                        isPausedUpload: true,
+                        isNavigationReady: bleManager.isNavigationReady
+                    )
+                )
                 .accessibilityLabel("Resume map upload")
                 .accessibilityHint("Reconnects to the device Wi-Fi and resumes the saved map")
             } else if let activationProgress = manager.activationProgress {
@@ -747,7 +754,7 @@ private struct DownloadingMapsSettingsSection: View {
                     .foregroundColor(.red)
             }
 
-            if manager.isBusy, manager.hasPendingMapJob {
+            if manager.isMapJobProcessing, manager.hasPendingMapJob {
                 Button(role: .destructive) {
                     manager.pausePendingMapJob()
                 } label: {
@@ -1020,9 +1027,12 @@ private struct SavedMapRow: View {
                 }
                 .buttonStyle(.borderless)
                 .disabled(
-                    manager.isBusy ||
-                        (!isPausedUpload && manager.hasActiveBackgroundUpload) ||
-                        !bleManager.isNavigationReady
+                    !SavedMapDeviceTransferPolicy.canStart(
+                        isDeviceTransferBusy: manager.isDeviceTransferBusy,
+                        hasActiveBackgroundUpload: manager.hasActiveBackgroundUpload,
+                        isPausedUpload: isPausedUpload,
+                        isNavigationReady: bleManager.isNavigationReady
+                    )
                 )
                 .accessibilityLabel(
                     isPausedUpload

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -755,6 +755,7 @@ struct NavigationProtocolTests {
         testMapUploadProgressReconciliation()
         testOfflineMapDownloadingSectionPresentation()
         testOfflineMapActivityCounterOverlappingOperations()
+        testSavedMapDeviceTransferPolicy()
         testOfflineMapJobPersistence()
         testOfflineMapInstallationIdentity()
         testOfflineMapJobRecoverySelection()
@@ -6439,6 +6440,54 @@ struct NavigationProtocolTests {
         assert(!counter.isBusy, "busy state clears after the final operation finishes")
     }
 
+    static func testSavedMapDeviceTransferPolicy() {
+        assert(
+            SavedMapDeviceTransferPolicy.canStart(
+                isDeviceTransferBusy: false,
+                hasActiveBackgroundUpload: false,
+                isPausedUpload: false,
+                isNavigationReady: true
+            ),
+            "server map processing does not block an independent saved-map transfer"
+        )
+        assert(
+            !SavedMapDeviceTransferPolicy.canStart(
+                isDeviceTransferBusy: true,
+                hasActiveBackgroundUpload: false,
+                isPausedUpload: false,
+                isNavigationReady: true
+            ),
+            "a foreground device transfer blocks a second transfer"
+        )
+        assert(
+            !SavedMapDeviceTransferPolicy.canStart(
+                isDeviceTransferBusy: false,
+                hasActiveBackgroundUpload: true,
+                isPausedUpload: false,
+                isNavigationReady: true
+            ),
+            "a background upload blocks a different saved map"
+        )
+        assert(
+            SavedMapDeviceTransferPolicy.canStart(
+                isDeviceTransferBusy: false,
+                hasActiveBackgroundUpload: true,
+                isPausedUpload: true,
+                isNavigationReady: true
+            ),
+            "a paused upload remains resumable through background arbitration"
+        )
+        assert(
+            !SavedMapDeviceTransferPolicy.canStart(
+                isDeviceTransferBusy: false,
+                hasActiveBackgroundUpload: false,
+                isPausedUpload: false,
+                isNavigationReady: false
+            ),
+            "BLE navigation readiness remains required"
+        )
+    }
+
     @MainActor
     static func testPendingOfflineMapJobBlocksEveryCreationIngress() {
         let suite = "offline-map-pending-ingress-\(UUID().uuidString)"
@@ -8402,8 +8451,11 @@ struct NavigationProtocolTests {
             "deleting a saved map requires explicit confirmation"
         )
         assert(
-            source.contains("manager.hasActiveBackgroundUpload"),
-            "a restored upload disables conflicting saved-map upload and delete actions"
+            source.contains("SavedMapDeviceTransferPolicy.canStart(") &&
+                source.contains("isDeviceTransferBusy: manager.isDeviceTransferBusy") &&
+                source.contains("manager.hasActiveBackgroundUpload") &&
+                source.contains("if manager.isMapJobProcessing, manager.hasPendingMapJob"),
+            "map controls separate server work from conflicting device transfers"
         )
         assert(
             source.contains("SavedMapThumbnail(") &&


### PR DESCRIPTION
## Summary

- allow Saved Maps uploads while an unrelated server map job is preparing or downloading
- track server-job and device-transfer activity separately while preserving one device upload at a time
- wait before an automatic device install if another map transfer is still active
- add regression coverage for BLE readiness, foreground transfers, background uploads, and paused-upload resume

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- complete iPhone app Swift source type-check for the iOS 16.4 simulator target
- `git diff --check`

The local project-level `xcodebuild` build service stalled during pre-compilation tool discovery; no Swift compiler error was emitted. GitHub CI remains the full-project build gate.