### PR TITLE
Verify Singapore building relation closure

### DIFF
--- a/docs/plans/shanghai-city-scale-3d-map-orchestration-implementation-plan.md
+++ b/docs/plans/shanghai-city-scale-3d-map-orchestration-implementation-plan.md
@@ -139,10 +139,13 @@ and 26,285 nodes), so neither the relation-object ceiling nor host RAM was the
 cause. Reproducing the preserved clipped PBF showed source relation `r11258294`
 (`Guangfulin Culture Exhibition Hall`) is tagged `type=building` but contains
 only a `part` member and no outline. That is an invalid/incomplete relation and
-is not eligible for the general relation policy. The reviewed narrow fallback
-now retains a single direct way member as a standalone part only when that way
-itself is explicitly tagged `building=yes`; ambiguous, multi-part, or untagged
-cases remain fail-closed. The worker
+is not eligible for the general relation policy. At that historical checkpoint,
+the fallback retained a single direct way member
+as a standalone part only when that way itself was explicitly tagged
+`building=yes`; ambiguous, multi-part, or untagged cases remained fail-closed.
+PR #278 later broadened this identity-versioned fallback to unambiguous
+incomplete relations whose direct members are all explicitly tagged
+`building=yes` or `building:part=yes`. The worker
 cgroup peaked at 6,121,091,072 bytes during the final retry, with no OOM event;
 the prior generic task error also exposed a diagnostics gap. The follow-up
 pipeline change parses typed conversion failures in chunk execution and stores
@@ -1327,10 +1330,12 @@ A subsequent image's relation-heavy validation probe
 `a932f748a388475ca0e1` (26.537229464 km² around Guangfulin) reached
 `ready` with 4/4 receipts, an 894,886-byte ZIP, and artifact SHA-256
 `9f88a32fa8ef4274cd0e0ca330d55fe77f397afa90721bf146b71029607ec2e1`.
-This confirms the reviewed narrow fallback: a malformed `type=building`
-relation with exactly one direct way explicitly tagged `building=yes` is
+This confirms the then-active narrow fallback: a malformed `type=building`
+relation with exactly one direct way explicitly tagged `building=yes` was
 retained as a standalone part; ambiguous, multi-part, and untagged cases still
-fail closed. The exact full-bbox retry `c2b1ae53bede438ab02e` was then run
+failed closed. The later #278 policy also accepts an unambiguous multi-part
+relation when every direct way is explicitly tagged `building=yes` or
+`building:part=yes`. The exact full-bbox retry `c2b1ae53bede438ab02e` was then run
 against the cached China parent snapshot as a 16-chunk, 442-block cold
 acceptance benchmark. Its first two chunks published 48 receipts with no
 retries or splits before the calibration edge failure described below; the

--- a/docs/runbooks/shanghai-3d-map-orchestration.md
+++ b/docs/runbooks/shanghai-3d-map-orchestration.md
@@ -202,10 +202,13 @@ parts but no outline (for example, `source relation r11258294 ...`). Preserve
 that detail from the public job error and preserve it with the immutable source
 snapshot identity. Do not silently drop
 the relation or promote a higher closure limit. The exact full-bbox job may
-proceed under the identity-versioned narrow policy only when the relation has
-one direct way member whose source way is explicitly tagged `building=yes`.
-All ambiguous, multi-part, or untagged relations still require corrected
-source data or an explicit product-policy review.
+proceed under the identity-versioned narrow policy when every direct relation
+member is a way explicitly tagged `building=yes` or
+`building:part=yes`, each member belongs only to that incomplete relation, and
+none is already associated with another building relation. Those ways are
+retained as standalone target-3 parts. Ambiguous, nested, shared, or untagged
+relations still require corrected source data or an explicit product-policy
+review.
 
 ## Completion checks
 

--- a/tools/OSM_Extract/scripts/extract_building_relations.py
+++ b/tools/OSM_Extract/scripts/extract_building_relations.py
@@ -132,9 +132,10 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         """Apply the narrow standalone-part normalization after all ways arrive.
 
         OSM objects are normally delivered ways before relations, but the
-        policy must not depend on callback order. Only a single direct way
-        member with an explicit ``building`` tag qualifies. Any part shared
-        with another malformed relation remains fail-closed rather than being
+        policy must not depend on callback order. Every direct member must be
+        a way with an explicit ``building`` or ``building:part`` tag. Parts
+        shared with another incomplete relation, or already associated with a
+        different building relation, remain fail-closed rather than being
         silently reinterpreted.
         """
 
@@ -166,7 +167,7 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         unsafe_parts.update(
             part
             for part, count in relation_part_counts.items()
-            if count != 1 or part in self.part_parents
+            if count != 1 or part in self.part_parents or part in self.parent_tags
         )
         safe_relations = {
             relation_key

--- a/tools/OSM_Extract/tests/fixtures/singapore_r14346906.osm
+++ b/tools/OSM_Extract/tests/fixtures/singapore_r14346906.osm
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="open-bike-computer-tests">
+  <node id="101" lat="1.30940" lon="103.86450" version="1" />
+  <node id="102" lat="1.30940" lon="103.86480" version="1" />
+  <node id="103" lat="1.30960" lon="103.86480" version="1" />
+  <node id="104" lat="1.30960" lon="103.86450" version="1" />
+  <node id="105" lat="1.30940" lon="103.86485" version="1" />
+  <node id="106" lat="1.30940" lon="103.86510" version="1" />
+  <node id="107" lat="1.30960" lon="103.86510" version="1" />
+  <node id="108" lat="1.30960" lon="103.86485" version="1" />
+  <node id="109" lat="1.30940" lon="103.86515" version="1" />
+  <node id="110" lat="1.30940" lon="103.86540" version="1" />
+  <node id="111" lat="1.30960" lon="103.86540" version="1" />
+  <node id="112" lat="1.30960" lon="103.86515" version="1" />
+  <node id="113" lat="1.30965" lon="103.86450" version="1" />
+  <node id="114" lat="1.30965" lon="103.86480" version="1" />
+  <node id="115" lat="1.30990" lon="103.86480" version="1" />
+  <node id="116" lat="1.30990" lon="103.86450" version="1" />
+  <node id="117" lat="1.30965" lon="103.86485" version="1" />
+  <node id="118" lat="1.30965" lon="103.86510" version="1" />
+  <node id="119" lat="1.30990" lon="103.86510" version="1" />
+  <node id="120" lat="1.30990" lon="103.86485" version="1" />
+
+  <way id="1077928781" version="1">
+    <nd ref="101" /><nd ref="102" /><nd ref="103" /><nd ref="104" /><nd ref="101" />
+    <tag k="building:colour" v="green" />
+    <tag k="building:levels" v="5" />
+    <tag k="building:material" v="concrete" />
+    <tag k="building:part" v="yes" />
+    <tag k="roof:colour" v="grey" />
+  </way>
+  <way id="1077928782" version="1">
+    <nd ref="105" /><nd ref="106" /><nd ref="107" /><nd ref="108" /><nd ref="105" />
+    <tag k="building:colour" v="brown" />
+    <tag k="building:levels" v="5.5" />
+    <tag k="building:part" v="yes" />
+    <tag k="roof:colour" v="grey" />
+    <tag k="roof:levels" v="1" />
+    <tag k="roof:shape" v="pyramidal" />
+  </way>
+  <way id="1077928783" version="1">
+    <nd ref="109" /><nd ref="110" /><nd ref="111" /><nd ref="112" /><nd ref="109" />
+    <tag k="building:colour" v="grey" />
+    <tag k="building:levels" v="5" />
+    <tag k="building:material" v="concrete" />
+    <tag k="building:part" v="yes" />
+  </way>
+  <way id="1077928784" version="1">
+    <nd ref="113" /><nd ref="114" /><nd ref="115" /><nd ref="116" /><nd ref="113" />
+    <tag k="building:colour" v="brown" />
+    <tag k="building:levels" v="12" />
+    <tag k="building:min_level" v="11" />
+    <tag k="building:part" v="yes" />
+    <tag k="roof:colour" v="grey" />
+    <tag k="roof:levels" v="1" />
+    <tag k="roof:shape" v="pyramidal" />
+  </way>
+  <way id="1077928785" version="1">
+    <nd ref="117" /><nd ref="118" /><nd ref="119" /><nd ref="120" /><nd ref="117" />
+    <tag k="building:colour" v="beige" />
+    <tag k="building:levels" v="11" />
+    <tag k="building:material" v="concrete" />
+    <tag k="building:part" v="yes" />
+    <tag k="roof:colour" v="grey" />
+    <tag k="roof:material" v="concrete" />
+  </way>
+
+  <relation id="14346906" version="1">
+    <member type="way" ref="1077928784" role="part" />
+    <member type="way" ref="1077928782" role="part" />
+    <member type="way" ref="1077928781" role="part" />
+    <member type="way" ref="1077928785" role="part" />
+    <member type="way" ref="1077928783" role="part" />
+    <tag k="addr:city" v="Singapore" />
+    <tag k="addr:country" v="SG" />
+    <tag k="addr:housenumber" v="20" />
+    <tag k="addr:postcode" v="339411" />
+    <tag k="addr:street" v="Kallang Avenue" />
+    <tag k="building" v="commercial" />
+    <tag k="height" v="0" />
+    <tag k="name" v="Pico Creative Centre" />
+    <tag k="type" v="building" />
+  </relation>
+</osm>

--- a/tools/OSM_Extract/tests/test_building_pipeline.py
+++ b/tools/OSM_Extract/tests/test_building_pipeline.py
@@ -141,6 +141,43 @@ class BuildingPipelineTests(unittest.TestCase):
         self.assertEqual(report["standaloneRelationPartCount"], 1)
         self.assertEqual(report["containmentAssociationCount"], 0)
 
+    def test_singapore_relation_parts_emit_five_target3_buildings(self):
+        members = [
+            feature(
+                1_077_928_781 + index,
+                box(100 + index * 40, 100, 130 + index * 40, 130),
+                '"building:part"=>"yes","building:levels"=>"5"',
+                building=None,
+            )
+            for index in range(5)
+        ]
+        standalone_keys = [
+            f"w{1_077_928_781 + index}" for index in range(5)
+        ]
+
+        buildings, report, _flat = prepare_buildings(
+            members,
+            self.rules,
+            {"standalonePartKeys": standalone_keys},
+            strict_relations=True,
+        )
+        records, stats = clip_buildings(
+            buildings,
+            box(0, 0, 400, 400),
+            0,
+            0,
+        )
+        section, metadata = _building_section(records)
+
+        self.assertEqual(len(buildings), 5)
+        self.assertEqual(report["standaloneRelationPartCount"], 5)
+        self.assertEqual(len(records), 5)
+        self.assertEqual(metadata["buildings"], 5)
+        self.assertGreater(metadata["buildingPoints"], 0)
+        self.assertGreater(metadata["buildingBytes"], 16)
+        self.assertEqual(metadata["buildingBytes"], len(section))
+        self.assertGreater(stats["emittedWallCount"], 0)
+
     def test_complexity_snapshot_precedes_containment_and_is_bounded(self):
         outline = feature(1, box(0, 0, 100, 100), '"building"=>"yes"')
         part = feature(

--- a/tools/OSM_Extract/tests/test_building_relations.py
+++ b/tools/OSM_Extract/tests/test_building_relations.py
@@ -23,6 +23,9 @@ from extract_building_relations import (  # noqa: E402
 
 ROOT = Path(__file__).resolve().parents[1]
 FIXTURE = Path(__file__).resolve().parent / "fixtures" / "building_relations.osm"
+SINGAPORE_FIXTURE = (
+    Path(__file__).resolve().parent / "fixtures" / "singapore_r14346906.osm"
+)
 SCRIPT = ROOT / "scripts" / "extract_building_relations.py"
 
 
@@ -188,6 +191,145 @@ class BuildingRelationIngressTests(unittest.TestCase):
 
         self.assertEqual(handler.standalone_part_keys, {"w31", "w32"})
         self.assertFalse(handler.parts_without_outline)
+
+    def test_unoutlined_relation_with_shared_part_remains_fail_closed(self):
+        handler = BuildingRelationHandler(
+            expected_closure={
+                "requiredRelationKeys": ["r109", "r110"],
+                "requiredWayKeys": ["w33"],
+            }
+        )
+
+        class Tags(list):
+            def get(self, key):
+                return next((tag.v for tag in self if tag.k == key), None)
+
+        handler.way(
+            SimpleNamespace(
+                id=33,
+                nodes=[],
+                tags=Tags([SimpleNamespace(k="building:part", v="yes")]),
+            )
+        )
+        for relation_id in (109, 110):
+            handler.relation(
+                self.relation(
+                    relation_id,
+                    [{"type": "w", "ref": 33, "role": "part"}],
+                )
+            )
+        handler.finalize()
+
+        self.assertFalse(handler.standalone_part_keys)
+        self.assertEqual(handler.parts_without_outline, {"w33"})
+
+    def test_unoutlined_part_reused_as_outline_remains_fail_closed(self):
+        handler = BuildingRelationHandler(
+            expected_closure={
+                "requiredRelationKeys": ["r111", "r112"],
+                "requiredWayKeys": ["w33", "w34"],
+            }
+        )
+
+        class Tags(list):
+            def get(self, key):
+                return next((tag.v for tag in self if tag.k == key), None)
+
+        for way_id in (33, 34):
+            handler.way(
+                SimpleNamespace(
+                    id=way_id,
+                    nodes=[],
+                    tags=Tags([SimpleNamespace(k="building:part", v="yes")]),
+                )
+            )
+        handler.relation(
+            self.relation(
+                111,
+                [
+                    {"type": "w", "ref": 33, "role": "outline"},
+                    {"type": "w", "ref": 34, "role": "part"},
+                ],
+            )
+        )
+        handler.relation(
+            self.relation(
+                112,
+                [{"type": "w", "ref": 33, "role": "part"}],
+            )
+        )
+        handler.finalize()
+
+        self.assertFalse(handler.standalone_part_keys)
+        self.assertEqual(handler.parts_without_outline, {"w33"})
+
+    def test_singapore_r14346906_fixture_passes_exact_scope_closure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source_sha = hashlib.sha256(SINGAPORE_FIXTURE.read_bytes()).hexdigest()
+            index = BuildingSourceIndex(root / "cache", source_sha)
+            index.build_with_scanner(
+                lambda path: scan_source(SINGAPORE_FIXTURE, path)
+            )
+            scope = {
+                "schemaVersion": 1,
+                "policy": {
+                    "relationClosureMode": "source_snapshot_index",
+                    "maxRelationObjectsPerJob": 1_000,
+                },
+                # plan_building_scope for bbox [103.852, 1.302, 103.858, 1.308].
+                "outputBlocks": [
+                    {
+                        "x": 2822,
+                        "y": 35,
+                        "boundsMeters": [11558912, 143360, 11563008, 147456],
+                    }
+                ],
+                "calibration": {"cellSizeMeters": 8192, "haloCells": 1},
+            }
+            scope_path = root / "scope.json"
+            scope_path.write_bytes(
+                canonical_json(
+                    {
+                        **scope,
+                        "scopePlanSha256": hashlib.sha256(
+                            canonical_json(scope)
+                        ).hexdigest(),
+                    }
+                )
+            )
+            output = root / "relation-index.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(SINGAPORE_FIXTURE),
+                    str(output),
+                    "--source-index-manifest",
+                    str(index.manifest_path),
+                    "--scope-plan",
+                    str(scope_path),
+                ],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            value = json.loads(output.read_text())
+            self.assertEqual(
+                value["standalonePartKeys"],
+                [
+                    "w1077928781",
+                    "w1077928782",
+                    "w1077928783",
+                    "w1077928784",
+                    "w1077928785",
+                ],
+            )
+            self.assertEqual(value["closureAudit"]["closureRelationCount"], 1)
+            self.assertEqual(value["closureAudit"]["closureWayCount"], 5)
+            self.assertEqual(value["closureAudit"]["closureNodeCount"], 20)
+            self.assertEqual(value["closureAudit"]["relationRetryCount"], 0)
 
     def test_cli_indexes_real_osm_building_relations_deterministically(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- add an exact bounded fixture for relation `r14346906` with all five explicit `building:part` ways
- preserve fail-closed behavior for shared parts and parts reused as another relation's outline
- verify source-index closure and downstream target-3 FMB emission for all five standalone parts
- update the runbook and historical plan to document the identity-versioned multi-part fallback introduced by PR #278

## Validation
- `python3 -m unittest discover -s tools/OSM_Extract/tests -p 'test_*.py' -v`: 137 passed; one target-3 OGR test is blocked by the local Homebrew `libheif`/`x265` dylib environment
- focused relation suite: 12 passed
- focused building pipeline suite: 20 passed
- `git diff --check` and Python compilation pass

Issue: #282
