### PR TITLE
Handle multi-outline building relations

### DIFF
--- a/docs/runbooks/shanghai-3d-map-orchestration.md
+++ b/docs/runbooks/shanghai-3d-map-orchestration.md
@@ -210,6 +210,18 @@ retained as standalone target-3 parts. Ambiguous, nested, shared, or untagged
 relations still require corrected source data or an explicit product-policy
 review.
 
+Multiple explicit `outline` members within one otherwise complete
+`type=building` relation are handled separately from cross-relation ambiguity.
+The extractor preserves the declared outline set and the geometry stage must
+select a containing parent from that set. It fails closed if a declared
+candidate is missing, none contains the part within the relation-only 25 cm
+boundary tolerance, or the part belongs to more than one building relation.
+When GDAL suppresses a sole outer way in favor of its building multipolygon,
+the relation index restores the relation geometry under the declared outline
+way identity; missing or non-unique providers remain errors. Error details for
+shared parts name the actual part, candidate outlines, and relation IDs; do not
+infer the culprit from an unrelated outline-less relation in the same closure.
+
 ## Completion checks
 
 Before accepting a Shanghai job's server-side ZIP as ready, verify all of the

--- a/tools/OSM_Extract/README.md
+++ b/tools/OSM_Extract/README.md
@@ -154,6 +154,19 @@ to strict relation processing; ordinary legacy conversions retain GDAL's
 default filtering, and unrelated tagless ways are rejected by building
 collection.
 
+A `type=building` relation may declare several explicit `outline` members for
+one building complex. Those members are not competing relations: the relation
+index records them as the only allowed parent candidates for each part, and
+the spatial association stage selects the smallest declared outline that
+contains the part. Explicit relation candidates permit up to 25 cm of boundary
+drift to accommodate nearly coincident OSM rings; ordinary inferred
+containment keeps its 5 cm tolerance. If GDAL suppresses a sole closed outer
+way because it also emits an enclosing building multipolygon, the relation
+index restores that exact relation geometry under the way's outline identity.
+A missing or non-unique geometry provider, a part outside every declared
+outline tolerance, or a part shared across different building relations still
+fails closed.
+
 Buildings are clipped only when FMB blocks are emitted; new clip edges receive
 a cleared wall bit so adjacent blocks do not render artificial seam facades.
 Plan-aware builds cache the canonical FMB building section for each global

--- a/tools/OSM_Extract/scripts/building_pipeline.py
+++ b/tools/OSM_Extract/scripts/building_pipeline.py
@@ -48,6 +48,7 @@ from map_format import MAX_BUILDING_RINGS
 BUILDING_PROFILE_VERSION = 1
 BUILDING_FLAG_PART = 1 << 0
 BUILDING_FLAG_FLAT_BASE = 1 << 1
+RELATION_PARENT_TOLERANCE_METERS = 0.25
 RING_FLAG_HOLE = 1 << 0
 EARTH_RADIUS_METERS = 6_378_137
 MAX_BUILDING_COMPLEXITY_PRODUCT = 9_000_000_000_000_000
@@ -74,8 +75,11 @@ class OutlineSpatialIndex:
     STRtree only removes outlines whose envelopes cannot possibly contain a
     part. The exact legacy predicates and tie-breaking remain authoritative,
     so replacing the previous all-outlines scan cannot change associations.
-    Prepared 5 cm buffers are materialized only for envelope candidates and
-    retained for the rest of the request.
+    Prepared buffers are materialized only for envelope candidates and
+    retained for the rest of the request. Ordinary inferred containment keeps
+    the legacy exact envelope predicate and 5 cm geometry buffer; explicit
+    relation candidates allow 25 cm of envelope and geometry tolerance for
+    small source-boundary drift.
     """
 
     def __init__(self, outlines: Iterable[SourceBuilding]):
@@ -88,7 +92,7 @@ class OutlineSpatialIndex:
         self._indices_by_geometry_wkb: dict[bytes, list[int]] = defaultdict(list)
         for index, geometry in enumerate(self.envelopes):
             self._indices_by_geometry_wkb[geometry.wkb].append(index)
-        self._prepared: dict[int, Any] = {}
+        self._prepared: dict[tuple[int, float], Any] = {}
         self.query_count = 0
         self.spatial_candidate_count = 0
         self.envelope_candidate_count = 0
@@ -116,21 +120,43 @@ class OutlineSpatialIndex:
             indices.update(self._indices_by_geometry_wkb.get(candidate.wkb, ()))
         return sorted(indices)
 
-    def containment_parent(self, part: SourceBuilding) -> str | None:
+    def containment_parent(
+        self,
+        part: SourceBuilding,
+        *,
+        allowed_keys: set[str] | None = None,
+        tolerance_meters: float = 0.05,
+        envelope_tolerance_meters: float = 0.0,
+    ) -> str | None:
         self.query_count += 1
         part_envelope = part.geometry.envelope
-        indices = self._query_indices(part_envelope)
+        query_envelope = (
+            part_envelope.buffer(envelope_tolerance_meters)
+            if envelope_tolerance_meters
+            else part_envelope
+        )
+        indices = self._query_indices(query_envelope)
         self.spatial_candidate_count += len(indices)
         candidates: list[SourceBuilding] = []
         for index in indices:
             outline = self.outlines[index]
-            if not self.envelopes[index].covers(part_envelope):
+            if allowed_keys is not None and outline.object_key not in allowed_keys:
+                continue
+            min_x, min_y, max_x, max_y = self.envelopes[index].bounds
+            part_min_x, part_min_y, part_max_x, part_max_y = part_envelope.bounds
+            if (
+                part_min_x < min_x - envelope_tolerance_meters
+                or part_min_y < min_y - envelope_tolerance_meters
+                or part_max_x > max_x + envelope_tolerance_meters
+                or part_max_y > max_y + envelope_tolerance_meters
+            ):
                 continue
             self.envelope_candidate_count += 1
-            prepared = self._prepared.get(index)
+            prepared_key = (index, tolerance_meters)
+            prepared = self._prepared.get(prepared_key)
             if prepared is None:
-                prepared = prep(outline.geometry.buffer(0.05))
-                self._prepared[index] = prepared
+                prepared = prep(outline.geometry.buffer(tolerance_meters))
+                self._prepared[prepared_key] = prepared
             if prepared.covers(part.geometry):
                 candidates.append(outline)
         if not candidates:
@@ -145,7 +171,9 @@ class OutlineSpatialIndex:
             "containmentQueryCount": self.query_count,
             "containmentSpatialCandidateCount": self.spatial_candidate_count,
             "containmentEnvelopeCandidateCount": self.envelope_candidate_count,
-            "containmentPreparedOutlineCount": len(self._prepared),
+            "containmentPreparedOutlineCount": len(
+                {index for index, _tolerance in self._prepared}
+            ),
         }
 
 
@@ -174,6 +202,8 @@ def load_relation_index(
         }
     value = json.loads(path.read_text(encoding="utf-8"))
     standalone_part_keys = value.get("standalonePartKeys", [])
+    part_parent_candidates = value.get("partParentCandidates", {})
+    parent_geometry_sources = value.get("parentGeometrySources", {})
     closure = value.get("closureAudit")
     closure_count_fields = {
         "closureRelationCount",
@@ -207,6 +237,8 @@ def load_relation_index(
         not isinstance(value, dict)
         or value.get("schemaVersion") != 1
         or not isinstance(value.get("partParents"), dict)
+        or not isinstance(part_parent_candidates, dict)
+        or not isinstance(parent_geometry_sources, dict)
         or not isinstance(standalone_part_keys, list)
         or any(
             not isinstance(key, str)
@@ -221,6 +253,38 @@ def load_relation_index(
             or not parent.startswith(("w", "r"))
             for child, parent in value.get("partParents", {}).items()
         )
+        or any(
+            not isinstance(child, str)
+            or not child.startswith(("w", "r"))
+            or child in value.get("partParents", {})
+            or child in standalone_part_keys
+            or not isinstance(parents, list)
+            or len(parents) < 2
+            or parents != sorted(set(parents))
+            or any(
+                not isinstance(parent, str)
+                or not parent.startswith(("w", "r"))
+                for parent in parents
+            )
+            for child, parents in part_parent_candidates.items()
+        )
+        or any(
+            not isinstance(parent, str)
+            or not parent.startswith("w")
+            or parent not in {
+                *value.get("partParents", {}).values(),
+                *(
+                    candidate
+                    for candidates in part_parent_candidates.values()
+                    for candidate in candidates
+                ),
+            }
+            or not isinstance(source, str)
+            or not source.startswith("r")
+            for parent, source in parent_geometry_sources.items()
+        )
+        or len(set(parent_geometry_sources.values()))
+        != len(parent_geometry_sources)
         or not isinstance(value.get("parentTags", {}), dict)
         or any(
             not isinstance(parent, str)
@@ -260,6 +324,12 @@ def collect_building_features(
     """
     collected = list(polygon_features)
     part_parents = dict((relation_index or {}).get("partParents", {}))
+    part_parent_candidates = dict(
+        (relation_index or {}).get("partParentCandidates", {})
+    )
+    parent_geometry_sources = dict(
+        (relation_index or {}).get("parentGeometrySources", {})
+    )
     standalone_part_keys = set(
         (relation_index or {}).get("standalonePartKeys", ())
     )
@@ -268,6 +338,12 @@ def collect_building_features(
         for key in {
             *part_parents,
             *part_parents.values(),
+            *part_parent_candidates,
+            *(
+                parent
+                for parents in part_parent_candidates.values()
+                for parent in parents
+            ),
             *standalone_part_keys,
         }
         if key.startswith("w")
@@ -325,6 +401,53 @@ def collect_building_features(
             }
         )
         known_keys.add(object_key)
+
+    features_by_key = {
+        source_object_key(properties): feature
+        for feature in collected
+        if isinstance((properties := feature.get("properties")), Mapping)
+    }
+    required_relationship_keys = {
+        *part_parents,
+        *part_parents.values(),
+        *part_parent_candidates,
+        *(
+            parent
+            for parents in part_parent_candidates.values()
+            for parent in parents
+        ),
+        *standalone_part_keys,
+    }
+    replaced_geometry_sources: set[str] = set()
+    for parent, geometry_source in sorted(parent_geometry_sources.items()):
+        if geometry_source not in features_by_key:
+            continue
+        if parent in features_by_key:
+            if geometry_source not in required_relationship_keys:
+                replaced_geometry_sources.add(geometry_source)
+            continue
+        source_feature = features_by_key[geometry_source]
+        cloned = {
+            **source_feature,
+            # Use only the restored way identity. The extractor supplies the
+            # target outline's exact tags via parentTags; retaining the
+            # multipolygon provider's tags could incorrectly turn the clone
+            # into a building part.
+            "properties": {"osm_way_id": parent[1:]},
+        }
+        collected.append(cloned)
+        features_by_key[parent] = cloned
+        if geometry_source not in required_relationship_keys:
+            replaced_geometry_sources.add(geometry_source)
+    if replaced_geometry_sources:
+        collected = [
+            feature
+            for feature in collected
+            if not (
+                isinstance((properties := feature.get("properties")), Mapping)
+                and source_object_key(properties) in replaced_geometry_sources
+            )
+        ]
     return collected
 
 
@@ -354,11 +477,21 @@ def prepare_buildings(
         )
     diagnostics: dict[str, int] = {}
     part_parents = dict((relation_index or {}).get("partParents", {}))
+    part_parent_candidates = {
+        child: tuple(parents)
+        for child, parents in (relation_index or {})
+        .get("partParentCandidates", {})
+        .items()
+    }
     standalone_part_keys = set(
         (relation_index or {}).get("standalonePartKeys", ())
     )
     parent_tags = dict((relation_index or {}).get("parentTags", {}))
-    explicit_parent_keys = set(part_parents.values())
+    explicit_parent_keys = set(part_parents.values()) | {
+        parent
+        for parents in part_parent_candidates.values()
+        for parent in parents
+    }
     sources: list[SourceBuilding] = []
     for feature in features:
         properties = feature.get("properties")
@@ -373,6 +506,7 @@ def prepare_buildings(
             diagnostics,
             explicit_part=(
                 object_key in part_parents
+                or object_key in part_parent_candidates
                 or object_key in standalone_part_keys
             ),
             explicit_parent=object_key in explicit_parent_keys,
@@ -419,26 +553,55 @@ def prepare_buildings(
             continue
         parent_key = part_parents.get(source.object_key)
         association = "relation" if parent_key in by_key else "none"
+        used_containment = False
         if parent_key is not None and association == "none" and strict_relations:
             raise CalibrationCacheError(
                 "building_relation_incomplete",
                 "an explicit building parent is missing from converted geometry",
             )
-        if parent_key is None:
+        candidate_keys = part_parent_candidates.get(source.object_key)
+        if candidate_keys is not None:
+            available_candidates = {
+                key
+                for key in candidate_keys
+                if key in by_key and not by_key[key].is_part
+            }
+            if strict_relations and len(available_candidates) != len(candidate_keys):
+                raise CalibrationCacheError(
+                    "building_relation_incomplete",
+                    "a declared building parent candidate is missing from converted geometry",
+                )
+            parent_key = containment_index.containment_parent(
+                source,
+                allowed_keys=available_candidates,
+                tolerance_meters=RELATION_PARENT_TOLERANCE_METERS,
+                envelope_tolerance_meters=RELATION_PARENT_TOLERANCE_METERS,
+            )
+            association = "relation" if parent_key is not None else "none"
+            if strict_relations and parent_key is None:
+                raise CalibrationCacheError(
+                    "building_relation_incomplete",
+                    "a building part is not contained by any declared parent candidate",
+                )
+            associated_unresolved_parts += 1
+            used_containment = True
+        elif parent_key is None:
             parent_key = containment_index.containment_parent(source)
             association = "containment" if parent_key is not None else "none"
             associated_unresolved_parts += 1
-            if (
-                on_association_progress is not None
-                and (
-                    associated_unresolved_parts == unresolved_parts
-                    or associated_unresolved_parts % progress_interval == 0
-                )
-            ):
-                on_association_progress(
-                    associated_unresolved_parts,
-                    unresolved_parts,
-                )
+            used_containment = True
+        if (
+            used_containment
+            and on_association_progress is not None
+            and (
+                associated_unresolved_parts == unresolved_parts
+                or associated_unresolved_parts % progress_interval == 0
+            )
+        ):
+            on_association_progress(
+                associated_unresolved_parts,
+                unresolved_parts,
+            )
         associated.append(replace(source, parent_key=parent_key, association=association))
     sources = associated
     by_key = {source.object_key: source for source in sources}

--- a/tools/OSM_Extract/scripts/extract_building_relations.py
+++ b/tools/OSM_Extract/scripts/extract_building_relations.py
@@ -38,6 +38,11 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         self.building_relations: set[str] = set()
         self.way_tags: dict[str, dict[str, str]] = {}
         self.part_parent_candidates: dict[str, set[str]] = {}
+        self.part_parent_relations: dict[str, set[str]] = {}
+        self.deferred_part_parent_candidates: dict[str, tuple[str, ...]] = {}
+        self.parent_geometry_source_candidates: dict[str, set[str]] = {}
+        self.parent_geometry_sources: dict[str, str] = {}
+        self._ambiguous_parent_keys: set[str] = set()
         self.parts_without_outline: set[str] = set()
         # Keep the relation identity alongside the legacy part set. The set is
         # used for closure intersection; this detail map makes a fail-closed
@@ -77,6 +82,26 @@ class BuildingRelationHandler(osmium.SimpleHandler):
             ]
             if is_building_relation(relation_tags):
                 self.building_relations.add(relation_key)
+            outer_members = [
+                member_key(member)
+                for member in relation.members
+                if member.role == "outer" and member.type == "w"
+            ]
+            # GDAL emits a building multipolygon as the relation geometry and
+            # can suppress its sole closed outer way even with
+            # report_all_ways=yes. Remember that exact one-ring geometry
+            # provider so an explicit type=building outline can be restored
+            # under its own way identity after conversion. Multi-outer
+            # relations remain fail-closed because no one relation geometry
+            # can safely stand in for an individual outer member.
+            if (
+                relation_tags.get("type") == "multipolygon"
+                and is_building_relation(relation_tags)
+                and len(outer_members) == 1
+            ):
+                self.parent_geometry_source_candidates.setdefault(
+                    outer_members[0], set()
+                ).add(relation_key)
         if relation.tags.get("type") != "building":
             return
         outlines = sorted(
@@ -108,25 +133,30 @@ class BuildingRelationHandler(osmium.SimpleHandler):
                 self.incomplete_relation_parts[relation_key] = tuple(parts)
             return
         self.relations += 1
-        parent = outlines[0]
-        existing_parent_tags = self.parent_tags.get(parent)
         canonical_parent_tags = dict(sorted(relation_tags.items()))
-        if (
-            existing_parent_tags is not None
-            and existing_parent_tags != canonical_parent_tags
-        ):
-            self.ambiguous_parts += 1
-        else:
-            self.parent_tags[parent] = canonical_parent_tags
+        for parent in outlines:
+            existing_parent_tags = self.parent_tags.get(parent)
+            if (
+                existing_parent_tags is not None
+                and existing_parent_tags != canonical_parent_tags
+            ):
+                self._ambiguous_parent_keys.add(parent)
+            else:
+                self.parent_tags[parent] = canonical_parent_tags
         for part in parts:
             if self.audit_enabled:
                 self.part_parent_candidates.setdefault(part, set()).update(outlines)
-            existing = self.part_parents.get(part)
-            if existing is not None and existing != parent:
-                self.ambiguous_parts += 1
-                self.part_parents[part] = min(existing, parent)
-            else:
-                self.part_parents[part] = parent
+                self.part_parent_relations.setdefault(part, set()).add(
+                    relation_key
+                )
+            if len(outlines) == 1 or not self.audit_enabled:
+                parent = outlines[0]
+                existing = self.part_parents.get(part)
+                if existing is not None and existing != parent:
+                    self.ambiguous_parts += 1
+                self.part_parents[part] = (
+                    min(existing, parent) if existing is not None else parent
+                )
 
     def finalize(self) -> None:
         """Apply the narrow standalone-part normalization after all ways arrive.
@@ -138,6 +168,40 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         different building relation, remain fail-closed rather than being
         silently reinterpreted.
         """
+
+        if self.audit_enabled:
+            self.part_parents = {
+                part: next(iter(parents))
+                for part, parents in self.part_parent_candidates.items()
+                if len(parents) == 1
+                and len(self.part_parent_relations.get(part, ())) == 1
+            }
+            self.deferred_part_parent_candidates = {
+                part: tuple(sorted(parents))
+                for part, parents in self.part_parent_candidates.items()
+                if len(parents) > 1
+                and len(self.part_parent_relations.get(part, ())) == 1
+            }
+            for parent, tags in self.parent_tags.items():
+                if parent.startswith("w"):
+                    self.parent_tags[parent] = {
+                        **tags,
+                        **self.way_tags.get(parent, {}),
+                    }
+            self.parent_geometry_sources = {
+                parent: next(iter(sources))
+                for parent, sources in self.parent_geometry_source_candidates.items()
+                if parent in self.parent_tags and len(sources) == 1
+            }
+            self._ambiguous_parent_keys.update(
+                parent
+                for parent, sources in self.parent_geometry_source_candidates.items()
+                if parent in self.parent_tags and len(sources) != 1
+            )
+            self.ambiguous_parts = len(self._ambiguous_parent_keys) + sum(
+                len(relations) != 1
+                for relations in self.part_parent_relations.values()
+            )
 
         qualified_relations = {
             relation_key
@@ -167,7 +231,9 @@ class BuildingRelationHandler(osmium.SimpleHandler):
         unsafe_parts.update(
             part
             for part, count in relation_part_counts.items()
-            if count != 1 or part in self.part_parents or part in self.parent_tags
+            if count != 1
+            or part in self.part_parent_candidates
+            or part in self.parent_tags
         )
         safe_relations = {
             relation_key
@@ -284,18 +350,19 @@ def audit_closure(
         required_nodes = set(expected["requiredNodeKeys"])
         ambiguous_parts = {
             part
-            for part, parents in handler.part_parent_candidates.items()
-            if len(parents) != 1 and part in required_ways | required_relations
+            for part, relations in handler.part_parent_relations.items()
+            if len(relations) != 1 and part in required_ways | required_relations
         }
         missing_parent_parts = handler.parts_without_outline.intersection(
             required_ways | required_relations
         )
         if ambiguous_parts or missing_parent_parts:
+            offending_parts = ambiguous_parts | missing_parent_parts
             incomplete_relations = [
                 (relation_key, handler.incomplete_relation_parts[relation_key])
                 for relation_key in sorted(handler.incomplete_relation_parts)
                 if set(handler.incomplete_relation_parts[relation_key])
-                & (required_ways | required_relations)
+                & offending_parts
             ]
             if incomplete_relations:
                 relation_key, parts = incomplete_relations[0]
@@ -315,6 +382,21 @@ def audit_closure(
                 raise BuildingSourceIndexError(
                     "building_relation_incomplete",
                     detail,
+                )
+            if ambiguous_parts:
+                values = []
+                for part in sorted(ambiguous_parts)[:8]:
+                    parents = sorted(handler.part_parent_candidates.get(part, ()))
+                    relations = sorted(handler.part_parent_relations.get(part, ()))
+                    values.append(
+                        f"{part}[parents={','.join(parents)};"
+                        f"relations={','.join(relations)}]"
+                    )
+                suffix = ",..." if len(ambiguous_parts) > 8 else ""
+                raise BuildingSourceIndexError(
+                    "building_relation_incomplete",
+                    "output building parts belong to multiple building relations "
+                    f"({','.join(values)}{suffix})",
                 )
             raise BuildingSourceIndexError(
                 "building_relation_incomplete",
@@ -530,6 +612,14 @@ def main() -> None:
     }
     if handler.standalone_part_keys:
         result["standalonePartKeys"] = sorted(handler.standalone_part_keys)
+    if handler.deferred_part_parent_candidates:
+        result["partParentCandidates"] = dict(
+            sorted(handler.deferred_part_parent_candidates.items())
+        )
+    if handler.parent_geometry_sources:
+        result["parentGeometrySources"] = dict(
+            sorted(handler.parent_geometry_sources.items())
+        )
     if closure_audit is not None:
         result["closureAudit"] = closure_audit
     Path(args.output).write_text(

--- a/tools/OSM_Extract/tests/test_building_pipeline.py
+++ b/tools/OSM_Extract/tests/test_building_pipeline.py
@@ -1,5 +1,7 @@
+import json
 import pathlib
 import sys
+import tempfile
 import unittest
 from dataclasses import replace
 from unittest.mock import patch
@@ -14,6 +16,7 @@ ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT / "scripts"))
 
 from building_height import HeightProvenance, HeightRules
+from building_calibration_cache import CalibrationCacheError
 from building_pipeline import (
     BUILDING_FLAG_FLAT_BASE,
     OutlineSpatialIndex,
@@ -21,8 +24,10 @@ from building_pipeline import (
     _calibration_cell,
     clip_buildings,
     collect_building_features,
+    load_relation_index,
     prepare_buildings,
     projected_selection_geometry,
+    source_object_key,
 )
 from map_format import MAX_BUILDING_RINGS, _building_section
 
@@ -44,6 +49,38 @@ class BuildingPipelineTests(unittest.TestCase):
     def setUpClass(cls):
         raw = yaml.safe_load((ROOT / "conf" / "building_height_rules.yaml").read_text())
         cls.rules = HeightRules.from_mapping(raw)
+
+    def test_load_relation_index_accepts_multi_outline_candidates(self):
+        value = {
+            "schemaVersion": 1,
+            "partParents": {},
+            "partParentCandidates": {"w30": ["w10", "w20"]},
+            "parentGeometrySources": {"w10": "r190"},
+            "parentTags": {},
+            "relations": 1,
+            "ambiguousParts": 0,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "relations.json"
+            path.write_text(json.dumps(value), encoding="utf-8")
+
+            self.assertEqual(load_relation_index(path), value)
+
+    def test_load_relation_index_rejects_overlapping_parent_encodings(self):
+        value = {
+            "schemaVersion": 1,
+            "partParents": {"w30": "w10"},
+            "partParentCandidates": {"w30": ["w10", "w20"]},
+            "parentTags": {},
+            "relations": 1,
+            "ambiguousParts": 0,
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            path = pathlib.Path(tmp) / "relations.json"
+            path.write_text(json.dumps(value), encoding="utf-8")
+
+            with self.assertRaisesRegex(ValueError, "relation index is invalid"):
+                load_relation_index(path)
 
     def test_legacy_calibration_keeps_representative_point_anchor(self):
         geometry = Polygon(
@@ -118,6 +155,202 @@ class BuildingPipelineTests(unittest.TestCase):
         self.assertEqual([item.object_key for item in buildings], ["w1", "w2"])
         self.assertEqual(report["partCount"], 1)
         self.assertEqual(report["relationAssociationCount"], 1)
+
+    def test_restores_suppressed_outline_from_multipolygon_geometry(self):
+        provider = feature(
+            190,
+            box(0, 0, 100, 100),
+            '"building"=>"commercial"',
+            relation=True,
+        )
+        part = feature(
+            30,
+            box(10, 10, 90, 90),
+            '"building:part"=>"yes","height"=>"15"',
+            building=None,
+        )
+        relation_index = {
+            "partParents": {"w30": "w10"},
+            "parentGeometrySources": {"w10": "r190"},
+            "parentTags": {"w10": {"building": "office", "height": "40"}},
+        }
+
+        collected = collect_building_features(
+            [provider, part],
+            [],
+            relation_index,
+        )
+        buildings, report, _flat = prepare_buildings(
+            collected,
+            self.rules,
+            relation_index,
+            strict_relations=True,
+        )
+
+        by_key = {building.object_key: building for building in buildings}
+        self.assertEqual(set(by_key), {"w10", "w30"})
+        self.assertEqual(by_key["w30"].parent_key, "w10")
+        self.assertEqual(by_key["w30"].resolved.height_dm, 150)
+        self.assertEqual(report["relationAssociationCount"], 1)
+
+    def test_retains_geometry_provider_when_it_is_also_a_relation_part(self):
+        provider_part = feature(
+            190,
+            box(0, 0, 100, 100),
+            '"building:part"=>"yes","height"=>"30"',
+            building=None,
+            relation=True,
+        )
+        second_part = feature(
+            30,
+            box(10, 10, 30, 30),
+            '"building:part"=>"yes","height"=>"15"',
+            building=None,
+        )
+        relation_index = {
+            "partParents": {"r190": "w10", "w30": "w10"},
+            "parentGeometrySources": {"w10": "r190"},
+            "parentTags": {"w10": {"building": "office", "height": "40"}},
+        }
+
+        collected = collect_building_features(
+            [provider_part, second_part],
+            [],
+            relation_index,
+        )
+        buildings, report, _flat = prepare_buildings(
+            collected,
+            self.rules,
+            relation_index,
+            strict_relations=True,
+        )
+
+        by_key = {building.object_key: building for building in buildings}
+        self.assertEqual(set(by_key), {"r190", "w10", "w30"})
+        self.assertEqual(by_key["r190"].parent_key, "w10")
+        self.assertEqual(by_key["w30"].parent_key, "w10")
+        self.assertEqual(report["relationAssociationCount"], 2)
+
+    def test_suppresses_unused_provider_when_outline_is_already_converted(self):
+        outline = feature(10, box(0, 0, 100, 100), '"building"=>"office"')
+        provider = feature(
+            190,
+            box(0, 0, 100, 100),
+            '"building"=>"commercial"',
+            relation=True,
+        )
+        part = feature(
+            30,
+            box(10, 10, 90, 90),
+            '"building:part"=>"yes"',
+            building=None,
+        )
+        relation_index = {
+            "partParents": {"w30": "w10"},
+            "parentGeometrySources": {"w10": "r190"},
+        }
+
+        collected = collect_building_features(
+            [outline, provider, part],
+            [],
+            relation_index,
+        )
+
+        keys = {
+            source_object_key(feature["properties"])
+            for feature in collected
+        }
+        self.assertEqual(keys, {"w10", "w30"})
+
+    def test_multi_outline_relation_uses_only_declared_containment_candidates(self):
+        unrelated = feature(
+            1,
+            box(205, 5, 225, 25),
+            '"building"=>"yes","height"=>"5"',
+        )
+        first_outline = feature(
+            10,
+            box(0, 0, 100, 100),
+            '"building"=>"retail","height"=>"20"',
+        )
+        second_outline = feature(
+            20,
+            box(200, 0, 300, 100),
+            '"building"=>"office","height"=>"40"',
+        )
+        part = feature(
+            30,
+            box(210, 10, 220, 20),
+            '"building:part"=>"yes","height"=>"15"',
+            building=None,
+        )
+
+        buildings, report, _flat = prepare_buildings(
+            [unrelated, first_outline, second_outline, part],
+            self.rules,
+            {"partParentCandidates": {"w30": ["w10", "w20"]}},
+            strict_relations=True,
+        )
+
+        selected_part = next(
+            building for building in buildings if building.object_key == "w30"
+        )
+        self.assertEqual(selected_part.parent_key, "w20")
+        self.assertEqual(selected_part.association, "relation")
+        self.assertEqual(report["relationAssociationCount"], 1)
+        self.assertEqual(report["containmentAssociationCount"], 0)
+
+    def test_multi_outline_relation_fails_when_no_candidate_contains_part(self):
+        first_outline = feature(10, box(0, 0, 100, 100), '"building"=>"yes"')
+        second_outline = feature(
+            20,
+            box(200, 0, 300, 100),
+            '"building"=>"yes"',
+        )
+        part = feature(
+            30,
+            box(400, 10, 410, 20),
+            '"building:part"=>"yes"',
+            building=None,
+        )
+
+        with self.assertRaisesRegex(
+            CalibrationCacheError,
+            "not contained by any declared parent candidate",
+        ):
+            prepare_buildings(
+                [first_outline, second_outline, part],
+                self.rules,
+                {"partParentCandidates": {"w30": ["w10", "w20"]}},
+                strict_relations=True,
+            )
+
+    def test_multi_outline_relation_allows_small_declared_boundary_drift(self):
+        outline = feature(10, box(0, 0, 100, 100), '"building"=>"yes"')
+        other_outline = feature(
+            20,
+            box(200, 0, 300, 100),
+            '"building"=>"yes"',
+        )
+        part = feature(
+            30,
+            box(-0.2, 10, 20, 20),
+            '"building:part"=>"yes"',
+            building=None,
+        )
+
+        buildings, _report, _flat = prepare_buildings(
+            [outline, other_outline, part],
+            self.rules,
+            {"partParentCandidates": {"w30": ["w10", "w20"]}},
+            strict_relations=True,
+        )
+
+        selected_part = next(
+            building for building in buildings if building.object_key == "w30"
+        )
+        self.assertEqual(selected_part.parent_key, "w10")
+        self.assertEqual(selected_part.association, "relation")
 
     def test_retains_a_safe_single_part_relation_without_containment(self):
         standalone = feature(

--- a/tools/OSM_Extract/tests/test_building_relations.py
+++ b/tools/OSM_Extract/tests/test_building_relations.py
@@ -70,14 +70,17 @@ class BuildingRelationIngressTests(unittest.TestCase):
         )
 
     @staticmethod
-    def relation(relation_id, members):
+    def relation(relation_id, members, tags=None):
         class Tags(list):
             def get(self, key):
                 return next((tag.v for tag in self if tag.k == key), None)
 
         return SimpleNamespace(
             id=relation_id,
-            tags=Tags([SimpleNamespace(k="type", v="building")]),
+            tags=Tags(
+                SimpleNamespace(k=key, v=value)
+                for key, value in (tags or {"type": "building"}).items()
+            ),
             members=[SimpleNamespace(**member) for member in members],
         )
 
@@ -114,6 +117,84 @@ class BuildingRelationIngressTests(unittest.TestCase):
         )
         self.assertFalse(handler.part_parents)
         self.assertEqual(handler.parts_without_outline, {"w21"})
+
+    def test_multiple_explicit_outlines_defer_to_declared_containment(self):
+        handler = BuildingRelationHandler(
+            expected_closure={"requiredRelationKeys": ["r105"]}
+        )
+        handler.relation(
+            self.relation(
+                105,
+                [
+                    {"type": "w", "ref": 12, "role": "outline"},
+                    {"type": "w", "ref": 13, "role": "outline"},
+                    {"type": "w", "ref": 21, "role": "part"},
+                ],
+            )
+        )
+        handler.finalize()
+
+        self.assertFalse(handler.part_parents)
+        self.assertEqual(
+            handler.deferred_part_parent_candidates,
+            {"w21": ("w12", "w13")},
+        )
+        self.assertEqual(set(handler.parent_tags), {"w12", "w13"})
+        self.assertEqual(handler.ambiguous_parts, 0)
+
+    def test_part_shared_across_relations_remains_ambiguous(self):
+        handler = BuildingRelationHandler(
+            expected_closure={"requiredRelationKeys": ["r105", "r106"]}
+        )
+        for relation_id, outline_id in ((105, 12), (106, 13)):
+            handler.relation(
+                self.relation(
+                    relation_id,
+                    [
+                        {"type": "w", "ref": outline_id, "role": "outline"},
+                        {"type": "w", "ref": 21, "role": "part"},
+                    ],
+                )
+            )
+        handler.finalize()
+
+        self.assertFalse(handler.part_parents)
+        self.assertFalse(handler.deferred_part_parent_candidates)
+        self.assertEqual(handler.ambiguous_parts, 1)
+
+    def test_single_outer_multipolygon_can_restore_suppressed_outline_geometry(self):
+        handler = BuildingRelationHandler(
+            expected_closure={"requiredRelationKeys": ["r190", "r200"]}
+        )
+        handler.way_tags["w10"] = {
+            "building": "office",
+            "height": "40",
+        }
+        handler.relation(
+            self.relation(
+                190,
+                [{"type": "w", "ref": 10, "role": "outer"}],
+                tags={"type": "multipolygon", "building:part": "yes"},
+            )
+        )
+        handler.relation(
+            self.relation(
+                200,
+                [
+                    {"type": "w", "ref": 10, "role": "outline"},
+                    {"type": "r", "ref": 190, "role": "part"},
+                ],
+            )
+        )
+        handler.finalize()
+
+        self.assertEqual(handler.parent_geometry_sources, {"w10": "r190"})
+        self.assertEqual(
+            handler.parent_tags["w10"],
+            {"building": "office", "height": "40", "type": "building"},
+        )
+        self.assertEqual(handler.part_parents, {"r190": "w10"})
+        self.assertEqual(handler.ambiguous_parts, 0)
 
     def test_part_only_relation_keeps_actionable_relation_identity(self):
         handler = BuildingRelationHandler(
@@ -330,6 +411,101 @@ class BuildingRelationIngressTests(unittest.TestCase):
             self.assertEqual(value["closureAudit"]["closureWayCount"], 5)
             self.assertEqual(value["closureAudit"]["closureNodeCount"], 20)
             self.assertEqual(value["closureAudit"]["relationRetryCount"], 0)
+
+    def test_multi_outline_relation_passes_with_declared_parent_candidates(self):
+        source_document = """<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="open-bike-computer-tests">
+  <node id="1" lat="1.3030" lon="103.8530" version="1" />
+  <node id="2" lat="1.3030" lon="103.8540" version="1" />
+  <node id="3" lat="1.3040" lon="103.8540" version="1" />
+  <node id="4" lat="1.3040" lon="103.8530" version="1" />
+  <node id="5" lat="1.3030" lon="103.8550" version="1" />
+  <node id="6" lat="1.3030" lon="103.8560" version="1" />
+  <node id="7" lat="1.3040" lon="103.8560" version="1" />
+  <node id="8" lat="1.3040" lon="103.8550" version="1" />
+  <node id="9" lat="1.3032" lon="103.8552" version="1" />
+  <node id="10" lat="1.3032" lon="103.8558" version="1" />
+  <node id="11" lat="1.3038" lon="103.8558" version="1" />
+  <node id="12" lat="1.3038" lon="103.8552" version="1" />
+  <way id="10" version="1">
+    <nd ref="1"/><nd ref="2"/><nd ref="3"/><nd ref="4"/><nd ref="1"/>
+    <tag k="building" v="retail"/>
+  </way>
+  <way id="20" version="1">
+    <nd ref="5"/><nd ref="6"/><nd ref="7"/><nd ref="8"/><nd ref="5"/>
+    <tag k="building" v="office"/>
+  </way>
+  <way id="30" version="1">
+    <nd ref="9"/><nd ref="10"/><nd ref="11"/><nd ref="12"/><nd ref="9"/>
+    <tag k="building:part" v="yes"/>
+  </way>
+  <relation id="200" version="1">
+    <member type="way" ref="10" role="outline"/>
+    <member type="way" ref="20" role="outline"/>
+    <member type="way" ref="30" role="part"/>
+    <tag k="name" v="Two-building complex"/>
+    <tag k="type" v="building"/>
+  </relation>
+</osm>
+"""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            source = root / "multi-outline.osm"
+            source.write_text(source_document)
+            source_sha = hashlib.sha256(source.read_bytes()).hexdigest()
+            index = BuildingSourceIndex(root / "cache", source_sha)
+            index.build_with_scanner(lambda path: scan_source(source, path))
+            scope = {
+                "schemaVersion": 1,
+                "policy": {
+                    "relationClosureMode": "source_snapshot_index",
+                    "maxRelationObjectsPerJob": 1_000,
+                },
+                "outputBlocks": [
+                    {
+                        "x": 2822,
+                        "y": 35,
+                        "boundsMeters": [11558912, 143360, 11563008, 147456],
+                    }
+                ],
+                "calibration": {"cellSizeMeters": 8192, "haloCells": 1},
+            }
+            scope_path = root / "scope.json"
+            scope_path.write_bytes(
+                canonical_json(
+                    {
+                        **scope,
+                        "scopePlanSha256": hashlib.sha256(
+                            canonical_json(scope)
+                        ).hexdigest(),
+                    }
+                )
+            )
+            output = root / "relation-index.json"
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT),
+                    str(source),
+                    str(output),
+                    "--source-index-manifest",
+                    str(index.manifest_path),
+                    "--scope-plan",
+                    str(scope_path),
+                ],
+                text=True,
+                capture_output=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
+            value = json.loads(output.read_text())
+            self.assertEqual(value["partParents"], {})
+            self.assertEqual(
+                value["partParentCandidates"],
+                {"w30": ["w10", "w20"]},
+            )
+            self.assertEqual(set(value["parentTags"]), {"w10", "w20"})
+            self.assertEqual(value["ambiguousParts"], 0)
 
     def test_cli_indexes_real_osm_building_relations_deterministically(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary

- distinguish multiple explicit outlines in one `type=building` relation from a part shared across different relations
- defer same-relation outline choice to deterministic, declared-candidate geometry containment
- restore a sole outer way from its GDAL multipolygon geometry provider when GDAL suppresses the way
- keep strict failures for missing/non-unique providers, cross-relation sharing, and geometry outside the bounded relation tolerance
- report the actual offending part/relation instead of blaming an unrelated incomplete relation

Supports #282. The issue should remain open until the fix is promoted and a valid production target-3 artifact is verified.

## Verification

- `python3 -m unittest tests.test_building_relations tests.test_building_pipeline` (44 passed)
- full OSM suite in isolated Linux container using the current production image dependencies (150 passed, 8 skipped)
- exact captured production PBF/closure replay: relation audit passed; strict geometry preparation completed with all 20 multi-outline parts associated only to declared candidates and all 14 previously missing direct-parent associations restored
- local macOS full suite: 148 tests passed; one unrelated OGR integration test cannot launch because the local Homebrew `libheif` links to missing `libx265.215.dylib`
