### PR TITLE
Show workout summary metrics on ended screen

### DIFF
--- a/esp32/lib/ble_navigation/workout_telemetry_state.hpp
+++ b/esp32/lib/ble_navigation/workout_telemetry_state.hpp
@@ -29,6 +29,10 @@ struct State {
   OptionalMetric<uint32_t> elapsedSeconds{};
   OptionalMetric<uint32_t> distanceMeters{};
   OptionalMetric<uint16_t> speedCentimetersPerSecond{};
+  // Highest speed observed in the accepted workout telemetry stream. HealthKit
+  // exposes the speed samples, but the device only needs the terminal maximum
+  // and can retain it without expanding the BLE frame contract.
+  OptionalMetric<uint16_t> maximumSpeedCentimetersPerSecond{};
   OptionalMetric<uint16_t> currentHeartRateBpm{};
 
   uint8_t sourceFlags = 0;
@@ -70,6 +74,8 @@ inline bool operator==(const State &lhs, const State &rhs) {
          lhs.elapsedSeconds == rhs.elapsedSeconds &&
          lhs.distanceMeters == rhs.distanceMeters &&
          lhs.speedCentimetersPerSecond == rhs.speedCentimetersPerSecond &&
+         lhs.maximumSpeedCentimetersPerSecond ==
+             rhs.maximumSpeedCentimetersPerSecond &&
          lhs.currentHeartRateBpm == rhs.currentHeartRateBpm &&
          lhs.sourceFlags == rhs.sourceFlags &&
          lhs.averageHeartRateBpm == rhs.averageHeartRateBpm &&
@@ -358,6 +364,11 @@ private:
       next.distanceMeters = decodeUnsignedMetric(distance, UNAVAILABLE_UINT32);
       next.speedCentimetersPerSecond =
           decodeUnsignedMetric(speed, UNAVAILABLE_UINT16);
+      if (speed != UNAVAILABLE_UINT16 &&
+          (!next.maximumSpeedCentimetersPerSecond.available ||
+           speed > next.maximumSpeedCentimetersPerSecond.value)) {
+        next.maximumSpeedCentimetersPerSecond = {true, speed};
+      }
       next.currentHeartRateBpm =
           decodeUnsignedMetric(currentHeartRate, UNAVAILABLE_UINT16);
     }

--- a/esp32/lib/gui/src/mainScr.cpp
+++ b/esp32/lib/gui/src/mainScr.cpp
@@ -215,6 +215,7 @@ uint64_t workoutSignature(uint32_t nowMs) {
   hashOptionalMetric(hash, state.elapsedSeconds);
   hashOptionalMetric(hash, state.distanceMeters);
   hashOptionalMetric(hash, state.speedCentimetersPerSecond);
+  hashOptionalMetric(hash, state.maximumSpeedCentimetersPerSecond);
   hashOptionalMetric(hash, state.currentHeartRateBpm);
   hashScalar(hash, state.sourceFlags);
   hashOptionalMetric(hash, state.averageHeartRateBpm);

--- a/esp32/lib/gui/src/rideTelemetryPresenter.hpp
+++ b/esp32/lib/gui/src/rideTelemetryPresenter.hpp
@@ -27,6 +27,8 @@ struct ViewModel {
   uint8_t sourceFlags = 0;
 
   workout_telemetry::OptionalMetric<uint32_t> speedTenthsKmh{};
+  workout_telemetry::OptionalMetric<uint32_t> averageSpeedTenthsKmh{};
+  workout_telemetry::OptionalMetric<uint32_t> maximumSpeedTenthsKmh{};
   workout_telemetry::OptionalMetric<uint16_t> currentHeartRateBpm{};
   workout_telemetry::OptionalMetric<uint16_t> averageHeartRateBpm{};
   workout_telemetry::OptionalMetric<uint8_t> currentHeartRateZone{};
@@ -50,12 +52,40 @@ enum class BottomMetric : uint8_t {
   RouteRemaining,
   Power,
   Cadence,
+  MaximumSpeed,
+  Energy,
 };
 
 struct BottomMetricSelection {
   BottomMetric left = BottomMetric::Altitude;
   BottomMetric right = BottomMetric::RouteRemaining;
 };
+
+inline workout_telemetry::OptionalMetric<uint32_t> averageSpeed(
+    const workout_telemetry::OptionalMetric<uint32_t> &distance,
+    const workout_telemetry::OptionalMetric<uint32_t> &elapsed) {
+  if (!distance.available || !elapsed.available || elapsed.value == 0) {
+    return {};
+  }
+
+  // m * 36 / s is km/h in tenths. Keep the multiplication wide so a valid
+  // but large workout cannot wrap before the division.
+  const uint64_t scaledDistance =
+      static_cast<uint64_t>(distance.value) * 36ULL;
+  const uint64_t rounded =
+      (scaledDistance + static_cast<uint64_t>(elapsed.value) / 2ULL) /
+      static_cast<uint64_t>(elapsed.value);
+  return {true, rounded > UINT32_MAX ? UINT32_MAX
+                                      : static_cast<uint32_t>(rounded)};
+}
+
+inline workout_telemetry::OptionalMetric<uint32_t> speedTenths(
+    const workout_telemetry::OptionalMetric<uint16_t> &speed) {
+  if (!speed.available) {
+    return {};
+  }
+  return {true, (static_cast<uint32_t>(speed.value) * 36U + 50U) / 100U};
+}
 
 inline ViewModel makeViewModel(
     const workout_telemetry::Snapshot &workout,
@@ -73,12 +103,8 @@ inline ViewModel makeViewModel(
     model.stale = workout.stale;
     model.sessionState = state.sessionState;
     model.sourceFlags = state.sourceFlags;
-    if (state.speedCentimetersPerSecond.available && !workout.stale) {
-      model.speedTenthsKmh = {
-          true,
-          (static_cast<uint32_t>(state.speedCentimetersPerSecond.value) * 36U +
-           50U) /
-              100U};
+    if (!workout.stale) {
+      model.speedTenthsKmh = speedTenths(state.speedCentimetersPerSecond);
     }
     model.currentHeartRateBpm = state.currentHeartRateBpm;
     model.averageHeartRateBpm = state.averageHeartRateBpm;
@@ -86,6 +112,10 @@ inline ViewModel makeViewModel(
     model.heartRateZoneCount = state.heartRateZoneCount;
     model.distanceMeters = state.distanceMeters;
     model.elapsedSeconds = state.elapsedSeconds;
+    model.averageSpeedTenthsKmh =
+        averageSpeed(model.distanceMeters, model.elapsedSeconds);
+    model.maximumSpeedTenthsKmh =
+        speedTenths(state.maximumSpeedCentimetersPerSecond);
     if (state.originReceived) {
       model.wallElapsedSeconds = state.wallElapsedSeconds;
       model.pauseOrigin = state.pauseOrigin;
@@ -124,6 +154,24 @@ inline void formatSpeed(const ViewModel &model, char *buffer,
     return;
   }
   formatTenths(model.speedTenthsKmh.value, buffer, size);
+}
+
+inline void formatAverageSpeed(const ViewModel &model, char *buffer,
+                               std::size_t size) {
+  if (!model.averageSpeedTenthsKmh.available) {
+    unavailable(buffer, size);
+    return;
+  }
+  formatTenths(model.averageSpeedTenthsKmh.value, buffer, size);
+}
+
+inline void formatMaximumSpeed(const ViewModel &model, char *buffer,
+                               std::size_t size) {
+  if (!model.maximumSpeedTenthsKmh.available) {
+    unavailable(buffer, size);
+    return;
+  }
+  formatTenths(model.maximumSpeedTenthsKmh.value, buffer, size);
 }
 
 template <typename T>
@@ -212,6 +260,10 @@ inline void formatCadence(const ViewModel &model, char *buffer,
 }
 
 inline BottomMetricSelection selectBottomMetrics(const ViewModel &model) {
+  if (model.usesWorkout && model.sessionState == SessionState::Ended) {
+    return {BottomMetric::MaximumSpeed, BottomMetric::Energy};
+  }
+
   const bool hasPower = model.cyclingPowerWatts.available;
   const bool hasCadence = model.cyclingCadenceTenthsRpm.available;
   if (model.usesWorkout && model.wallElapsedSeconds.available) {
@@ -249,6 +301,10 @@ inline const char *bottomMetricTitle(BottomMetric metric) {
     return "Power W";
   case BottomMetric::Cadence:
     return "Cadence rpm";
+  case BottomMetric::MaximumSpeed:
+    return "Max speed";
+  case BottomMetric::Energy:
+    return "Calories";
   }
   return "--";
 }
@@ -270,6 +326,12 @@ inline void formatBottomMetric(BottomMetric metric, const ViewModel &model,
     return;
   case BottomMetric::Cadence:
     formatCadence(model, buffer, size);
+    return;
+  case BottomMetric::MaximumSpeed:
+    formatMaximumSpeed(model, buffer, size);
+    return;
+  case BottomMetric::Energy:
+    formatEnergy(model, buffer, size);
     return;
   }
   unavailable(buffer, size);

--- a/esp32/lib/gui/src/rideTelemetryScr.cpp
+++ b/esp32/lib/gui/src/rideTelemetryScr.cpp
@@ -32,6 +32,7 @@ struct MetricLabels {
 lv_obj_t *ridePage = nullptr;
 lv_obj_t *rideStatus = nullptr;
 lv_obj_t *rideSpeedValue = nullptr;
+lv_obj_t *rideSpeedUnit = nullptr;
 MetricLabels rideHeartRate{};
 lv_obj_t *rideHeartRateHeart = nullptr;
 lv_obj_t *rideZoneTitle = nullptr;
@@ -328,13 +329,16 @@ void updateZoneMetric(const ride_telemetry_presenter::ViewModel &model) {
 void updateHeartRateMetric(
     const ride_telemetry_presenter::ViewModel &model) {
   const ride_telemetry_layout::Rect &metric = rideMetricPlacement.heartRate;
+  const bool ended = model.sessionState ==
+                     workout_telemetry_protocol::SessionState::Ended;
+  const auto heartRate = ended ? model.averageHeartRateBpm
+                               : model.currentHeartRateBpm;
   char value[24];
-  ride_telemetry_presenter::formatInteger(model.currentHeartRateBpm, value,
-                                          sizeof(value));
+  ride_telemetry_presenter::formatInteger(heartRate, value, sizeof(value));
   const ride_telemetry_layout::HeartRatePresentation presentation =
       ride_telemetry_layout::makeHeartRatePresentation(
           metric, rideLayout.screenWidth,
-          model.currentHeartRateBpm.available);
+          heartRate.available);
 
   if (!presentation.showHeart) {
     lv_obj_set_pos(rideHeartRate.value, presentation.unavailableValue.x,
@@ -757,13 +761,13 @@ void rideTelemetryScr(_lv_obj_t *screen) {
   lv_obj_set_style_text_align(rideSpeedValue, LV_TEXT_ALIGN_CENTER, 0);
   lv_label_set_text_static(rideSpeedValue, "0.0");
 
-  lv_obj_t *speedUnit = lv_label_create(ridePage);
-  lv_obj_set_width(speedUnit, rideLayout.heroUnit.width);
-  lv_obj_set_pos(speedUnit, rideLayout.heroUnit.x, rideLayout.heroUnit.y);
-  lv_obj_set_style_text_font(speedUnit, &lv_font_montserrat_18, 0);
-  lv_obj_set_style_text_color(speedUnit, lv_color_hex(0x999999), 0);
-  lv_obj_set_style_text_align(speedUnit, LV_TEXT_ALIGN_CENTER, 0);
-  lv_label_set_text_static(speedUnit, "km/h");
+  rideSpeedUnit = lv_label_create(ridePage);
+  lv_obj_set_width(rideSpeedUnit, rideLayout.heroUnit.width);
+  lv_obj_set_pos(rideSpeedUnit, rideLayout.heroUnit.x, rideLayout.heroUnit.y);
+  lv_obj_set_style_text_font(rideSpeedUnit, &lv_font_montserrat_18, 0);
+  lv_obj_set_style_text_color(rideSpeedUnit, lv_color_hex(0x999999), 0);
+  lv_obj_set_style_text_align(rideSpeedUnit, LV_TEXT_ALIGN_CENTER, 0);
+  lv_label_set_text_static(rideSpeedUnit, "km/h");
 
   rideHeartRate =
       createMetric(ridePage, "Heart rate", rideLayout.metrics[0]);
@@ -842,8 +846,21 @@ void updateRideTelemetryEvent(lv_event_t *) {
   updateStatusLabel(rideStatus, model);
   updateDetectionWaitingMessage(millis());
 
+  const bool ended = model.usesWorkout &&
+                     model.sessionState ==
+                         workout_telemetry_protocol::SessionState::Ended;
+  setLabelIfChanged(rideSpeedUnit, ended ? "average km/h" : "km/h");
+  if (model.usesWorkout) {
+    setLabelIfChanged(rideHeartRate.title,
+                      ended ? "Average HR" : "Heart rate");
+  }
+
   char value[24];
-  ride_telemetry_presenter::formatSpeed(model, value, sizeof(value));
+  if (ended) {
+    ride_telemetry_presenter::formatAverageSpeed(model, value, sizeof(value));
+  } else {
+    ride_telemetry_presenter::formatSpeed(model, value, sizeof(value));
+  }
   setLabelIfChanged(rideSpeedValue, value);
   if (model.usesWorkout) {
     updateHeartRateMetric(model);

--- a/esp32/tools/tests/test_workout_telemetry_state.cpp
+++ b/esp32/tools/tests/test_workout_telemetry_state.cpp
@@ -138,6 +138,8 @@ int main() {
   assert(reducer.state().elapsedSeconds.value == 3661);
   assert(reducer.state().distanceMeters.value == 12345);
   assert(reducer.state().speedCentimetersPerSecond.value == 1234);
+  assert(reducer.state().maximumSpeedCentimetersPerSecond.available);
+  assert(reducer.state().maximumSpeedCentimetersPerSecond.value == 1234);
   assert(reducer.state().currentHeartRateBpm.value == 157);
   assert(reducer.applyFrame(extended, sizeof(extended), 300, true) ==
          ApplyResult::Applied);
@@ -335,6 +337,60 @@ int main() {
   auto nonFiveZoneModel = pausedModel;
   nonFiveZoneModel.heartRateZoneCount.value = 6;
   assert(ride_telemetry_presenter::fiveZoneIndex(nonFiveZoneModel) == -1);
+
+  Reducer endedReducer;
+  assert(endedReducer.applyFrame(core, sizeof(core), 1000, true) ==
+         ApplyResult::Applied);
+  uint8_t fasterCore[sizeof(core)];
+  std::memcpy(fasterCore, core, sizeof(fasterCore));
+  writeUInt16LE(fasterCore, 12, 2000);
+  assert(endedReducer.applyFrame(fasterCore, sizeof(fasterCore), 1100, true) ==
+         ApplyResult::Applied);
+  assert(endedReducer.state().maximumSpeedCentimetersPerSecond.value == 2000);
+  assert(endedReducer.applyFrame(extended, sizeof(extended), 1200, true) ==
+         ApplyResult::Applied);
+  uint8_t summaryEndedCore[sizeof(core)];
+  std::memcpy(summaryEndedCore, fasterCore, sizeof(summaryEndedCore));
+  summaryEndedCore[1] = static_cast<uint8_t>(SessionState::Ended);
+  writeUInt16LE(summaryEndedCore, 12,
+                workout_telemetry_protocol::UNAVAILABLE_UINT16);
+  assert(endedReducer.applyFrame(summaryEndedCore, sizeof(summaryEndedCore),
+                                 1300, true) == ApplyResult::Applied);
+  assert(endedReducer.state().sessionState == SessionState::Ended);
+  assert(endedReducer.state().maximumSpeedCentimetersPerSecond.value == 2000);
+  uint8_t summaryEndedExtended[sizeof(extended)];
+  std::memcpy(summaryEndedExtended, extended, sizeof(summaryEndedExtended));
+  summaryEndedExtended[1] &= static_cast<uint8_t>(~0x03);
+  assert(endedReducer.applyFrame(summaryEndedExtended,
+                                 sizeof(summaryEndedExtended), 1400, true) ==
+         ApplyResult::Applied);
+  const auto summaryEndedModel = ride_telemetry_presenter::makeViewModel(
+      workout_telemetry::makeSnapshot(endedReducer.state(), 1400),
+      ride_telemetry_presenter::LegacyRideTelemetry{});
+  assert(summaryEndedModel.sessionState == SessionState::Ended);
+  ride_telemetry_presenter::formatAverageSpeed(summaryEndedModel, formatted,
+                                                sizeof(formatted));
+  assertText(formatted, "12.1");
+  ride_telemetry_presenter::formatMaximumSpeed(summaryEndedModel, formatted,
+                                                sizeof(formatted));
+  assertText(formatted, "72.0");
+  assertBottomMetrics(summaryEndedModel,
+                      ride_telemetry_presenter::BottomMetric::MaximumSpeed,
+                      ride_telemetry_presenter::BottomMetric::Energy);
+  assertText(ride_telemetry_presenter::bottomMetricTitle(
+                 ride_telemetry_presenter::BottomMetric::MaximumSpeed),
+             "Max speed");
+  assertText(ride_telemetry_presenter::bottomMetricTitle(
+                 ride_telemetry_presenter::BottomMetric::Energy),
+             "Calories");
+  ride_telemetry_presenter::formatBottomMetric(
+      ride_telemetry_presenter::BottomMetric::MaximumSpeed, summaryEndedModel,
+      formatted, sizeof(formatted));
+  assertText(formatted, "72.0");
+  ride_telemetry_presenter::formatBottomMetric(
+      ride_telemetry_presenter::BottomMetric::Energy, summaryEndedModel,
+      formatted, sizeof(formatted));
+  assertText(formatted, "456.7");
 
   using ride_telemetry_presenter::BottomMetric;
   assertBottomMetrics(pausedModel, BottomMetric::WallElapsed,


### PR DESCRIPTION
## Summary

- Show derived average speed on the ENDED hero as `average km/h`.
- Show `Average HR`, `Max speed`, and `Calories` in the ended workout layout.
- Retain the highest accepted workout speed sample on-device without changing the BLE frame contract.

## Validation

- `test_workout_telemetry_protocol`
- `test_gui_layout`
- `test_workout_telemetry_state`
- `git diff --check`

All host C++ checks pass. PlatformIO/device build and hardware flashing were not run. Max speed is the highest accepted telemetry sample, not a new terminal HealthKit maximum field.