### PR TITLE
Fix remote D1 promotion migration

### DIFF
--- a/map-platform/catalog/migrations/0005_promotion_leases.sql
+++ b/map-platform/catalog/migrations/0005_promotion_leases.sql
@@ -37,7 +37,8 @@ CREATE TRIGGER promotion_publication_requires_live_lease
 BEFORE INSERT ON publication_events
 WHEN NEW.promotion_lease_id IS NOT NULL
 BEGIN
-    SELECT CASE WHEN NEW.channel <> 'production' OR NOT EXISTS (
+    -- Keep CASE parenthesized for Wrangler's remote D1 migration parser.
+    SELECT (CASE WHEN NEW.channel <> 'production' OR NOT EXISTS (
         SELECT 1
           FROM promotion_leases lease
           JOIN artifacts source ON source.id = lease.source_artifact_id
@@ -53,5 +54,5 @@ BEGIN
            AND source.object_key = lease.source_object_key
            AND source.byte_count = lease.source_byte_count
            AND source.sha256 = lease.source_sha256
-    ) THEN RAISE(ABORT, 'promotion lease is not active') END;
+    ) THEN RAISE(ABORT, 'promotion lease is not active') END);
 END;


### PR DESCRIPTION
## Summary
- parenthesize the promotion lease trigger CASE expression for Wrangler's remote D1 migration parser
- preserve the existing trigger behavior

## Verification
- fresh remote D1: all migrations 0001-0009 applied successfully through `wrangler d1 migrations apply --remote`
- `pnpm check` (53 tests, typecheck, formatting, staging and production dry-runs)
- `git diff --check`