### PR TITLE
Fix device diagnostics export failures

### DIFF
--- a/docs/ble-protocol.md
+++ b/docs/ble-protocol.md
@@ -1430,12 +1430,40 @@ the existing bearer token. The read-only API is:
 Every route requires the authenticated transfer token and an active
 `diagnostics` mode. The device never accepts an arbitrary filesystem path or a
 remote-delete request. Before enabling the HTTP session, the firmware writer
-drains all earlier queue entries and seals its current chunk; short, normal
-rides are therefore included without exposing a mutable tail. Chunk GET resolves
-one strict canonical path and never re-hashes the complete index. iOS downloads
-one bounded chunk at a time, rejects oversized responses while streaming,
-verifies length, SHA-256, JSONL schema/source, per-field types, and sequence
-ordering within and across chunks, then atomically
+performs a fresh directory and write/flush/close/remove probe, drains all
+earlier queue entries, and seals its current chunk; short, normal rides are
+therefore included without exposing a mutable tail. The recorder root is stable
+for the complete boot. When removable SD was mounted at boot, diagnostics uses
+that mount without unmounting it beneath map/font readers. When the boot is
+already using the bounded internal FFat fallback, diagnostics exports FFat and
+does not switch to a newly inserted removable card while recorder or map file
+handles may still be open; adopting removable storage requires a reboot.
+
+The diagnostics-entry `DSTS.lastError` codes are stable and stage-specific:
+
+| Code | Failed stage |
+| --- | --- |
+| `diagnostics_mount_failed` | Diagnostics storage was not mounted as a directory. |
+| `diagnostics_card_missing` | A mounted removable backend no longer reported a card. |
+| `diagnostics_writable_probe_failed` | The fresh write/flush/close/remove probe failed. |
+| `diagnostics_flush_failed` | Flushing the sealed active chunk failed. |
+| `diagnostics_close_failed` | Closing the sealed active chunk failed. |
+| `diagnostics_seal_timeout` | The recorder did not drain to the requested cutoff before the bounded deadline. |
+| `diagnostics_seal_failed` | Recorder initialization or another seal invariant failed. |
+
+iOS treats a fresh rejection as authoritative during every handshake polling
+iteration, surfaces the code immediately, and records entry failures even when
+no HTTP session was opened. Chunk GET resolves one strict canonical path and
+never re-hashes the complete index. Zero-byte closed files are ignored as empty
+crash artifacts. A non-empty file that cannot be stated, bounded, opened, read,
+or hashed makes the index fail closed with HTTP error code
+`diagnostics_index_unreadable`; it is never silently omitted. A non-empty
+checksum-verified chunk with one truncated final JSON record remains evidence:
+iOS imports its original bytes, ignores only the incomplete tail while
+validating records, and rejects any later non-empty chunk for the same boot.
+iOS downloads one bounded chunk at a time, rejects oversized responses while
+streaming, verifies length, SHA-256, JSONL schema/source, per-field types, and
+sequence ordering within and across chunks, then atomically
 retains it under its local diagnostics root. Repeating a download skips an
 already-imported chunk with the same hash.
 Creating the index starts a bounded transfer snapshot lease. Retention pruning

--- a/docs/ride-diagnostics-format.md
+++ b/docs/ride-diagnostics-format.md
@@ -47,6 +47,15 @@ fields are strings; all three validators enforce the same source-specific type
 contract. A truncated final line is reported and ignored; a
 truncated line in the middle of a stream is an error.
 
+Firmware may leave a zero-byte closed-chunk filename when power is lost after
+file creation but before its first complete record. The authenticated device
+index omits that empty artifact because it contains no evidence. It includes a
+non-empty final chunk byte-for-byte even when the last JSON record is truncated;
+the checksum binds the original crash tail and validators salvage the preceding
+complete records. A truncated tail cannot be followed by another non-empty
+chunk in the same boot. Any other non-empty candidate that cannot be read and
+hashed makes the index fail closed instead of silently dropping evidence.
+
 Firmware that starts before its wall clock is valid omits `wallTime`. Its first
 later timestamped event and every subsequent RTC correction emit a
 `lifecycle.clock_anchor` carrying the same uptime and persistent boot sequence.

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -2320,9 +2320,16 @@ static void cancelDiagnosticsSessionStart() {
 static void diagnosticsSessionStartTask(void *context) {
   const uint32_t generation = static_cast<uint32_t>(
       reinterpret_cast<uintptr_t>(context));
-  bool ready = storage.ensureDiagnosticsSdMounted();
-  if (ready)
-    ready = ride_diagnostics::sealActiveChunk();
+  const ride_diagnostics::transfer_policy::StoragePreparation storageResult =
+      storage.prepareDiagnosticsStorage();
+  const bool storageReady =
+      ride_diagnostics::transfer_policy::storageReady(storageResult);
+  const ride_diagnostics::transfer_policy::SealPreparation sealResult =
+      storageReady ? ride_diagnostics::sealActiveChunkForTransfer()
+                   : ride_diagnostics::transfer_policy::SealPreparation::
+                         StorageUnavailable;
+  const bool ready = storageReady &&
+                     ride_diagnostics::transfer_policy::sealReady(sealResult);
 
   bool stillCurrent = false;
   if (diagnosticsSessionMutex != nullptr &&
@@ -2343,23 +2350,33 @@ static void diagnosticsSessionStartTask(void *context) {
           enabled ? ride_diagnostics::Level::Info
                   : ride_diagnostics::Level::Warning,
           "transfer", "diagnostics_transfer_entered",
-          enabled ? "{\"active\":true,\"mode\":\"diagnostics\"}"
-                  : "{\"active\":false,\"mode\":\"diagnostics\"}");
+          enabled
+              ? (ride_diagnostics::transfer_policy::usingInternalFallback(
+                     storageResult)
+                     ? "{\"active\":true,\"mode\":\"diagnostics\",\"storage\":\"internal_ffat\"}"
+                     : "{\"active\":true,\"mode\":\"diagnostics\",\"storage\":\"removable_sd\"}")
+              : "{\"active\":false,\"mode\":\"diagnostics\",\"code\":\"diagnostics_start_failed\"}");
       Serial.printf(
           "BLE Device Transfer: diagnostics async enter applied, enabled=%d\n",
           enabled);
     } else if (stillCurrent) {
+      const ride_diagnostics::transfer_policy::Failure failure =
+          storageReady
+              ? ride_diagnostics::transfer_policy::sealFailure(sealResult)
+              : ride_diagnostics::transfer_policy::storageFailure(
+                    storageResult);
       deviceTransferHttp.setLastError(
-          "diagnostics_storage_unavailable",
-          ready ? "another transfer mode became active"
-                : "device diagnostics could not mount removable storage and "
-                  "seal a readable checkpoint");
+          ready ? "transfer_busy" : failure.code,
+          ready ? "another transfer mode became active" : failure.message);
       Serial.println(
           "BLE Device Transfer: diagnostics async enter failed");
+      char fields[192] = {};
+      snprintf(fields, sizeof(fields),
+               "{\"active\":false,\"mode\":\"diagnostics\",\"code\":\"%s\"}",
+               ready ? "transfer_busy" : failure.code);
       (void)ride_diagnostics::record(
           ride_diagnostics::Level::Warning, "transfer",
-          "diagnostics_transfer_entered",
-          "{\"active\":false,\"mode\":\"diagnostics\"}");
+          "diagnostics_transfer_entered", fields);
     }
     xSemaphoreGive(diagnosticsSessionMutex);
   }
@@ -2557,7 +2574,7 @@ static void processPendingTransferControl() {
       Serial.println("BLE Device Transfer: diagnostics enter already applied");
     } else if (!startDiagnosticsSessionAsync()) {
       deviceTransferHttp.setLastError(
-          "diagnostics_storage_unavailable",
+          "diagnostics_seal_failed",
           "device diagnostics could not start the storage checkpoint task");
       Serial.println(
           "BLE Device Transfer: diagnostics enter rejected, task unavailable");

--- a/esp32/lib/ride_diagnostics/ride_diagnostics.cpp
+++ b/esp32/lib/ride_diagnostics/ride_diagnostics.cpp
@@ -128,7 +128,8 @@ char activePath[192] = {};
 std::atomic<bool> lastStorageAvailable{false};
 std::atomic<bool> sealRequested{false};
 std::atomic<uint32_t> sealSequenceCutoff{0};
-std::atomic<bool> sealSucceeded{false};
+std::atomic<transfer_policy::SealPreparation> sealPreparationResult{
+    transfer_policy::SealPreparation::SealFailed};
 std::atomic<bool> clockAnchorEmitted{false};
 std::atomic<bool> checkpointRequested{false};
 std::atomic<bool> storageTransitionRequested{false};
@@ -441,22 +442,32 @@ bool initializePersistentBootSequenceIfNeeded() {
   return true;
 }
 
-bool closeActiveFile() {
+enum class ActiveFileCloseResult : uint8_t {
+  Ready = 0,
+  FlushFailed,
+  CloseFailed,
+};
+
+ActiveFileCloseResult closeActiveFile() {
   if (activeFile == nullptr)
-    return true;
+    return ActiveFileCloseResult::Ready;
   const int flushResult =
       storage != nullptr ? storage->flush(activeFile) : fflush(activeFile);
   const int closeResult =
       storage != nullptr ? storage->close(activeFile) : fclose(activeFile);
   activeFile = nullptr;
-  return flushResult == 0 && closeResult == 0;
+  if (flushResult != 0)
+    return ActiveFileCloseResult::FlushFailed;
+  if (closeResult != 0)
+    return ActiveFileCloseResult::CloseFailed;
+  return ActiveFileCloseResult::Ready;
 }
 
-bool closeAndAdvanceActiveChunk() {
+ActiveFileCloseResult closeAndAdvanceActiveChunk() {
   char closingPath[sizeof(activePath)] = {};
   if (activePath[0] != '\0')
     strncpy(closingPath, activePath, sizeof(closingPath) - 1);
-  const bool closedCleanly = closeActiveFile();
+  const ActiveFileCloseResult closeResult = closeActiveFile();
   // stdio may buffer a short capture entirely until fclose(). Determine
   // whether the chunk exists only after the close has flushed those bytes.
   const bool hadActiveChunk = closingPath[0] != '\0' &&
@@ -470,7 +481,12 @@ bool closeAndAdvanceActiveChunk() {
     activeChunkSnapshot.store(activeChunk);
     pruneRetention();
   }
-  return closedCleanly;
+  return closeResult;
+}
+
+const char *closeFailureEvent(ActiveFileCloseResult result) {
+  return result == ActiveFileCloseResult::CloseFailed ? "close_failed"
+                                                       : "flush_failed";
 }
 
 bool ensurePaths() {
@@ -684,11 +700,15 @@ bool writeQueuedEvent(const QueuedEvent &event) {
     updateFaultCapsule(Level::Error, "storage", "write_unavailable", true);
     return false;
   }
-  if (event.rotateBeforeWrite && !closeAndAdvanceActiveChunk()) {
-    storage->markDiagnosticsSdUnavailable();
-    storageErrors.fetch_add(1);
-    updateFaultCapsule(Level::Error, "storage", "flush_failed", true);
-    return false;
+  if (event.rotateBeforeWrite) {
+    const ActiveFileCloseResult closeResult = closeAndAdvanceActiveChunk();
+    if (closeResult != ActiveFileCloseResult::Ready) {
+      storage->markDiagnosticsSdUnavailable();
+      storageErrors.fetch_add(1);
+      updateFaultCapsule(Level::Error, "storage",
+                         closeFailureEvent(closeResult), true);
+      return false;
+    }
   }
   if (activeFile == nullptr && !prepareChunkWriteReserve()) {
     storageErrors.fetch_add(1);
@@ -702,10 +722,12 @@ bool writeQueuedEvent(const QueuedEvent &event) {
     return false;
   }
   if (activeFileBytes + event.length > kChunkBytes) {
-    if (!closeAndAdvanceActiveChunk()) {
+    const ActiveFileCloseResult closeResult = closeAndAdvanceActiveChunk();
+    if (closeResult != ActiveFileCloseResult::Ready) {
       storage->markDiagnosticsSdUnavailable();
       storageErrors.fetch_add(1);
-      updateFaultCapsule(Level::Error, "storage", "flush_failed", true);
+      updateFaultCapsule(Level::Error, "storage",
+                         closeFailureEvent(closeResult), true);
       return false;
     }
     if (!prepareChunkWriteReserve()) {
@@ -756,11 +778,15 @@ bool writeQueuedEvent(const QueuedEvent &event) {
     clearFaultCapsule(event.faultCapsuleBoot,
                       event.faultCapsuleChecksum);
   }
-  if (event.rotateAfterWrite && !closeAndAdvanceActiveChunk()) {
-    storage->markDiagnosticsSdUnavailable();
-    storageErrors.fetch_add(1);
-    updateFaultCapsule(Level::Error, "storage", "flush_failed", true);
-    return false;
+  if (event.rotateAfterWrite) {
+    const ActiveFileCloseResult closeResult = closeAndAdvanceActiveChunk();
+    if (closeResult != ActiveFileCloseResult::Ready) {
+      storage->markDiagnosticsSdUnavailable();
+      storageErrors.fetch_add(1);
+      updateFaultCapsule(Level::Error, "storage",
+                         closeFailureEvent(closeResult), true);
+      return false;
+    }
   }
   if (faultCapsuleGeneration.load(std::memory_order_acquire) !=
       faultCapsuleQueuedGeneration.load(std::memory_order_acquire))
@@ -858,16 +884,23 @@ bool completeSealIfReady() {
   if (!queue_policy::readyToSeal(hasNext, next.sequence, cutoff))
     return false;
 
-  bool success = storage != nullptr && storage->getDiagnosticsSdLoaded();
-  if (success && !closeAndAdvanceActiveChunk()) {
-    success = false;
-    if (storage != nullptr) {
+  transfer_policy::SealPreparation result =
+      transfer_policy::SealPreparation::Ready;
+  if (storage == nullptr || !storage->getDiagnosticsSdLoaded()) {
+    result = transfer_policy::SealPreparation::StorageUnavailable;
+  } else {
+    const ActiveFileCloseResult closeResult = closeAndAdvanceActiveChunk();
+    if (closeResult != ActiveFileCloseResult::Ready) {
+      result = closeResult == ActiveFileCloseResult::CloseFailed
+                   ? transfer_policy::SealPreparation::CloseFailed
+                   : transfer_policy::SealPreparation::FlushFailed;
       storage->markDiagnosticsSdUnavailable();
       storageErrors.fetch_add(1);
-      updateFaultCapsule(Level::Error, "storage", "flush_failed", true);
+      updateFaultCapsule(Level::Error, "storage",
+                         closeFailureEvent(closeResult), true);
     }
   }
-  sealSucceeded.store(success, std::memory_order_release);
+  sealPreparationResult.store(result, std::memory_order_release);
   // Publish completion before exposing an idle request slot. Otherwise a
   // retry can publish a new cutoff and consume this predecessor's late give.
   if (sealComplete != nullptr)
@@ -1443,79 +1476,99 @@ bool detailedCaptureEnabled() {
   return !capture_policy::detailedCaptureExpired(millis(), deadline);
 }
 
-bool sealActiveChunk(uint32_t timeoutMs) {
+transfer_policy::SealPreparation
+sealActiveChunkForTransfer(uint32_t timeoutMs) {
 #if !PERSISTENT_RIDE_DIAGNOSTICS
   (void)timeoutMs;
-  return false;
+  return transfer_policy::SealPreparation::RecorderUnavailable;
 #else
-  if (writerTaskHandle == nullptr || producerMutex == nullptr ||
-      sealComplete == nullptr || storage == nullptr ||
-      !storage->getDiagnosticsSdLoaded()) {
-    return false;
-  }
-  // A removable card can reappear after an outage. Queue the retained gap
-  // capsule before taking the producer lock so the sealed cutoff includes the
-  // recovery evidence. recordInternal() takes the same producer lock.
-  if (faultCapsuleGeneration.load(std::memory_order_acquire) !=
-          faultCapsuleQueuedGeneration.load(std::memory_order_acquire) &&
-      !flushFaultCapsulesIfPossible()) {
-    return false;
-  }
   const uint32_t startedMs = millis();
-  if (xSemaphoreTake(producerMutex, pdMS_TO_TICKS(timeoutMs)) != pdTRUE)
-    return false;
-  // A producer or writer failure may have updated the capsule between the
-  // flush above and this lock acquisition. Never advertise a checkpoint that
-  // knowingly omits that evidence; the next explicit request will retry it.
-  if (faultCapsuleGeneration.load(std::memory_order_acquire) !=
-      faultCapsuleQueuedGeneration.load(std::memory_order_acquire)) {
-    xSemaphoreGive(producerMutex);
-    return false;
+  const auto remainingMs = [startedMs, timeoutMs]() -> uint32_t {
+    const uint32_t elapsed = static_cast<uint32_t>(millis() - startedMs);
+    return elapsed >= timeoutMs ? 0 : timeoutMs - elapsed;
+  };
+  if (writerTaskHandle == nullptr || producerMutex == nullptr ||
+      sealComplete == nullptr || storage == nullptr) {
+    return transfer_policy::SealPreparation::RecorderUnavailable;
   }
-  if (!initializePersistentBootSequenceIfNeeded()) {
-    xSemaphoreGive(producerMutex);
-    return false;
-  }
-  // A prior caller may have timed out while the writer was already flushing.
-  // Join that exact request while holding the producer lock, then issue a new
-  // cutoff so events queued after the old cutoff are included too. Never tear
-  // storage down while the writer still owns an in-flight close.
-  while (sealRequested.load(std::memory_order_acquire)) {
-    if (static_cast<uint32_t>(millis() - startedMs) >= timeoutMs) {
-      xSemaphoreGive(producerMutex);
-      return false;
+  if (!storage->getDiagnosticsSdLoaded())
+    return transfer_policy::SealPreparation::StorageUnavailable;
+
+  // Producers deliberately use a non-blocking mutex and record a retained gap
+  // when they race the seal. Converge those transient races inside this one
+  // bounded request instead of rejecting the download and requiring the user
+  // to press the button again.
+  while (remainingMs() > 0) {
+    while (faultCapsuleGeneration.load(std::memory_order_acquire) !=
+           faultCapsuleQueuedGeneration.load(std::memory_order_acquire)) {
+      if (flushFaultCapsulesIfPossible())
+        continue;
+      if (remainingMs() == 0)
+        return transfer_policy::SealPreparation::SealFailed;
+      vTaskDelay(pdMS_TO_TICKS(5));
     }
-    vTaskDelay(pdMS_TO_TICKS(5));
+
+    const uint32_t producerWaitMs = remainingMs();
+    if (producerWaitMs == 0 ||
+        xSemaphoreTake(producerMutex, pdMS_TO_TICKS(producerWaitMs)) !=
+            pdTRUE) {
+      return transfer_policy::SealPreparation::DrainTimeout;
+    }
+    // A callback may have recorded a gap between the capsule flush and this
+    // lock acquisition. Release and converge it instead of failing one-shot.
+    if (faultCapsuleGeneration.load(std::memory_order_acquire) !=
+        faultCapsuleQueuedGeneration.load(std::memory_order_acquire)) {
+      xSemaphoreGive(producerMutex);
+      continue;
+    }
+    if (!initializePersistentBootSequenceIfNeeded()) {
+      xSemaphoreGive(producerMutex);
+      return transfer_policy::SealPreparation::SealFailed;
+    }
+    // Join a predecessor that timed out while the writer was already closing,
+    // then publish a new cutoff. Storage is never torn down under that writer.
+    while (sealRequested.load(std::memory_order_acquire)) {
+      if (remainingMs() == 0) {
+        xSemaphoreGive(producerMutex);
+        return transfer_policy::SealPreparation::DrainTimeout;
+      }
+      vTaskDelay(pdMS_TO_TICKS(5));
+    }
+    while (xSemaphoreTake(sealComplete, 0) == pdTRUE) {
+    }
+    sealPreparationResult.store(transfer_policy::SealPreparation::SealFailed,
+                                std::memory_order_release);
+    sealSequenceCutoff.store(nextSequence.load(), std::memory_order_release);
+    // Publish only after the cutoff/result/completion slot describe this
+    // exact request. The writer re-peeks both priority queues afterward.
+    sealRequested.store(true, std::memory_order_release);
+    xSemaphoreGive(producerMutex);
+
+    const uint32_t completionWaitMs = remainingMs();
+    if (completionWaitMs == 0 ||
+        xSemaphoreTake(sealComplete, pdMS_TO_TICKS(completionWaitMs)) !=
+            pdTRUE) {
+      // The writer still owns an in-flight close. A later request must join
+      // it rather than consuming this request's eventual completion signal.
+      return transfer_policy::SealPreparation::DrainTimeout;
+    }
+    const transfer_policy::SealPreparation result =
+        sealPreparationResult.load(std::memory_order_acquire);
+    if (!transfer_policy::sealReady(result))
+      return result;
+    if (faultCapsuleGeneration.load(std::memory_order_acquire) ==
+        faultCapsuleQueuedGeneration.load(std::memory_order_acquire)) {
+      return transfer_policy::SealPreparation::Ready;
+    }
+    // A producer raced the just-completed seal. The next loop persists that
+    // bounded gap into a new chunk and seals it within the same deadline.
   }
-  while (xSemaphoreTake(sealComplete, 0) == pdTRUE) {
-  }
-  sealSucceeded.store(false);
-  sealSequenceCutoff.store(nextSequence.load(), std::memory_order_release);
-  // Publish only after the cutoff/result/completion slot describe this exact
-  // request. The writer acquires this flag before re-peeking both queues.
-  sealRequested.store(true, std::memory_order_release);
-  xSemaphoreGive(producerMutex);
-  const uint32_t elapsedMs =
-      static_cast<uint32_t>(millis() - startedMs);
-  if (elapsedMs >= timeoutMs ||
-      xSemaphoreTake(sealComplete,
-                     pdMS_TO_TICKS(timeoutMs - elapsedMs)) != pdTRUE) {
-    // The writer may already be closing/flushing this request. Leave it
-    // owned by the writer until that exact completion is acknowledged; a
-    // later caller must not reuse the shared completion semaphore and mistake
-    // this in-flight seal for its own cutoff.
-    return false;
-  }
-  if (!sealSucceeded.load(std::memory_order_acquire))
-    return false;
-  // Producers use a non-blocking mutex so a callback that races with the
-  // short seal critical section records its omission in the fault capsule
-  // instead of stalling BLE/UI work. Do not advertise the sealed checkpoint
-  // if such a gap appeared after the pre-seal capsule flush; a retry will
-  // enqueue that gap and seal it into the next immutable chunk.
-  return faultCapsuleGeneration.load(std::memory_order_acquire) ==
-         faultCapsuleQueuedGeneration.load(std::memory_order_acquire);
+  return transfer_policy::SealPreparation::DrainTimeout;
 #endif
+}
+
+bool sealActiveChunk(uint32_t timeoutMs) {
+  return transfer_policy::sealReady(sealActiveChunkForTransfer(timeoutMs));
 }
 
 bool beginStorageTransition(uint32_t timeoutMs) {

--- a/esp32/lib/ride_diagnostics/ride_diagnostics.hpp
+++ b/esp32/lib/ride_diagnostics/ride_diagnostics.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ride_diagnostics_transfer_policy.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
@@ -131,6 +133,8 @@ DetailedCaptureLease detailedCaptureLease();
 bool clearCaptureIfMatches(const DetailedCaptureLease &lease);
 const char *captureId();
 bool detailedCaptureEnabled();
+transfer_policy::SealPreparation
+sealActiveChunkForTransfer(uint32_t timeoutMs = 5000);
 bool sealActiveChunk(uint32_t timeoutMs = 2000);
 // Pause the writer after sealing its current cutoff so a caller can remount
 // storage without a recorder FILE reopening between seal and unmount.

--- a/esp32/lib/ride_diagnostics/ride_diagnostics_http.cpp
+++ b/esp32/lib/ride_diagnostics/ride_diagnostics_http.cpp
@@ -3,6 +3,7 @@
 #include "../storage/storage.hpp"
 #include "ride_diagnostics.hpp"
 #include "ride_diagnostics_http_policy.hpp"
+#include "ride_diagnostics_index_policy.hpp"
 
 #include <Arduino.h>
 #include <dirent.h>
@@ -32,6 +33,11 @@ struct Chunk {
   uint32_t bytes = 0;
   std::string path;
   std::string sha256;
+};
+
+struct ChunkIndex {
+  std::vector<Chunk> chunks;
+  bool readable = true;
 };
 
 bool chunkOlder(const Chunk &left, const Chunk &right) {
@@ -130,22 +136,26 @@ bool sha256File(const char *path, std::string &out, uint32_t &bytes,
   return true;
 }
 
-std::vector<Chunk> listChunks(
+ChunkIndex listChunks(
     device_transfer::HttpTransferServer *server,
     const device_transfer::HttpRequest &request) {
-  std::vector<Chunk> chunks;
+  ChunkIndex index;
+  std::vector<Chunk> &chunks = index.chunks;
   chunks.reserve(kMaximumChunks);
   char bootsRoot[192] = {};
   snprintf(bootsRoot, sizeof(bootsRoot),
            "%s/BICINO/DIAGNOSTICS/v1/boots",
            storage.diagnosticsRootPath());
   DIR *boots = opendir(bootsRoot);
-  if (boots == nullptr)
-    return chunks;
+  if (boots == nullptr) {
+    index.readable = false;
+    return index;
+  }
   while (struct dirent *bootEntry = readdir(boots)) {
     if (!requestStillAuthorized(server, request)) {
       closedir(boots);
-      return {};
+      index.readable = false;
+      return index;
     }
     uint32_t boot = 0;
     if (!parseUnsigned(bootEntry->d_name, boot))
@@ -154,13 +164,16 @@ std::vector<Chunk> listChunks(
     snprintf(directory, sizeof(directory), "%s/%s", bootsRoot,
              bootEntry->d_name);
     DIR *dir = opendir(directory);
-    if (dir == nullptr)
+    if (dir == nullptr) {
+      index.readable = false;
       continue;
+    }
     while (struct dirent *entry = readdir(dir)) {
       if (!requestStillAuthorized(server, request)) {
         closedir(dir);
         closedir(boots);
-        return {};
+        index.readable = false;
+        return index;
       }
       const std::string name(entry->d_name);
       if (name.size() < 14 || name.rfind("events-", 0) != 0 ||
@@ -174,9 +187,20 @@ std::vector<Chunk> listChunks(
       char path[220] = {};
       snprintf(path, sizeof(path), "%s/%s", directory, name.c_str());
       struct stat metadata = {};
-      if (::stat(path, &metadata) != 0 || !S_ISREG(metadata.st_mode) ||
-          metadata.st_size <= 0 ||
-          static_cast<uint64_t>(metadata.st_size) > kChunkBytes) {
+      if (::stat(path, &metadata) != 0 || !S_ISREG(metadata.st_mode)) {
+        index.readable = false;
+        continue;
+      }
+      const index_policy::CandidateDisposition disposition =
+          index_policy::classifyCandidate(metadata.st_size, kChunkBytes);
+      // FAT can retain a zero-byte crash artifact when power is lost between
+      // create and the first complete JSONL write. It contains no evidence and
+      // is deliberately omitted. Non-empty invalid candidates fail the index
+      // instead of being silently hidden from the phone.
+      if (disposition == index_policy::CandidateDisposition::IgnoreEmpty)
+        continue;
+      if (disposition == index_policy::CandidateDisposition::Reject) {
+        index.readable = false;
         continue;
       }
       Chunk candidate = {boot, chunkNumber,
@@ -199,6 +223,7 @@ std::vector<Chunk> listChunks(
     if (!sha256File(chunk->path.c_str(), digest, bytes, server, request) ||
         bytes == 0 ||
         bytes != chunk->bytes || bytes > kChunkBytes) {
+      index.readable = false;
       chunk = chunks.erase(chunk);
       continue;
     }
@@ -206,7 +231,7 @@ std::vector<Chunk> listChunks(
     chunk->sha256 = std::move(digest);
     ++chunk;
   }
-  return chunks;
+  return index;
 }
 
 bool sendBody(WiFiClient &client, const std::string &body,
@@ -341,12 +366,19 @@ bool RideDiagnosticsHttp::handleRequest(
   }
   if (route.kind == http_policy::RouteKind::Index) {
     beginTransferSnapshotLease();
-    const std::vector<Chunk> chunks = listChunks(server_, request);
+    const ChunkIndex index = listChunks(server_, request);
     if (!requestStillAuthorized(server_, request)) {
       endTransferSnapshotLease();
       client.stop();
       return false;
     }
+    if (!index.readable) {
+      endTransferSnapshotLease();
+      return device_transfer::sendHttpError(
+          client, 500, "diagnostics_index_unreadable",
+          "one or more non-empty diagnostic chunks could not be read safely");
+    }
+    const std::vector<Chunk> &chunks = index.chunks;
     const Stats snapshot = stats();
     std::string body = "{\"schema\":1,\"source\":\"firmware\",\"bootSequence\":" +
                        std::to_string(currentBootSequence()) +

--- a/esp32/lib/ride_diagnostics/ride_diagnostics_index_policy.hpp
+++ b/esp32/lib/ride_diagnostics/ride_diagnostics_index_policy.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ride_diagnostics::index_policy {
+
+enum class CandidateDisposition : uint8_t {
+  IgnoreEmpty = 0,
+  Include,
+  Reject,
+};
+
+constexpr CandidateDisposition classifyCandidate(int64_t bytes,
+                                                  uint64_t maximumBytes) {
+  if (bytes == 0)
+    return CandidateDisposition::IgnoreEmpty;
+  if (bytes < 0 || static_cast<uint64_t>(bytes) > maximumBytes)
+    return CandidateDisposition::Reject;
+  return CandidateDisposition::Include;
+}
+
+} // namespace ride_diagnostics::index_policy

--- a/esp32/lib/ride_diagnostics/ride_diagnostics_transfer_policy.hpp
+++ b/esp32/lib/ride_diagnostics/ride_diagnostics_transfer_policy.hpp
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <cstdint>
+
+namespace ride_diagnostics::transfer_policy {
+
+enum class StoragePreparation : uint8_t {
+  ReadyRemovable = 0,
+  ReadyInternalFallback,
+  MountFailed,
+  CardMissing,
+  WritableProbeFailed,
+};
+
+enum class SealPreparation : uint8_t {
+  Ready = 0,
+  RecorderUnavailable,
+  StorageUnavailable,
+  SealFailed,
+  DrainTimeout,
+  FlushFailed,
+  CloseFailed,
+};
+
+struct Failure {
+  const char *code;
+  const char *message;
+};
+
+constexpr bool storageReady(StoragePreparation result) {
+  return result == StoragePreparation::ReadyRemovable ||
+         result == StoragePreparation::ReadyInternalFallback;
+}
+
+constexpr bool usingInternalFallback(StoragePreparation result) {
+  return result == StoragePreparation::ReadyInternalFallback;
+}
+
+constexpr Failure storageFailure(StoragePreparation result) {
+  switch (result) {
+  case StoragePreparation::MountFailed:
+    return {"diagnostics_mount_failed",
+            "device diagnostics could not mount storage"};
+  case StoragePreparation::CardMissing:
+    return {"diagnostics_card_missing",
+            "device diagnostics could not detect the removable card"};
+  case StoragePreparation::WritableProbeFailed:
+    return {"diagnostics_writable_probe_failed",
+            "diagnostics storage mounted but failed its writable probe"};
+  case StoragePreparation::ReadyRemovable:
+  case StoragePreparation::ReadyInternalFallback:
+    return {"", ""};
+  }
+  return {"diagnostics_mount_failed",
+          "device diagnostics storage preparation failed"};
+}
+
+constexpr bool sealReady(SealPreparation result) {
+  return result == SealPreparation::Ready;
+}
+
+constexpr Failure sealFailure(SealPreparation result) {
+  switch (result) {
+  case SealPreparation::FlushFailed:
+    return {"diagnostics_flush_failed",
+            "device diagnostics could not flush the active checkpoint"};
+  case SealPreparation::CloseFailed:
+    return {"diagnostics_close_failed",
+            "device diagnostics could not close the active checkpoint"};
+  case SealPreparation::DrainTimeout:
+    return {"diagnostics_seal_timeout",
+            "device diagnostics timed out while draining the recorder"};
+  case SealPreparation::RecorderUnavailable:
+  case SealPreparation::StorageUnavailable:
+  case SealPreparation::SealFailed:
+    return {"diagnostics_seal_failed",
+            "device diagnostics could not seal a readable checkpoint"};
+  case SealPreparation::Ready:
+    return {"", ""};
+  }
+  return {"diagnostics_seal_failed",
+          "device diagnostics could not seal a readable checkpoint"};
+}
+
+} // namespace ride_diagnostics::transfer_policy

--- a/esp32/lib/storage/storage.cpp
+++ b/esp32/lib/storage/storage.cpp
@@ -37,10 +37,31 @@ namespace {
 #define WAVESHARE_SD_SPI_FREQ_HZ 4000000
 #endif
 
-constexpr char kDiagnosticsAlternateRoot[] = "/diag-sd";
-static_assert(storage_mount_policy::validEspVfsMountPathLength(
-                  sizeof(kDiagnosticsAlternateRoot) - 1),
-              "diagnostics SD VFS root exceeds ESP_VFS_PATH_MAX");
+using ride_diagnostics::transfer_policy::StoragePreparation;
+
+bool mountedDirectoryAvailable(const char *root) {
+  struct stat mounted = {};
+  return root != nullptr && ::stat(root, &mounted) == 0 &&
+         S_ISDIR(mounted.st_mode);
+}
+
+bool writableProbeSucceeded(const char *root) {
+  char probePath[128] = {};
+  snprintf(probePath, sizeof(probePath), "%s/.bicino-diag-probe", root);
+  FILE *probe = fopen(probePath, "wb");
+  if (probe == nullptr)
+    return false;
+  const uint8_t marker = 1;
+  const bool wrote =
+      fwrite(&marker, 1, sizeof(marker), probe) == sizeof(marker);
+  const bool flushed = wrote && fflush(probe) == 0;
+  // fclose() closes the stream even when its implicit flush reports failure,
+  // so remove the probe in every opened-file path. A failed remove is itself
+  // evidence that the backend cannot complete the export lifecycle safely.
+  const bool closed = fclose(probe) == 0;
+  const bool removed = unlink(probePath) == 0;
+  return wrote && flushed && closed && removed;
+}
 
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
 SPIClass &waveshareSdBus() {
@@ -111,7 +132,6 @@ bool Storage::ensureSdMounted(bool allowInternalFallback) {
             allowInternalFallback, internalFallbackMounted.load());
     FFat.end();
     SD.end();
-    diagnosticsSdMountedAtAlternateRoot = false;
     delay(25);
 #endif
     ready = initSD() == ESP_OK;
@@ -152,97 +172,55 @@ uint64_t Storage::removableSdFreeBytes() const {
 #endif
 }
 
-bool Storage::ensureDiagnosticsSdMounted() {
+StoragePreparation Storage::prepareDiagnosticsStorage() {
   power_management::ScopedLock powerLock(
       power_management::LockDomain::Storage);
   if (mountMutex == nullptr)
     mountMutex = xSemaphoreCreateMutex();
-  if (mountMutex == nullptr)
-    return false;
+  if (mountMutex == nullptr) {
+    lastDiagnosticsMountResult = StoragePreparation::MountFailed;
+    return StoragePreparation::MountFailed;
+  }
   xSemaphoreTake(mountMutex, portMAX_DELAY);
 
-  const auto writableProbeSucceeded = [](const char *root) {
-    char probePath[128] = {};
-    snprintf(probePath, sizeof(probePath), "%s/.bicino-diag-probe", root);
-    FILE *probe = fopen(probePath, "wb");
-    const uint8_t marker = 1;
-    bool ready = false;
-    if (probe != nullptr) {
-      const bool wrote =
-          fwrite(&marker, 1, sizeof(marker), probe) == sizeof(marker);
-      const bool flushed = wrote && fflush(probe) == 0;
-      const bool closed = fclose(probe) == 0;
-      ready = wrote && flushed && closed;
-    }
-    if (ready)
-      unlink(probePath);
-    return ready;
-  };
-
   const bool mainMounted = isSdLoaded.load();
-  const bool alternateMounted =
-      diagnosticsSdMountedAtAlternateRoot.load();
-  if ((mainMounted || alternateMounted) && diagnosticsSdHealthy.load()) {
-    xSemaphoreGive(mountMutex);
-    return true;
-  }
-
-  // First recover a transient recorder-only fault without changing the VFS
-  // mount generation. Other subsystems keep long-lived map/font FILE handles
-  // on /sdcard, and the HTTP transfer may be reading the alternate mount.
-  if (mainMounted || alternateMounted) {
-    const char *root = alternateMounted ? kDiagnosticsAlternateRoot
-                                        : "/sdcard";
-    const bool ready = writableProbeSucceeded(root);
-    if (ready) {
-      diagnosticsSdHealthy = true;
-      xSemaphoreGive(mountMutex);
-      return true;
+  const bool internalMounted = internalFallbackMounted.load();
+  constexpr const char *root = "/sdcard";
+  if (mainMounted || internalMounted) {
+    StoragePreparation result = StoragePreparation::ReadyRemovable;
+    if (!mountedDirectoryAvailable(root)) {
+      result = StoragePreparation::MountFailed;
     }
-    // Never remount the application's primary /sdcard at runtime. Preserve
-    // its readers and require reboot/manual lifecycle recovery instead.
-    if (mainMounted) {
-      xSemaphoreGive(mountMutex);
-      return false;
+#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206) ||          \
+    defined(SPI_SHARED)
+    else if (!internalMounted && SD.cardType() == CARD_NONE) {
+      result = StoragePreparation::CardMissing;
     }
-  }
-
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-  if (diagnosticsSdMountedAtAlternateRoot.load()) {
-    // The mount was already marked unhealthy and failed a writable probe.
-    // Directory metadata/cardType can remain visible for a removed or full
-    // card, so accepting them here would report success while recorder health
-    // remains false and would prevent the only remount/recovery path.
-    SD.end();
-    diagnosticsSdMountedAtAlternateRoot = false;
-  }
-
-  if (internalFallbackMounted.load()) {
-    pinMode(SD_CS, OUTPUT);
-    digitalWrite(SD_CS, HIGH);
-    SPIClass &hspi = waveshareSdBus();
-    hspi.begin(SD_CLK, SD_MISO, SD_MOSI, SD_CS);
-    const bool mounted = SD.begin(
-        SD_CS, hspi, WAVESHARE_SD_SPI_FREQ_HZ,
-        kDiagnosticsAlternateRoot);
-    const bool ready = storage_mount_policy::diagnosticsMountReady(
-        mounted, mounted && SD.cardType() != CARD_NONE,
-        mounted && writableProbeSucceeded(kDiagnosticsAlternateRoot));
-    if (!ready) {
-      SD.end();
-      diagnosticsSdMountedAtAlternateRoot = false;
-      xSemaphoreGive(mountMutex);
-      return false;
-    }
-    diagnosticsSdMountedAtAlternateRoot = true;
-    diagnosticsSdHealthy = true;
-    xSemaphoreGive(mountMutex);
-    return true;
-  }
 #endif
+    else if (!writableProbeSucceeded(root)) {
+      result = StoragePreparation::WritableProbeFailed;
+    } else if (internalMounted) {
+      // The diagnostics backend remains stable for the complete boot. This
+      // intentionally exports the bounded FFat recorder instead of mounting a
+      // newly inserted card at another root while an FFat FILE may be open.
+      result = StoragePreparation::ReadyInternalFallback;
+    }
+    diagnosticsSdHealthy =
+        ride_diagnostics::transfer_policy::storageReady(result);
+    lastDiagnosticsMountResult = result;
+    xSemaphoreGive(mountMutex);
+    return result;
+  }
 
   xSemaphoreGive(mountMutex);
-  return ensureSdMounted(false);
+  if (!ensureSdMounted(false))
+    return lastDiagnosticsMountResult.load();
+  return prepareDiagnosticsStorage();
+}
+
+bool Storage::ensureDiagnosticsSdMounted() {
+  return ride_diagnostics::transfer_policy::storageReady(
+      prepareDiagnosticsStorage());
 }
 
 void Storage::markDiagnosticsSdUnavailable() {
@@ -251,16 +229,14 @@ void Storage::markDiagnosticsSdUnavailable() {
 
 bool Storage::getDiagnosticsSdLoaded() const {
   return diagnosticsSdHealthy.load() &&
-         (isSdLoaded.load() || diagnosticsSdMountedAtAlternateRoot.load() ||
-          internalFallbackMounted.load());
+         (isSdLoaded.load() || internalFallbackMounted.load());
 }
 
 bool Storage::canRetryDiagnosticsSd() const {
   if (!diagnosticsSdHealthy.load())
     return true;
   return storage_mount_policy::shouldAttemptDiagnosticsRemovableRetry(
-      isSdLoaded.load(), diagnosticsSdMountedAtAlternateRoot.load(),
-      internalFallbackMounted.load());
+      isSdLoaded.load(), internalFallbackMounted.load());
 }
 
 uint64_t Storage::diagnosticsSdFreeBytes() const {
@@ -270,8 +246,7 @@ uint64_t Storage::diagnosticsSdFreeBytes() const {
     return 0;
 #if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206) ||          \
     defined(SPI_SHARED)
-  if (internalFallbackMounted.load() &&
-      !diagnosticsSdMountedAtAlternateRoot.load()) {
+  if (internalFallbackMounted.load()) {
     const uint64_t total = FFat.totalBytes();
     const uint64_t used = FFat.usedBytes();
     return total > used ? total - used : 0;
@@ -285,9 +260,7 @@ uint64_t Storage::diagnosticsSdFreeBytes() const {
 }
 
 const char *Storage::diagnosticsRootPath() const {
-  return diagnosticsSdMountedAtAlternateRoot.load()
-             ? kDiagnosticsAlternateRoot
-             : "/sdcard";
+  return "/sdcard";
 }
 
 /**
@@ -322,6 +295,7 @@ esp_err_t Storage::initSD() {
                   (unsigned long)(millis() - mountStartMs),
                   (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ);
     isSdLoaded = false;
+    lastDiagnosticsMountResult = StoragePreparation::MountFailed;
     return ESP_FAIL;
   }
 
@@ -332,6 +306,7 @@ esp_err_t Storage::initSD() {
                   (unsigned long)(millis() - mountStartMs),
                   (unsigned long)WAVESHARE_SD_SPI_FREQ_HZ);
     isSdLoaded = false;
+    lastDiagnosticsMountResult = StoragePreparation::CardMissing;
     return ESP_FAIL;
   }
 
@@ -369,8 +344,8 @@ esp_err_t Storage::initSD() {
 
   isSdLoaded = true;
   internalFallbackMounted = false;
-  diagnosticsSdMountedAtAlternateRoot = false;
   diagnosticsSdHealthy = true;
+  lastDiagnosticsMountResult = StoragePreparation::ReadyRemovable;
   return ESP_OK;
 
 #elif defined(SPI_SHARED)
@@ -382,12 +357,14 @@ esp_err_t Storage::initSD() {
   if (!SD.begin(SD_CS, SPI, 4000000, "/sdcard")) {
     ESP_LOGE(TAG, "SD Card Mount Failed");
     isSdLoaded = false;
+    lastDiagnosticsMountResult = StoragePreparation::MountFailed;
     return ESP_FAIL;
   } else {
     ESP_LOGI(TAG, "SD Card Mounted");
     isSdLoaded = true;
     internalFallbackMounted = false;
     diagnosticsSdHealthy = true;
+    lastDiagnosticsMountResult = StoragePreparation::ReadyRemovable;
     return ESP_OK;
   }
 
@@ -437,6 +414,7 @@ esp_err_t Storage::initSD() {
   if (ret != ESP_OK) {
     ESP_LOGE(TAG, "Failed to initialize SPI bus: %s (0x%x)",
              esp_err_to_name(ret), ret);
+    lastDiagnosticsMountResult = StoragePreparation::MountFailed;
     return ret;
   }
 
@@ -456,6 +434,7 @@ esp_err_t Storage::initSD() {
       ESP_LOGE(TAG, "Failed to initialize the card (%s).",
                esp_err_to_name(ret));
     }
+    lastDiagnosticsMountResult = StoragePreparation::MountFailed;
     return ret;
   } else {
     ESP_LOGI(TAG, "SD card initialized successfully");
@@ -463,6 +442,7 @@ esp_err_t Storage::initSD() {
     isSdLoaded = true;
     internalFallbackMounted = false;
     diagnosticsSdHealthy = true;
+    lastDiagnosticsMountResult = StoragePreparation::ReadyRemovable;
     return ESP_OK;
   }
 #endif
@@ -496,7 +476,6 @@ esp_err_t Storage::initSPIFFS() {
   size_t used = FFat.usedBytes();
   ESP_LOGI(TAG, "FFat Mounted at /sdcard. Total: %d, Used: %d", total, used);
   internalFallbackMounted = true;
-  diagnosticsSdMountedAtAlternateRoot = false;
   diagnosticsSdHealthy = true;
 
 #ifdef WAVESHARE_SD_LIST_ROOT

--- a/esp32/lib/storage/storage.hpp
+++ b/esp32/lib/storage/storage.hpp
@@ -14,6 +14,7 @@
 #include "driver/sdspi_host.h"
 #include "esp_err.h"
 #include "esp_spiffs.h"
+#include "../ride_diagnostics/ride_diagnostics_transfer_policy.hpp"
 #include "sdmmc_cmd.h"
 #include <atomic>
 #include <freertos/FreeRTOS.h>
@@ -25,17 +26,6 @@
 #include <time.h>
 #include <unistd.h>
 #include <utime.h>
-
-#ifdef SPI_SHARED
-#include "Arduino.h"
-#include "SD.h"
-#include "SD_MMC.h"
-#endif
-
-#if defined(WAVESHARE_AMOLED_175) || defined(WAVESHARE_AMOLED_206)
-#include "Arduino.h"
-#include "SD_MMC.h"
-#endif
 
 struct SDCardInfo {
   std::string name;
@@ -128,13 +118,12 @@ private:
   // failed SD retry must restore it so the rest of the application keeps the
   // same fallback behavior as the non-diagnostics firmware.
   std::atomic<bool> internalFallbackMounted{false};
-  // When FFat owns /sdcard, diagnostics may mount a newly inserted removable
-  // card at a separate VFS root. This preserves every live fallback/map handle
-  // while allowing the recorder to recover without a reboot.
-  std::atomic<bool> diagnosticsSdMountedAtAlternateRoot{false};
   // Recorder health is separate from the physical mount. A write fault must
   // not unmount SD beneath map/font readers or an in-flight diagnostics GET.
   std::atomic<bool> diagnosticsSdHealthy{true};
+  std::atomic<ride_diagnostics::transfer_policy::StoragePreparation>
+      lastDiagnosticsMountResult{
+          ride_diagnostics::transfer_policy::StoragePreparation::MountFailed};
   sdmmc_card_t *card;
   SemaphoreHandle_t mountMutex = nullptr;
 
@@ -143,13 +132,15 @@ public:
 
   esp_err_t initSD();
   // Remount the removable card when requested. Existing callers retain the
-  // FFat fallback by default; diagnostics can opt out so an absent card never
-  // turns into an unbounded internal log sink.
+  // FFat fallback by default. Diagnostics keeps whichever backend owns
+  // /sdcard stable for the complete boot.
   bool ensureSdMounted(bool allowInternalFallback = true);
   void markSdUnavailable();
   bool hasInternalFallbackMounted() const;
   bool canRetryRemovableSd() const;
   uint64_t removableSdFreeBytes() const;
+  ride_diagnostics::transfer_policy::StoragePreparation
+  prepareDiagnosticsStorage();
   bool ensureDiagnosticsSdMounted();
   void markDiagnosticsSdUnavailable();
   bool getDiagnosticsSdLoaded() const;

--- a/esp32/lib/storage/storage_mount_policy.hpp
+++ b/esp32/lib/storage/storage_mount_policy.hpp
@@ -1,19 +1,6 @@
 #pragma once
 
-#include <cstddef>
-
 namespace storage_mount_policy {
-
-constexpr std::size_t kMaximumEspVfsMountPathBytes = 15;
-
-constexpr bool validEspVfsMountPathLength(std::size_t length) {
-  return length > 1 && length <= kMaximumEspVfsMountPathBytes;
-}
-
-constexpr bool diagnosticsMountReady(bool mounted, bool cardPresent,
-                                     bool writableProbeSucceeded) {
-  return mounted && cardPresent && writableProbeSucceeded;
-}
 
 inline bool shouldAttemptAutomaticRemovableRetry(bool removableMounted,
                                                  bool fallbackMounted) {
@@ -25,11 +12,12 @@ inline bool shouldRestoreFallbackAfterFailedRetry(bool callerAllowsFallback,
   return callerAllowsFallback || fallbackWasMounted;
 }
 
-inline bool shouldAttemptDiagnosticsRemovableRetry(
-    bool removableMounted, bool diagnosticsAlternateMounted,
-    bool fallbackMounted) {
-  (void)fallbackMounted;
-  return !removableMounted && !diagnosticsAlternateMounted;
+inline bool shouldAttemptDiagnosticsRemovableRetry(bool removableMounted,
+                                                   bool fallbackMounted) {
+  // A recorder that started on FFat must keep one stable root for the whole
+  // boot. Switching it to an alternate removable mount can split one boot's
+  // chunks across two filesystems while an FFat FILE is still open.
+  return !removableMounted && !fallbackMounted;
 }
 
 } // namespace storage_mount_policy

--- a/esp32/tools/tests/test_ride_diagnostics_control.cpp
+++ b/esp32/tools/tests/test_ride_diagnostics_control.cpp
@@ -1,4 +1,5 @@
 #include "../../lib/ride_diagnostics/ride_diagnostics_control.hpp"
+#include "../../lib/ride_diagnostics/ride_diagnostics_transfer_policy.hpp"
 
 #include <cassert>
 #include <iostream>
@@ -45,6 +46,27 @@ int main() {
   assert(markerSequenceAfterBinding(captureA, captureA, 7) == 7);
   assert(markerSequenceAfterBinding(captureA, captureB, 7) == 0);
   assert(markerSequenceAfterBinding(nullptr, captureB, 7) == 0);
+
+  using namespace ride_diagnostics::transfer_policy;
+  assert(storageReady(StoragePreparation::ReadyRemovable));
+  assert(storageReady(StoragePreparation::ReadyInternalFallback));
+  assert(usingInternalFallback(StoragePreparation::ReadyInternalFallback));
+  assert(!storageReady(StoragePreparation::CardMissing));
+  assert(std::string(storageFailure(StoragePreparation::MountFailed).code) ==
+         "diagnostics_mount_failed");
+  assert(std::string(storageFailure(StoragePreparation::CardMissing).code) ==
+         "diagnostics_card_missing");
+  assert(std::string(
+             storageFailure(StoragePreparation::WritableProbeFailed).code) ==
+         "diagnostics_writable_probe_failed");
+  assert(std::string(sealFailure(SealPreparation::FlushFailed).code) ==
+         "diagnostics_flush_failed");
+  assert(std::string(sealFailure(SealPreparation::CloseFailed).code) ==
+         "diagnostics_close_failed");
+  assert(std::string(sealFailure(SealPreparation::DrainTimeout).code) ==
+         "diagnostics_seal_timeout");
+  assert(std::string(sealFailure(SealPreparation::SealFailed).code) ==
+         "diagnostics_seal_failed");
 
   std::cout << "ride diagnostics control tests passed\n";
   return 0;

--- a/esp32/tools/tests/test_ride_diagnostics_http_contract.py
+++ b/esp32/tools/tests/test_ride_diagnostics_http_contract.py
@@ -43,6 +43,8 @@ class RideDiagnosticsHttpContractTests(unittest.TestCase):
         self.assertIn("listChunks(server_, request)", index)
         self.assertIn("kMaximumIndexBytes", index)
         self.assertIn("snapshot.dropped", index)
+        self.assertIn("diagnostics_index_unreadable", index)
+        self.assertIn("index.readable", index)
 
         chunk = HTTP[
             HTTP.index("http_policy::RouteKind::Chunk") :
@@ -52,6 +54,11 @@ class RideDiagnosticsHttpContractTests(unittest.TestCase):
         self.assertIn("sendFile(client, chunk, server_, request)", chunk)
         self.assertIn("sent == chunk.bytes", HTTP)
         self.assertIn("storage.hasError(file)", HTTP)
+
+    def test_zero_byte_crash_artifacts_are_ignored_but_read_errors_fail_closed(self):
+        self.assertIn("CandidateDisposition::IgnoreEmpty", HTTP)
+        self.assertIn("CandidateDisposition::Reject", HTTP)
+        self.assertIn("index.readable = false", HTTP)
 
     def test_exit_is_deferred_until_clean_response(self):
         self.assertIn("exitAfterResponse_ = true", HTTP)

--- a/esp32/tools/tests/test_ride_diagnostics_http_policy.cpp
+++ b/esp32/tools/tests/test_ride_diagnostics_http_policy.cpp
@@ -1,10 +1,13 @@
 #include "../../lib/ride_diagnostics/ride_diagnostics_http_policy.hpp"
+#include "../../lib/ride_diagnostics/ride_diagnostics_index_policy.hpp"
 
 #include <cassert>
 #include <cstdint>
 #include <string>
 
 using ride_diagnostics::http_policy::RouteKind;
+using ride_diagnostics::index_policy::CandidateDisposition;
+using ride_diagnostics::index_policy::classifyCandidate;
 
 int main() {
   constexpr char prefix[] = "/device-diagnostics/v1/";
@@ -27,6 +30,15 @@ int main() {
   assert(ride_diagnostics::http_policy::parseRoute(
              "GET", std::string(prefix) + "session/exit", prefix)
              .kind == RouteKind::Unknown);
+
+  assert(classifyCandidate(0, 256 * 1024) ==
+         CandidateDisposition::IgnoreEmpty);
+  // The firmware indexes readable crash-tail bytes as-is. iOS verifies the
+  // checksum and ignores only the incomplete final JSON record.
+  assert(classifyCandidate(66560, 256 * 1024) ==
+         CandidateDisposition::Include);
+  assert(classifyCandidate(256 * 1024 + 1, 256 * 1024) ==
+         CandidateDisposition::Reject);
 
   const auto chunk = ride_diagnostics::http_policy::parseRoute(
       "GET", std::string(prefix) + "chunks/12/34", prefix);

--- a/esp32/tools/tests/test_ride_diagnostics_storage_contract.py
+++ b/esp32/tools/tests/test_ride_diagnostics_storage_contract.py
@@ -10,11 +10,13 @@ RECORDER = (ROOT / "lib/ride_diagnostics/ride_diagnostics.cpp").read_text(
 
 
 class RideDiagnosticsStorageContractTests(unittest.TestCase):
-    def test_alternate_mount_requires_probe_and_tears_down_unhealthy_mount(self):
+    def test_transfer_preparation_probes_the_stable_recorder_backend(self):
         self.assertIn("writableProbeSucceeded", STORAGE)
-        self.assertIn("storage_mount_policy::diagnosticsMountReady", STORAGE)
-        self.assertIn("if (!ready) {\n      SD.end();", STORAGE)
-        self.assertIn("diagnosticsSdMountedAtAlternateRoot = false", STORAGE)
+        self.assertIn("prepareDiagnosticsStorage", STORAGE)
+        self.assertIn("StoragePreparation::CardMissing", STORAGE)
+        self.assertIn("StoragePreparation::WritableProbeFailed", STORAGE)
+        self.assertIn("StoragePreparation::ReadyInternalFallback", STORAGE)
+        self.assertNotIn("SD.begin(\n        SD_CS, hspi, WAVESHARE_SD_SPI_FREQ_HZ,\n        kDiagnosticsAlternateRoot)", STORAGE)
 
     def test_ffat_fallback_is_a_valid_diagnostics_backend(self):
         self.assertIn("internalFallbackMounted.load()", STORAGE)

--- a/esp32/tools/tests/test_storage_mount_policy.cpp
+++ b/esp32/tools/tests/test_storage_mount_policy.cpp
@@ -4,30 +4,19 @@
 #include <iostream>
 
 int main() {
-  using storage_mount_policy::diagnosticsMountReady;
   using storage_mount_policy::shouldAttemptAutomaticRemovableRetry;
   using storage_mount_policy::shouldAttemptDiagnosticsRemovableRetry;
   using storage_mount_policy::shouldRestoreFallbackAfterFailedRetry;
-  using storage_mount_policy::validEspVfsMountPathLength;
-
-  assert(validEspVfsMountPathLength(sizeof("/diag-sd") - 1));
-  assert(!validEspVfsMountPathLength(1));
-  assert(!validEspVfsMountPathLength(16));
-
-  assert(diagnosticsMountReady(true, true, true));
-  assert(!diagnosticsMountReady(false, true, true));
-  assert(!diagnosticsMountReady(true, false, true));
-  assert(!diagnosticsMountReady(true, true, false));
 
   assert(shouldAttemptAutomaticRemovableRetry(false, false));
   assert(!shouldAttemptAutomaticRemovableRetry(true, false));
   assert(!shouldAttemptAutomaticRemovableRetry(false, true));
   assert(!shouldAttemptAutomaticRemovableRetry(true, true));
 
-  assert(shouldAttemptDiagnosticsRemovableRetry(false, false, false));
-  assert(shouldAttemptDiagnosticsRemovableRetry(false, false, true));
-  assert(!shouldAttemptDiagnosticsRemovableRetry(true, false, false));
-  assert(!shouldAttemptDiagnosticsRemovableRetry(false, true, true));
+  assert(shouldAttemptDiagnosticsRemovableRetry(false, false));
+  assert(!shouldAttemptDiagnosticsRemovableRetry(false, true));
+  assert(!shouldAttemptDiagnosticsRemovableRetry(true, false));
+  assert(!shouldAttemptDiagnosticsRemovableRetry(true, true));
 
   assert(!shouldRestoreFallbackAfterFailedRetry(false, false));
   assert(shouldRestoreFallbackAfterFailedRetry(true, false));

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceDiagnosticsTransferManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceDiagnosticsTransferManager.swift
@@ -36,6 +36,7 @@ enum DeviceDiagnosticsTransferError: LocalizedError {
     case deviceIdentityUnavailable
     case invalidIndex
     case requestFailed(Int)
+    case deviceRejected(code: String, message: String)
     case oversizedChunk
     case hashMismatch
     case malformedChunk
@@ -48,6 +49,11 @@ enum DeviceDiagnosticsTransferError: LocalizedError {
             return "The device returned an invalid diagnostics index."
         case .requestFailed(let status):
             return "The device diagnostics request failed (HTTP \(status))."
+        case .deviceRejected(let code, let message):
+            return DeviceDiagnosticsRejectionPolicy.message(
+                code: code,
+                fallback: message
+            )
         case .oversizedChunk:
             return "The device diagnostics chunk exceeded the safety limit."
         case .hashMismatch:
@@ -63,6 +69,16 @@ enum DeviceDiagnosticsTransferError: LocalizedError {
 /// recorder pull can contain tens of millions of bytes and must not monopolize
 /// UI scheduling while enforcing the streaming byte limit.
 nonisolated private enum DeviceDiagnosticsHTTPClient {
+    private struct ErrorEnvelope: Decodable {
+        struct Detail: Decodable {
+            let code: String
+            let message: String
+        }
+
+        let ok: Bool
+        let error: Detail
+    }
+
     static func request(
         _ request: URLRequest,
         configuration: URLSessionConfiguration,
@@ -71,12 +87,7 @@ nonisolated private enum DeviceDiagnosticsHTTPClient {
         let urlSession = URLSession(configuration: configuration)
         defer { urlSession.invalidateAndCancel() }
         let (bytes, response) = try await urlSession.bytes(for: request)
-        guard let status = (response as? HTTPURLResponse)?.statusCode,
-              200..<300 ~= status else {
-            throw DeviceDiagnosticsTransferError.requestFailed(
-                (response as? HTTPURLResponse)?.statusCode ?? -1
-            )
-        }
+        let status = (response as? HTTPURLResponse)?.statusCode ?? -1
         let expectedLength = response.expectedContentLength
         guard expectedLength < 0 || expectedLength <= Int64(maximumBytes) else {
             throw DeviceDiagnosticsTransferError.oversizedChunk
@@ -90,6 +101,18 @@ nonisolated private enum DeviceDiagnosticsHTTPClient {
                 throw DeviceDiagnosticsTransferError.oversizedChunk
             }
             data.append(byte)
+        }
+        guard 200..<300 ~= status else {
+            if let envelope = try? JSONDecoder().decode(
+                ErrorEnvelope.self,
+                from: data
+            ), !envelope.ok, !envelope.error.code.isEmpty {
+                throw DeviceDiagnosticsTransferError.deviceRejected(
+                    code: envelope.error.code,
+                    message: envelope.error.message
+                )
+            }
+            throw DeviceDiagnosticsTransferError.requestFailed(status)
         }
         return data
     }
@@ -155,11 +178,13 @@ final class DeviceDiagnosticsTransferManager {
             event: "diagnostics_download_started",
             fields: ["mode": DeviceTransferSession.Mode.diagnostics.rawValue]
         )
-        let session = try await transferManager.enterDiagnostics(
-            bleManager: bleManager,
-            status: status
-        )
+        var openedSession: DeviceTransferSession?
         do {
+            let session = try await transferManager.enterDiagnostics(
+                bleManager: bleManager,
+                status: status
+            )
+            openedSession = session
             status("reading device diagnostics index")
             let indexData = try await request(
                 session: session,
@@ -277,19 +302,55 @@ final class DeviceDiagnosticsTransferManager {
             // unstructured MainActor task (which does not inherit cancellation)
             // and await it so network restoration and device revocation get a
             // deterministic bounded cleanup attempt before we rethrow.
-            let cleanup = Task { @MainActor [weak self] in
-                guard let self else { return }
-                try? await self.closeSession(session, bleManager: bleManager)
+            if let openedSession {
+                let cleanup = Task { @MainActor [weak self] in
+                    guard let self else { return }
+                    try? await self.closeSession(
+                        openedSession,
+                        bleManager: bleManager
+                    )
+                }
+                await cleanup.value
             }
-            await cleanup.value
+            let failure = Self.failureFields(
+                error,
+                enteredSession: openedSession != nil
+            )
             recorder.record(
                 level: .warning,
                 category: .transfer,
                 event: "diagnostics_download_failed",
-                fields: ["reason": "transfer_failed"]
+                fields: failure
             )
             throw error
         }
+    }
+
+    private static func failureFields(
+        _ error: Error,
+        enteredSession: Bool
+    ) -> [String: String] {
+        var code = "unknown"
+        if let rejection = error as? RemoteDeviceDebugError {
+            code = rejection.diagnosticCode
+        } else if let transfer = error as? DeviceDiagnosticsTransferError {
+            switch transfer {
+            case .deviceIdentityUnavailable: code = "device_identity_unavailable"
+            case .invalidIndex: code = "invalid_index"
+            case .requestFailed(let status): code = "http_\(status)"
+            case .deviceRejected(let rejectedCode, _): code = rejectedCode
+            case .oversizedChunk: code = "oversized_chunk"
+            case .hashMismatch: code = "hash_mismatch"
+            case .malformedChunk: code = "malformed_chunk"
+            }
+        } else if error is CancellationError {
+            code = "cancelled"
+        }
+        return [
+            "reason": enteredSession ? "transfer_failed" : "entry_failed",
+            "code": code,
+            "mode": DeviceTransferSession.Mode.diagnostics.rawValue,
+        ]
     }
 
     private func closeSession(

--- a/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/DeviceTransferManager.swift
@@ -164,11 +164,38 @@ struct RemoteDebugLANCredentialStore {
     }
 }
 
+enum DeviceDiagnosticsRejectionPolicy {
+    static func message(code: String, fallback: String?) -> String {
+        let explanation: String
+        switch code {
+        case "diagnostics_mount_failed":
+            explanation = "The bike computer could not mount diagnostics storage."
+        case "diagnostics_card_missing":
+            explanation = "The bike computer did not detect the removable card."
+        case "diagnostics_writable_probe_failed":
+            explanation = "Diagnostics storage mounted, but its writable probe failed."
+        case "diagnostics_flush_failed":
+            explanation = "The bike computer could not flush the active diagnostics checkpoint."
+        case "diagnostics_close_failed":
+            explanation = "The bike computer could not close the active diagnostics checkpoint."
+        case "diagnostics_seal_timeout":
+            explanation = "The bike computer timed out while draining diagnostics records."
+        case "diagnostics_seal_failed":
+            explanation = "The bike computer could not seal a readable diagnostics checkpoint."
+        case "diagnostics_index_unreadable":
+            explanation = "The bike computer found a non-empty diagnostics chunk that could not be read safely."
+        default:
+            explanation = fallback.flatMap { $0.isEmpty ? nil : $0 } ?? code
+        }
+        return "\(explanation) [\(code)]"
+    }
+}
+
 enum RemoteDeviceDebugError: LocalizedError, Equatable {
     case deviceNotReady
     case unsupportedFirmware
     case transferCommandNotSent
-    case rejected(String)
+    case rejected(code: String, message: String)
     case missingSession
 
     var errorDescription: String? {
@@ -179,10 +206,20 @@ enum RemoteDeviceDebugError: LocalizedError, Equatable {
             return "The connected firmware does not support remote device debugging."
         case .transferCommandNotSent:
             return "The remote-debug request could not be sent."
-        case .rejected(let message):
+        case .rejected(_, let message):
             return message
         case .missingSession:
             return "The device did not return a fresh remote-debug session."
+        }
+    }
+
+    var diagnosticCode: String {
+        switch self {
+        case .deviceNotReady: return "device_not_ready"
+        case .unsupportedFirmware: return "unsupported_firmware"
+        case .transferCommandNotSent: return "transfer_command_not_sent"
+        case .rejected(let code, _): return code
+        case .missingSession: return "missing_session"
         }
     }
 }
@@ -596,11 +633,23 @@ final class DeviceTransferManager {
             )
             return session
         } catch {
-            if enterWasQueued {
+            let rejectedBeforeSession: Bool
+            if let remoteError = error as? RemoteDeviceDebugError,
+               case .rejected = remoteError {
+                rejectedBeforeSession =
+                    bleManager.deviceTransferMode !=
+                    DeviceTransferSession.Mode.diagnostics.rawValue
+            } else {
+                rejectedBeforeSession = false
+            }
+            if enterWasQueued && !rejectedBeforeSession {
                 // An unstructured task does not inherit cancellation from the
                 // failed entry attempt. Await its bounded exit handshake so a
                 // cancel during status/LAN/hotspot setup cannot strand the
                 // device in diagnostics mode or leave the joined AP behind.
+                // A fresh firmware rejection while no diagnostics session is
+                // active needs no cleanup; returning it immediately preserves
+                // the fail-fast contract and its original error code.
                 let cleanup = Task { @MainActor [weak self] in
                     guard let self else { return }
                     try? await self.exitDiagnostics(bleManager: bleManager)
@@ -634,6 +683,22 @@ final class DeviceTransferManager {
                     hotspotFallbackReason: bleManager.deviceTransferHotspotFallbackReason
                 )
             }
+            // A fresh firmware rejection is authoritative. Do not spend the
+            // remainder of the LAN/hotspot readiness window polling after the
+            // device has already classified storage or seal preparation.
+            if bleManager.deviceTransferStatusRevision != initialRevision,
+               let code = bleManager.deviceTransferLastErrorCode,
+               !code.isEmpty {
+                let fallback = bleManager.deviceTransferLastErrorMessage
+                    .flatMap { $0.isEmpty ? nil : $0 }
+                throw RemoteDeviceDebugError.rejected(
+                    code: code,
+                    message: DeviceDiagnosticsRejectionPolicy.message(
+                        code: code,
+                        fallback: fallback
+                    )
+                )
+            }
             if DeviceTransferHandshakePolicy.shouldRequestStatus(attempt: attempt) {
                 _ = bleManager.requestDeviceTransferStatus()
             }
@@ -644,12 +709,32 @@ final class DeviceTransferManager {
         if bleManager.deviceTransferStatusRevision != initialRevision,
            let code = bleManager.deviceTransferLastErrorCode,
            !code.isEmpty {
-            let message = bleManager.deviceTransferLastErrorMessage
-                .flatMap { $0.isEmpty ? nil : $0 } ?? code
-            throw RemoteDeviceDebugError.rejected(message)
+            let fallback = bleManager.deviceTransferLastErrorMessage
+                .flatMap { $0.isEmpty ? nil : $0 }
+            throw RemoteDeviceDebugError.rejected(
+                code: code,
+                message: DeviceDiagnosticsRejectionPolicy.message(
+                    code: code,
+                    fallback: fallback
+                )
+            )
         }
         throw RemoteDeviceDebugError.missingSession
     }
+
+#if HOST_TESTING
+    func waitForDiagnosticsSessionForTesting(
+        bleManager: BLEManager,
+        afterRevision initialRevision: UInt64,
+        attemptCount: Int
+    ) async throws -> DeviceTransferSession {
+        try await waitForDiagnosticsSession(
+            bleManager: bleManager,
+            afterRevision: initialRevision,
+            attemptCount: attemptCount
+        )
+    }
+#endif
 
     private func stopDiagnostics(bleManager: BLEManager) async throws {
         let initialRevision = bleManager.deviceTransferStatusRevision
@@ -671,7 +756,8 @@ final class DeviceTransferManager {
             )
         }
         throw RemoteDeviceDebugError.rejected(
-            "The device did not confirm that the diagnostics session ended."
+            code: "diagnostics_exit_unconfirmed",
+            message: "The device did not confirm that the diagnostics session ended."
         )
     }
 
@@ -786,7 +872,10 @@ final class DeviceTransferManager {
            !code.isEmpty {
             let message = bleManager.deviceTransferLastErrorMessage
                 .flatMap { $0.isEmpty ? nil : $0 } ?? code
-            throw RemoteDeviceDebugError.rejected(message)
+            throw RemoteDeviceDebugError.rejected(
+                code: code,
+                message: message
+            )
         }
         throw RemoteDeviceDebugError.missingSession
     }
@@ -811,7 +900,8 @@ final class DeviceTransferManager {
             )
         }
         throw RemoteDeviceDebugError.rejected(
-            "The device did not confirm that the debug session ended."
+            code: "debug_exit_unconfirmed",
+            message: "The device did not confirm that the debug session ended."
         )
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -2702,12 +2702,14 @@ private struct RemoteDeviceDebugSettingsSection: View {
                         password: lanPassword
                     ) else {
                         throw RemoteDeviceDebugError.rejected(
-                            lanValidationMessage ?? "Invalid local Wi-Fi credentials."
+                            code: "invalid_lan_credentials",
+                            message: lanValidationMessage ?? "Invalid local Wi-Fi credentials."
                         )
                     }
                     guard credentialStore.save(validated) else {
                         throw RemoteDeviceDebugError.rejected(
-                            "The local Wi-Fi credentials could not be saved to Keychain."
+                            code: "lan_credentials_not_saved",
+                            message: "The local Wi-Fi credentials could not be saved to Keychain."
                         )
                     }
                     credentials = validated

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -261,11 +261,13 @@ final class TestDeviceDiagnosticsSessionController:
 {
     weak var diagnosticsRecorder: (any RideDiagnosticsEventSink)?
     let session: DeviceTransferSession
+    let enterError: Error?
     private(set) var enterCount = 0
     private(set) var exitCount = 0
 
-    init(session: DeviceTransferSession) {
+    init(session: DeviceTransferSession, enterError: Error? = nil) {
         self.session = session
+        self.enterError = enterError
     }
 
     func enterDiagnostics(
@@ -274,6 +276,9 @@ final class TestDeviceDiagnosticsSessionController:
     ) async throws -> DeviceTransferSession {
         _ = bleManager
         enterCount += 1
+        if let enterError {
+            throw enterError
+        }
         status("test diagnostics session ready")
         return session
     }
@@ -786,6 +791,8 @@ struct NavigationProtocolTests {
         await testDeviceTransferManagerConfirmsDebugExit()
         await testDeviceTransferManagerUsesFreshDeviceSessionWithoutMapStatus()
         await testDeviceDiagnosticsTransferPolicy()
+        await testDeviceDiagnosticsFailsFastOnFirmwareRejection()
+        await testDeviceDiagnosticsRecordsEntryFailure()
         await testDeviceDiagnosticsDownloadEndToEnd()
         await testOfflineMapInstallationCredentialClient()
         testOfflineMapPreparationTimeEstimate()
@@ -17899,6 +17906,29 @@ struct NavigationProtocolTests {
             assert(false, "oversized diagnostics stream has the right error")
         }
 
+        OfflineMapTestURLProtocol.configure { _ in
+            (500, Data("""
+            {"ok":false,"error":{"code":"diagnostics_index_unreadable","message":"chunk could not be read"}}
+            """.utf8))
+        }
+        do {
+            _ = try await manager.requestForTesting(
+                session: session,
+                path: "device-diagnostics/v1/index",
+                maximumBytes: 4096
+            )
+            assert(false, "structured diagnostics rejection is thrown")
+        } catch DeviceDiagnosticsTransferError.deviceRejected(
+            let code, let message
+        ) {
+            assertEqual(code, "diagnostics_index_unreadable",
+                        "HTTP diagnostics errors retain their firmware code")
+            assert(message.contains("chunk could not be read"),
+                   "HTTP diagnostics errors retain their firmware detail")
+        } catch {
+            assert(false, "structured diagnostics rejection has the right error")
+        }
+
         let validIndex = Data("""
         {"schema":1,"source":"firmware","bootSequence":1,"activeChunk":2,"stats":{"enqueued":2,"written":1,"dropped":0,"storageErrors":0},"chunks":[{"bootSequence":1,"chunk":1,"bytes":3,"sha256":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]}
         """.utf8)
@@ -17976,7 +18006,14 @@ struct NavigationProtocolTests {
             ]),
             "chunks from one boot cannot silently change firmware identity"
         )
-        let truncatedFirstStream = validStream + Data("{\"schema\":".utf8)
+        let truncatedFirstStream = validStream +
+            Data("\n{\"schema\":".utf8)
+        assert(
+            DeviceDiagnosticsTransferManager.validateJSONLForTesting(
+                truncatedFirstStream
+            ) != nil,
+            "one truncated crash-tail record is recoverable on a final chunk"
+        )
         assert(
             !DeviceDiagnosticsTransferManager.streamsAreOrderedForTesting([
                 (1, truncatedFirstStream), (1, laterStream),
@@ -18017,6 +18054,132 @@ struct NavigationProtocolTests {
     }
 
     @MainActor
+    static func testDeviceDiagnosticsFailsFastOnFirmwareRejection() async {
+        let bleManager = BLEManager()
+        let initialRevision = bleManager.deviceTransferStatusRevision
+        let manager = DeviceTransferManager()
+        let started = Date()
+        let wait = Task {
+            try await manager.waitForDiagnosticsSessionForTesting(
+                bleManager: bleManager,
+                afterRevision: initialRevision,
+                attemptCount: 32
+            )
+        }
+        try? await Task.sleep(nanoseconds: 20_000_000)
+        let rejectedStatus = """
+        {"configured":true,"enabled":false,"mode":"","lastError":{"code":"diagnostics_writable_probe_failed","message":"probe failed"}}
+        """
+        _ = bleManager.handleDeviceTransferStatusNotification(
+            Data(DeviceBLEProtocol.deviceTransferStatusPrefix.utf8) +
+                Data(rejectedStatus.utf8)
+        )
+        do {
+            _ = try await wait.value
+            assert(false, "firmware diagnostics rejection must fail entry")
+        } catch RemoteDeviceDebugError.rejected(let code, let message) {
+            assertEqual(code, "diagnostics_writable_probe_failed",
+                        "diagnostics handshake retains the firmware code")
+            assert(message.contains("diagnostics_writable_probe_failed"),
+                   "diagnostics rejection presented to the user includes its code")
+            assert(Date().timeIntervalSince(started) < 1.5,
+                   "fresh firmware rejection bypasses the full polling window")
+        } catch {
+            assert(false, "firmware diagnostics rejection has the right error")
+        }
+    }
+
+    @MainActor
+    static func testDeviceDiagnosticsRecordsEntryFailure() async {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(
+                "device-diagnostics-entry-failure-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let defaultsSuite =
+            "DeviceDiagnosticsEntryFailure.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: defaultsSuite)!
+        defer { defaults.removePersistentDomain(forName: defaultsSuite) }
+        let recorder = RideDiagnosticsRecorder(
+            rootURL: root,
+            userDefaults: defaults
+        )
+        let bleManager = BLEManager()
+        bleManager.setConnectedDeviceIDForTesting(
+            "01234567-89ab-cdef-0123-456789abcdef"
+        )
+        let session = DeviceTransferSession(
+            mode: .diagnostics,
+            baseURL: URL(string: "https://diagnostics.test")!,
+            accessPointSSID: nil,
+            sessionToken: "unused-token"
+        )
+        let sessionController = TestDeviceDiagnosticsSessionController(
+            session: session,
+            enterError: RemoteDeviceDebugError.rejected(
+                code: "diagnostics_seal_timeout",
+                message: "seal timed out [diagnostics_seal_timeout]"
+            )
+        )
+        let manager = DeviceDiagnosticsTransferManager(
+            transferManager: sessionController
+        )
+        do {
+            _ = try await manager.downloadDeviceLogs(
+                bleManager: bleManager,
+                recorder: recorder,
+                status: { _ in }
+            )
+            assert(false, "diagnostics entry rejection must fail download")
+        } catch RemoteDeviceDebugError.rejected(let code, _) {
+            assertEqual(code, "diagnostics_seal_timeout",
+                        "entry rejection reaches the diagnostics caller")
+        } catch {
+            assert(false, "diagnostics entry failure has the right error")
+        }
+        recorder.flush()
+        assertEqual(sessionController.enterCount, 1,
+                    "entry failure performs one diagnostics entry attempt")
+        assertEqual(sessionController.exitCount, 0,
+                    "entry failure does not exit a session that never opened")
+
+        var failureEvent: RideDiagnosticEvent?
+        let appDirectory = root
+            .appendingPathComponent("app", isDirectory: true)
+            .appendingPathComponent(
+                recorder.processId.uuidString.lowercased(),
+                isDirectory: true
+            )
+        let eventFiles = (try? FileManager.default.contentsOfDirectory(
+            at: appDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        for fileURL in eventFiles where fileURL.pathExtension == "jsonl" {
+            guard let data = try? Data(contentsOf: fileURL),
+                  let text = String(data: data, encoding: .utf8) else {
+                continue
+            }
+            for line in text.split(separator: "\n") {
+                guard let event = try? JSONDecoder().decode(
+                    RideDiagnosticEvent.self,
+                    from: Data(line.utf8)
+                ), event.event == "diagnostics_download_failed" else {
+                    continue
+                }
+                failureEvent = event
+            }
+        }
+        assertEqual(failureEvent?.fields["reason"], "entry_failed",
+                    "iOS records that diagnostics failed during entry")
+        assertEqual(
+            failureEvent?.fields["code"],
+            "diagnostics_seal_timeout",
+            "iOS records the exact firmware diagnostics rejection code"
+        )
+    }
+
+    @MainActor
     static func testDeviceDiagnosticsDownloadEndToEnd() async {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(
@@ -18041,8 +18204,7 @@ struct NavigationProtocolTests {
         )
         let stream = Data("""
         {"schema":1,"source":"firmware","sequence":7,"level":"info","category":"boot","event":"ready","fields":{"bootSequence":1,"firmwareFingerprint":"A1B2C3D4"}}
-
-        """.utf8)
+        """.utf8) + Data("\n{\"schema\":1,\"source\":\"firmware\"".utf8)
         let digest = SHA256.hash(data: stream).map {
             String(format: "%02x", $0)
         }.joined()
@@ -18100,7 +18262,7 @@ struct NavigationProtocolTests {
                     sha256: digest
                 ),
                 stream,
-                "end-to-end diagnostics persists the verified chunk"
+                "end-to-end diagnostics preserves the verified crash-tail chunk"
             )
             let requests = OfflineMapTestURLProtocol.requests()
             assertEqual(


### PR DESCRIPTION
## Summary

- replace the generic diagnostics storage/seal rejection with stage-specific mount, card-detection, writable-probe, flush, close, seal-timeout, seal, and readable-index errors
- make recorder sealing converge transient producer/fault-capsule races within one bounded request
- keep one storage backend for the complete boot while allowing bounded internal FFat diagnostics export when removable storage is unavailable
- ignore zero-byte crash artifacts, preserve checksum-verified chunks with a truncated final JSON record, and fail closed for unreadable non-empty chunks
- make iOS fail immediately on fresh firmware rejection and record diagnostics-entry failures with their exact code

The captured failing boot had a mounted storage backend and failed before the active chunk advanced or closed. The old Boolean result cannot identify its finer internal seal branch retrospectively; this change makes those branches observable and removes the misleading mount-only message.

## Validation

- `python3 -m unittest discover -s tools/tests` — 67 passed
- focused C++ diagnostics/storage policy tests — passed
- focused diagnostics source-contract tests — 8 passed
- `ios-app/scripts/run-navigation-tests.sh` — navigation, cycling sensor, layout, and saved-map tests passed
- unsigned iPhone/Watch build through `ios-app/scripts/xcodebuild-cli.sh` — succeeded
- build-only `WAVESHARE_AMOLED_175_PRODUCTION` firmware compile/link — succeeded, 96.3% flash and 28.4% RAM; the dirty validation artifact was upload-ineligible and was not flashed
- `git diff origin/main...HEAD --check` — passed

Physical validation is intentionally pending. No device was flashed, no app was installed, and the mounted SD card and evidence backups were not modified. The known FAT orphaned clusters were not repaired and may now surface as a precise writable-probe or readable-index failure.

## Contributor License Agreement

Choose the statement that applies:

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License
  Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md).
  By checking this box and submitting the pull request, I adopt my GitHub
  account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all
  third-party material and applicable license notices.
