### PR TITLE
Decode phase-only offline map progress

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -593,6 +593,27 @@ struct OfflineMapJobProgress: Decodable, Equatable {
     let total: Int?
     let indeterminate: Bool?
 
+    private enum CodingKeys: String, CodingKey {
+        case completedBlocks
+        case totalBlocks
+        case phase
+        case unit
+        case completed
+        case total
+        case indeterminate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        completedBlocks = try container.decodeIfPresent(Int.self, forKey: .completedBlocks) ?? 0
+        totalBlocks = try container.decodeIfPresent(Int.self, forKey: .totalBlocks) ?? 0
+        phase = try container.decodeIfPresent(String.self, forKey: .phase)
+        unit = try container.decodeIfPresent(String.self, forKey: .unit)
+        completed = try container.decodeIfPresent(Int.self, forKey: .completed)
+        total = try container.decodeIfPresent(Int.self, forKey: .total)
+        indeterminate = try container.decodeIfPresent(Bool.self, forKey: .indeterminate)
+    }
+
     var fraction: Double {
         guard totalBlocks > 0 else { return 0 }
         return min(max(Double(completedBlocks) / Double(totalBlocks), 0), 1)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -797,6 +797,7 @@ struct NavigationProtocolTests {
         await testOfflineMapInstallationCredentialClient()
         testOfflineMapPreparationTimeEstimate()
         testOfflineMapJobProgressDecoding()
+        testOfflineMapJobPhaseOnlyProgressDecoding()
         testOfflineMapJobProgressAbsentFallback()
         testOfflineMapProgressPresentation()
         testOfflineMapByteProgressPresentation()
@@ -7712,6 +7713,38 @@ struct NavigationProtocolTests {
             "231 of 266 map blocks · 7 of 8 chunks ready · 1 active",
             "aggregate progress explains block and chunk completion"
         )
+    }
+
+    static func testOfflineMapJobPhaseOnlyProgressDecoding() {
+        let payload = Data(
+            """
+            {
+              "jobId": "phase-only-progress",
+              "status": "converting_features",
+              "progress": {
+                "phase": "building_preprocessing",
+                "unit": "building_part_association",
+                "completed": 4772,
+                "total": 4772,
+                "fraction": 1.0,
+                "indeterminate": false
+              }
+            }
+            """.utf8
+        )
+        guard let job = try? JSONDecoder().decode(OfflineMapJob.self, from: payload),
+              let progress = job.progress else {
+            assert(false, "phase-only map progress should decode without block counts")
+            return
+        }
+
+        assertEqual(progress.completedBlocks, 0, "missing completed block count defaults to zero")
+        assertEqual(progress.totalBlocks, 0, "missing total block count defaults to zero")
+        assertEqual(progress.phase, "building_preprocessing", "phase-only progress decodes phase")
+        assertEqual(progress.unit, "building_part_association", "phase-only progress decodes unit")
+        assertEqual(progress.percentage, 100, "phase-only progress uses completed units")
+        assert(abs(progress.fraction) < 0.000001, "phase-only progress has no block fraction")
+        assertEqual(progress.detail, "Preparing 3D buildings", "phase-only progress explains preprocessing")
     }
 
     static func testOfflineMapJobProgressAbsentFallback() {


### PR DESCRIPTION
## Summary
- decode preprocessing progress when the backend omits block-count fields
- preserve phase-unit progress and default unavailable block counts to zero
- cover the live phase-only response shape with a regression test

## Validation
- `cd ios-app && ./scripts/run-navigation-tests.sh`
- `cd ios-app && ./scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination "generic/platform=iOS" CODE_SIGNING_ALLOWED=NO build`