### PR TITLE
Reconcile installed map status in Saved Maps

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -8415,6 +8415,54 @@ extension BLEManager: CBPeripheralDelegate {
         return applyMapTransferStatusBody(body)
     }
 
+    func applyAuthenticatedMapTransferStatus(_ status: MapTransferDeviceStatus) {
+        if let enabled = status.enabled {
+            mapTransferModeEnabled = enabled
+        }
+        mapTransferActiveMapId = status.activeMapId ?? ""
+        mapTransferActiveSessionId = status.activeSessionId ?? ""
+        activeMapManifestReceipt = status.activeManifestReceipt ?? ""
+        if let mapID = status.activeMapId {
+            activeDeviceMap = DeviceActiveMapDescriptor(
+                mapID: mapID,
+                sessionID: status.activeSessionId,
+                manifestReceipt: status.activeManifestReceipt,
+                displayName: status.activeMapDisplayName,
+                boundsE7: status.activeMapBoundsE7
+            )
+        } else {
+            activeDeviceMap = nil
+        }
+
+        if let activation = status.activation {
+            mapTransferActivationStatus = activation.status ?? "idle"
+            mapTransferActivationSequence = activation.sequence
+            mapTransferActivationSessionId = activation.sessionId ?? ""
+            mapTransferActivationMapId = activation.mapId ?? ""
+            mapTransferActivationStep = activation.step
+            mapTransferActivationStepCount = activation.steps
+            mapTransferActivationProgress = activation.progress
+            if let error = activation.error {
+                let code = error.code ?? "activation_error"
+                let message = error.message ?? ""
+                mapTransferActivationError = message.isEmpty
+                    ? code
+                    : "\(code): \(message)"
+            } else {
+                mapTransferActivationError = nil
+            }
+        } else {
+            mapTransferActivationStatus = "idle"
+            mapTransferActivationSequence = nil
+            mapTransferActivationSessionId = ""
+            mapTransferActivationMapId = ""
+            mapTransferActivationStep = nil
+            mapTransferActivationStepCount = nil
+            mapTransferActivationProgress = nil
+            mapTransferActivationError = nil
+        }
+    }
+
     private func applyMapTransferStatusBody(_ body: Data) -> Bool {
         guard let object = try? JSONSerialization.jsonObject(with: body) as? [String: Any] else {
             mapTransferStatusDescription = "invalid status"

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -2146,17 +2146,51 @@ final class OfflineMapManager: ObservableObject {
 
     func isPausedMapUpload(_ packURL: URL) -> Bool {
         let metadata = SavedMapArtifactMetadataStore.load(for: packURL)
+        let candidateMapID = savedMapID(for: packURL)
+        let sessionID = metadata?.lastTransferSessionID ?? defaults.string(
+            forKey: OfflineMapDefaults.lastTransferSessionIdKey
+        )
+        let backgroundUploadSucceeded = sessionID.flatMap { sessionID in
+            BackgroundMapUploadStateStore.latest(
+                mapID: candidateMapID,
+                sessionID: sessionID,
+                defaults: defaults
+            )?.succeeded
+        }
         return PausedMapUploadResumePolicy.isAvailable(
             lastTransferOutcome: lastTransferOutcome,
             lastTransferMapID: lastTransferMapId,
-            candidateMapID: savedMapID(for: packURL),
+            candidateMapID: candidateMapID,
             lastTransferArtifactFilename: defaults.string(
                 forKey: OfflineMapDefaults.lastTransferArtifactFilenameKey
             ),
             candidateArtifactFilename: packURL.lastPathComponent,
             lastDeviceState: metadata?.lastDeviceState,
+            backgroundUploadSucceeded: backgroundUploadSucceeded,
             statusMessage: statusMessage
         )
+    }
+
+    func isAwaitingMapActivationConfirmation(_ packURL: URL) -> Bool {
+        let candidateMapID = savedMapID(for: packURL)
+        guard lastTransferOutcome == "unconfirmed",
+              lastTransferMapId == candidateMapID,
+              defaults.string(
+                  forKey: OfflineMapDefaults.lastTransferArtifactFilenameKey
+              ) == packURL.lastPathComponent,
+              let sessionID = defaults.string(
+                  forKey: OfflineMapDefaults.lastTransferSessionIdKey
+              ),
+              !sessionID.isEmpty else {
+            return false
+        }
+        let metadata = SavedMapArtifactMetadataStore.load(for: packURL)
+        guard metadata?.lastDeviceState != "paused" else { return false }
+        return BackgroundMapUploadStateStore.latest(
+            mapID: candidateMapID,
+            sessionID: sessionID,
+            defaults: defaults
+        )?.succeeded == true
     }
 
     func mapUploadProgress(for packURL: URL) -> Double? {
@@ -4675,6 +4709,7 @@ final class OfflineMapManager: ObservableObject {
                     sessionToken: transferSession.sessionToken
                 )
                 let initialDeviceStatus = try await client.status()
+                bleManager.applyAuthenticatedMapTransferStatus(initialDeviceStatus)
                 if case .stream = prepared,
                    let activation = initialDeviceStatus.activation,
                    activation.sessionId == sessionId,
@@ -4924,7 +4959,14 @@ final class OfflineMapManager: ObservableObject {
             )
             updateLastTransferOutcome(outcome)
             if outcome == "unconfirmed" {
-                statusMessage = "Map upload paused. Tap Upload to resume."
+                let uploadSucceeded = BackgroundMapUploadStateStore.latest(
+                    mapID: expectedMapId,
+                    sessionID: sessionId,
+                    defaults: defaults
+                )?.succeeded == true
+                statusMessage = uploadSucceeded
+                    ? "Activation confirmation delayed. Reconnecting to device…"
+                    : "Map upload paused. Tap Upload to resume."
                 errorMessage = nil
                 startActivationReconciliationMonitor(bleManager: bleManager)
                 return
@@ -5118,6 +5160,9 @@ final class OfflineMapManager: ObservableObject {
         activationMayBeInFlight: inout Bool
     ) async throws {
         let statusBeforeActivation = try? await client.status()
+        if let statusBeforeActivation {
+            bleManager.applyAuthenticatedMapTransferStatus(statusBeforeActivation)
+        }
         let activationAlreadyStarted = statusBeforeActivation?.activation?.sessionId == sessionID
         let previousMapID = statusBeforeActivation?.activeMapId ??
             initialDeviceStatus.activeMapId ?? bleManager.mapTransferActiveMapId
@@ -5179,6 +5224,9 @@ final class OfflineMapManager: ObservableObject {
         artifactURL: URL
     ) async throws {
         let statusAfterUpload = try? await client.status()
+        if let statusAfterUpload {
+            bleManager.applyAuthenticatedMapTransferStatus(statusAfterUpload)
+        }
         let previousMapID = initialDeviceStatus.activeMapId ?? bleManager.mapTransferActiveMapId
         let previousSessionID = initialDeviceStatus.activeSessionId ??
             bleManager.mapTransferActiveSessionId
@@ -5284,6 +5332,7 @@ final class OfflineMapManager: ObservableObject {
             do {
                 let status = try await client.status()
                 receivedHTTPStatus = true
+                bleManager.applyAuthenticatedMapTransferStatus(status)
                 let activation = status.activation
                 updateActivationProgress(
                     status: activation?.status,

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -748,6 +748,7 @@ nonisolated enum PausedMapUploadResumePolicy {
         lastTransferArtifactFilename: String? = nil,
         candidateArtifactFilename: String? = nil,
         lastDeviceState: String?,
+        backgroundUploadSucceeded: Bool? = nil,
         statusMessage: String = ""
     ) -> Bool {
         guard lastTransferOutcome == "unconfirmed",
@@ -760,6 +761,13 @@ nonisolated enum PausedMapUploadResumePolicy {
                   lastTransferArtifactFilename == candidateArtifactFilename else {
                 return false
             }
+        }
+        if backgroundUploadSucceeded == true {
+            // A successful protocol-2 upload may close the accessory HTTP
+            // server before iOS receives the terminal activation response.
+            // Wait for authenticated device reconciliation instead of
+            // offering a second payload write from a stale local message.
+            return lastDeviceState == "paused"
         }
         return lastDeviceState == "paused" ||
             lastDeviceState == "idle" ||

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1011,6 +1011,14 @@ private struct SavedMapsSettingsSection: View {
         .onAppear {
             manager.updateActiveDeviceMap(bleManager.activeDeviceMap)
             manager.reconcileLastTransfer(bleManager: bleManager)
+            if bleManager.isNavigationReady {
+                bleManager.requestMapTransferStatus()
+            }
+        }
+        .onChange(of: bleManager.isNavigationReady) { isReady in
+            if isReady {
+                bleManager.requestMapTransferStatus()
+            }
         }
         .onChange(of: bleManager.activeDeviceMap) { descriptor in
             manager.updateActiveDeviceMap(descriptor)
@@ -1104,6 +1112,9 @@ private struct SavedMapRow: View {
         let displayName = item.displayName
         let packURL = item.packURL
         let isPausedUpload = packURL.map(manager.isPausedMapUpload) ?? false
+        let isAwaitingActivation = packURL.map(
+            manager.isAwaitingMapActivationConfirmation
+        ) ?? false
         let previewImage = manager.previewImage(for: item)
         let catalogAvailability = item.catalogMap.map(manager.catalogAvailability(for:))
 
@@ -1211,6 +1222,13 @@ private struct SavedMapRow: View {
                             ? "Shows the installed map status"
                             : "This map is not saved on this iPhone"
                     )
+                } else if isAwaitingActivation {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .foregroundColor(.secondary)
+                        .frame(width: 32, height: 32)
+                        .accessibilityLabel(
+                            "Waiting for the Bike Computer to confirm \(displayName)"
+                        )
                 } else if let packURL {
                     Button {
                         finishRenaming()

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -2326,6 +2326,27 @@ struct NavigationProtocolTests {
                 lastTransferOutcome: "unconfirmed",
                 lastTransferMapID: "map-a",
                 candidateMapID: "map-a",
+                lastDeviceState: "idle",
+                backgroundUploadSucceeded: true,
+                statusMessage: "Map upload paused. Tap Upload to resume."
+            ),
+            "a completed stream upload waits for activation reconciliation instead of rewriting"
+        )
+        assert(
+            PausedMapUploadResumePolicy.isAvailable(
+                lastTransferOutcome: "unconfirmed",
+                lastTransferMapID: "map-a",
+                candidateMapID: "map-a",
+                lastDeviceState: "paused",
+                backgroundUploadSucceeded: true
+            ),
+            "an explicit device pause remains resumable after a completed transport"
+        )
+        assert(
+            !PausedMapUploadResumePolicy.isAvailable(
+                lastTransferOutcome: "unconfirmed",
+                lastTransferMapID: "map-a",
+                candidateMapID: "map-a",
                 lastDeviceState: "receiving"
             ),
             "a receiving transfer remains owned by its active background task"
@@ -10399,6 +10420,13 @@ struct NavigationProtocolTests {
             "tapping installed status explains that the map is already on the device"
         )
         assert(
+            source.contains("manager.isAwaitingMapActivationConfirmation") &&
+                source.contains("clock.arrow.circlepath") &&
+                source.contains("Waiting for the Bike Computer to confirm") &&
+                source.contains("bleManager.requestMapTransferStatus()"),
+            "ambiguous activation waits for authenticated status instead of offering another upload"
+        )
+        assert(
             source.contains("isShowingDeleteConfirmation = true") &&
                 source.contains("\"Delete Saved Map?\"") &&
                 source.contains("Button(\"Delete\", role: .destructive)"),
@@ -12035,8 +12063,9 @@ struct NavigationProtocolTests {
         FirmwareRequestCaptureProtocol.handler = { request, _ in
             statusRequests += 1
             let state = statusRequests == 1 ? "activating" : "installed"
+            let activeSession = statusRequests == 1 ? "old-session" : "session-1"
             let body = Data("""
-            {"activeMapId":"map-1","activation":{"status":"\(state)","sequence":8,"sessionId":"session-1","mapId":"map-1"}}
+            {"activeMapId":"map-1","activeSessionId":"\(activeSession)","activeManifestReceipt":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","activeMapDisplayName":"Singapore new","activeMapBoundsE7":[1038375134,12767316,1038683621,13075725],"activation":{"status":"\(state)","sequence":8,"sessionId":"session-1","mapId":"map-1","step":3,"steps":3,"progress":100}}
             """.utf8)
             let response = HTTPURLResponse(
                 url: request.url!, statusCode: 200, httpVersion: nil,
@@ -12062,6 +12091,19 @@ struct NavigationProtocolTests {
         assertEqual(confirmation, .installed, "HTTP polling confirms installation")
         assertEqual(statusRequests, 2,
                     "confirmation polls from activating through installed")
+        assertEqual(bleManager.activeDeviceMap?.mapID, "map-1",
+                    "authenticated HTTP status refreshes the active map row")
+        assertEqual(bleManager.activeDeviceMap?.sessionID, "session-1",
+                    "the active row keeps the exact installed stream session")
+        assertEqual(bleManager.activeDeviceMap?.manifestReceipt,
+                    String(repeating: "a", count: 64),
+                    "the active row keeps the authenticated manifest receipt")
+        assertEqual(bleManager.activeDeviceMap?.displayName, "Singapore new",
+                    "the active row uses the device-confirmed map name")
+        assertEqual(bleManager.mapTransferActivationStep, 3,
+                    "HTTP reconciliation projects terminal activation progress")
+        assertEqual(bleManager.mapTransferActivationProgress, 100,
+                    "HTTP reconciliation projects terminal activation completion")
 
         statusRequests = 0
         FirmwareRequestCaptureProtocol.handler = { request, _ in
@@ -12141,6 +12183,20 @@ struct NavigationProtocolTests {
         assertEqual(status.activeMapBoundsE7,
                     [1_037_500_000, 12_400_000, 1_039_300_000, 13_700_000],
                     "HTTP status exposes normalized preview bounds")
+
+        let bleManager = BLEManager()
+        bleManager.applyAuthenticatedMapTransferStatus(status)
+        assertEqual(bleManager.activeDeviceMap?.mapID, "old-map",
+                    "authenticated HTTP status updates the active-device model")
+        assertEqual(bleManager.activeDeviceMap?.sessionID, "old-map-session",
+                    "authenticated HTTP status preserves the active session")
+        assertEqual(bleManager.mapTransferActivationStatus, "failed",
+                    "authenticated HTTP status projects activation state")
+        assertEqual(
+            bleManager.mapTransferActivationError,
+            "file_sha256: sha mismatch for VECTMAP/new-map/1.fmb",
+            "authenticated HTTP status projects the device activation error"
+        )
     }
 
     static func testFirmwareManifestDecodingAndHash() {


### PR DESCRIPTION
## Summary
- project authenticated map-transfer HTTP status into the Saved Maps active-device state
- refresh map status when Saved Maps appears or BLE becomes ready
- keep a successfully uploaded stream in activation-confirmation state instead of offering a duplicate upload
- add regression coverage for installed-map projection and resume gating

## Verification
- `cd ios-app && ./scripts/run-navigation-tests.sh`
- `cd ios-app && ./scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj -scheme BikeComputer -destination 'generic/platform=iOS' -derivedDataPath /private/tmp/open-bike-active-map-derived-rerun CODE_SIGNING_ALLOWED=NO build`
