### PR TITLE
Complete chunked map status notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -724,6 +724,7 @@ jobs:
           /tmp/test_map_stream_install
       - name: Transfer control dispatch host tests
         run: |
+          python -m unittest tools.tests.test_ble_notification_dispatch
           g++ -std=c++17 \
             tools/tests/test_transfer_control_dispatch.cpp \
             -o /tmp/test_transfer_control_dispatch

--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -131,6 +131,9 @@ static constexpr uint8_t CAPABILITY_BATTERY_STATUS_SCREEN = 1 << 5;
 static char pendingAuthNonce[33] = "";
 static NimBLECharacteristic *authCharacteristic = nullptr;
 static NimBLECharacteristic *mapTransferStatusCharacteristic = nullptr;
+static map_transfer_status_protocol::ChunkTransmission
+    pendingMapTransferStatusChunks;
+static std::atomic<bool> pendingMapTransferStatusContinuation{false};
 static BLEDebugStats bleDebugStats;
 static gps_input_freshness::State gpsFreshnessState;
 static_assert(BLE_HS_CONN_HANDLE_NONE == ble_connection_policy::noConnection,
@@ -237,6 +240,7 @@ static bool notifyAuthenticatedNavigation(NimBLECharacteristic *characteristic,
 static void processDeferredNotifications();
 static void scheduleDeferredNotificationEvent();
 static void deferredNotificationEventHandler(struct ble_npl_event *event);
+static void pumpPendingMapTransferStatusChunks();
 
 static void clearRendererWindowRequest() {
   portENTER_CRITICAL(&rendererWindowRequestMux);
@@ -1143,6 +1147,15 @@ static bool enqueueDeferredNotification(NimBLECharacteristic *characteristic,
   return queued;
 }
 
+static uint8_t deferredNotificationAvailableCapacity() {
+  uint8_t available = 0;
+  portENTER_CRITICAL(&deferredNotificationMux);
+  available = static_cast<uint8_t>(kDeferredNotificationCapacity -
+                                   deferredNotificationCount);
+  portEXIT_CRITICAL(&deferredNotificationMux);
+  return available;
+}
+
 static void scheduleDeferredNotificationEvent() {
   if (!deferredNotificationEventReady.load(std::memory_order_acquire) ||
       !deferredNotificationEventPending.load(std::memory_order_acquire)) {
@@ -1240,6 +1253,9 @@ static void deferredNotificationEventHandler(struct ble_npl_event *event) {
   // returned.
   processDeferredNotifications();
   deferredNotificationEventScheduled.store(false, std::memory_order_release);
+  if (pendingMapTransferStatusContinuation.load(std::memory_order_acquire)) {
+    ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
+  }
 }
 
 static void notifyAuthResponse(const std::string &response) {
@@ -2038,6 +2054,10 @@ static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
   if (pChar == nullptr) {
     return;
   }
+  if (pendingMapTransferStatusChunks.active()) {
+    pumpPendingMapTransferStatusChunks();
+    return;
+  }
 
   static map_transfer_status_protocol::ChunkSession chunkSession;
   const std::string body = mapTransferStatusJson();
@@ -2066,24 +2086,49 @@ static void notifyMapTransferStatus(NimBLECharacteristic *pChar) {
     return;
   }
   const uint8_t transferId = chunkSession.transferIdFor(body);
-  for (size_t index = 0; index < chunkCount; index++) {
-    const size_t offset = index * chunkBytes;
-    const size_t length = std::min(chunkBytes, body.size() - offset);
-    std::string frame = "MSTC";
-    frame.push_back(static_cast<char>(transferId));
-    frame.push_back(static_cast<char>(index));
-    frame.push_back(static_cast<char>(chunkCount));
-    frame.append(body.data() + offset, length);
-    if (!notifyAuthenticatedNavigation(
-            pChar, reinterpret_cast<const uint8_t *>(frame.data()),
-            frame.size())) {
-      Serial.println("BLE Map Transfer: protected status chunk failed");
+  if (!pendingMapTransferStatusChunks.begin(body, transferId, chunkBytes)) {
+    Serial.printf("BLE Map Transfer: status too large (%u bytes)\n",
+                  (unsigned)body.size());
+    return;
+  }
+  pendingMapTransferStatusContinuation.store(true,
+                                             std::memory_order_release);
+  pumpPendingMapTransferStatusChunks();
+}
+
+static void pumpPendingMapTransferStatusChunks() {
+  if (!pendingMapTransferStatusChunks.active()) {
+    pendingMapTransferStatusContinuation.store(false,
+                                               std::memory_order_release);
+    return;
+  }
+  if (!bleSessionAuthenticated ||
+      activeConnHandle == BLE_HS_CONN_HANDLE_NONE ||
+      mapTransferStatusCharacteristic == nullptr) {
+    pendingMapTransferStatusChunks.reset();
+    pendingMapTransferStatusContinuation.store(false,
+                                               std::memory_order_release);
+    return;
+  }
+
+  const uint8_t available = deferredNotificationAvailableCapacity();
+  for (uint8_t slot = 0;
+       slot < available && pendingMapTransferStatusChunks.active(); ++slot) {
+    const std::string frame = pendingMapTransferStatusChunks.nextFrame();
+    if (frame.empty() ||
+        !notifyAuthenticatedNavigation(
+            mapTransferStatusCharacteristic,
+            reinterpret_cast<const uint8_t *>(frame.data()), frame.size())) {
       return;
     }
-    delay(2);
+    pendingMapTransferStatusChunks.advance();
   }
-  Serial.printf("BLE Map Transfer: status notified (%u bytes, %u chunks)\n",
-                (unsigned)body.size(), (unsigned)chunkCount);
+
+  if (!pendingMapTransferStatusChunks.active()) {
+    pendingMapTransferStatusChunks.reset();
+    pendingMapTransferStatusContinuation.store(false,
+                                               std::memory_order_release);
+  }
 }
 
 static void notifyGenericTransferStatus(NimBLECharacteristic *pChar) {
@@ -4839,6 +4884,8 @@ void BLENavigationServer::process() {
     ESP.restart();
   }
   processPendingTransferControl();
+  pumpPendingMapTransferStatusChunks();
+  scheduleDeferredNotificationEvent();
   const uint32_t nowMs = millis();
 #if BLE_RADIO_CHARACTERIZATION
   processRadioCharacterization(nowMs, pServer);

--- a/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
+++ b/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
@@ -105,4 +105,85 @@ private:
   bool hasBody_ = false;
 };
 
+// A map-status response can exceed the fixed deferred-notification queue even
+// after it is split for the negotiated ATT MTU. Keep the plaintext chunk
+// stream on the Arduino owner task and advance it only after each protected
+// frame is accepted by that queue. The NimBLE host task can then drain one
+// bounded batch before the owner task pumps the next one.
+class ChunkTransmission {
+public:
+  bool begin(const std::string &body, uint8_t transferId,
+             size_t chunkPayloadBytes) {
+    reset();
+    if (body.empty() || chunkPayloadBytes == 0) {
+      return false;
+    }
+    const size_t count =
+        (body.size() + chunkPayloadBytes - 1) / chunkPayloadBytes;
+    if (count == 0 || count > 255) {
+      return false;
+    }
+    body_ = body;
+    transferId_ = transferId;
+    chunkPayloadBytes_ = chunkPayloadBytes;
+    chunkCount_ = count;
+    active_ = true;
+    return true;
+  }
+
+  bool matches(const std::string &body, uint8_t transferId,
+               size_t chunkPayloadBytes) const {
+    return active_ && body_ == body && transferId_ == transferId &&
+           chunkPayloadBytes_ == chunkPayloadBytes;
+  }
+
+  bool active() const { return active_; }
+  size_t bodySize() const { return body_.size(); }
+  size_t chunkCount() const { return chunkCount_; }
+  size_t nextIndex() const { return nextIndex_; }
+
+  std::string nextFrame() const {
+    if (!active_ || nextIndex_ >= chunkCount_) {
+      return {};
+    }
+    const size_t offset = nextIndex_ * chunkPayloadBytes_;
+    const size_t remaining = body_.size() - offset;
+    const size_t length =
+        remaining < chunkPayloadBytes_ ? remaining : chunkPayloadBytes_;
+    std::string frame = "MSTC";
+    frame.push_back(static_cast<char>(transferId_));
+    frame.push_back(static_cast<char>(nextIndex_));
+    frame.push_back(static_cast<char>(chunkCount_));
+    frame.append(body_.data() + offset, length);
+    return frame;
+  }
+
+  void advance() {
+    if (!active_) {
+      return;
+    }
+    ++nextIndex_;
+    if (nextIndex_ >= chunkCount_) {
+      active_ = false;
+    }
+  }
+
+  void reset() {
+    body_.clear();
+    transferId_ = 0;
+    chunkPayloadBytes_ = 0;
+    chunkCount_ = 0;
+    nextIndex_ = 0;
+    active_ = false;
+  }
+
+private:
+  std::string body_;
+  uint8_t transferId_ = 0;
+  size_t chunkPayloadBytes_ = 0;
+  size_t chunkCount_ = 0;
+  size_t nextIndex_ = 0;
+  bool active_ = false;
+};
+
 } // namespace map_transfer_status_protocol

--- a/esp32/tools/tests/test_ble_notification_dispatch.py
+++ b/esp32/tools/tests/test_ble_notification_dispatch.py
@@ -79,6 +79,34 @@ class BLENotificationDispatchTests(unittest.TestCase):
         )
         self.assertIn("deferredNotificationEventScheduled.store(false", init)
 
+    def test_chunked_map_status_resumes_after_each_host_drain(self):
+        notify = function_body(
+            BLE_SOURCE, "static void notifyMapTransferStatus"
+        )
+        self.assertIn("pendingMapTransferStatusChunks.begin", notify)
+        self.assertIn("pumpPendingMapTransferStatusChunks()", notify)
+
+        pump = function_body(
+            BLE_SOURCE, "static void pumpPendingMapTransferStatusChunks() {"
+        )
+        self.assertIn("deferredNotificationAvailableCapacity()", pump)
+        self.assertIn("notifyAuthenticatedNavigation", pump)
+        self.assertIn("pendingMapTransferStatusChunks.advance()", pump)
+        self.assertLess(
+            pump.index("notifyAuthenticatedNavigation"),
+            pump.index("pendingMapTransferStatusChunks.advance()"),
+        )
+
+        event_handler = function_body(
+            BLE_SOURCE,
+            "static void deferredNotificationEventHandler(struct ble_npl_event *event) {",
+        )
+        self.assertIn("pendingMapTransferStatusContinuation.load", event_handler)
+        self.assertIn("ui_scheduler::notify(ui_scheduler::WakeReason::Ble)", event_handler)
+
+        process = function_body(BLE_SOURCE, "void BLENavigationServer::process()")
+        self.assertIn("pumpPendingMapTransferStatusChunks()", process)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
+++ b/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
@@ -82,6 +82,77 @@ int main() {
   assert(installed != activating);
   assert(session.transferIdFor("{\"status\":\"installed\"}") == installed);
 
+  map_transfer_status_protocol::ChunkTransmission transmission;
+  assert(!transmission.begin("", initial, 8));
+  assert(!transmission.begin("status", initial, 0));
+  assert(!transmission.active());
+
+  const std::string chunkBody = "abcdefghijklmnopqrstuvwxyz";
+  assert(transmission.begin(chunkBody, installed, 8));
+  assert(transmission.active());
+  assert(transmission.bodySize() == chunkBody.size());
+  assert(transmission.chunkCount() == 4);
+  assert(transmission.nextIndex() == 0);
+  assert(transmission.matches(chunkBody, installed, 8));
+  assert(!transmission.matches(chunkBody + "!", installed, 8));
+
+  std::string frame = transmission.nextFrame();
+  assert(frame.size() == 15);
+  assert(frame.substr(0, 4) == "MSTC");
+  assert(static_cast<uint8_t>(frame[4]) == installed);
+  assert(static_cast<uint8_t>(frame[5]) == 0);
+  assert(static_cast<uint8_t>(frame[6]) == 4);
+  assert(frame.substr(7) == "abcdefgh");
+
+  transmission.advance();
+  frame = transmission.nextFrame();
+  assert(static_cast<uint8_t>(frame[5]) == 1);
+  assert(frame.substr(7) == "ijklmnop");
+  transmission.advance();
+  frame = transmission.nextFrame();
+  assert(static_cast<uint8_t>(frame[5]) == 2);
+  assert(frame.substr(7) == "qrstuvwx");
+  transmission.advance();
+  frame = transmission.nextFrame();
+  assert(static_cast<uint8_t>(frame[5]) == 3);
+  assert(frame.substr(7) == "yz");
+  transmission.advance();
+  assert(!transmission.active());
+  assert(transmission.nextFrame().empty());
+
+  const std::string oversizedQueueBody = "0123456789ABCDEFGHIJ";
+  assert(transmission.begin(oversizedQueueBody, activating, 1));
+  for (size_t slot = 0; slot < 8; ++slot) {
+    assert(transmission.active());
+    assert(transmission.nextIndex() == slot);
+    transmission.advance();
+  }
+  assert(transmission.active());
+  assert(transmission.nextIndex() == 8);
+  for (size_t slot = 0; slot < 8; ++slot) {
+    assert(transmission.active());
+    assert(transmission.nextIndex() == slot + 8);
+    transmission.advance();
+  }
+  assert(transmission.active());
+  assert(transmission.nextIndex() == 16);
+  for (size_t slot = 0; slot < 4; ++slot) {
+    assert(transmission.active());
+    assert(transmission.nextIndex() == slot + 16);
+    transmission.advance();
+  }
+  assert(!transmission.active());
+  assert(transmission.nextIndex() == oversizedQueueBody.size());
+
+  transmission.reset();
+  assert(!transmission.active());
+  assert(transmission.bodySize() == 0);
+  assert(transmission.chunkCount() == 0);
+  assert(transmission.nextIndex() == 0);
+
+  assert(!transmission.begin(std::string(256, 'x'), initial, 1));
+  assert(!transmission.active());
+
   std::cout << "map transfer status chunk session tests passed\n";
   return 0;
 }


### PR DESCRIPTION
## Summary
- retain chunked map-status snapshots until all protected BLE notification chunks are queued
- resume the bounded chunk pump after each NimBLE host-queue drain
- add host regressions for queue-capacity overflow and dispatch wiring

## Validation
- python3 -m unittest tools.tests.test_ble_notification_dispatch
- C++17 map-transfer status chunk-session host test with warnings as errors
- python3 -m unittest discover -s tools/tests (67 tests)
- python3 tools/build_firmware.py WAVESHARE_AMOLED_175

Physical validation is intentionally pending; this PR does not claim that the connected device was flashed or that the app icon turned green.