### PR TITLE
Preserve BLE notifications under backpressure

### DIFF
--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -21,6 +21,7 @@
 #include "map_setting_redraw_policy.hpp"
 #include "map_profile_persistence.hpp"
 #include "device_capabilities_protocol.hpp"
+#include "deferred_notification_dispatch_policy.hpp"
 #include "scoped_watch_payload_policy.hpp"
 #include "map_transfer_status_chunk_session.hpp"
 #include "renderer_diagnostics_ble_protocol.hpp"
@@ -67,6 +68,9 @@
 #include <freertos/semphr.h>
 #include <freertos/task.h>
 #include <host/ble_hs_id.h>
+#include <host/ble_gatt.h>
+#include <host/ble_hs.h>
+#include <host/ble_hs_mbuf.h>
 #include <nimble/porting/nimble/include/nimble/nimble_port.h>
 #include <mbedtls/md.h>
 #include <WiFi.h>
@@ -1174,20 +1178,24 @@ static void scheduleDeferredNotificationEvent() {
                      &deferredNotificationEvent);
 }
 
-static bool sendWireNotification(NimBLECharacteristic *characteristic,
-                                 uint16_t connectionHandle,
-                                 const uint8_t *data, size_t length,
-                                 const char *label) {
+static ble_notification_dispatch_policy::TransportResult
+sendWireNotification(NimBLECharacteristic *characteristic,
+                     uint16_t connectionHandle, const uint8_t *data,
+                     size_t length, const char *label) {
+  using ble_notification_dispatch_policy::TransportResult;
   if (characteristic == nullptr || data == nullptr || length == 0 ||
-      notificationTransportMutex == nullptr ||
-      xSemaphoreTake(notificationTransportMutex, pdMS_TO_TICKS(100)) != pdTRUE) {
-    return false;
+      notificationTransportMutex == nullptr) {
+    return TransportResult::Drop;
+  }
+  if (xSemaphoreTake(notificationTransportMutex, pdMS_TO_TICKS(100)) !=
+      pdTRUE) {
+    return TransportResult::Retry;
   }
   if (connectionHandle == BLE_HS_CONN_HANDLE_NONE ||
       activeConnHandle != connectionHandle ||
       characteristic->getSubscribedCount() == 0) {
     xSemaphoreGive(notificationTransportMutex);
-    return false;
+    return TransportResult::Drop;
   }
   uint16_t peerMtu = 23;
   NimBLEService *service = characteristic->getService();
@@ -1200,12 +1208,33 @@ static bool sendWireNotification(NimBLECharacteristic *characteristic,
                   label == nullptr ? "wire" : label,
                   static_cast<unsigned>(length + 3), peerMtu);
     xSemaphoreGive(notificationTransportMutex);
-    return false;
+    return TransportResult::Drop;
   }
+
+  os_mbuf *payload =
+      ble_hs_mbuf_from_flat(data, static_cast<uint16_t>(length));
+  if (payload == nullptr) {
+    xSemaphoreGive(notificationTransportMutex);
+    return TransportResult::Retry;
+  }
+
   characteristic->setValue(data, length);
-  characteristic->notify();
+  // NimBLE-Arduino 1.4's characteristic notify() API returns void and drops
+  // the host result. Use the underlying free-form server notification so a
+  // finite ATT/L2CAP buffer condition can preserve and retry this exact frame.
+  const int result = ble_gatts_notify_custom(
+      connectionHandle, characteristic->getHandle(), payload);
   xSemaphoreGive(notificationTransportMutex);
-  return true;
+  if (result == 0) {
+    return TransportResult::Sent;
+  }
+  if (result == BLE_HS_EAGAIN || result == BLE_HS_ENOMEM ||
+      result == BLE_HS_EBUSY || result == BLE_HS_ENOMEM_EVT) {
+    return TransportResult::Retry;
+  }
+  Serial.printf("BLE: %s notification dropped by host rc=%d\n",
+                label == nullptr ? "wire" : label, result);
+  return TransportResult::Drop;
 }
 
 static bool isNimbleCallbackContext() {
@@ -1214,30 +1243,44 @@ static bool isNimbleCallbackContext() {
 }
 
 static void processDeferredNotifications() {
+  using ble_notification_dispatch_policy::TransportResult;
   const uint32_t dropped =
       deferredNotificationDrops.exchange(0, std::memory_order_acq_rel);
   if (dropped != 0) {
     Serial.printf("BLE: Deferred notification queue dropped=%lu\n",
                   static_cast<unsigned long>(dropped));
   }
-  while (true) {
-    DeferredNotification pending;
-    bool available = false;
-    portENTER_CRITICAL(&deferredNotificationMux);
-    if (deferredNotificationCount > 0) {
-      pending = deferredNotifications[deferredNotificationHead];
-      deferredNotificationHead = static_cast<uint8_t>(
-          (deferredNotificationHead + 1) % kDeferredNotificationCapacity);
-      deferredNotificationCount--;
-      available = true;
-    }
-    portEXIT_CRITICAL(&deferredNotificationMux);
-    if (!available) {
-      return;
-    }
-    (void)sendWireNotification(pending.characteristic,
-                               pending.connectionHandle, pending.payload,
-                               pending.length, "deferred");
+  DeferredNotification pending;
+  uint8_t queuedBefore = 0;
+  portENTER_CRITICAL(&deferredNotificationMux);
+  queuedBefore = deferredNotificationCount;
+  if (queuedBefore > 0) {
+    pending = deferredNotifications[deferredNotificationHead];
+  }
+  portEXIT_CRITICAL(&deferredNotificationMux);
+  if (queuedBefore == 0) {
+    return;
+  }
+
+  const TransportResult result = sendWireNotification(
+      pending.characteristic, pending.connectionHandle, pending.payload,
+      pending.length, "deferred");
+  const auto decision =
+      ble_notification_dispatch_policy::decideAfterAttempt(result,
+                                                            queuedBefore);
+
+  bool continueLater = decision.continueLater;
+  portENTER_CRITICAL(&deferredNotificationMux);
+  if (decision.consumeHead && deferredNotificationCount > 0) {
+    deferredNotificationHead = static_cast<uint8_t>(
+        (deferredNotificationHead + 1) % kDeferredNotificationCapacity);
+    deferredNotificationCount--;
+  }
+  continueLater = continueLater || deferredNotificationCount > 0;
+  portEXIT_CRITICAL(&deferredNotificationMux);
+
+  if (continueLater) {
+    deferredNotificationEventPending.store(true, std::memory_order_release);
   }
 }
 
@@ -1253,7 +1296,8 @@ static void deferredNotificationEventHandler(struct ble_npl_event *event) {
   // returned.
   processDeferredNotifications();
   deferredNotificationEventScheduled.store(false, std::memory_order_release);
-  if (pendingMapTransferStatusContinuation.load(std::memory_order_acquire)) {
+  if (deferredNotificationEventPending.load(std::memory_order_acquire) ||
+      pendingMapTransferStatusContinuation.load(std::memory_order_acquire)) {
     ui_scheduler::notify(ui_scheduler::WakeReason::Ble);
   }
 }

--- a/esp32/lib/ble_navigation/deferred_notification_dispatch_policy.hpp
+++ b/esp32/lib/ble_navigation/deferred_notification_dispatch_policy.hpp
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <cstddef>
+
+namespace ble_notification_dispatch_policy {
+
+enum class TransportResult {
+  Sent,
+  Retry,
+  Drop,
+};
+
+struct DispatchDecision {
+  bool consumeHead = false;
+  bool continueLater = false;
+};
+
+// The transport owns only one ATT notification attempt at a time. A transient
+// host failure must leave the exact protected frame at the queue head so its
+// authentication sequence is not skipped. Successful and terminal attempts
+// consume the head; another owner/host handoff is required when more work
+// remains so notifications are paced through NimBLE's finite TX buffers.
+constexpr DispatchDecision decideAfterAttempt(TransportResult result,
+                                              size_t queuedBefore) {
+  if (queuedBefore == 0) {
+    return {};
+  }
+  if (result == TransportResult::Retry) {
+    return {false, true};
+  }
+  return {true, queuedBefore > 1};
+}
+
+} // namespace ble_notification_dispatch_policy

--- a/esp32/tools/tests/test_ble_notification_dispatch.py
+++ b/esp32/tools/tests/test_ble_notification_dispatch.py
@@ -40,9 +40,15 @@ class BLENotificationDispatchTests(unittest.TestCase):
         self.assertIn("deferredNotificationEventScheduled", schedule)
         self.assertIn("compare_exchange_strong", schedule)
 
-        send = function_body(BLE_SOURCE, "static bool sendWireNotification")
+        send = function_body(
+            BLE_SOURCE,
+            "sendWireNotification(NimBLECharacteristic *characteristic",
+        )
         self.assertIn("server->getPeerMTU", send)
-        self.assertIn("characteristic->notify()", send)
+        self.assertIn("ble_gatts_notify_custom", send)
+        self.assertIn("BLE_HS_ENOMEM", send)
+        self.assertIn("TransportResult::Retry", send)
+        self.assertNotIn("characteristic->notify()", send)
 
         for producer in (
             function_body(BLE_SOURCE, "static void notifyMapTransferStatus"),
@@ -54,6 +60,14 @@ class BLENotificationDispatchTests(unittest.TestCase):
             self.assertIn("activePeerMtu.load", producer)
 
     def test_arduino_loop_does_not_drain_deferred_transport(self):
+        drain = function_body(
+            BLE_SOURCE, "static void processDeferredNotifications() {"
+        )
+        self.assertNotIn("while (true)", drain)
+        self.assertIn("decideAfterAttempt", drain)
+        self.assertIn("decision.consumeHead", drain)
+        self.assertIn("deferredNotificationEventPending.store(true", drain)
+
         process = function_body(BLE_SOURCE, "void BLENavigationServer::process()")
         self.assertNotIn("processDeferredNotifications()", process)
         self.assertIn("scheduleDeferredNotificationEvent()", process)
@@ -66,6 +80,7 @@ class BLENotificationDispatchTests(unittest.TestCase):
             "deferredNotificationEventScheduled.store(false",
             event_handler,
         )
+        self.assertIn("deferredNotificationEventPending.load", event_handler)
         self.assertLess(
             event_handler.index("deferredNotificationEventPending.store(false"),
             event_handler.index("processDeferredNotifications()"),

--- a/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
+++ b/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
@@ -1,9 +1,62 @@
 #include "../../lib/ble_navigation/map_transfer_status_chunk_session.hpp"
+#include "../../lib/ble_navigation/deferred_notification_dispatch_policy.hpp"
 
 #include <cassert>
 #include <iostream>
+#include <vector>
 
 int main() {
+  using ble_notification_dispatch_policy::TransportResult;
+
+  auto dispatch =
+      ble_notification_dispatch_policy::decideAfterAttempt(
+          TransportResult::Sent, 1);
+  assert(dispatch.consumeHead);
+  assert(!dispatch.continueLater);
+  dispatch = ble_notification_dispatch_policy::decideAfterAttempt(
+      TransportResult::Sent, 3);
+  assert(dispatch.consumeHead);
+  assert(dispatch.continueLater);
+  dispatch = ble_notification_dispatch_policy::decideAfterAttempt(
+      TransportResult::Retry, 1);
+  assert(!dispatch.consumeHead);
+  assert(dispatch.continueLater);
+  dispatch = ble_notification_dispatch_policy::decideAfterAttempt(
+      TransportResult::Drop, 2);
+  assert(dispatch.consumeHead);
+  assert(dispatch.continueLater);
+  dispatch = ble_notification_dispatch_policy::decideAfterAttempt(
+      TransportResult::Drop, 1);
+  assert(dispatch.consumeHead);
+  assert(!dispatch.continueLater);
+  dispatch = ble_notification_dispatch_policy::decideAfterAttempt(
+      TransportResult::Retry, 0);
+  assert(!dispatch.consumeHead);
+  assert(!dispatch.continueLater);
+
+  const std::vector<int> protectedFrames = {41, 42, 43};
+  const std::vector<TransportResult> transportResults = {
+      TransportResult::Retry, TransportResult::Sent, TransportResult::Sent,
+      TransportResult::Sent};
+  std::vector<int> attemptedFrames;
+  size_t queueHead = 0;
+  size_t queuedFrames = protectedFrames.size();
+  for (const TransportResult transportResult : transportResults) {
+    assert(queuedFrames > 0);
+    attemptedFrames.push_back(protectedFrames[queueHead]);
+    const auto attemptDecision =
+        ble_notification_dispatch_policy::decideAfterAttempt(transportResult,
+                                                              queuedFrames);
+    if (attemptDecision.consumeHead) {
+      ++queueHead;
+      --queuedFrames;
+    }
+    assert(attemptDecision.continueLater == (queuedFrames > 0));
+  }
+  assert((attemptedFrames == std::vector<int>{41, 41, 42, 43}));
+  assert(queueHead == protectedFrames.size());
+  assert(queuedFrames == 0);
+
   std::string statusBody = "{\"status\":\"idle\"";
   map_transfer_status_protocol::ActiveMapPresentation presentation;
   presentation.displayName = "Chris's \"Bike\"";


### PR DESCRIPTION
The signed map is active on the ESP32, but the physical iPhone remains blue because it never receives a complete authenticated map-status response. The prior queue-capacity fix still allowed NimBLE host buffer failures to discard individual chunks.

This change:
- observes the NimBLE host notification result directly
- preserves and retries the exact protected queue head on transient backpressure
- paces delivery one notification per host event
- adds regression coverage for retry ordering and dispatch structure

Verification:
- `python3 -m unittest tools.tests.test_ble_notification_dispatch`
- `c++ -std=c++17 -Wall -Wextra -Werror tools/tests/test_map_transfer_status_chunk_session.cpp`
- clean attested `WAVESHARE_AMOLED_175` build at fd04eff12ea184a11eb032aa1e4254c5232367c7

Physical hardware validation remains required after merge; this PR does not claim the blue-to-green gate has passed.