### PR TITLE
Refresh BLE MTU before map status chunking

### DIFF
--- a/esp32/lib/ble_navigation/ble_navigation.cpp
+++ b/esp32/lib/ble_navigation/ble_navigation.cpp
@@ -155,8 +155,10 @@ static std::atomic<uint8_t> radioRequestedConnectionProfile{
 #endif
 static std::atomic<uint16_t> radioConnectionHandle{BLE_HS_CONN_HANDLE_NONE};
 // Producers may run on the Arduino/LVGL task, while NimBLE owns the live
-// connection state on its host task. Keep the last host-reported MTU in an
-// atomic snapshot so chunking never calls getPeerMTU() outside that task.
+// connection state on its host task. Refresh the host-reported MTU from each
+// incoming callback as well as onMTUChange: some restored iOS connections do
+// not deliver the latter callback even though their ATT MTU is already larger
+// than 23. Chunking must never call getPeerMTU() outside the host task.
 static std::atomic<uint16_t> activePeerMtu{23};
 static std::atomic<uint32_t> lastConnectionParameterSampleMs{0};
 struct RadioDebugSnapshot {
@@ -4085,6 +4087,14 @@ public:
   ScopedNimbleCallback() {
     previousTask = nimbleCallbackTask.exchange(
         xTaskGetCurrentTaskHandle(), std::memory_order_acq_rel);
+    const uint16_t connectionHandle = activeConnHandle;
+    NimBLEServer *server = NimBLEDevice::getServer();
+    if (connectionHandle != BLE_HS_CONN_HANDLE_NONE && server != nullptr) {
+      const uint16_t peerMtu = server->getPeerMTU(connectionHandle);
+      if (peerMtu >= 23) {
+        activePeerMtu.store(peerMtu, std::memory_order_release);
+      }
+    }
   }
   ~ScopedNimbleCallback() {
     nimbleCallbackTask.store(previousTask, std::memory_order_release);

--- a/esp32/tools/tests/test_ble_notification_dispatch.py
+++ b/esp32/tools/tests/test_ble_notification_dispatch.py
@@ -94,6 +94,16 @@ class BLENotificationDispatchTests(unittest.TestCase):
         )
         self.assertIn("deferredNotificationEventScheduled.store(false", init)
 
+    def test_host_callback_refreshes_peer_mtu_before_deferring_work(self):
+        callback = function_body(BLE_SOURCE, "ScopedNimbleCallback() {")
+        self.assertIn("NimBLEDevice::getServer()", callback)
+        self.assertIn("server->getPeerMTU(connectionHandle)", callback)
+        self.assertIn("activePeerMtu.store(peerMtu", callback)
+        self.assertLess(
+            callback.index("server->getPeerMTU(connectionHandle)"),
+            callback.index("activePeerMtu.store(peerMtu"),
+        )
+
     def test_chunked_map_status_resumes_after_each_host_drain(self):
         notify = function_body(
             BLE_SOURCE, "static void notifyMapTransferStatus"


### PR DESCRIPTION
## Summary
- refresh the negotiated peer MTU inside each NimBLE host callback
- keep map-status chunk sizing off the Arduino owner task
- cover restored iOS connections that do not emit the MTU-change callback

## Evidence
- physical main run recovered the signed active map but Bicino never received an MSTS/MSTC snapshot
- authenticated 4-byte requests were delivered as 26-byte protected frames, proving the live ATT MTU exceeded the stale cached value of 23
- focused notification-dispatch tests pass
- map-status chunk-session host test passes
- locked WAVESHARE_AMOLED_175 build passes for c626c1b9fd9c913ca7bb1d5d0bcee525ebe1c6c8