### PR TITLE
Leave headroom in map status chunks

### DIFF
--- a/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
+++ b/esp32/lib/ble_navigation/map_transfer_status_chunk_session.hpp
@@ -71,17 +71,27 @@ inline void appendActiveMapPresentation(std::string &body,
 
 // ATT notifications reserve three bytes for the protocol header. Each
 // authenticated notification then adds a 22-byte envelope, and chunked map
-// status payloads carry a seven-byte MSTC header. Size the body portion from
-// the peer's negotiated MTU so modern centrals receive a status snapshot in as
-// few notifications as possible without exceeding the transport limit.
+// status payloads carry a seven-byte MSTC header. Keep the body portion at or
+// below the 128-byte size already used by the generic transfer-status path.
+// Some iOS/NimBLE links negotiate a larger ATT MTU but do not reliably deliver
+// notifications that consume that exact limit. The conservative ceiling keeps
+// headroom while the bounded continuation queue still supports larger status
+// snapshots without blocking the NimBLE host task.
 constexpr size_t chunkPayloadBytes(uint16_t peerMtu) {
   constexpr size_t kAttNotificationOverhead = 3;
   constexpr size_t kAuthenticatedEnvelopeOverhead = 22;
   constexpr size_t kChunkHeaderBytes = 7;
+  constexpr size_t kMaximumChunkPayloadBytes = 128;
   constexpr size_t kTotalOverhead = kAttNotificationOverhead +
                                     kAuthenticatedEnvelopeOverhead +
                                     kChunkHeaderBytes;
-  return peerMtu > kTotalOverhead ? peerMtu - kTotalOverhead : 0;
+  if (peerMtu <= kTotalOverhead) {
+    return 0;
+  }
+  const size_t mtuPayloadBytes = peerMtu - kTotalOverhead;
+  return mtuPayloadBytes < kMaximumChunkPayloadBytes
+             ? mtuPayloadBytes
+             : kMaximumChunkPayloadBytes;
 }
 
 // Repeated status requests must retransmit the same logical chunk stream.

--- a/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
+++ b/esp32/tools/tests/test_map_transfer_status_chunk_session.cpp
@@ -113,8 +113,9 @@ int main() {
   assert(map_transfer_status_protocol::chunkPayloadBytes(32) == 0);
   assert(map_transfer_status_protocol::chunkPayloadBytes(33) == 1);
   assert(map_transfer_status_protocol::chunkPayloadBytes(45) == 13);
-  assert(map_transfer_status_protocol::chunkPayloadBytes(185) == 153);
-  assert(map_transfer_status_protocol::chunkPayloadBytes(512) == 480);
+  assert(map_transfer_status_protocol::chunkPayloadBytes(160) == 128);
+  assert(map_transfer_status_protocol::chunkPayloadBytes(185) == 128);
+  assert(map_transfer_status_protocol::chunkPayloadBytes(512) == 128);
 
   map_transfer_status_protocol::ChunkSession session;
 


### PR DESCRIPTION
The physical iPhone run on merged main showed that generic 128-byte transfer-status chunks complete, while map-status chunks sized to the exact negotiated ATT limit do not complete. Repeated authenticated MSTS requests were sent without a full status response.

Cap map-status chunk bodies at the same proven 128-byte size while retaining MTU-aware sizing for smaller links and the bounded continuation queue for larger responses.

Validation:
- focused C++ map-status chunk/session test
- BLE notification-dispatch tests
- 379 of 380 broad local Python tests passed; the remaining local error was only the unavailable optional qrcode dependency
- locked WAVESHARE_AMOLED_175 real-target build passed and was upload-eligible