### PR TITLE
Provision production Cloudflare map catalog

### DIFF
--- a/map-platform/catalog/README.md
+++ b/map-platform/catalog/README.md
@@ -40,10 +40,10 @@ pnpm check
 `pnpm check` typechecks the Worker, runs the D1 integration tests, and performs
 staging and production Wrangler dry-runs. It does not deploy anything.
 
-The checked-in `wrangler.jsonc` contains the provisioned staging D1 binding and
-the repository owner's non-secret Cloudflare/Apple identifiers. The production
-D1 binding remains invalid until staging passes; replace it only during the
-production step in
+The checked-in `wrangler.jsonc` contains the provisioned staging and production
+D1 bindings plus the repository owner's non-secret Cloudflare/Apple
+identifiers. Provision or replace the production binding only after staging
+passes, following
 [`../../docs/runbooks/cloudflare-r2-final-map-library.md`](../../docs/runbooks/cloudflare-r2-final-map-library.md).
 
 ## Security boundaries

--- a/map-platform/catalog/wrangler.jsonc
+++ b/map-platform/catalog/wrangler.jsonc
@@ -188,7 +188,7 @@
         {
           "binding": "DB",
           "database_name": "bicino-map-catalog",
-          "database_id": "00000000-0000-0000-0000-000000000000",
+          "database_id": "5461c9bf-cbc6-478b-88bf-3da4e1b24b0f",
           "migrations_dir": "migrations",
         },
       ],


### PR DESCRIPTION
## Summary
- bind the newly provisioned production D1 database in Wrangler
- update the catalog README to reflect provisioned staging and production bindings

## Rollout evidence
- created private R2 buckets `bicino-final-maps-dev` and `bicino-final-maps-prod`
- created production D1 database `bicino-map-catalog`
- applied migrations 0001 through 0009 remotely

## Validation
- `pnpm check` (53 tests, typecheck, formatting, staging and production Wrangler dry-runs)
- `git diff --check`

Production Worker traffic remains disabled until independent production R2 credentials and Worker secrets are installed.