### PR TITLE
Fix production map promotion rollout

### DIFF
--- a/map-platform/backend/map_platform/catalog.py
+++ b/map-platform/backend/map_platform/catalog.py
@@ -519,6 +519,7 @@ class CatalogClient:
             headers={
                 "Content-Type": "application/json",
                 "Accept": "application/json",
+                "User-Agent": "BicinoMapPlatform/1.0",
                 "X-Catalog-Key-Id": self.service_key_id,
                 "X-Catalog-Timestamp": timestamp,
                 "X-Catalog-Idempotency-Key": idempotency_key,

--- a/map-platform/backend/map_platform/catalog_promotion.py
+++ b/map-platform/backend/map_platform/catalog_promotion.py
@@ -267,6 +267,8 @@ def promote_catalog_map(
 
     if catalog_client.channel != "production":
         raise CatalogPromotionError("catalog promotion requires the production channel")
+    if not bool(getattr(artifact_store, "catalog_delivery_backed", False)):
+        raise CatalogPromotionError("promotion requires shared artifact storage")
     if grant is None:
         grant = catalog_client.promotion_grant(entry_id)
     existing = already_production_result(entry_id, grant)
@@ -431,10 +433,6 @@ def promote_catalog_map(
             producer_build_sha256=producer_build_sha256,
             producer_image_digest=producer_image_digest,
         )
-        if not bool(getattr(artifact_store, "catalog_delivery_backed", False)):
-            raise CatalogPromotionError(
-                "promotion requires shared artifact storage"
-            )
         if not artifact_store.verify(
             stream_record.object_key,
             sha256=stream_record.sha256,

--- a/map-platform/backend/map_platform/catalog_promotion.py
+++ b/map-platform/backend/map_platform/catalog_promotion.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
 import os
@@ -210,6 +211,38 @@ def _extract_validated_archive(archive_path: Path, root: Path) -> dict[str, Any]
                     shutil.copyfileobj(source, output, length=1024 * 1024)
     except (OSError, ValueError, zipfile.BadZipFile, json.JSONDecodeError) as exc:
         raise CatalogPromotionError("promotion ZIP extraction failed") from exc
+    preview = manifest.get("preview")
+    if preview is not None:
+        if not isinstance(preview, dict):
+            raise CatalogPromotionError("promotion ZIP preview metadata is invalid")
+        relative = preview.get("path")
+        expected_bytes = preview.get("bytes")
+        expected_sha256 = preview.get("sha256")
+        if (
+            not isinstance(relative, str)
+            or not relative
+            or Path(relative).is_absolute()
+            or ".." in Path(relative).parts
+            or type(expected_bytes) is not int
+            or expected_bytes <= 0
+            or not isinstance(expected_sha256, str)
+            or re.fullmatch(r"[0-9a-f]{64}", expected_sha256) is None
+        ):
+            raise CatalogPromotionError("promotion ZIP preview metadata is invalid")
+        try:
+            preview_bytes = root.joinpath(*Path(relative).parts).read_bytes()
+        except OSError as exc:
+            raise CatalogPromotionError(
+                "promotion ZIP preview is unavailable"
+            ) from exc
+        if (
+            len(preview_bytes) != expected_bytes
+            or hashlib.sha256(preview_bytes).hexdigest() != expected_sha256
+        ):
+            raise CatalogPromotionError("promotion ZIP preview identity is invalid")
+        # ZIP manifests omit this redundant copy, while the canonical stream
+        # identity includes it. Rebuild it only from the verified preview bytes.
+        preview["dataBase64"] = base64.b64encode(preview_bytes).decode("ascii")
     return manifest
 
 

--- a/map-platform/backend/map_platform/catalog_promotion.py
+++ b/map-platform/backend/map_platform/catalog_promotion.py
@@ -170,7 +170,13 @@ def _download_exact_zip(
         raise CatalogPromotionError("promotion download endpoint is invalid")
     digest = hashlib.sha256()
     written = 0
-    request = Request(url, headers={"Accept": ZIP_MEDIA_TYPE})
+    request = Request(
+        url,
+        headers={
+            "Accept": ZIP_MEDIA_TYPE,
+            "User-Agent": "BicinoMapPlatform/1.0",
+        },
+    )
     try:
         with urlopen(request, timeout=timeout_seconds) as response:
             final = urlparse(response.geturl())

--- a/map-platform/backend/map_platform/cli.py
+++ b/map-platform/backend/map_platform/cli.py
@@ -819,11 +819,6 @@ def main() -> int:
 
         if catalog_client is None:
             raise SystemExit("MAP_PLATFORM_CATALOG_URL is required")
-        grant = catalog_client.promotion_grant(args.map_entry_id)
-        existing = already_production_result(args.map_entry_id, grant)
-        if existing is not None:
-            print(json.dumps(existing, indent=2, sort_keys=True))
-            return 0
         signer = load_map_artifact_signer_from_environment()
         if signer is None:
             raise SystemExit("production map stream signing is not enabled")
@@ -834,10 +829,16 @@ def main() -> int:
         )
         assert producer_build_sha256 is not None
         assert producer_image_digest is not None
+        artifact_store = create_artifact_store_from_environment(data_root)
+        grant = catalog_client.promotion_grant(args.map_entry_id)
+        existing = already_production_result(args.map_entry_id, grant)
+        if existing is not None:
+            print(json.dumps(existing, indent=2, sort_keys=True))
+            return 0
         result = promote_catalog_map(
             args.map_entry_id,
             catalog_client=catalog_client,
-            artifact_store=create_artifact_store_from_environment(data_root),
+            artifact_store=artifact_store,
             signer=signer,
             producer_build_sha256=producer_build_sha256,
             producer_image_digest=producer_image_digest,

--- a/map-platform/backend/map_platform/cli.py
+++ b/map-platform/backend/map_platform/cli.py
@@ -812,7 +812,6 @@ def main() -> int:
 
     if args.command == "promote-catalog-map":
         from .catalog_promotion import (
-            already_production_result,
             promote_catalog_map,
         )
         from .map_signing import load_map_artifact_signer_from_environment
@@ -830,11 +829,6 @@ def main() -> int:
         assert producer_build_sha256 is not None
         assert producer_image_digest is not None
         artifact_store = create_artifact_store_from_environment(data_root)
-        grant = catalog_client.promotion_grant(args.map_entry_id)
-        existing = already_production_result(args.map_entry_id, grant)
-        if existing is not None:
-            print(json.dumps(existing, indent=2, sort_keys=True))
-            return 0
         result = promote_catalog_map(
             args.map_entry_id,
             catalog_client=catalog_client,
@@ -843,7 +837,6 @@ def main() -> int:
             producer_build_sha256=producer_build_sha256,
             producer_image_digest=producer_image_digest,
             work_root=data_root / "promotions",
-            grant=grant,
         )
         print(json.dumps(result, indent=2, sort_keys=True))
         return 0

--- a/map-platform/backend/tests/test_catalog.py
+++ b/map-platform/backend/tests/test_catalog.py
@@ -331,6 +331,27 @@ class CatalogTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "at least 32 bytes"):
             CatalogClient("https://maps.invalid", "development", "dev", "short")
 
+    def test_catalog_client_sends_an_explicit_service_user_agent(self):
+        response = Mock()
+        response.read.return_value = b"{}"
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=None)
+        client = CatalogClient(
+            "https://maps.invalid",
+            "development",
+            "dev",
+            "x" * 32,
+        )
+
+        with patch("map_platform.catalog.urlopen", return_value=response) as open_url:
+            self.assertEqual(
+                client._request("/v1/internal/test", {}, idempotency_key="test"),
+                {},
+            )
+
+        request = open_url.call_args.args[0]
+        self.assertEqual(request.get_header("User-agent"), "BicinoMapPlatform/1.0")
+
     def test_catalog_delivery_identity_only_accepts_complete_firmware_tuple(self):
         with patch.dict(
             os.environ,

--- a/map-platform/backend/tests/test_catalog_promotion.py
+++ b/map-platform/backend/tests/test_catalog_promotion.py
@@ -303,12 +303,28 @@ class CatalogPromotionIdentityTests(unittest.TestCase):
             return promote_catalog_map(
                 grant["map"]["mapEntryId"],
                 catalog_client=FakePromotionCatalog(grant),
-                artifact_store=object(),
+                artifact_store=SimpleNamespace(catalog_delivery_backed=True),
                 signer=object(),
                 producer_build_sha256="2" * 64,
                 producer_image_digest="sha256:" + "3" * 64,
                 work_root=Path(temporary),
             )
+
+    def test_promotion_rejects_unshared_storage_before_acquiring_a_grant(self):
+        catalog = Mock(channel="production")
+
+        with self.assertRaisesRegex(CatalogPromotionError, "shared artifact storage"):
+            promote_catalog_map(
+                "map_v1_" + "M" * 43,
+                catalog_client=catalog,
+                artifact_store=SimpleNamespace(catalog_delivery_backed=False),
+                signer=object(),
+                producer_build_sha256="2" * 64,
+                producer_image_digest="sha256:" + "3" * 64,
+                work_root=Path("/path/that/must/not/be/created"),
+            )
+
+        catalog.promotion_grant.assert_not_called()
 
     def test_already_production_short_circuits_all_local_work(self):
         entry_id = "map_v1_" + "M" * 43

--- a/map-platform/backend/tests/test_catalog_promotion.py
+++ b/map-platform/backend/tests/test_catalog_promotion.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import base64
 import hashlib
+import json
 import tempfile
 import threading
 import unittest
+import zipfile
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -13,6 +16,7 @@ from map_platform.catalog_promotion import (
     CatalogPromotionError,
     _PromotionLeaseHeartbeat,
     _download_exact_zip,
+    _extract_validated_archive,
     promote_catalog_map,
 )
 from map_platform.map_stream import canonical_stream_manifest_bytes, manifest_receipt
@@ -61,6 +65,51 @@ class FakePromotionCatalog:
 
 
 class CatalogPromotionDownloadTests(unittest.TestCase):
+    def test_extract_restores_the_verified_archive_preview_identity(self):
+        preview_bytes = b"verified-preview-png"
+        manifest = {
+            "preview": {
+                "path": "preview.png",
+                "bytes": len(preview_bytes),
+                "sha256": hashlib.sha256(preview_bytes).hexdigest(),
+            }
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive_path = root / "source.zip"
+            extract_root = root / "extract"
+            extract_root.mkdir()
+            with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+                archive.writestr("manifest.json", json.dumps(manifest))
+                archive.writestr("preview.png", preview_bytes)
+
+            extracted = _extract_validated_archive(archive_path, extract_root)
+
+        self.assertEqual(
+            extracted["preview"]["dataBase64"],
+            base64.b64encode(preview_bytes).decode("ascii"),
+        )
+
+    def test_extract_rejects_a_preview_that_does_not_match_its_identity(self):
+        manifest = {
+            "preview": {
+                "path": "preview.png",
+                "bytes": 8,
+                "sha256": hashlib.sha256(b"expected").hexdigest(),
+            }
+        }
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            archive_path = root / "source.zip"
+            extract_root = root / "extract"
+            extract_root.mkdir()
+            with zipfile.ZipFile(archive_path, "w", compression=zipfile.ZIP_STORED) as archive:
+                archive.writestr("manifest.json", json.dumps(manifest))
+                archive.writestr("preview.png", b"tampered")
+
+            with self.assertRaisesRegex(CatalogPromotionError, "preview identity"):
+                _extract_validated_archive(archive_path, extract_root)
+
     def test_download_streams_exact_receipt_from_configured_r2_host(self):
         body = b"validated final ZIP bytes"
         with tempfile.TemporaryDirectory() as temporary:

--- a/map-platform/backend/tests/test_catalog_promotion.py
+++ b/map-platform/backend/tests/test_catalog_promotion.py
@@ -120,7 +120,7 @@ class CatalogPromotionDownloadTests(unittest.TestCase):
                     body,
                     "https://a" + "1" * 31 + ".r2.cloudflarestorage.com/map-artifacts/source.zip",
                 ),
-            ):
+            ) as open_url:
                 _download_exact_zip(
                     "https://maps-share.8o.vc/v1/internal/promotions/downloads/token",
                     destination,
@@ -131,6 +131,8 @@ class CatalogPromotionDownloadTests(unittest.TestCase):
                     timeout_seconds=10,
                 )
             self.assertEqual(destination.read_bytes(), body)
+            request = open_url.call_args.args[0]
+            self.assertEqual(request.get_header("User-agent"), "BicinoMapPlatform/1.0")
 
     def test_download_rejects_redirect_away_from_configured_r2_host(self):
         body = b"untrusted"


### PR DESCRIPTION
## Summary
- send an explicit service User-Agent for catalog calls behind Cloudflare
- restore the canonical preview identity from verified ZIP bytes during promotion
- validate signer, producer identity, and artifact storage before acquiring a promotion lease

## Verification
- `pytest` full backend suite: 574 passed, 3 skipped
- focused catalog and promotion tests: 20 passed
- `git diff --check`
- production promotion completed with `map-prod-2026-08` and exact R2 HEAD verification