### PR TITLE
Optimize CI execution policy

### DIFF
--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -211,6 +211,16 @@ def git_diff_command(event: str, base: str, head: str) -> Sequence[str] | None:
             f"{base_sha}...{head_sha}",
             "--",
         )
+    if event == "merge_group":
+        return (
+            "git",
+            "diff",
+            "--no-renames",
+            "--name-only",
+            "-z",
+            f"{base_sha}..{head_sha}",
+            "--",
+        )
     if event == "push":
         if base_sha == ZERO_SHA:
             return (

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -305,6 +305,23 @@ class ChangedComponentsTests(unittest.TestCase):
             changed_components.git_diff_command("pull_request", base, head),
         )
 
+    def test_merge_group_uses_exact_queue_diff(self) -> None:
+        base = "a" * 40
+        head = "b" * 40
+
+        self.assertEqual(
+            (
+                "git",
+                "diff",
+                "--no-renames",
+                "--name-only",
+                "-z",
+                f"{base}..{head}",
+                "--",
+            ),
+            changed_components.git_diff_command("merge_group", base, head),
+        )
+
     def test_new_ref_push_uses_root_diff(self) -> None:
         head = "b" * 40
 

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -29,18 +29,6 @@ DIAGNOSTIC_FIRMWARE_TARGETS = {
     "WAVESHARE_AMOLED_206_POWER_METRICS",
     "WAVESHARE_AMOLED_206_LIGHT_SLEEP",
 }
-SHARED_CONTRACT_PATHS = {
-    "docs/app-store-privacy-disclosures.md",
-    "docs/device-ownership-test-vectors.json",
-    "docs/firmware-battery-life-hardware-validation.md",
-    "docs/firmware-build-provenance.md",
-    "docs/firmware-factory-release.md",
-    "docs/firmware-map-memory-diagnostics.md",
-    "docs/firmware-map-render-scheduler.md",
-    "docs/firmware-map-rendering-psram.md",
-    "docs/firmware-runtime-maintenance.md",
-    "docs/releases/watchos-workout-companion.md",
-}
 JOB_KEY_PATTERN = re.compile(
     r'(?:"(?P<double>[A-Za-z_][A-Za-z0-9_-]*)"|'
     r"'(?P<single>[A-Za-z_][A-Za-z0-9_-]*)'|"
@@ -321,12 +309,82 @@ class WorkflowPolicyTests(unittest.TestCase):
             general_ci,
         )
 
-    def test_feature_branch_pushes_do_not_duplicate_pull_request_ci(self) -> None:
+    def test_ios_workout_suite_does_not_repeat_ride_diagnostics_xctest(self) -> None:
         general_ci = workflow_source("ci.yml")
 
-        self.assertIn("  push:\n    branches:\n      - main\n", general_ci)
+        self.assertNotIn("Run ride diagnostics XCTest target", general_ci)
+        self.assertNotIn("run-ride-diagnostics-xctest.sh", general_ci)
+        self.assertIn("Run workout contract tests on iOS", general_ci)
+        self.assertIn("./scripts/run-workout-platform-tests.sh ios", general_ci)
+
+    def test_release_container_owns_watch_build_validation(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        self.assertNotIn("Build watch app", general_ci)
+        self.assertNotIn("-target BikeComputerWatch", general_ci)
+        self.assertIn("Build Release app container", general_ci)
+        self.assertIn("Validate Release app container", general_ci)
+        self.assertIn("./scripts/verify-release-container.sh", general_ci)
+
+    def test_ios_platform_tests_share_only_job_scoped_derived_data(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        ios = mapping_block(general_ci, "ios", indent=2)
+
+        self.assertIn(
+            'CI_DERIVED_DATA_PATH=$RUNNER_TEMP/BikeComputerDerivedData',
+            ios,
+        )
+        self.assertIn('>> "$GITHUB_ENV"', ios)
+        self.assertNotIn("actions/cache", ios)
+
+    def test_general_ci_does_not_repeat_after_merge(self) -> None:
+        general_ci = workflow_source("ci.yml")
+
+        self.assertNotRegex(general_ci, r"(?m)^  push:")
         self.assertIn("  pull_request:\n", general_ci)
+        self.assertIn("  workflow_call:\n", general_ci)
+        self.assertIn("  workflow_dispatch:\n", general_ci)
         self.assertIn("  cancel-in-progress: true\n", general_ci)
+
+    def test_ready_prs_and_merge_groups_restore_full_ci(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        pull_request = mapping_block(general_ci, "pull_request", indent=2)
+        merge_group = mapping_block(general_ci, "merge_group", indent=2)
+        changes = mapping_block(general_ci, "changes", indent=2)
+
+        for event_type in ("opened", "synchronize", "reopened", "ready_for_review"):
+            with self.subTest(event_type=event_type):
+                self.assertIn(f"      - {event_type}", pull_request)
+        self.assertIn("      - checks_requested", merge_group)
+        self.assertIn("heavy_ci: ${{ steps.policy.outputs.heavy_ci }}", changes)
+        self.assertIn("PULL_REQUEST_DRAFT", changes)
+        self.assertIn("github.event.merge_group.base_sha", changes)
+        self.assertIn("github.event.merge_group.head_sha", changes)
+
+    def test_draft_prs_keep_fast_checks_and_skip_heavy_jobs(self) -> None:
+        general_ci = workflow_source("ci.yml")
+        esp32 = mapping_block(general_ci, "esp32", indent=2)
+        ios_fast = mapping_block(general_ci, "ios-fast", indent=2)
+        ios = mapping_block(general_ci, "ios", indent=2)
+        host = mapping_block(general_ci, "esp32-host", indent=2)
+        gate = mapping_block(general_ci, "gate", indent=2)
+
+        self.assertIn("needs.changes.outputs.heavy_ci == 'true'", esp32)
+        self.assertIn("if: needs.changes.outputs.ios == 'true'", ios_fast)
+        self.assertNotIn("needs.changes.outputs.heavy_ci", ios_fast)
+        self.assertIn("needs.changes.outputs.heavy_ci == 'true'", ios)
+        self.assertNotIn("needs.changes.outputs.heavy_ci", host)
+        self.assertIn("- ios-fast", gate)
+        self.assertIn("HEAVY_CI", gate)
+        self.assertIn("IOS_FAST_RESULT", gate)
+        self.assertIn(
+            'test "$FIRMWARE_BUILD_CHANGED" = true && test "$HEAVY_CI" = true',
+            gate,
+        )
+        self.assertIn(
+            'test "$IOS_CHANGED" = true && test "$HEAVY_CI" = true',
+            gate,
+        )
 
     def test_concurrency_separates_events_and_manual_scopes(self) -> None:
         general_ci = workflow_source("ci.yml")
@@ -354,10 +412,8 @@ class WorkflowPolicyTests(unittest.TestCase):
             "firmware_targets: ${{ steps.components.outputs.firmware_targets }}",
             changes,
         )
-        self.assertIn(
-            "if: needs.changes.outputs.firmware_build == 'true'",
-            esp32,
-        )
+        self.assertIn("needs.changes.outputs.firmware_build == 'true'", esp32)
+        self.assertIn("needs.changes.outputs.heavy_ci == 'true'", esp32)
         self.assertIn(
             "if: needs.changes.outputs.firmware_host == 'true'",
             host,
@@ -482,19 +538,6 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn("tools/package_factory_firmware.py", general_ci)
         self.assertIn("tar -xzf", general_ci)
         self.assertIn("sha256sum --check SHA256SUMS", general_ci)
-
-    def test_main_push_filter_includes_shared_contract_inputs(self) -> None:
-        general_ci = workflow_source("ci.yml")
-
-        for path in SHARED_CONTRACT_PATHS:
-            with self.subTest(path=path):
-                self.assertIn(f'      - "{path}"', general_ci)
-        self.assertIn('      - ".github/actions/**"', general_ci)
-        self.assertIn('      - "test-fixtures/fmb/**"', general_ci)
-        self.assertIn('      - "tools/firmware_manifest.py"', general_ci)
-        self.assertIn('      - "tools/firmware-signing-requirements.txt"', general_ci)
-        self.assertIn('      - "tools/verify_github_release_assets.py"', general_ci)
-        self.assertIn('      - "tools/tests/**"', general_ci)
 
     def test_promotion_contract_requires_the_aggregate_gate(self) -> None:
         agent_instructions = (REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,43 +13,15 @@ on:
         required: false
         default: "175"
         type: string
-  push:
-    branches:
-      - main
-    paths:
-      - ".dockerignore"
-      - ".github/actions/**"
-      - ".github/scripts/**"
-      - ".github/workflows/ci.yml"
-      - ".github/workflows/firmware-diagnostics.yml"
-      - ".github/workflows/firmware-release.yml"
-      - ".github/workflows/firmware-runtime-performance.yml"
-      - ".github/workflows/firmware-runtime-publish.yml"
-      - ".github/workflows/firmware-runtime-refresh.yml"
-      - ".github/workflows/map-platform-ci.yml"
-      - ".github/workflows/map-platform-image.yml"
-      - ".github/workflows/speaker-firmware.yml"
-      - "docs/app-store-privacy-disclosures.md"
-      - "docs/device-ownership-test-vectors.json"
-      - "docs/firmware-battery-life-hardware-validation.md"
-      - "docs/firmware-build-provenance.md"
-      - "docs/firmware-factory-release.md"
-      - "docs/firmware-map-memory-diagnostics.md"
-      - "docs/firmware-map-render-scheduler.md"
-      - "docs/firmware-map-rendering-psram.md"
-      - "docs/firmware-runtime-maintenance.md"
-      - "docs/releases/watchos-workout-companion.md"
-      - "esp32/**"
-      - "ios-app/**"
-      - "map-platform/**"
-      - "test-fixtures/fmb/**"
-      - "tools/firmware_manifest.py"
-      - "tools/factory_release_manifest.py"
-      - "tools/firmware-signing-requirements.txt"
-      - "tools/verify_github_release_assets.py"
-      - "tools/tests/**"
-      - "tools/OSM_Extract/**"
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  merge_group:
+    types:
+      - checks_requested
   workflow_dispatch:
     inputs:
       scope:
@@ -90,6 +62,7 @@ jobs:
       firmware_build: ${{ steps.components.outputs.firmware_build }}
       firmware_host: ${{ steps.components.outputs.firmware_host }}
       firmware_targets: ${{ steps.components.outputs.firmware_targets }}
+      heavy_ci: ${{ steps.policy.outputs.heavy_ci }}
       ios: ${{ steps.components.outputs.ios }}
       map_backend: ${{ steps.components.outputs.map_backend }}
       osm: ${{ steps.components.outputs.osm }}
@@ -99,6 +72,17 @@ jobs:
           fetch-depth: 0
       - name: Test CI component routing
         run: python3 -m unittest discover -s .github/scripts/tests
+      - id: policy
+        name: Select CI cost policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PULL_REQUEST_DRAFT: ${{ github.event.pull_request.draft || false }}
+        run: |
+          heavy_ci=true
+          if test "$EVENT_NAME" = pull_request && test "$PULL_REQUEST_DRAFT" = true; then
+            heavy_ci=false
+          fi
+          echo "heavy_ci=${heavy_ci}" >> "$GITHUB_OUTPUT"
       - name: Validate the protected partial gate scope
         if: >-
           github.event_name == 'workflow_dispatch' && inputs.scope == 'map' &&
@@ -120,11 +104,11 @@ jobs:
       - id: components
         name: Select changed components
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '0000000000000000000000000000000000000000' }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '0000000000000000000000000000000000000000' }}
           CI_SCOPE: ${{ github.ref_type == 'tag' && 'all' || inputs.scope || 'auto' }}
           EVENT_NAME: ${{ github.event_name }}
           FIRMWARE_HARDWARE: ${{ inputs.firmware_hardware || '175' }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || github.sha }}
         run: >-
           python3 .github/scripts/changed_components.py
           --event "$EVENT_NAME"
@@ -137,7 +121,9 @@ jobs:
   esp32:
     name: ESP32 (${{ matrix.target }})
     needs: changes
-    if: needs.changes.outputs.firmware_build == 'true'
+    if: >-
+      needs.changes.outputs.firmware_build == 'true' &&
+      needs.changes.outputs.heavy_ci == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -231,8 +217,8 @@ jobs:
               raise SystemExit(f"Missing remote-debug routes: {', '.join(missing)}")
           PY
 
-  ios:
-    name: iOS
+  ios-fast:
+    name: iOS Fast Tests
     needs: changes
     if: needs.changes.outputs.ios == 'true'
     runs-on: macos-latest
@@ -247,9 +233,6 @@ jobs:
       - name: Run ride diagnostics recorder tests
         run: ./scripts/run-ride-diagnostics-tests.sh
         working-directory: ios-app
-      - name: Run ride diagnostics XCTest target
-        run: bash ./scripts/run-ride-diagnostics-xctest.sh
-        working-directory: ios-app
       - name: Run shared route and Watch BLE contract tests
         run: ./scripts/run-ride-shared-tests.sh
         working-directory: ios-app
@@ -262,26 +245,23 @@ jobs:
       - name: Run workout contract tests
         run: ./scripts/run-workout-contract-tests.sh
         working-directory: ios-app
+
+  ios:
+    name: iOS
+    needs: changes
+    if: >-
+      needs.changes.outputs.ios == 'true' &&
+      needs.changes.outputs.heavy_ci == 'true'
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Configure job-scoped Xcode DerivedData
+        run: echo "CI_DERIVED_DATA_PATH=$RUNNER_TEMP/BikeComputerDerivedData" >> "$GITHUB_ENV"
       - name: Run workout contract tests on iOS
         run: ./scripts/run-workout-platform-tests.sh ios
         working-directory: ios-app
       - name: Run workout contract tests on watchOS
         run: ./scripts/run-workout-platform-tests.sh watchos
-        working-directory: ios-app
-      - name: Build watch app
-        run: |
-          ./scripts/xcodebuild-cli.sh \
-            -project BikeComputer/BikeComputer.xcodeproj \
-            -target BikeComputerWatch \
-            -configuration Release \
-            -sdk watchos \
-            -arch arm64_32 \
-            ONLY_ACTIVE_ARCH=YES \
-            CONFIGURATION_BUILD_DIR="$RUNNER_TEMP/bike-computer-watch" \
-            OBJROOT="$RUNNER_TEMP/bike-computer-watch-obj" \
-            SYMROOT="$RUNNER_TEMP/bike-computer-watch-sym" \
-            CODE_SIGNING_ALLOWED=NO \
-            build
         working-directory: ios-app
       - name: Build Release app container
         run: |
@@ -794,6 +774,7 @@ jobs:
       - changes
       - esp32
       - esp32-host
+      - ios-fast
       - ios
       - map-platform
     if: always()
@@ -806,7 +787,9 @@ jobs:
           FIRMWARE_BUILD_CHANGED: ${{ needs.changes.outputs.firmware_build }}
           FIRMWARE_HOST_CHANGED: ${{ needs.changes.outputs.firmware_host }}
           HOST_RESULT: ${{ needs.esp32-host.result }}
+          HEAVY_CI: ${{ needs.changes.outputs.heavy_ci }}
           IOS_CHANGED: ${{ needs.changes.outputs.ios }}
+          IOS_FAST_RESULT: ${{ needs.ios-fast.result }}
           IOS_RESULT: ${{ needs.ios.result }}
           MAP_BACKEND_CHANGED: ${{ needs.changes.outputs.map_backend }}
           MAP_RESULT: ${{ needs.map-platform.result }}
@@ -824,7 +807,7 @@ jobs:
 
           require_result "CI component selection" "$CHANGES_RESULT" success
 
-          if test "$FIRMWARE_BUILD_CHANGED" = true; then
+          if test "$FIRMWARE_BUILD_CHANGED" = true && test "$HEAVY_CI" = true; then
             require_result "ESP32 builds" "$ESP32_RESULT" success
           else
             require_result "ESP32 builds" "$ESP32_RESULT" skipped
@@ -837,6 +820,12 @@ jobs:
           fi
 
           if test "$IOS_CHANGED" = true; then
+            require_result "iOS fast tests" "$IOS_FAST_RESULT" success
+          else
+            require_result "iOS fast tests" "$IOS_FAST_RESULT" skipped
+          fi
+
+          if test "$IOS_CHANGED" = true && test "$HEAVY_CI" = true; then
             require_result "iOS" "$IOS_RESULT" success
           else
             require_result "iOS" "$IOS_RESULT" skipped

--- a/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutLiveActivityControllerTests.swift
@@ -164,16 +164,26 @@ private final class MemoryWorkoutLiveActivitySuppressionStore:
 private final class WorkoutLiveActivityWaitScheduler {
     private(set) var requestedIntervals: [TimeInterval] = []
     private var continuations: [CheckedContinuation<Void, Error>] = []
+    private var registrationWaiters: [CheckedContinuation<Void, Never>] = []
 
     func wait(_ interval: TimeInterval) async throws {
         requestedIntervals.append(interval)
         try await withCheckedThrowingContinuation { continuation in
             continuations.append(continuation)
+            let waiters = registrationWaiters
+            registrationWaiters.removeAll()
+            for waiter in waiters {
+                waiter.resume()
+            }
         }
     }
 
-    func resumeNext() {
-        guard !continuations.isEmpty else { return }
+    func resumeNext() async {
+        if continuations.isEmpty {
+            await withCheckedContinuation { continuation in
+                registrationWaiters.append(continuation)
+            }
+        }
         continuations.removeFirst().resume()
     }
 }
@@ -217,6 +227,22 @@ private final class FakeWorkoutBackgroundExecutionLease:
 final class WorkoutLiveActivityControllerTests: XCTestCase {
     private let capturedAt =
         Date(timeIntervalSinceReferenceDate: 800_500_000)
+
+    func testWaitSchedulerResumeWaitsForRegistration() async throws {
+        let scheduler = WorkoutLiveActivityWaitScheduler()
+        let resumeTask = Task { @MainActor in
+            await scheduler.resumeNext()
+        }
+        await Task.yield()
+        let waitTask = Task { @MainActor in
+            try await scheduler.wait(1)
+        }
+
+        await resumeTask.value
+        try await waitTask.value
+
+        XCTAssertEqual(scheduler.requestedIntervals, [1])
+    }
 
     func testForegroundVerifiedWorkoutRequestsOnlyOneActivity() async {
         let sessionID = UUID()
@@ -378,7 +404,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
 
         XCTAssertTrue(client.updates.isEmpty)
         XCTAssertEqual(scheduler.requestedIntervals.count, 1)
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         XCTAssertEqual(client.updates.count, 1)
@@ -419,7 +445,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
             )
         )
         await settle()
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         source.send(
@@ -433,7 +459,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
 
         XCTAssertTrue(client.updates.isEmpty)
         XCTAssertEqual(scheduler.requestedIntervals.count, 2)
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
         XCTAssertEqual(
             client.updates.last?.1.currentSpeedKilometersPerHour,
@@ -857,7 +883,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         source.send(active)
         await settle()
         XCTAssertFalse(lease.isActive)
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         XCTAssertEqual(client.endings.map(\.0), ["other"])
@@ -886,7 +912,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         controller.start(isApplicationForeground: false)
         await settle()
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         XCTAssertEqual(client.endings.count, 1)
@@ -921,7 +947,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         XCTAssertTrue(lease.isActive)
         XCTAssertEqual(scheduler.requestedIntervals, [3])
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         XCTAssertFalse(lease.isActive)
@@ -995,7 +1021,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         await settle()
         XCTAssertTrue(lease.isActive)
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
 
         XCTAssertEqual(client.endings.count, 1)
@@ -1047,7 +1073,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         controller.start(isApplicationForeground: true)
         await settle()
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
         XCTAssertEqual(client.endAttempts, ["ending"])
 
@@ -1095,7 +1121,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         controller.start(isApplicationForeground: true)
         await settle()
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         source.send(
             makeLiveActivityPresentation(
                 sessionID: sessionID,
@@ -1162,7 +1188,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         controller.start(isApplicationForeground: true)
         await settle()
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
         XCTAssertEqual(client.endAttempts, ["unrelated"])
         XCTAssertTrue(
@@ -1223,7 +1249,7 @@ final class WorkoutLiveActivityControllerTests: XCTestCase {
         controller.start(isApplicationForeground: true)
         await settle()
 
-        scheduler.resumeNext()
+        await scheduler.resumeNext()
         await settle()
         XCTAssertEqual(client.endAttempts, ["existing"])
 

--- a/ios-app/scripts/run-workout-platform-tests.sh
+++ b/ios-app/scripts/run-workout-platform-tests.sh
@@ -23,14 +23,31 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_APP_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
-DERIVED_DATA="$(mktemp -d "${TMPDIR:-/tmp}/open-bike-${SCHEME}.XXXXXX")"
+OWNS_DERIVED_DATA=0
+if [[ -n "${CI_DERIVED_DATA_PATH:-}" ]]; then
+  if [[ "${CI_DERIVED_DATA_PATH}" != /* || "${CI_DERIVED_DATA_PATH}" == "/" ]]; then
+    echo "CI_DERIVED_DATA_PATH must be a non-root absolute path" >&2
+    exit 64
+  fi
+  DERIVED_DATA="${CI_DERIVED_DATA_PATH}"
+  if [[ -L "${DERIVED_DATA}" ]]; then
+    echo "CI_DERIVED_DATA_PATH must not be a symlink" >&2
+    exit 64
+  fi
+  mkdir -p "${DERIVED_DATA}"
+else
+  DERIVED_DATA="$(mktemp -d "${TMPDIR:-/tmp}/open-bike-${SCHEME}.XXXXXX")"
+  OWNS_DERIVED_DATA=1
+fi
 SIMULATOR_BOOTED_BY_SCRIPT=0
 
 cleanup() {
   if [[ "${SIMULATOR_BOOTED_BY_SCRIPT}" -eq 1 && -n "${SIMULATOR_UDID:-}" ]]; then
     xcrun simctl shutdown "${SIMULATOR_UDID}" 2>/dev/null || true
   fi
-  rm -rf "${DERIVED_DATA}"
+  if [[ "${OWNS_DERIVED_DATA}" -eq 1 ]]; then
+    rm -rf "${DERIVED_DATA}"
+  fi
 }
 trap cleanup EXIT
 

--- a/ios-app/scripts/tests/test_run_workout_platform_tests.py
+++ b/ios-app/scripts/tests/test_run_workout_platform_tests.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "run-workout-platform-tests.sh"
+
+
+class WorkoutPlatformScriptTests(unittest.TestCase):
+    def run_script(self, root: Path, *, shared: Path | None) -> Path:
+        bin_dir = root / "bin"
+        bin_dir.mkdir(parents=True)
+        args_log = root / "xcodebuild-args.json"
+        simulator_payload = json.dumps(
+            {
+                "devices": {
+                    "com.apple.CoreSimulator.SimRuntime.iOS-26-5": [
+                        {
+                            "udid": "00000000-0000-0000-0000-000000000001",
+                            "state": "Booted",
+                            "isAvailable": True,
+                        }
+                    ]
+                }
+            },
+            separators=(",", ":"),
+        )
+        xcrun = bin_dir / "xcrun"
+        xcrun.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "if [[ \"$*\" == \"simctl list devices available --json\" ]]; then\n"
+            f"  printf '%s\\n' '{simulator_payload}'\n"
+            "  exit 0\n"
+            "fi\n"
+            "if [[ \"${1:-}\" == \"simctl\" ]]; then exit 0; fi\n"
+            "exit 64\n",
+            encoding="utf-8",
+        )
+        xcrun.chmod(0o755)
+        xcodebuild = bin_dir / "xcodebuild"
+        xcodebuild.write_text(
+            "#!/usr/bin/env bash\n"
+            "set -euo pipefail\n"
+            "/usr/bin/python3 - \"$XCODEBUILD_ARGS_LOG\" \"$@\" <<'PY'\n"
+            "import json, sys\n"
+            "from pathlib import Path\n"
+            "Path(sys.argv[1]).write_text(json.dumps(sys.argv[2:]), encoding='utf-8')\n"
+            "PY\n",
+            encoding="utf-8",
+        )
+        xcodebuild.chmod(0o755)
+
+        temp_root = root / "tmp"
+        temp_root.mkdir()
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{bin_dir}:{environment['PATH']}",
+                "TMPDIR": f"{temp_root}/",
+                "XCODEBUILD_ARGS_LOG": str(args_log),
+            }
+        )
+        if shared is None:
+            environment.pop("CI_DERIVED_DATA_PATH", None)
+        else:
+            environment["CI_DERIVED_DATA_PATH"] = str(shared)
+
+        subprocess.run(
+            ["bash", str(SCRIPT), "ios"],
+            cwd=SCRIPT.parents[1],
+            env=environment,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return args_log
+
+    def test_external_derived_data_is_reused_across_invocations_and_preserved(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            shared = root / "shared-derived-data"
+            shared.mkdir()
+            sentinel = shared / "preserve-me"
+            sentinel.write_text("shared", encoding="utf-8")
+
+            first_log = self.run_script(root / "first", shared=shared)
+            second_log = self.run_script(root / "second", shared=shared)
+            first_arguments = json.loads(first_log.read_text(encoding="utf-8"))
+            second_arguments = json.loads(second_log.read_text(encoding="utf-8"))
+
+            self.assertTrue(shared.is_dir())
+            self.assertEqual("shared", sentinel.read_text(encoding="utf-8"))
+            self.assertEqual(
+                str(shared),
+                first_arguments[first_arguments.index("-derivedDataPath") + 1],
+            )
+            self.assertEqual(
+                str(shared),
+                second_arguments[second_arguments.index("-derivedDataPath") + 1],
+            )
+
+    def test_script_owned_derived_data_is_removed(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            args_log = self.run_script(root, shared=None)
+            arguments = json.loads(args_log.read_text(encoding="utf-8"))
+            derived_data = Path(arguments[arguments.index("-derivedDataPath") + 1])
+
+            self.assertFalse(derived_data.exists())
+
+    def test_external_derived_data_rejects_root_and_relative_paths(self) -> None:
+        for value in ("/", "relative/path"):
+            with self.subTest(value=value), tempfile.TemporaryDirectory() as temporary:
+                environment = os.environ.copy()
+                environment["CI_DERIVED_DATA_PATH"] = value
+                result = subprocess.run(
+                    ["bash", str(SCRIPT), "ios"],
+                    cwd=SCRIPT.parents[1],
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                )
+
+                self.assertEqual(64, result.returncode)
+                self.assertIn("non-root absolute path", result.stderr)
+
+    def test_external_derived_data_rejects_symlink(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = root / "target"
+            target.mkdir()
+            link = root / "derived-data-link"
+            link.symlink_to(target, target_is_directory=True)
+            environment = os.environ.copy()
+            environment["CI_DERIVED_DATA_PATH"] = str(link)
+
+            result = subprocess.run(
+                ["bash", str(SCRIPT), "ios"],
+                cwd=SCRIPT.parents[1],
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(64, result.returncode)
+            self.assertIn("must not be a symlink", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- remove duplicate post-merge CI, the diagnostics-only XCTest rerun, and the redundant standalone Watch build
- split inexpensive iOS checks from heavy Xcode work so draft PRs keep fast feedback
- add `ready_for_review` and `merge_group` orchestration with router and aggregate-gate support
- reuse one job-scoped DerivedData directory without adding a persistent cache
- retain the full three-variant firmware matrix on ready PRs because merge queue is unavailable for this user-owned repository
- make the Live Activity test wait scheduler deterministic after hosted CI exposed a registration race

## Verification

- `python3 -m unittest discover -s .github/scripts/tests` (63 tests)
- `python3 -m unittest discover -s ios-app/scripts/tests` (24 tests)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/ci.yml`
- all commands assigned to the new iOS Fast Tests job pass locally
- hosted CI proves `RideDiagnosticsTests` still runs in the complete iOS XCTest target
- hosted Release and Debug container validation verifies the embedded Watch app and complication without the standalone Watch build
