### PR TITLE
Move map library into developer settings

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -2778,6 +2778,29 @@ final class OfflineMapManager: ObservableObject {
         )
     }
 
+    func catalogArtifactNeedsRefresh(for item: SavedMapListItem) -> Bool {
+        guard let record = item.localRecord,
+              let map = item.catalogMap else {
+            return false
+        }
+        let metadata = SavedMapArtifactMetadataStore.load(for: record.packURL)
+        let localArtifactSHA256s: Set<String> = Set([
+            metadata?.primaryArtifact?.sha256,
+            metadata?.legacyArtifact?.sha256,
+        ].compactMap { (value: String?) -> String? in
+            guard let value, !value.isEmpty else { return nil }
+            return value
+        })
+        return OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+            localArtifactSHA256s: localArtifactSHA256s,
+            map: map,
+            channel: OfflineMapCatalogConfig.channel(
+                generationServerURLString: serverURLString
+            ),
+            trustStore: mapStreamTrustStore
+        )
+    }
+
     func catalogAvailability(
         for preview: OfflineMapSharePreview
     ) -> OfflineMapCatalogAvailability {

--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapCatalog.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapCatalog.swift
@@ -200,15 +200,12 @@ nonisolated enum OfflineMapCatalogAvailabilityPolicy {
             return .unavailable
         }
 
-        if map.artifacts.contains(where: {
-            isCompatible(
-                $0,
-                map: map,
-                channel: channel,
-                trustStore: trustStore,
-                readerCapabilities: readerCapabilities
-            )
-        }) {
+        if !preferredCompatibleArtifacts(
+            for: map,
+            channel: channel,
+            trustStore: trustStore,
+            readerCapabilities: readerCapabilities
+        ).isEmpty {
             return .available
         }
 
@@ -226,6 +223,30 @@ nonisolated enum OfflineMapCatalogAvailabilityPolicy {
         return .incompatible
     }
 
+    static func localArtifactNeedsRefresh(
+        localArtifactSHA256s: Set<String>,
+        map: OfflineMapCatalogMap,
+        channel: String,
+        trustStore: BikeMapStreamTrustStore,
+        readerCapabilities: OfflineMapReaderCapabilities = .current
+    ) -> Bool {
+        let deliveryState = map.deliveryState.lowercased()
+        guard deliveryState != "blocked", deliveryState != "tombstoned" else {
+            return false
+        }
+        let preferredArtifacts = preferredCompatibleArtifacts(
+            for: map,
+            channel: channel,
+            trustStore: trustStore,
+            readerCapabilities: readerCapabilities
+        )
+        guard !preferredArtifacts.isEmpty else { return false }
+        let localSHA256s = Set(localArtifactSHA256s.map { $0.lowercased() })
+        return preferredArtifacts.allSatisfy {
+            !localSHA256s.contains($0.sha256.lowercased())
+        }
+    }
+
     static func availability(
         for preview: OfflineMapSharePreview,
         channel: String
@@ -239,6 +260,35 @@ nonisolated enum OfflineMapCatalogAvailabilityPolicy {
             return .available
         default:
             return .incompatible
+        }
+    }
+
+    private static func preferredCompatibleArtifacts(
+        for map: OfflineMapCatalogMap,
+        channel: String,
+        trustStore: BikeMapStreamTrustStore,
+        readerCapabilities: OfflineMapReaderCapabilities
+    ) -> [OfflineMapCatalogArtifact] {
+        let normalizedChannel = channel.lowercased()
+        let compatibleArtifacts = map.artifacts.filter {
+            isCompatible(
+                $0,
+                map: map,
+                channel: normalizedChannel,
+                trustStore: trustStore,
+                readerCapabilities: readerCapabilities
+            )
+        }
+        if normalizedChannel == "development" {
+            let developmentArtifacts = compatibleArtifacts.filter {
+                $0.deliveryTier.lowercased() == "development"
+            }
+            if !developmentArtifacts.isEmpty {
+                return developmentArtifacts
+            }
+        }
+        return compatibleArtifacts.filter {
+            $0.deliveryTier.lowercased() == "production"
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/OfflineMapsView.swift
@@ -16,10 +16,19 @@ struct OfflineMapsView: View {
             Section(header: Text("Map Server")) {
                 OfflineMapValueRow(title: "Service", value: manager.serverURLString)
                 Button {
-                    manager.serverURLString = OfflineMapServiceConfig.defaultServerURLString
+                    manager.serverURLString =
+                        OfflineMapServiceConfig.productionServerURLString
                 } label: {
                     Label("Use Production Server", systemImage: "checkmark.seal")
                 }
+#if DEBUG
+                Button {
+                    manager.serverURLString =
+                        OfflineMapServiceConfig.developmentServerURLString
+                } label: {
+                    Label("Use Development Server", systemImage: "hammer")
+                }
+#endif
             }
 
             Section(header: Text("Download Map")) {

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -120,18 +120,6 @@ struct SettingsView: View {
                     manager: offlineMapManager,
                     focusedPackFilename: $focusedSavedMapFilename
                 )
-                Section {
-                    NavigationLink {
-                        MapLibrarySettingsView(manager: offlineMapManager)
-                    } label: {
-                        Label("Map Library", systemImage: "map.circle")
-                    }
-                } footer: {
-                    Text(
-                        "Manage shared map links or link Bicino and Bicino Dev " +
-                            "when shared Keychain access is unavailable."
-                    )
-                }
                 if OfflineMapDownloadingSectionPresentation.isVisible(
                     isBusy: offlineMapManager.isBusy,
                     hasPendingJob: offlineMapManager.hasPendingMapJob,
@@ -873,9 +861,10 @@ private struct MapLibrarySettingsView: View {
                 Text("Link Bicino Apps")
             } footer: {
                 Text(
-                    "Normally both apps share the same private Keychain library. " +
-                        "If they do not, create a code in the app whose library " +
-                        "you want to keep, then enter it in the other app within 10 minutes."
+                    "Normally both apps use the same private Cloudflare map library " +
+                        "credential from the shared Keychain. If they do not, create " +
+                        "a code in the app whose library you want to keep, then enter " +
+                        "it in the other app within 10 minutes."
                 )
             }
 
@@ -1117,6 +1106,7 @@ private struct SavedMapRow: View {
         ) ?? false
         let previewImage = manager.previewImage(for: item)
         let catalogAvailability = item.catalogMap.map(manager.catalogAvailability(for:))
+        let catalogArtifactNeedsRefresh = manager.catalogArtifactNeedsRefresh(for: item)
 
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 12) {
@@ -1229,6 +1219,26 @@ private struct SavedMapRow: View {
                         .accessibilityLabel(
                             "Waiting for the Bike Computer to confirm \(displayName)"
                         )
+                } else if catalogArtifactNeedsRefresh,
+                          let catalogMap = item.catalogMap {
+                    Button {
+                        finishRenaming()
+                        focusedPackFilename = nil
+                        manager.downloadCatalogMap(catalogMap)
+                    } label: {
+                        Image(systemName: "arrow.down.circle")
+                            .frame(width: 32, height: 32)
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(
+                        manager.isBusy ||
+                            manager.isDeviceTransferBusy ||
+                            manager.hasActiveBackgroundUpload ||
+                            isPausedUpload ||
+                            catalogAvailability?.canDownload != true
+                    )
+                    .accessibilityLabel("Update \(displayName) on this iPhone")
+                    .accessibilityHint("Downloads the current compatible map artifact")
                 } else if let packURL {
                     Button {
                         finishRenaming()
@@ -1317,6 +1327,13 @@ private struct SavedMapRow: View {
                     .font(.caption)
                     .foregroundColor(.secondary)
                     .accessibilityLabel("\(displayName): \(status)")
+            }
+
+            if catalogArtifactNeedsRefresh {
+                Label("Updated map available", systemImage: "arrow.down.circle")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .accessibilityLabel("\(displayName): Updated map available")
             }
 
             if let mapEntryID = item.catalogMap?.mapEntryId,
@@ -3006,11 +3023,27 @@ private struct DeveloperSettingsView: View {
 
             Section(header: Text("Map Server")) {
                 SettingsValueRow(title: "Service", value: offlineMapManager.serverURLString)
-                Button {
-                    offlineMapManager.serverURLString = OfflineMapServiceConfig.defaultServerURLString
-                } label: {
+                Button(action: useProductionMapServer) {
                     Label("Use Production Server", systemImage: "checkmark.seal")
                 }
+#if DEBUG
+                Button(action: useDevelopmentMapServer) {
+                    Label("Use Development Server", systemImage: "hammer")
+                }
+#endif
+            }
+
+            Section {
+                NavigationLink {
+                    MapLibrarySettingsView(manager: offlineMapManager)
+                } label: {
+                    Label("Map Library", systemImage: "map.circle")
+                }
+            } footer: {
+                Text(
+                    "Manage the private Cloudflare map library, shared links, " +
+                        "and Bicino app linking."
+                )
             }
 
             Section {
@@ -3141,6 +3174,18 @@ private struct DeveloperSettingsView: View {
                 .foregroundColor(bleManager.isConnected ? .green : .red)
         }
     }
+
+    private func useProductionMapServer() {
+        offlineMapManager.serverURLString =
+            OfflineMapServiceConfig.productionServerURLString
+    }
+
+#if DEBUG
+    private func useDevelopmentMapServer() {
+        offlineMapManager.serverURLString =
+            OfflineMapServiceConfig.developmentServerURLString
+    }
+#endif
 
     private var connectionStatusText: String {
         guard bleManager.isConnected else {

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -6435,6 +6435,7 @@ struct NavigationProtocolTests {
             id: String,
             tier: String,
             requiredBuild: String?,
+            sha256: String = String(repeating: "c", count: 64),
             includesReaderRequirements: Bool = true,
             readerSchemaVersion: Int = 1,
             streamFormat: String = OfflineMapArtifact.bikeMapStreamFormat,
@@ -6449,7 +6450,7 @@ struct NavigationProtocolTests {
                 mediaType: "application/vnd.openbikecomputer.map-stream",
                 filename: "test.bmap",
                 bytes: 100,
-                sha256: String(repeating: "c", count: 64),
+                sha256: sha256,
                 manifestReceipt: String(repeating: "d", count: 64),
                 signedManifestReceipt: String(repeating: "e", count: 64),
                 signatureKeyId: keyID,
@@ -6480,7 +6481,7 @@ struct NavigationProtocolTests {
 
         func map(
             deliveryState: String,
-            artifact: OfflineMapCatalogArtifact
+            artifacts: [OfflineMapCatalogArtifact]
         ) -> OfflineMapCatalogMap {
             OfflineMapCatalogMap(
                 mapEntryId: "map_v1_" + String(repeating: "m", count: 43),
@@ -6499,8 +6500,15 @@ struct NavigationProtocolTests {
                 generatedAt: nil,
                 addedAt: "2026-08-25T00:00:00.000Z",
                 updatedAt: "2026-08-25T00:00:00.000Z",
-                artifacts: [artifact]
+                artifacts: artifacts
             )
+        }
+
+        func map(
+            deliveryState: String,
+            artifact: OfflineMapCatalogArtifact
+        ) -> OfflineMapCatalogMap {
+            map(deliveryState: deliveryState, artifacts: [artifact])
         }
 
         let developmentMap = map(
@@ -6538,6 +6546,82 @@ struct NavigationProtocolTests {
             ),
             .available,
             "production exposes an exact compatible promoted artifact"
+        )
+        let developmentSHA256 = String(repeating: "2", count: 64)
+        let productionSHA256 = String(repeating: "3", count: 64)
+        let mixedTierMap = map(
+            deliveryState: "production",
+            artifacts: [
+                artifact(
+                    id: "mixed-dev",
+                    tier: "development",
+                    requiredBuild: nil,
+                    sha256: developmentSHA256
+                ),
+                artifact(
+                    id: "mixed-prod",
+                    tier: "production",
+                    requiredBuild: nil,
+                    sha256: productionSHA256
+                ),
+            ]
+        )
+        assert(
+            OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [developmentSHA256],
+                map: mixedTierMap,
+                channel: "production",
+                trustStore: .production
+            ),
+            "production refreshes a cached development artifact for the same map entry"
+        )
+        assert(
+            !OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [productionSHA256.uppercased()],
+                map: mixedTierMap,
+                channel: "production",
+                trustStore: .production
+            ),
+            "production keeps a cached compatible production artifact"
+        )
+        assert(
+            !OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [developmentSHA256],
+                map: mixedTierMap,
+                channel: "development",
+                trustStore: .production
+            ),
+            "development keeps its preferred compatible development artifact"
+        )
+        assert(
+            OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [productionSHA256],
+                map: mixedTierMap,
+                channel: "development",
+                trustStore: .production
+            ),
+            "development refreshes a production fallback when a development artifact exists"
+        )
+        assert(
+            OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [],
+                map: mixedTierMap,
+                channel: "production",
+                trustStore: .production
+            ),
+            "a catalog-backed local file without verified artifact identity is refreshed"
+        )
+        assert(
+            !OfflineMapCatalogAvailabilityPolicy.localArtifactNeedsRefresh(
+                localArtifactSHA256s: [developmentSHA256],
+                map: map(
+                    deliveryState: "blocked",
+                    artifacts: mixedTierMap.artifacts
+                ),
+                channel: "production",
+                trustStore: .production
+            ),
+            "blocked maps never advertise a catalog artifact refresh"
         )
         let olderBuildMap = map(
             deliveryState: "production",
@@ -10447,6 +10531,17 @@ struct NavigationProtocolTests {
             "catalog rows explain and disable downloads that are pending or incompatible"
         )
         assert(
+            source.contains(
+                "let catalogArtifactNeedsRefresh = manager.catalogArtifactNeedsRefresh(for: item)"
+            ) &&
+                source.contains("Label(\"Updated map available\"") &&
+                source.contains(".accessibilityLabel(\"Update \\(displayName) on this iPhone\")") &&
+                source.contains("manager.isDeviceTransferBusy ||") &&
+                source.contains("manager.hasActiveBackgroundUpload ||") &&
+                source.contains("isPausedUpload ||"),
+            "a stale local catalog artifact offers a current verified download before transfer"
+        )
+        assert(
             source.contains("SavedMapDeviceTransferPolicy.canStart(") &&
                 source.contains("isDeviceTransferBusy: manager.isDeviceTransferBusy") &&
                 source.contains("manager.hasActiveBackgroundUpload") &&
@@ -10646,6 +10741,38 @@ struct NavigationProtocolTests {
         }
         let developerSource = String(source[developerStart...])
         let rootSettingsSource = String(source[..<developerStart])
+        guard let rootBodyStart = source.range(
+            of: "var body: some View {"
+        )?.lowerBound,
+        let rootBodyEnd = source.range(
+            of: "private var shouldPromoteBikeComputerSettings",
+            range: rootBodyStart..<source.endIndex
+        )?.lowerBound else {
+            assert(false, "root settings body boundaries should be present")
+            return
+        }
+        let rootBodySource = String(source[rootBodyStart..<rootBodyEnd])
+        assert(
+            !rootBodySource.contains("MapLibrarySettingsView") &&
+                developerSource.contains(
+                    "MapLibrarySettingsView(manager: offlineMapManager)"
+                ) &&
+                developerSource.contains(
+                    "Label(\"Map Library\", systemImage: \"map.circle\")"
+                ),
+            "Map Library is available only from Developer Settings"
+        )
+        assert(
+            developerSource.contains("Button(action: useProductionMapServer)") &&
+                developerSource.contains(
+                    "OfflineMapServiceConfig.productionServerURLString"
+                ) &&
+                developerSource.contains("Button(action: useDevelopmentMapServer)") &&
+                developerSource.contains(
+                    "OfflineMapServiceConfig.developmentServerURLString"
+                ),
+            "Developer Settings explicitly selects production or development maps"
+        )
         assert(
             !rootSettingsSource.contains("title: \"App Version\"") &&
                 developerSource.contains("Section(header: Text(\"App\"))") &&


### PR DESCRIPTION
## Summary

- move Map Library out of the main Settings form and into Developer Settings
- explicitly let Bicino Dev select production or development map servers
- detect when a local catalog map belongs to the wrong artifact tier and offer a verified refresh before device transfer
- suppress refresh actions for blocked maps and while a transfer is active or paused
- clarify that Keychain shares the private Cloudflare library credential, not map bytes

## Validation

- `./ios-app/scripts/run-navigation-tests.sh`
- `python3 -m unittest ios-app/scripts/tests/test_workout_release_assets.py`
- Swift parser checks for all modified Swift sources
- `git diff --check`
- sequential standard review/fix loop: 3 P2 findings fixed and verified; confirming pass clean

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [ ] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.