### PR TITLE
Keep catalog maintenance healthy with legacy maps

### DIFF
--- a/map-platform/backend/map_platform/catalog.py
+++ b/map-platform/backend/map_platform/catalog.py
@@ -617,13 +617,13 @@ def publish_ready_job(
         return job
     if job.catalog_publication_state == "finalized":
         return job
-    job.catalog_publication_id = publication_id(job, client.channel)
-    job.catalog_map_entry_id = map_entry_id(job)
     job.catalog_publication_state = "pending"
     job.catalog_publication_error = None
     job.updated_at = utc_now_iso()
     store.save(job)
     try:
+        job.catalog_publication_id = publication_id(job, client.channel)
+        job.catalog_map_entry_id = map_entry_id(job)
         _verify_catalog_artifacts(job, artifact_store)
         result = client.finalize(job)
     except Exception as exc:
@@ -660,15 +660,31 @@ def retry_ready_publications(
         raise ValueError("catalog publication retry limit must be positive")
     if client is None:
         return {"attempted": 0, "finalized": 0, "failed": 0}
-    candidates = sorted(
+    pending = sorted(
         (
             job
             for job in store.list()
             if job.status == JobStatus.READY
             and job.catalog_publication_state != "finalized"
         ),
-        key=lambda value: (value.catalog_publication_updated_at or value.finished_at or value.created_at),
-    )[:maximum_jobs]
+        key=lambda value: (
+            value.catalog_publication_updated_at
+            or value.finished_at
+            or value.created_at
+        ),
+    )
+    candidates: list[MapJob] = []
+    for job in pending:
+        try:
+            map_entry_id(job)
+        except CatalogPublicationError:
+            # READY jobs created before renderer targets became mandatory are
+            # immutable but not safely catalogable. Leave their local download
+            # intact without letting them consume every retry slot.
+            continue
+        candidates.append(job)
+        if len(candidates) == maximum_jobs:
+            break
     finalized = 0
     for job in candidates:
         result = publish_ready_job(

--- a/map-platform/backend/tests/test_catalog.py
+++ b/map-platform/backend/tests/test_catalog.py
@@ -18,6 +18,7 @@ from map_platform.catalog import (
     map_entry_id,
     publication_payload,
     publish_ready_job,
+    retry_ready_publications,
 )
 from map_platform.jobs import JobStore
 from map_platform.models import (
@@ -245,6 +246,59 @@ class CatalogTests(unittest.TestCase):
             self.assertEqual(result.catalog_publication_state, "failed")
             self.assertEqual(result.catalog_publication_attempts, 1)
             self.assertNotIn("secret value", result.catalog_publication_error)
+
+    def test_legacy_ready_map_without_target_fails_closed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp) / "jobs")
+            legacy = ready_job()
+            legacy.request.pop("target")
+            store.save(legacy)
+            catalog = SuccessfulCatalog()
+            catalog.finalize = Mock(wraps=catalog.finalize)
+
+            result = publish_ready_job(
+                store,
+                catalog,
+                legacy.job_id,
+                artifact_store=VerifyingArtifactStore(),
+            )
+
+            self.assertEqual(result.status, JobStatus.READY)
+            self.assertEqual(result.catalog_publication_state, "failed")
+            self.assertEqual(result.catalog_publication_attempts, 1)
+            catalog.finalize.assert_not_called()
+
+    def test_legacy_ready_map_does_not_starve_catalogable_retry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(Path(tmp) / "jobs")
+            legacy = ready_job()
+            legacy.job_id = "job-legacy"
+            legacy.request.pop("target")
+            legacy.finished_at = "2026-08-24T00:00:00Z"
+            catalogable = ready_job()
+            catalogable.job_id = "job-current"
+            catalogable.finished_at = "2026-08-25T00:00:00Z"
+            store.save(legacy)
+            store.save(catalogable)
+
+            result = retry_ready_publications(
+                store,
+                SuccessfulCatalog(),
+                artifact_store=VerifyingArtifactStore(),
+                maximum_jobs=1,
+            )
+
+            self.assertEqual(
+                result,
+                {"attempted": 1, "finalized": 1, "failed": 0},
+            )
+            self.assertIsNone(
+                store.get(legacy.job_id).catalog_publication_state
+            )
+            self.assertEqual(
+                store.get(catalogable.job_id).catalog_publication_state,
+                "finalized",
+            )
 
     def test_catalog_never_finalizes_without_every_shared_artifact(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## Summary
- fail closed when an immutable READY job lacks catalog compatibility metadata
- skip incompatible legacy jobs when selecting bounded publication retries so newer maps are not starved
- preserve those legacy maps for their existing local download path

## Verification
- `PYTHONPATH=. python3 -m unittest tests.test_catalog` (11 passed)
- `PYTHONPATH=. python3 -m unittest discover -s tests` (577 passed, 2 skipped)
- `git diff --check`

## Production context
Production R2 compatibility passed and 13 eligible READY jobs were backfilled and finalized. Two legacy jobs have no renderer target metadata and remain unmodified. Maintenance is paused until this fix is deployed; API, worker, catalog, and existing downloads remain healthy.