### PR TITLE
Add iPhone MapKit appearance controls

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 
 | Plan | Status |
 | --- | --- |
-| [iPhone MapKit appearance switcher](plans/iphone-mapkit-appearance-switcher-implementation-plan.md) | Implemented in software; simulator and physical validation pending |
+| [iPhone MapKit appearance switcher](plans/iphone-mapkit-appearance-switcher-implementation-plan.md) | Implemented in software; redesigned control rail pending physical validation |
 | [Opportunistic Bicino discovery and single-session BLE scanning](plans/opportunistic-bicino-discovery-implementation-plan.md) | Implemented in software; physical validation pending |
 | [Geofabrik/OSM 3D buildings](plans/geofabrik-osm-3d-buildings-implementation-plan.md) | Implemented; physical rendering validated on the 1.75-inch device |
 | [Cycling sensor settings and workout tile gating](plans/cycling-sensor-settings-implementation-plan.md) | Implemented slice; direct ESP32 sensor support remains in [issue #85](https://github.com/seichris/open-bike-computer/issues/85) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@
 
 | Plan | Status |
 | --- | --- |
+| [iPhone MapKit appearance switcher](plans/iphone-mapkit-appearance-switcher-implementation-plan.md) | Planned |
 | [Opportunistic Bicino discovery and single-session BLE scanning](plans/opportunistic-bicino-discovery-implementation-plan.md) | Implemented in software; physical validation pending |
 | [Geofabrik/OSM 3D buildings](plans/geofabrik-osm-3d-buildings-implementation-plan.md) | Implemented; physical rendering validated on the 1.75-inch device |
 | [Cycling sensor settings and workout tile gating](plans/cycling-sensor-settings-implementation-plan.md) | Implemented slice; direct ESP32 sensor support remains in [issue #85](https://github.com/seichris/open-bike-computer/issues/85) |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,7 +23,7 @@
 
 | Plan | Status |
 | --- | --- |
-| [iPhone MapKit appearance switcher](plans/iphone-mapkit-appearance-switcher-implementation-plan.md) | Planned |
+| [iPhone MapKit appearance switcher](plans/iphone-mapkit-appearance-switcher-implementation-plan.md) | Implemented in software; simulator and physical validation pending |
 | [Opportunistic Bicino discovery and single-session BLE scanning](plans/opportunistic-bicino-discovery-implementation-plan.md) | Implemented in software; physical validation pending |
 | [Geofabrik/OSM 3D buildings](plans/geofabrik-osm-3d-buildings-implementation-plan.md) | Implemented; physical rendering validated on the 1.75-inch device |
 | [Cycling sensor settings and workout tile gating](plans/cycling-sensor-settings-implementation-plan.md) | Implemented slice; direct ESP32 sensor support remains in [issue #85](https://github.com/seichris/open-bike-computer/issues/85) |

--- a/docs/plans/iphone-mapkit-appearance-switcher-implementation-plan.md
+++ b/docs/plans/iphone-mapkit-appearance-switcher-implementation-plan.md
@@ -10,6 +10,12 @@ switch the Apple MapKit presentation without leaving the main map:
 - Hybrid satellite imagery with roads and labels; and
 - optional realistic 3D terrain for any of those base maps.
 
+Present Settings, a direct 2D/3D camera toggle, and Layers in one vertical
+bottom-right control rail. Put MapKit's adaptive compass immediately above the
+rail so it remains hidden at north-up and appears after the map rotates. Use
+native Liquid Glass for the rail on iOS 26 and a system material fallback on
+older supported iOS versions.
+
 The switcher uses MapKit's supported map-configuration APIs. It does not add a
 third-party tile provider, custom topographic tiles, contour lines, or a new
 route provider. The existing Apple route, destination pins, user location,
@@ -63,11 +69,13 @@ configurations. The local Xcode 26.5 SDK marks live-map
 `preferredConfiguration` and realistic elevation as available from iOS 16.0,
 so the iOS 16.4 app target does not require a legacy `mapType` fallback.
 
-MapKit provides a pitch button through
-[`pitchButtonVisibility`](https://developer.apple.com/documentation/mapkit/mkmapview/pitchbuttonvisibility)
-on iOS 17 and later, but it does not provide an iOS control that chooses among
-Standard, Imagery, and Hybrid configurations. Bicino therefore needs a small
-native switcher UI while continuing to let MapKit render and manage the map.
+MapKit provides official compass and pitch controls, but it does not provide an
+iOS control that chooses among Standard, Imagery, and Hybrid configurations.
+Bicino therefore owns the unified SwiftUI rail while reusing
+[`MKCompassButton`](https://developer.apple.com/documentation/mapkit/mkcompassbutton)
+for correct heading behavior. The custom rail uses SwiftUI's official
+[`glassEffect`](https://developer.apple.com/documentation/swiftui/view/glasseffect(_:in:))
+on iOS 26.
 
 ## Product contract
 
@@ -112,13 +120,17 @@ iphoneMapAppearance.realisticElevation.v1
 
 ### Switcher placement and behavior
 
-Add a 44-by-44-point SwiftUI `Menu` button to `ContentView.topOverlay`, between
-the expanding connection-status view and the existing Settings button.
+Add one trailing, bottom-right vertical rail above Bicino's existing dynamic
+bottom overlay. Its order from top to bottom is Settings, 2D/3D, and Layers.
 
-- Use `square.3.layers.3d` or the closest available system symbol.
-- Give the button the same foreground, shadow, hit-target, and plain-button
-  treatment as Settings.
-- Use the accessibility label `Map appearance`.
+- Give every item at least a 44-by-44-point hit target and use standard system
+  symbols.
+- Settings opens the existing settings sheet.
+- 2D/3D directly toggles the live camera between 0 and 45 degrees without
+  changing base style or realistic elevation.
+- Disable the pitch action during active navigation so it cannot compete with
+  the existing 58-degree navigation camera.
+- Layers uses the accessibility label `Layers` and opens the appearance menu.
 - Organize menu commands into Base Map and Elevation sections.
 - Show a checkmark beside the selected base map and beside 3D Terrain when it
   is enabled.
@@ -129,10 +141,15 @@ the expanding connection-status view and the existing Settings button.
   interaction priority while they are visible.
 - Changing a choice updates the existing map immediately and closes the menu.
 - Do not open the full Settings sheet merely to change the live map.
+- Apply one interactive Liquid Glass surface to the whole rail on iOS 26. Use
+  `.ultraThinMaterial`, a subtle stroke, and a small shadow on iOS 16.4 through
+  iOS 25.
+- Place the standard adaptive `MKCompassButton` directly above the rail. It is
+  hidden by default and appears only when the map heading differs from north.
 
 The menu is Bicino-owned UI because MapKit has no base-style picker. It should
 still use standard SwiftUI menu semantics, Dynamic Type, VoiceOver, and system
-symbols rather than a custom floating palette.
+symbols. The native compass retains MapKit's behavior and accessibility.
 
 ### Camera and pitch behavior
 
@@ -141,16 +158,14 @@ symbols rather than a custom floating palette.
   when a map appearance changes.
 - The existing 58-degree navigation camera immediately reveals realistic
   terrain during active navigation.
-- Outside navigation, the person can use MapKit's standard pitch gesture.
-- On iOS 17 and later, set `pitchButtonVisibility = .adaptive` so MapKit may
-  expose its official pitch/flatten control. Use the repository's existing
-  `if #available(iOS 17.0, macCatalyst 17.0, *)` guard shape so the iOS 16.4
-  Catalyst host tests still compile. Keep the normal gesture fallback on iOS
-  16.4.
-- Validate that MapKit's adaptive pitch control does not collide with
-  Bicino's top overlay, custom compass, or tracking button. If MapKit chooses a
-  conflicting placement on a supported device, hide the adaptive button and
-  retain gestures rather than adding a second custom camera state machine.
+- Outside navigation, the person can use either MapKit's pitch gesture or the
+  rail's direct 2D/3D action.
+- On iOS 17 and later, set `pitchButtonVisibility = .hidden` because the rail
+  now owns the explicit pitch action and a second control would be redundant.
+- Observe camera changes through the existing `MKMapViewDelegate` so the rail's
+  action icon stays correct after gestures and compass resets.
+- The adaptive compass is never forced visible during navigation; its
+  visibility depends only on heading.
 
 Not changing the camera is intentional. A base-layer choice must not interrupt
 free panning, dismiss a destination callout, or make the map jump while the
@@ -176,13 +191,20 @@ person is riding.
 10. Do not market realistic elevation as a complete topographic map.
 11. Do not add provider selection, Apple Maps caching controls, downloadable
     Apple map data, or custom tile overlays.
-12. Keep iOS 16.4 support. Any use of the iOS 17 pitch-button API remains
-    availability-guarded.
+12. Keep iOS 16.4 support. Liquid Glass and the iOS 17 pitch-button visibility
+    API remain availability-guarded with native fallbacks.
+13. Keep realistic elevation and camera pitch independent: Layers chooses the
+    terrain surface, while 2D/3D chooses the viewing angle.
+14. Use MapKit's adaptive compass instead of recreating heading behavior.
 
 ## Proposed architecture
 
 ```text
-SwiftUI Map appearance menu
+SwiftUI bottom-right control rail
+       |
+       +---- Settings
+       +---- 2D/3D camera action ----> MapViewControlState ----> MKMapCamera
+       +---- Layers menu
        |
        +---- persisted base-style raw value
        +---- persisted realistic-elevation Boolean
@@ -247,6 +269,10 @@ Build one resolved `IPhoneMapAppearance` and pass it to `MapViewContainer`.
 The menu writes only those two persisted values. It must not reach into the
 coordinator, BLE manager, or `MKMapView` directly.
 
+A narrow observable control state bridges the explicit 2D/3D action and native
+compass to the existing `MKMapView`. It does not own appearance persistence,
+route state, or navigation policy.
+
 ### UIKit application boundary
 
 Add `appearance: IPhoneMapAppearance` to `MapViewContainer`.
@@ -296,10 +322,12 @@ the only owner of those transitions.
 
 ## UI details
 
-Suggested menu hierarchy:
+Control rail and menu hierarchy:
 
 ```text
-Map appearance
+Settings
+2D / 3D
+Layers
   Base Map
     [check] Standard
             Satellite
@@ -312,7 +340,9 @@ Suggested symbols:
 
 | Item | Symbol |
 | --- | --- |
-| Menu button | `square.3.layers.3d` |
+| Settings | `gearshape.fill` |
+| 2D/3D action | `view.2d` / `view.3d` |
+| Layers menu | `map.fill` |
 | Standard | `map` |
 | Satellite | `globe.americas.fill` |
 | Hybrid | `map.fill` |
@@ -321,10 +351,9 @@ Suggested symbols:
 Use availability-safe symbol fallbacks if any selected symbol is unavailable
 on iOS 16.4. Symbol availability must not raise the deployment target.
 
-The menu label should remain legible over Standard, Satellite, and Hybrid in
-light and dark system appearance. Reuse the Settings button's current styling
-first; change the shared treatment only if visual testing demonstrates a real
-contrast failure.
+The unified rail should remain legible over Standard, Satellite, and Hybrid in
+light and dark system appearance. Liquid Glass supplies the iOS 26 treatment;
+the system-material fallback supplies contrast on older iOS versions.
 
 ## Persistence and recovery behavior
 
@@ -356,7 +385,9 @@ Required assertions:
 5. an unknown raw base style falls back to Standard;
 6. changing only terrain produces a different appearance value; and
 7. equal appearance values compare equal so the coordinator can suppress
-   redundant assignments.
+   redundant assignments; and
+8. camera pitches around the threshold resolve to the correct 2D/3D state and
+   action target.
 
 Keep MapKit renderer behavior out of pure tests. Validate only Bicino's mapping,
 normalization, and idempotence contract there.
@@ -402,12 +433,16 @@ Validate at minimum:
    same geographic bounds;
 9. Standard, Satellite, and Hybrid keep the route line and controls readable
    in light/dark appearance and portrait/landscape;
-10. the menu and pitch control have correct VoiceOver labels, selected state,
-    and 44-point hit targets;
-11. iOS 16.4 uses pitch gestures without calling iOS 17-only APIs;
-12. iOS 17 or later presents the adaptive MapKit pitch control without
-    overlapping Bicino controls; and
-13. changing styles during slow or unavailable networking does not crash or
+10. all three rail actions have correct VoiceOver labels, state, and at least
+    44-point hit targets;
+11. iOS 16.4 uses the system-material rail fallback without calling iOS 26-only
+    APIs;
+12. iOS 26 presents the native Liquid Glass rail;
+13. the compass is absent at north-up, appears above the rail after rotation,
+    and resets the map correctly when tapped;
+14. the 2D/3D action tracks gesture-driven pitch changes, toggles 0/45 degrees,
+    and stays disabled during active navigation; and
+15. changing styles during slow or unavailable networking does not crash or
     remove application overlays. MapKit-owned placeholder/loading behavior is
     acceptable.
 
@@ -428,7 +463,10 @@ readability in motion.
 
 - Add versioned persisted base-style and terrain state.
 - Build the resolved appearance value.
-- Add the Map appearance `Menu` to `topOverlay`.
+- Move Settings into a bottom-right vertical control rail.
+- Add the direct 2D/3D action and Layers menu to that rail.
+- Apply native Liquid Glass on iOS 26 and the material fallback earlier.
+- Place the MapKit compass immediately above the rail.
 - Pass the appearance into `MapViewContainer`.
 - Preserve existing overlay ordering and settings presentation.
 
@@ -438,13 +476,15 @@ readability in motion.
 - Apply it during `makeUIView`.
 - Apply changes idempotently during `updateUIView`.
 - Explicitly enable pitch.
-- Availability-guard adaptive pitch-button visibility on iOS 17 and later.
+- Add a narrow camera-control state and update it from delegate callbacks.
+- Hide MapKit's separate pitch button on iOS 17 and later.
+- Keep the existing navigation-only tracking control.
 - Preserve all route, annotation, tracking, and camera ownership boundaries.
 
 ### `ios-app/BikeComputerTests/MapAppearanceTests.swift`
 
 - Cover defaults, normalization, configuration-class mapping, elevation
-  mapping, and equality/idempotence inputs.
+  mapping, equality/idempotence inputs, and pitch-state/action mapping.
 
 ### `ios-app/scripts/run-navigation-tests.sh`
 
@@ -453,7 +493,8 @@ readability in motion.
 
 ### `docs/README.md`
 
-- Index this implementation plan with status `Planned`.
+- Index this implementation plan and track the remaining physical-validation
+  status.
 
 No change is expected in:
 
@@ -470,8 +511,9 @@ No change is expected in:
 2. Thread the resolved appearance through `ContentView` and
    `MapViewContainer` without adding UI, then verify the default is unchanged.
 3. Add the idempotent `preferredConfiguration` application helper.
-4. Add the layers menu and persisted bindings.
-5. Add pitch enablement and the iOS 17 adaptive pitch control.
+4. Add the Layers menu and persisted bindings.
+5. Add the bottom-right Settings / 2D-3D / Layers rail, native compass, and
+   iOS 26 Liquid Glass with the earlier-system fallback.
 6. Run host tests and the unsigned generic iOS build.
 7. Exercise route preview, callout free-pan, offline selection, simulation, and
    active-navigation continuity in Simulator.
@@ -519,12 +561,13 @@ the same detail.
 
 ### Pitch-control layout
 
-MapKit owns placement of its adaptive iOS 17 pitch button, while Bicino already
-has SwiftUI and UIKit controls.
+The rail sits above dynamic route, workout, and search panels, and the adaptive
+compass needs a stable position even while hidden.
 
-Mitigation: validate all supported orientations and compact heights. If the
-system control overlaps, hide it and retain the standard pitch gesture instead
-of introducing custom camera-state synchronization.
+Mitigation: keep the rail inside the same bottom overlay stack so it moves above
+the panels, reserve the compass's 44-point slot to avoid rail jumps, and
+validate portrait, landscape, compact height, navigation, and offline-selection
+states.
 
 ### Network and data use
 
@@ -544,7 +587,8 @@ preloading, and do not promise offline availability.
 - synchronizing the iPhone style with device Map/Map + Navigation profiles;
 - changing MapKit routing or transport type;
 - changing saved-map preview thumbnails;
-- automatic camera flyovers or forced pitch changes;
+- automatic camera flyovers or non-user-initiated pitch changes outside the
+  existing navigation camera;
 - Apple Maps offline-download management; and
 - telemetry or analytics for map-style selection.
 
@@ -553,6 +597,10 @@ preloading, and do not promise offline availability.
 The implementation is complete when:
 
 - the app presents a native, accessible Map appearance menu;
+- Settings, 2D/3D, and Layers appear in one bottom-right rail with the adaptive
+  compass above it;
+- iOS 26 uses native Liquid Glass and older supported systems use native
+  material fallback;
 - Standard, Satellite, and Hybrid use the correct official MapKit
   configurations;
 - 3D Terrain independently selects flat or realistic elevation;
@@ -560,7 +608,8 @@ The implementation is complete when:
 - the selection persists safely across relaunches;
 - configuration changes are idempotent and retain camera, route, annotations,
   callouts, tracking, and SwiftUI overlays;
-- iOS 16.4 and iOS 17+ pitch paths behave as specified;
+- the camera action and adaptive compass behave as specified without competing
+  with navigation camera ownership;
 - host tests, the unsigned generic iOS build, and `git diff --check` pass;
 - physical-iPhone testing demonstrates realistic mountain terrain in a pitched
   view and acceptable control/route readability; and

--- a/docs/plans/iphone-mapkit-appearance-switcher-implementation-plan.md
+++ b/docs/plans/iphone-mapkit-appearance-switcher-implementation-plan.md
@@ -1,0 +1,568 @@
+# iPhone MapKit Appearance Switcher Implementation Plan
+
+## Outcome
+
+Add an in-map appearance control to the Bicino iPhone app that lets a person
+switch the Apple MapKit presentation without leaving the main map:
+
+- Standard street map;
+- Satellite imagery;
+- Hybrid satellite imagery with roads and labels; and
+- optional realistic 3D terrain for any of those base maps.
+
+The switcher uses MapKit's supported map-configuration APIs. It does not add a
+third-party tile provider, custom topographic tiles, contour lines, or a new
+route provider. The existing Apple route, destination pins, user location,
+simulation marker, camera, and Bicino overlays remain on the same `MKMapView`
+while its base presentation changes.
+
+This is an iPhone-app feature only. It does not change the ESP32 map renderer,
+offline `.fmb` map contents, BLE settings, map-platform jobs, Watch maps, or
+saved-map preview images.
+
+## Baseline
+
+This plan was prepared from freshly fetched `origin/main` at
+`29be0efcd34fd7a9a9d685df3d311a2ca679d9b3`.
+
+The current implementation has these relevant properties:
+
+- `ContentView` places one `MapViewContainer` behind the app's SwiftUI
+  overlays.
+- `MapViewContainer` owns one UIKit `MKMapView`; it does not currently set
+  `preferredConfiguration`, `mapType`, or an elevation style.
+- The visible map therefore uses MapKit's default standard presentation.
+- The navigation camera uses a 58-degree pitch. Browsing can also use MapKit's
+  normal map gestures, but the app does not expose a map-appearance choice.
+- The app installs custom `MKCompassButton` and `MKUserTrackingButton`
+  controls. The SwiftUI top overlay separately contains the Bicino connection
+  control and Settings button.
+- The iPhone app's minimum deployment target is iOS 16.4.
+- `OfflineMapManager` deliberately creates small, light-mode, flat standard
+  `MKMapSnapshotter` images for saved-map bounds. Those are catalog previews,
+  not the live iPhone map.
+- The existing Settings screen's Map and Map + Navigation appearance controls
+  are BLE-backed settings for the physical Bicino display. They are not an
+  appropriate place to store or label the iPhone's Apple MapKit preference.
+
+Apple's supported configuration surface is:
+
+- [`MKMapView.preferredConfiguration`](https://developer.apple.com/documentation/mapkit/mkmapview/preferredconfiguration)
+  for changing the live map presentation;
+- [`MKStandardMapConfiguration`](https://developer.apple.com/documentation/mapkit/mkstandardmapconfiguration)
+  for the street map;
+- [`MKImageryMapConfiguration`](https://developer.apple.com/documentation/mapkit/mkimagerymapconfiguration)
+  for satellite imagery;
+- [`MKHybridMapConfiguration`](https://developer.apple.com/documentation/mapkit/mkhybridmapconfiguration)
+  for satellite imagery with roads and labels; and
+- [`MKMapConfiguration.ElevationStyle.realistic`](https://developer.apple.com/documentation/mapkit/mkmapconfiguration/elevationstyle-swift.enum/realistic)
+  for realistic ground contours.
+
+The older `MKMapView.mapType` API is deprecated in favor of map
+configurations. The local Xcode 26.5 SDK marks live-map
+`preferredConfiguration` and realistic elevation as available from iOS 16.0,
+so the iOS 16.4 app target does not require a legacy `mapType` fallback.
+
+MapKit provides a pitch button through
+[`pitchButtonVisibility`](https://developer.apple.com/documentation/mapkit/mkmapview/pitchbuttonvisibility)
+on iOS 17 and later, but it does not provide an iOS control that chooses among
+Standard, Imagery, and Hybrid configurations. Bicino therefore needs a small
+native switcher UI while continuing to let MapKit render and manage the map.
+
+## Product contract
+
+### Map appearance choices
+
+Expose two independent choices rather than multiplying every combination into
+a long preset list:
+
+| Control | Choices | MapKit mapping |
+| --- | --- | --- |
+| Base map | Standard | `MKStandardMapConfiguration` |
+| Base map | Satellite | `MKImageryMapConfiguration` |
+| Base map | Hybrid | `MKHybridMapConfiguration` |
+| 3D Terrain | Off | `.flat` elevation |
+| 3D Terrain | On | `.realistic` elevation |
+
+This yields six supported combinations while keeping the mental model simple.
+The user-facing term is **3D Terrain**, not **Topographic**. MapKit realistic
+elevation creates a terrain surface, but it does not promise contour lines,
+trail-specific symbology, slope shading, or downloadable topographic maps.
+
+### Defaults and persistence
+
+- A fresh install defaults to Standard plus 3D Terrain off. This preserves the
+  current map exactly until a person opts into another presentation.
+- Persist the base-map choice and terrain toggle across launches.
+- Treat the preference as app-global, not per Bicino. It changes only the
+  iPhone's Apple map and has no device capability dependency.
+- Debug and Release naturally retain separate preferences because they use
+  separate app bundle identifiers and sandboxes.
+- Unknown or corrupt stored base-style values resolve to Standard. Missing or
+  invalid terrain state resolves to off.
+- Do not migrate, read, or write the BLE-backed device Map or Map + Navigation
+  style settings.
+
+Use versioned UserDefaults keys, for example:
+
+```text
+iphoneMapAppearance.baseStyle.v1
+iphoneMapAppearance.realisticElevation.v1
+```
+
+### Switcher placement and behavior
+
+Add a 44-by-44-point SwiftUI `Menu` button to `ContentView.topOverlay`, between
+the expanding connection-status view and the existing Settings button.
+
+- Use `square.3.layers.3d` or the closest available system symbol.
+- Give the button the same foreground, shadow, hit-target, and plain-button
+  treatment as Settings.
+- Use the accessibility label `Map appearance`.
+- Organize menu commands into Base Map and Elevation sections.
+- Show a checkmark beside the selected base map and beside 3D Terrain when it
+  is enabled.
+- Give 3D Terrain the accessibility hint `Adds realistic elevation; tilt the
+  map to see the terrain.`
+- Keep the menu available before, during, and after navigation. The existing
+  higher-z-index map-selection and onboarding surfaces continue to take
+  interaction priority while they are visible.
+- Changing a choice updates the existing map immediately and closes the menu.
+- Do not open the full Settings sheet merely to change the live map.
+
+The menu is Bicino-owned UI because MapKit has no base-style picker. It should
+still use standard SwiftUI menu semantics, Dynamic Type, VoiceOver, and system
+symbols rather than a custom floating palette.
+
+### Camera and pitch behavior
+
+- Explicitly keep `mapView.isPitchEnabled = true`.
+- Do not recenter, zoom, rotate, flatten, or automatically pitch the camera
+  when a map appearance changes.
+- The existing 58-degree navigation camera immediately reveals realistic
+  terrain during active navigation.
+- Outside navigation, the person can use MapKit's standard pitch gesture.
+- On iOS 17 and later, set `pitchButtonVisibility = .adaptive` so MapKit may
+  expose its official pitch/flatten control. Use the repository's existing
+  `if #available(iOS 17.0, macCatalyst 17.0, *)` guard shape so the iOS 16.4
+  Catalyst host tests still compile. Keep the normal gesture fallback on iOS
+  16.4.
+- Validate that MapKit's adaptive pitch control does not collide with
+  Bicino's top overlay, custom compass, or tracking button. If MapKit chooses a
+  conflicting placement on a supported device, hide the adaptive button and
+  retain gestures rather than adding a second custom camera state machine.
+
+Not changing the camera is intentional. A base-layer choice must not interrupt
+free panning, dismiss a destination callout, or make the map jump while the
+person is riding.
+
+## Decisions locked into this plan
+
+1. Use `preferredConfiguration`; do not use deprecated `mapType` for the live
+   map.
+2. Keep base map and elevation as independent persisted choices.
+3. Preserve Standard plus flat elevation as the default.
+4. Change the configuration on the existing `MKMapView`; do not recreate the
+   UIKit view.
+5. Apply a configuration only when the resolved appearance value changes.
+   SwiftUI updates for GPS, BLE, workouts, or route progress must not repeatedly
+   replace the configuration.
+6. Do not mutate the camera as a side effect of changing appearance.
+7. Continue rendering the route above roads and retain every current annotation
+   and callout path.
+8. Keep the iPhone preference independent of Bicino device settings and BLE.
+9. Keep saved-map catalog snapshots flat Standard for consistent, inexpensive,
+   readable thumbnails.
+10. Do not market realistic elevation as a complete topographic map.
+11. Do not add provider selection, Apple Maps caching controls, downloadable
+    Apple map data, or custom tile overlays.
+12. Keep iOS 16.4 support. Any use of the iOS 17 pitch-button API remains
+    availability-guarded.
+
+## Proposed architecture
+
+```text
+SwiftUI Map appearance menu
+       |
+       +---- persisted base-style raw value
+       +---- persisted realistic-elevation Boolean
+                         |
+                         v
+              IPhoneMapAppearance value
+                         |
+                         v
+                 MapViewContainer
+                         |
+                         v
+          Coordinator.applyAppearanceIfNeeded
+                         |
+                         v
+      existing MKMapView.preferredConfiguration
+        |                |                 |
+        v                v                 v
+     Standard         Imagery           Hybrid
+        \________________|________________/
+                         |
+                   flat or realistic
+```
+
+### Appearance value model
+
+Add a narrow value model under the iPhone app, for example
+`Models/IPhoneMapAppearance.swift`:
+
+```swift
+enum IPhoneMapBaseStyle: String, CaseIterable, Identifiable {
+    case standard
+    case satellite
+    case hybrid
+}
+
+struct IPhoneMapAppearance: Equatable {
+    var baseStyle: IPhoneMapBaseStyle
+    var usesRealisticElevation: Bool
+}
+```
+
+The model owns:
+
+- stable persisted raw values;
+- user-facing labels and system symbols, if keeping those properties out of
+  `ContentView` improves readability;
+- normalization of unknown persisted values; and
+- a MapKit configuration factory that creates a new configuration of the
+  correct subclass with `.flat` or `.realistic` elevation.
+
+Do not persist `MKMapConfiguration` objects. They are mutable presentation
+objects, not application settings. Persist only Bicino's small value model and
+create a fresh MapKit configuration when the value changes.
+
+### SwiftUI persistence boundary
+
+`ContentView` owns the two app-level values through `@AppStorage` or an
+equivalent injectable UserDefaults-backed store. Prefer the smallest approach
+that still permits deterministic invalid-value tests.
+
+Build one resolved `IPhoneMapAppearance` and pass it to `MapViewContainer`.
+The menu writes only those two persisted values. It must not reach into the
+coordinator, BLE manager, or `MKMapView` directly.
+
+### UIKit application boundary
+
+Add `appearance: IPhoneMapAppearance` to `MapViewContainer`.
+
+In `makeUIView`:
+
+1. create the existing `MKMapView`;
+2. enable pitch;
+3. apply the initial appearance before the first region/camera work; and
+4. install the existing controls, gestures, and delegate.
+
+In `updateUIView`:
+
+1. ask the coordinator to apply the appearance if it differs from the last
+   applied value; then
+2. continue the existing location, route, annotation, camera, and tracking
+   updates unchanged.
+
+The coordinator stores `lastAppliedAppearance`. Its application helper:
+
+- returns immediately for an equal value;
+- assigns exactly one newly created object to
+  `mapView.preferredConfiguration` for a changed value;
+- updates the stored value only after assignment; and
+- does not remove overlays, annotations, or change `userTrackingMode`.
+
+Keep configuration creation separate from application so the mapping can be
+host-tested without driving a live map renderer.
+
+### Overlay and route continuity
+
+Map appearance changes must leave these objects and states intact:
+
+- `MKRoute.polyline` and its current renderer;
+- destination and simulated-position annotations;
+- the selected destination callout and asynchronous reverse-geocoded label;
+- `showsUserLocation` and authorization handling;
+- `.follow` or `.followWithHeading` tracking;
+- offline area-selection free pan and bounds conversion;
+- current camera center, distance, pitch, and heading; and
+- the current search, workout, route-alternative, and navigation overlays in
+  SwiftUI.
+
+Do not call `removeOverlays`, `setRegion`, `setVisibleMapRect`, or `setCamera`
+from the appearance application helper. Existing route/lifecycle code remains
+the only owner of those transitions.
+
+## UI details
+
+Suggested menu hierarchy:
+
+```text
+Map appearance
+  Base Map
+    [check] Standard
+            Satellite
+            Hybrid
+  Elevation
+    [check] 3D Terrain
+```
+
+Suggested symbols:
+
+| Item | Symbol |
+| --- | --- |
+| Menu button | `square.3.layers.3d` |
+| Standard | `map` |
+| Satellite | `globe.americas.fill` |
+| Hybrid | `map.fill` |
+| 3D Terrain | `mountain.2.fill` |
+
+Use availability-safe symbol fallbacks if any selected symbol is unavailable
+on iOS 16.4. Symbol availability must not raise the deployment target.
+
+The menu label should remain legible over Standard, Satellite, and Hybrid in
+light and dark system appearance. Reuse the Settings button's current styling
+first; change the shared treatment only if visual testing demonstrates a real
+contrast failure.
+
+## Persistence and recovery behavior
+
+The persisted state is convenience UI state, not a security or device-authority
+boundary.
+
+- Load and normalize it synchronously with the view.
+- Never delay map creation on disk or network work.
+- If the raw base style is unknown, use Standard without crashing.
+- If a future version removes a style, old values safely fall back to Standard.
+- Do not copy preferences between Debug and Release or into an App Group.
+- Do not sync the preference to iCloud, WatchConnectivity, BLE, or the map
+  backend.
+
+## Testing strategy
+
+### Host tests
+
+Add focused Catalyst-compatible coverage, for example
+`ios-app/BikeComputerTests/MapAppearanceTests.swift`, and include the new model
+in the relevant host-test compile commands.
+
+Required assertions:
+
+1. the default resolves to Standard plus flat elevation;
+2. each base style creates the intended MapKit configuration subclass;
+3. the terrain Boolean maps to `.flat` and `.realistic` for every base style;
+4. persisted raw values round-trip;
+5. an unknown raw base style falls back to Standard;
+6. changing only terrain produces a different appearance value; and
+7. equal appearance values compare equal so the coordinator can suppress
+   redundant assignments.
+
+Keep MapKit renderer behavior out of pure tests. Validate only Bicino's mapping,
+normalization, and idempotence contract there.
+
+If the new model is a separate source file, update the existing Catalyst
+`DestinationCalloutLayoutTests` compile list because `MapView.swift` will now
+reference it. Add a separate small executable for `MapAppearanceTests` rather
+than folding unrelated assertions into destination-callout tests.
+
+### Existing regression checks
+
+Run:
+
+```sh
+cd ios-app
+./scripts/run-navigation-tests.sh
+./scripts/xcodebuild-cli.sh -project BikeComputer/BikeComputer.xcodeproj \
+  -scheme BikeComputer -destination 'generic/platform=iOS' \
+  CODE_SIGNING_ALLOWED=NO build
+```
+
+Also run `git diff --check` and inspect the final plan/implementation diff for
+accidental firmware, BLE, map-platform, Watch, or saved-preview changes.
+
+### Simulator and physical-device acceptance
+
+Validate at minimum:
+
+1. a fresh install starts with the same Standard flat map as current `main`;
+2. all three base maps switch without recreating the screen or losing the
+   visible region;
+3. the 3D Terrain toggle survives app termination and relaunch;
+4. a pitched view around a well-defined mountain area visibly uses MapKit
+   realistic terrain when enabled and returns to a flat ground surface when
+   disabled;
+5. switching appearance during route preview retains the entire route and its
+   fitted camera;
+6. switching during simulated and real navigation retains the 58-degree camera,
+   heading, tracking, route, and position marker;
+7. switching while a destination callout is selected does not dismiss it or
+   resume tracking;
+8. offline area selection still converts the visible selection frame to the
+   same geographic bounds;
+9. Standard, Satellite, and Hybrid keep the route line and controls readable
+   in light/dark appearance and portrait/landscape;
+10. the menu and pitch control have correct VoiceOver labels, selected state,
+    and 44-point hit targets;
+11. iOS 16.4 uses pitch gestures without calling iOS 17-only APIs;
+12. iOS 17 or later presents the adaptive MapKit pitch control without
+    overlapping Bicino controls; and
+13. changing styles during slow or unavailable networking does not crash or
+    remove application overlays. MapKit-owned placeholder/loading behavior is
+    acceptable.
+
+Use a physical iPhone for the final terrain and control-layout check. A green
+build proves API compatibility, not terrain coverage, gesture quality, or
+readability in motion.
+
+## File-by-file implementation
+
+### `ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift`
+
+- Add the base-style enum and appearance value.
+- Add safe raw-value normalization.
+- Add the MapKit configuration factory.
+- Keep the model independent of BLE and offline-map models.
+
+### `ios-app/BikeComputer/BikeComputer/ContentView.swift`
+
+- Add versioned persisted base-style and terrain state.
+- Build the resolved appearance value.
+- Add the Map appearance `Menu` to `topOverlay`.
+- Pass the appearance into `MapViewContainer`.
+- Preserve existing overlay ordering and settings presentation.
+
+### `ios-app/BikeComputer/BikeComputer/Views/MapView.swift`
+
+- Accept the appearance value.
+- Apply it during `makeUIView`.
+- Apply changes idempotently during `updateUIView`.
+- Explicitly enable pitch.
+- Availability-guard adaptive pitch-button visibility on iOS 17 and later.
+- Preserve all route, annotation, tracking, and camera ownership boundaries.
+
+### `ios-app/BikeComputerTests/MapAppearanceTests.swift`
+
+- Cover defaults, normalization, configuration-class mapping, elevation
+  mapping, and equality/idempotence inputs.
+
+### `ios-app/scripts/run-navigation-tests.sh`
+
+- Compile the appearance model anywhere `MapView.swift` is compiled.
+- Add and execute the focused Catalyst map-appearance test binary.
+
+### `docs/README.md`
+
+- Index this implementation plan with status `Planned`.
+
+No change is expected in:
+
+- `BLEManager.swift` or the BLE protocol;
+- firmware sources;
+- `OfflineMapManager` saved-map snapshot configuration;
+- map-platform services;
+- Watch targets; or
+- App Store privacy disclosures.
+
+## Implementation sequence
+
+1. Add the value model, persistence keys, and mapping tests.
+2. Thread the resolved appearance through `ContentView` and
+   `MapViewContainer` without adding UI, then verify the default is unchanged.
+3. Add the idempotent `preferredConfiguration` application helper.
+4. Add the layers menu and persisted bindings.
+5. Add pitch enablement and the iOS 17 adaptive pitch control.
+6. Run host tests and the unsigned generic iOS build.
+7. Exercise route preview, callout free-pan, offline selection, simulation, and
+   active-navigation continuity in Simulator.
+8. Validate realistic terrain and control placement on a physical iPhone.
+9. Record any MapKit coverage limitation as a validation note rather than
+   adding proprietary terrain data to this feature.
+
+## Risks and mitigations
+
+### Reassigning configuration on every SwiftUI update
+
+GPS, route progress, workout state, and BLE events can update `ContentView`
+frequently. Recreating MapKit configuration on every pass may reload tiles or
+produce flicker.
+
+Mitigation: compare the small appearance value in the coordinator and assign a
+new configuration only after an actual user preference change.
+
+### Camera or overlay disruption
+
+A careless implementation may treat a style change like map recreation and
+lose camera/tracking state or overlays.
+
+Mitigation: keep one `MKMapView`, never clear map content from the appearance
+helper, and explicitly validate route/callout/free-pan continuity.
+
+### Satellite route legibility
+
+The existing six-point system-blue route may have weaker contrast over some
+imagery.
+
+Mitigation: make route readability an acceptance gate across representative
+urban, forest, water, and mountainous imagery. Do not silently redesign the
+route in the same patch unless that gate demonstrates a failure; if it does,
+add the smallest style-independent casing treatment with its own tests.
+
+### Terrain expectations
+
+Realistic elevation depends on Apple's map data, selected zoom, camera pitch,
+OS, and region. It is not a digital-elevation export or contour map.
+
+Mitigation: label the toggle 3D Terrain, document the limitation, test a known
+supported mountainous area, and avoid claims that every mountain or region has
+the same detail.
+
+### Pitch-control layout
+
+MapKit owns placement of its adaptive iOS 17 pitch button, while Bicino already
+has SwiftUI and UIKit controls.
+
+Mitigation: validate all supported orientations and compact heights. If the
+system control overlaps, hide it and retain the standard pitch gesture instead
+of introducing custom camera-state synchronization.
+
+### Network and data use
+
+Satellite and hybrid imagery can load more data than Standard, and MapKit owns
+its cache and network behavior.
+
+Mitigation: make imagery explicitly user-selected, avoid background
+preloading, and do not promise offline availability.
+
+## Out of scope
+
+- contour lines, elevation labels, trail grading, slope shading, or a true
+  hiking/cycling topographic style;
+- custom raster/vector tile providers or overlays;
+- exporting Apple elevation or map imagery to the ESP32;
+- changing Bicino `.fmb` map generation or 3D-building rendering;
+- synchronizing the iPhone style with device Map/Map + Navigation profiles;
+- changing MapKit routing or transport type;
+- changing saved-map preview thumbnails;
+- automatic camera flyovers or forced pitch changes;
+- Apple Maps offline-download management; and
+- telemetry or analytics for map-style selection.
+
+## Definition of done
+
+The implementation is complete when:
+
+- the app presents a native, accessible Map appearance menu;
+- Standard, Satellite, and Hybrid use the correct official MapKit
+  configurations;
+- 3D Terrain independently selects flat or realistic elevation;
+- Standard plus flat remains the fresh-install default;
+- the selection persists safely across relaunches;
+- configuration changes are idempotent and retain camera, route, annotations,
+  callouts, tracking, and SwiftUI overlays;
+- iOS 16.4 and iOS 17+ pitch paths behave as specified;
+- host tests, the unsigned generic iOS build, and `git diff --check` pass;
+- physical-iPhone testing demonstrates realistic mountain terrain in a pitched
+  view and acceptable control/route readability; and
+- no firmware, BLE, Watch, map-platform, saved-preview, or custom-topographic
+  scope has entered the change.

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -979,7 +979,7 @@ struct ContentView: View {
     }
 
     private var mapControlCluster: some View {
-        VStack(alignment: .trailing, spacing: 10) {
+        VStack(alignment: .center, spacing: 10) {
             MapCompassControl(controlState: mapViewControlState)
                 .frame(width: 44, height: 44)
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -960,7 +960,6 @@ struct ContentView: View {
         )
         .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, 18)
-        .padding(.top, 8)
         .zIndex(10)
     }
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -51,6 +51,7 @@ struct ContentView: View {
     // MARK: - State
     
     @StateObject private var coordinator: BikeComputerCoordinator
+    @StateObject private var mapViewControlState: MapViewControlState
     @StateObject private var offlineMapManager: OfflineMapManager
     @StateObject private var watchAvailability: WorkoutWatchAvailabilityMonitor
     @ObservedObject private var routeLibrary: PhoneRouteLibrary
@@ -188,6 +189,9 @@ struct ContentView: View {
         _coordinator = StateObject(
             wrappedValue: coordinator
         )
+        _mapViewControlState = StateObject(
+            wrappedValue: MapViewControlState()
+        )
         _offlineMapManager = StateObject(
             wrappedValue: OfflineMapManager(
                 diagnosticsRecorder: rideDiagnosticsRecorder
@@ -257,6 +261,14 @@ struct ContentView: View {
                     }
 
                     Spacer()
+
+                    HStack {
+                        Spacer()
+                        mapControlCluster
+                    }
+                    .padding(.trailing, 18)
+                    .padding(.bottom, 12)
+                    .zIndex(10)
 
                     bottomOverlay(
                         maxHeight: proxy.size.height * 0.68,
@@ -939,26 +951,13 @@ struct ContentView: View {
     }
 
     private var topOverlay: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .center) {
             ConnectionStatusView(
                 isConnected: coordinator.isConnected,
                 hasRegisteredDevice:
                     !coordinator.bleManager.knownDevices.isEmpty,
                 onReconnect: { coordinator.reconnect() }
             )
-
-            mapAppearanceMenu
-
-            Button(action: { presentedSheet = .settings }) {
-                Image(systemName: "gearshape.fill")
-                    .font(.title3)
-                    .foregroundColor(.primary)
-                    .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Settings")
         }
         .padding(.horizontal, 18)
         .padding(.top, 8)
@@ -979,7 +978,99 @@ struct ContentView: View {
         )
     }
 
-    private var mapAppearanceMenu: some View {
+    private var mapControlCluster: some View {
+        VStack(alignment: .trailing, spacing: 10) {
+            MapCompassControl(controlState: mapViewControlState)
+                .frame(width: 44, height: 44)
+
+            mapControlRail
+        }
+    }
+
+    @ViewBuilder
+    private var mapControlRail: some View {
+        if #available(iOS 26.0, *) {
+            mapControlRailContent
+                .glassEffect(
+                    .regular.interactive(),
+                    in: .rect(cornerRadius: 26)
+                )
+        } else {
+            mapControlRailContent
+                .background(
+                    .ultraThinMaterial,
+                    in: RoundedRectangle(
+                        cornerRadius: 26,
+                        style: .continuous
+                    )
+                )
+                .overlay {
+                    RoundedRectangle(cornerRadius: 26, style: .continuous)
+                        .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+                }
+                .shadow(
+                    color: .black.opacity(0.14),
+                    radius: 7,
+                    x: 0,
+                    y: 3
+                )
+        }
+    }
+
+    private var mapControlRailContent: some View {
+        VStack(spacing: 0) {
+            Button(action: { presentedSheet = .settings }) {
+                mapControlIcon("gearshape.fill")
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Settings")
+
+            mapControlDivider
+
+            Button(action: { mapViewControlState.togglePitch() }) {
+                mapControlIcon(
+                    mapViewControlState.isPitched ? "view.2d" : "view.3d"
+                )
+            }
+            .buttonStyle(.plain)
+            .disabled(coordinator.isNavigating)
+            .opacity(coordinator.isNavigating ? 0.45 : 1)
+            .accessibilityLabel(
+                mapViewControlState.isPitched
+                    ? "Show map in 2D"
+                    : "Show map in 3D"
+            )
+            .accessibilityValue(
+                mapViewControlState.isPitched ? "3D view" : "2D view"
+            )
+            .accessibilityHint(
+                coordinator.isNavigating
+                    ? "Available outside navigation."
+                    : "Changes the viewing angle. Realistic terrain is controlled in Layers."
+            )
+
+            mapControlDivider
+
+            mapLayersMenu
+        }
+        .frame(width: 52)
+        .accessibilityElement(children: .contain)
+    }
+
+    private func mapControlIcon(_ systemName: String) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: 20, weight: .semibold))
+            .foregroundStyle(.primary)
+            .frame(width: 52, height: 50)
+            .contentShape(Rectangle())
+    }
+
+    private var mapControlDivider: some View {
+        Divider()
+            .padding(.horizontal, 11)
+    }
+
+    private var mapLayersMenu: some View {
         Menu {
             Section("Base Map") {
                 Picker("Base Map", selection: mapBaseStyleBinding) {
@@ -1001,15 +1092,10 @@ struct ContentView: View {
                 )
             }
         } label: {
-            Image(systemName: "square.3.layers.3d")
-                .font(.title3)
-                .foregroundColor(.primary)
-                .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
-                .frame(width: 44, height: 44)
-                .contentShape(Rectangle())
+            mapControlIcon("map.fill")
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Map appearance")
+        .accessibilityLabel("Layers")
         .accessibilityValue(
             "\(mapAppearance.baseStyle.title), " +
             (usesRealisticMapElevation ? "3D Terrain on" : "3D Terrain off")
@@ -1326,6 +1412,7 @@ struct ContentView: View {
 
         return MapViewContainer(
             appearance: mapAppearance,
+            controlState: mapViewControlState,
             location: coordinator.currentLocation,
             route: coordinator.currentRoute ?? coordinator.routePreview,
             simulatedPosition: coordinator.simulatedPosition,

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -266,7 +266,7 @@ struct ContentView: View {
                         Spacer()
                         mapControlCluster
                     }
-                    .padding(.trailing, 18)
+                    .padding(.trailing, 12)
                     .padding(.bottom, 12)
                     .zIndex(10)
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -1083,7 +1083,7 @@ struct ContentView: View {
                 .labelsHidden()
             }
 
-            Section("Elevation") {
+            Section {
                 Toggle(isOn: $usesRealisticMapElevation) {
                     Label("3D Terrain", systemImage: "mountain.2.fill")
                 }

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -951,14 +951,14 @@ struct ContentView: View {
     }
 
     private var topOverlay: some View {
-        HStack(alignment: .center) {
-            ConnectionStatusView(
-                isConnected: coordinator.isConnected,
-                hasRegisteredDevice:
-                    !coordinator.bleManager.knownDevices.isEmpty,
-                onReconnect: { coordinator.reconnect() }
-            )
-        }
+        ConnectionStatusView(
+            isConnected: coordinator.isConnected,
+            deviceName: coordinator.peripheralName,
+            hasRegisteredDevice:
+                !coordinator.bleManager.knownDevices.isEmpty,
+            onReconnect: { coordinator.reconnect() }
+        )
+        .frame(maxWidth: .infinity, alignment: .center)
         .padding(.horizontal, 18)
         .padding(.top, 8)
         .zIndex(10)

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -986,34 +986,9 @@ struct ContentView: View {
         }
     }
 
-    @ViewBuilder
     private var mapControlRail: some View {
-        if #available(iOS 26.0, *) {
-            mapControlRailContent
-                .glassEffect(
-                    .regular.interactive(),
-                    in: .rect(cornerRadius: 26)
-                )
-        } else {
-            mapControlRailContent
-                .background(
-                    .ultraThinMaterial,
-                    in: RoundedRectangle(
-                        cornerRadius: 26,
-                        style: .continuous
-                    )
-                )
-                .overlay {
-                    RoundedRectangle(cornerRadius: 26, style: .continuous)
-                        .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
-                }
-                .shadow(
-                    color: .black.opacity(0.14),
-                    radius: 7,
-                    x: 0,
-                    y: 3
-                )
-        }
+        mapControlRailContent
+            .mapOverlayGlassSurface(cornerRadius: 26)
     }
 
     private var mapControlRailContent: some View {

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -1059,7 +1059,7 @@ struct ContentView: View {
 
     private func mapControlIcon(_ systemName: String) -> some View {
         Image(systemName: systemName)
-            .font(.system(size: 20, weight: .semibold))
+            .font(.system(size: 16, weight: .semibold))
             .foregroundStyle(.primary)
             .frame(width: 52, height: 50)
             .contentShape(Rectangle())

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -91,6 +91,12 @@ struct ContentView: View {
     private var hasCompletedFirstRunWelcome = false
     @AppStorage("offlineMapOnboarding.existingInstallMigrationCompleted.v1")
     private var hasMigratedExistingInstallOnboarding = false
+    @AppStorage(IPhoneMapAppearance.baseStyleDefaultsKey)
+    private var iPhoneMapBaseStyleRawValue =
+        IPhoneMapAppearance.defaultValue.baseStyle.rawValue
+    @AppStorage(IPhoneMapAppearance.realisticElevationDefaultsKey)
+    private var usesRealisticMapElevation =
+        IPhoneMapAppearance.defaultValue.usesRealisticElevation
     @State private var offlineMapSelectionWidth: CGFloat?
     @State private var offlineMapSelectionHeight: CGFloat?
     @State private var offlineMapSelectionCenterY: CGFloat?
@@ -941,6 +947,8 @@ struct ContentView: View {
                 onReconnect: { coordinator.reconnect() }
             )
 
+            mapAppearanceMenu
+
             Button(action: { presentedSheet = .settings }) {
                 Image(systemName: "gearshape.fill")
                     .font(.title3)
@@ -955,6 +963,57 @@ struct ContentView: View {
         .padding(.horizontal, 18)
         .padding(.top, 8)
         .zIndex(10)
+    }
+
+    private var mapAppearance: IPhoneMapAppearance {
+        IPhoneMapAppearance(
+            persistedBaseStyleRawValue: iPhoneMapBaseStyleRawValue,
+            usesRealisticElevation: usesRealisticMapElevation
+        )
+    }
+
+    private var mapBaseStyleBinding: Binding<IPhoneMapBaseStyle> {
+        Binding(
+            get: { mapAppearance.baseStyle },
+            set: { iPhoneMapBaseStyleRawValue = $0.rawValue }
+        )
+    }
+
+    private var mapAppearanceMenu: some View {
+        Menu {
+            Section("Base Map") {
+                Picker("Base Map", selection: mapBaseStyleBinding) {
+                    ForEach(IPhoneMapBaseStyle.allCases) { style in
+                        Label(style.title, systemImage: style.systemImage)
+                            .tag(style)
+                    }
+                }
+                .pickerStyle(.inline)
+                .labelsHidden()
+            }
+
+            Section("Elevation") {
+                Toggle(isOn: $usesRealisticMapElevation) {
+                    Label("3D Terrain", systemImage: "mountain.2.fill")
+                }
+                .accessibilityHint(
+                    "Adds realistic elevation; tilt the map to see the terrain."
+                )
+            }
+        } label: {
+            Image(systemName: "square.3.layers.3d")
+                .font(.title3)
+                .foregroundColor(.primary)
+                .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Map appearance")
+        .accessibilityValue(
+            "\(mapAppearance.baseStyle.title), " +
+            (usesRealisticMapElevation ? "3D Terrain on" : "3D Terrain off")
+        )
     }
 
     @ViewBuilder
@@ -1266,6 +1325,7 @@ struct ContentView: View {
         let canSelectDestination = !coordinator.isNavigating && !offlineMapManager.isMapAreaSelectionActive
 
         return MapViewContainer(
+            appearance: mapAppearance,
             location: coordinator.currentLocation,
             route: coordinator.currentRoute ?? coordinator.routePreview,
             simulatedPosition: coordinator.simulatedPosition,

--- a/ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift
@@ -1,0 +1,90 @@
+import Foundation
+import MapKit
+
+enum IPhoneMapBaseStyle: String, CaseIterable, Identifiable {
+    case standard
+    case satellite
+    case hybrid
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .standard:
+            return "Standard"
+        case .satellite:
+            return "Satellite"
+        case .hybrid:
+            return "Hybrid"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .standard:
+            return "map"
+        case .satellite:
+            return "globe.americas.fill"
+        case .hybrid:
+            return "map.fill"
+        }
+    }
+
+    static func resolved(persistedRawValue: String?) -> Self {
+        persistedRawValue.flatMap(Self.init(rawValue:)) ?? .standard
+    }
+}
+
+struct IPhoneMapAppearance: Equatable {
+    static let baseStyleDefaultsKey = "iphoneMapAppearance.baseStyle.v1"
+    static let realisticElevationDefaultsKey =
+        "iphoneMapAppearance.realisticElevation.v1"
+    static let defaultValue = Self(
+        baseStyle: .standard,
+        usesRealisticElevation: false
+    )
+
+    let baseStyle: IPhoneMapBaseStyle
+    let usesRealisticElevation: Bool
+
+    init(
+        baseStyle: IPhoneMapBaseStyle,
+        usesRealisticElevation: Bool
+    ) {
+        self.baseStyle = baseStyle
+        self.usesRealisticElevation = usesRealisticElevation
+    }
+
+    init(
+        persistedBaseStyleRawValue: String?,
+        usesRealisticElevation: Bool
+    ) {
+        self.init(
+            baseStyle: .resolved(
+                persistedRawValue: persistedBaseStyleRawValue
+            ),
+            usesRealisticElevation: usesRealisticElevation
+        )
+    }
+
+    @MainActor
+    func makeConfiguration() -> MKMapConfiguration {
+        let elevationStyle: MKMapConfiguration.ElevationStyle =
+            usesRealisticElevation ? .realistic : .flat
+
+        switch baseStyle {
+        case .standard:
+            return MKStandardMapConfiguration(
+                elevationStyle: elevationStyle
+            )
+        case .satellite:
+            return MKImageryMapConfiguration(
+                elevationStyle: elevationStyle
+            )
+        case .hybrid:
+            return MKHybridMapConfiguration(
+                elevationStyle: elevationStyle
+            )
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift
@@ -16,4 +16,20 @@ enum MapTrackingPolicy {
               !isDestinationSelectionActive else { return .none }
         return isNavigating ? .followWithHeading : .follow
     }
+
+    static func shouldApplyDesiredMode(
+        currentMode: MapTrackingBehavior,
+        desiredMode: MapTrackingBehavior,
+        preservesStoppedTracking: Bool
+    ) -> Bool {
+        guard currentMode != desiredMode else { return false }
+
+        if preservesStoppedTracking,
+           currentMode == .none,
+           desiredMode != .none {
+            return false
+        }
+
+        return true
+    }
 }

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -39,8 +39,8 @@ struct ConnectionStatusView: View {
                     )
 
                 Text(displayName)
-                    .font(.caption)
-                    .foregroundColor(isConnected ? .primary : statusColor)
+                    .font(.footnote.weight(.medium))
+                    .foregroundColor(isConnected ? .primary : .black)
                     .shadow(
                         color: isConnected
                             ? .white.opacity(0.8)

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -11,33 +11,52 @@ import SwiftUI
 
 struct ConnectionStatusView: View {
     let isConnected: Bool
+    let deviceName: String
     let hasRegisteredDevice: Bool
     let onReconnect: () -> Void
+
+    private var displayName: String {
+        guard isConnected else { return "Bicino" }
+        let trimmedName = deviceName.trimmingCharacters(
+            in: .whitespacesAndNewlines
+        )
+        return trimmedName.isEmpty ? "Bicino" : trimmedName
+    }
+
+    private var statusColor: Color {
+        isConnected ? .green : Color(uiColor: .systemGray3)
+    }
     
     var body: some View {
         Button(action: onReconnect) {
             HStack(spacing: 8) {
                 Image(systemName: "circle.fill")
                     .font(.caption)
-                    .foregroundColor(isConnected ? .green : .red)
+                    .foregroundColor(statusColor)
                     .shadow(
-                        color: isConnected ? .green.opacity(0.5) : .red.opacity(0.5),
+                        color: isConnected ? .green.opacity(0.5) : .clear,
                         radius: 4
                     )
 
-                Text("Bicino")
+                Text(displayName)
                     .font(.caption)
-                    .foregroundColor(.primary)
-                    .shadow(color: .white.opacity(0.8), radius: 2, x: 0, y: 1)
+                    .foregroundColor(isConnected ? .primary : statusColor)
+                    .shadow(
+                        color: isConnected
+                            ? .white.opacity(0.8)
+                            : .clear,
+                        radius: 2,
+                        x: 0,
+                        y: 1
+                    )
             }
             .frame(minHeight: 44)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityLabel(
             isConnected
-                ? "Bicino connected"
+                ? "\(displayName) connected"
                 : hasRegisteredDevice
                     ? "Reconnect Bicino"
                     : "Connect Bicino"

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -57,20 +57,23 @@ struct ConnectionStatusView: View {
         return trimmedName.isEmpty ? "Bicino" : trimmedName
     }
 
-    private var statusColor: Color {
-        isConnected ? .green : Color(uiColor: .systemGray3)
+    private var statusSymbolName: String {
+        isConnected
+            ? "antenna.radiowaves.left.and.right"
+            : "antenna.radiowaves.left.and.right.slash"
+    }
+
+    private var statusSymbolColor: Color {
+        isConnected ? .black : Color(uiColor: .systemGray3)
     }
     
     var body: some View {
         Button(action: onReconnect) {
             HStack(spacing: 8) {
-                Image(systemName: "circle.fill")
-                    .font(.caption)
-                    .foregroundColor(statusColor)
-                    .shadow(
-                        color: isConnected ? .green.opacity(0.5) : .clear,
-                        radius: 4
-                    )
+                Image(systemName: statusSymbolName)
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundStyle(statusSymbolColor)
+                    .accessibilityHidden(true)
 
                 Text(displayName)
                     .font(.footnote.weight(.medium))

--- a/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/AuxiliaryViews.swift
@@ -7,6 +7,40 @@
 
 import SwiftUI
 
+extension View {
+    @ViewBuilder
+    func mapOverlayGlassSurface(cornerRadius: CGFloat) -> some View {
+        if #available(iOS 26.0, *) {
+            self.glassEffect(
+                .regular.interactive(),
+                in: .rect(cornerRadius: cornerRadius)
+            )
+        } else {
+            self
+                .background(
+                    .ultraThinMaterial,
+                    in: RoundedRectangle(
+                        cornerRadius: cornerRadius,
+                        style: .continuous
+                    )
+                )
+                .overlay {
+                    RoundedRectangle(
+                        cornerRadius: cornerRadius,
+                        style: .continuous
+                    )
+                    .stroke(Color.primary.opacity(0.1), lineWidth: 0.5)
+                }
+                .shadow(
+                    color: .black.opacity(0.14),
+                    radius: 7,
+                    x: 0,
+                    y: 3
+                )
+        }
+    }
+}
+
 // MARK: - Connection Status View
 
 struct ConnectionStatusView: View {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -44,7 +44,15 @@ class SimulatedPositionAnnotation: MKPointAnnotation {}
 
 // MARK: - Map View Container
 
+@MainActor
+protocol MapAppearanceConfigurationTarget: AnyObject {
+    var preferredConfiguration: MKMapConfiguration { get set }
+}
+
+extension MKMapView: MapAppearanceConfigurationTarget {}
+
 struct MapViewContainer: UIViewRepresentable {
+    let appearance: IPhoneMapAppearance
     let location: CLLocation?
     let route: MKRoute?
     let simulatedPosition: CLLocationCoordinate2D?
@@ -58,6 +66,14 @@ struct MapViewContainer: UIViewRepresentable {
     
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
+        mapView.isPitchEnabled = true
+        if #available(iOS 17.0, macCatalyst 17.0, *) {
+            mapView.pitchButtonVisibility = .adaptive
+        }
+        context.coordinator.applyAppearanceIfNeeded(
+            appearance,
+            to: mapView
+        )
         mapView.delegate = context.coordinator
         mapView.showsUserLocation = isUserLocationAuthorized
         mapView.userTrackingMode = isUserLocationAuthorized ? .follow : .none
@@ -96,6 +112,10 @@ struct MapViewContainer: UIViewRepresentable {
     }
     
     func updateUIView(_ uiView: MKMapView, context: Context) {
+        context.coordinator.applyAppearanceIfNeeded(
+            appearance,
+            to: uiView
+        )
         let isOfflineMapSelectionActive = offlineMapSelectionFrame != nil
         let isFreePanActive = context.coordinator.isFreePanActive(
             mapView: uiView,
@@ -236,6 +256,7 @@ struct MapViewContainer: UIViewRepresentable {
         var isUserLocationAuthorized = false
         var simulatedPosition: CLLocationCoordinate2D?
         var hasSetInitialRegion = false
+        private(set) var lastAppliedAppearance: IPhoneMapAppearance?
         private var compassButton: MKCompassButton?
         private var trackingButton: MKUserTrackingButton?
         private var lastNavigationCoordinate: CLLocationCoordinate2D?
@@ -250,6 +271,16 @@ struct MapViewContainer: UIViewRepresentable {
         init(addressResolver: AddressResolver?) {
             self.addressResolver = addressResolver
             super.init()
+        }
+
+        func applyAppearanceIfNeeded(
+            _ appearance: IPhoneMapAppearance,
+            to target: any MapAppearanceConfigurationTarget
+        ) {
+            guard appearance != lastAppliedAppearance else { return }
+
+            target.preferredConfiguration = appearance.makeConfiguration()
+            lastAppliedAppearance = appearance
         }
 
         func installMapControls(on mapView: MKMapView) {

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -300,7 +300,8 @@ struct MapViewContainer: UIViewRepresentable {
                 context.coordinator.updateUserTrackingMode(
                     mapView: uiView,
                     isNavigating: isNavigating,
-                    isOfflineMapSelectionActive: isOfflineMapSelectionActive
+                    isOfflineMapSelectionActive: isOfflineMapSelectionActive,
+                    preservesStoppedTracking: true
                 )
             } else {
                 if uiView.showsUserLocation {
@@ -395,6 +396,7 @@ struct MapViewContainer: UIViewRepresentable {
             mapView: MKMapView,
             isNavigating: Bool,
             isOfflineMapSelectionActive: Bool,
+            preservesStoppedTracking: Bool = false,
             animated: Bool = true
         ) {
             let isDestinationSelectionActive = mapView.selectedAnnotations.contains {
@@ -415,9 +417,26 @@ struct MapViewContainer: UIViewRepresentable {
             case .followWithHeading:
                 desiredTrackingMode = .followWithHeading
             }
-            if mapView.userTrackingMode != desiredTrackingMode {
-                mapView.setUserTrackingMode(desiredTrackingMode, animated: animated)
+
+            let currentTrackingBehavior: MapTrackingBehavior
+            switch mapView.userTrackingMode {
+            case .none:
+                currentTrackingBehavior = .none
+            case .follow:
+                currentTrackingBehavior = .follow
+            case .followWithHeading:
+                currentTrackingBehavior = .followWithHeading
+            @unknown default:
+                currentTrackingBehavior = .none
             }
+
+            guard MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: currentTrackingBehavior,
+                desiredMode: desiredTrackingBehavior,
+                preservesStoppedTracking: preservesStoppedTracking
+            ) else { return }
+
+            mapView.setUserTrackingMode(desiredTrackingMode, animated: animated)
         }
 
         func isFreePanActive(

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 import MapKit
 import CoreLocation
+import Combine
 
 // MARK: - Destination Annotation
 
@@ -51,8 +52,75 @@ protocol MapAppearanceConfigurationTarget: AnyObject {
 
 extension MKMapView: MapAppearanceConfigurationTarget {}
 
+@MainActor
+final class MapViewControlState: ObservableObject {
+    static let pitchedThreshold: CLLocationDegrees = 5
+    static let defaultPitchedAngle: CLLocationDegrees = 45
+
+    @Published private(set) var mapView: MKMapView?
+    @Published private(set) var isPitched = false
+
+    static func isPitched(_ pitch: CLLocationDegrees) -> Bool {
+        pitch > pitchedThreshold
+    }
+
+    static func targetPitch(
+        isCurrentlyPitched: Bool
+    ) -> CLLocationDegrees {
+        isCurrentlyPitched ? 0 : defaultPitchedAngle
+    }
+
+    func connect(to mapView: MKMapView) {
+        if self.mapView !== mapView {
+            self.mapView = mapView
+        }
+        updatePitch(from: mapView)
+    }
+
+    func disconnect(from mapView: MKMapView) {
+        guard self.mapView === mapView else { return }
+        self.mapView = nil
+        isPitched = false
+    }
+
+    func updatePitch(from mapView: MKMapView) {
+        let newValue = Self.isPitched(mapView.camera.pitch)
+        guard newValue != isPitched else { return }
+        isPitched = newValue
+    }
+
+    func togglePitch() {
+        guard let mapView else { return }
+
+        let currentCamera = mapView.camera
+        let camera = MKMapCamera(
+            lookingAtCenter: currentCamera.centerCoordinate,
+            fromDistance: currentCamera.centerCoordinateDistance,
+            pitch: Self.targetPitch(isCurrentlyPitched: isPitched),
+            heading: currentCamera.heading
+        )
+        mapView.setCamera(camera, animated: true)
+    }
+}
+
+struct MapCompassControl: UIViewRepresentable {
+    @ObservedObject var controlState: MapViewControlState
+
+    func makeUIView(context: Context) -> MKCompassButton {
+        let compass = MKCompassButton(mapView: controlState.mapView)
+        compass.compassVisibility = .adaptive
+        return compass
+    }
+
+    func updateUIView(_ compass: MKCompassButton, context: Context) {
+        compass.mapView = controlState.mapView
+        compass.compassVisibility = .adaptive
+    }
+}
+
 struct MapViewContainer: UIViewRepresentable {
     let appearance: IPhoneMapAppearance
+    let controlState: MapViewControlState
     let location: CLLocation?
     let route: MKRoute?
     let simulatedPosition: CLLocationCoordinate2D?
@@ -68,7 +136,7 @@ struct MapViewContainer: UIViewRepresentable {
         let mapView = MKMapView()
         mapView.isPitchEnabled = true
         if #available(iOS 17.0, macCatalyst 17.0, *) {
-            mapView.pitchButtonVisibility = .adaptive
+            mapView.pitchButtonVisibility = .hidden
         }
         context.coordinator.applyAppearanceIfNeeded(
             appearance,
@@ -81,7 +149,8 @@ struct MapViewContainer: UIViewRepresentable {
         // Configure map appearance
         mapView.showsCompass = false
         mapView.showsScale = true
-        context.coordinator.installMapControls(on: mapView)
+        context.coordinator.controlState = controlState
+        context.coordinator.installTrackingControl(on: mapView)
         
         // Add long press gesture recognizer
         let longPress = UILongPressGestureRecognizer(
@@ -107,6 +176,10 @@ struct MapViewContainer: UIViewRepresentable {
         context.coordinator.isSimulationMode = isSimulationMode
         context.coordinator.isUserLocationAuthorized = isUserLocationAuthorized
         context.coordinator.simulatedPosition = simulatedPosition
+
+        DispatchQueue.main.async {
+            controlState.connect(to: mapView)
+        }
         
         return mapView
     }
@@ -124,6 +197,7 @@ struct MapViewContainer: UIViewRepresentable {
 
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
+        context.coordinator.controlState = controlState
         context.coordinator.onMapTapped = onMapTapped
         context.coordinator.offlineMapSelectionFrame = offlineMapSelectionFrame
         context.coordinator.onOfflineMapSelectionBoundsChanged = onOfflineMapSelectionBoundsChanged
@@ -133,6 +207,11 @@ struct MapViewContainer: UIViewRepresentable {
         context.coordinator.isUserLocationAuthorized = isUserLocationAuthorized
         context.coordinator.simulatedPosition = simulatedPosition
         context.coordinator.updateControlVisibility(isNavigating: isNavigating)
+        if controlState.mapView !== uiView {
+            DispatchQueue.main.async {
+                controlState.connect(to: uiView)
+            }
+        }
         context.coordinator.updateOfflineMapSelectionBounds()
         
         context.coordinator.updateInitialRegionIfNeeded(
@@ -241,12 +320,20 @@ struct MapViewContainer: UIViewRepresentable {
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
+
+    static func dismantleUIView(
+        _ uiView: MKMapView,
+        coordinator: Coordinator
+    ) {
+        coordinator.controlState?.disconnect(from: uiView)
+    }
     
     class Coordinator: NSObject, MKMapViewDelegate, UIGestureRecognizerDelegate {
         typealias AddressResolver = @MainActor (CLLocation) async -> String?
 
         var lastRoute: MKRoute?
         var mapView: MKMapView?
+        weak var controlState: MapViewControlState?
         var onMapTapped: (() -> Void)?
         var offlineMapSelectionFrame: CGRect?
         var onOfflineMapSelectionBoundsChanged: ((OfflineMapBounds) -> Void)?
@@ -257,7 +344,6 @@ struct MapViewContainer: UIViewRepresentable {
         var simulatedPosition: CLLocationCoordinate2D?
         var hasSetInitialRegion = false
         private(set) var lastAppliedAppearance: IPhoneMapAppearance?
-        private var compassButton: MKCompassButton?
         private var trackingButton: MKUserTrackingButton?
         private var lastNavigationCoordinate: CLLocationCoordinate2D?
         private var lastNavigationHeading: CLLocationDirection = 0
@@ -283,32 +369,25 @@ struct MapViewContainer: UIViewRepresentable {
             lastAppliedAppearance = appearance
         }
 
-        func installMapControls(on mapView: MKMapView) {
-            guard compassButton == nil else { return }
-
-            let compass = MKCompassButton(mapView: mapView)
-            compass.compassVisibility = .adaptive
-            compass.translatesAutoresizingMaskIntoConstraints = false
-            mapView.addSubview(compass)
+        func installTrackingControl(on mapView: MKMapView) {
+            guard trackingButton == nil else { return }
 
             let tracking = MKUserTrackingButton(mapView: mapView)
             tracking.translatesAutoresizingMaskIntoConstraints = false
             mapView.addSubview(tracking)
 
             NSLayoutConstraint.activate([
-                compass.leadingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.leadingAnchor, constant: 18),
-                compass.topAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.topAnchor, constant: 220),
-
                 tracking.trailingAnchor.constraint(equalTo: mapView.safeAreaLayoutGuide.trailingAnchor, constant: -18),
-                tracking.topAnchor.constraint(equalTo: compass.topAnchor)
+                tracking.topAnchor.constraint(
+                    equalTo: mapView.safeAreaLayoutGuide.topAnchor,
+                    constant: 220
+                )
             ])
 
-            compassButton = compass
             trackingButton = tracking
         }
 
         func updateControlVisibility(isNavigating: Bool) {
-            compassButton?.compassVisibility = isNavigating ? .visible : .adaptive
             trackingButton?.isHidden = !isNavigating
         }
 
@@ -503,6 +582,7 @@ struct MapViewContainer: UIViewRepresentable {
         }
 
         func mapView(_ mapView: MKMapView, regionDidChangeAnimated animated: Bool) {
+            controlState?.updatePitch(from: mapView)
             updateOfflineMapSelectionBounds()
         }
 

--- a/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/RouteInputView.swift
@@ -81,8 +81,7 @@ struct RouteSearchPanel: View {
                 collapsedSearchButton
             }
         }
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 24, style: .continuous))
-        .shadow(color: .black.opacity(0.18), radius: 18, x: 0, y: 8)
+        .mapOverlayGlassSurface(cornerRadius: 24)
         .frame(maxHeight: isExpanded ? maxExpandedHeight : nil, alignment: .bottom)
         .onAppear {
             updateSearchRegions()

--- a/ios-app/BikeComputerTests/MapAppearanceTests.swift
+++ b/ios-app/BikeComputerTests/MapAppearanceTests.swift
@@ -35,6 +35,7 @@ struct MapAppearanceTests {
         testAppearanceEquality()
         testIdempotentApplication()
         testMapPitchControlTargets()
+        testStoppedTrackingPreservesCamera()
 
         print("MapAppearanceTests passed")
     }
@@ -175,6 +176,44 @@ struct MapAppearanceTests {
         )
         precondition(
             MapViewControlState.targetPitch(isCurrentlyPitched: true) == 0
+        )
+    }
+
+    private static func testStoppedTrackingPreservesCamera() {
+        precondition(
+            !MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: .none,
+                desiredMode: .follow,
+                preservesStoppedTracking: true
+            )
+        )
+        precondition(
+            !MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: .none,
+                desiredMode: .followWithHeading,
+                preservesStoppedTracking: true
+            )
+        )
+        precondition(
+            MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: .follow,
+                desiredMode: .none,
+                preservesStoppedTracking: true
+            )
+        )
+        precondition(
+            MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: .follow,
+                desiredMode: .followWithHeading,
+                preservesStoppedTracking: true
+            )
+        )
+        precondition(
+            MapTrackingPolicy.shouldApplyDesiredMode(
+                currentMode: .none,
+                desiredMode: .follow,
+                preservesStoppedTracking: false
+            )
         )
     }
 }

--- a/ios-app/BikeComputerTests/MapAppearanceTests.swift
+++ b/ios-app/BikeComputerTests/MapAppearanceTests.swift
@@ -34,6 +34,7 @@ struct MapAppearanceTests {
         testConfigurationMapping()
         testAppearanceEquality()
         testIdempotentApplication()
+        testMapPitchControlTargets()
 
         print("MapAppearanceTests passed")
     }
@@ -162,6 +163,18 @@ struct MapAppearanceTests {
         precondition(coordinator.lastAppliedAppearance == terrain)
         precondition(
             target.preferredConfiguration.elevationStyle == .realistic
+        )
+    }
+
+    private static func testMapPitchControlTargets() {
+        precondition(!MapViewControlState.isPitched(0))
+        precondition(!MapViewControlState.isPitched(5))
+        precondition(MapViewControlState.isPitched(5.01))
+        precondition(
+            MapViewControlState.targetPitch(isCurrentlyPitched: false) == 45
+        )
+        precondition(
+            MapViewControlState.targetPitch(isCurrentlyPitched: true) == 0
         )
     }
 }

--- a/ios-app/BikeComputerTests/MapAppearanceTests.swift
+++ b/ios-app/BikeComputerTests/MapAppearanceTests.swift
@@ -1,0 +1,167 @@
+import Foundation
+import MapKit
+
+// MapView only needs the selection bounds shape in this focused Catalyst test.
+struct OfflineMapBounds {
+    let minLon: Double
+    let minLat: Double
+    let maxLon: Double
+    let maxLat: Double
+}
+
+@MainActor
+private final class RecordingMapAppearanceTarget:
+    MapAppearanceConfigurationTarget {
+    private(set) var assignmentCount = 0
+    var preferredConfiguration: MKMapConfiguration {
+        didSet { assignmentCount += 1 }
+    }
+
+    init() {
+        preferredConfiguration = MKStandardMapConfiguration(
+            elevationStyle: .flat
+        )
+    }
+}
+
+@MainActor
+@main
+struct MapAppearanceTests {
+    static func main() {
+        testDefaultAppearance()
+        testPersistedBaseStyleRoundTrip()
+        testUnknownPersistedStyleFallsBackToStandard()
+        testConfigurationMapping()
+        testAppearanceEquality()
+        testIdempotentApplication()
+
+        print("MapAppearanceTests passed")
+    }
+
+    private static func testDefaultAppearance() {
+        precondition(
+            IPhoneMapAppearance.defaultValue == IPhoneMapAppearance(
+                baseStyle: .standard,
+                usesRealisticElevation: false
+            )
+        )
+    }
+
+    private static func testPersistedBaseStyleRoundTrip() {
+        let suiteName = "MapAppearanceTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            preconditionFailure("unable to create isolated defaults")
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        for style in IPhoneMapBaseStyle.allCases {
+            defaults.set(
+                style.rawValue,
+                forKey: IPhoneMapAppearance.baseStyleDefaultsKey
+            )
+            let restored = IPhoneMapAppearance(
+                persistedBaseStyleRawValue: defaults.string(
+                    forKey: IPhoneMapAppearance.baseStyleDefaultsKey
+                ),
+                usesRealisticElevation: false
+            )
+            precondition(restored.baseStyle == style)
+        }
+
+        defaults.set(
+            true,
+            forKey: IPhoneMapAppearance.realisticElevationDefaultsKey
+        )
+        let restoredTerrain = IPhoneMapAppearance(
+            persistedBaseStyleRawValue: IPhoneMapBaseStyle.standard.rawValue,
+            usesRealisticElevation: defaults.bool(
+                forKey: IPhoneMapAppearance.realisticElevationDefaultsKey
+            )
+        )
+        precondition(restoredTerrain.usesRealisticElevation)
+    }
+
+    private static func testUnknownPersistedStyleFallsBackToStandard() {
+        let appearance = IPhoneMapAppearance(
+            persistedBaseStyleRawValue: "future-style",
+            usesRealisticElevation: true
+        )
+        precondition(appearance.baseStyle == .standard)
+        precondition(appearance.usesRealisticElevation)
+    }
+
+    private static func testConfigurationMapping() {
+        for style in IPhoneMapBaseStyle.allCases {
+            assertConfiguration(
+                for: IPhoneMapAppearance(
+                    baseStyle: style,
+                    usesRealisticElevation: false
+                ),
+                expectedStyle: style,
+                expectedElevation: .flat
+            )
+            assertConfiguration(
+                for: IPhoneMapAppearance(
+                    baseStyle: style,
+                    usesRealisticElevation: true
+                ),
+                expectedStyle: style,
+                expectedElevation: .realistic
+            )
+        }
+    }
+
+    private static func assertConfiguration(
+        for appearance: IPhoneMapAppearance,
+        expectedStyle: IPhoneMapBaseStyle,
+        expectedElevation: MKMapConfiguration.ElevationStyle
+    ) {
+        let configuration = appearance.makeConfiguration()
+        switch expectedStyle {
+        case .standard:
+            precondition(configuration is MKStandardMapConfiguration)
+        case .satellite:
+            precondition(configuration is MKImageryMapConfiguration)
+        case .hybrid:
+            precondition(configuration is MKHybridMapConfiguration)
+        }
+        precondition(configuration.elevationStyle == expectedElevation)
+    }
+
+    private static func testAppearanceEquality() {
+        let standard = IPhoneMapAppearance.defaultValue
+        precondition(standard == IPhoneMapAppearance.defaultValue)
+        precondition(
+            standard != IPhoneMapAppearance(
+                baseStyle: .standard,
+                usesRealisticElevation: true
+            )
+        )
+    }
+
+    private static func testIdempotentApplication() {
+        let coordinator = MapViewContainer.Coordinator()
+        let target = RecordingMapAppearanceTarget()
+        let standard = IPhoneMapAppearance.defaultValue
+
+        coordinator.applyAppearanceIfNeeded(standard, to: target)
+        let firstConfiguration = target.preferredConfiguration
+        precondition(target.assignmentCount == 1)
+        precondition(coordinator.lastAppliedAppearance == standard)
+
+        coordinator.applyAppearanceIfNeeded(standard, to: target)
+        precondition(target.assignmentCount == 1)
+        precondition(target.preferredConfiguration === firstConfiguration)
+
+        let terrain = IPhoneMapAppearance(
+            baseStyle: .standard,
+            usesRealisticElevation: true
+        )
+        coordinator.applyAppearanceIfNeeded(terrain, to: target)
+        precondition(target.assignmentCount == 2)
+        precondition(coordinator.lastAppliedAppearance == terrain)
+        precondition(
+            target.preferredConfiguration.elevationStyle == .realistic
+        )
+    }
+}

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -93,12 +93,33 @@ xcrun swiftc \
   -L "${IOS_SUPPORT}/usr/lib/swift" \
   -o "${CATALYST_OUT}" \
   ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
+  ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
   ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
 
 "${CATALYST_OUT}"
+
+MAP_APPEARANCE_CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-map-appearance-tests"
+
+xcrun swiftc \
+  -D HOST_TESTING \
+  -parse-as-library \
+  -target "$(uname -m)-apple-ios16.4-macabi" \
+  -sdk "${MACOS_SDK}" \
+  -F "${IOS_SUPPORT}/System/Library/Frameworks" \
+  -I "${IOS_SUPPORT}/usr/lib/swift" \
+  -L "${IOS_SUPPORT}/usr/lib/swift" \
+  -o "${MAP_APPEARANCE_CATALYST_OUT}" \
+  ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
+  ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
+  ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
+  ios-app/BikeComputerTests/MapAppearanceTests.swift
+
+"${MAP_APPEARANCE_CATALYST_OUT}"
 
 PREVIEW_CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-saved-map-preview-tests"
 


### PR DESCRIPTION
## Summary

- add native standard and satellite map styles plus 2D and 3D terrain controls
- group map controls in a glass rail, align the compass, and refine connected-device status presentation
- preserve the current map camera while changing appearance or downloading an area
- add focused map appearance and camera-tracking coverage plus the implementation plan

## Verification

- `ios-app/scripts/run-navigation-tests.sh`
- signed Release iPhone build with Xcode 26.6
- installed and launched production Bicino on the connected iPhone 16 Pro Max
- `git diff --check origin/main...HEAD`
- clean synthetic merge against current `origin/main`