### PR TITLE
Improve Saved Maps preview quality

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -119,11 +119,26 @@ nonisolated enum OfflineMapSharedSecretMigration {
 
 @MainActor
 enum OfflineMapSnapshotPreviewRenderer {
+    nonisolated struct Configuration: Equatable, Sendable {
+        let size: CGSize
+        let scale: CGFloat
+
+        static let thumbnail = Configuration(
+            size: CGSize(width: 160, height: 96),
+            scale: 1
+        )
+        static let detail = Configuration(
+            size: CGSize(width: 400, height: 240),
+            scale: 3
+        )
+    }
+
 #if canImport(UIKit) && canImport(MapKit)
     struct Request {
         let options: MKMapSnapshotter.Options
         let northWestCoordinate: CLLocationCoordinate2D
         let southEastCoordinate: CLLocationCoordinate2D
+        let configuration: Configuration
     }
 
     struct SnapshotResult {
@@ -136,9 +151,12 @@ enum OfflineMapSnapshotPreviewRenderer {
     ) async throws -> SnapshotResult
 #endif
 
-    static func pngData(for bounds: OfflineMapPreviewBounds) async throws -> Data? {
+    static func pngData(
+        for bounds: OfflineMapPreviewBounds,
+        configuration: Configuration = .thumbnail
+    ) async throws -> Data? {
 #if canImport(UIKit) && canImport(MapKit)
-        try await pngData(for: bounds) { options in
+        try await pngData(for: bounds, configuration: configuration) { options in
             let snapshotter = MKMapSnapshotter(options: options)
             let snapshot = try await withTaskCancellationHandler {
                 try await snapshotter.start()
@@ -155,8 +173,19 @@ enum OfflineMapSnapshotPreviewRenderer {
 #endif
     }
 
+    static func detailPNGData(for bounds: OfflineMapPreviewBounds) async throws -> Data? {
 #if canImport(UIKit) && canImport(MapKit)
-    static func request(for bounds: OfflineMapPreviewBounds) -> Request {
+        try await pngData(for: bounds, configuration: .detail)
+#else
+        nil
+#endif
+    }
+
+#if canImport(UIKit) && canImport(MapKit)
+    static func request(
+        for bounds: OfflineMapPreviewBounds,
+        configuration: Configuration = .thumbnail
+    ) -> Request {
         let options = MKMapSnapshotter.Options()
         let northWestCoordinate = CLLocationCoordinate2D(
             latitude: bounds.maxLatitude,
@@ -174,8 +203,8 @@ enum OfflineMapSnapshotPreviewRenderer {
             width: abs(southEast.x - northWest.x),
             height: abs(southEast.y - northWest.y)
         )
-        options.size = CGSize(width: 160, height: 96)
-        options.scale = 1
+        options.size = configuration.size
+        options.scale = configuration.scale
         options.traitCollection = UITraitCollection(userInterfaceStyle: .light)
         if #available(iOS 17.0, macCatalyst 17.0, *) {
             options.preferredConfiguration = MKStandardMapConfiguration(elevationStyle: .flat)
@@ -185,15 +214,17 @@ enum OfflineMapSnapshotPreviewRenderer {
         return Request(
             options: options,
             northWestCoordinate: northWestCoordinate,
-            southEastCoordinate: southEastCoordinate
+            southEastCoordinate: southEastCoordinate,
+            configuration: configuration
         )
     }
 
     static func pngData(
         for bounds: OfflineMapPreviewBounds,
+        configuration: Configuration = .thumbnail,
         snapshot: SnapshotOperation
     ) async throws -> Data? {
-        let request = request(for: bounds)
+        let request = request(for: bounds, configuration: configuration)
         let result = try await snapshot(request.options)
         try Task.checkCancellation()
         guard let croppedImage = croppedImage(
@@ -214,14 +245,15 @@ enum OfflineMapSnapshotPreviewRenderer {
         croppedImage(
             from: image,
             northWestPoint: pointForCoordinate(request.northWestCoordinate),
-            southEastPoint: pointForCoordinate(request.southEastCoordinate)
+            southEastPoint: pointForCoordinate(request.southEastCoordinate),
+            configuration: request.configuration
         )
     }
 
     static func hasMeaningfulVisualVariation(_ image: UIImage) -> Bool {
         guard let source = image.cgImage else { return false }
-        let width = source.width
-        let height = source.height
+        let width = min(source.width, 64)
+        let height = min(source.height, 64)
         var pixels = [UInt8](repeating: 0, count: width * height * 4)
         let rendered = pixels.withUnsafeMutableBytes { bytes -> Bool in
             guard let context = CGContext(
@@ -257,7 +289,8 @@ enum OfflineMapSnapshotPreviewRenderer {
     private static func croppedImage(
         from image: UIImage,
         northWestPoint: CGPoint,
-        southEastPoint: CGPoint
+        southEastPoint: CGPoint,
+        configuration: Configuration
     ) -> UIImage? {
         guard let source = image.cgImage else { return nil }
         let scale = image.scale
@@ -292,11 +325,17 @@ enum OfflineMapSnapshotPreviewRenderer {
             orientation: image.imageOrientation
         )
         let normalizedSize = CGSize(
-            width: min(160, max(1, floor(croppedImage.size.width))),
-            height: min(96, max(1, floor(croppedImage.size.height)))
+            width: min(
+                configuration.size.width,
+                max(1, floor(croppedImage.size.width))
+            ),
+            height: min(
+                configuration.size.height,
+                max(1, floor(croppedImage.size.height))
+            )
         )
         let format = UIGraphicsImageRendererFormat()
-        format.scale = 1
+        format.scale = configuration.scale
         format.opaque = true
         return UIGraphicsImageRenderer(size: normalizedSize, format: format).image { _ in
             croppedImage.draw(in: CGRect(origin: .zero, size: normalizedSize))
@@ -319,9 +358,40 @@ typealias OfflineMapPreviewLoadOperation = @MainActor (
 ) async -> OfflineMapPreviewLoadResult
 
 #if canImport(UIKit)
+nonisolated private enum SavedMapPreviewPNGValidator {
+    private static let pngSignature = Data([
+        0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+    ])
+
+    static func isValid(
+        _ data: Data,
+        maximumImageBytes: Int,
+        maximumPixelDimension: UInt32,
+        minimumLongestEdge: UInt32 = 1
+    ) -> Bool {
+        guard (33...maximumImageBytes).contains(data.count),
+              data.starts(with: pngSignature),
+              uint32BE(data, at: 8) == 13,
+              data.subdata(in: 12..<16) == Data("IHDR".utf8) else {
+            return false
+        }
+        let width = uint32BE(data, at: 16)
+        let height = uint32BE(data, at: 20)
+        return (1...maximumPixelDimension).contains(width) &&
+            (1...maximumPixelDimension).contains(height) &&
+            max(width, height) >= minimumLongestEdge
+    }
+
+    private static func uint32BE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset]) << 24 |
+            UInt32(data[offset + 1]) << 16 |
+            UInt32(data[offset + 2]) << 8 |
+            UInt32(data[offset + 3])
+    }
+}
+
 nonisolated enum SavedMapSnapshotPreviewStore {
     static let maximumImageBytes = 1_048_576
-    private static let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
 
     static func imageURL(for artifactURL: URL) -> URL {
         artifactURL.appendingPathExtension("thumbnail.png")
@@ -355,28 +425,111 @@ nonisolated enum SavedMapSnapshotPreviewStore {
     }
 
     static func isValidPNG(_ data: Data) -> Bool {
-        guard (33...maximumImageBytes).contains(data.count),
-              data.starts(with: pngSignature),
-              uint32BE(data, at: 8) == 13,
-              data.subdata(in: 12..<16) == Data("IHDR".utf8) else {
-            return false
-        }
-        let width = uint32BE(data, at: 16)
-        let height = uint32BE(data, at: 20)
-        return (1...1_024).contains(width) && (1...1_024).contains(height)
+        SavedMapPreviewPNGValidator.isValid(
+            data,
+            maximumImageBytes: maximumImageBytes,
+            maximumPixelDimension: 1_024
+        )
+    }
+}
+
+nonisolated enum SavedMapDetailPreviewStore {
+    static let cacheVersion = 1
+    static let maximumImageBytes = 4_194_304
+    static let maximumPixelDimension: UInt32 = 1_200
+    static let minimumLongestEdge: UInt32 = 600
+
+    static func imageURL(for artifactURL: URL) -> URL {
+        artifactURL.appendingPathExtension("detail-preview-v\(cacheVersion).png")
     }
 
-    private static func uint32BE(_ data: Data, at offset: Int) -> UInt32 {
-        UInt32(data[offset]) << 24 |
-            UInt32(data[offset + 1]) << 16 |
-            UInt32(data[offset + 2]) << 8 |
-            UInt32(data[offset + 3])
+    static func imageData(for artifactURL: URL) -> Data? {
+        imageData(at: imageURL(for: artifactURL))
+    }
+
+    static func save(_ data: Data, for artifactURL: URL) throws {
+        guard isValidPNG(data) else {
+            throw OfflineMapPlatformError.invalidPack(
+                "map detail preview is not a high-resolution PNG"
+            )
+        }
+        try data.write(to: imageURL(for: artifactURL), options: .atomic)
+    }
+
+    static func delete(for artifactURL: URL) throws {
+        let url = imageURL(for: artifactURL)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    static func isValidPNG(_ data: Data) -> Bool {
+        SavedMapPreviewPNGValidator.isValid(
+            data,
+            maximumImageBytes: maximumImageBytes,
+            maximumPixelDimension: maximumPixelDimension,
+            minimumLongestEdge: minimumLongestEdge
+        )
+    }
+
+    static func imageData(at url: URL) -> Data? {
+        guard let values = try? url.resourceValues(
+            forKeys: [.fileSizeKey, .isRegularFileKey]
+        ),
+        values.isRegularFile == true,
+        let fileSize = values.fileSize,
+        (33...maximumImageBytes).contains(fileSize),
+        let data = try? Data(contentsOf: url),
+        isValidPNG(data) else {
+            return nil
+        }
+        return data
+    }
+}
+
+nonisolated private enum DeviceMapPreviewCachePolicy {
+    private static let maximumEntryCount = 16
+    private static let maximumEntryAge: TimeInterval = 30 * 24 * 60 * 60
+
+    static func prune(directory: URL, now: Date = Date()) {
+        guard var entries = try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey,
+                .isRegularFileKey,
+            ],
+            options: []
+        ) else {
+            return
+        }
+        entries = entries.filter { url in
+            let values = try? url.resourceValues(
+                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+            )
+            return values?.isRegularFile == true &&
+                url.pathExtension.lowercased() == "png"
+        }
+        entries.sort { lhs, rhs in
+            let lhsDate = (try? lhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            let rhsDate = (try? rhs.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            return lhsDate > rhsDate
+        }
+        for (index, url) in entries.enumerated() {
+            let date = (try? url.resourceValues(
+                forKeys: [.contentModificationDateKey]
+            ).contentModificationDate) ?? .distantPast
+            if index >= maximumEntryCount || now.timeIntervalSince(date) > maximumEntryAge {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
     }
 }
 
 nonisolated enum DeviceMapSnapshotPreviewStore {
-    private static let maximumEntryCount = 16
-    private static let maximumEntryAge: TimeInterval = 30 * 24 * 60 * 60
 
     static func imageData(
         for descriptor: DeviceActiveMapDescriptor,
@@ -419,7 +572,7 @@ nonisolated enum DeviceMapSnapshotPreviewStore {
             to: imageURL(for: descriptor, in: cacheRoot),
             options: .atomic
         )
-        prune(directory: directory)
+        DeviceMapPreviewCachePolicy.prune(directory: directory)
     }
 
     static func imageURL(
@@ -433,42 +586,71 @@ nonisolated enum DeviceMapSnapshotPreviewStore {
     private static func previewDirectory(in cacheRoot: URL) -> URL {
         cacheRoot.appendingPathComponent("DeviceMapPreviews", isDirectory: true)
     }
+}
 
-    private static func prune(directory: URL, now: Date = Date()) {
-        guard var entries = try? FileManager.default.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [
-                .contentModificationDateKey,
-                .isRegularFileKey,
-            ],
-            options: []
-        ) else {
-            return
+nonisolated enum DeviceMapDetailPreviewStore {
+    static func imageData(
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) -> Data? {
+        let url = imageURL(for: descriptor, in: cacheRoot)
+        guard let data = SavedMapDetailPreviewStore.imageData(at: url) else {
+            return nil
         }
-        entries = entries.filter { url in
-            let values = try? url.resourceValues(
-                forKeys: [.contentModificationDateKey, .isRegularFileKey]
+        try? FileManager.default.setAttributes(
+            [.modificationDate: Date()],
+            ofItemAtPath: url.path
+        )
+        return data
+    }
+
+    static func save(
+        _ data: Data,
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) throws {
+        guard SavedMapDetailPreviewStore.isValidPNG(data) else {
+            throw OfflineMapPlatformError.invalidPack(
+                "device map detail preview is not a high-resolution PNG"
             )
-            return values?.isRegularFile == true &&
-                url.pathExtension.lowercased() == "png"
         }
-        entries.sort { lhs, rhs in
-            let lhsDate = (try? lhs.resourceValues(
-                forKeys: [.contentModificationDateKey]
-            ).contentModificationDate) ?? .distantPast
-            let rhsDate = (try? rhs.resourceValues(
-                forKeys: [.contentModificationDateKey]
-            ).contentModificationDate) ?? .distantPast
-            return lhsDate > rhsDate
+        let directory = previewDirectory(in: cacheRoot)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        try data.write(
+            to: imageURL(for: descriptor, in: cacheRoot),
+            options: .atomic
+        )
+        DeviceMapPreviewCachePolicy.prune(directory: directory)
+    }
+
+    static func imageURL(
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) -> URL {
+        previewDirectory(in: cacheRoot).appendingPathComponent(
+            descriptor.previewFilename + ".detail-v\(SavedMapDetailPreviewStore.cacheVersion).png",
+            isDirectory: false
+        )
+    }
+
+    static func delete(
+        for descriptor: DeviceActiveMapDescriptor,
+        in cacheRoot: URL
+    ) throws {
+        let url = imageURL(for: descriptor, in: cacheRoot)
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
         }
-        for (index, url) in entries.enumerated() {
-            let date = (try? url.resourceValues(
-                forKeys: [.contentModificationDateKey]
-            ).contentModificationDate) ?? .distantPast
-            if index >= maximumEntryCount || now.timeIntervalSince(date) > maximumEntryAge {
-                try? FileManager.default.removeItem(at: url)
-            }
-        }
+    }
+
+    private static func previewDirectory(in cacheRoot: URL) -> URL {
+        cacheRoot.appendingPathComponent(
+            "DeviceMapDetailPreviews-v\(SavedMapDetailPreviewStore.cacheVersion)",
+            isDirectory: true
+        )
     }
 }
 
@@ -1702,6 +1884,7 @@ final class OfflineMapManager: ObservableObject {
     private let packDownload: PackDownloadOperation
     private let previewLoad: OfflineMapPreviewLoadOperation
     private let mapSnapshot: OfflineMapSnapshotOperation
+    private let detailMapSnapshot: OfflineMapSnapshotOperation
     private let metadataSave: SavedMapArtifactMetadataSaveOperation
     private let cacheDirectoryOverride: URL?
     private let mapStreamTrustStore: BikeMapStreamTrustStore
@@ -1725,9 +1908,13 @@ final class OfflineMapManager: ObservableObject {
     private var activityCounter = OfflineMapActivityCounter()
 #if canImport(UIKit)
     @Published private var packPreviewImages: [String: UIImage] = [:]
+    @Published private var detailPreviewImages: [String: UIImage] = [:]
+    @Published private var detailPreviewLoadingKeys: Set<String> = []
     private var unavailablePackPreviews: Set<String> = []
+    private var unavailableDetailPreviews: Set<String> = []
     private var previewLoadTasks: [String: Task<Void, Never>] = [:]
     private let previewLoadRegistry = OfflineMapPreviewLoadRegistry()
+    private let detailPreviewLoadRegistry = OfflineMapPreviewLoadRegistry()
     private var currentActiveDeviceMap: DeviceActiveMapDescriptor?
 #endif
 
@@ -1764,6 +1951,9 @@ final class OfflineMapManager: ObservableObject {
         mapSnapshot: @escaping OfflineMapSnapshotOperation = { bounds in
             try await OfflineMapSnapshotPreviewRenderer.pngData(for: bounds)
         },
+        detailMapSnapshot: @escaping OfflineMapSnapshotOperation = { bounds in
+            try await OfflineMapSnapshotPreviewRenderer.detailPNGData(for: bounds)
+        },
         metadataSave: @escaping SavedMapArtifactMetadataSaveOperation = { metadata, url in
             try SavedMapArtifactMetadataStore.save(metadata, for: url)
         },
@@ -1781,6 +1971,7 @@ final class OfflineMapManager: ObservableObject {
         self.packDownload = packDownload
         self.previewLoad = previewLoad
         self.mapSnapshot = mapSnapshot
+        self.detailMapSnapshot = detailMapSnapshot
         self.metadataSave = metadataSave
         self.cacheDirectoryOverride = cacheDirectory
         self.mapStreamTrustStore = mapStreamTrustStore ??
@@ -2378,6 +2569,10 @@ final class OfflineMapManager: ObservableObject {
             previewLoadTasks.removeValue(forKey: key)?.cancel()
             packPreviewImages.removeValue(forKey: key)
             unavailablePackPreviews.remove(key)
+            detailPreviewLoadRegistry.invalidate(key)
+            detailPreviewImages.removeValue(forKey: key)
+            detailPreviewLoadingKeys.remove(key)
+            unavailableDetailPreviews.remove(key)
         }
         currentActiveDeviceMap = descriptor
     }
@@ -2397,6 +2592,123 @@ final class OfflineMapManager: ObservableObject {
         }
         guard let descriptor = item.deviceMap else { return }
         loadDevicePreviewIfNeeded(for: descriptor)
+    }
+
+    func detailPreviewImage(for item: SavedMapListItem) -> UIImage? {
+        guard let key = detailPreviewCacheKey(for: item) else { return nil }
+        return detailPreviewImages[key]
+    }
+
+    func isDetailPreviewLoading(for item: SavedMapListItem) -> Bool {
+        guard let key = detailPreviewCacheKey(for: item) else { return false }
+        return detailPreviewLoadingKeys.contains(key)
+    }
+
+    func loadDetailPreviewIfNeeded(for item: SavedMapListItem) async {
+        guard let key = detailPreviewCacheKey(for: item),
+              detailPreviewImages[key] == nil,
+              !unavailableDetailPreviews.contains(key),
+              !detailPreviewLoadingKeys.contains(key) else {
+            return
+        }
+        let token = detailPreviewLoadRegistry.begin(for: key)
+        detailPreviewLoadingKeys.insert(key)
+        defer {
+            if detailPreviewLoadRegistry.finishIfCurrent(token, for: key) {
+                detailPreviewLoadingKeys.remove(key)
+            }
+        }
+
+        let storedData: Data?
+        let bounds: OfflineMapPreviewBounds?
+        let storedFileExists: Bool
+        let cacheRoot: URL?
+        if let packURL = item.packURL {
+            let loaded = await Task.detached(priority: .utility) {
+                let storedURL = SavedMapDetailPreviewStore.imageURL(for: packURL)
+                return (
+                    SavedMapDetailPreviewStore.imageData(for: packURL),
+                    OfflineMapPackPreviewReader.content(for: packURL)?.bounds,
+                    FileManager.default.fileExists(atPath: storedURL.path)
+                )
+            }.value
+            storedData = loaded.0
+            bounds = loaded.1
+            storedFileExists = loaded.2
+            cacheRoot = nil
+        } else if let descriptor = item.deviceMap,
+                  let root = try? cachedPackDirectory() {
+            let loaded = await Task.detached(priority: .utility) {
+                let storedURL = DeviceMapDetailPreviewStore.imageURL(
+                    for: descriptor,
+                    in: root
+                )
+                return (
+                    DeviceMapDetailPreviewStore.imageData(
+                        for: descriptor,
+                        in: root
+                    ),
+                    FileManager.default.fileExists(atPath: storedURL.path)
+                )
+            }.value
+            storedData = loaded.0
+            bounds = descriptor.bounds
+            storedFileExists = loaded.1
+            cacheRoot = root
+        } else {
+            unavailableDetailPreviews.insert(key)
+            return
+        }
+
+        guard detailPreviewLoadRegistry.isCurrent(token, for: key),
+              !Task.isCancelled,
+              isDetailPreviewTargetCurrent(item, key: key) else {
+            return
+        }
+        if let image = usableDetailPreviewImage(from: storedData) {
+            detailPreviewImages[key] = image
+            return
+        }
+        if storedFileExists {
+            if let packURL = item.packURL {
+                try? SavedMapDetailPreviewStore.delete(for: packURL)
+            } else if let descriptor = item.deviceMap, let cacheRoot {
+                try? DeviceMapDetailPreviewStore.delete(
+                    for: descriptor,
+                    in: cacheRoot
+                )
+            }
+        }
+        guard let bounds else {
+            unavailableDetailPreviews.insert(key)
+            return
+        }
+
+        let generatedData: Data?
+        do {
+            generatedData = try await detailMapSnapshot(bounds)
+        } catch is CancellationError {
+            return
+        } catch {
+            generatedData = nil
+        }
+        guard detailPreviewLoadRegistry.isCurrent(token, for: key),
+              !Task.isCancelled,
+              isDetailPreviewTargetCurrent(item, key: key),
+              let generatedData,
+              let image = usableDetailPreviewImage(from: generatedData) else {
+            return
+        }
+        if let packURL = item.packURL {
+            try? SavedMapDetailPreviewStore.save(generatedData, for: packURL)
+        } else if let descriptor = item.deviceMap, let cacheRoot {
+            try? DeviceMapDetailPreviewStore.save(
+                generatedData,
+                for: descriptor,
+                in: cacheRoot
+            )
+        }
+        detailPreviewImages[key] = image
     }
 
     func previewImage(forCachedPack packURL: URL) -> UIImage? {
@@ -2517,6 +2829,34 @@ final class OfflineMapManager: ObservableObject {
             return nil
         }
         return image
+    }
+
+    private func usableDetailPreviewImage(from data: Data?) -> UIImage? {
+        guard let data,
+              SavedMapDetailPreviewStore.isValidPNG(data),
+              let image = UIImage(data: data),
+              OfflineMapSnapshotPreviewRenderer.hasMeaningfulVisualVariation(image) else {
+            return nil
+        }
+        return image
+    }
+
+    private func detailPreviewCacheKey(for item: SavedMapListItem) -> String? {
+        if let packURL = item.packURL {
+            return previewCacheKey(for: packURL)
+        }
+        guard let descriptor = item.deviceMap else { return nil }
+        return devicePreviewCacheKey(for: descriptor)
+    }
+
+    private func isDetailPreviewTargetCurrent(
+        _ item: SavedMapListItem,
+        key: String
+    ) -> Bool {
+        if item.packURL != nil {
+            return cachedPackURLs.contains { previewCacheKey(for: $0) == key }
+        }
+        return item.deviceMap == currentActiveDeviceMap
     }
 
     private func loadDevicePreviewIfNeeded(
@@ -5796,11 +6136,19 @@ final class OfflineMapManager: ObservableObject {
             for key in Array(packPreviewImages.keys) where !activePreviewKeys.contains(key) {
                 packPreviewImages.removeValue(forKey: key)
             }
+            for key in Array(detailPreviewImages.keys) where !activePreviewKeys.contains(key) {
+                detailPreviewImages.removeValue(forKey: key)
+            }
             for key in Array(previewLoadTasks.keys) where !activePreviewKeys.contains(key) {
                 previewLoadTasks.removeValue(forKey: key)?.cancel()
                 previewLoadRegistry.invalidate(key)
             }
+            for key in detailPreviewLoadingKeys where !activePreviewKeys.contains(key) {
+                detailPreviewLoadRegistry.invalidate(key)
+            }
+            detailPreviewLoadingKeys.formIntersection(activePreviewKeys)
             unavailablePackPreviews.formIntersection(activePreviewKeys)
+            unavailableDetailPreviews.formIntersection(activePreviewKeys)
 #endif
             cacheDefaultDisplayNames(for: packURLs)
             cachedMapRecords = packURLs.map(cachedMapRecord)
@@ -5813,7 +6161,11 @@ final class OfflineMapManager: ObservableObject {
             previewLoadTasks.removeAll()
             previewLoadRegistry.removeAll()
             packPreviewImages.removeAll()
+            detailPreviewLoadRegistry.removeAll()
+            detailPreviewImages.removeAll()
+            detailPreviewLoadingKeys.removeAll()
             unavailablePackPreviews.removeAll()
+            unavailableDetailPreviews.removeAll()
 #endif
             cachedPackURLs = []
             cachedMapRecords = []
@@ -5837,7 +6189,12 @@ final class OfflineMapManager: ObservableObject {
         previewLoadTasks.removeValue(forKey: key)?.cancel()
         packPreviewImages.removeValue(forKey: key)
         unavailablePackPreviews.remove(key)
+        detailPreviewLoadRegistry.invalidate(key)
+        detailPreviewImages.removeValue(forKey: key)
+        detailPreviewLoadingKeys.remove(key)
+        unavailableDetailPreviews.remove(key)
         try? SavedMapSnapshotPreviewStore.delete(for: packURL)
+        try? SavedMapDetailPreviewStore.delete(for: packURL)
     }
 #else
     private func invalidateCachedPreview(for packURL: URL) {}

--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -1793,6 +1793,8 @@ nonisolated enum SavedMapRemovalPolicy {
 
 @MainActor
 final class OfflineMapManager: ObservableObject {
+    private static let maximumInMemoryDetailPreviewCount = 3
+
     typealias PackDownloadOperation = (
         URL,
         OfflineMapDownloadConstraints,
@@ -1910,6 +1912,7 @@ final class OfflineMapManager: ObservableObject {
     @Published private var packPreviewImages: [String: UIImage] = [:]
     @Published private var detailPreviewImages: [String: UIImage] = [:]
     @Published private var detailPreviewLoadingKeys: Set<String> = []
+    private var detailPreviewAccessOrder: [String] = []
     private var unavailablePackPreviews: Set<String> = []
     private var unavailableDetailPreviews: Set<String> = []
     private var previewLoadTasks: [String: Task<Void, Never>] = [:]
@@ -2570,7 +2573,7 @@ final class OfflineMapManager: ObservableObject {
             packPreviewImages.removeValue(forKey: key)
             unavailablePackPreviews.remove(key)
             detailPreviewLoadRegistry.invalidate(key)
-            detailPreviewImages.removeValue(forKey: key)
+            removeDetailPreviewImage(forKey: key)
             detailPreviewLoadingKeys.remove(key)
             unavailableDetailPreviews.remove(key)
         }
@@ -2595,8 +2598,12 @@ final class OfflineMapManager: ObservableObject {
     }
 
     func detailPreviewImage(for item: SavedMapListItem) -> UIImage? {
-        guard let key = detailPreviewCacheKey(for: item) else { return nil }
-        return detailPreviewImages[key]
+        guard let key = detailPreviewCacheKey(for: item),
+              let image = detailPreviewImages[key] else {
+            return nil
+        }
+        recordDetailPreviewAccess(forKey: key)
+        return image
     }
 
     func isDetailPreviewLoading(for item: SavedMapListItem) -> Bool {
@@ -2607,8 +2614,7 @@ final class OfflineMapManager: ObservableObject {
     func loadDetailPreviewIfNeeded(for item: SavedMapListItem) async {
         guard let key = detailPreviewCacheKey(for: item),
               detailPreviewImages[key] == nil,
-              !unavailableDetailPreviews.contains(key),
-              !detailPreviewLoadingKeys.contains(key) else {
+              !unavailableDetailPreviews.contains(key) else {
             return
         }
         let token = detailPreviewLoadRegistry.begin(for: key)
@@ -2666,7 +2672,7 @@ final class OfflineMapManager: ObservableObject {
             return
         }
         if let image = usableDetailPreviewImage(from: storedData) {
-            detailPreviewImages[key] = image
+            cacheDetailPreviewImage(image, forKey: key)
             return
         }
         if storedFileExists {
@@ -2708,7 +2714,7 @@ final class OfflineMapManager: ObservableObject {
                 in: cacheRoot
             )
         }
-        detailPreviewImages[key] = image
+        cacheDetailPreviewImage(image, forKey: key)
     }
 
     func previewImage(forCachedPack packURL: URL) -> UIImage? {
@@ -2839,6 +2845,25 @@ final class OfflineMapManager: ObservableObject {
             return nil
         }
         return image
+    }
+
+    private func cacheDetailPreviewImage(_ image: UIImage, forKey key: String) {
+        detailPreviewImages[key] = image
+        recordDetailPreviewAccess(forKey: key)
+        while detailPreviewAccessOrder.count > Self.maximumInMemoryDetailPreviewCount {
+            let evictedKey = detailPreviewAccessOrder.removeFirst()
+            detailPreviewImages.removeValue(forKey: evictedKey)
+        }
+    }
+
+    private func recordDetailPreviewAccess(forKey key: String) {
+        detailPreviewAccessOrder.removeAll { $0 == key }
+        detailPreviewAccessOrder.append(key)
+    }
+
+    private func removeDetailPreviewImage(forKey key: String) {
+        detailPreviewImages.removeValue(forKey: key)
+        detailPreviewAccessOrder.removeAll { $0 == key }
     }
 
     private func detailPreviewCacheKey(for item: SavedMapListItem) -> String? {
@@ -6137,7 +6162,7 @@ final class OfflineMapManager: ObservableObject {
                 packPreviewImages.removeValue(forKey: key)
             }
             for key in Array(detailPreviewImages.keys) where !activePreviewKeys.contains(key) {
-                detailPreviewImages.removeValue(forKey: key)
+                removeDetailPreviewImage(forKey: key)
             }
             for key in Array(previewLoadTasks.keys) where !activePreviewKeys.contains(key) {
                 previewLoadTasks.removeValue(forKey: key)?.cancel()
@@ -6163,6 +6188,7 @@ final class OfflineMapManager: ObservableObject {
             packPreviewImages.removeAll()
             detailPreviewLoadRegistry.removeAll()
             detailPreviewImages.removeAll()
+            detailPreviewAccessOrder.removeAll()
             detailPreviewLoadingKeys.removeAll()
             unavailablePackPreviews.removeAll()
             unavailableDetailPreviews.removeAll()
@@ -6190,7 +6216,7 @@ final class OfflineMapManager: ObservableObject {
         packPreviewImages.removeValue(forKey: key)
         unavailablePackPreviews.remove(key)
         detailPreviewLoadRegistry.invalidate(key)
-        detailPreviewImages.removeValue(forKey: key)
+        removeDetailPreviewImage(forKey: key)
         detailPreviewLoadingKeys.remove(key)
         unavailableDetailPreviews.remove(key)
         try? SavedMapSnapshotPreviewStore.delete(for: packURL)

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -1130,8 +1130,9 @@ private struct SavedMapRow: View {
                     finishRenaming()
                     focusedPackFilename = nil
                     presentedPreview = SavedMapPreviewPresentation(
+                        item: item,
                         displayName: displayName,
-                        image: previewImage
+                        fallbackImage: previewImage
                     )
                 } label: {
                     SavedMapThumbnail(image: previewImage)
@@ -1423,7 +1424,7 @@ private struct SavedMapRow: View {
             )
         }
         .sheet(item: $presentedPreview) { preview in
-            SavedMapPreviewSheet(preview: preview)
+            SavedMapPreviewSheet(manager: manager, preview: preview)
                 .presentationDetents([.large])
         }
     }
@@ -1436,32 +1437,54 @@ private struct SavedMapRow: View {
 }
 
 private struct SavedMapPreviewPresentation: Identifiable {
-    let id = UUID()
+    let item: SavedMapListItem
     let displayName: String
-    let image: UIImage
+    let fallbackImage: UIImage
+
+    var id: String { item.id }
 }
 
 private struct SavedMapPreviewSheet: View {
     @Environment(\.dismiss) private var dismiss
+    @ObservedObject var manager: OfflineMapManager
     let preview: SavedMapPreviewPresentation
 
     var body: some View {
+        let image = manager.detailPreviewImage(for: preview.item) ??
+            preview.fallbackImage
+
         NavigationView {
-            Image(uiImage: preview.image)
-                .resizable()
-                .scaledToFit()
-                .padding()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .background(Color(uiColor: .systemBackground))
-                .navigationTitle(preview.displayName)
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .cancellationAction) {
-                        Button("Close") {
-                            dismiss()
-                        }
+            ZStack(alignment: .bottom) {
+                Image(uiImage: image)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .padding()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    .accessibilityLabel("\(preview.displayName) map preview")
+
+                if manager.isDetailPreviewLoading(for: preview.item) {
+                    Label("Loading high-resolution preview", systemImage: "sparkles")
+                        .font(.caption)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(.thinMaterial, in: Capsule())
+                        .padding(.bottom, 12)
+                }
+            }
+            .background(Color(uiColor: .systemBackground))
+            .navigationTitle(preview.displayName)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") {
+                        dismiss()
                     }
                 }
+            }
+        }
+        .task(id: preview.id) {
+            await manager.loadDetailPreviewIfNeeded(for: preview.item)
         }
     }
 }

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -10609,10 +10609,20 @@ struct NavigationProtocolTests {
         assert(
             source.contains("presentedPreview = SavedMapPreviewPresentation(") &&
                 source.contains(".sheet(item: $presentedPreview)") &&
-                source.contains("SavedMapPreviewSheet(preview: preview)") &&
+                source.contains("SavedMapPreviewSheet(manager: manager, preview: preview)") &&
                 source.contains(".accessibilityLabel(\"Show preview for \\(displayName)\")") &&
                 source.contains("Button(\"Close\")"),
             "tapping an available saved-map thumbnail opens an accessible preview modal"
+        )
+        assert(
+            source.contains("manager.detailPreviewImage(for: preview.item)") &&
+                source.contains("Loading high-resolution preview") &&
+                source.contains(".interpolation(.high)") &&
+                source.contains(".task(id: preview.id)") &&
+                source.contains(
+                    "await manager.loadDetailPreviewIfNeeded(for: preview.item)"
+                ),
+            "the preview modal upgrades its thumbnail through cancellable Retina loading"
         )
         assert(
             source.contains("manager.savedMapListItems(") &&
@@ -10633,6 +10643,15 @@ struct NavigationProtocolTests {
                 managerSource.contains("OfflineMapFallbackPreviewRenderer.image") &&
                 !managerSource.contains("packURLs.forEach(cachePreviewIfAvailable)"),
             "saved-map previews load lazily and render bounds when an old pack has no image"
+        )
+        assert(
+            managerSource.contains("size: CGSize(width: 400, height: 240)") &&
+                managerSource.contains("scale: 3") &&
+                managerSource.contains("detail-preview-v\\(cacheVersion).png") &&
+                managerSource.contains("minimumLongestEdge: UInt32 = 600") &&
+                managerSource.contains("SavedMapSnapshotPreviewStore.save(") &&
+                managerSource.contains("SavedMapDetailPreviewStore.save("),
+            "thumbnail and versioned Retina detail previews use independent cache policies"
         )
         assert(
             managerSource.contains(

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -150,20 +150,32 @@ private func cropFixtureImage() -> UIImage {
     }
 }
 
-private func variedSnapshotPNG() -> Data {
+private func variedSnapshotPNG(
+    size: CGSize = CGSize(width: 160, height: 96)
+) -> Data {
     let format = UIGraphicsImageRendererFormat()
     format.scale = 1
     format.opaque = true
     let image = UIGraphicsImageRenderer(
-        size: CGSize(width: 160, height: 96),
+        size: size,
         format: format
     ).image { context in
         UIColor(red: 0.88, green: 0.86, blue: 0.75, alpha: 1).setFill()
-        context.cgContext.fill(CGRect(x: 0, y: 0, width: 160, height: 96))
+        context.cgContext.fill(CGRect(origin: .zero, size: size))
         UIColor(red: 0.28, green: 0.66, blue: 0.78, alpha: 1).setFill()
-        context.cgContext.fill(CGRect(x: 70, y: 0, width: 18, height: 96))
+        context.cgContext.fill(CGRect(
+            x: size.width * 0.4375,
+            y: 0,
+            width: size.width * 0.1125,
+            height: size.height
+        ))
         UIColor(red: 0.45, green: 0.43, blue: 0.40, alpha: 1).setFill()
-        context.cgContext.fill(CGRect(x: 0, y: 38, width: 160, height: 7))
+        context.cgContext.fill(CGRect(
+            x: 0,
+            y: size.height * 0.3958,
+            width: size.width,
+            height: size.height * 0.0729
+        ))
     }
     guard let data = image.pngData() else {
         fail("varied test snapshot should encode as PNG")
@@ -277,6 +289,13 @@ struct SavedMapPreviewCatalystTests {
 
         let outlinePNG = solidPNG(color: .systemBlue)
         let snapshotPNG = variedSnapshotPNG()
+        let detailSnapshotPNG = variedSnapshotPNG(
+            size: CGSize(width: 1_200, height: 720)
+        )
+        guard SavedMapDetailPreviewStore.isValidPNG(detailSnapshotPNG),
+              !SavedMapDetailPreviewStore.isValidPNG(snapshotPNG) else {
+            fail("detail cache should accept Retina output and reject thumbnail resolution")
+        }
         let snapshotMapID = "custom-map-snapshot"
         let snapshotPackURL = cacheDirectory
             .appendingPathComponent("\(snapshotMapID).zip")
@@ -657,9 +676,78 @@ struct SavedMapPreviewCatalystTests {
         guard restoredGenerationCount == 0 else {
             fail("persisted map snapshot should avoid an unnecessary MapKit request")
         }
+
+        do {
+            try SavedMapDetailPreviewStore.save(snapshotPNG, for: snapshotPackURL)
+            fail("thumbnail-resolution data must not enter the detail cache")
+        } catch {
+            // Expected: the versioned detail cache enforces a Retina-size floor.
+        }
+        var detailGenerationCount = 0
+        var detailGeneratedBounds: OfflineMapPreviewBounds?
+        let detailManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil },
+            detailMapSnapshot: { bounds in
+                detailGenerationCount += 1
+                detailGeneratedBounds = bounds
+                return detailSnapshotPNG
+            }
+        )
+        guard let detailItem = detailManager.savedMapListItems(
+            activeDeviceMap: nil
+        ).first(where: {
+            $0.packURL?.lastPathComponent == snapshotPackURL.lastPathComponent
+        }) else {
+            fail("saved-map detail fixture should appear in the local inventory")
+        }
+        await detailManager.loadDetailPreviewIfNeeded(for: detailItem)
+        guard detailGenerationCount == 1,
+              detailGeneratedBounds == expectedBounds,
+              imageMatchesPNG(
+                  detailManager.detailPreviewImage(for: detailItem),
+                  data: detailSnapshotPNG
+              ),
+              SavedMapDetailPreviewStore.imageData(for: snapshotPackURL) ==
+                  detailSnapshotPNG,
+              SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) ==
+                  snapshotPNG,
+              SavedMapDetailPreviewStore.imageURL(for: snapshotPackURL)
+                  .lastPathComponent.contains("detail-preview-v1") else {
+            fail("opening a saved map should generate an independent versioned Retina preview")
+        }
+
+        var restoredDetailGenerationCount = 0
+        let restoredDetailManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil },
+            detailMapSnapshot: { _ in
+                restoredDetailGenerationCount += 1
+                return nil
+            }
+        )
+        guard let restoredDetailItem = restoredDetailManager.savedMapListItems(
+            activeDeviceMap: nil
+        ).first(where: {
+            $0.packURL?.lastPathComponent == snapshotPackURL.lastPathComponent
+        }) else {
+            fail("restored saved-map detail fixture should remain in the inventory")
+        }
+        await restoredDetailManager.loadDetailPreviewIfNeeded(for: restoredDetailItem)
+        guard restoredDetailGenerationCount == 0,
+              imageMatchesPNG(
+                  restoredDetailManager.detailPreviewImage(for: restoredDetailItem),
+                  data: detailSnapshotPNG
+              ) else {
+            fail("the versioned Retina preview should survive relaunch without regeneration")
+        }
+
         restoredManager.deleteCachedPack(at: snapshotPackURL)
-        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil else {
-            fail("deleting a saved map should delete its persisted snapshot")
+        guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil,
+              SavedMapDetailPreviewStore.imageData(for: snapshotPackURL) == nil else {
+            fail("deleting a saved map should delete thumbnail and detail preview caches")
         }
 
         let cancellationMapID = "custom-map-cancel"
@@ -681,6 +769,58 @@ struct SavedMapPreviewCatalystTests {
         } catch {
             fail("cancellation test pack should write: \(error)")
         }
+        var detailSnapshotStarted = false
+        var detailSnapshotCancelled = false
+        let detailCancellationManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil },
+            detailMapSnapshot: { _ in
+                detailSnapshotStarted = true
+                do {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                    return detailSnapshotPNG
+                } catch is CancellationError {
+                    detailSnapshotCancelled = true
+                    throw CancellationError()
+                }
+            }
+        )
+        guard let detailCancellationItem = detailCancellationManager.savedMapListItems(
+            activeDeviceMap: nil
+        ).first(where: {
+            $0.packURL?.lastPathComponent == cancellationPackURL.lastPathComponent
+        }) else {
+            fail("detail cancellation fixture should appear in the local inventory")
+        }
+        let detailCancellationTask = Task { @MainActor in
+            await detailCancellationManager.loadDetailPreviewIfNeeded(
+                for: detailCancellationItem
+            )
+        }
+        let detailStartedDeadline = Date().addingTimeInterval(3)
+        while !detailSnapshotStarted && Date() < detailStartedDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard detailSnapshotStarted,
+              detailCancellationManager.isDetailPreviewLoading(
+                  for: detailCancellationItem
+              ) else {
+            fail("the sheet-owned detail request should enter its loading state")
+        }
+        detailCancellationTask.cancel()
+        await detailCancellationTask.value
+        guard detailSnapshotCancelled,
+              !detailCancellationManager.isDetailPreviewLoading(
+                  for: detailCancellationItem
+              ),
+              detailCancellationManager.detailPreviewImage(
+                  for: detailCancellationItem
+              ) == nil,
+              SavedMapDetailPreviewStore.imageData(for: cancellationPackURL) == nil else {
+            fail("cancelling the sheet task must stop and discard detail generation")
+        }
+
         var snapshotStarted = false
         var snapshotCancelled = false
         let cancellationManager = OfflineMapManager(
@@ -785,6 +925,7 @@ struct SavedMapPreviewCatalystTests {
             boundsE7: [1_209_000_000, 307_000_000, 1_219_500_000, 315_500_000]
         )!
         var deviceSnapshotGenerationCount = 0
+        var deviceDetailGenerationCount = 0
         let devicePreviewManager = OfflineMapManager(
             defaults: defaults,
             cacheDirectory: cacheDirectory,
@@ -794,6 +935,13 @@ struct SavedMapPreviewCatalystTests {
                 }
                 deviceSnapshotGenerationCount += 1
                 return snapshotPNG
+            },
+            detailMapSnapshot: { bounds in
+                guard bounds == expectedBounds else {
+                    fail("device-only detail preview should use its reported bounds")
+                }
+                deviceDetailGenerationCount += 1
+                return detailSnapshotPNG
             }
         )
         devicePreviewManager.updateActiveDeviceMap(deviceDescriptor)
@@ -821,16 +969,33 @@ struct SavedMapPreviewCatalystTests {
               DeviceMapSnapshotPreviewStore.imageData(
                   for: deviceDescriptor,
                   in: cacheDirectory
-              ) == snapshotPNG else {
+        ) == snapshotPNG else {
             fail("device-only map should generate and persist its MapKit preview")
+        }
+        await devicePreviewManager.loadDetailPreviewIfNeeded(for: deviceItem)
+        guard deviceDetailGenerationCount == 1,
+              imageMatchesPNG(
+                  devicePreviewManager.detailPreviewImage(for: deviceItem),
+                  data: detailSnapshotPNG
+              ),
+              DeviceMapDetailPreviewStore.imageData(
+                  for: deviceDescriptor,
+                  in: cacheDirectory
+              ) == detailSnapshotPNG else {
+            fail("device-only map should generate and persist a Retina detail preview")
         }
 
         var restoredDeviceGenerationCount = 0
+        var restoredDeviceDetailGenerationCount = 0
         let restoredDevicePreviewManager = OfflineMapManager(
             defaults: defaults,
             cacheDirectory: cacheDirectory,
             mapSnapshot: { _ in
                 restoredDeviceGenerationCount += 1
+                return nil
+            },
+            detailMapSnapshot: { _ in
+                restoredDeviceDetailGenerationCount += 1
                 return nil
             }
         )
@@ -852,12 +1017,27 @@ struct SavedMapPreviewCatalystTests {
               imageMatchesPNG(
                   restoredDevicePreviewManager.previewImage(for: restoredDeviceItem),
                   data: snapshotPNG
-              ) else {
+        ) else {
             fail("device preview cache should survive relaunch without another snapshot")
         }
+        await restoredDevicePreviewManager.loadDetailPreviewIfNeeded(
+            for: restoredDeviceItem
+        )
+        guard restoredDeviceDetailGenerationCount == 0,
+              imageMatchesPNG(
+                  restoredDevicePreviewManager.detailPreviewImage(
+                      for: restoredDeviceItem
+                  ),
+                  data: detailSnapshotPNG
+              ) else {
+            fail("device Retina preview cache should survive relaunch")
+        }
         restoredDevicePreviewManager.updateActiveDeviceMap(nil)
-        guard restoredDevicePreviewManager.previewImage(for: restoredDeviceItem) == nil else {
-            fail("disconnect should clear live device-only preview state")
+        guard restoredDevicePreviewManager.previewImage(for: restoredDeviceItem) == nil,
+              restoredDevicePreviewManager.detailPreviewImage(
+                  for: restoredDeviceItem
+              ) == nil else {
+            fail("disconnect should clear live device-only thumbnail and detail state")
         }
 
         let sessionlessDescriptorA = DeviceActiveMapDescriptor(
@@ -1015,6 +1195,57 @@ struct SavedMapPreviewCatalystTests {
         }
         guard OfflineMapSnapshotPreviewRenderer.hasMeaningfulVisualVariation(croppedFixture) else {
             fail("production renderer output should contain varied map content")
+        }
+
+        guard let detailSource = UIImage(data: detailSnapshotPNG)?.cgImage else {
+            fail("detail renderer fixture should decode")
+        }
+        let scaledDetailSource = UIImage(
+            cgImage: detailSource,
+            scale: 3,
+            orientation: .up
+        )
+        var capturedDetailSize: CGSize?
+        var capturedDetailScale: CGFloat?
+        let deterministicDetailData: Data
+        do {
+            guard let data = try await OfflineMapSnapshotPreviewRenderer.pngData(
+                for: expectedBounds,
+                configuration: .detail,
+                snapshot: { options in
+                    capturedDetailSize = options.size
+                    capturedDetailScale = options.scale
+                    return OfflineMapSnapshotPreviewRenderer.SnapshotResult(
+                        image: scaledDetailSource,
+                        pointForCoordinate: { coordinate in
+                            coordinatesMatch(coordinate, northWestCoordinate)
+                                ? .zero
+                                : CGPoint(x: 400, y: 240)
+                        }
+                    )
+                }
+            ) else {
+                fail("detail renderer should process a deterministic snapshot fixture")
+            }
+            deterministicDetailData = data
+        } catch {
+            fail("deterministic detail renderer should complete: \(error)")
+        }
+        guard capturedDetailSize == CGSize(width: 400, height: 240),
+              (capturedDetailScale ?? 0) >= 2,
+              let deterministicDetailImage = UIImage(data: deterministicDetailData),
+              deterministicDetailImage.cgImage?.width == 1_200,
+              deterministicDetailImage.cgImage?.height == 720,
+              SavedMapDetailPreviewStore.isValidPNG(deterministicDetailData) else {
+            fail(
+                "detail renderer should produce a cacheable 1200x720 Retina PNG " +
+                    "(request: \(String(describing: capturedDetailSize)) @ " +
+                    "\(String(describing: capturedDetailScale)), pixels: " +
+                    "\(String(describing: UIImage(data: deterministicDetailData)?.cgImage?.width))x" +
+                    "\(String(describing: UIImage(data: deterministicDetailData)?.cgImage?.height)), " +
+                    "bytes: \(deterministicDetailData.count), valid: " +
+                    "\(SavedMapDetailPreviewStore.isValidPNG(deterministicDetailData)))"
+            )
         }
 
         do {

--- a/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
+++ b/ios-app/BikeComputerTests/SavedMapPreviewCatalystTests.swift
@@ -744,6 +744,46 @@ struct SavedMapPreviewCatalystTests {
             fail("the versioned Retina preview should survive relaunch without regeneration")
         }
 
+        let memoryPackData: Data
+        do {
+            memoryPackData = try Data(contentsOf: snapshotPackURL)
+        } catch {
+            fail("detail memory fixture should read: \(error)")
+        }
+        let memoryPackURLs = (0..<4).map { index in
+            cacheDirectory.appendingPathComponent("detail-memory-\(index).zip")
+        }
+        do {
+            for url in memoryPackURLs {
+                try memoryPackData.write(to: url)
+            }
+        } catch {
+            fail("detail memory fixtures should write: \(error)")
+        }
+        let detailMemoryManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil },
+            detailMapSnapshot: { _ in detailSnapshotPNG }
+        )
+        let detailMemoryItems = memoryPackURLs.compactMap { url in
+            detailMemoryManager.savedMapListItems(activeDeviceMap: nil).first {
+                $0.packURL?.lastPathComponent == url.lastPathComponent
+            }
+        }
+        guard detailMemoryItems.count == memoryPackURLs.count else {
+            fail("all detail memory fixtures should appear in the local inventory")
+        }
+        for item in detailMemoryItems {
+            await detailMemoryManager.loadDetailPreviewIfNeeded(for: item)
+        }
+        guard detailMemoryManager.detailPreviewImage(for: detailMemoryItems[0]) == nil,
+              detailMemoryItems.dropFirst().allSatisfy({
+                  detailMemoryManager.detailPreviewImage(for: $0) != nil
+              }) else {
+            fail("decoded Retina previews should retain only the three most recent maps")
+        }
+
         restoredManager.deleteCachedPack(at: snapshotPackURL)
         guard SavedMapSnapshotPreviewStore.imageData(for: snapshotPackURL) == nil,
               SavedMapDetailPreviewStore.imageData(for: snapshotPackURL) == nil else {
@@ -819,6 +859,60 @@ struct SavedMapPreviewCatalystTests {
               ) == nil,
               SavedMapDetailPreviewStore.imageData(for: cancellationPackURL) == nil else {
             fail("cancelling the sheet task must stop and discard detail generation")
+        }
+
+        var supersedingDetailRequestCount = 0
+        let supersedingDetailManager = OfflineMapManager(
+            defaults: defaults,
+            cacheDirectory: cacheDirectory,
+            mapSnapshot: { _ in nil },
+            detailMapSnapshot: { _ in
+                supersedingDetailRequestCount += 1
+                if supersedingDetailRequestCount == 1 {
+                    try await Task.sleep(nanoseconds: 5_000_000_000)
+                }
+                return detailSnapshotPNG
+            }
+        )
+        guard let supersedingDetailItem = supersedingDetailManager.savedMapListItems(
+            activeDeviceMap: nil
+        ).first(where: {
+            $0.packURL?.lastPathComponent == cancellationPackURL.lastPathComponent
+        }) else {
+            fail("superseding detail fixture should appear in the local inventory")
+        }
+        let firstDetailTask = Task { @MainActor in
+            await supersedingDetailManager.loadDetailPreviewIfNeeded(
+                for: supersedingDetailItem
+            )
+        }
+        let firstDetailDeadline = Date().addingTimeInterval(3)
+        while supersedingDetailRequestCount < 1 && Date() < firstDetailDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let secondDetailTask = Task { @MainActor in
+            await supersedingDetailManager.loadDetailPreviewIfNeeded(
+                for: supersedingDetailItem
+            )
+        }
+        let secondDetailDeadline = Date().addingTimeInterval(1)
+        while supersedingDetailRequestCount < 2 && Date() < secondDetailDeadline {
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        guard supersedingDetailRequestCount == 2 else {
+            firstDetailTask.cancel()
+            await firstDetailTask.value
+            await secondDetailTask.value
+            fail("a reopened sheet should supersede an unwinding detail request")
+        }
+        firstDetailTask.cancel()
+        await firstDetailTask.value
+        await secondDetailTask.value
+        guard imageMatchesPNG(
+            supersedingDetailManager.detailPreviewImage(for: supersedingDetailItem),
+            data: detailSnapshotPNG
+        ) else {
+            fail("the superseding detail request should publish its Retina preview")
         }
 
         var snapshotStarted = false


### PR DESCRIPTION
## Summary

- keep the lightweight Saved Maps thumbnail for immediate display
- generate and cache a dedicated 1200x720 Retina preview when the detail sheet opens
- version local and device-only detail caches and invalidate them on replacement, deletion, or disconnect
- cancel in-flight detail rendering when the preview sheet is dismissed
- add regression coverage for resolution, persistence, invalidation, cancellation, and device-only maps

## Testing

- `ios-app/scripts/run-navigation-tests.sh`
- focused `SavedMapPreviewCatalystTests` run
- unsigned BikeComputer iOS Simulator build with `CODE_SIGNING_ALLOWED=NO`
- `git diff --check`