### PR TITLE
Protect firmware signing behind a default-branch publisher

### DIFF
--- a/.github/scripts/changed_components.py
+++ b/.github/scripts/changed_components.py
@@ -31,6 +31,7 @@ FIRMWARE_HOST_ONLY_PATH_PREFIXES = ("esp32/tools/tests/",)
 FIRMWARE_HOST_PATH_PREFIXES = (".github/actions/require-immutable-releases/",)
 FIRMWARE_WORKFLOW_PATHS = {
     ".github/workflows/firmware-diagnostics.yml",
+    ".github/workflows/firmware-release-candidate.yml",
     ".github/workflows/firmware-release.yml",
     ".github/workflows/firmware-runtime-performance.yml",
     ".github/workflows/firmware-runtime-publish.yml",
@@ -57,7 +58,9 @@ FIRMWARE_MANIFEST_PATHS = {
 }
 RIDE_DIAGNOSTICS_TOOL_PATHS = {"tools/ride_diagnostics.py"}
 FIRMWARE_RELEASE_TOOL_PATHS = {
+    ".github/scripts/firmware_release_gate.py",
     "tools/factory_release_manifest.py",
+    "tools/firmware_release_candidate.py",
     "tools/firmware-signing-requirements.txt",
     "tools/verify_github_release_assets.py",
 }

--- a/.github/scripts/firmware_release_gate.py
+++ b/.github/scripts/firmware_release_gate.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Validate an unprivileged firmware candidate before privileged publication."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+import tempfile
+
+
+EXPECTED_WORKFLOW_NAME = "Firmware Release Candidate"
+EXPECTED_ARTIFACTS = {
+    "firmware-WAVESHARE_AMOLED_175",
+    "firmware-WAVESHARE_AMOLED_206",
+}
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256_DIGEST = re.compile(r"^sha256:[0-9a-f]{64}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RELEASE_TAG = re.compile(
+    r"^v[0-9]+\.[0-9]+\.[0-9]+(?:[.-][A-Za-z0-9][A-Za-z0-9.-]*)?$"
+)
+WORKFLOW_PATH = re.compile(r"^\.github/workflows/[A-Za-z0-9_.-]+\.ya?ml$")
+MAX_EVENT_BYTES = 2 * 1024 * 1024
+MAX_API_BYTES = 1024 * 1024
+MAX_ARTIFACT_BYTES = 96 * 1024 * 1024
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"JSON contains duplicate key: {key}")
+        value[key] = item
+    return value
+
+
+def _load_json(path: pathlib.Path, maximum_bytes: int) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"JSON input is missing or unsafe: {path}")
+    encoded = path.read_bytes()
+    if not encoded or len(encoded) > maximum_bytes:
+        raise ValueError(f"JSON input has an invalid size: {path}")
+    try:
+        value = json.loads(
+            encoded.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"JSON input is invalid: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON input must contain an object: {path}")
+    return value
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
+def _write_atomic(path: pathlib.Path, value: object) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise ValueError(f"output path is unsafe: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as stream:
+            temporary = stream.name
+            stream.write(_canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            pathlib.Path(temporary).unlink(missing_ok=True)
+
+
+def _positive_int(value: object, label: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value <= 0:
+        raise ValueError(f"{label} must be a positive integer")
+    return value
+
+
+def _object(value: object, label: str) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise ValueError(f"{label} must be an object")
+    return value
+
+
+def validate_gate(
+    event: dict[str, object],
+    workflow: dict[str, object],
+    artifacts: dict[str, object],
+    *,
+    repository: str,
+    expected_workflow_path: str,
+) -> dict[str, object]:
+    """Return a canonical gate receipt or reject the workflow-run boundary."""
+
+    if REPOSITORY.fullmatch(repository) is None:
+        raise ValueError("expected repository is invalid")
+    if WORKFLOW_PATH.fullmatch(expected_workflow_path) is None:
+        raise ValueError("expected workflow path is invalid")
+    if event.get("action") != "completed":
+        raise ValueError("candidate workflow event is not completed")
+    event_repository = _object(event.get("repository"), "event repository")
+    if event_repository.get("full_name") != repository:
+        raise ValueError("candidate event repository does not match")
+
+    workflow_id = _positive_int(workflow.get("id"), "expected workflow ID")
+    if (
+        workflow.get("name") != EXPECTED_WORKFLOW_NAME
+        or workflow.get("path") != expected_workflow_path
+        or workflow.get("state") != "active"
+    ):
+        raise ValueError("expected candidate workflow identity does not match")
+
+    run = _object(event.get("workflow_run"), "candidate workflow run")
+    run_id = _positive_int(run.get("id"), "candidate run ID")
+    run_repository = _object(
+        run.get("head_repository"), "candidate head repository"
+    )
+    event_path = str(run.get("path", "")).split("@", 1)[0]
+    tag = run.get("head_branch")
+    git_sha = run.get("head_sha")
+    if (
+        run.get("workflow_id") != workflow_id
+        or run.get("name") != EXPECTED_WORKFLOW_NAME
+        or event_path != expected_workflow_path
+        or run.get("event") != "push"
+        or run.get("status") != "completed"
+        or run.get("conclusion") != "success"
+        or run.get("run_attempt") != 1
+        or run_repository.get("full_name") != repository
+        or not isinstance(tag, str)
+        or RELEASE_TAG.fullmatch(tag) is None
+        or not isinstance(git_sha, str)
+        or FULL_SHA.fullmatch(git_sha) is None
+    ):
+        raise ValueError("candidate workflow run identity does not match")
+
+    artifact_values = artifacts.get("artifacts")
+    if not isinstance(artifact_values, list):
+        raise ValueError("candidate artifact response has no artifact list")
+    if artifacts.get("total_count") != len(artifact_values):
+        raise ValueError("candidate artifact response is incomplete")
+    inventory: list[dict[str, object]] = []
+    names: set[str] = set()
+    ids: set[int] = set()
+    for raw_artifact in artifact_values:
+        artifact = _object(raw_artifact, "candidate artifact")
+        name = artifact.get("name")
+        if name not in EXPECTED_ARTIFACTS:
+            continue
+        artifact_id = _positive_int(artifact.get("id"), "candidate artifact ID")
+        size = artifact.get("size_in_bytes")
+        digest = artifact.get("digest")
+        artifact_run = _object(
+            artifact.get("workflow_run"), "candidate artifact workflow run"
+        )
+        if (
+            name in names
+            or artifact_id in ids
+            or isinstance(size, bool)
+            or not isinstance(size, int)
+            or size <= 0
+            or size > MAX_ARTIFACT_BYTES
+            or not isinstance(digest, str)
+            or SHA256_DIGEST.fullmatch(digest) is None
+            or artifact.get("expired") is not False
+            or artifact_run.get("id") != run_id
+            or artifact_run.get("head_sha") != git_sha
+        ):
+            raise ValueError("candidate artifact identity does not match")
+        names.add(name)
+        ids.add(artifact_id)
+        inventory.append(
+            {
+                "id": artifact_id,
+                "name": name,
+                "size": size,
+                "digest": digest,
+            }
+        )
+    if names != EXPECTED_ARTIFACTS:
+        raise ValueError("candidate artifact set is not exact")
+
+    return {
+        "schemaVersion": 1,
+        "repository": repository,
+        "workflowId": workflow_id,
+        "candidateRunId": run_id,
+        "candidateRunAttempt": 1,
+        "tag": tag,
+        "gitSha": git_sha,
+        "artifacts": sorted(inventory, key=lambda item: str(item["name"])),
+    }
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--event", type=pathlib.Path, required=True)
+    parser.add_argument("--workflow", type=pathlib.Path, required=True)
+    parser.add_argument("--artifacts", type=pathlib.Path, required=True)
+    parser.add_argument("--repository", required=True)
+    parser.add_argument("--expected-workflow-path", required=True)
+    parser.add_argument("--github-output", type=pathlib.Path, required=True)
+    parser.add_argument("--output-receipt", type=pathlib.Path, required=True)
+    args = parser.parse_args(argv)
+    try:
+        receipt = validate_gate(
+            _load_json(args.event, MAX_EVENT_BYTES),
+            _load_json(args.workflow, MAX_API_BYTES),
+            _load_json(args.artifacts, MAX_API_BYTES),
+            repository=args.repository,
+            expected_workflow_path=args.expected_workflow_path,
+        )
+        _write_atomic(args.output_receipt, receipt)
+        if args.github_output.is_symlink() or not args.github_output.is_file():
+            raise ValueError("GitHub output path is missing or unsafe")
+        with args.github_output.open("a", encoding="utf-8", newline="\n") as stream:
+            stream.write(f"candidate_run_id={receipt['candidateRunId']}\n")
+            stream.write(f"release_tag={receipt['tag']}\n")
+            stream.write(f"git_sha={receipt['gitSha']}\n")
+        print(json.dumps(receipt, sort_keys=True))
+        return 0
+    except (OSError, ValueError) as error:
+        print(f"firmware release gate failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/.github/scripts/tests/test_changed_components.py
+++ b/.github/scripts/tests/test_changed_components.py
@@ -47,6 +47,7 @@ class ChangedComponentsTests(unittest.TestCase):
             "esp32/tools/tests/test_build_firmware.py",
             "tools/tests/test_future_release_tool.py",
             ".github/actions/require-immutable-releases/action.yml",
+            ".github/workflows/firmware-release-candidate.yml",
             ".github/workflows/firmware-release.yml",
             "docs/firmware-build-provenance.md",
         ):
@@ -158,7 +159,9 @@ class ChangedComponentsTests(unittest.TestCase):
 
     def test_release_tools_select_firmware_only(self) -> None:
         for path in (
+            ".github/scripts/firmware_release_gate.py",
             "tools/factory_release_manifest.py",
+            "tools/firmware_release_candidate.py",
             "tools/firmware-signing-requirements.txt",
             "tools/verify_github_release_assets.py",
         ):

--- a/.github/scripts/tests/test_firmware_release_gate.py
+++ b/.github/scripts/tests/test_firmware_release_gate.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import copy
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "firmware_release_gate.py"
+SPEC = importlib.util.spec_from_file_location("firmware_release_gate", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+gate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(gate)
+
+REPOSITORY = "owner/repository"
+WORKFLOW_PATH = ".github/workflows/firmware-release-candidate.yml"
+GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+class FirmwareReleaseGateTests(unittest.TestCase):
+    def fixture(self) -> tuple[dict, dict, dict]:
+        workflow = {
+            "id": 91,
+            "name": gate.EXPECTED_WORKFLOW_NAME,
+            "path": WORKFLOW_PATH,
+            "state": "active",
+        }
+        run = {
+            "id": 1234,
+            "workflow_id": 91,
+            "name": gate.EXPECTED_WORKFLOW_NAME,
+            "path": f"{WORKFLOW_PATH}@refs/tags/v1.2.3-release.4",
+            "event": "push",
+            "status": "completed",
+            "conclusion": "success",
+            "run_attempt": 1,
+            "head_branch": "v1.2.3-release.4",
+            "head_sha": GIT_SHA,
+            "head_repository": {"full_name": REPOSITORY},
+        }
+        event = {
+            "action": "completed",
+            "repository": {"full_name": REPOSITORY},
+            "workflow_run": run,
+        }
+        artifacts = {
+            "total_count": 2,
+            "artifacts": [
+                {
+                    "id": index,
+                    "name": target,
+                    "size_in_bytes": 1024 + index,
+                    "digest": f"sha256:{str(index)[-1] * 64}",
+                    "expired": False,
+                    "workflow_run": {"id": 1234, "head_sha": GIT_SHA},
+                }
+                for index, target in enumerate(
+                    gate.EXPECTED_ARTIFACTS, start=100
+                )
+            ],
+        }
+        return event, workflow, artifacts
+
+    def validate(self, event: dict, workflow: dict, artifacts: dict) -> dict:
+        return gate.validate_gate(
+            event,
+            workflow,
+            artifacts,
+            repository=REPOSITORY,
+            expected_workflow_path=WORKFLOW_PATH,
+        )
+
+    def test_accepts_exact_first_attempt_candidate_and_artifacts(self) -> None:
+        event, workflow, artifacts = self.fixture()
+        artifacts["artifacts"].append(
+            {"id": 999, "name": "unrelated-ci-diagnostics"}
+        )
+        artifacts["total_count"] = 3
+
+        receipt = self.validate(event, workflow, artifacts)
+
+        self.assertEqual(1234, receipt["candidateRunId"])
+        self.assertEqual("v1.2.3-release.4", receipt["tag"])
+        self.assertEqual(GIT_SHA, receipt["gitSha"])
+        self.assertEqual(
+            sorted(gate.EXPECTED_ARTIFACTS),
+            [artifact["name"] for artifact in receipt["artifacts"]],
+        )
+
+    def test_rejects_wrong_or_replayed_workflow_identity(self) -> None:
+        mutations = {
+            "event repository": lambda event, workflow, artifacts: event[
+                "repository"
+            ].update(full_name="attacker/fork"),
+            "head repository": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ]["head_repository"].update(full_name="attacker/fork"),
+            "workflow id": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(workflow_id=92),
+            "workflow name": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(name="Lookalike"),
+            "workflow path": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(path=".github/workflows/lookalike.yml"),
+            "inactive workflow": lambda event, workflow, artifacts: workflow.update(
+                state="disabled_manually"
+            ),
+            "wrong event": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(event="workflow_dispatch"),
+            "not completed": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(status="in_progress"),
+            "failed": lambda event, workflow, artifacts: event["workflow_run"].update(
+                conclusion="failure"
+            ),
+            "rerun": lambda event, workflow, artifacts: event["workflow_run"].update(
+                run_attempt=2
+            ),
+            "unsafe tag": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(head_branch="release/latest"),
+            "short sha": lambda event, workflow, artifacts: event[
+                "workflow_run"
+            ].update(head_sha="abc123"),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                event, workflow, artifacts = copy.deepcopy(self.fixture())
+                mutate(event, workflow, artifacts)
+                with self.assertRaises(ValueError):
+                    self.validate(event, workflow, artifacts)
+
+    def test_rejects_incomplete_or_unsafe_artifact_inventory(self) -> None:
+        mutations = {
+            "missing": lambda artifacts: artifacts["artifacts"].pop(),
+            "wrong total": lambda artifacts: artifacts.update(total_count=3),
+            "unexpected": lambda artifacts: artifacts["artifacts"][0].update(
+                name="firmware-other"
+            ),
+            "duplicate": lambda artifacts: artifacts["artifacts"][0].update(
+                name=artifacts["artifacts"][1]["name"]
+            ),
+            "expired": lambda artifacts: artifacts["artifacts"][0].update(
+                expired=True
+            ),
+            "oversized": lambda artifacts: artifacts["artifacts"][0].update(
+                size_in_bytes=gate.MAX_ARTIFACT_BYTES + 1
+            ),
+            "bad digest": lambda artifacts: artifacts["artifacts"][0].update(
+                digest="sha256:abc"
+            ),
+            "wrong run": lambda artifacts: artifacts["artifacts"][0][
+                "workflow_run"
+            ].update(id=99),
+            "wrong sha": lambda artifacts: artifacts["artifacts"][0][
+                "workflow_run"
+            ].update(head_sha="f" * 40),
+        }
+        for label, mutate in mutations.items():
+            with self.subTest(label=label):
+                event, workflow, artifacts = copy.deepcopy(self.fixture())
+                mutate(artifacts)
+                with self.assertRaises(ValueError):
+                    self.validate(event, workflow, artifacts)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW_ROOT = REPO_ROOT / ".github" / "workflows"
+CACHE_ACTION_SHA = "55cc8345863c7cc4c66a329aec7e433d2d1c52a9"
 CORE_FIRMWARE_TARGETS = {
     "WAVESHARE_AMOLED_175",
     "WAVESHARE_AMOLED_175_PRODUCTION",
@@ -144,7 +145,7 @@ def sequence_mapping_blocks(
 
 def is_verified_download_cache_step(step: str) -> bool:
     if not re.search(
-        r"(?m)^uses:\s*actions/cache@v6\s*(?:#.*)?$",
+        rf"(?m)^uses:\s*actions/cache@(?:v6|{CACHE_ACTION_SHA})\s*(?:#.*)?$",
         step,
     ):
         return False
@@ -453,6 +454,7 @@ class WorkflowPolicyTests(unittest.TestCase):
     def test_release_tags_use_one_gated_validation_orchestrator(self) -> None:
         general_ci = workflow_source("ci.yml")
         diagnostic_ci = workflow_source("firmware-diagnostics.yml")
+        candidate = workflow_source("firmware-release-candidate.yml")
         release = workflow_source("firmware-release.yml")
 
         self.assertIn("  workflow_call:\n", general_ci)
@@ -460,22 +462,56 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertNotIn('      - "v*"', general_ci)
         self.assertIn("  workflow_call:\n", diagnostic_ci)
         self.assertNotIn('      - "v*"', diagnostic_ci)
-        self.assertIn('      - "v*"', release)
-        self.assertIn("uses: ./.github/workflows/ci.yml", release)
-        self.assertIn("firmware_hardware: all", release)
+        self.assertIn('      - "v*"', candidate)
+        self.assertNotIn('      - "v*"', release)
+        self.assertIn("uses: ./.github/workflows/ci.yml", candidate)
+        self.assertIn("firmware_hardware: all", candidate)
         self.assertIn(
-            "uses: ./.github/workflows/firmware-diagnostics.yml", release
+            "uses: ./.github/workflows/firmware-diagnostics.yml", candidate
         )
-        self.assertIn("      - build\n      - diagnostics\n      - validate\n", release)
-        release_permissions = mapping_block(release, "permissions", indent=0)
-        self.assertIn("  attestations: read", release_permissions)
-        self.assertIn("  contents: read", release_permissions)
-        self.assertIn("  packages: read", release_permissions)
+        self.assertIn(
+            "      - build\n      - diagnostics\n      - validate\n", candidate
+        )
+        candidate_permissions = mapping_block(candidate, "permissions", indent=0)
+        self.assertIn("  attestations: read", candidate_permissions)
+        self.assertIn("  contents: read", candidate_permissions)
+        self.assertIn("  packages: read", candidate_permissions)
+        self.assertNotIn("write", candidate_permissions)
+        self.assertNotIn("secrets.", candidate)
+        self.assertNotRegex(candidate, r"(?m)^    environment:")
+
+        self.assertIn("  workflow_run:\n", release)
+        self.assertIn("      - Firmware Release Candidate", release)
+        gate_job = mapping_block(release, "gate", indent=2)
+        self.assertIn("firmware_release_gate.py", gate_job)
+        self.assertIn("run_attempt", (
+            REPO_ROOT / ".github" / "scripts" / "firmware_release_gate.py"
+        ).read_text(encoding="utf-8"))
+        self.assertIn("git merge-base --is-ancestor", gate_job)
+        self.assertIn('"${RELEASE_TAG}^{commit}"', gate_job)
+        self.assertIn("ref: ${{ github.sha }}", gate_job)
         publish_job = mapping_block(release, "publish", indent=2)
+        self.assertIn("needs: gate", publish_job)
+        self.assertIn("environment: firmware-release", publish_job)
         self.assertIn("contents: write", publish_job)
-        self.assertIn("pages: write", publish_job)
+        self.assertNotIn("pages: write", publish_job)
+        self.assertNotIn(
+            "    env:\n      GH_TOKEN: ${{ github.token }}\n      FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY",
+            publish_job,
+        )
+        signing_step = next(
+            block
+            for block in sequence_mapping_blocks(publish_job, "steps", indent=4)
+            if "name: Generate signed manifests" in block
+        )
+        self.assertIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", signing_step)
+        self.assertIn("Re-resolve the protected branch and release tag", publish_job)
+        deploy_job = mapping_block(release, "deploy-pages", indent=2)
+        self.assertIn("pages: write", deploy_job)
+        self.assertNotIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", deploy_job)
 
     def test_release_publishes_signed_factory_flash_bundles(self) -> None:
+        candidate = workflow_source("firmware-release-candidate.yml")
         release = workflow_source("firmware-release.yml")
         immutable_preflight = (
             REPO_ROOT
@@ -485,13 +521,19 @@ class WorkflowPolicyTests(unittest.TestCase):
             / "action.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertIn("--factory-output-dir dist", release)
-        self.assertNotIn("tools/package_factory_firmware.py", release)
-        self.assertIn('"${target}.factory.tar.gz"', release)
-        self.assertIn('"${target}.factory-bundle.json"', release)
+        self.assertIn("--factory-output-dir dist", candidate)
+        self.assertIn("firmware_release_candidate.py record", candidate)
+        self.assertNotIn("tools/package_factory_firmware.py", candidate)
+        self.assertNotIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", candidate)
+        self.assertIn("firmware_release_candidate.py verify", release)
+        self.assertIn("firmware_release_candidate.py extract", release)
+        self.assertIn("actions/artifacts/${artifact_id}/zip", release)
+        self.assertIn("sha256sum", release)
+        self.assertIn("${target}.factory.tar.gz", release)
+        self.assertIn("${target}.factory-bundle.json", release)
         self.assertIn("tools/factory_release_manifest.py", release)
         self.assertIn(
-            '--output "release-assets/${target}.factory-release.json"',
+            '--output "${release_assets}/${target}.factory-release.json"',
             release,
         )
         self.assertNotIn("find dist -name '*.bin'", release)
@@ -534,8 +576,14 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn("--require-immutable", recovery)
         self.assertIn('gh release verify "${RELEASE_TAG}"', recovery)
         self.assertIn('gh release verify-asset "${RELEASE_TAG}"', recovery)
-        self.assertIn("actions/upload-pages-artifact@v3", recovery)
-        self.assertIn("actions/deploy-pages@v4", recovery)
+        self.assertIn(
+            "actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa",
+            recovery,
+        )
+        self.assertIn(
+            "actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e",
+            recovery,
+        )
         self.assertNotIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", recovery)
 
     def test_production_ci_extracts_and_checks_factory_bundles(self) -> None:

--- a/.github/workflows/firmware-release-candidate.yml
+++ b/.github/workflows/firmware-release-candidate.yml
@@ -1,0 +1,100 @@
+name: Firmware Release Candidate
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  attestations: read
+  contents: read
+  packages: read
+
+concurrency:
+  group: firmware-release-candidate-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate release CI
+    uses: ./.github/workflows/ci.yml
+    with:
+      scope: all
+      firmware_hardware: all
+
+  diagnostics:
+    name: Validate diagnostic firmware
+    uses: ./.github/workflows/firmware-diagnostics.yml
+
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: WAVESHARE_AMOLED_175
+            environment: WAVESHARE_AMOLED_175_PRODUCTION
+          - target: WAVESHARE_AMOLED_206
+            environment: WAVESHARE_AMOLED_206_PRODUCTION
+    defaults:
+      run:
+        working-directory: esp32
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Restore pinned PlatformIO downloads
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
+        with:
+          path: esp32/.pio/open-bike-build/downloads
+          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
+      - name: Build with the repository-owned firmware runtime
+        run: env -u LD_LIBRARY_PATH python3 tools/build_firmware.py "${{ matrix.environment }}" --factory-output-dir dist
+      - name: Bind the exact release candidate
+        env:
+          RELEASE_TARGET: ${{ matrix.target }}
+          RELEASE_ENVIRONMENT: ${{ matrix.environment }}
+          RELEASE_REPOSITORY: ${{ github.repository }}
+          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_GIT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          cp ".pio/build/${RELEASE_ENVIRONMENT}/firmware.bin" "dist/${RELEASE_TARGET}.bin"
+          python3 ../tools/firmware_release_candidate.py record \
+            --artifact-dir dist \
+            --output dist/candidate-receipt.json \
+            --target "${RELEASE_TARGET}" \
+            --environment "${RELEASE_ENVIRONMENT}" \
+            --repository "${RELEASE_REPOSITORY}" \
+            --tag "${RELEASE_TAG}" \
+            --git-sha "${RELEASE_GIT_SHA}"
+          shasum -a 256 dist/*
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: firmware-${{ matrix.target }}
+          path: esp32/dist/
+          if-no-files-found: error
+          retention-days: 14
+
+  ready:
+    name: Release candidate ready
+    if: ${{ always() }}
+    needs:
+      - build
+      - diagnostics
+      - validate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    env:
+      BUILD_RESULT: ${{ needs.build.result }}
+      DIAGNOSTICS_RESULT: ${{ needs.diagnostics.result }}
+      VALIDATE_RESULT: ${{ needs.validate.result }}
+    steps:
+      - name: Require every candidate gate
+        run: |
+          set -euo pipefail
+          test "${BUILD_RESULT}" = success
+          test "${DIAGNOSTICS_RESULT}" = success
+          test "${VALIDATE_RESULT}" = success

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -1,9 +1,11 @@
 name: Firmware Release
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_run:
+    workflows:
+      - Firmware Release Candidate
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       release_tag:
@@ -12,129 +14,259 @@ on:
         type: string
 
 permissions:
-  attestations: read
+  actions: read
   contents: read
-  packages: read
+
+concurrency:
+  group: firmware-release-${{ github.event.workflow_run.id || inputs.release_tag }}
+  cancel-in-progress: false
 
 jobs:
-  validate:
-    name: Validate release CI
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/ci.yml
-    with:
-      scope: all
-      firmware_hardware: all
-
-  diagnostics:
-    name: Validate diagnostic firmware
-    if: github.event_name == 'push'
-    uses: ./.github/workflows/firmware-diagnostics.yml
-
-  build:
-    name: Build ${{ matrix.target }}
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: WAVESHARE_AMOLED_175
-            environment: WAVESHARE_AMOLED_175_PRODUCTION
-          - target: WAVESHARE_AMOLED_206
-            environment: WAVESHARE_AMOLED_206_PRODUCTION
-    defaults:
-      run:
-        working-directory: esp32
+  gate:
+    name: Gate unprivileged release candidate
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    outputs:
+      candidate_run_id: ${{ steps.candidate.outputs.candidate_run_id }}
+      git_sha: ${{ steps.candidate.outputs.git_sha }}
+      release_tag: ${{ steps.candidate.outputs.release_tag }}
     steps:
-      - uses: actions/checkout@v7
-      - name: Restore pinned PlatformIO downloads
-        uses: actions/cache@v6
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
-          path: esp32/.pio/open-bike-build/downloads
-          key: esp32-pinned-downloads-${{ runner.os }}-${{ hashFiles('esp32/tools/generated_sdkconfig.py') }}
-      - name: Build with the repository-owned firmware runtime
-        run: env -u LD_LIBRARY_PATH python3 tools/build_firmware.py "${{ matrix.environment }}" --factory-output-dir dist
-      - name: Stage OTA image and factory-flash bundle
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Read the registered workflow and candidate artifacts
+        env:
+          CANDIDATE_RUN_ID: ${{ github.event.workflow_run.id }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          cp ".pio/build/${{ matrix.environment }}/firmware.bin" "dist/${{ matrix.target }}.bin"
-          shasum -a 256 dist/*
-      - uses: actions/upload-artifact@v4
+          [[ "${CANDIDATE_RUN_ID}" =~ ^[1-9][0-9]*$ ]]
+          gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/firmware-release-candidate.yml" \
+            > "${RUNNER_TEMP}/candidate-workflow.json"
+          gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${CANDIDATE_RUN_ID}/artifacts?per_page=100" \
+            > "${RUNNER_TEMP}/candidate-artifacts.json"
+      - id: candidate
+        name: Validate the candidate workflow boundary
+        run: |
+          python3 .github/scripts/firmware_release_gate.py \
+            --event "${GITHUB_EVENT_PATH}" \
+            --workflow "${RUNNER_TEMP}/candidate-workflow.json" \
+            --artifacts "${RUNNER_TEMP}/candidate-artifacts.json" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --expected-workflow-path .github/workflows/firmware-release-candidate.yml \
+            --github-output "${GITHUB_OUTPUT}" \
+            --output-receipt "${RUNNER_TEMP}/firmware-release-gate.json"
+      - name: Require an unchanged tag on protected main and no existing release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GIT_SHA: ${{ steps.candidate.outputs.git_sha }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ steps.candidate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          git check-ref-format --branch "${DEFAULT_BRANCH}" >/dev/null
+          git fetch --force --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          git fetch --force --no-tags origin \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          test "$(git rev-parse "${RELEASE_TAG}^{commit}")" = "${GIT_SHA}"
+          git merge-base --is-ancestor \
+            "${GIT_SHA}" "refs/remotes/origin/${DEFAULT_BRANCH}"
+
+          set +e
+          gh api --include -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
+            > "${RUNNER_TEMP}/release-response.txt" 2> "${RUNNER_TEMP}/release-error.txt"
+          api_status=$?
+          set -e
+          http_status="$(awk '/^HTTP\// { status=$2 } END { print status }' \
+            "${RUNNER_TEMP}/release-response.txt")"
+          if [ "${http_status}" = 200 ]; then
+            echo "Release ${RELEASE_TAG} already exists; refusing to replace assets" >&2
+            exit 1
+          fi
+          if [ "${http_status}" != 404 ] || [ "${api_status}" -eq 0 ]; then
+            cat "${RUNNER_TEMP}/release-error.txt" >&2
+            echo "Unable to prove that release ${RELEASE_TAG} does not exist" >&2
+            exit 1
+          fi
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: firmware-${{ matrix.target }}
-          path: esp32/dist/
+          name: firmware-release-gate-${{ github.event.workflow_run.id }}
+          path: ${{ runner.temp }}/firmware-release-gate.json
           if-no-files-found: error
+          retention-days: 90
 
   publish:
-    name: Publish Firmware
-    if: github.event_name == 'push'
-    runs-on: ubuntu-latest
-    needs:
-      - build
-      - diagnostics
-      - validate
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+    name: Approval-gated firmware publication
+    if: github.event_name == 'workflow_run'
+    needs: gate
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: firmware-release
     permissions:
+      actions: read
       contents: write
-      id-token: write
-      pages: write
     env:
       GH_TOKEN: ${{ github.token }}
-      FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY: ${{ secrets.FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY }}
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-python@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
+      - name: Read the candidate boundary again after approval
+        env:
+          CANDIDATE_RUN_ID: ${{ needs.gate.outputs.candidate_run_id }}
+        run: |
+          set -euo pipefail
+          gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/actions/workflows/firmware-release-candidate.yml" \
+            > "${RUNNER_TEMP}/candidate-workflow.json"
+          gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+            "repos/${GITHUB_REPOSITORY}/actions/runs/${CANDIDATE_RUN_ID}/artifacts?per_page=100" \
+            > "${RUNNER_TEMP}/candidate-artifacts.json"
+      - name: Revalidate the approved candidate
+        run: |
+          python3 .github/scripts/firmware_release_gate.py \
+            --event "${GITHUB_EVENT_PATH}" \
+            --workflow "${RUNNER_TEMP}/candidate-workflow.json" \
+            --artifacts "${RUNNER_TEMP}/candidate-artifacts.json" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --expected-workflow-path .github/workflows/firmware-release-candidate.yml \
+            --github-output "${GITHUB_OUTPUT}" \
+            --output-receipt "${RUNNER_TEMP}/firmware-release-gate-revalidated.json"
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: firmware-release-gate-${{ needs.gate.outputs.candidate_run_id }}
+          path: ${{ runner.temp }}/release-gate
+      - name: Require the unchanged pre-approval gate receipt
+        run: |
+          cmp \
+            "${RUNNER_TEMP}/release-gate/firmware-release-gate.json" \
+            "${RUNNER_TEMP}/firmware-release-gate-revalidated.json"
+      - name: Download and hash the exact candidate archives
+        run: |
+          set -euo pipefail
+          gate_receipt="${RUNNER_TEMP}/firmware-release-gate-revalidated.json"
+          mkdir -p \
+            "${RUNNER_TEMP}/candidate-archives" \
+            "${RUNNER_TEMP}/firmware-candidates"
+          for target in WAVESHARE_AMOLED_175 WAVESHARE_AMOLED_206; do
+            artifact_name="firmware-${target}"
+            read -r artifact_id artifact_digest < <(
+              python - "${gate_receipt}" "${artifact_name}" <<'PY'
+          import json
+          import pathlib
+          import sys
+
+          receipt = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+          matches = [
+              artifact
+              for artifact in receipt["artifacts"]
+              if artifact["name"] == sys.argv[2]
+          ]
+          if len(matches) != 1:
+              raise SystemExit("candidate artifact is missing or ambiguous")
+          print(matches[0]["id"], matches[0]["digest"])
+          PY
+            )
+            [[ "${artifact_id}" =~ ^[1-9][0-9]*$ ]]
+            [[ "${artifact_digest}" =~ ^sha256:[0-9a-f]{64}$ ]]
+            archive="${RUNNER_TEMP}/candidate-archives/${artifact_name}.zip"
+            gh api -H "X-GitHub-Api-Version: 2026-03-10" \
+              "repos/${GITHUB_REPOSITORY}/actions/artifacts/${artifact_id}/zip" \
+              > "${archive}"
+            test "sha256:$(sha256sum "${archive}" | cut -d ' ' -f 1)" = \
+              "${artifact_digest}"
+            python3 tools/firmware_release_candidate.py extract \
+              --archive "${archive}" \
+              --output-dir "${RUNNER_TEMP}/firmware-candidates/${artifact_name}" \
+              --target "${target}"
+          done
+      - name: Verify and stage the exact candidate files
+        env:
+          CANDIDATE_RUN_ID: ${{ needs.gate.outputs.candidate_run_id }}
+          GIT_SHA: ${{ needs.gate.outputs.git_sha }}
+          RELEASE_TAG: ${{ needs.gate.outputs.release_tag }}
+        run: |
+          python3 tools/firmware_release_candidate.py verify \
+            --artifact-root "${RUNNER_TEMP}/firmware-candidates" \
+            --release-assets "${RUNNER_TEMP}/release-assets" \
+            --output-receipt "${RUNNER_TEMP}/candidate-verification.json" \
+            --repository "${GITHUB_REPOSITORY}" \
+            --tag "${RELEASE_TAG}" \
+            --git-sha "${GIT_SHA}" \
+            --run-id "${CANDIDATE_RUN_ID}"
       - name: Install exact hashed manifest dependencies
         run: >-
           python -m pip install --require-hashes --only-binary=:all: --no-deps
           -r tools/firmware-signing-requirements.txt
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
+      - name: Re-resolve the protected branch and release tag
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          GIT_SHA: ${{ needs.gate.outputs.git_sha }}
+          RELEASE_TAG: ${{ needs.gate.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          git check-ref-format --branch "${DEFAULT_BRANCH}" >/dev/null
+          git fetch --force --no-tags origin \
+            "+refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          git fetch --force --no-tags origin \
+            "+refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          test "$(git rev-parse "${RELEASE_TAG}^{commit}")" = "${GIT_SHA}"
+          git merge-base --is-ancestor \
+            "${GIT_SHA}" "refs/remotes/origin/${DEFAULT_BRANCH}"
       - name: Generate signed manifests
+        env:
+          FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY: ${{ secrets.FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY }}
+          GIT_SHA: ${{ needs.gate.outputs.git_sha }}
+          RELEASE_TAG: ${{ needs.gate.outputs.release_tag }}
         run: |
           set -euo pipefail
           if [ -z "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" ]; then
             echo "FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY is required" >&2
             exit 1
           fi
-          mkdir -p release-assets public/firmware
-          git_sha_full="$(git rev-parse HEAD)"
-          git_sha_short="$(git rev-parse --short=12 HEAD)"
+          release_assets="${RUNNER_TEMP}/release-assets"
+          candidate_receipt="${RUNNER_TEMP}/candidate-verification.json"
+          firmware_version="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["firmwareVersion"]["version"])' "${candidate_receipt}")"
+          firmware_build="$(python -c 'import json,sys; print(json.load(open(sys.argv[1]))["firmwareVersion"]["build"])' "${candidate_receipt}")"
+          git_sha_short="${GIT_SHA:0:12}"
+          mkdir -p public/firmware
           for target in WAVESHARE_AMOLED_175 WAVESHARE_AMOLED_206; do
-            artifact_dir="dist/firmware-${target}"
-            for artifact in \
-              "${target}.bin" \
-              "${target}.factory.tar.gz" \
-              "${target}.factory-bundle.json"; do
-              if [ ! -f "${artifact_dir}/${artifact}" ]; then
-                echo "Missing release artifact: ${artifact_dir}/${artifact}" >&2
-                exit 1
-              fi
-              cp "${artifact_dir}/${artifact}" release-assets/
-            done
             python tools/firmware_manifest.py \
-              --firmware "release-assets/${target}.bin" \
+              --firmware "${release_assets}/${target}.bin" \
               --target "${target}" \
-              --repository "${{ github.repository }}" \
-              --tag "${GITHUB_REF_NAME}" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --tag "${RELEASE_TAG}" \
               --git-sha "${git_sha_short}" \
+              --version "${firmware_version}" \
+              --build "${firmware_build}" \
               --private-key-base64 "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" \
               --output "public/firmware/${target}/manifest.json"
-            cp "public/firmware/${target}/manifest.json" "release-assets/${target}.manifest.json"
+            cp \
+              "public/firmware/${target}/manifest.json" \
+              "${release_assets}/${target}.manifest.json"
             python tools/factory_release_manifest.py \
-              --bundle "release-assets/${target}.factory.tar.gz" \
-              --bundle-manifest "release-assets/${target}.factory-bundle.json" \
+              --bundle "${release_assets}/${target}.factory.tar.gz" \
+              --bundle-manifest "${release_assets}/${target}.factory-bundle.json" \
               --target "${target}" \
-              --repository "${{ github.repository }}" \
-              --tag "${GITHUB_REF_NAME}" \
-              --git-sha "${git_sha_full}" \
+              --repository "${GITHUB_REPOSITORY}" \
+              --tag "${RELEASE_TAG}" \
+              --git-sha "${GIT_SHA}" \
+              --version "${firmware_version}" \
+              --build "${firmware_build}" \
               --private-key-base64 "${FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY}" \
-              --output "release-assets/${target}.factory-release.json"
+              --output "${release_assets}/${target}.factory-release.json"
           done
       - name: Require immutable releases
         uses: ./.github/actions/require-immutable-releases
@@ -142,21 +274,24 @@ jobs:
           app-id: ${{ vars.FIRMWARE_RELEASE_PREFLIGHT_APP_ID }}
           private-key: ${{ secrets.FIRMWARE_RELEASE_PREFLIGHT_APP_PRIVATE_KEY }}
       - name: Publish GitHub release assets
+        env:
+          RELEASE_TAG: ${{ needs.gate.outputs.release_tag }}
         run: |
           set -euo pipefail
-          if gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1; then
-            echo "Release ${GITHUB_REF_NAME} already exists; refusing to replace assets" >&2
+          release_assets="${RUNNER_TEMP}/release-assets"
+          if gh release view "${RELEASE_TAG}" >/dev/null 2>&1; then
+            echo "Release ${RELEASE_TAG} already exists; refusing to replace assets" >&2
             exit 1
           fi
-          gh release create "${GITHUB_REF_NAME}" \
+          gh release create "${RELEASE_TAG}" \
             --draft \
             --verify-tag \
-            --title "${GITHUB_REF_NAME}" \
+            --title "${RELEASE_TAG}" \
             --generate-notes
-          gh release upload "${GITHUB_REF_NAME}" release-assets/*
+          gh release upload "${RELEASE_TAG}" "${release_assets}"/*
           release_id="$(
             gh api "repos/${GITHUB_REPOSITORY}/releases?per_page=100" |
-              jq -er --arg tag "${GITHUB_REF_NAME}" '
+              jq -er --arg tag "${RELEASE_TAG}" '
                 [.[] | select(.tag_name == $tag and .draft == true)] |
                 if length == 1 then .[0].id
                 else error("expected exactly one matching draft release")
@@ -168,31 +303,52 @@ jobs:
             > "${RUNNER_TEMP}/release.json"
           python tools/verify_github_release_assets.py \
             --release-json "${RUNNER_TEMP}/release.json" \
-            --asset-dir release-assets
-          gh release edit "${GITHUB_REF_NAME}" --draft=false
+            --asset-dir "${release_assets}"
+          gh release edit "${RELEASE_TAG}" --draft=false
           gh api -H "X-GitHub-Api-Version: 2026-03-10" \
-            "repos/${GITHUB_REPOSITORY}/releases/tags/${GITHUB_REF_NAME}" \
+            "repos/${GITHUB_REPOSITORY}/releases/tags/${RELEASE_TAG}" \
             > "${RUNNER_TEMP}/release.json"
           python tools/verify_github_release_assets.py \
             --release-json "${RUNNER_TEMP}/release.json" \
-            --asset-dir release-assets \
+            --asset-dir "${release_assets}" \
             --require-immutable \
             --output "${RUNNER_TEMP}/publication-receipt.json"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: firmware-release-publication-receipt
-          path: ${{ runner.temp }}/publication-receipt.json
+          name: firmware-release-publication-receipts
+          path: |
+            ${{ runner.temp }}/candidate-verification.json
+            ${{ runner.temp }}/firmware-release-gate-revalidated.json
+            ${{ runner.temp }}/publication-receipt.json
           if-no-files-found: error
-      - uses: actions/upload-pages-artifact@v3
+          retention-days: 90
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: public
+
+  deploy-pages:
+    name: Deploy Firmware OTA Pages
+    if: github.event_name == 'workflow_run'
+    needs: publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      pages: write
+    steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
   recover-pages:
     name: Recover Firmware OTA Pages
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -216,10 +372,11 @@ jobs:
             echo "Invalid firmware release tag: ${RELEASE_TAG}" >&2
             exit 1
           fi
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
+          persist-credentials: false
       - name: Verify immutable release and stage exact OTA manifests
         run: |
           set -euo pipefail
@@ -250,13 +407,14 @@ jobs:
             echo "Recovery payload must contain exactly two OTA manifests" >&2
             exit 1
           fi
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: firmware-release-recovery-receipt-${{ inputs.release_tag }}
           path: ${{ runner.temp }}/recovery-receipt.json
           if-no-files-found: error
-      - uses: actions/upload-pages-artifact@v3
+          retention-days: 90
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: public
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/docs/firmware-factory-release.md
+++ b/docs/firmware-factory-release.md
@@ -23,6 +23,45 @@ The option is deliberately absent from ordinary developer and device-test
 builds. Diagnostic/calibration images stored elsewhere are not production
 inputs.
 
+Tagged publication is split across two trust domains. A pushed `v*` tag starts
+`.github/workflows/firmware-release-candidate.yml`, which has read-only
+permissions, no environment, and no signing or release credential. It runs the
+full CI and diagnostic gates, builds both production targets, and records a
+canonical receipt for the exact OTA image, factory archive, and factory
+descriptor from the tagged commit.
+
+Only `.github/workflows/firmware-release.yml`, loaded by GitHub from the
+protected default branch through `workflow_run`, may publish. Before entering
+the `firmware-release` environment, it verifies the registered candidate
+workflow ID and path, repository, first successful push attempt, semantic tag,
+full source SHA, exact candidate artifact names and GitHub SHA-256 digests, tag
+target, protected-main ancestry, and absence of an existing release. After
+environment approval it repeats the workflow/artifact and tag checks, then
+uses only protected-default-branch verification and signing tools. Tagged code
+is never checked out or executed by the publisher.
+
+Before merging and using this flow, repository administrators must:
+
+1. Create the `firmware-release` environment, require at least one named human
+   reviewer, prevent self-review, restrict deployments to the protected
+   default branch used by `workflow_run`, and limit bypass actors to the
+   reviewed break-glass owner.
+2. Make `FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY`,
+   `FIRMWARE_RELEASE_PREFLIGHT_APP_ID`, and
+   `FIRMWARE_RELEASE_PREFLIGHT_APP_PRIVATE_KEY` available to that environment
+   with no broader scope than operationally required. Store both private keys
+   as environment secrets and remove any repository-level copies after the
+   environment migration is verified.
+3. Add a `v*` tag ruleset that restricts tag creation, update, and deletion to
+   release maintainers. Enable GitHub's full-SHA Actions policy after every
+   workflow has landed with immutable action pins.
+4. Run a non-production rehearsal proving that an off-main tag, moved tag,
+   rerun candidate, altered candidate receipt, missing artifact, and existing
+   release all stop before signing.
+
+Source changes alone do not prove those live controls are configured. Do not
+push the first release tag until their read-back has been reviewed.
+
 Compilation, host tests, and a merged pull request establish software readiness;
 they do not establish physical acceptance. Before calling an artifact
 factory/golden firmware, record the target-specific device identity, attested
@@ -41,7 +80,8 @@ speaker soak is an accepted non-blocking risk documented in
 
 ## Release outputs
 
-For each production target, `.github/workflows/firmware-release.yml` publishes:
+For each production target, the candidate and protected publisher together
+publish:
 
 | Asset | Purpose |
 |---|---|

--- a/esp32/tools/tests/test_firmware_profile_config.py
+++ b/esp32/tools/tests/test_firmware_profile_config.py
@@ -370,13 +370,18 @@ assert not raw_write_offenders, (
     + ", ".join(raw_write_offenders)
 )
 
-release_workflow = (repo_root / ".github/workflows/firmware-release.yml").read_text()
-assert "env -u LD_LIBRARY_PATH python3 tools/build_firmware.py" in release_workflow
+release_candidate_workflow = (
+    repo_root / ".github/workflows/firmware-release-candidate.yml"
+).read_text()
+assert (
+    "env -u LD_LIBRARY_PATH python3 tools/build_firmware.py"
+    in release_candidate_workflow
+)
 for environment in remote_debug_profiles:
-    assert environment.removeprefix("env:") not in release_workflow
+    assert environment.removeprefix("env:") not in release_candidate_workflow
 for environment, target in expected_targets.items():
     profile = environment.removeprefix("env:")
     mapping = f"target: {target}\n            environment: {profile}"
-    assert mapping in release_workflow
+    assert mapping in release_candidate_workflow
 
 print("firmware production profile contracts passed")

--- a/tools/firmware_release_candidate.py
+++ b/tools/firmware_release_candidate.py
@@ -1,0 +1,511 @@
+#!/usr/bin/env python3
+"""Record and verify the exact secretless firmware release candidate files."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import re
+import shutil
+import stat
+import struct
+import sys
+import tempfile
+import zipfile
+
+
+TARGET_ENVIRONMENTS = {
+    "WAVESHARE_AMOLED_175": "WAVESHARE_AMOLED_175_PRODUCTION",
+    "WAVESHARE_AMOLED_206": "WAVESHARE_AMOLED_206_PRODUCTION",
+}
+FULL_SHA = re.compile(r"^[0-9a-f]{40}$")
+SHA256 = re.compile(r"^[0-9a-f]{64}$")
+REPOSITORY = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+RELEASE_TAG = re.compile(
+    r"^v[0-9]+\.[0-9]+\.[0-9]+(?:[.-][A-Za-z0-9][A-Za-z0-9.-]*)?$"
+)
+VERSION = re.compile(r"^[0-9]+\.[0-9]+\.[0-9]+$")
+MAX_FILE_BYTES = {
+    ".bin": 16 * 1024 * 1024,
+    ".factory.tar.gz": 64 * 1024 * 1024,
+    ".factory-bundle.json": 1024 * 1024,
+}
+MAX_RECEIPT_BYTES = 64 * 1024
+MAX_ARTIFACT_ARCHIVE_BYTES = 96 * 1024 * 1024
+MAX_ZIP_METADATA_BYTES = 4096
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, object]]) -> dict[str, object]:
+    value: dict[str, object] = {}
+    for key, item in pairs:
+        if key in value:
+            raise ValueError(f"JSON contains duplicate key: {key}")
+        value[key] = item
+    return value
+
+
+def _load_json(path: pathlib.Path, maximum_bytes: int) -> dict[str, object]:
+    if path.is_symlink() or not path.is_file():
+        raise ValueError(f"JSON file is missing or unsafe: {path}")
+    encoded = path.read_bytes()
+    if not encoded or len(encoded) > maximum_bytes:
+        raise ValueError(f"JSON file has an invalid size: {path}")
+    try:
+        value = json.loads(
+            encoded.decode("utf-8"), object_pairs_hook=_reject_duplicate_keys
+        )
+    except (UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"JSON file is invalid: {path}: {error}") from error
+    if not isinstance(value, dict):
+        raise ValueError(f"JSON file must contain an object: {path}")
+    return value
+
+
+def _canonical(value: object) -> bytes:
+    return (
+        json.dumps(value, sort_keys=True, separators=(",", ":")) + "\n"
+    ).encode("utf-8")
+
+
+def _write_atomic(path: pathlib.Path, value: object) -> None:
+    if path.is_symlink() or (path.exists() and not path.is_file()):
+        raise ValueError(f"output path is unsafe: {path}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary: str | None = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            mode="wb", dir=path.parent, prefix=f".{path.name}.", delete=False
+        ) as stream:
+            temporary = stream.name
+            stream.write(_canonical(value))
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        temporary = None
+    finally:
+        if temporary is not None:
+            pathlib.Path(temporary).unlink(missing_ok=True)
+
+
+def _sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        for chunk in iter(lambda: stream.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _identity(
+    *, target: str, environment: str, repository: str, tag: str, git_sha: str
+) -> None:
+    if target not in TARGET_ENVIRONMENTS:
+        raise ValueError(f"unsupported release target: {target}")
+    if environment != TARGET_ENVIRONMENTS[target]:
+        raise ValueError("candidate environment does not match its target")
+    if REPOSITORY.fullmatch(repository) is None:
+        raise ValueError("candidate repository is invalid")
+    if RELEASE_TAG.fullmatch(tag) is None:
+        raise ValueError("candidate release tag is invalid")
+    if FULL_SHA.fullmatch(git_sha) is None:
+        raise ValueError("candidate Git SHA is invalid")
+
+
+def _expected_names(target: str) -> tuple[str, str, str]:
+    return (
+        f"{target}.bin",
+        f"{target}.factory-bundle.json",
+        f"{target}.factory.tar.gz",
+    )
+
+
+def _zip_entry_count(path: pathlib.Path) -> int:
+    size = path.stat().st_size
+    tail_size = min(size, 65_557)
+    with path.open("rb") as stream:
+        stream.seek(size - tail_size)
+        tail = stream.read(tail_size)
+    marker = tail.rfind(b"PK\x05\x06")
+    if marker < 0 or marker + 22 > len(tail):
+        raise ValueError("candidate artifact ZIP has no bounded end record")
+    (
+        signature,
+        disk,
+        central_disk,
+        disk_entries,
+        total_entries,
+        central_size,
+        central_offset,
+        comment_size,
+    ) = struct.unpack_from("<4s4H2LH", tail, marker)
+    absolute_marker = size - tail_size + marker
+    if (
+        signature != b"PK\x05\x06"
+        or disk != 0
+        or central_disk != 0
+        or disk_entries != total_entries
+        or total_entries != 4
+        or central_size in {0, 0xFFFFFFFF}
+        or central_offset == 0xFFFFFFFF
+        or central_offset + central_size != absolute_marker
+        or absolute_marker + 22 + comment_size != size
+        or comment_size > MAX_ZIP_METADATA_BYTES
+    ):
+        raise ValueError("candidate artifact ZIP directory is invalid")
+    return total_entries
+
+
+def extract_candidate_archive(
+    archive: pathlib.Path, output_dir: pathlib.Path, *, target: str
+) -> None:
+    if target not in TARGET_ENVIRONMENTS:
+        raise ValueError(f"unsupported release target: {target}")
+    if archive.is_symlink() or not archive.is_file():
+        raise ValueError("candidate artifact ZIP is missing or unsafe")
+    archive_size = archive.stat().st_size
+    if archive_size <= 0 or archive_size > MAX_ARTIFACT_ARCHIVE_BYTES:
+        raise ValueError("candidate artifact ZIP has an invalid size")
+    if output_dir.is_symlink() or output_dir.exists():
+        raise ValueError("candidate extraction path must not already exist")
+    _zip_entry_count(archive)
+    expected = {*_expected_names(target), "candidate-receipt.json"}
+    output_dir.mkdir(parents=True)
+    try:
+        with zipfile.ZipFile(archive) as bundle:
+            infos = bundle.infolist()
+            names = {info.filename for info in infos}
+            if len(infos) != len(expected) or names != expected:
+                raise ValueError("candidate artifact ZIP file set is not exact")
+            for info in infos:
+                maximum = (
+                    MAX_RECEIPT_BYTES
+                    if info.filename == "candidate-receipt.json"
+                    else _file_limit(info.filename)
+                )
+                unix_mode = (info.external_attr >> 16) & 0xFFFF
+                if (
+                    info.is_dir()
+                    or info.flag_bits & 0x1
+                    or info.compress_type
+                    not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}
+                    or info.file_size <= 0
+                    or info.file_size > maximum
+                    or info.compress_size > MAX_ARTIFACT_ARCHIVE_BYTES
+                    or len(info.extra) > MAX_ZIP_METADATA_BYTES
+                    or len(info.comment) > MAX_ZIP_METADATA_BYTES
+                    or (unix_mode and not stat.S_ISREG(unix_mode))
+                ):
+                    raise ValueError("candidate artifact ZIP entry is unsafe")
+                destination = output_dir / info.filename
+                copied = 0
+                with bundle.open(info, "r") as source, destination.open("xb") as output:
+                    while True:
+                        chunk = source.read(min(1024 * 1024, maximum - copied + 1))
+                        if not chunk:
+                            break
+                        copied += len(chunk)
+                        if copied > maximum:
+                            raise ValueError(
+                                "candidate artifact ZIP entry is oversized"
+                            )
+                        output.write(chunk)
+                if copied != info.file_size:
+                    raise ValueError("candidate artifact ZIP entry is truncated")
+    except Exception:
+        shutil.rmtree(output_dir, ignore_errors=True)
+        raise
+
+
+def _regular_files(directory: pathlib.Path) -> dict[str, pathlib.Path]:
+    if directory.is_symlink() or not directory.is_dir():
+        raise ValueError(f"candidate directory is missing or unsafe: {directory}")
+    files: dict[str, pathlib.Path] = {}
+    for path in directory.iterdir():
+        if path.is_symlink() or not path.is_file() or path.name in files:
+            raise ValueError(f"candidate file is unsafe: {path.name}")
+        files[path.name] = path
+    return files
+
+
+def _file_limit(name: str) -> int:
+    for suffix, maximum in MAX_FILE_BYTES.items():
+        if name.endswith(suffix):
+            return maximum
+    raise ValueError(f"candidate filename is unsupported: {name}")
+
+
+def _validate_factory_descriptor(
+    descriptor_path: pathlib.Path,
+    firmware_path: pathlib.Path,
+    *,
+    target: str,
+    environment: str,
+    git_sha: str,
+    tag: str,
+) -> dict[str, object]:
+    descriptor = _load_json(descriptor_path, MAX_FILE_BYTES[".factory-bundle.json"])
+    firmware_version = descriptor.get("firmwareVersion")
+    if (
+        descriptor.get("schemaVersion") != 2
+        or descriptor.get("artifactType") != "esp32-factory-flash-bundle"
+        or descriptor.get("target") != target
+        or descriptor.get("environment") != environment
+        or descriptor.get("sourceIdentity") != git_sha
+        or not isinstance(firmware_version, dict)
+    ):
+        raise ValueError("factory descriptor identity does not match the candidate")
+    version = firmware_version.get("version")
+    build = firmware_version.get("build")
+    if (
+        not isinstance(version, str)
+        or VERSION.fullmatch(version) is None
+        or not (
+            tag == f"v{version}"
+            or tag.startswith(f"v{version}.")
+            or tag.startswith(f"v{version}-")
+        )
+        or isinstance(build, bool)
+        or not isinstance(build, int)
+        or build < 0
+    ):
+        raise ValueError("factory descriptor firmware version is invalid")
+    flash_plan = descriptor.get("flashPlan")
+    if not isinstance(flash_plan, dict) or not isinstance(
+        flash_plan.get("images"), list
+    ):
+        raise ValueError("factory descriptor has no flash image inventory")
+    application_images = []
+    for image in flash_plan["images"]:
+        if not isinstance(image, dict):
+            raise ValueError("factory descriptor contains an invalid image")
+        name = image.get("file")
+        if isinstance(name, str) and name.endswith("-firmware.bin"):
+            application_images.append(image)
+    if len(application_images) != 1:
+        raise ValueError("factory descriptor must identify one application image")
+    application = application_images[0]
+    if (
+        application.get("size") != firmware_path.stat().st_size
+        or application.get("sha256") != _sha256(firmware_path)
+    ):
+        raise ValueError("OTA image does not match the factory application image")
+    return {"version": version, "build": build}
+
+
+def candidate_receipt(
+    directory: pathlib.Path,
+    *,
+    target: str,
+    environment: str,
+    repository: str,
+    tag: str,
+    git_sha: str,
+    allow_embedded_receipt: bool = False,
+) -> dict[str, object]:
+    _identity(
+        target=target,
+        environment=environment,
+        repository=repository,
+        tag=tag,
+        git_sha=git_sha,
+    )
+    files = _regular_files(directory)
+    if allow_embedded_receipt:
+        files.pop("candidate-receipt.json", None)
+    expected = set(_expected_names(target))
+    if set(files) != expected:
+        raise ValueError("candidate artifact directory has an unexpected file set")
+    inventory: list[dict[str, object]] = []
+    for name in sorted(expected):
+        path = files[name]
+        size = path.stat().st_size
+        if size <= 0 or size > _file_limit(name):
+            raise ValueError(f"candidate artifact size is invalid: {name}")
+        inventory.append({"name": name, "size": size, "sha256": _sha256(path)})
+    firmware_version = _validate_factory_descriptor(
+        files[f"{target}.factory-bundle.json"],
+        files[f"{target}.bin"],
+        target=target,
+        environment=environment,
+        git_sha=git_sha,
+        tag=tag,
+    )
+    return {
+        "schemaVersion": 1,
+        "repository": repository,
+        "tag": tag,
+        "gitSha": git_sha,
+        "target": target,
+        "environment": environment,
+        "firmwareVersion": firmware_version,
+        "files": inventory,
+    }
+
+
+def record_candidate(
+    directory: pathlib.Path,
+    output: pathlib.Path,
+    *,
+    target: str,
+    environment: str,
+    repository: str,
+    tag: str,
+    git_sha: str,
+) -> dict[str, object]:
+    receipt = candidate_receipt(
+        directory,
+        target=target,
+        environment=environment,
+        repository=repository,
+        tag=tag,
+        git_sha=git_sha,
+    )
+    _write_atomic(output, receipt)
+    return receipt
+
+
+def verify_candidates(
+    artifact_root: pathlib.Path,
+    release_assets: pathlib.Path,
+    output_receipt: pathlib.Path,
+    *,
+    repository: str,
+    tag: str,
+    git_sha: str,
+    run_id: int,
+) -> dict[str, object]:
+    if run_id <= 0:
+        raise ValueError("candidate run ID is invalid")
+    if artifact_root.is_symlink() or not artifact_root.is_dir():
+        raise ValueError("candidate artifact root is missing or unsafe")
+    directories = {path.name: path for path in artifact_root.iterdir()}
+    expected_directories = {f"firmware-{target}" for target in TARGET_ENVIRONMENTS}
+    if set(directories) != expected_directories or any(
+        path.is_symlink() or not path.is_dir() for path in directories.values()
+    ):
+        raise ValueError("downloaded candidate artifact set is not exact")
+    if release_assets.is_symlink() or release_assets.exists():
+        raise ValueError("release asset staging path must not already exist")
+    release_assets.mkdir(parents=True)
+
+    receipts: list[dict[str, object]] = []
+    try:
+        for target, environment in TARGET_ENVIRONMENTS.items():
+            directory = directories[f"firmware-{target}"]
+            files = _regular_files(directory)
+            receipt_path = files.pop("candidate-receipt.json", None)
+            if receipt_path is None or receipt_path.stat().st_size > MAX_RECEIPT_BYTES:
+                raise ValueError("candidate receipt is missing or oversized")
+            observed = _load_json(receipt_path, MAX_RECEIPT_BYTES)
+            if receipt_path.read_bytes() != _canonical(observed):
+                raise ValueError("candidate receipt is not canonical")
+            expected = candidate_receipt(
+                directory,
+                target=target,
+                environment=environment,
+                repository=repository,
+                tag=tag,
+                git_sha=git_sha,
+                allow_embedded_receipt=True,
+            )
+            if observed != expected:
+                raise ValueError("candidate receipt does not match its files")
+            receipts.append(expected)
+            for name in _expected_names(target):
+                source = directory / name
+                destination = release_assets / name
+                shutil.copyfile(source, destination)
+                if (
+                    destination.stat().st_size != source.stat().st_size
+                    or _sha256(destination) != _sha256(source)
+                ):
+                    raise ValueError("candidate changed while staging release assets")
+    except Exception:
+        shutil.rmtree(release_assets, ignore_errors=True)
+        raise
+
+    combined = {
+        "schemaVersion": 1,
+        "repository": repository,
+        "tag": tag,
+        "gitSha": git_sha,
+        "candidateRunId": run_id,
+        "targets": receipts,
+    }
+    versions = {
+        (
+            str(receipt["firmwareVersion"]["version"]),
+            int(receipt["firmwareVersion"]["build"]),
+        )
+        for receipt in receipts
+    }
+    if len(versions) != 1:
+        shutil.rmtree(release_assets, ignore_errors=True)
+        raise ValueError("candidate targets do not share one firmware version")
+    version, build = versions.pop()
+    combined["firmwareVersion"] = {"version": version, "build": build}
+    _write_atomic(output_receipt, combined)
+    return combined
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    record = subparsers.add_parser("record")
+    record.add_argument("--artifact-dir", type=pathlib.Path, required=True)
+    record.add_argument("--output", type=pathlib.Path, required=True)
+    record.add_argument("--target", required=True)
+    record.add_argument("--environment", required=True)
+    record.add_argument("--repository", required=True)
+    record.add_argument("--tag", required=True)
+    record.add_argument("--git-sha", required=True)
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--artifact-root", type=pathlib.Path, required=True)
+    verify.add_argument("--release-assets", type=pathlib.Path, required=True)
+    verify.add_argument("--output-receipt", type=pathlib.Path, required=True)
+    verify.add_argument("--repository", required=True)
+    verify.add_argument("--tag", required=True)
+    verify.add_argument("--git-sha", required=True)
+    verify.add_argument("--run-id", type=int, required=True)
+    extract = subparsers.add_parser("extract")
+    extract.add_argument("--archive", type=pathlib.Path, required=True)
+    extract.add_argument("--output-dir", type=pathlib.Path, required=True)
+    extract.add_argument("--target", required=True)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "record":
+            result = record_candidate(
+                args.artifact_dir,
+                args.output,
+                target=args.target,
+                environment=args.environment,
+                repository=args.repository,
+                tag=args.tag,
+                git_sha=args.git_sha,
+            )
+        elif args.command == "verify":
+            result = verify_candidates(
+                args.artifact_root,
+                args.release_assets,
+                args.output_receipt,
+                repository=args.repository,
+                tag=args.tag,
+                git_sha=args.git_sha,
+                run_id=args.run_id,
+            )
+        else:
+            extract_candidate_archive(
+                args.archive, args.output_dir, target=args.target
+            )
+            result = {"target": args.target, "output": str(args.output_dir)}
+        print(json.dumps(result, sort_keys=True))
+        return 0
+    except (OSError, ValueError, zipfile.BadZipFile) as error:
+        print(f"firmware candidate validation failed: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/tests/test_firmware_release_candidate.py
+++ b/tools/tests/test_firmware_release_candidate.py
@@ -1,0 +1,292 @@
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import stat
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "firmware_release_candidate.py"
+SPEC = importlib.util.spec_from_file_location("firmware_release_candidate", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+candidate = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(candidate)
+
+REPOSITORY = "owner/repository"
+TAG = "v1.2.3-release.4"
+GIT_SHA = "0123456789abcdef0123456789abcdef01234567"
+
+
+class FirmwareReleaseCandidateTests(unittest.TestCase):
+    def create_candidate(
+        self,
+        root: Path,
+        target: str,
+        *,
+        version: str = "1.2.3",
+        build: int = 4,
+    ) -> Path:
+        environment = candidate.TARGET_ENVIRONMENTS[target]
+        directory = root / f"firmware-{target}"
+        directory.mkdir(parents=True)
+        firmware = directory / f"{target}.bin"
+        firmware.write_bytes(f"firmware for {target}".encode())
+        (directory / f"{target}.factory.tar.gz").write_bytes(
+            f"factory archive for {target}".encode()
+        )
+        descriptor = {
+            "schemaVersion": 2,
+            "artifactType": "esp32-factory-flash-bundle",
+            "target": target,
+            "environment": environment,
+            "sourceIdentity": GIT_SHA,
+            "firmwareVersion": {"version": version, "build": build},
+            "flashPlan": {
+                "images": [
+                    {
+                        "file": "images/00010000-firmware.bin",
+                        "size": firmware.stat().st_size,
+                        "sha256": hashlib.sha256(firmware.read_bytes()).hexdigest(),
+                    }
+                ]
+            },
+        }
+        (directory / f"{target}.factory-bundle.json").write_text(
+            json.dumps(descriptor, sort_keys=True), encoding="utf-8"
+        )
+        receipt = directory / "candidate-receipt.json"
+        candidate.record_candidate(
+            directory,
+            receipt,
+            target=target,
+            environment=environment,
+            repository=REPOSITORY,
+            tag=TAG,
+            git_sha=GIT_SHA,
+        )
+        return directory
+
+    def create_all_candidates(self, root: Path) -> None:
+        for target in candidate.TARGET_ENVIRONMENTS:
+            self.create_candidate(root, target)
+
+    def test_record_is_canonical_and_binds_exact_candidate_files(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = "WAVESHARE_AMOLED_175"
+            directory = self.create_candidate(root, target)
+            receipt_path = directory / "candidate-receipt.json"
+            receipt = json.loads(receipt_path.read_text(encoding="utf-8"))
+
+            self.assertEqual(
+                receipt_path.read_bytes(), candidate._canonical(receipt)
+            )
+            self.assertEqual(target, receipt["target"])
+            self.assertEqual(GIT_SHA, receipt["gitSha"])
+            self.assertEqual(
+                [
+                    f"{target}.bin",
+                    f"{target}.factory-bundle.json",
+                    f"{target}.factory.tar.gz",
+                ],
+                [item["name"] for item in receipt["files"]],
+            )
+
+    def test_verify_stages_only_the_six_bound_release_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            self.create_all_candidates(artifacts)
+            release_assets = root / "release-assets"
+            combined_path = root / "candidate-verification.json"
+
+            combined = candidate.verify_candidates(
+                artifacts,
+                release_assets,
+                combined_path,
+                repository=REPOSITORY,
+                tag=TAG,
+                git_sha=GIT_SHA,
+                run_id=1234,
+            )
+
+            self.assertEqual(1234, combined["candidateRunId"])
+            self.assertEqual(2, len(combined["targets"]))
+            self.assertEqual(
+                {
+                    name
+                    for target in candidate.TARGET_ENVIRONMENTS
+                    for name in candidate._expected_names(target)
+                },
+                {path.name for path in release_assets.iterdir()},
+            )
+            self.assertEqual(
+                combined_path.read_bytes(), candidate._canonical(combined)
+            )
+
+    def test_verify_rejects_tamper_replay_and_unexpected_inputs(self) -> None:
+        mutators = {
+            "tampered firmware": lambda directory: (
+                directory / "WAVESHARE_AMOLED_175.bin"
+            ).write_bytes(b"changed"),
+            "replayed receipt": lambda directory: self.rewrite_receipt(
+                directory, gitSha="f" * 40
+            ),
+            "duplicate receipt key": lambda directory: (
+                directory / "candidate-receipt.json"
+            ).write_text('{"schemaVersion":1,"schemaVersion":1}\n', encoding="utf-8"),
+            "unexpected file": lambda directory: (
+                directory / "unexpected.txt"
+            ).write_text("unexpected", encoding="utf-8"),
+            "symlinked file": lambda directory: (
+                directory / "unsafe-link"
+            ).symlink_to(directory / "WAVESHARE_AMOLED_175.bin"),
+        }
+        for label, mutate in mutators.items():
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                artifacts = root / "artifacts"
+                artifacts.mkdir()
+                self.create_all_candidates(artifacts)
+                mutate(artifacts / "firmware-WAVESHARE_AMOLED_175")
+
+                with self.assertRaises(ValueError):
+                    candidate.verify_candidates(
+                        artifacts,
+                        root / "release-assets",
+                        root / "combined.json",
+                        repository=REPOSITORY,
+                        tag=TAG,
+                        git_sha=GIT_SHA,
+                        run_id=1234,
+                    )
+                self.assertFalse((root / "release-assets").exists())
+
+    def rewrite_receipt(self, directory: Path, **changes: object) -> None:
+        path = directory / "candidate-receipt.json"
+        value = json.loads(path.read_text(encoding="utf-8"))
+        value.update(changes)
+        path.write_bytes(candidate._canonical(value))
+
+    def test_verify_rejects_missing_target_and_existing_staging_path(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            self.create_candidate(artifacts, "WAVESHARE_AMOLED_175")
+            with self.assertRaisesRegex(ValueError, "artifact set is not exact"):
+                candidate.verify_candidates(
+                    artifacts,
+                    root / "release-assets",
+                    root / "combined.json",
+                    repository=REPOSITORY,
+                    tag=TAG,
+                    git_sha=GIT_SHA,
+                    run_id=1234,
+                )
+
+            self.create_candidate(artifacts, "WAVESHARE_AMOLED_206")
+            (root / "release-assets").mkdir()
+            with self.assertRaisesRegex(ValueError, "must not already exist"):
+                candidate.verify_candidates(
+                    artifacts,
+                    root / "release-assets",
+                    root / "combined.json",
+                    repository=REPOSITORY,
+                    tag=TAG,
+                    git_sha=GIT_SHA,
+                    run_id=1234,
+                )
+
+    def test_version_binding_rejects_wrong_tag_and_mixed_target_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            with self.assertRaisesRegex(ValueError, "firmware version is invalid"):
+                self.create_candidate(
+                    root, "WAVESHARE_AMOLED_175", version="1.2.4"
+                )
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            artifacts = root / "artifacts"
+            artifacts.mkdir()
+            self.create_candidate(
+                artifacts, "WAVESHARE_AMOLED_175", build=4
+            )
+            self.create_candidate(
+                artifacts, "WAVESHARE_AMOLED_206", build=5
+            )
+            with self.assertRaisesRegex(ValueError, "one firmware version"):
+                candidate.verify_candidates(
+                    artifacts,
+                    root / "release-assets",
+                    root / "combined.json",
+                    repository=REPOSITORY,
+                    tag=TAG,
+                    git_sha=GIT_SHA,
+                    run_id=1234,
+                )
+            self.assertFalse((root / "release-assets").exists())
+
+    def test_extract_accepts_only_the_exact_bounded_candidate_zip(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            target = "WAVESHARE_AMOLED_175"
+            directory = self.create_candidate(root, target)
+            archive = root / "candidate.zip"
+            with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+                for path in directory.iterdir():
+                    bundle.write(path, path.name)
+
+            output = root / "extracted"
+            candidate.extract_candidate_archive(archive, output, target=target)
+
+            self.assertEqual(
+                {path.name for path in directory.iterdir()},
+                {path.name for path in output.iterdir()},
+            )
+            for path in directory.iterdir():
+                self.assertEqual(path.read_bytes(), (output / path.name).read_bytes())
+
+    def test_extract_rejects_extra_and_symlink_entries(self) -> None:
+        for label, make_archive in (
+            ("extra", self.write_extra_archive),
+            ("symlink", self.write_symlink_archive),
+        ):
+            with self.subTest(label=label), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                target = "WAVESHARE_AMOLED_175"
+                archive = root / "candidate.zip"
+                make_archive(archive, target)
+                output = root / "extracted"
+
+                with self.assertRaises(ValueError):
+                    candidate.extract_candidate_archive(
+                        archive, output, target=target
+                    )
+                self.assertFalse(output.exists())
+
+    def write_extra_archive(self, archive: Path, target: str) -> None:
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+            for name in (*candidate._expected_names(target), "candidate-receipt.json"):
+                bundle.writestr(name, b"value")
+            bundle.writestr("unexpected", b"value")
+
+    def write_symlink_archive(self, archive: Path, target: str) -> None:
+        expected = (*candidate._expected_names(target), "candidate-receipt.json")
+        with zipfile.ZipFile(archive, "w", zipfile.ZIP_DEFLATED) as bundle:
+            for index, name in enumerate(expected):
+                info = zipfile.ZipInfo(name)
+                info.create_system = 3
+                mode = stat.S_IFLNK | 0o777 if index == 0 else stat.S_IFREG | 0o644
+                info.external_attr = mode << 16
+                bundle.writestr(info, b"value")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- split tag-triggered firmware work into a read-only, secretless candidate workflow and a `workflow_run` publisher loaded from protected `main`
- fail closed on workflow ID/path/repository, first-attempt success, semantic tag, exact source SHA, protected-main ancestry, moved tags, existing releases, and exact candidate artifact IDs/digests
- download candidate archives by immutable artifact ID, verify the GitHub SHA-256 before bounded safe extraction, then revalidate canonical per-target receipts and factory identities
- scope the manifest signing key to the signing step and separate release publication from GitHub Pages deployment
- document the required `firmware-release` environment, environment-secret migration, reviewer policy, protected-main deployment restriction, and `v*` tag ruleset

## Security boundary

Tagged code never receives a signing secret or write token. The privileged workflow checks out only the default-branch `github.sha`, executes only protected-branch verification/signing tools, repeats the candidate and tag checks after environment approval, and refuses reruns or replacement releases.

Source merge alone is not the full rollout. Before the next release tag, configure and read back the `firmware-release` environment with named reviewers, prevent self-review, restrict it to protected `main`, move both private keys to environment scope, and protect `v*` tag create/update/delete. No repository settings, secrets, tags, releases, deployments, or devices were changed by this PR.

## Validation

- `python3 -m unittest discover -s .github/scripts/tests` (66 passed)
- `python3 -m unittest discover -s tools/tests` (74 passed)
- pinned `actionlint` 1.7.7 image (no findings in the changed workflows; existing warnings remain in unrelated workflows)
- `git diff --check`
- verified against `origin/main` `03af8f9d6a3f14528e0c91a216b80c3f57bc5671`

Firmware board builds are delegated to PR CI. No firmware was flashed and no physical-device validation is claimed.