### PR TITLE
Require installation proof for map job access

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/OfflineMapManager.swift
@@ -2108,17 +2108,12 @@ final class OfflineMapManager: ObservableObject {
 
         startMapJobTask { manager in
             var client = try manager.makeClient()
-            if client.clientInstallationToken?.isEmpty == false {
-                client = try await manager.ensureRegisteredInstallation(client: client)
-            }
+            client = try await manager.ensureRegisteredInstallation(client: client)
             if try await manager.recoverOwnedServerJobIfAvailable(
                 client: client,
                 bleManager: bleManager
             ) {
                 return
-            }
-            if client.clientInstallationToken?.isEmpty != false {
-                client = try await manager.ensureRegisteredInstallation(client: client)
             }
             let request = OfflineMapJobRequest
                 .customBBox(bounds)
@@ -2176,9 +2171,9 @@ final class OfflineMapManager: ObservableObject {
                 persistedServerURL: persistedServerURL
             )
             var client = try manager.makeClient(serverURLString: recoveryServerURL)
-            if client.clientInstallationToken?.isEmpty == false {
-                client = try await manager.ensureRegisteredInstallation(client: client)
-            }
+            client = try await manager.ensureRegisteredInstallationWithRetry(
+                client: client
+            )
             var jobId = persistedJobId
             var shouldInstallOnDevice = persistedInstallIntent
 
@@ -2252,7 +2247,9 @@ final class OfflineMapManager: ObservableObject {
         guard let jobId = currentJob?.jobId else { return }
         Task {
             await runBusy {
-                let client = try self.makeClient()
+                let client = try await self.ensureRegisteredInstallation(
+                    client: self.makeClient()
+                )
                 self.currentJob = try await client.job(id: jobId)
                 self.statusMessage = self.currentJob?.status ?? ""
                 if self.currentJob?.mapId == nil {
@@ -2274,7 +2271,9 @@ final class OfflineMapManager: ObservableObject {
         }
         Task {
             await runBusy {
-                let client = try self.makeClient()
+                let client = try await self.ensureRegisteredInstallation(
+                    client: self.makeClient()
+                )
                 self.downloadURL = try await client.downloadURL(mapId: mapId, jobId: jobId)
                 self.statusMessage = "download ready"
             }
@@ -2284,7 +2283,10 @@ final class OfflineMapManager: ObservableObject {
     func downloadPack() {
         Task {
             await runBusy {
-                try await self.downloadReadyPack(client: self.makeClient())
+                let client = try await self.ensureRegisteredInstallation(
+                    client: self.makeClient()
+                )
+                try await self.downloadReadyPack(client: client)
             }
         }
     }
@@ -3668,17 +3670,12 @@ final class OfflineMapManager: ObservableObject {
         guard canStartNewMapJob() else { return }
         startMapJobTask { manager in
             var client = try manager.makeClient()
-            if client.clientInstallationToken?.isEmpty == false {
-                client = try await manager.ensureRegisteredInstallation(client: client)
-            }
+            client = try await manager.ensureRegisteredInstallation(client: client)
             if try await manager.recoverOwnedServerJobIfAvailable(
                 client: client,
                 bleManager: nil
             ) {
                 return
-            }
-            if client.clientInstallationToken?.isEmpty != false {
-                client = try await manager.ensureRegisteredInstallation(client: client)
             }
             manager.currentJob = nil
             manager.downloadURL = nil
@@ -3776,6 +3773,29 @@ final class OfflineMapManager: ObservableObject {
                 return try await client.jobs()
             } catch {
                 guard OfflineMapPollingRetryPolicy.shouldRetry(error) else { throw error }
+                failureCount += 1
+                statusMessage = "reconnecting to map server"
+                try await Task.sleep(
+                    nanoseconds: OfflineMapPollingRetryPolicy.delayNanoseconds(
+                        failureCount: failureCount
+                    )
+                )
+            }
+        }
+        throw CancellationError()
+    }
+
+    private func ensureRegisteredInstallationWithRetry(
+        client: OfflineMapPlatformClient
+    ) async throws -> OfflineMapPlatformClient {
+        var failureCount = 0
+        while !Task.isCancelled {
+            do {
+                return try await ensureRegisteredInstallation(client: client)
+            } catch {
+                guard OfflineMapPollingRetryPolicy.shouldRetry(error) else {
+                    throw error
+                }
                 failureCount += 1
                 statusMessage = "reconnecting to map server"
                 try await Task.sleep(

--- a/map-platform/backend/README.md
+++ b/map-platform/backend/README.md
@@ -9,9 +9,10 @@ contract and operating procedure.
 
 - `POST /v1/map-jobs` for curated, custom bbox, custom polygon, and route
   corridor requests, with installation-scoped idempotency metadata.
-- Installation-scoped job, list, map-pack, and download-URL reads. The client
-  installation ID is required for reads; legacy jobs without an owner remain
-  recoverable by ID.
+- Installation-authenticated creation, job/list reads, map-pack reads, and
+  download-URL issuance. Every public installation-owned request requires the
+  server-issued installation ID and matching `X-Installation-Token`; legacy
+  unowned jobs are available only through admin operations.
 - Source-region resolution from `map-platform/backend/config/source-regions.json`,
   with a cached Geofabrik catalog fallback for any requested area covered by
   Geofabrik.

--- a/map-platform/backend/map_platform/api.py
+++ b/map-platform/backend/map_platform/api.py
@@ -532,30 +532,17 @@ def create_app(
     def verify_registered_installation(
         installation_id: str | None,
         installation_token: str | None,
-        *,
-        required: bool = False,
-    ) -> str | None:
-        if installation_id is None:
-            if required:
-                raise HTTPException(status_code=401, detail="installation credential is required")
-            return None
+    ) -> str:
         if not isinstance(installation_id, str):
-            if required:
-                raise HTTPException(status_code=401, detail="installation credential is required")
-            return None
+            raise HTTPException(
+                status_code=401,
+                detail="installation credential is required",
+            )
         try:
-            registered = installation_store.is_registered(installation_id)
+            installation_store.verify(installation_id, installation_token)
         except InstallationCredentialError as exc:
-            if not required:
-                return None
             raise HTTPException(status_code=401, detail=str(exc)) from exc
-        if required or registered:
-            try:
-                installation_store.verify(installation_id, installation_token)
-            except InstallationCredentialError as exc:
-                raise HTTPException(status_code=401, detail=str(exc)) from exc
-            return installation_id
-        return None
+        return installation_id
 
     @app.get("/healthz")
     def healthz() -> dict[str, Any]:
@@ -583,9 +570,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         response.headers["Cache-Control"] = "private, no-store"
         result = service.generation_capabilities(installation_id)
         result["integrations"] = {
@@ -716,9 +701,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         enforce_rate_limits(
             (strava_oauth_start_ip_policy, client_ip(request)),
             (strava_oauth_start_installation_policy, installation_id),
@@ -816,9 +799,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         response.headers["Cache-Control"] = "private, no-store"
         return strava_integration.connection_status(installation_id)
 
@@ -835,9 +816,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         enforce_rate_limits(
             (strava_disconnect_ip_policy, client_ip(request)),
         )
@@ -858,9 +837,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         enforce_rate_limits(
             (strava_route_list_ip_policy, client_ip(request)),
             (strava_route_list_installation_policy, installation_id),
@@ -898,9 +875,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         enforce_rate_limits(
             (strava_route_import_ip_policy, client_ip(request)),
             (strava_route_import_installation_policy, installation_id),
@@ -932,9 +907,7 @@ def create_app(
         installation_id = verify_registered_installation(
             clientInstallationId,
             x_installation_token,
-            required=True,
         )
-        assert installation_id is not None
         enforce_rate_limits(
             (strava_route_validation_ip_policy, client_ip(request)),
             (strava_route_validation_installation_policy, installation_id),
@@ -1000,21 +973,19 @@ def create_app(
                 if existing is not None:
                     return public_job(
                         existing,
-                        payload.get("clientInstallationId"),
+                        registered_installation_id,
                         trust_capabilities,
                         app_build,
                         app_git_sha,
                         app_build_sha256,
                     )
-                rules = [(map_create_ip_policy, client_ip(request))]
-                if registered_installation_id is not None:
-                    rules.append(
-                        (map_create_installation_policy, registered_installation_id)
-                    )
-                enforce_rate_limits(*rules)
+                enforce_rate_limits(
+                    (map_create_ip_policy, client_ip(request)),
+                    (map_create_installation_policy, registered_installation_id),
+                )
                 return public_job(
                     service.create_job(payload),
-                    payload.get("clientInstallationId"),
+                    registered_installation_id,
                     trust_capabilities,
                     app_build,
                     app_git_sha,
@@ -1058,15 +1029,18 @@ def create_app(
                 x_map_stream_app_git_sha,
                 x_map_stream_app_build_sha256,
             )
-            verify_registered_installation(clientInstallationId, x_installation_token)
-            jobs = service.list_jobs(client_installation_id=clientInstallationId)
+            installation_id = verify_registered_installation(
+                clientInstallationId,
+                x_installation_token,
+            )
+            jobs = service.list_jobs(client_installation_id=installation_id)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
         return {
             "jobs": [
                 public_job(
                     job,
-                    clientInstallationId,
+                    installation_id,
                     trust_capabilities,
                     app_build,
                     app_git_sha,
@@ -1108,10 +1082,13 @@ def create_app(
                 x_map_stream_app_git_sha,
                 x_map_stream_app_build_sha256,
             )
-            verify_registered_installation(clientInstallationId, x_installation_token)
-            return public_job(
-                service.get_job_for_installation(job_id, clientInstallationId),
+            installation_id = verify_registered_installation(
                 clientInstallationId,
+                x_installation_token,
+            )
+            return public_job(
+                service.get_job_for_installation(job_id, installation_id),
+                installation_id,
                 trust_capabilities,
                 app_build,
                 app_git_sha,
@@ -1140,7 +1117,6 @@ def create_app(
             verify_registered_installation(
                 clientInstallationId,
                 x_installation_token,
-                required=True,
             )
             job = service.update_user_label_for_installation(
                 job_id,
@@ -1192,7 +1168,6 @@ def create_app(
             verify_registered_installation(
                 clientInstallationId,
                 x_installation_token,
-                required=True,
             )
             job = service.get_job_for_installation(
                 job_id,
@@ -1250,7 +1225,6 @@ def create_app(
             verify_registered_installation(
                 clientInstallationId,
                 x_installation_token,
-                required=True,
             )
             job = service.record_download_for_installation(
                 job_id,
@@ -1338,11 +1312,14 @@ def create_app(
                 x_map_stream_app_git_sha,
                 x_map_stream_app_build_sha256,
             )
-            verify_registered_installation(clientInstallationId, x_installation_token)
-            service.get_job_for_installation(job_id, clientInstallationId)
+            installation_id = verify_registered_installation(
+                clientInstallationId,
+                x_installation_token,
+            )
+            service.get_job_for_installation(job_id, installation_id)
             return public_job(
                 service.cancel_job(job_id),
-                clientInstallationId,
+                installation_id,
                 trust_capabilities,
                 app_build,
                 app_git_sha,
@@ -1446,10 +1423,13 @@ def create_app(
                 x_map_stream_app_git_sha,
                 x_map_stream_app_build_sha256,
             )
-            verify_registered_installation(clientInstallationId, x_installation_token)
+            installation_id = verify_registered_installation(
+                clientInstallationId,
+                x_installation_token,
+            )
             job = service.find_by_map_id(
                 map_id,
-                client_installation_id=clientInstallationId,
+                client_installation_id=installation_id,
             )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1457,7 +1437,7 @@ def create_app(
             raise HTTPException(status_code=404, detail="map pack not found")
         return public_job(
             job,
-            clientInstallationId,
+            installation_id,
             trust_capabilities,
             app_build,
             app_git_sha,
@@ -1480,24 +1460,25 @@ def create_app(
                 clientInstallationId,
                 x_installation_token,
             )
-            rules = [(download_url_ip_policy, client_ip(request))]
-            if registered_installation_id is not None:
-                rules.append(
-                    (
-                        download_url_installation_policy,
-                        registered_installation_id,
-                    )
-                )
-            enforce_rate_limits(*rules)
+            enforce_rate_limits(
+                (download_url_ip_policy, client_ip(request)),
+                (
+                    download_url_installation_policy,
+                    registered_installation_id,
+                ),
+            )
             if jobId is not None:
-                job = service.get_job_for_installation(jobId, clientInstallationId)
+                job = service.get_job_for_installation(
+                    jobId,
+                    registered_installation_id,
+                )
                 if job.map_id != map_id:
                     job = None
             else:
                 # Preserve older clients that only identify a stable map ID.
                 job = service.find_by_map_id(
                     map_id,
-                    client_installation_id=clientInstallationId,
+                    client_installation_id=registered_installation_id,
                 )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
@@ -1552,7 +1533,6 @@ def create_app(
             registered_installation_id = verify_registered_installation(
                 clientInstallationId,
                 x_installation_token,
-                required=True,
             )
             enforce_rate_limits(
                 (download_url_ip_policy, client_ip(request)),
@@ -1562,13 +1542,16 @@ def create_app(
                 ),
             )
             if jobId is not None:
-                job = service.get_job_for_installation(jobId, clientInstallationId)
+                job = service.get_job_for_installation(
+                    jobId,
+                    registered_installation_id,
+                )
                 if job.map_id != map_id:
                     job = None
             else:
                 job = service.find_by_map_id(
                     map_id,
-                    client_installation_id=clientInstallationId,
+                    client_installation_id=registered_installation_id,
                 )
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc

--- a/map-platform/backend/map_platform/jobs.py
+++ b/map-platform/backend/map_platform/jobs.py
@@ -1790,7 +1790,9 @@ class MapJobService:
     ) -> MapJob:
         job = self.get_job(job_id)
         if job.client_installation_id is None:
-            return job
+            if client_installation_id is None:
+                return job
+            raise KeyError(job_id)
         if client_installation_id is None:
             raise KeyError(job_id)
         normalized = _validate_identifier(client_installation_id, "clientInstallationId")
@@ -1828,8 +1830,11 @@ class MapJobService:
             if job.map_id == map_id and job.status == JobStatus.READY
         ]
         if normalized is not None:
-            owned = [job for job in candidates if job.client_installation_id == normalized]
-            candidates = owned or [job for job in candidates if job.client_installation_id is None]
+            candidates = [
+                job
+                for job in candidates
+                if job.client_installation_id == normalized
+            ]
         elif not allow_owned_without_installation:
             candidates = [job for job in candidates if job.client_installation_id is None]
         if not candidates:

--- a/map-platform/backend/tests/test_api.py
+++ b/map-platform/backend/tests/test_api.py
@@ -234,17 +234,68 @@ class MapJobRunAPITests(unittest.TestCase):
         self.client.headers["X-Map-Stream-App-Build"] = "100"
         self.client.headers["X-Map-Stream-App-Git-Sha"] = self.ios_git_sha
         self.client.headers["X-Map-Stream-App-Build-Sha256"] = self.ios_build_sha256
+        self.installation = self.issue_installation(self.client)
+        self.job_request_sequence = 0
 
     def tearDown(self):
         self.client.close()
         self.environment.stop()
         self.tmp.cleanup()
 
-    def create_job(self) -> str:
-        response = self.client.post(
-            "/v1/map-jobs",
-            json={"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]},
+    def issue_installation(self, client: TestClient) -> dict[str, str]:
+        response = client.post("/v1/installations")
+        self.assertEqual(response.status_code, 200)
+        return response.json()
+
+    @staticmethod
+    def installation_headers(
+        credential: dict[str, str],
+        **extra: str,
+    ) -> dict[str, str]:
+        return {
+            "X-Installation-Token": credential["clientInstallationToken"],
+            **extra,
+        }
+
+    @staticmethod
+    def installation_params(credential: dict[str, str]) -> dict[str, str]:
+        return {"clientInstallationId": credential["clientInstallationId"]}
+
+    def post_map_job(
+        self,
+        payload: dict | None = None,
+        *,
+        client: TestClient | None = None,
+        credential: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ):
+        self.job_request_sequence += 1
+        request_payload = dict(
+            payload
+            or {
+                "mode": "custom_bbox",
+                "bbox": [103.75, 1.24, 103.93, 1.37],
+            }
         )
+        request_credential = credential or self.installation
+        request_payload.setdefault(
+            "clientInstallationId",
+            request_credential["clientInstallationId"],
+        )
+        request_payload.setdefault(
+            "clientRequestId",
+            f"request-test-{self.job_request_sequence:08d}",
+        )
+        request_headers = self.installation_headers(request_credential)
+        request_headers.update(headers or {})
+        return (client or self.client).post(
+            "/v1/map-jobs",
+            json=request_payload,
+            headers=request_headers,
+        )
+
+    def create_job(self) -> str:
+        response = self.post_map_job()
         self.assertEqual(response.status_code, 200)
         return response.json()["jobId"]
 
@@ -445,12 +496,12 @@ class MapJobRunAPITests(unittest.TestCase):
             ):
                 client = TestClient(create_app())
                 try:
-                    response = client.post(
-                        "/v1/map-jobs",
-                        json={
+                    response = self.post_map_job(
+                        {
                             "mode": "custom_bbox",
                             "bbox": [103.75, 1.24, 103.93, 1.37],
                         },
+                        client=client,
                     )
                     self.assertEqual(response.status_code, 200)
                     payload = response.json()
@@ -481,7 +532,7 @@ class MapJobRunAPITests(unittest.TestCase):
                 "internationalFallback": "en",
             },
         }
-        enabled = self.client.post("/v1/map-jobs", json=payload)
+        enabled = self.post_map_job(payload)
         self.assertEqual(enabled.status_code, 200)
 
     def test_target_three_is_globally_available_after_production_promotion(self):
@@ -823,7 +874,7 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual(blocked.status_code, 429)
         self.assertGreater(int(blocked.headers["Retry-After"]), 0)
 
-    def test_anonymous_map_creation_is_limited_by_client_address(self):
+    def test_anonymous_map_creation_is_rejected_before_quota_consumption(self):
         limited_root = Path(self.tmp.name) / "anonymous-map-create-limit"
         with patch.dict(
             os.environ,
@@ -844,14 +895,21 @@ class MapJobRunAPITests(unittest.TestCase):
             finally:
                 client.close()
 
-        self.assertEqual(first.status_code, 200)
-        self.assertEqual(blocked.status_code, 429)
-        self.assertGreater(int(blocked.headers["Retry-After"]), 0)
+        self.assertEqual(first.status_code, 401)
+        self.assertEqual(blocked.status_code, 401)
+        self.assertEqual(
+            first.json()["detail"],
+            "installation credential is required",
+        )
+        with sqlite3.connect(limited_root / "rate-limits.sqlite3") as connection:
+            consumed = connection.execute(
+                "SELECT COUNT(*) FROM rate_limits WHERE scope LIKE 'map-create-%'"
+            ).fetchone()[0]
+        self.assertEqual(consumed, 0)
 
     def test_map_creation_rejects_unknown_fields_and_oversized_bodies(self):
-        unknown = self.client.post(
-            "/v1/map-jobs",
-            json={
+        unknown = self.post_map_job(
+            {
                 "mode": "custom_bbox",
                 "bbox": [103.75, 1.24, 103.93, 1.37],
                 "padding": "not persisted",
@@ -892,9 +950,8 @@ class MapJobRunAPITests(unittest.TestCase):
             [103.8 + index / 10_000_000, 1.3 + index / 10_000_000]
             for index in range(25_000)
         ]
-        response = self.client.post(
-            "/v1/map-jobs",
-            json={
+        response = self.post_map_job(
+            {
                 "mode": "route_corridor",
                 "route": route,
                 "corridorWidthM": 100,
@@ -1107,6 +1164,7 @@ class MapJobRunAPITests(unittest.TestCase):
         with patch("map_platform.api.run_job", return_value=result):
             response = self.client.post(
                 f"/v1/map-jobs/{job_id}/run",
+                params=self.installation_params(self.installation),
                 headers={"Authorization": "Bearer admin-secret"},
             )
 
@@ -1125,9 +1183,12 @@ class MapJobRunAPITests(unittest.TestCase):
         ):
             client = TestClient(create_app())
             try:
-                created = client.post(
-                    "/v1/map-jobs",
-                    json={"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]},
+                created = self.post_map_job(
+                    {
+                        "mode": "custom_bbox",
+                        "bbox": [103.75, 1.24, 103.93, 1.37],
+                    },
+                    client=client,
                 )
                 response = client.post(
                     f"/v1/map-jobs/{created.json()['jobId']}/run",
@@ -1173,12 +1234,10 @@ class MapJobRunAPITests(unittest.TestCase):
 
     def test_same_map_jobs_publish_and_download_exact_job_artifacts(self):
         def create_owned(request_id: str) -> str:
-            response = self.client.post(
-                "/v1/map-jobs",
-                json={
+            response = self.post_map_job(
+                {
                     "mode": "custom_bbox",
                     "bbox": [103.75, 1.24, 103.93, 1.37],
-                    "clientInstallationId": "installation-owner",
                     "clientRequestId": request_id,
                 },
             )
@@ -1228,9 +1287,12 @@ class MapJobRunAPITests(unittest.TestCase):
             signed = self.client.post(
                 "/v1/map-packs/map-shared/download-url",
                 params={
-                    "clientInstallationId": "installation-owner",
+                    "clientInstallationId": self.installation[
+                        "clientInstallationId"
+                    ],
                     "jobId": job_id,
                 },
+                headers=self.installation_headers(self.installation),
             )
             self.assertEqual(signed.status_code, 200)
             downloaded = self.client.get(signed.json()["url"])
@@ -1556,9 +1618,8 @@ class MapJobRunAPITests(unittest.TestCase):
     def test_malformed_stream_headers_are_rejected_before_reads_or_mutations(self):
         jobs_root = Path(self.tmp.name) / "jobs"
         before = len(list(jobs_root.glob("*.json"))) if jobs_root.exists() else 0
-        malformed_create = self.client.post(
-            "/v1/map-jobs",
-            json={"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]},
+        malformed_create = self.post_map_job(
+            {"mode": "custom_bbox", "bbox": [103.75, 1.24, 103.93, 1.37]},
             headers={"X-Map-Stream-Trust": "malformed"},
         )
         self.assertEqual(malformed_create.status_code, 400)
@@ -1568,25 +1629,41 @@ class MapJobRunAPITests(unittest.TestCase):
         job_id = self.create_job()
         malformed_cancel = self.client.post(
             f"/v1/map-jobs/{job_id}/cancel",
-            headers={"X-Map-Stream-App-Build": "not-a-build"},
+            params=self.installation_params(self.installation),
+            headers=self.installation_headers(
+                self.installation,
+                **{"X-Map-Stream-App-Build": "not-a-build"},
+            ),
         )
         self.assertEqual(malformed_cancel.status_code, 400)
         self.assertEqual(
-            self.client.get(f"/v1/map-jobs/{job_id}").json()["status"],
+            self.client.get(
+                f"/v1/map-jobs/{job_id}",
+                params=self.installation_params(self.installation),
+                headers=self.installation_headers(self.installation),
+            ).json()["status"],
             "queued",
         )
 
         incomplete_identity = self.client.post(
             f"/v1/map-jobs/{job_id}/cancel",
-            headers={
-                "X-Map-Stream-App-Build": "100",
-                "X-Map-Stream-App-Git-Sha": "",
-                "X-Map-Stream-App-Build-Sha256": "",
-            },
+            params=self.installation_params(self.installation),
+            headers=self.installation_headers(
+                self.installation,
+                **{
+                    "X-Map-Stream-App-Build": "100",
+                    "X-Map-Stream-App-Git-Sha": "",
+                    "X-Map-Stream-App-Build-Sha256": "",
+                },
+            ),
         )
         self.assertEqual(incomplete_identity.status_code, 400)
         self.assertEqual(
-            self.client.get(f"/v1/map-jobs/{job_id}").json()["status"],
+            self.client.get(
+                f"/v1/map-jobs/{job_id}",
+                params=self.installation_params(self.installation),
+                headers=self.installation_headers(self.installation),
+            ).json()["status"],
             "queued",
         )
 
@@ -1732,7 +1809,11 @@ class MapJobRunAPITests(unittest.TestCase):
 
         issued = self.client.post(
             "/v1/map-packs/map-expired/download-url",
-            params={"jobId": job_id},
+            params={
+                **self.installation_params(self.installation),
+                "jobId": job_id,
+            },
+            headers=self.installation_headers(self.installation),
         )
         self.assertEqual(issued.status_code, 200)
 
@@ -1749,9 +1830,10 @@ class MapJobRunAPITests(unittest.TestCase):
         download = self.client.post(
             "/v1/map-packs/map-expired/download-url",
             params={
-                "clientInstallationId": "installation-owner",
+                **self.installation_params(self.installation),
                 "jobId": job_id,
             },
+            headers=self.installation_headers(self.installation),
         )
         previously_issued_download = self.client.get(issued.json()["url"])
 
@@ -1786,6 +1868,7 @@ class MapJobRunAPITests(unittest.TestCase):
 
         response = self.client.post(
             f"/v1/map-jobs/{job_id}/run",
+            params=self.installation_params(self.installation),
             headers={"Authorization": "Bearer admin-secret"},
         )
 
@@ -1794,10 +1877,18 @@ class MapJobRunAPITests(unittest.TestCase):
 
     def test_run_route_rejects_cancelled_job(self):
         job_id = self.create_job()
-        self.assertEqual(self.client.post(f"/v1/map-jobs/{job_id}/cancel").status_code, 200)
+        self.assertEqual(
+            self.client.post(
+                f"/v1/map-jobs/{job_id}/cancel",
+                params=self.installation_params(self.installation),
+                headers=self.installation_headers(self.installation),
+            ).status_code,
+            200,
+        )
 
         response = self.client.post(
             f"/v1/map-jobs/{job_id}/run",
+            params=self.installation_params(self.installation),
             headers={"Authorization": "Bearer admin-secret"},
         )
 
@@ -1813,30 +1904,31 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual(response.status_code, 404)
 
     def test_list_jobs_filters_by_client_installation(self):
-        first = self.client.post(
-            "/v1/map-jobs",
-            json={
+        first_installation = self.issue_installation(self.client)
+        second_installation = self.issue_installation(self.client)
+        first = self.post_map_job(
+            {
                 "mode": "custom_bbox",
                 "bbox": [103.75, 1.24, 103.93, 1.37],
-                "clientInstallationId": "installation-first",
                 "clientRequestId": "request-first-123",
             },
+            credential=first_installation,
         )
         self.assertEqual(first.status_code, 200)
-        second = self.client.post(
-            "/v1/map-jobs",
-            json={
+        second = self.post_map_job(
+            {
                 "mode": "custom_bbox",
                 "bbox": [103.76, 1.25, 103.94, 1.38],
-                "clientInstallationId": "installation-second",
                 "clientRequestId": "request-second-123",
             },
+            credential=second_installation,
         )
         self.assertEqual(second.status_code, 200)
 
         response = self.client.get(
             "/v1/map-jobs",
-            params={"clientInstallationId": "installation-first"},
+            params=self.installation_params(first_installation),
+            headers=self.installation_headers(first_installation),
         )
 
         self.assertEqual(response.status_code, 200)
@@ -1844,43 +1936,89 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual([job["jobId"] for job in jobs], [first.json()["jobId"]])
 
     def test_job_reads_require_matching_installation(self):
-        owned = self.client.post(
-            "/v1/map-jobs",
-            json={
+        owner = self.issue_installation(self.client)
+        other_installation = self.issue_installation(self.client)
+        owned = self.post_map_job(
+            {
                 "mode": "custom_bbox",
                 "bbox": [103.75, 1.24, 103.93, 1.37],
-                "clientInstallationId": "installation-owner",
                 "clientRequestId": "request-owner-123",
             },
+            credential=owner,
         ).json()
 
         missing_filter = self.client.get("/v1/map-jobs")
         matching = self.client.get(
             f"/v1/map-jobs/{owned['jobId']}",
-            params={"clientInstallationId": "installation-owner"},
+            params=self.installation_params(owner),
+            headers=self.installation_headers(owner),
         )
         other = self.client.get(
             f"/v1/map-jobs/{owned['jobId']}",
-            params={"clientInstallationId": "installation-other"},
+            params=self.installation_params(other_installation),
+            headers=self.installation_headers(other_installation),
         )
         unscoped = self.client.get(f"/v1/map-jobs/{owned['jobId']}")
 
         self.assertEqual(missing_filter.status_code, 400)
         self.assertEqual(matching.status_code, 200)
         self.assertEqual(other.status_code, 404)
-        self.assertEqual(unscoped.status_code, 404)
+        self.assertEqual(unscoped.status_code, 401)
 
-    def test_legacy_job_remains_recoverable_by_an_installation(self):
+    def test_job_endpoints_reject_an_installation_id_without_its_token(self):
+        owner = self.issue_installation(self.client)
+        created = self.post_map_job(credential=owner)
+        self.assertEqual(created.status_code, 200)
+        job_id = created.json()["jobId"]
+        params = self.installation_params(owner)
+
+        attempts = [
+            self.client.get("/v1/map-jobs", params=params),
+            self.client.get(f"/v1/map-jobs/{job_id}", params=params),
+            self.client.post(f"/v1/map-jobs/{job_id}/cancel", params=params),
+        ]
+        for response in attempts:
+            with self.subTest(url=str(response.request.url)):
+                self.assertEqual(response.status_code, 401)
+                self.assertEqual(
+                    response.json()["detail"],
+                    "installation credential is required",
+                )
+
+        wrong_token = self.installation_headers(
+            owner,
+            **{"X-Installation-Token": "v1." + "A" * 43},
+        )
+        response = self.client.get(
+            f"/v1/map-jobs/{job_id}",
+            params=params,
+            headers=wrong_token,
+        )
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json()["detail"],
+            "installation credential is invalid",
+        )
+
+    def test_legacy_unowned_job_is_not_publicly_recoverable(self):
         legacy_job_id = self.create_job()
+        job_path = Path(self.tmp.name) / "jobs" / f"{legacy_job_id}.json"
+        legacy_job = json.loads(job_path.read_text())
+        legacy_job["clientInstallationId"] = None
+        legacy_job["clientRequestId"] = None
+        legacy_job["request"].pop("clientInstallationId", None)
+        legacy_job["request"].pop("clientRequestId", None)
+        self.client.app.state.job_store.save(MapJob.from_dict(legacy_job))
 
         response = self.client.get(
             f"/v1/map-jobs/{legacy_job_id}",
-            params={"clientInstallationId": "installation-owner"},
+            params=self.installation_params(self.installation),
+            headers=self.installation_headers(self.installation),
         )
         legacy_unscoped = self.client.get(f"/v1/map-jobs/{legacy_job_id}")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(legacy_unscoped.status_code, 200)
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(legacy_unscoped.status_code, 401)
 
     def test_client_metadata_validation_returns_bad_request(self):
         valid = {
@@ -1888,63 +2026,86 @@ class MapJobRunAPITests(unittest.TestCase):
             "bbox": [103.75, 1.24, 103.93, 1.37],
         }
         invalid_payloads = [
-            {**valid, "clientInstallationId": "installation-only"},
             {
                 **valid,
-                "clientInstallationId": "installation-owner",
+                "clientInstallationId": self.installation[
+                    "clientInstallationId"
+                ],
+            },
+            {
+                **valid,
+                "clientInstallationId": self.installation[
+                    "clientInstallationId"
+                ],
                 "clientRequestId": "request-owner-123",
                 "installOnDevice": "yes",
-            },
-            {
-                **valid,
-                "clientInstallationId": "bad",
-                "clientRequestId": "request-owner-123",
-            },
-            {
-                **valid,
-                "clientInstallationId": 123,
-                "clientRequestId": "request-owner-123",
             },
         ]
 
         for payload in invalid_payloads:
             with self.subTest(payload=payload):
-                response = self.client.post("/v1/map-jobs", json=payload)
+                response = self.client.post(
+                    "/v1/map-jobs",
+                    json=payload,
+                    headers=self.installation_headers(self.installation),
+                )
                 self.assertEqual(response.status_code, 400)
                 self.assertTrue(response.json()["detail"])
+
+        invalid_credentials = ["bad", 123]
+        for invalid_id in invalid_credentials:
+            with self.subTest(invalid_id=invalid_id):
+                response = self.client.post(
+                    "/v1/map-jobs",
+                    json={
+                        **valid,
+                        "clientInstallationId": invalid_id,
+                        "clientRequestId": "request-owner-123",
+                    },
+                    headers=self.installation_headers(self.installation),
+                )
+                self.assertEqual(response.status_code, 401)
 
         invalid_filter = self.client.get(
             "/v1/map-jobs",
             params={"clientInstallationId": "bad"},
+            headers=self.installation_headers(self.installation),
         )
-        self.assertEqual(invalid_filter.status_code, 400)
+        self.assertEqual(invalid_filter.status_code, 401)
 
     def test_map_pack_reads_are_scoped_and_choose_newest_owned_job(self):
-        def create_owned(installation_id: str, request_id: str, bbox: list[float]) -> str:
-            response = self.client.post(
-                "/v1/map-jobs",
-                json={
+        owner = self.issue_installation(self.client)
+        other_installation = self.issue_installation(self.client)
+        unknown_installation = self.issue_installation(self.client)
+
+        def create_owned(
+            credential: dict[str, str],
+            request_id: str,
+            bbox: list[float],
+        ) -> str:
+            response = self.post_map_job(
+                {
                     "mode": "custom_bbox",
                     "bbox": bbox,
-                    "clientInstallationId": installation_id,
                     "clientRequestId": request_id,
                 },
+                credential=credential,
             )
             self.assertEqual(response.status_code, 200)
             return response.json()["jobId"]
 
         older = create_owned(
-            "installation-owner",
+            owner,
             "request-owner-old",
             [103.75, 1.24, 103.93, 1.37],
         )
         newer = create_owned(
-            "installation-owner",
+            owner,
             "request-owner-new",
             [103.76, 1.25, 103.94, 1.38],
         )
         other = create_owned(
-            "installation-other",
+            other_installation,
             "request-other-new",
             [103.77, 1.26, 103.95, 1.39],
         )
@@ -1978,39 +2139,44 @@ class MapJobRunAPITests(unittest.TestCase):
 
         matching = self.client.get(
             "/v1/map-packs/map-shared",
-            params={"clientInstallationId": "installation-owner"},
+            params=self.installation_params(owner),
+            headers=self.installation_headers(owner),
         )
         unknown = self.client.get(
             "/v1/map-packs/map-shared",
-            params={"clientInstallationId": "installation-unknown"},
+            params=self.installation_params(unknown_installation),
+            headers=self.installation_headers(unknown_installation),
         )
         unscoped = self.client.get("/v1/map-packs/map-shared")
         download = self.client.post(
             "/v1/map-packs/map-shared/download-url",
             params={
-                "clientInstallationId": "installation-owner",
+                **self.installation_params(owner),
                 "jobId": newer,
             },
+            headers=self.installation_headers(owner),
         )
         older_download = self.client.post(
             "/v1/map-packs/map-shared/download-url",
             params={
-                "clientInstallationId": "installation-owner",
+                **self.installation_params(owner),
                 "jobId": older,
             },
+            headers=self.installation_headers(owner),
         )
         cross_install_download = self.client.post(
             "/v1/map-packs/map-shared/download-url",
             params={
-                "clientInstallationId": "installation-owner",
+                **self.installation_params(owner),
                 "jobId": other,
             },
+            headers=self.installation_headers(owner),
         )
 
         self.assertEqual(matching.status_code, 200)
         self.assertEqual(matching.json()["jobId"], newer)
         self.assertEqual(unknown.status_code, 404)
-        self.assertEqual(unscoped.status_code, 404)
+        self.assertEqual(unscoped.status_code, 401)
         self.assertEqual(download.status_code, 200)
         downloaded = self.client.get(download.json()["url"])
         self.assertEqual(downloaded.status_code, 200)
@@ -2029,29 +2195,30 @@ class MapJobRunAPITests(unittest.TestCase):
             status="ready",
             mapId="map-legacy",
             packPath=str(legacy_path),
+            clientInstallationId=None,
+            clientRequestId=None,
         )
-        self.assertEqual(self.client.get("/v1/map-packs/map-legacy").status_code, 200)
+        self.assertEqual(self.client.get("/v1/map-packs/map-legacy").status_code, 401)
         legacy_download = self.client.post(
             "/v1/map-packs/map-legacy/download-url",
             params={
-                "clientInstallationId": "installation-owner",
+                **self.installation_params(owner),
                 "jobId": legacy,
             },
+            headers=self.installation_headers(owner),
         )
-        self.assertEqual(legacy_download.status_code, 200)
-        legacy_file = self.client.get(legacy_download.json()["url"])
-        self.assertEqual(legacy_file.status_code, 200)
-        self.assertEqual(legacy_file.content, b"legacy")
+        self.assertEqual(legacy_download.status_code, 404)
 
     def test_modern_job_mutations_require_matching_installation(self):
-        response = self.client.post(
-            "/v1/map-jobs",
-            json={
+        owner = self.issue_installation(self.client)
+        other_installation = self.issue_installation(self.client)
+        response = self.post_map_job(
+            {
                 "mode": "custom_bbox",
                 "bbox": [103.75, 1.24, 103.93, 1.37],
-                "clientInstallationId": "installation-owner",
                 "clientRequestId": "request-owner-123",
             },
+            credential=owner,
         )
         self.assertEqual(response.status_code, 200)
         job_id = response.json()["jobId"]
@@ -2066,13 +2233,15 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual(
             self.client.post(
                 f"/v1/map-jobs/{job_id}/cancel",
-                params={"clientInstallationId": "installation-other"},
+                params=self.installation_params(other_installation),
+                headers=self.installation_headers(other_installation),
             ).status_code,
             404,
         )
         cancelled = self.client.post(
             f"/v1/map-jobs/{job_id}/cancel",
-            params={"clientInstallationId": "installation-owner"},
+            params=self.installation_params(owner),
+            headers=self.installation_headers(owner),
         )
         self.assertEqual(cancelled.status_code, 200)
         self.assertEqual(cancelled.json()["status"], "cancelled")


### PR DESCRIPTION
## Summary
- require the server-issued installation ID and matching `X-Installation-Token` for every public map job, pack lookup, cancellation, and download-URL request
- stop exposing legacy ownerless jobs through newly issued installation credentials while retaining admin access and already-issued short-lived signed downloads
- register or refresh the iOS installation credential before recovery, refresh, and download requests, with bounded retry behavior for transient launch failures
- update backend documentation and security regression coverage

## Compatibility
This intentionally removes the public legacy ID-only recovery path. Current iOS builds provision a credential before map operations; older anonymous clients must upgrade. Legacy ownerless records remain visible to authenticated admin operations but cannot be claimed or read through the public API.

## Validation
- `python3 -m unittest tests.test_api` (43 passed)
- `python3 -m unittest discover -s tests -p 'test_*.py'` (614 passed, 2 skipped)
- `ios-app/scripts/run-navigation-tests.sh` (navigation, cycling sensor, Catalyst layout/appearance, and saved-map preview suites passed)
- `python3 -m py_compile map_platform/api.py map_platform/jobs.py tests/test_api.py`
- `git diff --check`

No production settings, deployments, secrets, or physical devices were changed.
