### PR TITLE
Handle Apple App Attest extension flags

### DIFF
--- a/map-platform/backend/map_platform/app_attest.py
+++ b/map-platform/backend/map_platform/app_attest.py
@@ -425,7 +425,11 @@ def parse_authenticator_data(
                 "app_attest_wrong_environment", "App Attest environment is invalid"
             )
 
-    if has_extensions:
+    # Apple's App Attest attestation objects append launch-validation
+    # extensions even though their authenticator flags do not set ED. Keep
+    # that compatibility limited to attestation objects; assertions still
+    # require ED before any trailing extension data is accepted.
+    if has_extensions or (attestation and offset < len(auth_data)):
         decoder = BoundedCBORDecoder(auth_data[offset:])
         decoded_extensions = decoder.decode_one()
         if not isinstance(decoded_extensions, dict):

--- a/map-platform/backend/tests/test_app_attest.py
+++ b/map-platform/backend/tests/test_app_attest.py
@@ -32,6 +32,7 @@ from map_platform.app_attest import (
     base64url_encode,
     canonical_map_create_client_data,
     decode_base64,
+    parse_authenticator_data,
 )
 
 
@@ -89,6 +90,7 @@ def apple_attestation_fixture(
     *,
     challenge: bytes,
     app_build: str = TEST_APP_BUILD,
+    extension_data_flag: bool = True,
 ) -> tuple[bytes, str, x509.Certificate]:
     attested_key = ec.generate_private_key(ec.SECP256R1())
     public_key_x963 = attested_key.public_key().public_bytes(
@@ -114,7 +116,7 @@ def apple_attestation_fixture(
     )
     auth_data = (
         hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
-        + b"\xc0"
+        + (b"\xc0" if extension_data_flag else b"\x40")
         + (0).to_bytes(4, "big")
         + APP_ATTEST_PRODUCTION_AAGUID
         + len(key_id_bytes).to_bytes(2, "big")
@@ -192,6 +194,44 @@ class AppleAppAttestVerifierTests(unittest.TestCase):
             hashlib.sha256(verified.public_key_x963).digest(),
             base64.b64decode(key_id),
         )
+
+    def test_accepts_apple_attestation_extensions_without_ed_flag(self):
+        challenge = b"d" * 32
+        attestation, key_id, root = apple_attestation_fixture(
+            challenge=challenge,
+            extension_data_flag=False,
+        )
+        verifier = AppleAppAttestVerifier(
+            allowed_app_ids={TEST_APP_ID},
+            environment="production",
+            root_certificate=root,
+            allowed_validation_categories={4},
+        )
+
+        verified = verifier.verify_attestation(
+            attestation_object=attestation,
+            key_id=key_id,
+            challenge=challenge,
+            app_build=TEST_APP_BUILD,
+        )
+
+        self.assertEqual(verified.validation_category, 4)
+        self.assertEqual(verified.bundle_version, TEST_APP_BUILD)
+        self.assertEqual(
+            hashlib.sha256(verified.public_key_x963).digest(),
+            base64.b64decode(key_id),
+        )
+
+    def test_rejects_assertion_extensions_without_ed_flag(self):
+        auth_data = (
+            hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
+            + b"\x00"
+            + (1).to_bytes(4, "big")
+            + encode_cbor({"bundleVersion": TEST_APP_BUILD})
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "trailing bytes"):
+            parse_authenticator_data(auth_data, attestation=False)
 
     def test_rejects_wrong_challenge_and_bundle_version(self):
         challenge = b"c" * 32


### PR DESCRIPTION
## Summary

- accept Apple App Attest attestation launch-validation extensions when Apple leaves the WebAuthn ED flag clear
- keep assertion parsing strict: assertions still require ED before extension data
- add full-verifier and fail-closed parser regressions

## Why

The development map backend returned `401 app_attest_invalid_authenticator` for a real Bicino Dev enrollment. Apple’s published App Attest validation vector sets AT (`0x40`) but not ED (`0x80`) and still appends `apple_bundle_version_01` and `apple_validation_category_01`. The existing parser rejected those bytes before certificate, nonce, identity, category, or bundle validation.

Apple reference: https://developer.apple.com/documentation/devicecheck/validating-apps-that-connect-to-your-server

## Verification

- `python3 -m unittest discover -s tests -p test_app_attest.py` (9 passed)
- `python3 -m unittest discover -s tests` (639 passed, 2 skipped)
- `python3 -m unittest discover -s ../deploy/tests` (52 passed)
- `git diff --check`

No backend deployment has been performed from this branch.