### PR TITLE
Handle Apple App Attest assertion extensions

### DIFF
--- a/map-platform/backend/map_platform/app_attest.py
+++ b/map-platform/backend/map_platform/app_attest.py
@@ -425,11 +425,12 @@ def parse_authenticator_data(
                 "app_attest_wrong_environment", "App Attest environment is invalid"
             )
 
-    # Apple's App Attest attestation objects append launch-validation
-    # extensions even though their authenticator flags do not set ED. Keep
-    # that compatibility limited to attestation objects; assertions still
-    # require ED before any trailing extension data is accepted.
-    if has_extensions or (attestation and offset < len(auth_data)):
+    # Apple's App Attest objects append launch-validation extensions to both
+    # attestations and assertions even when their authenticator flags do not
+    # set ED. This parser is App Attest-specific: accept that framing while
+    # still requiring exactly one bounded CBOR map. The caller then applies
+    # the object-specific extension-key and value allowlist.
+    if has_extensions or offset < len(auth_data):
         decoder = BoundedCBORDecoder(auth_data[offset:])
         decoded_extensions = decoder.decode_one()
         if not isinstance(decoded_extensions, dict):

--- a/map-platform/backend/tests/test_app_attest.py
+++ b/map-platform/backend/tests/test_app_attest.py
@@ -222,15 +222,28 @@ class AppleAppAttestVerifierTests(unittest.TestCase):
             base64.b64decode(key_id),
         )
 
-    def test_rejects_assertion_extensions_without_ed_flag(self):
+    def test_accepts_assertion_extensions_without_ed_flag(self):
+        extensions = {"bundleVersion": TEST_APP_BUILD}
         auth_data = (
             hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
             + b"\x00"
             + (1).to_bytes(4, "big")
-            + encode_cbor({"bundleVersion": TEST_APP_BUILD})
+            + encode_cbor(extensions)
         )
 
-        with self.assertRaisesRegex(AppAttestError, "trailing bytes"):
+        parsed = parse_authenticator_data(auth_data, attestation=False)
+
+        self.assertEqual(parsed.extensions, extensions)
+
+    def test_rejects_non_map_assertion_trailing_data(self):
+        auth_data = (
+            hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
+            + b"\x00"
+            + (1).to_bytes(4, "big")
+            + encode_cbor(["not", "extensions"])
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "extensions"):
             parse_authenticator_data(auth_data, attestation=False)
 
     def test_rejects_wrong_challenge_and_bundle_version(self):
@@ -347,6 +360,7 @@ class AppAttestStoreTests(unittest.TestCase):
         counter,
         app_build=TEST_APP_BUILD,
         extensions=None,
+        extension_data_flag=True,
     ) -> bytes:
         client_data = canonical_map_create_client_data(
             challenge_id=challenge.challenge_id,
@@ -358,7 +372,11 @@ class AppAttestStoreTests(unittest.TestCase):
         )
         auth_data = (
             hashlib.sha256(TEST_APP_ID.encode()).digest()
-            + (b"\x80" if extensions is not None else b"\x00")
+            + (
+                b"\x80"
+                if extensions is not None and extension_data_flag
+                else b"\x00"
+            )
             + counter.to_bytes(4, "big")
         )
         if extensions is not None:
@@ -440,6 +458,83 @@ class AppAttestStoreTests(unittest.TestCase):
                 request_body=body,
                 payload=payload,
                 app_build="101",
+            )
+
+    def test_assertion_accepts_extensions_without_ed_flag(self):
+        installation_id = "inst_v2_" + "f" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-flagless-extensions-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            extensions={
+                "validationCategory": (4).to_bytes(4, "little"),
+                "bundleVersion": TEST_APP_BUILD,
+            },
+            extension_data_flag=False,
+        )
+
+        self.assertEqual(
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            ),
+            1,
+        )
+
+    def test_assertion_rejects_unknown_extensions_without_ed_flag(self):
+        installation_id = "inst_v2_" + "0" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-unknown-extensions-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            extensions={"unexpected": True},
+            extension_data_flag=False,
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "extensions"):
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
             )
 
     def test_assertion_is_bound_to_body_challenge_and_monotonic_counter(self):


### PR DESCRIPTION
## Summary

- accept Apple App Attest assertion extension maps when Apple leaves the WebAuthn ED flag clear
- continue requiring one bounded canonical CBOR map with assertion-specific key/value validation
- retain signature, challenge/body binding, app identity, bundle version, launch-category, and monotonic-counter checks

## Why

After #346 was deployed to the development map backend, a real Bicino Dev request successfully obtained an assertion challenge but `POST /v1/map-jobs` still returned `app_attest_invalid_authenticator`. The parser compatibility added by #346 applied only to attestation objects.

Apple’s current App Attest guidance says iOS 27 and later appends extensions to assertion authenticator data and that assertion extensions should be processed like attestation extensions:
https://developer.apple.com/videos/play/wwdc2026/201/

## Verification

- `python3 -m unittest discover -s tests -p test_app_attest.py` (12 passed)
- `python3 -m unittest discover -s tests` (642 passed, 2 skipped)
- `python3 -m unittest discover -s ../deploy/tests` (52 passed)
- `git diff --check`

Regression coverage includes a fully signed assertion with flagless extensions plus rejection of non-map trailing data and unknown extension keys. No deployment has been performed from this branch.