### PR TITLE
Log safe App Attest rejection diagnostics

### DIFF
--- a/map-platform/backend/map_platform/api.py
+++ b/map-platform/backend/map_platform/api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import html
+import logging
 import os
 import secrets
 import time
@@ -103,6 +104,9 @@ from .strava_integrations import (
     StravaIntegrationService,
 )
 from .worker import MapWorker, cleanup_work_dirs, expire_ready_jobs
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def _project_building_progress(
@@ -432,7 +436,12 @@ def create_app(
         request: Request,
         exc: AppAttestError,
     ) -> JSONResponse:
-        del request
+        _LOGGER.warning(
+            "App Attest rejected path=%s code=%s reason=%s",
+            request.url.path,
+            exc.code,
+            exc.safe_message,
+        )
         return JSONResponse(
             status_code=exc.status_code,
             content={

--- a/map-platform/backend/tests/test_api.py
+++ b/map-platform/backend/tests/test_api.py
@@ -748,6 +748,32 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual(replay.status_code, 200)
         self.assertEqual(replay.json()["jobId"], created.json()["jobId"])
 
+    def test_app_attest_rejection_logs_only_safe_diagnostics(self):
+        secret_assertion = "not-valid-secret-assertion"
+
+        with self.assertLogs("map_platform.api", level="WARNING") as captured:
+            response = self.post_map_job(
+                headers={"X-App-Attest-Assertion": secret_assertion}
+            )
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(
+            response.json()["detail"]["code"],
+            "app_attest_invalid_encoding",
+        )
+        diagnostics = "\n".join(captured.output)
+        self.assertIn(
+            "App Attest rejected path=/v1/map-jobs "
+            "code=app_attest_invalid_encoding "
+            "reason=App Attest assertion is invalid",
+            diagnostics,
+        )
+        self.assertNotIn(secret_assertion, diagnostics)
+        self.assertNotIn(
+            self.installation["clientInstallationToken"],
+            diagnostics,
+        )
+
     def test_unattested_stateless_credential_cannot_request_map_challenge(self):
         from map_platform.installations import InstallationCredentialStore
 


### PR DESCRIPTION
## Summary

- log only the matched request path, server-defined App Attest error code, and already-client-visible safe reason
- keep assertion bytes, installation credentials, tokens, headers, and request bodies out of logs
- cover the rejection diagnostic and secret exclusion contract

This lets maps-dev distinguish the live iOS 27 authenticator parsing branch without weakening App Attest or collecting credential material.

## Verification

- PYTHONPATH=tests python3 -m unittest test_api.MapJobRunAPITests.test_app_attest_rejection_logs_only_safe_diagnostics
- python3 -m unittest discover -s tests (643 tests, 2 skipped)
- python3 -m unittest discover -s ../deploy/tests (52 tests)
- git diff --check