### PR TITLE
Handle App Attest assertion AT extension framing

### DIFF
--- a/map-platform/backend/map_platform/app_attest.py
+++ b/map-platform/backend/map_platform/app_attest.py
@@ -355,6 +355,7 @@ class ParsedAuthenticatorData:
     credential_id: bytes | None
     public_key_x963: bytes | None
     extensions: dict[Any, Any] | None
+    assertion_at_extension_framing: bool
 
 
 def parse_authenticator_data(
@@ -376,7 +377,8 @@ def parse_authenticator_data(
 
     has_attested_data = bool(flags & 0x40)
     has_extensions = bool(flags & 0x80)
-    if attestation != has_attested_data:
+    assertion_at_extension_framing = not attestation and has_attested_data
+    if attestation and not has_attested_data:
         raise AppAttestError(
             "app_attest_invalid_authenticator", "authenticator flags are invalid"
         )
@@ -427,9 +429,12 @@ def parse_authenticator_data(
 
     # Apple's App Attest objects append launch-validation extensions to both
     # attestations and assertions even when their authenticator flags do not
-    # set ED. This parser is App Attest-specific: accept that framing while
-    # still requiring exactly one bounded CBOR map. The caller then applies
-    # the object-specific extension-key and value allowlist.
+    # set ED. A live Apple App Attest assertion has also used AT for this
+    # appended map without including WebAuthn attested credential data. This
+    # parser is App Attest-specific: accept either framing while still
+    # requiring exactly one bounded CBOR map. The assertion verifier below
+    # requires the complete Apple extension identity before accepting the AT
+    # compatibility shape.
     if has_extensions or offset < len(auth_data):
         decoder = BoundedCBORDecoder(auth_data[offset:])
         decoded_extensions = decoder.decode_one()
@@ -439,6 +444,10 @@ def parse_authenticator_data(
             )
         extensions = decoded_extensions
         offset += decoder.offset
+    if assertion_at_extension_framing and extensions is None:
+        raise AppAttestError(
+            "app_attest_invalid_authenticator", "authenticator flags are invalid"
+        )
     if offset != len(auth_data):
         raise AppAttestError(
             "app_attest_invalid_authenticator",
@@ -451,6 +460,7 @@ def parse_authenticator_data(
         credential_id=credential_id,
         public_key_x963=public_key_x963,
         extensions=extensions,
+        assertion_at_extension_framing=assertion_at_extension_framing,
     )
 
 
@@ -1199,6 +1209,14 @@ class AppAttestStore:
         validation_category, bundle_version = _assertion_extension_values(
             parsed.extensions
         )
+        if (
+            parsed.assertion_at_extension_framing
+            and validation_category is None
+        ):
+            raise AppAttestError(
+                "app_attest_invalid_extensions",
+                "App Attest assertion identity is invalid",
+            )
         if validation_category is not None:
             allowed_validation_categories = (
                 {2, 4} if environment == "production" else {3}

--- a/map-platform/backend/tests/test_app_attest.py
+++ b/map-platform/backend/tests/test_app_attest.py
@@ -234,6 +234,52 @@ class AppleAppAttestVerifierTests(unittest.TestCase):
         parsed = parse_authenticator_data(auth_data, attestation=False)
 
         self.assertEqual(parsed.extensions, extensions)
+        self.assertFalse(parsed.assertion_at_extension_framing)
+
+    def test_accepts_assertion_extensions_with_at_flag(self):
+        extensions = {
+            "validationCategory": (4).to_bytes(4, "little"),
+            "bundleVersion": TEST_APP_BUILD,
+        }
+        for flags in (b"\x40", b"\xc0"):
+            with self.subTest(flags=flags.hex()):
+                auth_data = (
+                    hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
+                    + flags
+                    + (1).to_bytes(4, "big")
+                    + encode_cbor(extensions)
+                )
+
+                parsed = parse_authenticator_data(
+                    auth_data,
+                    attestation=False,
+                )
+
+                self.assertEqual(parsed.extensions, extensions)
+                self.assertTrue(parsed.assertion_at_extension_framing)
+
+    def test_rejects_assertion_at_flag_without_extensions(self):
+        auth_data = (
+            hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
+            + b"\x40"
+            + (1).to_bytes(4, "big")
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "flags"):
+            parse_authenticator_data(auth_data, attestation=False)
+
+    def test_rejects_assertion_at_flag_with_attested_credential_data(self):
+        auth_data = (
+            hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
+            + b"\x40"
+            + (1).to_bytes(4, "big")
+            + APP_ATTEST_PRODUCTION_AAGUID
+            + (32).to_bytes(2, "big")
+            + (b"k" * 32)
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "extensions"):
+            parse_authenticator_data(auth_data, attestation=False)
 
     def test_rejects_non_map_assertion_trailing_data(self):
         auth_data = (
@@ -361,6 +407,7 @@ class AppAttestStoreTests(unittest.TestCase):
         app_build=TEST_APP_BUILD,
         extensions=None,
         extension_data_flag=True,
+        attested_credential_data_flag=False,
     ) -> bytes:
         client_data = canonical_map_create_client_data(
             challenge_id=challenge.challenge_id,
@@ -370,13 +417,14 @@ class AppAttestStoreTests(unittest.TestCase):
             payload=payload,
             app_build=app_build,
         )
+        flags = 0
+        if extensions is not None and extension_data_flag:
+            flags |= 0x80
+        if attested_credential_data_flag:
+            flags |= 0x40
         auth_data = (
             hashlib.sha256(TEST_APP_ID.encode()).digest()
-            + (
-                b"\x80"
-                if extensions is not None and extension_data_flag
-                else b"\x00"
-            )
+            + bytes([flags])
             + counter.to_bytes(4, "big")
         )
         if extensions is not None:
@@ -500,6 +548,85 @@ class AppAttestStoreTests(unittest.TestCase):
             ),
             1,
         )
+
+    def test_assertion_accepts_apple_at_extension_framing(self):
+        installation_id = "inst_v2_" + "1" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-at-extensions-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            extensions={
+                "validationCategory": (4).to_bytes(4, "little"),
+                "bundleVersion": TEST_APP_BUILD,
+            },
+            extension_data_flag=False,
+            attested_credential_data_flag=True,
+        )
+
+        self.assertEqual(
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            ),
+            1,
+        )
+
+    def test_assertion_at_framing_requires_complete_apple_identity(self):
+        installation_id = "inst_v2_" + "2" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-at-incomplete-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            extensions={},
+            extension_data_flag=False,
+            attested_credential_data_flag=True,
+        )
+
+        with self.assertRaisesRegex(AppAttestError, "identity"):
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            )
 
     def test_assertion_rejects_unknown_extensions_without_ed_flag(self):
         installation_id = "inst_v2_" + "0" * 32


### PR DESCRIPTION
## Summary

- accept the live Apple App Attest assertion shape that sets AT for the appended launch-validation extension map without including WebAuthn attested credential data
- keep ordinary attestations strict and reject assertion AT framing unless the remaining bytes are exactly one bounded CBOR map
- require the complete allowlisted `validationCategory` and `bundleVersion` identity for this compatibility path
- cover AT with and without ED, missing extensions, actual attested-credential bytes, incomplete identity, signature, app identity, challenge, and replay gates

## Live evidence

The signed maps-dev diagnostic image from #351 recorded the current Bicino Dev map-create assertion as:

`app_attest_invalid_authenticator — authenticator flags are invalid`

That rejection is possible at this parser location only when an assertion has the AT bit set. No assertion bytes, credentials, key IDs, tokens, headers, or request bodies were logged.

Apple documents that newer App Attest assertions append the launch-validation extension map to authenticator data and require servers to validate `validationCategory` and `bundleVersion`. This change treats AT as Apple-specific extension framing only under that complete signed identity contract. Signature, RP/app identity, monotonic counter, one-time challenge, request binding, environment, bundle version, and validation-category enforcement are unchanged.

## Verification

- `cd map-platform/backend && python3 -m unittest discover -s tests` — 648 passed, 2 skipped
- `cd map-platform/backend && python3 -m unittest discover -s ../deploy/tests` — 52 passed
- `git diff --check origin/main...HEAD`

Development promotion only after exact-head CI. Production is out of scope.
