### PR TITLE
Handle App Attest assertion AT flag without extensions

### DIFF
--- a/map-platform/backend/map_platform/app_attest.py
+++ b/map-platform/backend/map_platform/app_attest.py
@@ -355,7 +355,7 @@ class ParsedAuthenticatorData:
     credential_id: bytes | None
     public_key_x963: bytes | None
     extensions: dict[Any, Any] | None
-    assertion_at_extension_framing: bool
+    assertion_at_flag: bool
 
 
 def parse_authenticator_data(
@@ -377,7 +377,7 @@ def parse_authenticator_data(
 
     has_attested_data = bool(flags & 0x40)
     has_extensions = bool(flags & 0x80)
-    assertion_at_extension_framing = not attestation and has_attested_data
+    assertion_at_flag = not attestation and has_attested_data
     if attestation and not has_attested_data:
         raise AppAttestError(
             "app_attest_invalid_authenticator", "authenticator flags are invalid"
@@ -429,12 +429,12 @@ def parse_authenticator_data(
 
     # Apple's App Attest objects append launch-validation extensions to both
     # attestations and assertions even when their authenticator flags do not
-    # set ED. A live Apple App Attest assertion has also used AT for this
-    # appended map without including WebAuthn attested credential data. This
-    # parser is App Attest-specific: accept either framing while still
-    # requiring exactly one bounded CBOR map. The assertion verifier below
-    # requires the complete Apple extension identity before accepting the AT
-    # compatibility shape.
+    # set ED. A live Apple App Attest assertion has also set AT without
+    # including WebAuthn attested credential data or an appended extension
+    # map. This parser is App Attest-specific: treat AT as an assertion
+    # compatibility flag and, when bytes remain, still require exactly one
+    # bounded CBOR extension map. The signature verifier binds the complete
+    # authenticator data to the attested key, challenge, and request.
     if has_extensions or offset < len(auth_data):
         decoder = BoundedCBORDecoder(auth_data[offset:])
         decoded_extensions = decoder.decode_one()
@@ -444,10 +444,6 @@ def parse_authenticator_data(
             )
         extensions = decoded_extensions
         offset += decoder.offset
-    if assertion_at_extension_framing and extensions is None:
-        raise AppAttestError(
-            "app_attest_invalid_authenticator", "authenticator flags are invalid"
-        )
     if offset != len(auth_data):
         raise AppAttestError(
             "app_attest_invalid_authenticator",
@@ -460,7 +456,7 @@ def parse_authenticator_data(
         credential_id=credential_id,
         public_key_x963=public_key_x963,
         extensions=extensions,
-        assertion_at_extension_framing=assertion_at_extension_framing,
+        assertion_at_flag=assertion_at_flag,
     )
 
 
@@ -1210,7 +1206,8 @@ class AppAttestStore:
             parsed.extensions
         )
         if (
-            parsed.assertion_at_extension_framing
+            parsed.assertion_at_flag
+            and parsed.extensions is not None
             and validation_category is None
         ):
             raise AppAttestError(

--- a/map-platform/backend/tests/test_app_attest.py
+++ b/map-platform/backend/tests/test_app_attest.py
@@ -234,7 +234,7 @@ class AppleAppAttestVerifierTests(unittest.TestCase):
         parsed = parse_authenticator_data(auth_data, attestation=False)
 
         self.assertEqual(parsed.extensions, extensions)
-        self.assertFalse(parsed.assertion_at_extension_framing)
+        self.assertFalse(parsed.assertion_at_flag)
 
     def test_accepts_assertion_extensions_with_at_flag(self):
         extensions = {
@@ -256,17 +256,19 @@ class AppleAppAttestVerifierTests(unittest.TestCase):
                 )
 
                 self.assertEqual(parsed.extensions, extensions)
-                self.assertTrue(parsed.assertion_at_extension_framing)
+                self.assertTrue(parsed.assertion_at_flag)
 
-    def test_rejects_assertion_at_flag_without_extensions(self):
+    def test_accepts_assertion_at_flag_without_extensions(self):
         auth_data = (
             hashlib.sha256(TEST_APP_ID.encode("utf-8")).digest()
             + b"\x40"
             + (1).to_bytes(4, "big")
         )
 
-        with self.assertRaisesRegex(AppAttestError, "flags"):
-            parse_authenticator_data(auth_data, attestation=False)
+        parsed = parse_authenticator_data(auth_data, attestation=False)
+
+        self.assertIsNone(parsed.extensions)
+        self.assertTrue(parsed.assertion_at_flag)
 
     def test_rejects_assertion_at_flag_with_attested_credential_data(self):
         auth_data = (
@@ -590,6 +592,67 @@ class AppAttestStoreTests(unittest.TestCase):
             ),
             1,
         )
+
+    def test_assertion_accepts_signed_apple_at_flag_without_extensions(self):
+        installation_id = "inst_v2_" + "3" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-at-flag-only-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            attested_credential_data_flag=True,
+        )
+
+        self.assertEqual(
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            ),
+            1,
+        )
+
+        next_challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        request_bound_assertion = self.assertion(
+            private_key=private_key,
+            challenge=next_challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=2,
+            attested_credential_data_flag=True,
+        )
+        with self.assertRaisesRegex(AppAttestError, "signature"):
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=next_challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=request_bound_assertion,
+                request_body=body + b" ",
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            )
 
     def test_assertion_at_framing_requires_complete_apple_identity(self):
         installation_id = "inst_v2_" + "2" * 32


### PR DESCRIPTION
## Summary

- accept an Apple App Attest assertion whose signed authenticator data sets AT but contains neither WebAuthn attested credential data nor trailing extensions
- continue to require any trailing assertion bytes to be exactly one bounded CBOR extension map
- continue to require complete Apple identity fields when an AT assertion does contain extensions
- preserve RP/app identity, signature, challenge, exact request-body binding, monotonic counter, replay, environment, validation-category, and bundle-version checks

## Live evidence

After the exact PR #354 image was deployed to maps-dev, a fresh Bicino Dev map request was still rejected as app_attest_invalid_authenticator with reason authenticator flags are invalid. On the map-create assertion path, the deployed source can emit that exact reason only when AT is set and no extension map follows. Map geometry and job admission are downstream and were never reached.

This patch treats AT as an App Attest-specific assertion compatibility flag. It does not parse or accept WebAuthn attested credential data on assertions. The complete authenticator data remains covered by the hardware-key signature.

## Verification

- python3 -m unittest discover -s tests -p test_app_attest.py: 18 passed
- backend full suite: 649 passed, 2 skipped
- deploy suite: 52 passed
- compileall and git diff --check passed

The new signed-path test accepts the observed AT-without-extensions shape and proves that changing the bound request body still fails signature verification.

## Rollout

Promote the resulting signed image to maps-dev development only after exact-head CI. Production remains unchanged.