### PR TITLE
Verify App Attest assertion signatures with Apple hashing semantics

### DIFF
--- a/map-platform/backend/map_platform/app_attest.py
+++ b/map-platform/backend/map_platform/app_attest.py
@@ -18,7 +18,7 @@ from typing import Any, Protocol
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.x509.oid import ExtensionOID, ObjectIdentifier
 
 
@@ -1235,7 +1235,7 @@ class AppAttestStore:
             public_key.verify(
                 signature,
                 nonce,
-                ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+                ec.ECDSA(hashes.SHA256()),
             )
         except (ValueError, InvalidSignature) as exc:
             raise AppAttestError(

--- a/map-platform/backend/tests/app_attest_support.py
+++ b/map-platform/backend/tests/app_attest_support.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import ec, utils
+from cryptography.hazmat.primitives.asymmetric import ec
 
 from map_platform.app_attest import (
     APP_ATTEST_ATTESTATION_PURPOSE,
@@ -236,7 +236,7 @@ class AppAttestTestClient:
         ).digest()
         signature = installation.private_key.sign(
             nonce,
-            ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+            ec.ECDSA(hashes.SHA256()),
         )
         assertion = encode_cbor(
             {

--- a/map-platform/backend/tests/test_app_attest.py
+++ b/map-platform/backend/tests/test_app_attest.py
@@ -410,6 +410,7 @@ class AppAttestStoreTests(unittest.TestCase):
         extensions=None,
         extension_data_flag=True,
         attested_credential_data_flag=False,
+        prehashed_nonce=False,
     ) -> bytes:
         client_data = canonical_map_create_client_data(
             challenge_id=challenge.challenge_id,
@@ -436,11 +437,52 @@ class AppAttestStoreTests(unittest.TestCase):
         ).digest()
         signature = private_key.sign(
             nonce,
-            ec.ECDSA(utils.Prehashed(hashes.SHA256())),
+            (
+                ec.ECDSA(utils.Prehashed(hashes.SHA256()))
+                if prehashed_nonce
+                else ec.ECDSA(hashes.SHA256())
+            ),
         )
         return encode_cbor(
             {"signature": signature, "authenticatorData": auth_data}
         )
+
+    def test_assertion_rejects_single_hash_synthetic_signature(self):
+        installation_id = "inst_v2_" + "4" * 32
+        private_key, key_id = self.enroll(installation_id)
+        payload = {
+            "mode": "custom_bbox",
+            "bbox": [103.75, 1.24, 103.93, 1.37],
+            "clientInstallationId": installation_id,
+            "clientRequestId": "request-single-hash-1",
+        }
+        body = json.dumps(payload, separators=(",", ":")).encode()
+        challenge = self.store.issue_challenge(
+            purpose=APP_ATTEST_MAP_CREATE_PURPOSE,
+            installation_id=installation_id,
+        )
+        assertion = self.assertion(
+            private_key=private_key,
+            challenge=challenge,
+            installation_id=installation_id,
+            payload=payload,
+            body=body,
+            counter=1,
+            prehashed_nonce=True,
+        )
+
+        with self.assertRaises(AppAttestError) as raised:
+            self.store.verify_map_create_assertion(
+                installation_id=installation_id,
+                challenge_id=challenge.challenge_id,
+                key_id=key_id,
+                assertion_object=assertion,
+                request_body=body,
+                payload=payload,
+                app_build=TEST_APP_BUILD,
+            )
+
+        self.assertEqual(raised.exception.code, "app_attest_invalid_signature")
 
     def test_assertion_allows_signed_app_upgrade_and_rejects_wrong_category(self):
         installation_id = "inst_v2_" + "e" * 32


### PR DESCRIPTION
## Summary

- verify App Attest assertion signatures with standard ES256/SHA-256 hashing over Apple's computed nonce
- make shared backend fixtures reproduce the real-device double-hash semantics
- add a regression test proving the previous single-hash/prehashed synthetic signature is rejected

## Live failure evidence

After the authenticator-data compatibility fixes reached maps-dev, a fresh Bicino Dev request passed assertion parsing, app identity, extension handling, and the counter/replay precheck, then failed with `app_attest_invalid_signature`.

The verifier and synthetic fixtures both treated Apple's computed nonce as already prehashed. That made the tests agree with each other while disagreeing with genuine iPhone assertions. Apple's validation procedure computes the nonce from authenticator data and client data, then verifies the assertion signature for that nonce. With `cryptography`, `ECDSA(SHA256())` performs the signature hash over the supplied nonce; `Prehashed(SHA256())` incorrectly skips that final hash.

References:
- https://developer.apple.com/documentation/devicecheck/validating-apps-that-connect-to-your-server
- https://github.com/poshpaws/appattest-lambda-proxy/blob/main/docs/article.md#2-the-assertion-signature-is-a-double-hash

## Security boundary

All challenge, app identity, key binding, extension, request-body binding, and monotonic-counter checks remain unchanged. The change does not expose assertion material, keys, challenges, or request bodies in logs or responses.

## Verification

- `python3 -m unittest discover -s tests -p 'test_app_attest.py'` (19 passed)
- `python3 -m unittest discover -s tests` (650 passed, 2 skipped)
- `python3 -m unittest discover -s ../deploy/tests` (52 passed)
- CI-equivalent Python syntax checks
- generated map-stream trust registry check
- map-stream hardware-gate requirements check
- `git diff --check`
