### PR TITLE
Preserve generic polygons at FMB precision

### DIFF
--- a/tools/OSM_Extract/README.md
+++ b/tools/OSM_Extract/README.md
@@ -100,6 +100,14 @@ pass both `--debug-image-dir <directory>` and `--debug-image-limit <count>`.
 The image directory must be outside the map output folder so previews cannot
 be included in a packaged map.
 
+Generic polygon clipping first reduces valid geometry through GEOS' valid-output
+one-metre precision model, matching the integer coordinate grid stored by FMB.
+Only then are holes decomposed into bounded hole-free pieces. This lets
+unrepresentable sub-metre edges collapse deterministically while retaining
+representable holes. The encoder still rejects decomposition amplification or
+an area change larger than the geometric boundary strip permitted by that
+one-metre quantization.
+
 ## Renderer formats and OSM 3D buildings
 
 `extract_features.py --renderer-format` selects the durable binary output:

--- a/tools/OSM_Extract/scripts/funcs.py
+++ b/tools/OSM_Extract/scripts/funcs.py
@@ -8,7 +8,9 @@ from shapely import (
     Polygon,
     geometry,
     intersection,
+    set_precision,
 )
+from shapely.errors import GEOSException
 from shapely.ops import triangulate, unary_union
 import PIL.ImageDraw as ImageDraw
 import PIL.Image as Image
@@ -22,6 +24,8 @@ MAX_GENERIC_POLYGON_PIECES_PER_SOURCE = 2048
 MAX_GENERIC_POLYGON_PIECES_PER_BLOCK = 32768
 _GEOMETRY_EQUIVALENCE_RELATIVE_TOLERANCE = 1e-9
 _GEOMETRY_EQUIVALENCE_ABSOLUTE_TOLERANCE = 1e-7
+_FMB_COORDINATE_GRID_SIZE = 1.0
+_FMB_MAX_VERTEX_DISPLACEMENT = math.sqrt(0.5 ** 2 + 0.5 ** 2)
 
 
 class GenericGeometryError(ValueError):
@@ -374,6 +378,53 @@ def _equivalence_tolerance(polygon):
     )
 
 
+def _quantized_equivalence_tolerance(source, encoded):
+    """Bound area changes caused by rounding polygon vertices to the FMB grid.
+
+    FMB stores metre-relative integer coordinates.  Moving a vertex to its
+    nearest grid point can displace the boundary by at most half a grid-cell
+    on each axis.  The perimeter term is the corresponding boundary strip;
+    the disk term covers corners.  This is deliberately separate from the
+    near-exact floating-point decomposition check above.
+    """
+
+    radius = _FMB_MAX_VERTEX_DISPLACEMENT
+    return max(
+        _GEOMETRY_EQUIVALENCE_ABSOLUTE_TOLERANCE,
+        ((source.length + encoded.length) * radius / 2.0)
+        + (math.pi * radius * radius),
+    )
+
+
+def _snap_to_fmb_precision(polygon):
+    """Return the valid polygonal area representable by FMB coordinates.
+
+    Directly rounding each ring can collapse a narrow edge or make a hole
+    touch its shell.  GEOS' valid-output precision model performs the same
+    one-metre reduction while repairing those topology changes before the
+    hole-free decomposition is generated.
+    """
+
+    try:
+        snapped = set_precision(
+            polygon,
+            grid_size=_FMB_COORDINATE_GRID_SIZE,
+            mode="valid_output",
+        )
+    except (GEOSException, ValueError) as exc:
+        raise GenericGeometryError(
+            "generic polygon could not be reduced to FMB coordinate precision"
+        ) from exc
+
+    parts = [
+        _canonicalize_shapely_polygon(part)
+        for part in _polygonal_parts(snapped)
+        if not part.is_empty and part.area > 0
+    ]
+    parts.sort(key=_polygon_sort_key)
+    return parts
+
+
 def _decompose_hole_free(polygon, remaining_piece_budget):
     if not polygon.interiors:
         return [_canonicalize_shapely_polygon(polygon)]
@@ -431,7 +482,7 @@ def _validate_quantized_decomposition(source, pieces, min_x, min_y):
     quantized_source = _quantized_polygon(source, min_x, min_y)
     quantized_pieces = [_quantized_polygon(piece, min_x, min_y) for piece in pieces]
     merged = unary_union(quantized_pieces)
-    tolerance = _equivalence_tolerance(quantized_source)
+    tolerance = _quantized_equivalence_tolerance(quantized_source, merged)
     if quantized_source.symmetric_difference(merged).area > tolerance:
         raise GenericGeometryError(
             "generic polygon decomposition changes area at FMB coordinate precision"
@@ -468,8 +519,8 @@ def clip_polygons(
             _canonicalize_shapely_polygon(part)
             for part in _polygonal_parts(parts)
         ]
-        for part in sorted(polygonal_parts, key=_polygon_sort_key):
-            if part.is_valid and not part.is_empty:
+        for clipped_part in sorted(polygonal_parts, key=_polygon_sort_key):
+            for part in _snap_to_fmb_precision(clipped_part):
                 source_count = source_piece_counts.get(source_key, 0)
                 remaining_source = max_pieces_per_source - source_count
                 remaining_block = max_pieces_per_block - len(clipped)

--- a/tools/OSM_Extract/tests/test_generic_geometry.py
+++ b/tools/OSM_Extract/tests/test_generic_geometry.py
@@ -6,7 +6,7 @@ import tempfile
 import unittest
 
 from PIL import Image
-from shapely import Polygon, box
+from shapely import Polygon, box, set_precision
 from shapely.ops import unary_union
 
 
@@ -15,7 +15,9 @@ sys.path.insert(0, str(ROOT / "scripts"))
 
 from funcs import (  # noqa: E402
     BACKGROUND_COLOR,
+    GenericGeometryError,
     GenericGeometryLimitError,
+    _validate_quantized_decomposition,
     clip_polygons,
     get_geoms,
     render_map,
@@ -132,6 +134,100 @@ class GenericGeometryTests(unittest.TestCase):
                 (root / "first.fmb").read_bytes(),
                 (root / "second.fmb").read_bytes(),
             )
+
+    def test_fmb_precision_preserves_representable_real_world_hole(self):
+        # Reduced EPSG:3857 coordinates from an ordinary parking relation that
+        # previously failed after its hole-free pieces were rounded to FMB.
+        source = Polygon(
+            [
+                (552.031362, 2224.15555),
+                (613.379533, 2240.867527),
+                (622.38528, 2209.812423),
+                (613.969526, 2207.378518),
+                (625.902976, 2166.236491),
+                (620.748883, 2164.73971),
+                (610.407303, 2200.376164),
+                (564.076131, 2186.94415),
+                (560.847865, 2196.835942),
+                (558.220725, 2204.931599),
+                (552.031362, 2224.15555),
+            ],
+            [[
+                (575.219212, 2194.558226),
+                (606.711496, 2204.319869),
+                (606.56678, 2209.278786),
+                (608.615059, 2213.365664),
+                (604.96378, 2223.569851),
+                (601.178917, 2224.74125),
+                (569.820216, 2215.552275),
+                (575.219212, 2194.558226),
+            ]],
+        )
+        expected = set_precision(source, 1.0, mode="valid_output")
+        pieces = clip_polygons(
+            [styled_feature(source)],
+            box(0, 0, 4095, 4096),
+        )
+        geometries = [feature["geom"] for feature in pieces]
+        merged = unary_union(geometries)
+
+        self.assertGreater(len(geometries), 1)
+        self.assertTrue(all(not geometry.interiors for geometry in geometries))
+        self.assertLess(expected.symmetric_difference(merged).area, 1e-7)
+        self.assertGreater(expected.area, 1_700)
+        encoded = unary_union(
+            [
+                Polygon(
+                    [(round(x), round(y)) for x, y in geometry.exterior.coords]
+                )
+                for geometry in geometries
+            ]
+        )
+        hole = Polygon(expected.interiors[0])
+        self.assertFalse(encoded.covers(hole.representative_point()))
+
+    def test_fmb_precision_repairs_boundary_and_submetre_slivers(self):
+        sources = (
+            Polygon(
+                [
+                    (256.833672, 84.313821),
+                    (315.064898, 124.343063),
+                    (373.10688, 39.910804),
+                    (314.875655, -0.118164),
+                    (256.833672, 84.313821),
+                ]
+            ),
+            Polygon(
+                [
+                    (1430.786758, 158.878966),
+                    (1430.931474, 157.941692),
+                    (1440.059672, 158.644647),
+                    (1449.032023, 152.955915),
+                    (1449.321453, 153.424552),
+                    (1440.004012, 159.347603),
+                    (1430.786758, 158.878966),
+                ]
+            ),
+        )
+
+        for index, source in enumerate(sources):
+            with self.subTest(index=index):
+                pieces = clip_polygons(
+                    [styled_feature(source, f"precision-{index}")],
+                    box(0, 0, 4095, 4096),
+                )
+                self.assertTrue(pieces)
+                self.assertTrue(all(item["geom"].is_valid for item in pieces))
+
+    def test_fmb_precision_tolerance_still_rejects_filled_holes(self):
+        source = Polygon(
+            [(0, 0), (100, 0), (100, 100), (0, 100), (0, 0)],
+            [[(35, 35), (65, 35), (65, 65), (35, 65), (35, 35)]],
+        )
+        filled = Polygon(source.exterior)
+
+        with self.assertRaises(GenericGeometryError):
+            _validate_quantized_decomposition(source, [filled], 0, 0)
 
     def test_amplification_limit_fails_closed(self):
         source = Polygon(

--- a/tools/OSM_Extract/tests/test_parse_tags.py
+++ b/tools/OSM_Extract/tests/test_parse_tags.py
@@ -22,6 +22,10 @@ def load_funcs_module():
     ]:
         setattr(shapely, name, object)
     shapely.intersection = lambda *args, **kwargs: None
+    shapely.set_precision = lambda value, **kwargs: value
+
+    shapely_errors = types.ModuleType("shapely.errors")
+    shapely_errors.GEOSException = type("GEOSException", (Exception,), {})
 
     shapely_ops = types.ModuleType("shapely.ops")
     shapely_ops.triangulate = lambda *args, **kwargs: []
@@ -34,6 +38,7 @@ def load_funcs_module():
     original_modules = {}
     for name, module in [
         ("shapely", shapely),
+        ("shapely.errors", shapely_errors),
         ("shapely.ops", shapely_ops),
         ("PIL", pil),
         ("PIL.ImageDraw", pil_image_draw),


### PR DESCRIPTION
## Summary

- reduce clipped generic polygons through GEOS' valid-output one-metre precision model before hole-free decomposition
- validate encoded area changes against the bounded FMB grid boundary strip instead of unattainable sub-millimetre equivalence
- retain amplification limits and fail closed when a meaningful hole is filled
- cover the real Shanghai hole, boundary, and sub-metre sliver shapes that failed on maps-dev

## Root cause

Maps-dev job `b65228ad261a42f3b59c` authenticated and entered target-3 preparation, then failed with `generic_geometry_invalid`. PR #327 correctly began preserving generic polygon holes, but it validated independently rounded decomposition pieces against a directly rounded source with near-zero tolerance. Ordinary OSM rings can become invalid at the FMB one-metre grid, and internal decomposition edges can move a few square metres while preserving the representable topology.

The failed request used 3.8 GB peak RSS under the 12 GB worker limit. It was not an OOM, App Attest, map-overlap, phone, or SD-card failure.

## Validation

- 10 focused generic-geometry tests passed
- replayed the exact failed Shanghai GeoJSON: 1,273 generic features across four blocks, 2,032 encoded pieces, zero geometry failures
- the 12 formerly rejected Shanghai relations/ways all passed
- 500 deterministic rotated-hole precision cases passed
- 650 map backend tests passed, 2 skipped
- 52 deployment tests passed
- 74 repository tool tests passed
- local OSM discovery passed 160/161 tests; the remaining OGR test could not start because the workstation's Homebrew GDAL references a removed `libx265.215.dylib`
- the same targeted OGR/target-3 test passed in the current digest-pinned Linux map image
- `git diff --check` passed

Exact-head GitHub CI is pending. A fresh maps-dev request remains required after the development-only image promotion; this PR does not affect production until its separate production promotion process.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting this pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
