### PR TITLE
Fix source-wide building calibration timeout

### DIFF
--- a/docs/runbooks/shanghai-3d-map-orchestration.md
+++ b/docs/runbooks/shanghai-3d-map-orchestration.md
@@ -64,6 +64,14 @@ receipt-complete assembly is admitted only after the assembly pool is free. An
 expired parent-phase lease is removed by the normal recovery pass; do not add a
 second worker or manually delete the reservation.
 
+The source-wide building calibration precompute has a six-hour command wall
+limit because it scans the complete immutable source snapshot and publishes a
+generation reused by later jobs. This is separate from the 30-minute hard
+deadline for an individual workload scan or building chunk. A calibration that
+continues to emit progress and refresh its parent-phase lease is long-running,
+not a pathological chunk; preserve its source/checksum identity and let it
+finish.
+
 The worker executes at most one child task for a claimed parent before yielding
 the parent job. The next global claim is selected across eligible parents using
 admission priority, weighted virtual finish, last-claim ordering, and the

--- a/map-platform/backend/map_platform/pipeline.py
+++ b/map-platform/backend/map_platform/pipeline.py
@@ -357,6 +357,14 @@ BUILDING_PREPROCESSING_COMMAND_POLICY = CommandExecutionPolicy(
     max_progress_record_bytes=64 * 1024,
     termination_grace_seconds=5,
 )
+BUILDING_CALIBRATION_COMMAND_POLICY = CommandExecutionPolicy(
+    name="building_calibration",
+    wall_timeout_seconds=6 * 60 * 60,
+    idle_timeout_seconds=None,
+    max_captured_output_bytes=512 * 1024,
+    max_progress_record_bytes=64 * 1024,
+    termination_grace_seconds=5,
+)
 CONVERSION_COMMAND_POLICY = CommandExecutionPolicy(
     name="conversion",
     wall_timeout_seconds=6 * 60 * 60,
@@ -3396,6 +3404,7 @@ class MapBuildPipeline:
                 str(result_path),
             ],
             cwd=scripts_root,
+            policy=SOURCE_INDEX_COMMAND_POLICY,
             on_phase_progress=on_phase_progress,
             default_unit="source_index",
             total_blocks=len(global_plan.output_blocks),
@@ -3542,6 +3551,7 @@ class MapBuildPipeline:
                 str(ids_path),
             ],
             cwd=scripts_root,
+            policy=BUILDING_PREPROCESSING_COMMAND_POLICY,
             on_phase_progress=on_phase_progress,
             default_unit="relation_closure",
             total_blocks=len(scope_plan.output_blocks),
@@ -4660,6 +4670,7 @@ class MapBuildPipeline:
                         str(closure_ids_path),
                     ],
                     cwd=self.paths.osm_extract_root / "scripts",
+                    policy=BUILDING_PREPROCESSING_COMMAND_POLICY,
                     on_phase_progress=on_phase_progress,
                     default_unit="relation_closure",
                     total_blocks=len(scope_plan.output_blocks),
@@ -6476,6 +6487,7 @@ class MapBuildPipeline:
         args: list[str],
         *,
         cwd: Path,
+        policy: CommandExecutionPolicy,
         on_phase_progress,
         default_unit: str,
         total_blocks: int,
@@ -6483,11 +6495,6 @@ class MapBuildPipeline:
         cancellation_check=None,
     ) -> str:
         command_started = time.perf_counter()
-        command_policy = (
-            SOURCE_INDEX_COMMAND_POLICY
-            if default_unit == "source_index"
-            else BUILDING_PREPROCESSING_COMMAND_POLICY
-        )
         self._emit_phase_progress(
             on_phase_progress,
             unit=default_unit,
@@ -6520,14 +6527,14 @@ class MapBuildPipeline:
                     "on_output": handle_output,
                 }
                 if isinstance(self.runner, CommandRunner):
-                    streaming_kwargs["policy"] = command_policy
+                    streaming_kwargs["policy"] = policy
                 if cancellation_check is not None:
                     streaming_kwargs["cancellation_check"] = cancellation_check
                 output = self.runner.run_streaming(args, **streaming_kwargs)
             else:
                 run_kwargs = {"cwd": cwd}
                 if isinstance(self.runner, CommandRunner):
-                    run_kwargs["policy"] = command_policy
+                    run_kwargs["policy"] = policy
                 output = self.runner.run(args, **run_kwargs)
                 if on_phase_progress is not None:
                     for line in output.splitlines():
@@ -6710,6 +6717,7 @@ class MapBuildPipeline:
                     "--full-precompute",
                 ],
                 cwd=scripts_root,
+                policy=BUILDING_CALIBRATION_COMMAND_POLICY,
                 on_phase_progress=on_phase_progress,
                 default_unit="calibration_cells",
                 total_blocks=len(scope_plan.output_blocks),
@@ -6782,6 +6790,7 @@ class MapBuildPipeline:
                 "--result-json", str(source_index_result),
             ],
             cwd=scripts_root,
+            policy=SOURCE_INDEX_COMMAND_POLICY,
             on_phase_progress=on_phase_progress,
             default_unit="source_index",
             total_blocks=total_blocks,
@@ -6814,6 +6823,7 @@ class MapBuildPipeline:
                 "--ids-output", str(closure_ids),
             ],
             cwd=scripts_root,
+            policy=BUILDING_PREPROCESSING_COMMAND_POLICY,
             on_phase_progress=on_phase_progress,
             default_unit="relation_closure",
             total_blocks=total_blocks,
@@ -6865,6 +6875,7 @@ class MapBuildPipeline:
                 "--full-precompute",
             ],
             cwd=scripts_root,
+            policy=BUILDING_CALIBRATION_COMMAND_POLICY,
             on_phase_progress=on_phase_progress,
             default_unit="calibration_cells",
             total_blocks=total_blocks,
@@ -6968,6 +6979,7 @@ class MapBuildPipeline:
                     str(source_index_result),
                 ],
                 cwd=scripts_root,
+                policy=SOURCE_INDEX_COMMAND_POLICY,
                 on_phase_progress=on_phase_progress,
                 default_unit="source_index",
                 total_blocks=len(scope_plan.output_blocks),
@@ -6994,6 +7006,7 @@ class MapBuildPipeline:
                     str(closure_ids),
                 ],
                 cwd=scripts_root,
+                policy=BUILDING_PREPROCESSING_COMMAND_POLICY,
                 on_phase_progress=on_phase_progress,
                 default_unit="relation_closure",
                 total_blocks=len(scope_plan.output_blocks),

--- a/map-platform/backend/tests/test_pipeline_progress.py
+++ b/map-platform/backend/tests/test_pipeline_progress.py
@@ -16,6 +16,9 @@ from map_platform.jobs import JobStore, MapJobService
 from map_platform.building_scope import BuildingScopeError, plan_building_scope
 from map_platform.models import Bounds, SourceRegion
 from map_platform.pipeline import (
+    BUILDING_CALIBRATION_COMMAND_POLICY,
+    BUILDING_PREPROCESSING_COMMAND_POLICY,
+    SOURCE_INDEX_COMMAND_POLICY,
     BuildingChunkSplitRequired,
     CommandExecutionPolicy,
     CommandExecutionTimeout,
@@ -116,6 +119,22 @@ class BuildingPhaseStreamingRunner:
 
 
 class PipelineProgressTests(unittest.TestCase):
+    def test_source_wide_calibration_and_scoped_preprocessing_have_distinct_deadlines(
+        self,
+    ):
+        self.assertEqual(
+            BUILDING_CALIBRATION_COMMAND_POLICY.wall_timeout_seconds,
+            6 * 60 * 60,
+        )
+        self.assertEqual(
+            BUILDING_PREPROCESSING_COMMAND_POLICY.wall_timeout_seconds,
+            30 * 60,
+        )
+        self.assertGreater(
+            BUILDING_CALIBRATION_COMMAND_POLICY.wall_timeout_seconds,
+            BUILDING_PREPROCESSING_COMMAND_POLICY.wall_timeout_seconds,
+        )
+
     def assert_process_exits(self, process_id: int, *, timeout_seconds: float = 2) -> None:
         deadline = time.monotonic() + timeout_seconds
         while time.monotonic() < deadline:
@@ -911,6 +930,7 @@ class PipelineProgressTests(unittest.TestCase):
                         source_sha256,
                     ],
                     cwd=repo_root / "tools" / "OSM_Extract" / "scripts",
+                    policy=SOURCE_INDEX_COMMAND_POLICY,
                     on_phase_progress=None,
                     default_unit="source_index",
                     total_blocks=1,
@@ -943,6 +963,7 @@ class PipelineProgressTests(unittest.TestCase):
             pipeline._run_preprocessing_command(
                 ["preprocess"],
                 cwd=root,
+                policy=BUILDING_CALIBRATION_COMMAND_POLICY,
                 on_phase_progress=progress.append,
                 default_unit="calibration_cells",
                 total_blocks=12,
@@ -1076,6 +1097,11 @@ class PipelineProgressTests(unittest.TestCase):
                     pipeline._run_preprocessing_command(
                         ["preprocess"],
                         cwd=root,
+                        policy=(
+                            SOURCE_INDEX_COMMAND_POLICY
+                            if unit == "source_index"
+                            else BUILDING_PREPROCESSING_COMMAND_POLICY
+                        ),
                         on_phase_progress=lambda _progress: None,
                         default_unit=unit,
                         total_blocks=12,


### PR DESCRIPTION
## Summary
- give source-wide building calibration precompute a six-hour command policy
- keep relation closure and individual chunk preprocessing on the 30-minute hard deadline
- require every preprocessing caller to select its execution policy explicitly
- document the distinction in the Shanghai orchestration runbook

## Verification
- python3 -m py_compile map_platform/*.py tests/*.py tools/check_r2_compatibility.py ../deploy/*.py ../deploy/tests/*.py
- python3 -m unittest discover -s tests (653 tests, 2 skipped)
- python3 -m unittest discover -s ../deploy/tests (52 tests)