### PR TITLE
Resume incomplete source PBF downloads

### DIFF
--- a/map-platform/backend/README.md
+++ b/map-platform/backend/README.md
@@ -192,6 +192,12 @@ without that provenance falls back to its modification time and is replaced
 atomically once it becomes due. Jobs continue to bind their work to the
 verified file SHA-256.
 
+When an HTTP source declares `Content-Length`, the cache publishes it only
+after receiving exactly that many bytes. A premature EOF is resumed from the
+resolved source URL with `Range` plus a stable `ETag` or `Last-Modified`
+validator. Conflicting range, size, URL, or validator responses fail closed and
+leave the previous stable snapshot untouched.
+
 ## Coolify
 
 Use `map-platform/deploy/compose.yaml` for Coolify production. It independently

--- a/map-platform/backend/map_platform/source_cache.py
+++ b/map-platform/backend/map_platform/source_cache.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
 import math
 import os
-import fcntl
+import re
 import shutil
 import time
 import urllib.error
@@ -30,6 +31,7 @@ class SourceCacheStorageError(SourceCacheError):
 
 
 DEFAULT_SOURCE_REVALIDATE_SECONDS = 24 * 60 * 60
+MAX_SOURCE_DOWNLOAD_REQUESTS = 512
 
 
 @dataclass(frozen=True)
@@ -216,63 +218,153 @@ class SourceCache:
                             if existing is not None and not force
                             else {}
                         )
-                        request = (
-                            urllib.request.Request(
-                                region.url,
-                                headers=conditional_headers,
+                        download_url = region.url
+                        request_headers = conditional_headers
+                        downloaded_bytes = 0
+                        expected_bytes = None
+                        resolved_url = region.url
+                        response_etag = None
+                        response_last_modified = None
+                        for request_number in range(
+                            1,
+                            MAX_SOURCE_DOWNLOAD_REQUESTS + 1,
+                        ):
+                            request = (
+                                urllib.request.Request(
+                                    download_url,
+                                    headers=request_headers,
+                                )
+                                if request_headers
+                                else download_url
                             )
-                            if conditional_headers
-                            else region.url
-                        )
-                        with urllib.request.urlopen(
-                            request, timeout=60
-                        ) as response, tmp_path.open("wb") as output:
-                            headers = getattr(response, "headers", None)
-                            content_length = (
-                                headers.get("Content-Length")
-                                if headers is not None
-                                else None
-                            )
-                            if content_length is not None:
-                                try:
-                                    incoming_bytes = int(content_length)
-                                except ValueError as exc:
-                                    raise SourceCacheStorageError(
-                                        "source response Content-Length is invalid"
-                                    ) from exc
-                                if incoming_bytes < 0:
-                                    raise SourceCacheStorageError(
-                                        "source response Content-Length is invalid"
+                            with urllib.request.urlopen(
+                                request, timeout=60
+                            ) as response:
+                                headers = getattr(response, "headers", None)
+                                content_length = _content_length(headers)
+                                content_range = _content_range(headers)
+                                if downloaded_bytes:
+                                    status = _response_status(response)
+                                    if status != 206 or content_range is None:
+                                        raise SourceCacheError(
+                                            "source server did not honor a safe resume request"
+                                        )
+                                    range_start, range_end, range_total = content_range
+                                    if range_start != downloaded_bytes:
+                                        raise SourceCacheError(
+                                            "source resume range does not match partial download"
+                                        )
+                                    if expected_bytes != range_total:
+                                        raise SourceCacheError(
+                                            "source size changed during resumed download"
+                                        )
+                                    if (
+                                        content_length is not None
+                                        and content_length != range_end - range_start + 1
+                                    ):
+                                        raise SourceCacheError(
+                                            "source resume Content-Length does not match Content-Range"
+                                        )
+                                    output_mode = "ab"
+                                else:
+                                    if content_range is not None:
+                                        raise SourceCacheError(
+                                            "source returned an unexpected partial response"
+                                        )
+                                    expected_bytes = content_length
+                                    output_mode = "wb"
+
+                                if content_length is not None:
+                                    self._require_download_capacity(
+                                        target.parent,
+                                        minimum_free_bytes=minimum_free_bytes,
+                                        incoming_bytes=content_length,
                                     )
-                                self._require_download_capacity(
-                                    target.parent,
-                                    minimum_free_bytes=minimum_free_bytes,
-                                    incoming_bytes=incoming_bytes,
+
+                                observed_etag = (
+                                    headers.get("ETag")
+                                    if headers is not None
+                                    else None
                                 )
-                            while True:
+                                observed_last_modified = (
+                                    headers.get("Last-Modified")
+                                    if headers is not None
+                                    else None
+                                )
+                                if (
+                                    response_etag is not None
+                                    and observed_etag is not None
+                                    and observed_etag != response_etag
+                                ):
+                                    raise SourceCacheError(
+                                        "source ETag changed during resumed download"
+                                    )
+                                if (
+                                    response_last_modified is not None
+                                    and observed_last_modified is not None
+                                    and observed_last_modified != response_last_modified
+                                ):
+                                    raise SourceCacheError(
+                                        "source Last-Modified changed during resumed download"
+                                    )
+                                response_etag = response_etag or observed_etag
+                                response_last_modified = (
+                                    response_last_modified or observed_last_modified
+                                )
+                                observed_url = (
+                                    response.geturl()
+                                    if hasattr(response, "geturl")
+                                    else download_url
+                                )
+                                if downloaded_bytes and observed_url != resolved_url:
+                                    raise SourceCacheError(
+                                        "source URL changed during resumed download"
+                                    )
+                                resolved_url = observed_url
+
+                                with tmp_path.open(output_mode) as output:
+                                    while True:
+                                        _raise_if_cancelled(cancellation_check)
+                                        chunk = response.read(1024 * 1024)
+                                        if not chunk:
+                                            break
+                                        self._require_download_capacity(
+                                            target.parent,
+                                            minimum_free_bytes=minimum_free_bytes,
+                                            incoming_bytes=len(chunk),
+                                        )
+                                        output.write(chunk)
                                 _raise_if_cancelled(cancellation_check)
-                                chunk = response.read(1024 * 1024)
-                                if not chunk:
-                                    break
-                                self._require_download_capacity(
-                                    target.parent,
-                                    minimum_free_bytes=minimum_free_bytes,
-                                    incoming_bytes=len(chunk),
+
+                            received_bytes = tmp_path.stat().st_size
+                            if expected_bytes is None or received_bytes == expected_bytes:
+                                break
+                            if received_bytes > expected_bytes:
+                                raise SourceCacheError(
+                                    "source response exceeded its declared Content-Length"
                                 )
-                                output.write(chunk)
-                            _raise_if_cancelled(cancellation_check)
-                            resolved_url = (
-                                response.geturl()
-                                if hasattr(response, "geturl")
-                                else region.url
+                            if received_bytes <= downloaded_bytes:
+                                raise SourceCacheError(
+                                    "source response ended before Content-Length without progress"
+                                )
+                            validator = _if_range_validator(
+                                response_etag,
+                                response_last_modified,
                             )
-                            response_etag = (
-                                headers.get("ETag") if headers is not None else None
-                            )
-                            response_last_modified = (
-                                headers.get("Last-Modified")
-                                if headers is not None
-                                else None
+                            if validator is None:
+                                raise SourceCacheError(
+                                    "source response ended before Content-Length and cannot be resumed safely"
+                                )
+                            downloaded_bytes = received_bytes
+                            download_url = resolved_url
+                            request_headers = {
+                                "Range": f"bytes={downloaded_bytes}-",
+                                "If-Range": validator,
+                            }
+                        else:
+                            raise SourceCacheError(
+                                "source response remained incomplete after "
+                                f"{MAX_SOURCE_DOWNLOAD_REQUESTS} requests"
                             )
                     except urllib.error.HTTPError as exc:
                         if (
@@ -612,6 +704,49 @@ class SourceCache:
         finally:
             fcntl.flock(fd, fcntl.LOCK_UN)
             os.close(fd)
+
+
+def _content_length(headers) -> int | None:
+    value = headers.get("Content-Length") if headers is not None else None
+    if value is None:
+        return None
+    try:
+        length = int(value)
+    except (TypeError, ValueError) as exc:
+        raise SourceCacheStorageError(
+            "source response Content-Length is invalid"
+        ) from exc
+    if length < 0:
+        raise SourceCacheStorageError(
+            "source response Content-Length is invalid"
+        )
+    return length
+
+
+def _content_range(headers) -> tuple[int, int, int] | None:
+    value = headers.get("Content-Range") if headers is not None else None
+    if value is None:
+        return None
+    match = re.fullmatch(r"bytes (\d+)-(\d+)/(\d+)", value.strip())
+    if match is None:
+        raise SourceCacheError("source response Content-Range is invalid")
+    start, end, total = (int(part) for part in match.groups())
+    if start > end or end >= total:
+        raise SourceCacheError("source response Content-Range is invalid")
+    return start, end, total
+
+
+def _response_status(response) -> int | None:
+    status = getattr(response, "status", None)
+    if status is None and hasattr(response, "getcode"):
+        status = response.getcode()
+    return status if isinstance(status, int) else None
+
+
+def _if_range_validator(etag: str | None, last_modified: str | None) -> str | None:
+    if etag is not None and not etag.strip().startswith("W/"):
+        return etag
+    return last_modified
 
 
 def _raise_if_cancelled(cancellation_check) -> None:

--- a/map-platform/backend/tests/test_source_cache.py
+++ b/map-platform/backend/tests/test_source_cache.py
@@ -428,6 +428,191 @@ class SourceCacheTests(unittest.TestCase):
                 stale_digest,
             )
 
+    def test_incomplete_declared_response_resumes_exact_bytes(self):
+        class Response:
+            def __init__(self, *, headers, chunks, status=None):
+                self.headers = headers
+                self.chunks = iter(chunks)
+                self.status = status
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, _size):
+                return next(self.chunks, b"")
+
+            def geturl(self):
+                return "https://example.invalid/test-20260825.osm.pbf"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            region = SourceRegion(
+                id="test-region",
+                provider="test",
+                name="Test",
+                url="https://example.invalid/test-latest.osm.pbf",
+                bounds=Bounds(0, 0, 1, 1),
+                local_path="map-platform/backend/data/source-pbf/test.osm.pbf",
+            )
+            cache = SourceCache(
+                root / "repo",
+                root / "cache.json",
+                data_root=root / "data",
+            )
+            first = Response(
+                headers={
+                    "Content-Length": "10",
+                    "ETag": '"fresh-etag"',
+                    "Last-Modified": "Tue, 25 Aug 2026 00:00:00 GMT",
+                },
+                chunks=[b"fresh"],
+            )
+            resumed = Response(
+                headers={
+                    "Content-Length": "5",
+                    "Content-Range": "bytes 5-9/10",
+                    "ETag": '"fresh-etag"',
+                    "Last-Modified": "Tue, 25 Aug 2026 00:00:00 GMT",
+                },
+                chunks=[b"-data"],
+                status=206,
+            )
+
+            with patch(
+                "map_platform.source_cache.urllib.request.urlopen",
+                side_effect=[first, resumed],
+            ) as download:
+                cached = cache.ensure(region)
+
+            self.assertEqual(cached.bytes, 10)
+            self.assertEqual(cached.path.read_bytes(), b"fresh-data")
+            self.assertEqual(download.call_count, 2)
+            self.assertEqual(download.call_args_list[0].args[0], region.url)
+            resume_request = download.call_args_list[1].args[0]
+            self.assertIsInstance(resume_request, urllib.request.Request)
+            self.assertEqual(
+                resume_request.full_url,
+                "https://example.invalid/test-20260825.osm.pbf",
+            )
+            self.assertEqual(resume_request.get_header("Range"), "bytes=5-")
+            self.assertEqual(
+                resume_request.get_header("If-range"),
+                '"fresh-etag"',
+            )
+
+    def test_incomplete_response_without_validator_preserves_stable_target(self):
+        class Response:
+            headers = {"Content-Length": "10"}
+
+            def __init__(self):
+                self.done = False
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, _size):
+                if self.done:
+                    return b""
+                self.done = True
+                return b"short"
+
+            def geturl(self):
+                return "https://example.invalid/test.osm.pbf"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "data" / "source-pbf" / "test.osm.pbf"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"stable")
+            region = SourceRegion(
+                id="test-region",
+                provider="test",
+                name="Test",
+                url="https://example.invalid/test.osm.pbf",
+                bounds=Bounds(0, 0, 1, 1),
+                local_path="map-platform/backend/data/source-pbf/test.osm.pbf",
+            )
+            cache = SourceCache(
+                root / "repo",
+                root / "cache.json",
+                data_root=root / "data",
+            )
+
+            with patch(
+                "map_platform.source_cache.urllib.request.urlopen",
+                return_value=Response(),
+            ), self.assertRaisesRegex(SourceCacheError, "cannot be resumed safely"):
+                cache.ensure(region, force=True)
+
+            self.assertEqual(target.read_bytes(), b"stable")
+            self.assertFalse(target.with_suffix(target.suffix + ".tmp").exists())
+
+    def test_resume_rejects_changed_total_and_preserves_stable_target(self):
+        class Response:
+            def __init__(self, *, headers, chunks, status=None):
+                self.headers = headers
+                self.chunks = iter(chunks)
+                self.status = status
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self, _size):
+                return next(self.chunks, b"")
+
+            def geturl(self):
+                return "https://example.invalid/test-20260825.osm.pbf"
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            target = root / "data" / "source-pbf" / "test.osm.pbf"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"stable")
+            region = SourceRegion(
+                id="test-region",
+                provider="test",
+                name="Test",
+                url="https://example.invalid/test-latest.osm.pbf",
+                bounds=Bounds(0, 0, 1, 1),
+                local_path="map-platform/backend/data/source-pbf/test.osm.pbf",
+            )
+            cache = SourceCache(
+                root / "repo",
+                root / "cache.json",
+                data_root=root / "data",
+            )
+            first = Response(
+                headers={"Content-Length": "10", "ETag": '"fresh-etag"'},
+                chunks=[b"fresh"],
+            )
+            changed = Response(
+                headers={
+                    "Content-Length": "6",
+                    "Content-Range": "bytes 5-10/11",
+                    "ETag": '"fresh-etag"',
+                },
+                chunks=[b"-data!"],
+                status=206,
+            )
+
+            with patch(
+                "map_platform.source_cache.urllib.request.urlopen",
+                side_effect=[first, changed],
+            ), self.assertRaisesRegex(SourceCacheError, "size changed"):
+                cache.ensure(region, force=True)
+
+            self.assertEqual(target.read_bytes(), b"stable")
+            self.assertFalse(target.with_suffix(target.suffix + ".tmp").exists())
+
     def test_stale_mutable_snapshot_uses_validators_and_preserves_304_bytes(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)


### PR DESCRIPTION
## Summary
- require declared source downloads to reach their exact Content-Length before publication
- resume premature EOFs from the immutable resolved URL using validated HTTP byte ranges
- reject changed URLs, validators, ranges, and total sizes while preserving the prior stable snapshot

## Evidence
- live Geofabrik China response declares 1,587,693,648 bytes, while the failed dev cache published only 12,424,383 bytes and `osmium fileinfo -e` reports `unexpected EOF`
- live range probe returned HTTP 206 with matching ETag and exact Content-Range
- `python3 -m unittest discover -s tests -p "test_*.py"` in `map-platform/backend`: 656 passed, 2 skipped
- deployment tests: 52 passed

## Scope
Backend source-cache fix only. No production deployment and no Bicino app or device changes.