### PR TITLE
Tolerate invalid generic map polygons

### DIFF
--- a/map-platform/backend/map_platform/pipeline.py
+++ b/map-platform/backend/map_platform/pipeline.py
@@ -1080,6 +1080,15 @@ _CHUNK_SPLIT_FAILURE_CODES = frozenset(
         "building_scope_exceeded",
         "building_chunk_wall_time_exceeded",
         "building_worker_oom",
+        "generic_geometry_invalid",
+    }
+)
+_PATHOLOGICAL_BLOCK_FAILURE_CODES = frozenset(
+    {
+        "building_object_limit_exceeded",
+        "building_scope_exceeded",
+        "building_chunk_wall_time_exceeded",
+        "building_worker_oom",
     }
 )
 MAX_FINAL_ASSEMBLY_ARCHIVE_BYTES = 512 * 1024 * 1024
@@ -3050,7 +3059,7 @@ class MapBuildPipeline:
                     typed_failure = (
                         "building_pathological_block"
                         if len(task.blocks) == 1
-                        and exc.code in _CHUNK_SPLIT_FAILURE_CODES
+                        and exc.code in _PATHOLOGICAL_BLOCK_FAILURE_CODES
                         else exc.code
                     )
                     failure_resource = self._last_task_failure_resource()

--- a/map-platform/backend/map_platform/worker.py
+++ b/map-platform/backend/map_platform/worker.py
@@ -42,6 +42,8 @@ _NON_RETRYABLE_BUILD_ERROR_CODES = frozenset(
         "building_storage_admission",
         "building_worker_oom",
         "building_workload_receipt_mismatch",
+        "generic_geometry_amplification_limit",
+        "generic_geometry_invalid",
     }
 )
 

--- a/map-platform/backend/tests/test_map_buildings.py
+++ b/map-platform/backend/tests/test_map_buildings.py
@@ -1167,7 +1167,7 @@ class MapBuildingContractTests(unittest.TestCase):
                 "building_artifact_validation_failed",
             )
 
-    def test_multi_block_guard_failure_becomes_split_signal(self):
+    def test_multi_block_guard_or_geometry_failure_becomes_split_signal(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
             job = self._service(JobStore(root / "jobs")).create_job(
@@ -1186,19 +1186,25 @@ class MapBuildingContractTests(unittest.TestCase):
                     root / "packs",
                 )
             )
-            with self.assertRaises(BuildingChunkSplitRequired) as raised:
-                pipeline._raise_chunk_split_if_needed(
-                    BuildingScopeError(
-                        "building_object_limit_exceeded", "too many objects"
-                    ),
-                    task_id="task-1",
-                    scope_plan=scope_plan,
-                )
-            self.assertEqual(raised.exception.task_id, "task-1")
-            self.assertEqual(
-                raised.exception.blocks,
-                tuple((block.x, block.y) for block in scope_plan.output_blocks),
-            )
+            for failure_code in (
+                "building_object_limit_exceeded",
+                "generic_geometry_invalid",
+            ):
+                with self.subTest(failure_code=failure_code):
+                    with self.assertRaises(BuildingChunkSplitRequired) as raised:
+                        pipeline._raise_chunk_split_if_needed(
+                            BuildingScopeError(failure_code, "deterministic failure"),
+                            task_id="task-1",
+                            scope_plan=scope_plan,
+                        )
+                    self.assertEqual(raised.exception.task_id, "task-1")
+                    self.assertEqual(
+                        raised.exception.blocks,
+                        tuple(
+                            (block.x, block.y)
+                            for block in scope_plan.output_blocks
+                        ),
+                    )
 
     def test_building_block_cache_identity_is_scope_independent_and_hash_bound(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/map-platform/backend/tests/test_worker.py
+++ b/map-platform/backend/tests/test_worker.py
@@ -66,11 +66,14 @@ class FakePipeline:
 
 
 class DeterministicFailurePipeline:
+    def __init__(self, code="building_object_limit_exceeded"):
+        self.code = code
+
     def build(self, job, on_status=None, on_progress=None):
         del job, on_status, on_progress
         raise BuildingScopeError(
-            "building_object_limit_exceeded",
-            "building closure exceeds the job object limit",
+            self.code,
+            "deterministic map build failure",
         )
 
 
@@ -1104,6 +1107,32 @@ class WorkerTests(unittest.TestCase):
             self.assertIsNotNone(loaded.finished_at)
             self.assertFalse(next_result.processed)
             self.assertEqual(store.get(job.job_id).attempts, 1)
+
+    def test_worker_does_not_retry_deterministic_generic_geometry_failure(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            store = JobStore(tmp)
+            service = MapJobService(SourceIndex([self.source]), store)
+            job = service.create_job(
+                {
+                    "mode": "custom_bbox",
+                    "bbox": [103.75, 1.24, 103.93, 1.37],
+                }
+            )
+
+            worker = MapWorker(
+                store,
+                DeterministicFailurePipeline("generic_geometry_invalid"),
+                worker_id="worker-test",
+            )
+            result = worker.run_next()
+            next_result = worker.run_next()
+            loaded = store.get(job.job_id)
+
+            self.assertTrue(result.processed)
+            self.assertEqual(loaded.status, JobStatus.FAILED)
+            self.assertEqual(loaded.attempts, 1)
+            self.assertEqual(loaded.error_code, "generic_geometry_invalid")
+            self.assertFalse(next_result.processed)
 
     def test_worker_does_not_retry_exhausted_child_failure(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tools/OSM_Extract/scripts/extract_features.py
+++ b/tools/OSM_Extract/scripts/extract_features.py
@@ -640,14 +640,6 @@ polygons = process_features(
     conf['polygons'],
     geometry_diagnostics=geometry_diagnostics,
 ) # extracted_polygons
-print(
-    "GEOMETRY_DIAGNOSTICS:"
-    + json.dumps(
-        geometry_diagnostics,
-        sort_keys=True,
-        separators=(",", ":"),
-    )
-)
 normalization_seconds = time.perf_counter() - normalization_started
 print("Applying styles")
 # apply styles
@@ -731,7 +723,11 @@ for init_x, init_y in progress.track(block_positions):
             label_diagnostics=label_diagnostics if font_builder is not None else None,
         )
         try:
-            clipped_polygons = clip_polygons(polygons, mapblock_bbox)
+            clipped_polygons = clip_polygons(
+                polygons,
+                mapblock_bbox,
+                geometry_diagnostics=geometry_diagnostics,
+            )
         except GenericGeometryError as exc:
             fail_generic_geometry(exc)
         clipped_buildings = []
@@ -887,6 +883,15 @@ building_block_encoding_seconds = (
     else 0.0
 )
 
+print(
+    "GEOMETRY_DIAGNOSTICS:"
+    + json.dumps(
+        geometry_diagnostics,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+)
+
 if font_builder is not None:
     label_phase_timings["labelShaping"] = font_builder.shaping_seconds
     label_phase_timings["labelFmbWriting"] = max(
@@ -905,6 +910,7 @@ if font_builder is not None:
     print("LABEL_STATS:" + json.dumps(label_totals, sort_keys=True, separators=(",", ":")))
 
 if args.renderer_format == 3:
+    building_totals["geometryDiagnostics"] = geometry_diagnostics
     for key, value in building_report.items():
         if key not in building_totals:
             building_totals[key] = value

--- a/tools/OSM_Extract/scripts/funcs.py
+++ b/tools/OSM_Extract/scripts/funcs.py
@@ -22,6 +22,7 @@ IMG_WIDTH, IMG_HEIGHT = pow( 2, 12), pow( 2, 12) # 4096 x 4096
 BACKGROUND_COLOR = 0xDDDDDD
 MAX_GENERIC_POLYGON_PIECES_PER_SOURCE = 2048
 MAX_GENERIC_POLYGON_PIECES_PER_BLOCK = 32768
+MAX_GEOMETRY_DROP_SAMPLES = 8
 _GEOMETRY_EQUIVALENCE_RELATIVE_TOLERANCE = 1e-9
 _GEOMETRY_EQUIVALENCE_ABSOLUTE_TOLERANCE = 1e-7
 _FMB_COORDINATE_GRID_SIZE = 1.0
@@ -60,12 +61,16 @@ def parse_tags(tags_str):
     return res
 
 
-def _record_geometry_drop(diagnostics, code):
+def _record_geometry_drop(diagnostics, code, *, sample=None):
     if diagnostics is None:
         return
     diagnostics["droppedGeometryCount"] = diagnostics.get("droppedGeometryCount", 0) + 1
     dropped_by_code = diagnostics.setdefault("droppedByCode", {})
     dropped_by_code[code] = dropped_by_code.get(code, 0) + 1
+    if sample is not None:
+        samples = diagnostics.setdefault("droppedGeometrySamples", [])
+        if len(samples) < MAX_GEOMETRY_DROP_SAMPLES:
+            samples.append(sample)
 
 
 def _ring_area(coordinates):
@@ -499,6 +504,7 @@ def clip_polygons(
     *,
     max_pieces_per_source=MAX_GENERIC_POLYGON_PIECES_PER_SOURCE,
     max_pieces_per_block=MAX_GENERIC_POLYGON_PIECES_PER_BLOCK,
+    geometry_diagnostics=None,
 ):
     """ Clip polygons to the bbox area. Each polygon can be splitted into one or several polygons.
         Returns a list of polygons
@@ -507,49 +513,92 @@ def clip_polygons(
     source_piece_counts = {}
     min_x, min_y = bbox.bounds[:2]
     for feat in features:
-        polygon = feat['geom']
-        if not isinstance(polygon, Polygon):
-            raise GenericGeometryError("generic polygon feature is not a Polygon")
-        if not bbox.intersects( polygon) or bbox.touches( polygon): continue
-        parts = intersection( polygon, bbox)
-        if not parts.is_valid:
-            raise GenericGeometryError("clipping produced invalid generic geometry")
         source_key = feat.get('_source_geometry_key', str(feat.get('id', '')))
-        polygonal_parts = [
-            _canonicalize_shapely_polygon(part)
-            for part in _polygonal_parts(parts)
-        ]
-        for clipped_part in sorted(polygonal_parts, key=_polygon_sort_key):
-            for part in _snap_to_fmb_precision(clipped_part):
-                source_count = source_piece_counts.get(source_key, 0)
-                remaining_source = max_pieces_per_source - source_count
-                remaining_block = max_pieces_per_block - len(clipped)
-                if remaining_source <= 0 or remaining_block <= 0:
-                    raise GenericGeometryLimitError(
-                        "generic polygon decomposition exceeded its piece budget"
-                    )
-                pieces = _decompose_hole_free(
-                    part, min(remaining_source, remaining_block)
+        source_count = source_piece_counts.get(source_key, 0)
+        feature_clipped = []
+        try:
+            polygon = feat['geom']
+            if not isinstance(polygon, Polygon):
+                raise GenericGeometryError(
+                    "generic polygon feature is not a Polygon"
                 )
-                _validate_quantized_decomposition(part, pieces, min_x, min_y)
-                source_piece_counts[source_key] = source_count + len(pieces)
-                if source_piece_counts[source_key] > max_pieces_per_source:
-                    raise GenericGeometryLimitError(
-                        "generic polygon decomposition exceeded the per-source limit"
+            if not bbox.intersects(polygon) or bbox.touches(polygon):
+                continue
+            parts = intersection(polygon, bbox)
+            if not parts.is_valid:
+                raise GenericGeometryError(
+                    "clipping produced invalid generic geometry"
+                )
+            polygonal_parts = [
+                _canonicalize_shapely_polygon(part)
+                for part in _polygonal_parts(parts)
+            ]
+            for clipped_part in sorted(polygonal_parts, key=_polygon_sort_key):
+                for part in _snap_to_fmb_precision(clipped_part):
+                    remaining_source = max_pieces_per_source - source_count
+                    remaining_block = (
+                        max_pieces_per_block
+                        - len(clipped)
+                        - len(feature_clipped)
                     )
-                if len(clipped) + len(pieces) > max_pieces_per_block:
-                    raise GenericGeometryLimitError(
-                        "generic polygon decomposition exceeded the per-block limit"
-                    )
-                for p in pieces:
-                    if p.interiors:
-                        raise GenericGeometryError(
-                            "generic polygon output retained an interior ring"
+                    if remaining_source <= 0 or remaining_block <= 0:
+                        raise GenericGeometryLimitError(
+                            "generic polygon decomposition exceeded its piece budget"
                         )
-                    new_feat = dict(feat)
-                    new_feat['geom'] = p
-                    new_feat['bbox'] = p.bounds
-                    clipped.append(new_feat)
+                    pieces = _decompose_hole_free(
+                        part, min(remaining_source, remaining_block)
+                    )
+                    _validate_quantized_decomposition(part, pieces, min_x, min_y)
+                    source_count += len(pieces)
+                    if source_count > max_pieces_per_source:
+                        raise GenericGeometryLimitError(
+                            "generic polygon decomposition exceeded the per-source limit"
+                        )
+                    if (
+                        len(clipped) + len(feature_clipped) + len(pieces)
+                        > max_pieces_per_block
+                    ):
+                        raise GenericGeometryLimitError(
+                            "generic polygon decomposition exceeded the per-block limit"
+                        )
+                    for p in pieces:
+                        if p.interiors:
+                            raise GenericGeometryError(
+                                "generic polygon output retained an interior ring"
+                            )
+                        new_feat = dict(feat)
+                        new_feat['geom'] = p
+                        new_feat['bbox'] = p.bounds
+                        feature_clipped.append(new_feat)
+        except GenericGeometryLimitError:
+            # Piece limits protect worker memory and artifact size. They must
+            # remain hard failures instead of silently omitting large areas.
+            raise
+        except (GenericGeometryError, GEOSException) as exc:
+            # Generic OSM polygons are decorative map context. One malformed
+            # source component must not make an otherwise valid regional map
+            # unavailable. Keep the drop atomic so a failed component is
+            # never partially encoded, and retain bounded source/block detail
+            # for later diagnosis.
+            reason = (
+                str(exc)[:160]
+                if isinstance(exc, GenericGeometryError)
+                else "GEOS operation failed while clipping generic polygon"
+            )
+            _record_geometry_drop(
+                geometry_diagnostics,
+                "invalid_block_polygon",
+                sample={
+                    "blockOrigin": [int(min_x), int(min_y)],
+                    "component": int(feat.get('_source_geometry_component', 0)),
+                    "reason": reason,
+                    "sourceGeometryKey": str(source_key)[:80],
+                },
+            )
+            continue
+
+        source_piece_counts[source_key] = source_count
+        clipped.extend(feature_clipped)
         # if len( new_feat['geom'].coords) <= 2: continue
     return clipped
 

--- a/tools/OSM_Extract/tests/test_generic_geometry.py
+++ b/tools/OSM_Extract/tests/test_generic_geometry.py
@@ -4,6 +4,7 @@ import subprocess
 import sys
 import tempfile
 import unittest
+from unittest.mock import patch
 
 from PIL import Image
 from shapely import Polygon, box, set_precision
@@ -22,6 +23,7 @@ from funcs import (  # noqa: E402
     get_geoms,
     render_map,
 )
+import funcs  # noqa: E402
 from map_format import write_fmb  # noqa: E402
 
 
@@ -228,6 +230,56 @@ class GenericGeometryTests(unittest.TestCase):
 
         with self.assertRaises(GenericGeometryError):
             _validate_quantized_decomposition(source, [filled], 0, 0)
+
+    def test_invalid_block_polygon_is_dropped_with_bounded_diagnostics(self):
+        invalid = styled_feature(
+            Polygon([(0, 0), (10, 0), (10, 10), (0, 0)]),
+            "w123",
+        )
+        invalid["_source_geometry_component"] = 2
+        valid = styled_feature(
+            Polygon([(20, 0), (30, 0), (30, 10), (20, 0)]),
+            "w456",
+        )
+        diagnostics = {}
+        snap_to_fmb_precision = funcs._snap_to_fmb_precision
+
+        def fail_one_source(polygon):
+            if polygon.bounds[0] < 20:
+                raise GenericGeometryError(
+                    "generic polygon becomes invalid at FMB coordinate precision"
+                )
+            return snap_to_fmb_precision(polygon)
+
+        with patch(
+            "funcs._snap_to_fmb_precision",
+            side_effect=fail_one_source,
+        ):
+            pieces = clip_polygons(
+                [invalid, valid],
+                box(0, 0, 40, 40),
+                geometry_diagnostics=diagnostics,
+            )
+
+        self.assertEqual([item["id"] for item in pieces], ["w456"])
+        self.assertEqual(diagnostics["droppedGeometryCount"], 1)
+        self.assertEqual(
+            diagnostics["droppedByCode"],
+            {"invalid_block_polygon": 1},
+        )
+        self.assertEqual(
+            diagnostics["droppedGeometrySamples"],
+            [
+                {
+                    "blockOrigin": [0, 0],
+                    "component": 2,
+                    "reason": (
+                        "generic polygon becomes invalid at FMB coordinate precision"
+                    ),
+                    "sourceGeometryKey": "w123",
+                }
+            ],
+        )
 
     def test_amplification_limit_fails_closed(self):
         source = Polygon(


### PR DESCRIPTION
## Summary
- atomically omit one invalid decorative OSM polygon from a block while preserving all FMB validation for emitted geometry
- retain bounded source and block diagnostics in map build statistics
- split uncaught generic geometry failures to smaller chunks and avoid deterministic whole-job retries

## Validation
- `python3 -m unittest tools/OSM_Extract/tests/test_generic_geometry.py` (11 passed)
- `PYTHONPATH=map-platform/backend python3 -m unittest map-platform/backend/tests/test_worker.py map-platform/backend/tests/test_map_buildings.py map-platform/backend/tests/test_pipeline_progress.py` (140 passed, 2 skipped)
- full backend suite (657 passed, 2 skipped)
- OSM syntax checks passed; full local OSM suite had one unrelated Homebrew dyld failure because `libheif` references a missing `libx265.215.dylib`