### PR TITLE
Fix shared map catalog attachment authentication

### DIFF
--- a/map-platform/backend/map_platform/catalog.py
+++ b/map-platform/backend/map_platform/catalog.py
@@ -344,14 +344,22 @@ class CatalogClient:
         payload: dict[str, Any] = {"libraryCredential": library_credential}
         if alias is not None:
             payload["alias"] = alias
+        # The catalog accepts at most 128 characters in a service request key.
+        # Hash the full attachment identity: a publication ID plus a credential
+        # hash already exceeds that bound for normal generated publications.
+        attachment_identity = _canonical_sha256(
+            {
+                "publicationId": publication_id_value,
+                "libraryCredentialSha256": hashlib.sha256(
+                    library_credential.encode("utf-8")
+                ).hexdigest(),
+            }
+        )
         return self._request(
             "/v1/internal/publications/"
             f"{quote(publication_id_value, safe='')}/attach-library",
             payload,
-            idempotency_key=(
-                f"attach:{publication_id_value}:"
-                f"{hashlib.sha256(library_credential.encode('utf-8')).hexdigest()}"
-            ),
+            idempotency_key=f"attach:{attachment_identity}",
         )
 
     def promotion_grant(self, entry_id: str) -> dict[str, Any]:

--- a/map-platform/backend/tests/test_catalog.py
+++ b/map-platform/backend/tests/test_catalog.py
@@ -406,6 +406,35 @@ class CatalogTests(unittest.TestCase):
         request = open_url.call_args.args[0]
         self.assertEqual(request.get_header("User-agent"), "BicinoMapPlatform/1.0")
 
+    def test_attachment_request_keys_fit_service_auth_and_preserve_identity(self):
+        response = Mock()
+        response.read.return_value = b"{}"
+        response.__enter__ = Mock(return_value=response)
+        response.__exit__ = Mock(return_value=None)
+        client = CatalogClient("https://maps.invalid", "development", "dev", "x" * 32)
+
+        def request_key(publication, credential, alias=None):
+            with patch("map_platform.catalog.urlopen", return_value=response) as open_url:
+                client.attach_library(
+                    publication_id_value=publication,
+                    library_credential=credential,
+                    alias=alias,
+                )
+            request = open_url.call_args.args[0]
+            key = request.get_header("X-catalog-idempotency-key")
+            # Match the catalog Worker's verifyServiceRequest header contract.
+            self.assertRegex(key, r"\A[A-Za-z0-9._:-]{8,128}\Z")
+            return key
+
+        for channel in ("development", "production"):
+            with self.subTest(channel=channel):
+                publication = publication_payload(ready_job(), channel)["publicationId"]
+                first = request_key(publication, "a" * 64)
+                self.assertEqual(first, request_key(publication, "a" * 64, "New alias"))
+                self.assertNotEqual(first, request_key(publication, "b" * 64))
+                self.assertNotEqual(first, request_key(publication + "-other", "a" * 64))
+        request_key("p" * 128, "a" * 128)
+
     def test_catalog_delivery_identity_only_accepts_complete_firmware_tuple(self):
         with patch.dict(
             os.environ,


### PR DESCRIPTION
Generated map downloads could remain pending forever without a Share button: attachment requests used a 160-character idempotency key, exceeding the catalog's 128-character service-auth limit. The catalog rejected these requests with HTTP 401, which the map API surfaced as HTTP 503.

Hash the publication/credential identity into a stable 71-character attachment key. Retries keep the same identity, while different publications or library credentials remain distinct. No authentication limits are relaxed.

Validation: all 24 catalog and catalog-promotion tests pass. The new regression covers generated development/production publication IDs, maximum-length IDs, stable retries, and distinct attachment identities. A live diagnostic reproduced rejection of the old key and confirmed a compact key passes service authentication.
