### PR TITLE
Support legacy map attachment keys in shared catalog

### DIFF
--- a/map-platform/catalog/README.md
+++ b/map-platform/catalog/README.md
@@ -52,6 +52,11 @@ passes, following
   production HMAC service principals; request signatures bind the method,
   path, timestamp, idempotency key, and body SHA-256. A principal has the shape
   `{"channel":"development|production","secret":"..."}`.
+- Service idempotency keys normally remain limited to 128 characters. For
+  older map backends, the exact legacy `attach:<publicationId>:<credentialSha256>`
+  format is also accepted, only on the matching encoded publication's POST
+  `attach-library` route. This compatibility exception does not bypass HMAC,
+  timestamp, channel, or library-credential authorization.
 - `R2_DEVELOPMENT_*` and `R2_PRODUCTION_*` are read-only credentials and must
   never be reused by a map publisher.
 - Share previews contain bounded metadata and never reveal an R2 key or a

--- a/map-platform/catalog/src/security.ts
+++ b/map-platform/catalog/src/security.ts
@@ -74,6 +74,22 @@ export interface VerifiedServiceRequest {
   channel: Channel;
 }
 
+function supportedServiceRequestKey(request: Request, key: string): boolean {
+  if (/^[A-Za-z0-9._:-]{8,128}$/.test(key)) return true;
+
+  // Older map backends included the publication ID and credential digest.
+  // Accept that exact format only for its matching attachment operation.
+  const legacy = key.match(
+    /^attach:(publication:(?:development|production):[0-9a-f]{64}):[0-9a-f]{64}$/,
+  );
+  return (
+    legacy !== null &&
+    request.method === "POST" &&
+    new URL(request.url).pathname ===
+      `/v1/internal/publications/${encodeURIComponent(legacy[1])}/attach-library`
+  );
+}
+
 export async function verifyServiceRequest(
   request: Request,
   env: Env,
@@ -85,7 +101,7 @@ export async function verifyServiceRequest(
   if (
     !SERVICE_KEY_ID.test(keyID) ||
     !/^[0-9]{10,13}$/.test(timestamp) ||
-    !/^[A-Za-z0-9._:-]{8,128}$/.test(idempotencyKey) ||
+    !supportedServiceRequestKey(request, idempotencyKey) ||
     !HEX_64.test(suppliedSignature)
   ) {
     throw new HttpError(401, "invalid service authorization");

--- a/map-platform/catalog/test/security.test.ts
+++ b/map-platform/catalog/test/security.test.ts
@@ -1,0 +1,177 @@
+import { env } from "cloudflare:workers";
+import { describe, expect, it } from "vitest";
+
+import worker from "../src/index";
+import { sha256Hex, verifyServiceRequest } from "../src/security";
+import type { Channel, Env } from "../src/types";
+
+const encoder = new TextEncoder();
+
+function attachment(channel: Channel) {
+  const publicationID = `publication:${channel}:${"a".repeat(64)}`;
+  return {
+    path: `/v1/internal/publications/${encodeURIComponent(publicationID)}/attach-library`,
+    key: `attach:${publicationID}:${"b".repeat(64)}`,
+  };
+}
+
+async function signedRequest(
+  channel: Channel,
+  path: string,
+  idempotencyKey: string,
+  options: { method?: string; timestamp?: string; badSignature?: boolean } = {},
+): Promise<Request> {
+  const method = options.method ?? "POST";
+  const body = JSON.stringify({
+    libraryCredential: "not-a-library-credential",
+  });
+  const timestamp = options.timestamp ?? String(Math.floor(Date.now() / 1000));
+  const canonical = [
+    method,
+    path,
+    timestamp,
+    idempotencyKey,
+    await sha256Hex(body),
+  ].join("\n");
+  const secret = (channel === "development" ? "s" : "p").repeat(48);
+  const key = await crypto.subtle.importKey(
+    "raw",
+    encoder.encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = Array.from(
+    new Uint8Array(
+      await crypto.subtle.sign("HMAC", key, encoder.encode(canonical)),
+    ),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return new Request(`https://maps-share.8o.vc${path}`, {
+    method,
+    body,
+    headers: {
+      "content-type": "application/json",
+      "x-catalog-key-id": `test-${channel}`,
+      "x-catalog-timestamp": timestamp,
+      "x-catalog-idempotency-key": idempotencyKey,
+      "x-catalog-signature": options.badSignature ? "0".repeat(64) : signature,
+    },
+  });
+}
+
+describe("legacy backend attachment authorization", () => {
+  it.each(["development", "production"] as const)(
+    "accepts signed legacy %s attachment keys without bypassing library authorization",
+    async (channel) => {
+      const { path, key } = attachment(channel);
+      const request = await signedRequest(channel, path, key);
+      expect(key.length).toBeGreaterThan(128);
+      await expect(
+        verifyServiceRequest(
+          await signedRequest(channel, path, key),
+          env as Env,
+        ),
+      ).resolves.toMatchObject({
+        channel,
+        idempotencyKey: key,
+      });
+      const response = await worker.fetch(request, {
+        ...env,
+        SERVICE_MUTATION_RATE_LIMITER: {
+          async limit() {
+            return { success: true };
+          },
+        },
+      } as Env);
+      expect(response.status).toBe(401);
+      expect(await response.json()).toEqual({
+        error: "invalid library authorization",
+      });
+    },
+  );
+
+  it("still accepts compact attachment keys", async () => {
+    const { path } = attachment("production");
+    const key = `attach:${"c".repeat(64)}`;
+    await expect(
+      verifyServiceRequest(
+        await signedRequest("production", path, key),
+        env as Env,
+      ),
+    ).resolves.toMatchObject({ idempotencyKey: key, channel: "production" });
+  });
+
+  it.each([
+    [
+      "other operation",
+      "/v1/internal/publications",
+      attachment("production").key,
+      "POST",
+    ],
+    [
+      "other publication",
+      attachment("development").path,
+      attachment("production").key,
+      "POST",
+    ],
+    [
+      "other method",
+      attachment("production").path,
+      attachment("production").key,
+      "PUT",
+    ],
+    [
+      "arbitrary long key",
+      attachment("production").path,
+      "x".repeat(159),
+      "POST",
+    ],
+    [
+      "malformed digest",
+      attachment("production").path,
+      attachment("production").key + "b",
+      "POST",
+    ],
+  ])(
+    "rejects %s even with a valid signature",
+    async (_label, path, key, method) => {
+      await expect(
+        verifyServiceRequest(
+          await signedRequest("production", path, key, { method }),
+          env as Env,
+        ),
+      ).rejects.toMatchObject({
+        status: 401,
+        message: "invalid service authorization",
+      });
+    },
+  );
+
+  it("still rejects a bad signature", async () => {
+    const { path, key } = attachment("production");
+    await expect(
+      verifyServiceRequest(
+        await signedRequest("production", path, key, { badSignature: true }),
+        env as Env,
+      ),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: "invalid service authorization",
+    });
+  });
+
+  it("still rejects expired signatures", async () => {
+    const { path, key } = attachment("production");
+    const timestamp = String(Math.floor(Date.now() / 1000) - 3600);
+    await expect(
+      verifyServiceRequest(
+        await signedRequest("production", path, key, { timestamp }),
+        env as Env,
+      ),
+    ).rejects.toMatchObject({
+      status: 401,
+      message: "stale service authorization",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Restore library attachment for the existing production map backend without promoting unrelated generator changes.
- Accept only the exact legacy attachment key on its matching POST attachment path; keep normal keys limited to 128 characters.
- Preserve HMAC, timestamp, channel and library authorization checks.

## Validation
- pnpm check passed: formatting, TypeScript, 63 tests, staging and production deployment dry-runs.
- Added signed-request regression coverage for both channels, compact keys, wrong routes and methods, malformed oversized keys, bad signatures, expired timestamps, and library authorization.

## Rollout
Deploy the merged catalog Worker to staging first, then production. No backend image, firmware, database migration or secret changes.