### PR TITLE
Prepare production authentication compatibility candidate

### DIFF
--- a/.github/workflows/map-platform-ci.yml
+++ b/.github/workflows/map-platform-ci.yml
@@ -140,6 +140,11 @@ jobs:
         run: |
           python -m unittest discover -s tests
           python -m unittest discover -s ../deploy/tests
+      - name: Production authentication compatibility image
+        working-directory: .
+        run: >-
+          docker build --platform linux/amd64 --target validation
+          -f map-platform/deploy/compatibility/Dockerfile .
       - name: Production Compose config
         env:
           MAP_PLATFORM_DOWNLOAD_SECRET: ci-download-secret

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -22,6 +22,14 @@ on:
       - "map-platform/deploy/verify_registry_images.py"
   workflow_dispatch:
     inputs:
+      release_profile:
+        description: Standard release or authentication-only compatibility candidate (no automatic promotion)
+        required: true
+        default: standard
+        type: choice
+        options:
+          - standard
+          - production-auth-compatibility
       pending_worker:
         description: How to handle an open worker-moving promotion
         required: true
@@ -41,7 +49,7 @@ concurrency:
 
 jobs:
   publish:
-    name: Publish worker image
+    name: Publish candidate image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,18 +71,29 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Validate authentication compatibility candidate
+        if: inputs.release_profile == 'production-auth-compatibility'
+        env:
+          SOURCE_REF: ${{ github.ref }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          test "$SOURCE_REF" = "refs/heads/$DEFAULT_BRANCH"
+          docker build --platform linux/amd64 --target validation \
+            -f map-platform/deploy/compatibility/Dockerfile .
+
       - id: metadata
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/open-bike-computer-map-platform
-          tags: type=raw,value=${{ github.sha }}
+          tags: type=raw,value=${{ github.sha }}${{ inputs.release_profile == 'production-auth-compatibility' && '-auth-compat' || '' }}
 
       - id: image
         name: Build and publish image
         uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
-          file: map-platform/backend/Dockerfile
+          file: ${{ inputs.release_profile == 'production-auth-compatibility' && 'map-platform/deploy/compatibility/Dockerfile' || 'map-platform/backend/Dockerfile' }}
+          target: ${{ inputs.release_profile == 'production-auth-compatibility' && 'runtime' || '' }}
           platforms: linux/amd64
           push: true
           tags: ${{ steps.metadata.outputs.tags }}
@@ -89,7 +108,7 @@ jobs:
           push-to-registry: true
 
       - name: Move latest to the successful default-branch image
-        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+        if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && inputs.release_profile != 'production-auth-compatibility'
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
@@ -120,7 +139,7 @@ jobs:
   propose-production:
     name: Propose production image
     needs: publish
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && inputs.release_profile != 'production-auth-compatibility'
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -427,7 +446,7 @@ jobs:
   propose-development:
     name: Propose development image
     needs: publish
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch) && inputs.release_profile != 'production-auth-compatibility'
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/ios-app/BikeComputer/BikeComputer/Services/BicinoServiceSession.swift
+++ b/ios-app/BikeComputer/BikeComputer/Services/BicinoServiceSession.swift
@@ -280,14 +280,11 @@ final class BicinoServiceSession {
                 client.clientAppAttestKeyId,
                 serverURLString: client.baseURL.absoluteString
             )
-        guard hasUsableCredential else {
-            installationCredentialStore.delete(
-                serverURLString: client.baseURL.absoluteString
-            )
+        guard client.clientInstallationToken?.isEmpty == false else {
             return try await enrollManagedInstallation(replacing: client)
         }
 
-        if honorRefreshBackoff,
+        if hasUsableCredential, honorRefreshBackoff,
            OfflineMapInstallationRefreshBackoff.shouldDefer(
                 serverURLString: client.baseURL.absoluteString,
                 defaults: defaults
@@ -316,13 +313,7 @@ final class BicinoServiceSession {
                     credential.appAttestKeyId,
                     serverURLString: client.baseURL.absoluteString
                   ) else {
-                managedAppAttestClient.invalidate(
-                    serverURLString: client.baseURL.absoluteString
-                )
-                installationCredentialStore.delete(
-                    serverURLString: client.baseURL.absoluteString
-                )
-                return try await enrollManagedInstallation(replacing: client)
+                throw ManagedAppAttestError.invalidCredential
             }
             OfflineMapInstallationRefreshBackoff.clear(
                 serverURLString: client.baseURL.absoluteString,
@@ -330,25 +321,34 @@ final class BicinoServiceSession {
             )
             return try registeredClient(credential, replacing: client)
         } catch let error as OfflineMapPlatformError {
-            guard case .serverStatus(let status, _) = error,
-                  status == 401 else {
+            guard case .serverStatus(let status, let body) = error,
+                  status == 401,
+                  client.clientAppAttestKeyId == nil,
+                  let data = body.data(using: .utf8),
+                  let envelope = try? JSONDecoder().decode(InstallationMigrationError.self, from: data),
+                  envelope.detail.code == "installation_attestation_required" else {
                 throw error
             }
-            managedAppAttestClient.invalidate(
-                serverURLString: client.baseURL.absoluteString
-            )
-            installationCredentialStore.delete(
-                serverURLString: client.baseURL.absoluteString
-            )
-            return try await enrollManagedInstallation(replacing: client)
+            return try await enrollManagedInstallation(replacing: client, preservingCredential: true)
         }
     }
 
+    private struct InstallationMigrationError: Decodable {
+        struct Detail: Decodable { let code: String }
+        let detail: Detail
+    }
+
     private func enrollManagedInstallation(
-        replacing client: OfflineMapPlatformClient
+        replacing client: OfflineMapPlatformClient,
+        preservingCredential: Bool = false
     ) async throws -> OfflineMapPlatformClient {
         let credential = try await managedAppAttestClient.enroll(
-            baseURL: client.baseURL
+            baseURL: client.baseURL,
+            existingCredential: preservingCredential ? OfflineMapInstallationCredential(
+                clientInstallationId: client.clientInstallationId,
+                clientInstallationToken: client.clientInstallationToken!,
+                appAttestKeyId: client.clientAppAttestKeyId
+            ) : nil
         )
         OfflineMapInstallationRefreshBackoff.clear(
             serverURLString: client.baseURL.absoluteString,

--- a/ios-app/BikeComputer/BikeComputer/Services/ManagedAppAttestClient.swift
+++ b/ios-app/BikeComputer/BikeComputer/Services/ManagedAppAttestClient.swift
@@ -349,7 +349,10 @@ final class ManagedOfflineMapAppAttestClient {
         return keyStore.load(serverURLString: serverURLString) == keyID
     }
 
-    func enroll(baseURL: URL) async throws -> OfflineMapInstallationCredential {
+    func enroll(
+        baseURL: URL,
+        existingCredential: OfflineMapInstallationCredential? = nil
+    ) async throws -> OfflineMapInstallationCredential {
         guard service.isSupported else {
             throw ManagedAppAttestError.unsupported
         }
@@ -359,7 +362,6 @@ final class ManagedOfflineMapAppAttestClient {
         ) != nil else {
             throw ManagedAppAttestError.invalidConfiguration
         }
-        keyStore.delete(serverURLString: baseURL.absoluteString)
         let challenge = try await fetchChallenge(
             baseURL: baseURL,
             purpose: "attestation",
@@ -391,15 +393,28 @@ final class ManagedOfflineMapAppAttestClient {
         var request = URLRequest(
             url: try endpointURL(baseURL: baseURL, path: "/v1/installations")
         )
+        if let existingCredential {
+            var components = URLComponents(url: request.url!, resolvingAgainstBaseURL: false)!
+            components.queryItems = [URLQueryItem(
+                name: "clientInstallationId", value: existingCredential.clientInstallationId
+            )]
+            request.url = components.url
+            request.setValue(existingCredential.clientInstallationToken, forHTTPHeaderField: "X-Installation-Token")
+        }
         request.httpMethod = "POST"
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
         request.httpBody = try JSONEncoder.offlineMap.encode(body)
+        // Keep the key before submission so an authenticated refresh can recover
+        // an enrollment that committed on the server but lost its response.
+        try keyStore.save(keyID, serverURLString: baseURL.absoluteString)
         let credential: OfflineMapInstallationCredential = try await send(request)
-        guard credential.appAttestKeyId == keyID else {
+        guard credential.appAttestKeyId == keyID,
+              credential.clientInstallationId.range(of: "^inst_v2_[0-9a-f]{32}$", options: .regularExpression) != nil,
+              credential.clientInstallationToken.range(of: "^v1\\.[A-Za-z0-9_-]{43}$", options: .regularExpression) != nil,
+              existingCredential == nil || credential.clientInstallationId == existingCredential?.clientInstallationId else {
             throw ManagedAppAttestError.invalidCredential
         }
-        try keyStore.save(keyID, serverURLString: baseURL.absoluteString)
         return credential
     }
 

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -847,6 +847,7 @@ struct NavigationProtocolTests {
         await testOfflineMapInstallationCredentialClient()
         testOfflineMapAppAttestGoldenVector()
         await testManagedOfflineMapAppAttestContract()
+        await testManagedInstallationMigration()
         testOfflineMapPreparationTimeEstimate()
         testOfflineMapJobProgressDecoding()
         testOfflineMapJobPhaseOnlyProgressDecoding()
@@ -3030,6 +3031,86 @@ struct NavigationProtocolTests {
         } catch {
             assert(false, "installation credential client contract succeeds: \(error)")
         }
+    }
+
+    @MainActor
+    static func testManagedInstallationMigration() async {
+        let suite = "Migration-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [OfflineMapTestURLProtocol.self]
+        let urlSession = URLSession(configuration: configuration)
+        defer { urlSession.invalidateAndCancel(); OfflineMapTestURLProtocol.reset() }
+        let origin = OfflineMapServiceConfig.productionServerURLString
+        let keyID = Data(repeating: 0x63, count: 32).base64EncodedString()
+        let old = OfflineMapInstallationCredential(
+            clientInstallationId: "inst_v2_1234567890abcdef1234567890abcdef",
+            clientInstallationToken: "v1." + String(repeating: "A", count: 43)
+        )
+        let migrated = OfflineMapInstallationCredential(
+            clientInstallationId: old.clientInstallationId,
+            clientInstallationToken: old.clientInstallationToken,
+            appAttestKeyId: keyID
+        )
+        let store = OfflineMapInstallationCredentialStore(defaults: defaults)
+        let service = BicinoServiceSession(defaults: defaults, urlSession: urlSession,
+            appAttestService: TestOfflineMapAppAttestService(keyID: keyID), appAttestAppBuild: "123")
+        var committed = false
+        var enrollments = 0
+        OfflineMapTestURLProtocol.configure { request in
+            if request.url?.path == "/v1/installations/app-attest/challenges" {
+                let challenge = OfflineMapAppAttestChallenge(
+                    challengeId: String(repeating: "a", count: 32),
+                    challenge: Data(repeating: 1, count: 32).base64EncodedString()
+                        .replacingOccurrences(of: "=", with: ""),
+                    purpose: "attestation", expiresAt: Int64(Date().timeIntervalSince1970) + 300, keyId: nil)
+                return (200, try! JSONEncoder().encode(challenge))
+            }
+            assertEqual(request.value(forHTTPHeaderField: "X-Installation-Token"), old.clientInstallationToken,
+                "migration and refresh prove possession of the old token")
+            assert(request.url!.query!.contains(old.clientInstallationId), "migration keeps the old identity")
+            if !OfflineMapTestURLProtocol.bodyData(from: request).isEmpty {
+                enrollments += 1
+                committed = true
+                return (503, Data("lost enrollment response".utf8))
+            }
+            if committed { return (200, try! JSONEncoder().encode(migrated)) }
+            return (401, Data(#"{"detail":{"code":"installation_attestation_required"}}"#.utf8))
+        }
+        do {
+            try store.save(old, serverURLString: origin)
+            let client = try service.makeOfflineMapClient(serverURLString: origin)
+            do {
+                _ = try await service.ensureRegisteredInstallation(client: client)
+                assert(false, "lost response must fail without deleting credentials")
+            } catch {}
+            assertEqual(store.load(serverURLString: origin), old, "failed migration preserves old credentials")
+            let recovered = try await service.ensureRegisteredInstallation(client: client)
+            assertEqual(recovered.clientInstallationId, old.clientInstallationId, "refresh recovers the same owner")
+            assertEqual(store.load(serverURLString: origin), migrated, "refresh commits the recovered key")
+            assertEqual(enrollments, 1, "lost response does not trigger another enrollment")
+            for status in [401, 503] {
+                try store.save(old, serverURLString: origin)
+                OfflineMapTestURLProtocol.configure { _ in
+                    (status, Data(#"{"detail":"invalid installation credential"}"#.utf8))
+                }
+                do {
+                    _ = try await service.ensureRegisteredInstallation(client: client, honorRefreshBackoff: false)
+                    assert(false, "unrelated authentication/server errors must fail closed")
+                } catch {}
+                assertEqual(store.load(serverURLString: origin), old, "server errors never erase the owner credential")
+            }
+            let foreign = OfflineMapInstallationCredential(
+                clientInstallationId: "inst_v2_aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                clientInstallationToken: old.clientInstallationToken, appAttestKeyId: keyID)
+            OfflineMapTestURLProtocol.configure { _ in (200, try! JSONEncoder().encode(foreign)) }
+            do {
+                _ = try await service.ensureRegisteredInstallation(client: client, honorRefreshBackoff: false)
+                assert(false, "refresh must reject a different installation identity")
+            } catch {}
+            assertEqual(store.load(serverURLString: origin), old, "foreign refresh cannot replace the owner credential")
+        } catch { assert(false, "migration recovery succeeds: \(error)") }
     }
 
     @MainActor

--- a/map-platform/backend/map_platform/api.py
+++ b/map-platform/backend/map_platform/api.py
@@ -791,7 +791,15 @@ def create_app(
             alias="X-Installation-Token",
         ),
     ) -> dict[str, Any]:
-        if clientInstallationId is None:
+        installation_id = token = None
+        if clientInstallationId is not None:
+            try:
+                installation_id, token = installation_store.refresh(
+                    clientInstallationId, x_installation_token,
+                )
+            except InstallationCredentialError as exc:
+                raise HTTPException(status_code=401, detail=str(exc)) from exc
+        if clientInstallationId is None or (isinstance(payload, dict) and set(payload) == {"appAttest"}):
             del request
             if not isinstance(payload, dict) or set(payload) != {"appAttest"}:
                 raise AppAttestError(
@@ -826,7 +834,13 @@ def create_app(
                 field="App Attest object",
                 maximum_bytes=APP_ATTEST_MAX_OBJECT_BYTES,
             )
-            installation_id, token = installation_store.issue()
+            if installation_id is None:
+                installation_id, token = installation_store.issue()
+            elif app_attest_store.key_id_for_installation(installation_id) is not None:
+                raise AppAttestError(
+                    "app_attest_invalid_attestation",
+                    "installation is already bound to an App Attest key",
+                )
             app_attest_store.enroll(
                 installation_id=installation_id,
                 challenge_id=challenge_id,
@@ -837,13 +851,6 @@ def create_app(
         else:
             if payload is not None and payload != {}:
                 raise HTTPException(status_code=400, detail="refresh body is not allowed")
-            try:
-                installation_id, token = installation_store.refresh(
-                    clientInstallationId,
-                    x_installation_token,
-                )
-            except InstallationCredentialError as exc:
-                raise HTTPException(status_code=401, detail=str(exc)) from exc
             key_id = app_attest_store.key_id_for_installation(installation_id)
             if key_id is None:
                 raise AppAttestError(

--- a/map-platform/backend/tests/app_attest_support.py
+++ b/map-platform/backend/tests/app_attest_support.py
@@ -118,7 +118,7 @@ class AppAttestTestClient:
         self._installations: dict[str, TestInstallation] = {}
         self._lock = threading.Lock()
 
-    def issue_installation(self, client) -> dict[str, str]:
+    def issue_installation(self, client, *, existing_credential=None) -> dict[str, str]:
         challenge_response = client.post(
             "/v1/installations/app-attest/challenges",
             json={"purpose": APP_ATTEST_ATTESTATION_PURPOSE},
@@ -147,6 +147,8 @@ class AppAttestTestClient:
         )
         response = client.post(
             "/v1/installations",
+            params={"clientInstallationId": existing_credential["clientInstallationId"]} if existing_credential else None,
+            headers={"X-Installation-Token": existing_credential["clientInstallationToken"]} if existing_credential else None,
             json={
                 "appAttest": {
                     "challengeId": challenge_document["challengeId"],

--- a/map-platform/backend/tests/test_api.py
+++ b/map-platform/backend/tests/test_api.py
@@ -706,6 +706,16 @@ class MapJobRunAPITests(unittest.TestCase):
         self.assertEqual(blocked.json()["detail"], "request rate limit exceeded")
         self.assertGreater(int(blocked.headers["Retry-After"]), 0)
 
+    def test_legacy_installation_enrollment_preserves_owner(self):
+        old_id, old_token = self.client.app.state.installation_store.issue()
+        old = {"clientInstallationId": old_id, "clientInstallationToken": old_token}
+        credential = self.app_attest.issue_installation(self.client, existing_credential=old)
+        self.assertIsInstance(credential, dict)
+        self.assertEqual(credential["clientInstallationId"], old_id)
+        self.assertEqual(credential["clientInstallationToken"], old_token)
+        rejected = self.app_attest.issue_installation(self.client, existing_credential=old)
+        self.assertEqual(rejected.status_code, 401)
+
     def test_installation_issuance_requires_app_attest(self):
         response = self.client.post("/v1/installations")
 

--- a/map-platform/deploy/compatibility/Dockerfile
+++ b/map-platform/deploy/compatibility/Dockerfile
@@ -1,0 +1,28 @@
+# Authentication compatibility is built on the exact deployed production image.
+# No package installation or generation-source replacement is permitted here.
+FROM ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8 AS production-base
+FROM production-base AS runtime
+
+COPY map-platform/backend/map_platform/api.py /opt/bicino-auth-source/api.py
+COPY map-platform/backend/map_platform/app_attest.py /opt/bicino-auth-source/app_attest.py
+COPY map-platform/backend/map_platform/data/Apple_App_Attestation_Root_CA.pem /opt/bicino-auth-source/data/Apple_App_Attestation_Root_CA.pem
+COPY map-platform/deploy/compatibility/prepare_auth_backport.py /opt/bicino-auth-source/prepare_auth_backport.py
+COPY map-platform/deploy/compatibility/role_guard.py /opt/bicino-auth-source/role_guard.py
+RUN python /opt/bicino-auth-source/prepare_auth_backport.py \
+      --package /app/map-platform/backend/map_platform --current /opt/bicino-auth-source \
+    && python -c "from map_platform.app_attest import production_app_attest_verifier; production_app_attest_verifier('production')"
+
+LABEL org.bicino.release-profile="production-auth-compatibility" \
+      org.bicino.base-source="e739dfe6c0612e95db8241249dcc2edfe52d8372"
+ENTRYPOINT ["python", "/opt/bicino-auth-source/role_guard.py"]
+CMD ["uvicorn", "--factory", "map_platform.api:create_app", "--host", "0.0.0.0", "--port", "8080"]
+
+# Test-only dependencies never enter the published runtime target.
+FROM runtime AS validation
+COPY --from=production-base /app /opt/compatibility-base-app
+RUN python -m pip install 'httpx==0.28.1'
+COPY map-platform/backend/tests/app_attest_support.py /opt/compatibility-tests/app_attest_support.py
+COPY map-platform/backend/tests/test_app_attest.py /opt/compatibility-tests/test_app_attest.py
+COPY map-platform/backend/tests/fixtures/app_attest_map_create_v1.json /opt/compatibility-tests/fixtures/app_attest_map_create_v1.json
+COPY map-platform/deploy/compatibility/test_runtime.py /opt/compatibility-tests/test_runtime.py
+RUN python -m unittest discover -s /opt/compatibility-tests

--- a/map-platform/deploy/compatibility/README.md
+++ b/map-platform/deploy/compatibility/README.md
@@ -1,0 +1,101 @@
+# Production authentication compatibility candidate
+
+Status: **draft, not approved for deployment**. This prepares the dedicated
+compatibility release allowed by the deployment runbook. It does not waive the
+worker gates or enable a new-API/old-worker override.
+
+## Scope and evidence
+
+The runtime starts from the exact production image digest
+`sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8`,
+source `e739dfe6c0612e95db8241249dcc2edfe52d8372`. No runtime packages are
+installed or upgraded. The builder checks the base API's SHA-256 before making
+changes and transplants only authentication handlers and assertion checks
+from the reviewed current source. All job-creation, idempotency, rate-limit,
+storage, pipeline, source-cache, generator, signing, and maintenance code stays
+at the base version. Existing catalog requests use the backward compatibility
+deployed in PR 405.
+
+The current App Attest verifier and Apple root certificate are copied unchanged.
+The production verifier retains its production bundle, environment, validation
+category, certificate, nonce, challenge, and assertion-counter checks. Tests
+inject a verifier directly; no production environment variable enables it.
+
+The compatibility image's entrypoint allows only the exact API and maintenance
+commands in the production manifest and rejects inline/generation workers.
+The original generation image and worker source marker must remain pinned.
+The base producer-identity file is retained solely for the unchanged worker's
+control-plane checks; this compatibility image is never a signing candidate.
+
+## Local verification
+
+Use OrbStack on macOS, from the repository root:
+
+```sh
+docker build --platform linux/amd64 --target validation \
+  -f map-platform/deploy/compatibility/Dockerfile .
+docker build --platform linux/amd64 --target runtime \
+  -f map-platform/deploy/compatibility/Dockerfile \
+  -t bicino-production-auth-compat:local .
+```
+
+Validation runs the existing App Attest cryptographic/store tests plus actual
+generated-API tests for enrollment, refresh, owner isolation, signed creation,
+missing assertions, idempotent replay, restart persistence, and role guards.
+It compares every file under `/app` with the base: the only permitted changes
+are `api.py`, `app_attest.py`, and the Apple certificate. HTTP test dependencies
+exist only in the `validation` stage, never the `runtime` stage.
+
+## Existing-download migration is a deployment blocker
+
+The installed app currently deletes an installation credential without a usable
+App Attest key before enrollment succeeds. Enrollment issues a new installation
+identity. The compatibility API correctly refuses to give that new identity
+access to another installation's jobs. Old credentials remain valid for reading
+their own jobs, but the API cannot recover a credential already deleted from
+the phone's Keychain.
+
+Therefore a successful challenge endpoint is NOT proof that old downloaded maps
+can attach. Before release:
+
+1. Implement and test a credential-preserving app upgrade plus an authenticated
+   enrollment migration that preserves the old installation ID when the caller
+   proves possession of its existing token and a valid new Apple attestation.
+2. For phones that already lost that token, define and obtain approval for a
+   scoped recovery flow. Do not infer ownership from a map ID, filename, or
+   public hash; do not reassign jobs or insert catalog references directly.
+3. Verify the affected production downloads on the actual phone, including
+   catalog attachment and Share-button visibility. Test fixture success is not
+   physical-app evidence.
+
+No iOS credential mutation, data migration, production restart, or deployment
+is part of this preparation. The current production maps and generator remain
+unchanged.
+
+## Publish only after review and migration gates
+
+After merging the reviewed preparation through a PR to `main`, the existing
+Map Platform Image workflow supports an explicit candidate-only dispatch:
+
+```sh
+gh workflow run map-platform-image.yml --ref main \
+  -f release_profile=production-auth-compatibility
+```
+
+This validates the compatibility image, publishes only its runtime target under
+the source SHA plus `-auth-compat`, and attests it using the existing trusted
+workflow. It does not move `latest`, replace the pending full-worker promotion,
+or create either automatic deployment promotion. Standard builds are unchanged.
+
+Record the source SHA, immutable candidate digest, base digest, validation run,
+and migration receipt. Verify registry architecture and GitHub provenance with
+the existing tooling. Prepare a dedicated reviewed Compose-lock PR changing
+only the control-plane source/digest and retaining the exact worker source/digest.
+Never substitute the standard image built at the same source SHA.
+
+Do not merge that deployment PR until its exact CI Gate passes and all migration
+gates above have evidence. After deployment, verify API and maintenance health,
+the unchanged worker image, production App Attest enrollment, existing-map
+attachment, and the app UI. Roll back through a PR restoring the complete prior
+Compose lock; preserve the new App Attest database and do not restore an older
+authentication snapshot over newly enrolled principals.

--- a/map-platform/deploy/compatibility/README.md
+++ b/map-platform/deploy/compatibility/README.md
@@ -48,7 +48,7 @@ exist only in the `validation` stage, never the `runtime` stage.
 
 ## Existing-download migration is a deployment blocker
 
-The installed app currently deletes an installation credential without a usable
+The previously installed app deletes an installation credential without a usable
 App Attest key before enrollment succeeds. Enrollment issues a new installation
 identity. The compatibility API correctly refuses to give that new identity
 access to another installation's jobs. Old credentials remain valid for reading
@@ -58,9 +58,12 @@ the phone's Keychain.
 Therefore a successful challenge endpoint is NOT proof that old downloaded maps
 can attach. Before release:
 
-1. Implement and test a credential-preserving app upgrade plus an authenticated
-   enrollment migration that preserves the old installation ID when the caller
-   proves possession of its existing token and a valid new Apple attestation.
+1. Ship the credential-preserving app upgrade in this candidate together with
+   the authenticated enrollment migration. It retains the old installation ID
+   only when the caller proves possession of its existing token and a valid new
+   Apple attestation. Existing bindings cannot be replaced. The app keeps its
+   old credential on failure and persists the generated key before submission,
+   allowing authenticated refresh to recover a lost enrollment response.
 2. For phones that already lost that token, define and obtain approval for a
    scoped recovery flow. Do not infer ownership from a map ID, filename, or
    public hash; do not reassign jobs or insert catalog references directly.

--- a/map-platform/deploy/compatibility/prepare_auth_backport.py
+++ b/map-platform/deploy/compatibility/prepare_auth_backport.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Build an authentication-only API overlay on the exact production base.
+
+This is deliberately not a switch to run current API/job code with an old
+worker. All non-authentication code comes from the immutable base image.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import difflib
+import hashlib
+import json
+from pathlib import Path
+import shutil
+
+BASE_SOURCE = "e739dfe6c0612e95db8241249dcc2edfe52d8372"
+BASE_API_SHA256 = "0bb2596ebffa6d96f1caffb513c0d18a1ba38964ebcf78c9d6141bb7e121621a"
+AUTH_ARGUMENTS = {
+    "request_body", "x_app_attest_challenge_id", "x_app_attest_key_id",
+    "x_app_attest_assertion", "x_app_attest_app_build",
+}
+
+
+def named(nodes, name):
+    matches = [node for node in nodes if getattr(node, "name", None) == name]
+    if len(matches) != 1:
+        raise ValueError(f"expected exactly one {name}")
+    return matches[0]
+
+
+def dump(node):
+    return ast.dump(node, include_attributes=False)
+
+
+def authenticated_create_handler(current, baseline):
+    handler = copy.deepcopy(baseline)
+    offset = len(current.args.args) - len(current.args.defaults)
+    additions = [(a, current.args.defaults[i - offset])
+                 for i, a in enumerate(current.args.args) if a.arg in AUTH_ARGUMENTS and i >= offset]
+    if {a.arg for a, _ in additions} != AUTH_ARGUMENTS:
+        raise ValueError("authentication arguments changed")
+    handler.args.args.extend(copy.deepcopy(a) for a, _ in additions)
+    handler.args.defaults.extend(copy.deepcopy(d) for _, d in additions)
+    current_lock = next(n for n in ast.walk(current) if isinstance(n, ast.With))
+    authentication = []
+    for statement in current_lock.body:
+        text = ast.unparse(statement)
+        if (isinstance(statement, ast.If) and "x_app_attest_challenge_id" in text
+            or isinstance(statement, ast.Assign) and text.startswith("assertion_object =")
+            or isinstance(statement, ast.Expr) and text.startswith("app_attest_store.verify_map_create_assertion(")):
+            authentication.append(statement)
+    if len(authentication) != 3:
+        raise ValueError("authentication statements changed")
+    lock = next(n for n in ast.walk(handler) if isinstance(n, ast.With))
+    insertion = next(i for i, n in enumerate(lock.body)
+                     if isinstance(n, ast.If) and ast.unparse(n.test) == "existing is not None") + 1
+    lock.body[insertion:insertion] = copy.deepcopy(authentication)
+
+    # Prove that deleting ONLY the authentication additions recovers the exact
+    # base handler, including job persistence, idempotency and rate limiting.
+    projection = copy.deepcopy(handler)
+    projection.args.args = projection.args.args[:-len(additions)]
+    projection.args.defaults = projection.args.defaults[:-len(additions)]
+    projected_lock = next(n for n in ast.walk(projection) if isinstance(n, ast.With))
+    del projected_lock.body[insertion:insertion + len(authentication)]
+    if dump(projection) != dump(baseline):
+        difference = "\n".join(difflib.unified_diff(ast.unparse(baseline).splitlines(), ast.unparse(projection).splitlines()))
+        raise ValueError("current map-create logic is not compatible with the base worker:\n" + difference)
+    return handler
+
+
+def backport_api(baseline_text: str, current_text: str) -> str:
+    if hashlib.sha256(baseline_text.encode()).hexdigest() != BASE_API_SHA256:
+        raise ValueError("production API base does not match the reviewed source")
+    baseline, current = ast.parse(baseline_text), ast.parse(current_text)
+    old_factory = named(baseline.body, "create_app")
+    new_factory = named(current.body, "create_app")
+    old_factory.args = ast.parse(
+        "def create_app(*, app_attest_verifier: AppAttestationVerifying | None = None): pass"
+    ).body[0].args
+    replacements = {
+        "create_installation": copy.deepcopy(named(new_factory.body, "create_installation")),
+        "create_map_job": authenticated_create_handler(
+            named(new_factory.body, "create_map_job"), named(old_factory.body, "create_map_job")
+        ),
+    }
+    for index, node in enumerate(old_factory.body):
+        if getattr(node, "name", None) in replacements:
+            old_factory.body[index] = replacements[node.name]
+
+    imports = [n for n in current.body if isinstance(n, ast.ImportFrom) and n.module == "app_attest"]
+    if len(imports) != 1:
+        raise ValueError("App Attest import changed")
+    baseline.body[1:1] = ast.parse("import logging\n_LOGGER = logging.getLogger(__name__)\n").body + imports
+    setup = ast.parse('''
+app_attest_store = AppAttestStore(
+    data_root / "app-attest.sqlite3",
+    app_attest_verifier or production_app_attest_verifier(deployment_channel),
+    challenge_ttl_seconds=int(os.environ.get("MAP_PLATFORM_APP_ATTEST_CHALLENGE_TTL_SECONDS", "300")),
+)
+''').body[0]
+    channel_indices = [i for i, n in enumerate(old_factory.body)
+                       if isinstance(n, ast.Assign) and ast.unparse(n).startswith("deployment_channel =")]
+    if len(channel_indices) != 1:
+        raise ValueError("base deployment channel changed")
+    old_factory.body.insert(channel_indices[0] + 1, setup)
+    app_state_index = next(i for i, n in enumerate(old_factory.body)
+                           if ast.unparse(n).startswith("app.state.installation_store ="))
+    old_factory.body.insert(app_state_index + 1, ast.parse("app.state.app_attest_store = app_attest_store").body[0])
+    insertion = next(i for i, n in enumerate(old_factory.body) if getattr(n, "name", None) == "enforce_rate_limits")
+    old_factory.body[insertion:insertion] = [
+        copy.deepcopy(named(new_factory.body, name))
+        for name in ("app_attest_error", "captured_request_body")
+    ]
+    insertion = next(i for i, n in enumerate(old_factory.body) if getattr(n, "name", None) == "create_installation")
+    old_factory.body.insert(insertion, copy.deepcopy(named(new_factory.body, "create_app_attest_challenge")))
+    public = named(old_factory.body, "is_public_api_request")
+    text = ast.unparse(public)
+    needle = "path == '/v1/installations'"
+    if text.count(needle) != 1:
+        raise ValueError("base public route guard changed")
+    replacement = ast.parse(text.replace(needle, "path in {'/v1/installations', '/v1/installations/app-attest/challenges'}")).body[0]
+    old_factory.body[old_factory.body.index(public)] = replacement
+    health = named(old_factory.body, "healthz").body[0].value
+    new_health = named(new_factory.body, "healthz").body[0].value
+    attest = next(value for key, value in zip(new_health.keys, new_health.values) if key.value == "appAttest")
+    health.keys.append(ast.Constant("appAttest"))
+    health.values.append(copy.deepcopy(attest))
+    ast.fix_missing_locations(baseline)
+    result = ast.unparse(baseline) + "\n"
+    compile(result, "compatibility/api.py", "exec")
+    return result
+
+
+def prepare(package: Path, current: Path):
+    baseline = package / "api.py"
+    result = backport_api(baseline.read_text(), (current / "api.py").read_text())
+    # The package is inside a disposable build context/image, never live /data.
+    baseline.write_text(result)
+    for relative in ("app_attest.py", "data/Apple_App_Attestation_Root_CA.pem"):
+        target = package / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copyfile(current / relative, target)
+    print(json.dumps({"profile": "production-auth-compatibility", "baseSource": BASE_SOURCE,
+                      "apiSha256": hashlib.sha256(result.encode()).hexdigest()}))
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package", type=Path, required=True)
+    parser.add_argument("--current", type=Path, required=True)
+    args = parser.parse_args()
+    prepare(args.package, args.current)

--- a/map-platform/deploy/compatibility/role_guard.py
+++ b/map-platform/deploy/compatibility/role_guard.py
@@ -1,0 +1,19 @@
+"""Compatibility images must never become signed-map generation workers."""
+import os
+import sys
+
+
+def allowed(command, environment):
+    if environment.get("MAP_PLATFORM_INLINE_WORKER_ENABLED", "0").strip().lower() not in {"0", "false", "no"}:
+        return False
+    return command in [
+        ["uvicorn", "--factory", "map_platform.api:create_app", "--host", "0.0.0.0", "--port", "8080"],
+        ["map-platform", "maintenance-loop"],
+    ]
+
+
+if __name__ == "__main__":
+    command = sys.argv[1:]
+    if not allowed(command, os.environ):
+        sys.exit("authentication compatibility image only supports API and maintenance; keep the generation worker pinned")
+    os.execvp(command[0], command)

--- a/map-platform/deploy/compatibility/test_runtime.py
+++ b/map-platform/deploy/compatibility/test_runtime.py
@@ -61,6 +61,46 @@ class CompatibilityRuntimeTests(unittest.TestCase):
             "X-Installation-Token": credential["clientInstallationToken"],
         }).status_code, 401)
 
+    def test_legacy_migration_preserves_identity_and_rejects_rebinding(self):
+        old_id, old_token = self.app.state.installation_store.issue()
+        old = {"clientInstallationId": old_id, "clientInstallationToken": old_token}
+        fixture_owner = self.attest.issue_installation(self.client)
+        created = self.attest.post_map_job(self.client, credential=fixture_owner, payload={
+            "mode": "custom_bbox", "bbox": [103.85, 1.29, 103.86, 1.30],
+            "clientInstallationId": fixture_owner["clientInstallationId"],
+            "clientRequestId": "legacy-owner-fixture",
+        })
+        self.assertEqual(created.status_code, 200, created.text)
+        job_id = created.json()["jobId"]
+        # Seed a pre-attestation owner in this temporary test store only.
+        job = self.app.state.job_store.get(job_id)
+        job.client_installation_id = old_id
+        self.app.state.job_store.save(job)
+        migrated = self.attest.issue_installation(self.client, existing_credential=old)
+        self.assertIsInstance(migrated, dict)
+        self.assertEqual(migrated["clientInstallationId"], old_id)
+        self.assertEqual(migrated["clientInstallationToken"], old_token)
+        refreshed = self.client.post("/v1/installations", params={
+            "clientInstallationId": old_id,
+        }, headers={"X-Installation-Token": old_token})
+        self.assertEqual(refreshed.json(), migrated)
+        listing = self.client.get("/v1/map-jobs", params={"clientInstallationId": old_id},
+                                  headers={"X-Installation-Token": old_token})
+        self.assertEqual(listing.status_code, 200, listing.text)
+        self.assertIn(job_id, listing.text)
+        rejected = self.attest.issue_installation(self.client, existing_credential=old)
+        self.assertEqual(rejected.status_code, 401, rejected.text)
+        self.assertEqual(self.app.state.app_attest_store.key_id_for_installation(old_id), migrated["appAttestKeyId"])
+
+    def test_migration_requires_the_existing_owner_token(self):
+        old_id, _ = self.app.state.installation_store.issue()
+        _, other_token = self.app.state.installation_store.issue()
+        rejected = self.attest.issue_installation(self.client, existing_credential={
+            "clientInstallationId": old_id, "clientInstallationToken": other_token,
+        })
+        self.assertEqual(rejected.status_code, 401, rejected.text)
+        self.assertIsNone(self.app.state.app_attest_store.key_id_for_installation(old_id))
+
     def test_missing_assertion_cannot_create_a_map(self):
         credential = self.attest.issue_installation(self.client)
         payload = {

--- a/map-platform/deploy/compatibility/test_runtime.py
+++ b/map-platform/deploy/compatibility/test_runtime.py
@@ -1,0 +1,132 @@
+"""Tests run against the generated compatibility image, not current main API."""
+import importlib.util
+import hashlib
+import os
+from pathlib import Path
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from app_attest_support import AppAttestTestClient
+from map_platform.api import create_app
+
+
+class CompatibilityRuntimeTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        environment = patch.dict(os.environ, {
+            "MAP_PLATFORM_DATA_ROOT": self.temp.name,
+            "MAP_PLATFORM_INSTALLATION_SECRET": "compatibility-test-installation-secret-32-bytes",
+            "MAP_PLATFORM_DOWNLOAD_SECRET": "compatibility-test-download-secret-32-bytes",
+            "MAP_PLATFORM_DEPLOYMENT_CHANNEL": "production",
+            "MAP_PLATFORM_INLINE_WORKER_ENABLED": "0",
+            "MAP_PLATFORM_PREPARATION_ESTIMATES_MODE": "off",
+            "MAP_PLATFORM_MAP_STREAM_ENABLED": "0",
+            "MAP_PLATFORM_CATALOG_URL": "",
+        })
+        environment.start()
+        self.addCleanup(environment.stop)
+        self.attest = AppAttestTestClient()
+        self.app = create_app(app_attest_verifier=self.attest.verifier)
+        self.client = TestClient(self.app)
+        self.addCleanup(self.client.close)
+
+    def test_enrollment_health_refresh_and_owner_isolation(self):
+        health = self.client.get("/healthz").json()
+        self.assertTrue(health["appAttest"]["requiredForInstallation"])
+        self.assertNotIn("admissionPolicyVersion", health)
+        self.assertNotIn("stravaIntegration", health)
+        self.assertEqual(self.client.post("/v1/installations").status_code, 401)
+        credential = self.attest.issue_installation(self.client)
+        self.assertIsInstance(credential, dict)
+        params = {"clientInstallationId": credential["clientInstallationId"]}
+        headers = {"X-Installation-Token": credential["clientInstallationToken"]}
+        refresh = self.client.post("/v1/installations", params=params, headers=headers)
+        self.assertEqual(refresh.status_code, 200, refresh.text)
+        self.assertEqual(refresh.json()["clientInstallationId"], credential["clientInstallationId"])
+        self.assertEqual(self.client.get("/v1/map-jobs", params=params, headers=headers).status_code, 200)
+        self.assertEqual(self.client.get("/v1/map-jobs", params=params).status_code, 401)
+
+    def test_old_owner_token_still_reads_but_enrollment_does_not_inherit_it(self):
+        old_id, old_token = self.app.state.installation_store.issue()
+        params = {"clientInstallationId": old_id}
+        headers = {"X-Installation-Token": old_token}
+        self.assertEqual(self.client.get("/v1/map-jobs", params=params, headers=headers).status_code, 200)
+        credential = self.attest.issue_installation(self.client)
+        self.assertIsInstance(credential, dict)
+        self.assertNotEqual(credential["clientInstallationId"], old_id)
+        self.assertEqual(self.client.get("/v1/map-jobs", params=params, headers={
+            "X-Installation-Token": credential["clientInstallationToken"],
+        }).status_code, 401)
+
+    def test_missing_assertion_cannot_create_a_map(self):
+        credential = self.attest.issue_installation(self.client)
+        payload = {
+            "mode": "custom_bbox", "bbox": [103.85, 1.29, 103.86, 1.30],
+            "clientInstallationId": credential["clientInstallationId"],
+            "clientRequestId": "compatibility-map-request",
+        }
+        response = self.client.post("/v1/map-jobs", json=payload, headers={
+            "X-Installation-Token": credential["clientInstallationToken"],
+        })
+        self.assertEqual(response.status_code, 401, response.text)
+        self.assertEqual(response.json()["detail"]["code"], "app_attest_assertion_required")
+
+    def test_signed_request_creates_a_job_and_replays_idempotently(self):
+        credential = self.attest.issue_installation(self.client)
+        payload = {
+            "mode": "custom_bbox", "bbox": [103.85, 1.29, 103.86, 1.30],
+            "clientInstallationId": credential["clientInstallationId"],
+            "clientRequestId": "compatibility-signed-request",
+        }
+        response = self.attest.post_map_job(self.client, credential=credential, payload=payload)
+        self.assertEqual(response.status_code, 200, response.text)
+        job_id = response.json()["jobId"]
+        replay = self.client.post("/v1/map-jobs", json=payload, headers={
+            "X-Installation-Token": credential["clientInstallationToken"],
+        })
+        self.assertEqual(replay.status_code, 200, replay.text)
+        self.assertEqual(replay.json()["jobId"], job_id)
+        restarted = TestClient(create_app(app_attest_verifier=self.attest.verifier))
+        self.addCleanup(restarted.close)
+        listing = restarted.get("/v1/map-jobs", params={
+            "clientInstallationId": credential["clientInstallationId"],
+        }, headers={"X-Installation-Token": credential["clientInstallationToken"]})
+        self.assertEqual(listing.status_code, 200, listing.text)
+        self.assertIn(job_id, listing.text)
+
+    def test_role_guard_rejects_generation_and_inline_worker(self):
+        spec = importlib.util.spec_from_file_location("role_guard", "/opt/bicino-auth-source/role_guard.py")
+        guard = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(guard)
+        self.assertTrue(guard.allowed(["map-platform", "maintenance-loop"], {}))
+        self.assertFalse(guard.allowed(["map-platform", "worker-loop"], {}))
+        self.assertFalse(guard.allowed(["map-platform", "maintenance-loop"], {"MAP_PLATFORM_INLINE_WORKER_ENABLED": "1"}))
+
+    def test_all_other_base_image_files_are_unchanged(self):
+        def inventory(root):
+            return {str(p.relative_to(root)): hashlib.sha256(p.read_bytes()).hexdigest()
+                    for p in root.rglob("*") if p.is_file() and "__pycache__" not in p.parts}
+        before = inventory(Path("/opt/compatibility-base-app"))
+        after = inventory(Path("/app"))
+        differences = {key for key in before.keys() | after.keys() if before.get(key) != after.get(key)}
+        self.assertEqual(differences, {
+            "map-platform/backend/map_platform/api.py",
+            "map-platform/backend/map_platform/app_attest.py",
+            "map-platform/backend/map_platform/data/Apple_App_Attestation_Root_CA.pem",
+        })
+
+    def test_backport_refuses_a_different_base(self):
+        spec = importlib.util.spec_from_file_location("builder", "/opt/bicino-auth-source/prepare_auth_backport.py")
+        builder = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(builder)
+        baseline = Path("/opt/compatibility-base-app/map-platform/backend/map_platform/api.py").read_text()
+        current = Path("/opt/bicino-auth-source/api.py").read_text()
+        with self.assertRaisesRegex(ValueError, "base does not match"):
+            builder.backport_api(baseline + "\n", current)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/map-platform/deploy/tests/test_ci_workflow_split.py
+++ b/map-platform/deploy/tests/test_ci_workflow_split.py
@@ -97,6 +97,18 @@ class CIWorkflowSplitTests(unittest.TestCase):
 
         self.assertIn("  push:\n    branches:\n      - main\n", image_workflow)
 
+    def test_authentication_compatibility_is_candidate_only(self) -> None:
+        workflow = workflow_source("map-platform-image.yml")
+        excluded = "inputs.release_profile != 'production-auth-compatibility'"
+        self.assertEqual(workflow.count(excluded), 3)
+        self.assertIn("'-auth-compat' || ''", workflow)
+        self.assertIn("'runtime' || ''", workflow)
+        self.assertIn('test "$SOURCE_REF" = "refs/heads/$DEFAULT_BRANCH"', workflow)
+        self.assertIn("--target validation", workflow)
+        for job in ("propose-production", "propose-development"):
+            section = workflow.split(f"  {job}:\n", 1)[1].split("    runs-on:", 1)[0]
+            self.assertIn(excluded, section)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- Build an authentication-only API and maintenance image on the exact deployed production digest; keep the generator, job storage, pipeline, signing inputs and runtime dependencies unchanged.
- Reuse current App Attest verification with a fail-closed base-source check and generation-role guard.
- Add a candidate-only image workflow profile that cannot change latest or pending deployment promotions.
- Preserve the old installation ID during migration only with its valid token and a valid new Apple attestation; reject rebinding.
- Preserve iOS installation credentials on failure and recover interrupted enrollment by authenticated refresh using the key saved before submission.

## Validation
- Compatibility Docker validation: 28 tests passed, including same-owner migration, old-job visibility, cross-owner rejection, rebinding rejection, refresh, cryptographic/store tests and unchanged base files.
- Current backend API: 48 tests passed.
- Full iOS host regression script passed, including interrupted migration recovery, credential preservation on 401/503, and rejection of a foreign installation identity.
- Production Compose lock and live services are unchanged.

## Deployment gates
This remains a draft, not approval to deploy. The credential-preserving app/backend migration is implemented, but it cannot recover a token already deleted by the previously installed app. A scoped, ownership-verified recovery for already-lost credentials and actual production-phone attachment/Share-button verification remain release gates. No ownership bypass or direct catalog/job reassignment is included. See the README for provenance and rollback requirements.