### PR TITLE
Preserve published app authentication during rollout

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/OfflineMapPlatform.swift
@@ -3231,6 +3231,9 @@ struct OfflineMapPlatformClient {
         }
         var request = URLRequest(url: url)
         request.httpMethod = "POST"
+        if managedAppAttestClient != nil {
+            request.setValue("required", forHTTPHeaderField: "X-Bicino-App-Attest")
+        }
         authorizeInstallation(&request)
         let credential: OfflineMapInstallationCredential = try await send(request: request)
         let appAttestKeyIsValid = credential.appAttestKeyId.map(

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -3069,6 +3069,10 @@ struct NavigationProtocolTests {
             }
             assertEqual(request.value(forHTTPHeaderField: "X-Installation-Token"), old.clientInstallationToken,
                 "migration and refresh prove possession of the old token")
+            if OfflineMapTestURLProtocol.bodyData(from: request).isEmpty {
+                assertEqual(request.value(forHTTPHeaderField: "X-Bicino-App-Attest"), "required",
+                    "managed refresh explicitly selects the attested migration contract")
+            }
             assert(request.url!.query!.contains(old.clientInstallationId), "migration keeps the old identity")
             if !OfflineMapTestURLProtocol.bodyData(from: request).isEmpty {
                 enrollments += 1

--- a/map-platform/deploy/compatibility/README.md
+++ b/map-platform/deploy/compatibility/README.md
@@ -1,6 +1,6 @@
 # Production authentication compatibility candidate
 
-Status: **draft, not approved for deployment**. This prepares the dedicated
+Status: **rollout candidate; deploy only through a reviewed lock**. This prepares the dedicated
 compatibility release allowed by the deployment runbook. It does not waive the
 worker gates or enable a new-API/old-worker override.
 
@@ -11,7 +11,7 @@ The runtime starts from the exact production image digest
 source `e739dfe6c0612e95db8241249dcc2edfe52d8372`. No runtime packages are
 installed or upgraded. The builder checks the base API's SHA-256 before making
 changes and transplants only authentication handlers and assertion checks
-from the reviewed current source. All job-creation, idempotency, rate-limit,
+from the reviewed current source. All non-authentication job-creation, idempotency, rate-limit,
 storage, pipeline, source-cache, generator, signing, and maintenance code stays
 at the base version. Existing catalog requests use the backward compatibility
 deployed in PR 405.
@@ -28,6 +28,25 @@ The base producer-identity file is retained solely for the unchanged worker's
 control-plane checks; this compatibility image is never a signing candidate.
 
 ## Local verification
+
+### Coexistence with the published app
+
+The published app predates App Attest. This compatibility image retains the
+exact base installation issuance/refresh contract for requests without an
+enrollment body or `X-Bicino-App-Attest: required`. Updated managed clients send
+that header on refresh and use the authenticated same-owner migration when
+needed. A malformed enrollment body never falls back to legacy issuance.
+
+Unbound installations retain the existing token-authenticated map-create path.
+Once enrolled, the server requires assertions regardless of client headers;
+removing the header or downgrading the app cannot unbind the key. Apple bundle,
+environment, category, certificate and assertion verification remain unchanged.
+
+This is a staged compatibility rollout, NOT global App Attest enforcement.
+Health explicitly advertises `legacyCompatibility: true` and
+`requiredForAttestedInstallations: true`. Ending legacy issuance requires a
+separate coordinated supported-app-version rollout, not a silent policy flip
+as part of a sharing repair. Current-main API enforcement is unchanged.
 
 Use OrbStack on macOS, from the repository root:
 
@@ -46,7 +65,7 @@ It compares every file under `/app` with the base: the only permitted changes
 are `api.py`, `app_attest.py`, and the Apple certificate. HTTP test dependencies
 exist only in the `validation` stage, never the `runtime` stage.
 
-## Existing-download migration is a deployment blocker
+## Existing-download verification and recovery
 
 The previously installed app deletes an installation credential without a usable
 App Attest key before enrollment succeeds. Enrollment issues a new installation
@@ -56,7 +75,7 @@ their own jobs, but the API cannot recover a credential already deleted from
 the phone's Keychain.
 
 Therefore a successful challenge endpoint is NOT proof that old downloaded maps
-can attach. Before release:
+can attach. Keep these evidence boundaries through the rollout:
 
 1. Ship the credential-preserving app upgrade in this candidate together with
    the authenticated enrollment migration. It retains the old installation ID
@@ -64,16 +83,18 @@ can attach. Before release:
    Apple attestation. Existing bindings cannot be replaced. The app keeps its
    old credential on failure and persists the generated key before submission,
    allowing authenticated refresh to recover a lost enrollment response.
-2. For phones that already lost that token, define and obtain approval for a
+2. For phones that already lost that token, do not claim this rollout recovers
+   their historical access. Define and obtain approval for a
    scoped recovery flow. Do not infer ownership from a map ID, filename, or
    public hash; do not reassign jobs or insert catalog references directly.
 3. Verify the affected production downloads on the actual phone, including
    catalog attachment and Share-button visibility. Test fixture success is not
    physical-app evidence.
 
-No iOS credential mutation, data migration, production restart, or deployment
-is part of this preparation. The current production maps and generator remain
-unchanged.
+The compatibility deployment itself does not reassign ownership, mutate iOS
+credentials, or recover deleted credentials. Existing maps and the generator
+remain unchanged. Unresolved historical recovery must be reported separately;
+it must never be disguised by inserting catalog references or editing sidecars.
 
 ## Publish only after review and migration gates
 
@@ -96,8 +117,9 @@ the existing tooling. Prepare a dedicated reviewed Compose-lock PR changing
 only the control-plane source/digest and retaining the exact worker source/digest.
 Never substitute the standard image built at the same source SHA.
 
-Do not merge that deployment PR until its exact CI Gate passes and all migration
-gates above have evidence. After deployment, verify API and maintenance health,
+Do not merge that deployment PR until its exact CI Gate passes and the legacy,
+migration and no-downgrade regression tests pass against the candidate image.
+Record any unresolved phone recovery separately. After deployment, verify API and maintenance health,
 the unchanged worker image, production App Attest enrollment, existing-map
 attachment, and the app UI. Roll back through a PR restoring the complete prior
 Compose lock; preserve the new App Attest database and do not restore an older

--- a/map-platform/deploy/compatibility/prepare_auth_backport.py
+++ b/map-platform/deploy/compatibility/prepare_auth_backport.py
@@ -56,7 +56,11 @@ def authenticated_create_handler(current, baseline):
     lock = next(n for n in ast.walk(handler) if isinstance(n, ast.With))
     insertion = next(i for i, n in enumerate(lock.body)
                      if isinstance(n, ast.If) and ast.unparse(n.test) == "existing is not None") + 1
-    lock.body[insertion:insertion] = copy.deepcopy(authentication)
+    # Existing, unbound clients keep the exact deployed token contract during
+    # the app rollout. Once an installation enrolls, it cannot opt out again.
+    gate = ast.parse("if app_attest_store.key_id_for_installation(registered_installation_id) is not None: pass").body[0]
+    gate.body = copy.deepcopy(authentication)
+    lock.body[insertion:insertion] = [gate]
 
     # Prove that deleting ONLY the authentication additions recovers the exact
     # base handler, including job persistence, idempotency and rate limiting.
@@ -64,11 +68,25 @@ def authenticated_create_handler(current, baseline):
     projection.args.args = projection.args.args[:-len(additions)]
     projection.args.defaults = projection.args.defaults[:-len(additions)]
     projected_lock = next(n for n in ast.walk(projection) if isinstance(n, ast.With))
-    del projected_lock.body[insertion:insertion + len(authentication)]
+    del projected_lock.body[insertion:insertion + 1]
     if dump(projection) != dump(baseline):
         difference = "\n".join(difflib.unified_diff(ast.unparse(baseline).splitlines(), ast.unparse(projection).splitlines()))
         raise ValueError("current map-create logic is not compatible with the base worker:\n" + difference)
     return handler
+
+
+def compatible_installation_handler(current, baseline):
+    legacy = copy.deepcopy(baseline)
+    legacy.name = "create_legacy_installation"
+    legacy.decorator_list = []
+    handler = copy.deepcopy(current)
+    handler.body[:0] = ast.parse('''
+if payload is None and request.headers.get("X-Bicino-App-Attest") != "required":
+    result = create_legacy_installation(request, clientInstallationId, x_installation_token)
+    response.headers["Cache-Control"] = "private, no-store"
+    return result
+''').body
+    return legacy, handler
 
 
 def backport_api(baseline_text: str, current_text: str) -> str:
@@ -80,8 +98,11 @@ def backport_api(baseline_text: str, current_text: str) -> str:
     old_factory.args = ast.parse(
         "def create_app(*, app_attest_verifier: AppAttestationVerifying | None = None): pass"
     ).body[0].args
+    legacy_installation, installation = compatible_installation_handler(
+        named(new_factory.body, "create_installation"), named(old_factory.body, "create_installation")
+    )
     replacements = {
-        "create_installation": copy.deepcopy(named(new_factory.body, "create_installation")),
+        "create_installation": installation,
         "create_map_job": authenticated_create_handler(
             named(new_factory.body, "create_map_job"), named(old_factory.body, "create_map_job")
         ),
@@ -89,6 +110,7 @@ def backport_api(baseline_text: str, current_text: str) -> str:
     for index, node in enumerate(old_factory.body):
         if getattr(node, "name", None) in replacements:
             old_factory.body[index] = replacements[node.name]
+    old_factory.body.insert(old_factory.body.index(installation), legacy_installation)
 
     imports = [n for n in current.body if isinstance(n, ast.ImportFrom) and n.module == "app_attest"]
     if len(imports) != 1:
@@ -126,6 +148,12 @@ app_attest_store = AppAttestStore(
     health = named(old_factory.body, "healthz").body[0].value
     new_health = named(new_factory.body, "healthz").body[0].value
     attest = next(value for key, value in zip(new_health.keys, new_health.values) if key.value == "appAttest")
+    attest = copy.deepcopy(attest)
+    for index, key in enumerate(attest.keys):
+        if key.value in {"requiredForInstallation", "requiredForMapCreate"}:
+            attest.values[index] = ast.Constant(False)
+    attest.keys.extend([ast.Constant("legacyCompatibility"), ast.Constant("requiredForAttestedInstallations")])
+    attest.values.extend([ast.Constant(True), ast.Constant(True)])
     health.keys.append(ast.Constant("appAttest"))
     health.values.append(copy.deepcopy(attest))
     ast.fix_missing_locations(baseline)

--- a/map-platform/deploy/compatibility/test_runtime.py
+++ b/map-platform/deploy/compatibility/test_runtime.py
@@ -35,15 +35,21 @@ class CompatibilityRuntimeTests(unittest.TestCase):
 
     def test_enrollment_health_refresh_and_owner_isolation(self):
         health = self.client.get("/healthz").json()
-        self.assertTrue(health["appAttest"]["requiredForInstallation"])
+        self.assertFalse(health["appAttest"]["requiredForInstallation"])
+        self.assertTrue(health["appAttest"]["legacyCompatibility"])
+        self.assertTrue(health["appAttest"]["requiredForAttestedInstallations"])
         self.assertNotIn("admissionPolicyVersion", health)
         self.assertNotIn("stravaIntegration", health)
-        self.assertEqual(self.client.post("/v1/installations").status_code, 401)
+        self.assertEqual(self.client.post("/v1/installations", headers={
+            "X-Bicino-App-Attest": "required",
+        }).status_code, 401)
         credential = self.attest.issue_installation(self.client)
         self.assertIsInstance(credential, dict)
         params = {"clientInstallationId": credential["clientInstallationId"]}
         headers = {"X-Installation-Token": credential["clientInstallationToken"]}
-        refresh = self.client.post("/v1/installations", params=params, headers=headers)
+        refresh = self.client.post("/v1/installations", params=params, headers={
+            **headers, "X-Bicino-App-Attest": "required",
+        })
         self.assertEqual(refresh.status_code, 200, refresh.text)
         self.assertEqual(refresh.json()["clientInstallationId"], credential["clientInstallationId"])
         self.assertEqual(self.client.get("/v1/map-jobs", params=params, headers=headers).status_code, 200)
@@ -82,7 +88,7 @@ class CompatibilityRuntimeTests(unittest.TestCase):
         self.assertEqual(migrated["clientInstallationToken"], old_token)
         refreshed = self.client.post("/v1/installations", params={
             "clientInstallationId": old_id,
-        }, headers={"X-Installation-Token": old_token})
+        }, headers={"X-Installation-Token": old_token, "X-Bicino-App-Attest": "required"})
         self.assertEqual(refreshed.json(), migrated)
         listing = self.client.get("/v1/map-jobs", params={"clientInstallationId": old_id},
                                   headers={"X-Installation-Token": old_token})
@@ -100,6 +106,39 @@ class CompatibilityRuntimeTests(unittest.TestCase):
         })
         self.assertEqual(rejected.status_code, 401, rejected.text)
         self.assertIsNone(self.app.state.app_attest_store.key_id_for_installation(old_id))
+
+    def test_legacy_app_contract_survives_until_authenticated_migration(self):
+        malformed = self.client.post("/v1/installations", json={"unexpected": True})
+        self.assertEqual(malformed.status_code, 401, malformed.text)
+        issued = self.client.post("/v1/installations")
+        self.assertEqual(issued.status_code, 200, issued.text)
+        legacy = issued.json()
+        params = {"clientInstallationId": legacy["clientInstallationId"]}
+        headers = {"X-Installation-Token": legacy["clientInstallationToken"]}
+        refreshed = self.client.post("/v1/installations", params=params, headers=headers)
+        self.assertEqual(refreshed.json(), legacy)
+        strict_refresh = self.client.post("/v1/installations", params=params, headers={
+            **headers, "X-Bicino-App-Attest": "required",
+        })
+        self.assertEqual(strict_refresh.status_code, 401, strict_refresh.text)
+        self.assertEqual(strict_refresh.json()["detail"]["code"], "installation_attestation_required")
+        payload = {
+            "mode": "custom_bbox", "bbox": [103.85, 1.29, 103.86, 1.30],
+            "clientInstallationId": legacy["clientInstallationId"],
+            "clientRequestId": "legacy-before-migration",
+        }
+        self.assertEqual(self.client.post("/v1/map-jobs", json=payload).status_code, 401)
+        created = self.client.post("/v1/map-jobs", json=payload, headers=headers)
+        self.assertEqual(created.status_code, 200, created.text)
+        migrated = self.attest.issue_installation(self.client, existing_credential=legacy)
+        self.assertIsInstance(migrated, dict)
+        self.assertEqual(migrated["clientInstallationId"], legacy["clientInstallationId"])
+        payload["clientRequestId"] = "legacy-after-migration"
+        rejected = self.client.post("/v1/map-jobs", json=payload, headers=headers)
+        self.assertEqual(rejected.status_code, 401, rejected.text)
+        self.assertEqual(rejected.json()["detail"]["code"], "app_attest_assertion_required")
+        signed = self.attest.post_map_job(self.client, credential=migrated, payload=payload)
+        self.assertEqual(signed.status_code, 200, signed.text)
 
     def test_missing_assertion_cannot_create_a_map(self):
         credential = self.attest.issue_installation(self.client)


### PR DESCRIPTION
## Summary
- Keep the exact deployed installation issuance/refresh and token-authenticated creation contract for unbound legacy installations in the dedicated compatibility image.
- Updated managed apps explicitly select attested refresh; enrollment still requires existing-token proof to preserve identity.
- Enrolled installations always require assertions regardless of headers. Apple verification is unchanged, and current-main API enforcement is unchanged.
- Advertise the staged legacy policy honestly in health and document a separate coordinated sunset rather than breaking the published app during a sharing repair.
- Leave all generator, storage, pipeline, runtime dependency and signing inputs at the pinned production base.

## Validation
- Actual compatibility Docker image: 29 tests passed, including legacy issuance/refresh/create, same-owner migration, malformed enrollment rejection and no downgrade after enrollment.
- Full local iOS host regression script passed, including the explicit managed-refresh header assertion.
- Generated-image inventory still permits only the API overlay, App Attest module and Apple root to differ from the exact base.

## Delivery boundaries
Build 16 from PR 406 is installed on the user phone; it does not contain this new refresh-selection header. A direct Release rebuild will follow this merge. No TestFlight delivery is requested. Production has not been deployed. Historical maps whose original token is absent remain a separately disclosed recovery problem; this PR does not reassign their ownership or alter sidecars.