### PR TITLE
Deploy production authentication compatibility control plane

### DIFF
--- a/map-platform/deploy/compose.yaml
+++ b/map-platform/deploy/compose.yaml
@@ -1,4 +1,4 @@
-# control-plane-source-commit: e739dfe6c0612e95db8241249dcc2edfe52d8372
+# control-plane-source-commit: b40b825b137e8c5d3e00c11b8914850bba5fd391
 # worker-source-commit: e739dfe6c0612e95db8241249dcc2edfe52d8372
 
 # These digest-pinned images are the production deployment manifest. The API
@@ -10,7 +10,7 @@
 # and `/app/config`. New images retain aliases at those paths so control-plane
 # and worker pins can advance independently without a coordinated outage.
 x-map-platform-images:
-  control-plane: &map-platform-control-plane-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8
+  control-plane: &map-platform-control-plane-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:90fc4dd8a0d2c85a438607dbb78608125f884cbfde633e44ef30b663a06492be
   worker: &map-platform-worker-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8
 
 services:


### PR DESCRIPTION
## Scope

Promote only API and maintenance to the dedicated authentication compatibility image from merged main b40b825b137e8c5d3e00c11b8914850bba5fd391. The generation worker source and digest remain exactly unchanged. This is not the standard full image or pending worker promotion PR #317.

## Evidence

- Source PR #408 passed full CI Gate (run 34018628490).
- Image workflow 34019226381 passed 29 compatibility tests, published and attested immutable digest sha256:90fc4dd8a0d2c85a438607dbb78608125f884cbfde633e44ef30b663a06492be.
- The compatibility image starts from the exact deployed base and retains all non-authentication runtime files and dependencies. Worker execution is rejected by its role guard.
- Published legacy clients retain existing token authentication; enrolled installations require App Attest assertions without a downgrade escape. Apple verification is unchanged.
- Local manifest and Compose validation passed. Registry architecture/provenance verification and this exact PR CI Gate must pass before merge.

## Physical and recovery boundaries

Regular Bicino build 17 is directly installed from clean merged main; no TestFlight or uninstall. The previously lost production credential cannot be recovered by enrollment. Shanghai large and Taihu 300 old remain an unresolved historical recovery case: no ownership reassignment, token minting, catalog insertion, or sidecar edits are included. Post-deploy enrollment and phone UI remain required evidence.

## Deployment and rollback

The manifest merge triggers the existing production Coolify resource. Verify API and maintenance image/health, production authentication, and the unchanged worker. Roll back through a PR restoring the complete prior Compose lock. Preserve the new App Attest database; never restore an older authentication snapshot over new enrollments.