### PR TITLE
Add OpenStreetMap France fallback for Geofabrik PBF downloads

### DIFF
--- a/docs/osm-source-fallback.md
+++ b/docs/osm-source-fallback.md
@@ -1,0 +1,104 @@
+# PBF download fallback: OpenStreetMap France
+
+The backend keeps Geofabrik as its primary PBF provider. If an eligible source
+cannot be downloaded because of an upstream availability failure, `SourceCache`
+tries its explicitly mapped OpenStreetMap France extract once. This applies to
+worker downloads and source-cache refreshes using `SourceCache.ensure`.
+
+For Shanghai the pair is:
+
+```text
+https://download.geofabrik.de/asia/china/shanghai-latest.osm.pbf
+https://download.openstreetmap.fr/extracts/asia/china/shanghai-latest.osm.pbf
+```
+
+## Eligibility and failures
+
+`map-platform/backend/map_platform/osmfr_fallback.py` contains an exact HTTPS URL
+allowlist for selected countries and Chinese subdivisions, including Shanghai,
+Jiangsu and Zhejiang. There is no blanket hostname replacement. Naming aliases
+are explicit, for example `neimenggu` to `inner_mongolia` and `xizang` to `tibet`.
+
+Only `provider="geofabrik"` sources with a known `-latest.osm.pbf` URL and without
+a configured checksum or publication timestamp are eligible. Dated snapshots,
+checksum-pinned inputs, custom hosts, query strings, fragments and unknown
+regions are not translated. In particular, the combined
+`malaysia-singapore-brunei` extract must not become only `malaysia`, and
+`ireland-and-northern-ireland` must not become only `ireland`. Taiwan and those
+combined regions have no mapping in this change.
+
+Fallback is attempted after HTTP 404, 408, 410, 429 or 5xx, network URL errors,
+timeouts, connection failures, or an interrupted HTTP read. Authentication
+errors, TLS trust failures, checksum mismatches, invalid resume responses,
+cancellation and local storage failures do not trigger provider switching.
+The existing 60-second per-request socket timeout and bounded same-provider
+resume behavior are unchanged; this is not a whole-job deadline.
+
+## Cache and integrity behavior
+
+- Each attempt uses the existing per-source locks, data-volume admission lock,
+  free-space reserve, hashing, cancellation checks and atomic replacement path.
+  A failed attempt closes its response and removes temporary bytes before the
+  next provider starts. The previous stable file is not replaced on failure.
+- A provider switch starts from byte zero. `Range`, `If-Range`, ETag and
+  Last-Modified validators are never carried from one provider to the other.
+- Metadata records the actual successful `sourceUrl`, `resolvedUrl`, SHA-256,
+  byte count and HTTP validators. Region IDs and local cache paths stay stable.
+  A fallback download does not inherit a Geofabrik publication timestamp.
+- A fresh fallback cache entry is reused for the existing cache lifetime
+  (`MAP_PLATFORM_SOURCE_CACHE_REVALIDATE_SECONDS`, default 24 hours). When due
+  for revalidation, Geofabrik is tried first again. If unavailable, the fallback
+  may revalidate its own bytes with its own validators, including HTTP 304.
+  `force=True` bypasses cached bytes and conditional validators.
+- Before publication, a fallback response must have a bounded, complete first
+  `OSMHeader` blob and a final URL beneath the trusted HTTPS extracts prefix.
+  This rejects empty bodies, typical HTML error pages, truncated initial blobs
+  and off-provider final redirects. It is **not** whole-file PBF validation or
+  a check of geographic completeness; the existing extraction pipeline still
+  parses the downloaded PBF.
+- If both providers fail, the exception identifies both failures. No error page
+  or partially downloaded fallback replaces an existing source.
+
+OpenStreetMap France produces independent extracts, not byte-identical
+Geofabrik mirrors. Matching regional names do not prove identical boundaries,
+coverage near borders, relation completeness, or data timestamps. Check a
+provider's polygon and required coverage before extending the mapping or using
+it for a boundary-sensitive map. Reproducible jobs should pin their source
+checksum rather than rely on interchangeable latest snapshots.
+
+## Configuration and scope
+
+Fallback is enabled by default. Set `MAP_PLATFORM_OSMFR_FALLBACK=0` in the backend
+process/container environment to disable it; `false`, `no` and `off` also work.
+With fallback disabled, a cache entry from the alternative provider requires
+primary-source revalidation rather than remaining accepted as fresh.
+
+This change handles **PBF downloads after source resolution**. It does not add
+an OpenStreetMap France discovery catalogue. Configured sources and an existing
+cached Geofabrik catalogue remain usable during an outage, but a cold dynamic
+lookup with no cached catalogue still depends on Geofabrik. The API contract,
+iOS app and firmware are unchanged. Production image promotion remains the
+separate digest-pinned deployment workflow described in `AGENTS.md`.
+
+Destination listings used to review the mapping on 2026-09-06:
+
+- <https://download.openstreetmap.fr/extracts/asia/>
+- <https://download.openstreetmap.fr/extracts/asia/china/>
+- <https://download.openstreetmap.fr/extracts/europe/>
+
+## Regression tests
+
+From a complete repository checkout with backend dependencies installed:
+
+```sh
+cd map-platform/backend
+python -m unittest discover -s tests -p 'test_osmfr_fallback.py'
+python -m unittest discover -s tests -p 'test_source_cache.py'
+```
+
+The fallback tests use deterministic synthetic HTTP responses; they do not
+require either public provider to be up and do not claim to build a real map.
+They cover primary success and redirects, outage classification, interrupted
+reads and safe restarts, provider-isolated validators, HTTP 304, recovery after
+cache expiry, pinned inputs, cancellation, storage admission, invalid fallback
+bodies, trusted final URLs, and preservation of stable bytes and metadata.

--- a/docs/osm-source-fallback.md
+++ b/docs/osm-source-fallback.md
@@ -1,104 +1,113 @@
 # PBF download fallback: OpenStreetMap France
 
-The backend keeps Geofabrik as its primary PBF provider. If an eligible source
-cannot be downloaded because of an upstream availability failure, `SourceCache`
-tries its explicitly mapped OpenStreetMap France extract once. This applies to
-worker downloads and source-cache refreshes using `SourceCache.ensure`.
+The backend keeps Geofabrik primary. When a PBF download fails with an eligible
+upstream availability error, `SourceCache.ensure` tries one OpenStreetMap France
+candidate. Worker downloads and source-cache refreshes share this behavior.
 
-For Shanghai the pair is:
+## Per-request resolution
+
+For an unpinned, canonical HTTPS Geofabrik `-latest.osm.pbf` URL:
+
+1. Extract the path without the hostname or `-latest.osm.pbf` suffix.
+2. Stop if that exact source scope is in the documented exception table.
+3. Apply an exact researched alias when present; otherwise retain the path.
+4. Download from `https://download.openstreetmap.fr/extracts/` using that path.
+
+For example, Shanghai needs **no table entry**:
 
 ```text
 https://download.geofabrik.de/asia/china/shanghai-latest.osm.pbf
 https://download.openstreetmap.fr/extracts/asia/china/shanghai-latest.osm.pbf
 ```
 
-## Eligibility and failures
+The pure `fallback_url` function in
+`map-platform/backend/map_platform/osmfr_fallback.py` performs no network calls.
+There is no separate HEAD probe, remote catalogue fetch, directory crawl, or
+trial of multiple guessed names. The actual download is the availability test.
+A 404 from the candidate reports both provider failures instead of trying a
+larger parent, downloading an entire country, or replacing a combined source
+with one component. Existing bounded same-provider resume behavior is retained.
 
-`map-platform/backend/map_platform/osmfr_fallback.py` contains an exact HTTPS URL
-allowlist for selected countries and Chinese subdivisions, including Shanghai,
-Jiangsu and Zhejiang. There is no blanket hostname replacement. Naming aliases
-are explicit, for example `neimenggu` to `inner_mongolia` and `xizang` to `tibet`.
+`ALIASES` contains only naming/directory differences, not an allowlist of
+supported regions. Unknown valid paths receive the same-path candidate too;
+this is best-effort discovery, **not guaranteed worldwide coverage**. Aliases
+and exceptions match full source paths, not basenames or arbitrary prefixes.
+A parent's alias is not automatically inherited by its children. There is no
+blanket hyphen-to-underscore replacement: OSM.fr itself uses both conventions.
 
-Only `provider="geofabrik"` sources with a known `-latest.osm.pbf` URL and without
-a configured checksum or publication timestamp are eligible. Dated snapshots,
-checksum-pinned inputs, custom hosts, query strings, fragments and unknown
-regions are not translated. In particular, the combined
-`malaysia-singapore-brunei` extract must not become only `malaysia`, and
-`ireland-and-northern-ireland` must not become only `ireland`. Taiwan and those
-combined regions have no mapping in this change.
+See [the researched alias and exception table](osmfr-alias-research.md) for
+all entries, evidence, corrections to the original examples, and limitations.
 
-Fallback is attempted after HTTP 404, 408, 410, 429 or 5xx, network URL errors,
-timeouts, connection failures, or an interrupted HTTP read. Authentication
-errors, TLS trust failures, checksum mismatches, invalid resume responses,
-cancellation and local storage failures do not trigger provider switching.
-The existing 60-second per-request socket timeout and bounded same-provider
-resume behavior are unchanged; this is not a whole-job deadline.
+## Eligibility and errors
 
-## Cache and integrity behavior
+Only `provider="geofabrik"` sources without a configured checksum or publication
+timestamp can switch. Dated snapshots and other formats remain pinned to their
+original source. Full URL matching rejects custom/lookalike hosts, credentials,
+ports, query strings (even empty ones), fragments, whitespace/control characters,
+encoded separators, dot segments, empty path components and backslashes. URLs
+are not decoded or normalized into eligibility.
 
-- Each attempt uses the existing per-source locks, data-volume admission lock,
-  free-space reserve, hashing, cancellation checks and atomic replacement path.
-  A failed attempt closes its response and removes temporary bytes before the
-  next provider starts. The previous stable file is not replaced on failure.
-- A provider switch starts from byte zero. `Range`, `If-Range`, ETag and
-  Last-Modified validators are never carried from one provider to the other.
-- Metadata records the actual successful `sourceUrl`, `resolvedUrl`, SHA-256,
-  byte count and HTTP validators. Region IDs and local cache paths stay stable.
-  A fallback download does not inherit a Geofabrik publication timestamp.
-- A fresh fallback cache entry is reused for the existing cache lifetime
-  (`MAP_PLATFORM_SOURCE_CACHE_REVALIDATE_SECONDS`, default 24 hours). When due
-  for revalidation, Geofabrik is tried first again. If unavailable, the fallback
-  may revalidate its own bytes with its own validators, including HTTP 304.
-  `force=True` bypasses cached bytes and conditional validators.
-- Before publication, a fallback response must have a bounded, complete first
-  `OSMHeader` blob and a final URL beneath the trusted HTTPS extracts prefix.
-  This rejects empty bodies, typical HTML error pages, truncated initial blobs
-  and off-provider final redirects. It is **not** whole-file PBF validation or
-  a check of geographic completeness; the existing extraction pipeline still
-  parses the downloaded PBF.
-- If both providers fail, the exception identifies both failures. No error page
-  or partially downloaded fallback replaces an existing source.
+Fallback follows HTTP 404, 408, 410, 429 or 5xx, network URL errors, timeouts,
+connection failures, or interrupted HTTP reads. Authentication errors, TLS trust
+failures, checksum mismatches, invalid resume responses, cancellation and local
+storage failures do not trigger switching. The existing 60-second per-request
+socket timeout is not a whole-job deadline.
 
-OpenStreetMap France produces independent extracts, not byte-identical
-Geofabrik mirrors. Matching regional names do not prove identical boundaries,
-coverage near borders, relation completeness, or data timestamps. Check a
-provider's polygon and required coverage before extending the mapping or using
-it for a boundary-sensitive map. Reproducible jobs should pin their source
-checksum rather than rely on interchangeable latest snapshots.
+## Cache and integrity
+
+Each attempt retains the existing per-source locks, data-volume admission lock,
+free-space reserve, cancellation checks, hashing and atomic replacement path.
+Failed responses are closed and temporary bytes removed before switching.
+Fallback starts from byte zero. Range, If-Range, ETag and Last-Modified values
+never cross providers. Both providers failing preserves the stable file and
+its metadata; an HTML error page or partial download is not published.
+
+Metadata records the successful `sourceUrl`, final `resolvedUrl`, SHA-256,
+byte count and HTTP validators. Local cache paths and source IDs stay stable;
+fallback does not inherit a Geofabrik publication timestamp. A fresh fallback
+entry is reused for `MAP_PLATFORM_SOURCE_CACHE_REVALIDATE_SECONDS` (24 hours by
+default). Revalidation tries Geofabrik first again, then may revalidate the
+fallback's own bytes with its own validators, including HTTP 304. `force=True`
+bypasses cached bytes and conditional validators.
+
+Before publication, fallback downloads must have a complete, bounded initial
+`OSMHeader` blob and a final URL beneath the trusted HTTPS extracts prefix.
+This is **not whole-file PBF validation or geographic coverage validation**;
+the extraction pipeline still parses the downloaded PBF. The providers create
+independent snapshots: even matching names do not prove identical boundaries,
+border buffers, relation completeness, disputed-area treatment or timestamps.
+Pin source checksums for reproducibility. Boundary-sensitive jobs need actual
+polygon/required-area checks, not just HTTP 200 or the alias table.
 
 ## Configuration and scope
 
 Fallback is enabled by default. Set `MAP_PLATFORM_OSMFR_FALLBACK=0` in the backend
-process/container environment to disable it; `false`, `no` and `off` also work.
-With fallback disabled, a cache entry from the alternative provider requires
-primary-source revalidation rather than remaining accepted as fresh.
+environment to disable it (`false`, `no` and `off` also work). With it disabled,
+a fresh fallback entry requires primary-source revalidation instead of staying
+accepted as fresh.
 
-This change handles **PBF downloads after source resolution**. It does not add
-an OpenStreetMap France discovery catalogue. Configured sources and an existing
-cached Geofabrik catalogue remain usable during an outage, but a cold dynamic
-lookup with no cached catalogue still depends on Geofabrik. The API contract,
-iOS app and firmware are unchanged. Production image promotion remains the
-separate digest-pinned deployment workflow described in `AGENTS.md`.
+This handles **PBF downloads after source resolution**. It does not implement
+an independent OSM.fr source catalogue. Configured sources and a cached Geofabrik
+catalogue remain usable during outages; cold dynamic discovery without a cached
+catalogue still depends on Geofabrik. No API, iOS, firmware, deployment or
+production image pins are changed. Production promotion remains separate as
+described in `AGENTS.md`.
 
-Destination listings used to review the mapping on 2026-09-06:
+## Tests
 
-- <https://download.openstreetmap.fr/extracts/asia/>
-- <https://download.openstreetmap.fr/extracts/asia/china/>
-- <https://download.openstreetmap.fr/extracts/europe/>
-
-## Regression tests
-
-From a complete repository checkout with backend dependencies installed:
+From a complete checkout with backend dependencies installed:
 
 ```sh
 cd map-platform/backend
+python -m unittest discover -s tests -p 'test_osmfr_url_resolution.py'
 python -m unittest discover -s tests -p 'test_osmfr_fallback.py'
 python -m unittest discover -s tests -p 'test_source_cache.py'
 ```
 
-The fallback tests use deterministic synthetic HTTP responses; they do not
-require either public provider to be up and do not claim to build a real map.
-They cover primary success and redirects, outage classification, interrupted
-reads and safe restarts, provider-isolated validators, HTTP 304, recovery after
-cache expiry, pinned inputs, cancellation, storage admission, invalid fallback
-bodies, trusted final URLs, and preservation of stable bytes and metadata.
+Tests use deterministic synthetic responses, not live provider availability.
+URL tests cover the full table, unknown paths, exact matching, pinned sources,
+host/path attacks, semantic exceptions, and research-document consistency.
+Downloader regressions additionally cover new same-path sources, researched
+aliases, missing candidates without extra guesses, primary redirects/304,
+provider-isolated validators, resumes, cancellation, storage reserve, TTL,
+force/disable behavior, invalid bodies and preservation of stable bytes.

--- a/docs/osmfr-alias-research.md
+++ b/docs/osmfr-alias-research.md
@@ -1,0 +1,168 @@
+# OpenStreetMap France alias and exception research
+
+Reviewed: **2026-09-06**. Runtime source of truth:
+`map-platform/backend/map_platform/osmfr_fallback.py`.
+
+## Method and confidence
+
+The review compared Geofabrik's published PBF URLs and names in its official
+[index](https://download.geofabrik.de/index-v1.json) (also available
+[without geometry](https://download.geofabrik.de/index-v1-nogeom.json)) against
+OSM.fr's official [extract listings](https://download.openstreetmap.fr/extracts/)
+and [polygon directory](https://download.openstreetmap.fr/polygons/).
+The table below records observed naming correspondences and directory moves,
+**not identical polygon coverage or tested binary downloads**. Directory evidence
+is a point-in-time observation; cached listings and extract timestamps can lag.
+
+This is a reviewed set of differences, not an exhaustive match of every provider
+subregion. Ordinary identical paths are deliberately absent. They are derived
+per request, including newly published regions. Missing/unverified aliases are
+not guessed from punctuation, a basename, a parent region or a political label.
+An unpublished same-path candidate can fail with 404; that is not evidence that
+the similarly named larger/smaller extract is safe to substitute.
+
+The review included the continent listings, China, Japan, Canada, the four US
+regional directories, Germany, the UK, Russia, Oceania and its merged extracts.
+Only the ten US state relocations listed below were confirmed in the retrieved
+regional listings; no claim is made that those listings constitute all of OSM.fr.
+No 50-state routing table was inferred from US geography. Likewise, unconfirmed
+German-state, Australian-state and other subdivision spellings were not added.
+
+## Corrections and non-obvious cases
+
+Geofabrik currently calls the China sources `inner-mongolia` and `tibet`.
+The original examples `neimenggu` and `xizang` were not in the retrieved catalogue
+and have been removed from the alias table. Tibet, Macau, Shanghai, Jiangsu,
+Zhejiang, Shaanxi and Shanxi use the default same path; the last two stay distinct.
+
+US New York becomes `us-northeast/new-york`, **not** `us-northeast/new_york`.
+Canada's New Brunswick instead uses `new_brunswick`. Georgia the country moves
+from Geofabrik's `europe/` to OSM.fr's `asia/`; the US state moves to `us-south/`.
+Falkland Islands are under Geofabrik's `europe/united-kingdom/falklands` but
+OSM.fr's `south-america/falkland`. These rule keys therefore include the full path.
+
+For Fiji, OSM.fr publishes separate east/west extracts and a
+[merged file](https://download.openstreetmap.fr/extracts/merge/).
+Use `merge/fiji`, never only `oceania/fiji_east` or `oceania/fiji_west`.
+Israel and Palestine also have a combined OSM.fr extract: the alias points to
+`israel_and_palestine`, not to either constituent or only the West Bank.
+
+Geofabrik explicitly labels Indonesia as including East Timor, and New South
+Wales as including ACT and JBT. Their shorter destination names are not enough
+to establish preservation of that broader scope, so those parent sources are
+conservatively excluded. Independently requested children are not prefix-blocked.
+
+Taiwan has no researched alternative alias here. It is **not** redirected to
+China or permanently blocked merely because it was absent from a retrieved
+listing; its exact same-path candidate is allowed to succeed or fail normally.
+
+## Alias table
+
+Both columns omit `-latest.osm.pbf`. Prefix the source with
+`https://download.geofabrik.de/` and the destination with
+`https://download.openstreetmap.fr/extracts/`.
+Every source path is referenced by the Geofabrik index above; each row links
+the official directory where the destination PBF was listed.
+
+| Geofabrik source path | OSM.fr candidate path | Destination evidence |
+| --- | --- | --- |
+| `africa/congo-brazzaville` | `africa/congo_brazzaville` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `africa/congo-democratic-republic` | `africa/congo_kinshasa` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `africa/equatorial-guinea` | `africa/equatorial_guinea` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `africa/ivory-coast` | `africa/ivory_coast` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `africa/south-africa` | `africa/south_africa` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `africa/south-sudan` | `africa/south_sudan` | [Listing](https://download.openstreetmap.fr/extracts/africa/) |
+| `asia/china/hong-kong` | `asia/china/hong_kong` | [Listing](https://download.openstreetmap.fr/extracts/asia/china/) |
+| `asia/china/inner-mongolia` | `asia/china/inner_mongolia` | [Listing](https://download.openstreetmap.fr/extracts/asia/china/) |
+| `asia/east-timor` | `asia/east_timor` | [Listing](https://download.openstreetmap.fr/extracts/asia/) |
+| `asia/israel-and-palestine` | `asia/israel_and_palestine` | [Listing](https://download.openstreetmap.fr/extracts/asia/) |
+| `australia-oceania/australia` | `oceania/australia` | [Listing](https://download.openstreetmap.fr/extracts/oceania/) |
+| `australia-oceania/fiji` | `merge/fiji` | [Listing](https://download.openstreetmap.fr/extracts/merge/) |
+| `australia-oceania/new-caledonia` | `oceania/new_caledonia` | [Listing](https://download.openstreetmap.fr/extracts/oceania/) |
+| `australia-oceania/papua-new-guinea` | `oceania/papua_new_guinea` | [Listing](https://download.openstreetmap.fr/extracts/oceania/) |
+| `australia-oceania/solomon-islands` | `oceania/solomon_islands` | [Listing](https://download.openstreetmap.fr/extracts/oceania/) |
+| `central-america/costa-rica` | `central-america/costa_rica` | [Listing](https://download.openstreetmap.fr/extracts/central-america/) |
+| `central-america/el-salvador` | `central-america/el_salvador` | [Listing](https://download.openstreetmap.fr/extracts/central-america/) |
+| `europe/czech-republic` | `europe/czech_republic` | [Listing](https://download.openstreetmap.fr/extracts/europe/) |
+| `europe/georgia` | `asia/georgia` | [Listing](https://download.openstreetmap.fr/extracts/asia/) |
+| `europe/germany/nordrhein-westfalen` | `europe/germany/nordrhein_westfalen` | [Listing](https://download.openstreetmap.fr/extracts/europe/germany/) |
+| `europe/united-kingdom` | `europe/united_kingdom` | [Listing](https://download.openstreetmap.fr/extracts/europe/) |
+| `europe/united-kingdom/england` | `europe/united_kingdom/england` | [Listing](https://download.openstreetmap.fr/extracts/europe/united_kingdom/) |
+| `europe/united-kingdom/falklands` | `south-america/falkland` | [Listing](https://download.openstreetmap.fr/extracts/south-america/) |
+| `north-america/canada/british-columbia` | `north-america/canada/british_columbia` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/canada/new-brunswick` | `north-america/canada/new_brunswick` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/canada/newfoundland-and-labrador` | `north-america/canada/newfoundland_and_labrador` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/canada/northwest-territories` | `north-america/canada/northwest_territories` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/canada/nova-scotia` | `north-america/canada/nova_scotia` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/canada/prince-edward-island` | `north-america/canada/prince_edward_island` | [Listing](https://download.openstreetmap.fr/extracts/north-america/canada/) |
+| `north-america/us/california` | `north-america/us-west/california` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-west/) |
+| `north-america/us/colorado` | `north-america/us-west/colorado` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-west/) |
+| `north-america/us/florida` | `north-america/us-south/florida` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-south/) |
+| `north-america/us/georgia` | `north-america/us-south/georgia` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-south/) |
+| `north-america/us/illinois` | `north-america/us-midwest/illinois` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-midwest/) |
+| `north-america/us/michigan` | `north-america/us-midwest/michigan` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-midwest/) |
+| `north-america/us/new-york` | `north-america/us-northeast/new-york` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-northeast/) |
+| `north-america/us/north-carolina` | `north-america/us-south/north-carolina` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-south/) |
+| `north-america/us/texas` | `north-america/us-south/texas` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-south/) |
+| `north-america/us/virginia` | `north-america/us-south/virginia` | [Listing](https://download.openstreetmap.fr/extracts/north-america/us-south/) |
+| `russia/central-fed-district` | `russia/central_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/far-eastern-fed-district` | `russia/far_eastern_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/north-caucasus-fed-district` | `russia/north_caucasian_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/northwestern-fed-district` | `russia/northwestern_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/siberian-fed-district` | `russia/siberian_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/south-fed-district` | `russia/southern_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/ural-fed-district` | `russia/ural_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+| `russia/volga-fed-district` | `russia/volga_federal_district` | [Listing](https://download.openstreetmap.fr/extracts/russia/) |
+
+## Scope exceptions (no automatic candidate)
+
+The source scopes are identified in the Geofabrik index above. Compare the
+OSM.fr [Asia](https://download.openstreetmap.fr/extracts/asia/),
+[Africa](https://download.openstreetmap.fr/extracts/africa/),
+[Central America](https://download.openstreetmap.fr/extracts/central-america/),
+[Europe](https://download.openstreetmap.fr/extracts/europe/),
+[UK](https://download.openstreetmap.fr/extracts/europe/united_kingdom/),
+[North America](https://download.openstreetmap.fr/extracts/north-america/) and
+[Australian polygons](https://download.openstreetmap.fr/polygons/oceania/australia/).
+These exclusions express an unresolved scope mismatch, not a claim that OSM.fr
+can never publish a corresponding union. Remove an exclusion only after reviewing
+the full replacement, or implement explicit multi-extract assembly separately.
+
+| Geofabrik source path | Reason |
+| --- | --- |
+| `africa/senegal-and-gambia` | Combined source; Senegal alone omits Gambia. |
+| `africa/south-africa-and-lesotho` | Combined source; South Africa alone may omit Lesotho. |
+| `asia/gcc-states` | Combined source; no single member is an equivalent extract. |
+| `asia/indonesia` | Geofabrik explicitly includes East Timor; OSM.fr publishes it separately. |
+| `asia/malaysia-singapore-brunei` | Combined source; Malaysia alone omits Singapore and Brunei. |
+| `australia-oceania/australia/new-south-wales` | Geofabrik explicitly includes ACT and JBT; a state-only alias is unverified. |
+| `central-america/haiti-and-domrep` | Combined source; Haiti or Dominican Republic alone is incomplete. |
+| `europe/britain-and-ireland` | Combined source; neither the UK nor Ireland alone suffices. |
+| `europe/great-britain` | Great Britain is not the same source scope as the United Kingdom. |
+| `europe/ireland-and-northern-ireland` | Combined source; Ireland alone omits Northern Ireland. |
+| `north-america/us` | OSM.fr publishes regional US quadrants; none alone covers the whole US. |
+
+## Unresolved cases and maintenance
+
+Do not map a whole US source to a single quadrant, a combined country extract to
+one country, an island group to one province, or Great Britain to the UK merely
+to obtain HTTP 200. The same caution applies to Geofabrik's American Oceania,
+Micronesia/Polynesia, India zones, Indonesia island groups, historical French
+regions and changed Russian district boundaries: this change does not attempt
+to establish their coverage equivalence. Absent an exact alias, only the literal
+same-path candidate is constructed unless an explicit scope exception blocks it.
+
+Before adding an alias, inspect the exact Geofabrik PBF URL and advertised scope,
+find a published destination PBF, inspect the corresponding polygon and intended
+map area where boundary completeness matters, and record the evidence here.
+Do not treat a polygon filename alone as proof a downloadable PBF exists.
+Add a concrete expected-URL test, including any similarly named region or unsafe
+combined variant. Aliases must not be identical source/destination pairs and
+must not overlap exceptions. Tests enforce these properties and that this
+research table documents every runtime entry.
+
+The current downloader still carries the resolved source identity through the
+cache and is not aware of the requested map cutout. Choosing a smaller OSM.fr
+extract based on the user's actual bounding box would require a separate,
+geometry-aware source-resolution change. This PR intentionally does not claim
+that an alias table or a PBF header check solves geographic completeness.

--- a/map-platform/backend/map_platform/osmfr_fallback.py
+++ b/map-platform/backend/map_platform/osmfr_fallback.py
@@ -1,0 +1,158 @@
+"""Explicit PBF alternatives, not a hostname-rewriting mirror.
+
+OpenStreetMap France uses different region names, boundaries and snapshots.
+Only unpinned latest extracts with a known corresponding region may fail over.
+See docs/osm-source-fallback.md before extending the mapping.
+"""
+from __future__ import annotations
+
+import http.client
+import ssl
+import urllib.error
+from pathlib import Path
+
+from .models import SourceRegion
+
+GEOFABRIK_BASE = "https://download.geofabrik.de/"
+OSMFR_BASE = "https://download.openstreetmap.fr/extracts/"
+
+# These are explicit region names, not a rule for arbitrary Geofabrik paths.
+# Destination listings verified on 2026-09-06. In particular, never replace
+# malaysia-singapore-brunei with malaysia, or ireland-and-northern-ireland
+# with ireland: those would silently drop part of the requested source.
+_SAME_PATH_REGIONS = {
+    "asia/china",
+    "asia/japan",
+    "asia/india",
+    "asia/indonesia",
+    "asia/bhutan",
+    "asia/cambodia",
+    "asia/laos",
+    "asia/myanmar",
+    "asia/philippines",
+    "europe/andorra",
+    "europe/austria",
+    "europe/belgium",
+    "europe/denmark",
+    "europe/finland",
+    "europe/france",
+    "europe/germany",
+    "europe/italy",
+    "europe/luxembourg",
+    "europe/monaco",
+    "europe/netherlands",
+    "europe/norway",
+    "europe/poland",
+    "europe/portugal",
+    "europe/slovakia",
+    "europe/spain",
+    "europe/sweden",
+    "europe/switzerland",
+    "europe/ukraine",
+}
+_CHINA_REGIONS = {
+    "anhui", "beijing", "chongqing", "fujian", "gansu", "guangdong",
+    "guangxi", "guizhou", "hainan", "hebei", "heilongjiang", "henan",
+    "hubei", "hunan", "jiangsu", "jiangxi", "jilin", "liaoning", "ningxia",
+    "qinghai", "shaanxi", "shandong", "shanghai", "shanxi", "sichuan",
+    "tianjin", "xinjiang", "yunnan", "zhejiang",
+}
+_FALLBACK_URLS = {
+    f"{GEOFABRIK_BASE}{path}-latest.osm.pbf": f"{OSMFR_BASE}{path}-latest.osm.pbf"
+    for path in _SAME_PATH_REGIONS | {f"asia/china/{name}" for name in _CHINA_REGIONS}
+}
+
+# Explicit naming differences in the China subdivision catalog.
+_FALLBACK_URLS.update({
+    f"{GEOFABRIK_BASE}asia/china/{primary}-latest.osm.pbf":
+        f"{OSMFR_BASE}asia/china/{alternative}-latest.osm.pbf"
+    for primary, alternative in {
+        "xizang": "tibet",
+        "neimenggu": "inner_mongolia",
+        "hong-kong": "hong_kong",
+        "macau": "macau",
+    }.items()
+})
+
+
+def fallback_url(region: SourceRegion) -> str | None:
+    """Never translate pinned snapshots, custom hosts, or unknown regions."""
+    if region.provider != "geofabrik" or region.checksum or region.published_at:
+        return None
+    # Exact full-URL lookup also rejects credentials, queries, fragments,
+    # alternate ports, lookalike hosts, and path traversal.
+    return _FALLBACK_URLS.get(region.url)
+
+
+def is_upstream_unavailable(error: BaseException | None) -> bool:
+    """Classify transport/availability failures, not local or integrity errors."""
+    if isinstance(error, urllib.error.HTTPError):
+        return error.code in {404, 408, 410, 429} or 500 <= error.code <= 599
+    if isinstance(error, urllib.error.URLError):
+        # Do not conceal a TLS trust failure by silently changing provider.
+        return not isinstance(error.reason, ssl.SSLError)
+    return isinstance(
+        error,
+        (TimeoutError, ConnectionError, http.client.IncompleteRead, http.client.RemoteDisconnected),
+    )
+
+
+def validate_pbf_header(path: Path) -> None:
+    """Reject empty/HTML/truncated-header fallback bodies before publication.
+
+    This is a bounded BlobHeader sanity check, not whole-file OSM validation;
+    the extraction pipeline still parses the PBF and checks its contents.
+    """
+    with path.open("rb") as stream:
+        prefix = stream.read(4)
+        size = int.from_bytes(prefix, "big")
+        if len(prefix) != 4 or not 0 < size < 64 * 1024:
+            raise ValueError("fallback response is not an OSM PBF header")
+        header = stream.read(size)
+    if len(header) != size:
+        raise ValueError("fallback PBF header is truncated")
+    position = 0
+    blob_type = None
+    blob_size = None
+
+    def varint() -> int:
+        nonlocal position
+        value = 0
+        for shift in range(0, 70, 7):
+            if position >= len(header):
+                break
+            byte = header[position]
+            position += 1
+            value |= (byte & 127) << shift
+            if not byte & 128:
+                return value
+        raise ValueError("fallback PBF header has an invalid varint")
+
+    while position < len(header):
+        tag = varint()
+        field, wire = tag >> 3, tag & 7
+        if field == 0:
+            raise ValueError("fallback PBF header has an invalid field")
+        if wire == 0:
+            value = varint()
+            if field == 3:
+                blob_size = value
+        elif wire == 2:
+            length = varint()
+            end = position + length
+            if field == 1:
+                blob_type = header[position:end]
+            position = end
+        elif wire in {1, 5}:
+            position += 8 if wire == 1 else 4
+        else:
+            raise ValueError("fallback PBF header has an invalid wire type")
+        if position > len(header):
+            raise ValueError("fallback PBF header is truncated")
+    if (
+        blob_type != b"OSMHeader"
+        or blob_size is None
+        or not 0 < blob_size < 32 * 1024 * 1024
+        or path.stat().st_size < 4 + size + blob_size
+    ):
+        raise ValueError("fallback response has no complete OSMHeader blob")

--- a/map-platform/backend/map_platform/osmfr_fallback.py
+++ b/map-platform/backend/map_platform/osmfr_fallback.py
@@ -1,87 +1,119 @@
-"""Explicit PBF alternatives, not a hostname-rewriting mirror.
+"""Per-request PBF alternatives, not a byte-identical mirror or catalogue.
 
-OpenStreetMap France uses different region names, boundaries and snapshots.
-Only unpinned latest extracts with a known corresponding region may fail over.
-See docs/osm-source-fallback.md before extending the mapping.
+Derive the same path by default; use exact aliases only for reviewed differences.
+The download validates availability and file framing, not geographic equivalence.
+See docs/osmfr-alias-research.md for evidence and coverage exceptions.
 """
 from __future__ import annotations
 
 import http.client
+import re
 import ssl
 import urllib.error
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from .models import SourceRegion
+if TYPE_CHECKING:
+    from .models import SourceRegion
 
 GEOFABRIK_BASE = "https://download.geofabrik.de/"
 OSMFR_BASE = "https://download.openstreetmap.fr/extracts/"
 
-# These are explicit region names, not a rule for arbitrary Geofabrik paths.
-# Destination listings verified on 2026-09-06. In particular, never replace
-# malaysia-singapore-brunei with malaysia, or ireland-and-northern-ireland
-# with ireland: those would silently drop part of the requested source.
-_SAME_PATH_REGIONS = {
-    "asia/china",
-    "asia/japan",
-    "asia/india",
-    "asia/indonesia",
-    "asia/bhutan",
-    "asia/cambodia",
-    "asia/laos",
-    "asia/myanmar",
-    "asia/philippines",
-    "europe/andorra",
-    "europe/austria",
-    "europe/belgium",
-    "europe/denmark",
-    "europe/finland",
-    "europe/france",
-    "europe/germany",
-    "europe/italy",
-    "europe/luxembourg",
-    "europe/monaco",
-    "europe/netherlands",
-    "europe/norway",
-    "europe/poland",
-    "europe/portugal",
-    "europe/slovakia",
-    "europe/spain",
-    "europe/sweden",
-    "europe/switzerland",
-    "europe/ukraine",
-}
-_CHINA_REGIONS = {
-    "anhui", "beijing", "chongqing", "fujian", "gansu", "guangdong",
-    "guangxi", "guizhou", "hainan", "hebei", "heilongjiang", "henan",
-    "hubei", "hunan", "jiangsu", "jiangxi", "jilin", "liaoning", "ningxia",
-    "qinghai", "shaanxi", "shandong", "shanghai", "shanxi", "sichuan",
-    "tianjin", "xinjiang", "yunnan", "zhejiang",
-}
-_FALLBACK_URLS = {
-    f"{GEOFABRIK_BASE}{path}-latest.osm.pbf": f"{OSMFR_BASE}{path}-latest.osm.pbf"
-    for path in _SAME_PATH_REGIONS | {f"asia/china/{name}" for name in _CHINA_REGIONS}
+# Full source paths, without -latest.osm.pbf. No basename matching, fuzzy
+# translation, blanket punctuation replacement, or inheritance by descendants.
+# Reviewed 2026-09-06 against the provider catalogues/listings; see the research
+# document for evidence. These are naming correspondences, not polygon proofs.
+ALIASES = {
+    "africa/congo-brazzaville": "africa/congo_brazzaville",
+    "africa/congo-democratic-republic": "africa/congo_kinshasa",
+    "africa/equatorial-guinea": "africa/equatorial_guinea",
+    "africa/ivory-coast": "africa/ivory_coast",
+    "africa/south-africa": "africa/south_africa",
+    "africa/south-sudan": "africa/south_sudan",
+    "asia/china/hong-kong": "asia/china/hong_kong",
+    "asia/china/inner-mongolia": "asia/china/inner_mongolia",
+    "asia/east-timor": "asia/east_timor",
+    "asia/israel-and-palestine": "asia/israel_and_palestine",
+    "australia-oceania/australia": "oceania/australia",
+    "australia-oceania/fiji": "merge/fiji",
+    "australia-oceania/new-caledonia": "oceania/new_caledonia",
+    "australia-oceania/papua-new-guinea": "oceania/papua_new_guinea",
+    "australia-oceania/solomon-islands": "oceania/solomon_islands",
+    "central-america/costa-rica": "central-america/costa_rica",
+    "central-america/el-salvador": "central-america/el_salvador",
+    "europe/czech-republic": "europe/czech_republic",
+    "europe/georgia": "asia/georgia",
+    "europe/germany/nordrhein-westfalen": "europe/germany/nordrhein_westfalen",
+    "europe/united-kingdom": "europe/united_kingdom",
+    "europe/united-kingdom/england": "europe/united_kingdom/england",
+    "europe/united-kingdom/falklands": "south-america/falkland",
+    "north-america/canada/british-columbia": "north-america/canada/british_columbia",
+    "north-america/canada/new-brunswick": "north-america/canada/new_brunswick",
+    "north-america/canada/newfoundland-and-labrador": "north-america/canada/newfoundland_and_labrador",
+    "north-america/canada/northwest-territories": "north-america/canada/northwest_territories",
+    "north-america/canada/nova-scotia": "north-america/canada/nova_scotia",
+    "north-america/canada/prince-edward-island": "north-america/canada/prince_edward_island",
+    "north-america/us/california": "north-america/us-west/california",
+    "north-america/us/colorado": "north-america/us-west/colorado",
+    "north-america/us/florida": "north-america/us-south/florida",
+    "north-america/us/georgia": "north-america/us-south/georgia",
+    "north-america/us/illinois": "north-america/us-midwest/illinois",
+    "north-america/us/michigan": "north-america/us-midwest/michigan",
+    "north-america/us/new-york": "north-america/us-northeast/new-york",
+    "north-america/us/north-carolina": "north-america/us-south/north-carolina",
+    "north-america/us/texas": "north-america/us-south/texas",
+    "north-america/us/virginia": "north-america/us-south/virginia",
+    "russia/central-fed-district": "russia/central_federal_district",
+    "russia/far-eastern-fed-district": "russia/far_eastern_federal_district",
+    "russia/north-caucasus-fed-district": "russia/north_caucasian_federal_district",
+    "russia/northwestern-fed-district": "russia/northwestern_federal_district",
+    "russia/siberian-fed-district": "russia/siberian_federal_district",
+    "russia/south-fed-district": "russia/southern_federal_district",
+    "russia/ural-fed-district": "russia/ural_federal_district",
+    "russia/volga-fed-district": "russia/volga_federal_district",
 }
 
-# Explicit naming differences in the China subdivision catalog.
-_FALLBACK_URLS.update({
-    f"{GEOFABRIK_BASE}asia/china/{primary}-latest.osm.pbf":
-        f"{OSMFR_BASE}asia/china/{alternative}-latest.osm.pbf"
-    for primary, alternative in {
-        "xizang": "tibet",
-        "neimenggu": "inner_mongolia",
-        "hong-kong": "hong_kong",
-        "macau": "macau",
-    }.items()
-})
+# These particular source scopes must not be replaced by a smaller component
+# or an unreviewed larger union. Absence from a directory alone is NOT a reason
+# to block a same-path probe: unknown regions (including Taiwan) remain eligible.
+EXCEPTIONS = {
+    "africa/senegal-and-gambia": "Combined source; Senegal alone omits Gambia.",
+    "africa/south-africa-and-lesotho": "Combined source; South Africa alone may omit Lesotho.",
+    "asia/gcc-states": "Combined source; no single member is an equivalent extract.",
+    "asia/indonesia": "Geofabrik explicitly includes East Timor; OSM.fr publishes it separately.",
+    "asia/malaysia-singapore-brunei": "Combined source; Malaysia alone omits Singapore and Brunei.",
+    "australia-oceania/australia/new-south-wales": "Geofabrik explicitly includes ACT and JBT; a state-only alias is unverified.",
+    "central-america/haiti-and-domrep": "Combined source; Haiti or Dominican Republic alone is incomplete.",
+    "europe/britain-and-ireland": "Combined source; neither the UK nor Ireland alone suffices.",
+    "europe/great-britain": "Great Britain is not the same source scope as the United Kingdom.",
+    "europe/ireland-and-northern-ireland": "Combined source; Ireland alone omits Northern Ireland.",
+    "north-america/us": "OSM.fr publishes regional US quadrants; none alone covers the whole US.",
+}
+
+# Full matching deliberately rejects ports, credentials, queries, fragments,
+# encoded separators, dot segments, empty segments, backslashes and whitespace.
+# Do not normalize an untrusted URL before this check (urlsplit strips controls).
+_LATEST_URL = re.compile(
+    re.escape(GEOFABRIK_BASE)
+    + r"(?P<path>[a-z0-9][a-z0-9_-]*(?:/[a-z0-9][a-z0-9_-]*)*)-latest\.osm\.pbf"
+)
 
 
 def fallback_url(region: SourceRegion) -> str | None:
-    """Never translate pinned snapshots, custom hosts, or unknown regions."""
+    """Return one candidate for an unpinned canonical Geofabrik latest URL.
+
+    Candidate construction performs no I/O. SourceCache tries it only after an
+    eligible primary failure; a missing candidate fails normally, without a
+    catalogue crawl, additional guesses, or a larger parent-region download.
+    """
     if region.provider != "geofabrik" or region.checksum or region.published_at:
         return None
-    # Exact full-URL lookup also rejects credentials, queries, fragments,
-    # alternate ports, lookalike hosts, and path traversal.
-    return _FALLBACK_URLS.get(region.url)
+    if not isinstance(region.url, str) or (match := _LATEST_URL.fullmatch(region.url)) is None:
+        return None
+    path = match.group("path")
+    if path in EXCEPTIONS:
+        return None
+    return f"{OSMFR_BASE}{ALIASES.get(path, path)}-latest.osm.pbf"
 
 
 def is_upstream_unavailable(error: BaseException | None) -> bool:

--- a/map-platform/backend/map_platform/source_cache.py
+++ b/map-platform/backend/map_platform/source_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import fcntl
 import hashlib
 import json
+import logging
 import math
 import os
 import re
@@ -16,6 +17,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .models import SourceRegion, utc_now_iso
+from .osmfr_fallback import (
+    OSMFR_BASE, fallback_url, is_upstream_unavailable, validate_pbf_header,
+)
+
+logger = logging.getLogger(__name__)
 
 
 class SourceCacheError(RuntimeError):
@@ -96,6 +102,9 @@ class SourceCache:
             else self.data_root / "source-cache.json"
         )
         self.lock_stale_seconds = lock_stale_seconds
+        self.osmfr_fallback_enabled = os.environ.get(
+            "MAP_PLATFORM_OSMFR_FALLBACK", "1"
+        ).lower() not in {"0", "false", "no", "off"}
         raw_revalidation_seconds = revalidate_after_seconds
         if raw_revalidation_seconds is None:
             raw_revalidation_seconds = os.environ.get(
@@ -116,6 +125,55 @@ class SourceCache:
         self.metadata_path.parent.mkdir(parents=True, exist_ok=True)
 
     def ensure(
+        self,
+        region: SourceRegion,
+        *,
+        force: bool = False,
+        cancellation_check=None,
+        minimum_free_bytes: int | None = None,
+    ) -> CachedSource:
+        """Try the primary, then one known alternative on upstream failure.
+
+        Each attempt uses the same locking, reserve, hashing and atomic-replace
+        path. The failed attempt has closed its response and removed its .tmp
+        before failover; validators and partial bytes never cross providers.
+        """
+        options = {
+            "force": force,
+            "cancellation_check": cancellation_check,
+            "minimum_free_bytes": minimum_free_bytes,
+        }
+        try:
+            return self._ensure(region, **options)
+        except (SourceCacheCancelled, SourceCacheStorageError):
+            raise
+        except SourceCacheError as primary_error:
+            alternative_url = (
+                fallback_url(region) if self.osmfr_fallback_enabled else None
+            )
+            if (
+                alternative_url is None
+                or not is_upstream_unavailable(primary_error.__cause__)
+            ):
+                raise
+            _raise_if_cancelled(cancellation_check)
+            logger.warning(
+                "Source %s unavailable from Geofabrik; trying OpenStreetMap France: %s",
+                region.id,
+                alternative_url,
+            )
+            alternative = replace(region, url=alternative_url, published_at=None)
+            try:
+                return self._ensure(alternative, **options)
+            except (SourceCacheCancelled, SourceCacheStorageError):
+                raise
+            except SourceCacheError as fallback_error:
+                raise SourceCacheError(
+                    f"both source providers failed for {region.id}; "
+                    f"Geofabrik: {primary_error}; OpenStreetMap France: {fallback_error}"
+                ) from fallback_error
+
+    def _ensure(
         self,
         region: SourceRegion,
         *,
@@ -387,11 +445,13 @@ class SourceCache:
                                     else None
                                 ),
                             )
+                            exc.close()
                             self._record(
                                 validated,
                                 cancellation_check=cancellation_check,
                             )
                             return validated
+                        exc.close()
                         raise SourceCacheError(
                             f"failed to download source PBF for {region.id}: {exc}"
                         ) from exc
@@ -402,6 +462,13 @@ class SourceCache:
                             f"failed to download source PBF for {region.id}: {exc}"
                         ) from exc
 
+                    if region.url.startswith(OSMFR_BASE):
+                        if not resolved_url.startswith(OSMFR_BASE):
+                            raise SourceCacheError("fallback redirected outside the trusted HTTPS source")
+                        try:
+                            validate_pbf_header(tmp_path)
+                        except ValueError as exc:
+                            raise SourceCacheError(str(exc)) from exc
                     downloaded_at = utc_now_iso()
                     cached = self._cached_source(
                         region,
@@ -552,7 +619,10 @@ class SourceCache:
     ) -> bool:
         if region.checksum:
             return False
-        if cached.source_url is not None and cached.source_url != region.url:
+        accepted_urls = {region.url}
+        if self.osmfr_fallback_enabled and (alternative := fallback_url(region)):
+            accepted_urls.add(alternative)
+        if cached.source_url is not None and cached.source_url not in accepted_urls:
             return True
         if (
             region.published_at is not None

--- a/map-platform/backend/tests/test_osmfr_fallback.py
+++ b/map-platform/backend/tests/test_osmfr_fallback.py
@@ -1,0 +1,399 @@
+import errno
+import hashlib
+import http.client
+import io
+import os
+import ssl
+import tempfile
+import unittest
+import urllib.error
+import urllib.request
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from map_platform.models import Bounds, SourceRegion
+from map_platform.osmfr_fallback import (
+    GEOFABRIK_BASE, OSMFR_BASE, fallback_url, is_upstream_unavailable,
+    validate_pbf_header,
+)
+from map_platform.source_cache import (
+    SourceCache, SourceCacheCancelled, SourceCacheError, SourceCacheStorageError,
+)
+
+PRIMARY = GEOFABRIK_BASE + "asia/china/shanghai-latest.osm.pbf"
+ALTERNATIVE = OSMFR_BASE + "asia/china/shanghai-latest.osm.pbf"
+
+
+def pbf_bytes(marker=b"fixture"):
+    # Synthetic complete first Blob; tests do not claim a routable map fixture.
+    blob = b"\x0a" + bytes([len(marker)]) + marker
+    header = b"\x0a\x09OSMHeader\x18" + bytes([len(blob)])
+    return len(header).to_bytes(4, "big") + header + blob
+
+
+class Response(io.BytesIO):
+    def __init__(self, data, url=PRIMARY, headers=None, status=200):
+        super().__init__(data)
+        self.headers = {"Content-Length": str(len(data)), **(headers or {})}
+        self.url = url
+        self.status = status
+
+    def geturl(self):
+        return self.url
+
+
+def request_url(request):
+    return request.full_url if isinstance(request, urllib.request.Request) else request
+
+
+def request_headers(request):
+    return dict(request.header_items()) if isinstance(request, urllib.request.Request) else {}
+
+
+class FallbackTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.environment = patch.dict(os.environ, {"MAP_PLATFORM_OSMFR_FALLBACK": "1"})
+        self.environment.start()
+        self.addCleanup(self.environment.stop)
+        self.region = SourceRegion(
+            id="geofabrik-shanghai", provider="geofabrik", name="Shanghai",
+            url=PRIMARY, bounds=Bounds(120.8, 30.6, 122.0, 31.9),
+            local_path="backend/data/source-pbf/shanghai-latest.osm.pbf",
+        )
+        self.cache = SourceCache(self.root, data_root=self.root / "data")
+        self.target = self.cache._target_path(self.region)
+        self.temporary = self.target.with_suffix(self.target.suffix + ".tmp")
+
+    def download(self, responses, **kwargs):
+        with patch("map_platform.source_cache.urllib.request.urlopen", side_effect=responses) as opener:
+            cached = self.cache.ensure(self.region, **kwargs)
+        return cached, opener
+
+    def seed(self, fallback=False):
+        data = pbf_bytes(b"previous")
+        responses = [Response(data)]
+        if fallback:
+            responses = [TimeoutError("primary down"), Response(data, ALTERNATIVE, {"ETag": '"fr-old"'})]
+        cached, _ = self.download(responses)
+        return cached
+
+    def assert_clean(self):
+        self.assertFalse(self.temporary.exists())
+        self.assertFalse(self.cache.metadata_path.with_suffix(".json.tmp").exists())
+
+    def test_http_error_response_is_closed_before_fallback(self):
+        body = io.BytesIO(b"Service unavailable")
+        error = urllib.error.HTTPError(PRIMARY, 503, "down", {}, body)
+        def open_url(request, timeout):
+            if request_url(request) == PRIMARY:
+                raise error
+            self.assertTrue(body.closed)
+            return Response(pbf_bytes(b"fr"), ALTERNATIVE)
+        self.download(open_url)
+
+    def test_primary_304_still_reuses_primary_cache(self):
+        previous, _ = self.download([
+            Response(pbf_bytes(b"primary"), PRIMARY, {"ETag": '\"geo\"'}),
+        ])
+        self.cache.revalidate_after_seconds = 0
+        body = io.BytesIO()
+        unchanged = urllib.error.HTTPError(PRIMARY, 304, "Not Modified", {}, body)
+        cached, opener = self.download([unchanged])
+        self.assertEqual(opener.call_count, 1)
+        self.assertEqual(cached.source_url, PRIMARY)
+        self.assertEqual(cached.sha256, previous.sha256)
+        self.assertTrue(body.closed)
+
+    def test_cancellation_during_fallback_preserves_previous_source(self):
+        previous = self.seed()
+        old_bytes = previous.path.read_bytes()
+        old_metadata = self.cache.metadata_path.read_bytes()
+        cancelled = False
+        class Cancelling(Response):
+            def read(self, size=-1):
+                nonlocal cancelled
+                cancelled = True
+                return super().read(size)
+        with self.assertRaises(SourceCacheCancelled):
+            self.download([TimeoutError(), Cancelling(pbf_bytes(b"fr"), ALTERNATIVE)],
+                          force=True, cancellation_check=lambda: cancelled)
+        self.assertEqual(previous.path.read_bytes(), old_bytes)
+        self.assertEqual(self.cache.metadata_path.read_bytes(), old_metadata)
+        self.assert_clean()
+
+    def test_fallback_is_enabled_by_default(self):
+        os.environ.pop("MAP_PLATFORM_OSMFR_FALLBACK", None)
+        cache = SourceCache(self.root, data_root=self.root / "default")
+        self.assertTrue(cache.osmfr_fallback_enabled)
+
+    def test_primary_success_and_redirect_do_not_contact_fallback(self):
+        dated = PRIMARY.replace("latest", "260905")
+        data = pbf_bytes(b"primary")
+        cached, opener = self.download([Response(data, dated)])
+        self.assertEqual(opener.call_count, 1)
+        self.assertEqual(cached.source_url, PRIMARY)
+        self.assertEqual(cached.resolved_url, dated)
+        self.assertEqual(self.target.read_bytes(), data)
+
+    def test_availability_errors_fail_over_once_and_record_actual_source(self):
+        errors = [TimeoutError("timeout"), ConnectionResetError("reset"),
+                  urllib.error.URLError("DNS failed"), http.client.IncompleteRead(b"", 10)]
+        errors += [urllib.error.HTTPError(PRIMARY, code, "unavailable", {}, None)
+                   for code in (404, 408, 410, 429, 500, 502, 503, 504)]
+        data = pbf_bytes(b"fr")
+        for error in errors:
+            with self.subTest(error=repr(error)):
+                cached, opener = self.download([
+                    error, Response(data, ALTERNATIVE, {"ETag": '"fr"'}),
+                ], force=True)
+                self.assertEqual([request_url(call.args[0]) for call in opener.call_args_list],
+                                 [PRIMARY, ALTERNATIVE])
+                self.assertEqual(cached.source_url, ALTERNATIVE)
+                self.assertEqual(cached.resolved_url, ALTERNATIVE)
+                self.assertEqual(cached.sha256, hashlib.sha256(data).hexdigest())
+                self.assertIsNone(cached.source_published_at)
+                recorded = self.cache.metadata()["sources"][self.region.id]
+                self.assertEqual(recorded["sourceUrl"], ALTERNATIVE)
+                self.assertEqual(recorded["sha256"], cached.sha256)
+                with self.cache.verified_lease(self.region) as leased:
+                    self.assertEqual(leased.sha256, cached.sha256)
+                self.assert_clean()
+
+    def test_partial_primary_is_removed_before_fallback_and_not_appended(self):
+        data = pbf_bytes(b"fr")
+        class Interrupted(Response):
+            def read(self, size=-1):
+                if self.tell():
+                    raise TimeoutError("read timed out")
+                return super().read(5)
+        primary = Interrupted(pbf_bytes(b"unfinished primary"), headers={"ETag": '"geo"'})
+        def open_url(request, timeout):
+            if request_url(request) == PRIMARY:
+                return primary
+            self.assertTrue(primary.closed)
+            self.assertFalse(self.temporary.exists())
+            self.assertEqual(request_headers(request), {})
+            return Response(data, ALTERNATIVE)
+        cached, opener = self.download(open_url)
+        self.assertEqual(opener.call_count, 2)
+        self.assertEqual(cached.path.read_bytes(), data)
+        self.assert_clean()
+
+    def test_failed_same_provider_resume_restarts_fallback_without_range(self):
+        data = pbf_bytes(b"unfinished")
+        first = Response(data[:6], PRIMARY, {"Content-Length": str(len(data)), "ETag": '"geo"'})
+        cached, opener = self.download([
+            first, TimeoutError("resume down"), Response(pbf_bytes(b"fr"), ALTERNATIVE),
+        ])
+        resumed = request_headers(opener.call_args_list[1].args[0])
+        self.assertEqual(resumed["Range"], "bytes=6-")
+        self.assertEqual(resumed["If-range"], '"geo"')
+        self.assertEqual(request_headers(opener.call_args_list[2].args[0]), {})
+        self.assertEqual(cached.path.read_bytes(), pbf_bytes(b"fr"))
+        self.assert_clean()
+
+    def test_normal_same_provider_resume_is_unchanged(self):
+        data = pbf_bytes(b"primary")
+        cached, opener = self.download([
+            Response(data[:6], PRIMARY, {"Content-Length": str(len(data)), "ETag": '"geo"'}),
+            Response(data[6:], PRIMARY, {"Content-Range": f"bytes 6-{len(data)-1}/{len(data)}",
+                                        "ETag": '"geo"'}, status=206),
+        ])
+        self.assertEqual(opener.call_count, 2)
+        self.assertEqual(cached.path.read_bytes(), data)
+        self.assertEqual(cached.source_url, PRIMARY)
+
+    def test_fresh_fallback_cache_obeys_ttl_without_repeated_primary_timeout(self):
+        previous = self.seed(fallback=True)
+        cached, opener = self.download([])
+        opener.assert_not_called()
+        self.assertEqual(cached, previous)
+
+    def test_stale_fallback_retries_primary_without_leaking_fallback_validators(self):
+        self.seed(fallback=True)
+        self.cache.revalidate_after_seconds = 0
+        cached, opener = self.download([Response(pbf_bytes(b"recovered"))])
+        self.assertEqual(opener.call_count, 1)
+        self.assertEqual(request_headers(opener.call_args.args[0]), {})
+        self.assertEqual(cached.source_url, PRIMARY)
+
+    def test_primary_validators_are_not_sent_to_fallback(self):
+        self.download([Response(pbf_bytes(b"old"), PRIMARY, {"ETag": '"geo-old"'})])
+        self.cache.revalidate_after_seconds = 0
+        _, opener = self.download([TimeoutError(), Response(pbf_bytes(b"fr"), ALTERNATIVE)])
+        self.assertEqual(request_headers(opener.call_args_list[0].args[0])["If-none-match"], '"geo-old"')
+        self.assertEqual(request_headers(opener.call_args_list[1].args[0]), {})
+
+    def test_fallback_304_revalidates_only_its_own_bytes_and_metadata(self):
+        previous = self.seed(fallback=True)
+        self.cache.revalidate_after_seconds = 0
+        not_modified = urllib.error.HTTPError(ALTERNATIVE, 304, "Not Modified", {"ETag": '"fr-old"'}, None)
+        cached, opener = self.download([TimeoutError(), not_modified])
+        self.assertEqual(request_headers(opener.call_args_list[0].args[0]), {})
+        self.assertEqual(request_headers(opener.call_args_list[1].args[0])["If-none-match"], '"fr-old"')
+        self.assertEqual(cached.source_url, ALTERNATIVE)
+        self.assertEqual(cached.sha256, previous.sha256)
+        self.assertEqual(cached.downloaded_at, previous.downloaded_at)
+        self.assertGreaterEqual(cached.validated_at, previous.validated_at)
+        self.assert_clean()
+
+    def test_both_down_preserves_previous_file_and_metadata(self):
+        self.seed()
+        old_bytes = self.target.read_bytes()
+        old_metadata = self.cache.metadata_path.read_bytes()
+        self.cache.revalidate_after_seconds = 0
+        with self.assertRaisesRegex(SourceCacheError, "both source providers failed.*Geofabrik:.*OpenStreetMap France:"):
+            self.download([TimeoutError("primary down"), urllib.error.URLError("fallback down")])
+        self.assertEqual(self.target.read_bytes(), old_bytes)
+        self.assertEqual(self.cache.metadata_path.read_bytes(), old_metadata)
+        self.assert_clean()
+
+    def test_force_refresh_bypasses_fallback_cache_and_validators(self):
+        self.seed(fallback=True)
+        _, opener = self.download([TimeoutError(), Response(pbf_bytes(b"new"), ALTERNATIVE)], force=True)
+        self.assertEqual(opener.call_count, 2)
+        self.assertTrue(all(not request_headers(call.args[0]) for call in opener.call_args_list))
+
+    def test_disabled_fallback_is_not_attempted(self):
+        for value in ("0", "false", "no", "off", "FALSE"):
+            with self.subTest(value=value), patch.dict(os.environ, {"MAP_PLATFORM_OSMFR_FALLBACK": value}):
+                cache = SourceCache(self.root, data_root=self.root / "data")
+                with patch("map_platform.source_cache.urllib.request.urlopen", side_effect=TimeoutError()) as opener:
+                    with self.assertRaises(SourceCacheError):
+                        cache.ensure(self.region)
+                self.assertEqual(opener.call_count, 1)
+
+    def test_disabling_fallback_does_not_keep_using_fresh_fallback_cache(self):
+        self.seed(fallback=True)
+        self.cache.osmfr_fallback_enabled = False
+        cached, opener = self.download([Response(pbf_bytes(b"primary"))])
+        self.assertEqual(opener.call_count, 1)
+        self.assertEqual(cached.source_url, PRIMARY)
+
+    def test_pinned_or_unmapped_sources_never_fail_over(self):
+        variants = [
+            replace(self.region, checksum="a" * 64),
+            replace(self.region, published_at="2026-09-05T00:00:00Z"),
+            replace(self.region, url=PRIMARY.replace("latest", "260905")),
+            replace(self.region, provider="custom"),
+            replace(self.region, url=GEOFABRIK_BASE + "asia/malaysia-singapore-brunei-latest.osm.pbf"),
+        ]
+        for region in variants:
+            with self.subTest(region=region), patch("map_platform.source_cache.urllib.request.urlopen", side_effect=TimeoutError()) as opener:
+                with self.assertRaises(SourceCacheError):
+                    self.cache.ensure(region, force=True)
+                self.assertEqual(opener.call_count, 1)
+                self.assert_clean()
+
+    def test_checksum_mismatch_does_not_fail_over(self):
+        with patch("map_platform.source_cache.urllib.request.urlopen", return_value=Response(pbf_bytes())) as opener:
+            with self.assertRaisesRegex(SourceCacheError, "checksum mismatch"):
+                self.cache.ensure(replace(self.region, checksum="a" * 64))
+        self.assertEqual(opener.call_count, 1)
+        self.assertFalse(self.target.exists())
+        self.assert_clean()
+
+    def test_auth_tls_and_local_failures_are_not_outages(self):
+        errors = [
+            urllib.error.HTTPError(PRIMARY, code, "not an outage", {}, None)
+            for code in (304, 400, 401, 403, 416)
+        ] + [urllib.error.URLError(ssl.SSLCertVerificationError("invalid certificate")),
+             OSError(errno.ENOSPC, "disk full"), ValueError("invalid local configuration")]
+        for error in errors:
+            with self.subTest(error=repr(error)), patch("map_platform.source_cache.urllib.request.urlopen", side_effect=error) as opener:
+                with self.assertRaises(SourceCacheError):
+                    self.cache.ensure(self.region)
+                self.assertEqual(opener.call_count, 1)
+                self.assert_clean()
+
+    def test_storage_admission_never_becomes_fallback(self):
+        with patch("map_platform.source_cache.shutil.disk_usage", return_value=SimpleNamespace(free=1)), \
+             patch("map_platform.source_cache.urllib.request.urlopen") as opener:
+            with self.assertRaises(SourceCacheStorageError):
+                self.cache.ensure(self.region, minimum_free_bytes=100)
+        opener.assert_not_called()
+
+    def test_cancellation_between_providers_stops_fallback(self):
+        cancelled = False
+        def fail_primary(*args, **kwargs):
+            nonlocal cancelled
+            cancelled = True
+            raise TimeoutError()
+        with patch("map_platform.source_cache.urllib.request.urlopen", side_effect=fail_primary) as opener:
+            with self.assertRaises(SourceCacheCancelled):
+                self.cache.ensure(self.region, cancellation_check=lambda: cancelled)
+        self.assertEqual(opener.call_count, 1)
+        self.assert_clean()
+
+    def test_fallback_still_enforces_disk_reserve(self):
+        with patch("map_platform.source_cache.shutil.disk_usage", return_value=SimpleNamespace(free=1000)), \
+             patch("map_platform.source_cache.urllib.request.urlopen", side_effect=[
+                 TimeoutError(), Response(pbf_bytes(), ALTERNATIVE, {"Content-Length": "1000"}),
+             ]) as opener:
+            with self.assertRaises(SourceCacheStorageError):
+                self.cache.ensure(self.region, minimum_free_bytes=100)
+        self.assertEqual(opener.call_count, 2)
+        self.assertFalse(self.target.exists())
+        self.assert_clean()
+
+    def test_invalid_fallback_body_does_not_replace_existing_source(self):
+        self.seed()
+        old_bytes = self.target.read_bytes()
+        old_metadata = self.cache.metadata_path.read_bytes()
+        for body in (b"", b"<html>Maintenance</html>", pbf_bytes()[:-1], b"\x00\x01\x00\x00"):
+            with self.subTest(body=body), self.assertRaises(SourceCacheError):
+                self.download([TimeoutError(), Response(body, ALTERNATIVE)], force=True)
+            self.assertEqual(self.target.read_bytes(), old_bytes)
+            self.assertEqual(self.cache.metadata_path.read_bytes(), old_metadata)
+            self.assert_clean()
+
+    def test_untrusted_fallback_redirect_is_rejected(self):
+        for url in ("http://download.openstreetmap.fr/extracts/shanghai.osm.pbf", "https://example.invalid/map.osm.pbf"):
+            with self.subTest(url=url), self.assertRaisesRegex(SourceCacheError, "trusted HTTPS source"):
+                self.download([TimeoutError(), Response(pbf_bytes(), url)], force=True)
+            self.assertFalse(self.target.exists())
+            self.assert_clean()
+
+    def test_url_mapping_is_explicit_and_preserves_region(self):
+        self.assertEqual(fallback_url(self.region), ALTERNATIVE)
+        for source, destination in (("asia/china/jiangsu", "asia/china/jiangsu"),
+                                    ("europe/germany", "europe/germany"),
+                                    ("asia/china/xizang", "asia/china/tibet")):
+            region = replace(self.region, url=GEOFABRIK_BASE + source + "-latest.osm.pbf")
+            self.assertEqual(fallback_url(region), OSMFR_BASE + destination + "-latest.osm.pbf")
+        for url in (PRIMARY + "?x=1", PRIMARY + "#fragment", PRIMARY.replace("https:", "http:"),
+                    PRIMARY.replace(".de/", ".de.evil/"), PRIMARY.replace(".de/", ".de:443/"),
+                    PRIMARY.replace("https://", "https://user:pass@"),
+                    GEOFABRIK_BASE + "europe/ireland-and-northern-ireland-latest.osm.pbf",
+                    GEOFABRIK_BASE + "asia/taiwan-latest.osm.pbf"):
+            self.assertIsNone(fallback_url(replace(self.region, url=url)), url)
+
+    def test_error_classifier_does_not_retry_unrelated_errors(self):
+        for error in (None, RuntimeError("local"), OSError(errno.ENOSPC, "disk"), ssl.SSLError("TLS")):
+            self.assertFalse(is_upstream_unavailable(error))
+
+    def test_pbf_header_validation_accepts_reordered_fields(self):
+        blob = b"\x0a\x01x"
+        header = b"\x18\x03\x12\x02ab\x0a\x09OSMHeader"
+        path = self.root / "header.pbf"
+        path.write_bytes(len(header).to_bytes(4, "big") + header + blob)
+        validate_pbf_header(path)
+
+    def test_pbf_header_validation_rejects_malformed_protobuf(self):
+        headers = (b"\x80", b"\x00", b"\x0f", b"\x0a\xff\x01x", b"\x0a\x07OSMData\x18\x01",
+                   b"\x0a\x09OSMHeader", b"\x0a\x09OSMHeader\x18\x00")
+        path = self.root / "bad-header.pbf"
+        for header in headers:
+            with self.subTest(header=header):
+                path.write_bytes(len(header).to_bytes(4, "big") + header + b"x")
+                with self.assertRaises(ValueError):
+                    validate_pbf_header(path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/map-platform/backend/tests/test_osmfr_fallback.py
+++ b/map-platform/backend/tests/test_osmfr_fallback.py
@@ -275,7 +275,7 @@ class FallbackTests(unittest.TestCase):
         self.assertEqual(opener.call_count, 1)
         self.assertEqual(cached.source_url, PRIMARY)
 
-    def test_pinned_or_unmapped_sources_never_fail_over(self):
+    def test_pinned_or_excluded_sources_never_fail_over(self):
         variants = [
             replace(self.region, checksum="a" * 64),
             replace(self.region, published_at="2026-09-05T00:00:00Z"),
@@ -359,19 +359,55 @@ class FallbackTests(unittest.TestCase):
             self.assertFalse(self.target.exists())
             self.assert_clean()
 
-    def test_url_mapping_is_explicit_and_preserves_region(self):
+    def test_url_derivation_and_aliases_preserve_region(self):
         self.assertEqual(fallback_url(self.region), ALTERNATIVE)
         for source, destination in (("asia/china/jiangsu", "asia/china/jiangsu"),
                                     ("europe/germany", "europe/germany"),
-                                    ("asia/china/xizang", "asia/china/tibet")):
+                                    ("asia/china/inner-mongolia", "asia/china/inner_mongolia"),
+                                    ("asia/taiwan", "asia/taiwan")):
             region = replace(self.region, url=GEOFABRIK_BASE + source + "-latest.osm.pbf")
             self.assertEqual(fallback_url(region), OSMFR_BASE + destination + "-latest.osm.pbf")
         for url in (PRIMARY + "?x=1", PRIMARY + "#fragment", PRIMARY.replace("https:", "http:"),
                     PRIMARY.replace(".de/", ".de.evil/"), PRIMARY.replace(".de/", ".de:443/"),
                     PRIMARY.replace("https://", "https://user:pass@"),
-                    GEOFABRIK_BASE + "europe/ireland-and-northern-ireland-latest.osm.pbf",
-                    GEOFABRIK_BASE + "asia/taiwan-latest.osm.pbf"):
+                    GEOFABRIK_BASE + "europe/ireland-and-northern-ireland-latest.osm.pbf"):
             self.assertIsNone(fallback_url(replace(self.region, url=url)), url)
+
+    def test_previously_unlisted_path_downloads_one_same_path_candidate(self):
+        primary = GEOFABRIK_BASE + "asia/japan/kanto-latest.osm.pbf"
+        alternative = OSMFR_BASE + "asia/japan/kanto-latest.osm.pbf"
+        self.region = replace(self.region, url=primary)
+        cached, opener = self.download([TimeoutError(), Response(pbf_bytes(), alternative)])
+        self.assertEqual([request_url(c.args[0]) for c in opener.call_args_list], [primary, alternative])
+        self.assertEqual(cached.source_url, alternative)
+        self.assert_clean()
+
+    def test_researched_alias_download_preserves_source_identity(self):
+        primary = GEOFABRIK_BASE + "europe/georgia-latest.osm.pbf"
+        alternative = OSMFR_BASE + "asia/georgia-latest.osm.pbf"
+        self.region = replace(self.region, url=primary)
+        cached, opener = self.download([TimeoutError(), Response(pbf_bytes(), alternative)])
+        self.assertEqual([request_url(c.args[0]) for c in opener.call_args_list], [primary, alternative])
+        self.assertEqual(cached.source_url, alternative)
+        self.assertIn(self.region.id, self.cache.metadata()["sources"])
+        self.assertEqual(self.region.url, primary)
+        self.assert_clean()
+
+    def test_missing_candidate_does_not_guess_or_replace_stable_bytes(self):
+        self.seed()
+        old_bytes = self.target.read_bytes()
+        old_metadata = self.cache.metadata_path.read_bytes()
+        primary = GEOFABRIK_BASE + "asia/new-region-latest.osm.pbf"
+        alternative = OSMFR_BASE + "asia/new-region-latest.osm.pbf"
+        self.region = replace(self.region, url=primary)
+        missing = urllib.error.HTTPError(alternative, 404, "not published", {}, None)
+        with patch("map_platform.source_cache.urllib.request.urlopen", side_effect=[TimeoutError(), missing]) as opener:
+            with self.assertRaisesRegex(SourceCacheError, "both source providers failed"):
+                self.cache.ensure(self.region, force=True)
+        self.assertEqual([request_url(c.args[0]) for c in opener.call_args_list], [primary, alternative])
+        self.assertEqual(self.target.read_bytes(), old_bytes)
+        self.assertEqual(self.cache.metadata_path.read_bytes(), old_metadata)
+        self.assert_clean()
 
     def test_error_classifier_does_not_retry_unrelated_errors(self):
         for error in (None, RuntimeError("local"), OSError(errno.ENOSPC, "disk"), ssl.SSLError("TLS")):

--- a/map-platform/backend/tests/test_osmfr_url_resolution.py
+++ b/map-platform/backend/tests/test_osmfr_url_resolution.py
@@ -1,0 +1,165 @@
+"""Pure resolver tests; all networking remains in SourceCache."""
+import re
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from map_platform.osmfr_fallback import (
+    ALIASES, EXCEPTIONS, GEOFABRIK_BASE, OSMFR_BASE, fallback_url,
+)
+
+SUFFIX = "-latest.osm.pbf"
+
+
+def region(path="asia/china/shanghai", **overrides):
+    return SimpleNamespace(**{
+        "url": GEOFABRIK_BASE + path + SUFFIX,
+        "provider": "geofabrik", "checksum": None, "published_at": None,
+        **overrides,
+    })
+
+
+class OsmfrUrlResolutionTests(unittest.TestCase):
+    def test_same_paths_need_no_catalogue_entry(self):
+        for path in (
+            "asia/china/shanghai", "asia/china/jiangsu", "asia/china/zhejiang",
+            "asia/china/tibet", "asia/china/macau", "asia/japan/kanto",
+            "europe/germany", "south-america/brazil", "africa/kenya",
+            "asia/future-region/subregion_2", "asia/taiwan", "south-america",
+        ):
+            with self.subTest(path=path):
+                self.assertNotIn(path, ALIASES)
+                self.assertNotIn(path, EXCEPTIONS)
+                self.assertEqual(fallback_url(region(path)), OSMFR_BASE + path + SUFFIX)
+
+    def test_construction_is_pure_and_does_not_mutate_source(self):
+        source = region()
+        before = vars(source).copy()
+        with patch("urllib.request.urlopen", side_effect=AssertionError("unexpected network")):
+            self.assertEqual(fallback_url(source), OSMFR_BASE + "asia/china/shanghai" + SUFFIX)
+        self.assertEqual(vars(source), before)
+
+    def test_actual_chinese_catalogue_names(self):
+        self.assertEqual(fallback_url(region("asia/china/inner-mongolia")),
+                         OSMFR_BASE + "asia/china/inner_mongolia" + SUFFIX)
+        self.assertEqual(fallback_url(region("asia/china/hong-kong")),
+                         OSMFR_BASE + "asia/china/hong_kong" + SUFFIX)
+        for name in ("xizang", "neimenggu"):
+            self.assertNotIn("asia/china/" + name, ALIASES)
+
+    def test_similarly_named_chinese_provinces_stay_distinct(self):
+        for name in ("shanxi", "shaanxi"):
+            self.assertEqual(fallback_url(region("asia/china/" + name)),
+                             OSMFR_BASE + "asia/china/" + name + SUFFIX)
+
+    def test_country_and_us_state_georgia_are_not_confused(self):
+        self.assertEqual(fallback_url(region("europe/georgia")), OSMFR_BASE + "asia/georgia" + SUFFIX)
+        self.assertEqual(fallback_url(region("north-america/us/georgia")),
+                         OSMFR_BASE + "north-america/us-south/georgia" + SUFFIX)
+
+    def test_american_paths_keep_their_real_punctuation(self):
+        self.assertEqual(fallback_url(region("north-america/us/new-york")),
+                         OSMFR_BASE + "north-america/us-northeast/new-york" + SUFFIX)
+        self.assertEqual(fallback_url(region("north-america/canada/new-brunswick")),
+                         OSMFR_BASE + "north-america/canada/new_brunswick" + SUFFIX)
+
+    def test_fiji_uses_the_merged_extract_not_one_dateline_half(self):
+        self.assertEqual(fallback_url(region("australia-oceania/fiji")), OSMFR_BASE + "merge/fiji" + SUFFIX)
+
+    def test_falklands_use_the_actual_catalogue_path(self):
+        self.assertEqual(fallback_url(region("europe/united-kingdom/falklands")),
+                         OSMFR_BASE + "south-america/falkland" + SUFFIX)
+
+    def test_combined_israel_palestine_is_not_reduced_to_one_component(self):
+        self.assertEqual(fallback_url(region("asia/israel-and-palestine")),
+                         OSMFR_BASE + "asia/israel_and_palestine" + SUFFIX)
+
+    def test_russian_district_names_are_explicit(self):
+        self.assertEqual(fallback_url(region("russia/north-caucasus-fed-district")),
+                         OSMFR_BASE + "russia/north_caucasian_federal_district" + SUFFIX)
+        self.assertEqual(fallback_url(region("russia/south-fed-district")),
+                         OSMFR_BASE + "russia/southern_federal_district" + SUFFIX)
+
+    def test_table_contains_only_differences_and_safe_paths(self):
+        safe_path = re.compile(r"[a-z0-9][a-z0-9_-]*(?:/[a-z0-9][a-z0-9_-]*)*")
+        self.assertFalse(ALIASES.keys() & EXCEPTIONS.keys())
+        for source, destination in ALIASES.items():
+            with self.subTest(source=source):
+                self.assertNotEqual(source, destination)
+                self.assertIsNotNone(safe_path.fullmatch(source))
+                self.assertIsNotNone(safe_path.fullmatch(destination))
+                self.assertEqual(fallback_url(region(source)), OSMFR_BASE + destination + SUFFIX)
+
+    def test_every_exception_has_a_reason_and_is_not_attempted(self):
+        for path, reason in EXCEPTIONS.items():
+            with self.subTest(path=path):
+                self.assertTrue(reason.strip())
+                self.assertIsNone(fallback_url(region(path)))
+
+    def test_scope_exceptions_do_not_blacklist_safe_children(self):
+        # Indonesia's parent includes East Timor; an independently requested
+        # child is not replaced by the parent, nor rejected solely for its prefix.
+        self.assertIsNone(fallback_url(region("asia/indonesia")))
+        self.assertEqual(fallback_url(region("asia/indonesia/bali")),
+                         OSMFR_BASE + "asia/indonesia/bali" + SUFFIX)
+        self.assertIsNone(fallback_url(region("north-america/us")))
+        self.assertIsNotNone(fallback_url(region("north-america/us/california")))
+
+    def test_aliases_do_not_guess_child_paths_or_widen_to_parents(self):
+        for path in ("north-america/us/california/socal", "europe/united-kingdom/england/london",
+                     "europe/germany/nordrhein-westfalen/arnsberg-regbez"):
+            self.assertEqual(fallback_url(region(path)), OSMFR_BASE + path + SUFFIX)
+
+    def test_no_global_hyphen_replacement_or_basename_matching(self):
+        for path in ("asia/unknown-region", "europe/new-york", "asia/inner-mongolia"):
+            self.assertEqual(fallback_url(region(path)), OSMFR_BASE + path + SUFFIX)
+
+    def test_pinned_and_non_geofabrik_sources_do_not_switch(self):
+        for changes in ({"provider": "custom"}, {"provider": "osmfr"},
+                        {"checksum": "a" * 64}, {"published_at": "2026-09-06T00:00:00Z"}):
+            with self.subTest(changes=changes):
+                self.assertIsNone(fallback_url(region(**changes)))
+
+    def test_only_canonical_https_public_host_is_accepted(self):
+        tail = "asia/china/shanghai" + SUFFIX
+        for base in (
+            "http://download.geofabrik.de/", "https://download.geofabrik.de:443/",
+            "https://user:pass@download.geofabrik.de/", "https://download.geofabrik.de.evil/",
+            "https://download.geofabrik.de@evil/", "https://download.geofabrik.de./",
+            "https://osm-internal.download.geofabrik.de/", "https://example.org/",
+            "//download.geofabrik.de/", "https://DOWNLOAD.GEOFABRIK.DE/",
+        ):
+            with self.subTest(base=base):
+                self.assertIsNone(fallback_url(region(url=base + tail)))
+
+    def test_queries_fragments_controls_and_encoded_paths_are_rejected(self):
+        url = region().url
+        bad_urls = [url + tail for tail in ("?", "?token=x", "#", "#fragment", "/", "\n", "\r\n", " ")]
+        bad_urls += [" " + url, "\t" + url, url.replace("shanghai", "shan\tghai"),
+                     url.replace("shanghai", "%73hanghai"), url.replace("/china/", "/%2e%2e/"),
+                     url.replace("/china/", "/china%2f"), url.replace("/china/", "//china/"),
+                     url.replace("/china/", "/../china/"), url.replace("/china/", "/./china/"),
+                     url.replace("/china/", "\\china\\"), url.replace("shanghai", "上海"),
+                     url.replace("shanghai", "shanghai;extra"), None, b"not-a-text-url"]
+        for value in bad_urls:
+            with self.subTest(url=value):
+                self.assertIsNone(fallback_url(region(url=value)))
+
+    def test_dated_other_formats_and_empty_paths_are_rejected(self):
+        for tail in ("asia/china/shanghai-260905.osm.pbf", "asia/china/shanghai.osm.pbf",
+                     "asia/china/shanghai-latest-free.shp.zip", "-latest.osm.pbf",
+                     "/-latest.osm.pbf", "asia/china/-latest.osm.pbf", "asia/china/.osm.pbf"):
+            with self.subTest(tail=tail):
+                self.assertIsNone(fallback_url(region(url=GEOFABRIK_BASE + tail)))
+
+    def test_research_document_covers_the_runtime_tables(self):
+        document = (Path(__file__).resolve().parents[3] / "docs/osmfr-alias-research.md").read_text()
+        for source, destination in ALIASES.items():
+            self.assertIn(f"| `{source}` | `{destination}` |", document)
+        for source in EXCEPTIONS:
+            self.assertIn(f"| `{source}` |", document)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Add automatic OpenStreetMap France PBF download fallback to the backend's shared `SourceCache`, keeping Geofabrik primary. Updated at the owner's request to resolve fallback URLs **per request**, rather than maintaining a positive region allowlist.

- Derive the same OSM.fr path for any eligible canonical Geofabrik latest URL. Shanghai, Jiangsu, Zhejiang and other identical paths need no table entry; previously unlisted regions receive a candidate too.
- Apply **47 researched exact naming/directory aliases** and **11 documented source-scope exceptions**. All entries, official source references, confidence limits and maintenance guidance are in [docs/osmfr-alias-research.md](docs/osmfr-alias-research.md).
- Correct the original China examples: Geofabrik's catalogue uses `inner-mongolia` and `tibet`, not the earlier `neimenggu`/`xizang` examples. Tibet already uses the same path. Handle Georgia country versus US state, US regional folders, Canada underscores, Russian districts and merged Fiji explicitly.
- Construct **one candidate without network I/O**. No preliminary HEAD, directory crawl, additional name guesses, basename matching, blanket punctuation replacement or automatic parent-region download. Missing candidates fail normally; this is not guaranteed worldwide coverage.
- Accept only unpinned canonical HTTPS Geofabrik `-latest.osm.pbf` URLs. Reject custom/lookalike hosts, ports, credentials, query strings/fragments, controls, encoded separators, dot segments and other unsafe paths. Checksum/publication-time-pinned and dated snapshots never silently change provider.
- Retry the candidate only for eligible upstream availability/transport failures (HTTP 404/408/410/429/5xx, network URL errors, timeout, reset, interrupted reads). Authentication/TLS failures, local storage problems, cancellation, checksum mismatch and unsafe resume responses do not trigger switching.
- Preserve existing source-cache locks, disk reserves, cancellation, hashing and atomic publication. Remove partial bytes before switching; never carry Range/If-Range or HTTP validators between providers. Record the actual successful URL, resolved URL, hash and validators. Fresh fallback bytes obey the existing TTL; revalidation tries Geofabrik first again.
- Retain initial PBF-header sanity validation and trusted final-URL checks. Operator opt-out remains `MAP_PLATFORM_OSMFR_FALLBACK=0`. See [docs/osm-source-fallback.md](docs/osm-source-fallback.md).

## Research and scope limitations

Reviewed official Geofabrik indexes and OSM.fr extract/polygon listings on **2026-09-06**. The table is a researched set of naming differences, **not an exhaustive crosswalk of every leaf region** or proof of polygon equivalence. It deliberately does not invent unverified US-state or subdivision routes. Unknown safe paths get a literal same-path candidate; Taiwan is not redirected to China or arbitrarily blocked.

Scope exceptions prevent substituting a component for a combined source, such as Malaysia/Singapore/Brunei or Ireland/Northern Ireland. Geofabrik's Indonesia explicitly includes East Timor, and New South Wales includes ACT/JBT: those parent scopes are excluded pending coverage verification. Exceptions and aliases match exact full paths, not descendants.

The providers produce independent extracts. HTTP success, matching names and an initial PBF header do not establish equal boundaries, border buffers, relation completeness, timestamps or disputed-area coverage. **No complete live PBF download, map build or geographic-equivalence validation is claimed.**

This is download failover after source resolution, not independent source discovery. Cold dynamic discovery without a cached Geofabrik catalogue remains dependent on Geofabrik. No deployment, production image pins, API, firmware or iOS changes are made by this feature. The latest alias update was applied on top of the concurrent main-branch merge without overwriting it.

## Validation

For the current alias update:

- **20 deterministic resolver tests passed locally** in a partial checkout, running the actual helper module with only standard-library runtime dependencies. Tests exercise every alias/exception, unknown paths, pins, URL attacks, exact matching, ambiguous names and research-document consistency.
- Python compilation of the helper and both test files passed.
- Added **three downloader integration regressions** for previously unlisted same-path sources, researched aliases and missing-candidate behavior preserving stable bytes/metadata. The fallback test module now contains 32 tests. These integration tests and the full backend suite were **not rerun locally** in this partial environment.
- Uploaded code/document blobs match the locally checked files. The existing SourceCache implementation is unchanged by this alias update.
- GitHub Actions started for head `b88ed2d6b92f657794b6a983e7ecabbe3197e670`; full CI result is pending. No physical-device validation claimed.

Complete-checkout commands:

```sh
cd map-platform/backend
python -m unittest discover -s tests -p 'test_osmfr_url_resolution.py'
python -m unittest discover -s tests -p 'test_osmfr_fallback.py'
python -m unittest discover -s tests -p 'test_source_cache.py'
python -m unittest discover -s tests
```

## Contributor License Agreement

Submitted by automation at the repository owner's request. Legal/signature attestations are left for the owner to confirm; no CLA is signed on their behalf.

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the Open Bike Computer Contributor License Agreement.
- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
