### PR TITLE
Activate automatic production map promotion

### DIFF
--- a/map-platform/deploy/compose.yaml
+++ b/map-platform/deploy/compose.yaml
@@ -1,5 +1,6 @@
 # control-plane-source-commit: b40b825b137e8c5d3e00c11b8914850bba5fd391
 # worker-source-commit: e739dfe6c0612e95db8241249dcc2edfe52d8372
+# promotion-source-commit: 2bff706c442865ef9c07c2d5c5589991d0010ddf
 
 # These digest-pinned images are the production deployment manifest. The API
 # and maintenance control plane may advance to carry a rollout approval while
@@ -14,6 +15,47 @@ x-map-platform-images:
   worker: &map-platform-worker-image ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8
 
 services:
+  map-platform-promotion:
+    image: ghcr.io/seichris/open-bike-computer-map-platform@sha256:2be730596caad6dd911a488fe22d52c48a6a702fdba559393edfb18523d98593
+    mem_limit: 2g
+    cpus: 1
+    environment:
+      MAP_PLATFORM_REPO_ROOT: /app
+      MAP_PLATFORM_DATA_ROOT: /data
+      MAP_PLATFORM_AUTO_PROMOTION_ENABLED: '1'
+      MAP_PLATFORM_DEPLOYMENT_CHANNEL: production
+      MAP_PLATFORM_CATALOG_CHANNEL: production
+      MAP_PLATFORM_CATALOG_URL: ${MAP_PLATFORM_CATALOG_URL:-}
+      MAP_PLATFORM_CATALOG_SERVICE_KEY_ID: ${MAP_PLATFORM_CATALOG_SERVICE_KEY_ID:-}
+      MAP_PLATFORM_CATALOG_SERVICE_SECRET: ${MAP_PLATFORM_CATALOG_SERVICE_SECRET:-}
+      MAP_PLATFORM_CATALOG_TIMEOUT_SECONDS: ${MAP_PLATFORM_CATALOG_TIMEOUT_SECONDS:-10}
+      MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_VERSION: ${MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_VERSION:-}
+      MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_BUILD: ${MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_BUILD:-}
+      MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_GIT_SHA: ${MAP_PLATFORM_CATALOG_REQUIRED_FIRMWARE_GIT_SHA:-}
+      MAP_PLATFORM_MAP_STREAM_ENABLED: '1'
+      MAP_PLATFORM_MAP_SIGNING_KEY_ID: ${MAP_PLATFORM_MAP_SIGNING_KEY_ID:-}
+      MAP_PLATFORM_MAP_SIGNING_PRIVATE_KEY_BASE64: ${MAP_PLATFORM_MAP_SIGNING_PRIVATE_KEY_BASE64:-}
+      # This converter stays fixed even if the generation worker later advances.
+      MAP_PLATFORM_WORKER_IMAGE_REFERENCE: ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8
+      MAP_PLATFORM_ARTIFACT_STORE: s3
+      MAP_PLATFORM_S3_BUCKET: ${MAP_PLATFORM_S3_BUCKET:-}
+      MAP_PLATFORM_S3_PREFIX: ${MAP_PLATFORM_S3_PREFIX:-map-artifacts}
+      MAP_PLATFORM_S3_ENDPOINT_URL: ${MAP_PLATFORM_S3_ENDPOINT_URL:-}
+      MAP_PLATFORM_S3_CHECKSUM_MODE: ${MAP_PLATFORM_S3_CHECKSUM_MODE:-sha256}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_SESSION_TOKEN: ${AWS_SESSION_TOKEN:-}
+      AWS_REGION: ${AWS_REGION:-}
+    volumes:
+      - map-platform-promotion-data:/data
+    healthcheck:
+      test: ["CMD", "python", "-c", "import json,time; from pathlib import Path; assert time.time()-json.loads(Path('/data/automatic-promotion/heartbeat.json').read_text())['timestamp'] < 1900"]
+      start_period: 1900s
+      interval: 30s
+      timeout: 5s
+      retries: 3
+    restart: unless-stopped
+
   map-platform-api:
     image: *map-platform-control-plane-image
     environment:
@@ -250,3 +292,4 @@ services:
 
 volumes:
   map-platform-data:
+  map-platform-promotion-data:

--- a/map-platform/deploy/compose.yaml
+++ b/map-platform/deploy/compose.yaml
@@ -1,6 +1,6 @@
 # control-plane-source-commit: b40b825b137e8c5d3e00c11b8914850bba5fd391
 # worker-source-commit: e739dfe6c0612e95db8241249dcc2edfe52d8372
-# promotion-source-commit: 2bff706c442865ef9c07c2d5c5589991d0010ddf
+# promotion-source-commit: 8c3a14c3c0f619a91863af99429a21a6af663830
 
 # These digest-pinned images are the production deployment manifest. The API
 # and maintenance control plane may advance to carry a rollout approval while
@@ -16,7 +16,7 @@ x-map-platform-images:
 
 services:
   map-platform-promotion:
-    image: ghcr.io/seichris/open-bike-computer-map-platform@sha256:2be730596caad6dd911a488fe22d52c48a6a702fdba559393edfb18523d98593
+    image: ghcr.io/seichris/open-bike-computer-map-platform@sha256:0184002724c7ec96f2c7edd60662af2527fcbbebcb505229b082e919e7c09bb8
     mem_limit: 2g
     cpus: 1
     environment:

--- a/map-platform/deploy/tests/test_update_image.py
+++ b/map-platform/deploy/tests/test_update_image.py
@@ -18,6 +18,10 @@ SPEC.loader.exec_module(update_image)
 class UpdateImageTests(unittest.TestCase):
     def test_optional_promoter_requires_immutable_identity_and_fixed_role(self):
         text = MODULE_PATH.with_name("compose.yaml").read_text()
+        if "  map-platform-promotion:" in text:
+            body = update_image._service_body(text, "map-platform-promotion")
+            text = text.replace("  map-platform-promotion:\n" + body, "", 1)
+            text = "\n".join(line for line in text.split("\n") if not line.startswith("# promotion-source-commit:"))
         source = "a" * 40
         reference = update_image.IMAGE_REPOSITORY + "@sha256:" + "b" * 64
         converter = update_image.IMAGE_REPOSITORY + "@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8"
@@ -41,6 +45,18 @@ class UpdateImageTests(unittest.TestCase):
         ):
             with self.assertRaises(ValueError):
                 update_image.validate_manifest_text(invalid)
+
+    def test_committed_promoter_preserves_isolation_and_converter_identity(self):
+        text = MODULE_PATH.with_name("compose.yaml").read_text()
+        deployment = update_image.validate_manifest_text(text)
+        self.assertIsNotNone(deployment.promotion_reference)
+        body = update_image._service_body(text, "map-platform-promotion")
+        self.assertIn("      - map-platform-promotion-data:/data", body)
+        self.assertNotIn("      - map-platform-data:/data", body)
+        self.assertIn("    mem_limit: 2g", body)
+        self.assertIn("    cpus: 1", body)
+        self.assertIn("      MAP_PLATFORM_ARTIFACT_STORE: s3", body)
+        self.assertNotIn("    ports:", body)
 
     def setUp(self) -> None:
         self.compose = MODULE_PATH.with_name("compose.yaml")


### PR DESCRIPTION
Activates the isolated scheduler image published by Map Platform Image run 34024188732 from main 2bff706c442865ef9c07c2d5c5589991d0010ddf. Exact digest: sha256:2be730596caad6dd911a488fe22d52c48a6a702fdba559393edfb18523d98593. Registry architecture and GitHub provenance verified. API, maintenance and generation worker pins are unchanged. Scheduler has separate persistent storage, no public ports, 1 CPU and 2 GiB memory; existing production credentials stay production-only. Local deployment tests: 55 passed; Compose config validates. Catalog migration and endpoint rollout precede activation. Merge only after exact CI Gate passes.