### PR TITLE
Preserve converter identity in the promotion scheduler image

### DIFF
--- a/map-platform/backend/map_platform/automatic_promotion.py
+++ b/map-platform/backend/map_platform/automatic_promotion.py
@@ -19,7 +19,7 @@ import threading
 import time
 import uuid
 
-from .catalog import CatalogClient
+from map_platform.catalog import CatalogClient
 
 LOG = logging.getLogger(__name__)
 MAP_ID = re.compile(r"map_v1_[A-Za-z0-9_-]{43}")
@@ -112,7 +112,7 @@ def main() -> None:
     catalog = CatalogClient.from_environment()
     if catalog is None or catalog.channel != "production":
         raise SystemExit("production catalog configuration is required")
-    from .map_signing import load_map_artifact_signer_from_environment
+    from map_platform.map_signing import load_map_artifact_signer_from_environment
     if load_map_artifact_signer_from_environment() is None:
         raise SystemExit("production map signing configuration is required")
     root = Path(os.environ.get("MAP_PLATFORM_DATA_ROOT", "/data")) / "automatic-promotion"

--- a/map-platform/backend/tests/test_automatic_promotion.py
+++ b/map-platform/backend/tests/test_automatic_promotion.py
@@ -1,10 +1,16 @@
 import subprocess
+import importlib.util
+import os
 from pathlib import Path
 import tempfile
 import unittest
 from unittest.mock import Mock, patch
 
-from map_platform.automatic_promotion import JOB_TIMEOUT, PromotionQueue, run_promotion
+source = Path(os.environ.get("PROMOTION_SCHEDULER_SOURCE", Path(__file__).resolve().parents[1] / "map_platform" / "automatic_promotion.py"))
+spec = importlib.util.spec_from_file_location("automatic_promotion", source)
+promotion = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(promotion)
+JOB_TIMEOUT, PromotionQueue, run_promotion = promotion.JOB_TIMEOUT, promotion.PromotionQueue, promotion.run_promotion
 
 
 class AutomaticPromotionTests(unittest.TestCase):
@@ -23,7 +29,7 @@ class AutomaticPromotionTests(unittest.TestCase):
         self.queue.discover()
         self.assertTrue(self.queue.process_one(100))
         self.runner.assert_called_once_with(self.ids[0])
-        with patch("map_platform.automatic_promotion.subprocess.run") as run:
+        with patch.object(promotion.subprocess, "run") as run:
             run_promotion(self.ids[1])
         self.assertEqual(run.call_args.args[0], ["map-platform", "promote-catalog-map", self.ids[1]])
         self.assertEqual(run.call_args.kwargs["timeout"], JOB_TIMEOUT)
@@ -33,7 +39,7 @@ class AutomaticPromotionTests(unittest.TestCase):
     def test_failure_backoff_survives_discovery_restart_and_does_not_starve(self):
         self.queue.discover()
         self.runner.side_effect = RuntimeError("secret URL must not be logged")
-        with self.assertLogs("map_platform.automatic_promotion") as logs:
+        with self.assertLogs("automatic_promotion") as logs:
             self.queue.process_one(100)
         self.assertNotIn("secret URL", " ".join(logs.output))
         self.queue.close()

--- a/map-platform/deploy/promotion/Dockerfile
+++ b/map-platform/deploy/promotion/Dockerfile
@@ -2,10 +2,10 @@
 # signer, validation rules and producer identity byte-for-byte.
 FROM ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8 AS production-base
 FROM production-base AS runtime
-COPY map-platform/backend/map_platform/automatic_promotion.py /app/map-platform/backend/map_platform/automatic_promotion.py
+COPY map-platform/backend/map_platform/automatic_promotion.py /opt/bicino-promotion/automatic_promotion.py
 LABEL org.bicino.release-profile="production-map-promotion" \
       org.bicino.base-source="e739dfe6c0612e95db8241249dcc2edfe52d8372"
-ENTRYPOINT ["python", "-m", "map_platform.automatic_promotion"]
+ENTRYPOINT ["python", "/opt/bicino-promotion/automatic_promotion.py"]
 CMD []
 
 FROM runtime AS validation
@@ -13,4 +13,4 @@ COPY --from=production-base /app /opt/promotion-base-app
 COPY map-platform/backend/tests/test_automatic_promotion.py /opt/promotion-tests/test_automatic_promotion.py
 COPY map-platform/backend/tests/test_catalog_promotion.py /opt/promotion-tests/test_catalog_promotion.py
 COPY map-platform/deploy/promotion/test_runtime.py /opt/promotion-tests/test_runtime.py
-RUN python -m unittest discover -s /opt/promotion-tests
+RUN PROMOTION_SCHEDULER_SOURCE=/opt/bicino-promotion/automatic_promotion.py python -m unittest discover -s /opt/promotion-tests

--- a/map-platform/deploy/promotion/README.md
+++ b/map-platform/deploy/promotion/README.md
@@ -24,9 +24,10 @@ Successful publication is idempotent if its response is lost.
 
 ## Release and activation
 
-The dedicated Dockerfile adds only the scheduling module to the exact qualified
-production image. Its validation stage compares every `/app` file against the
-base and runs both scheduler and existing promotion tests. The original
+The dedicated Dockerfile puts the scheduling module under `/opt/bicino-promotion`,
+outside the qualified converter's hashed `/app` source tree. Its validation stage
+requires every `/app` file to match the base, runs the real converter identity
+check, and runs both scheduler and existing promotion tests. The original
 converter/signer producer identity remains accurate because that code is unchanged.
 No API or map-generation worker image is replaced by this candidate.
 

--- a/map-platform/deploy/promotion/test_runtime.py
+++ b/map-platform/deploy/promotion/test_runtime.py
@@ -1,7 +1,10 @@
 """The scheduling wrapper must not alter the qualified converter or signer."""
 import hashlib
+import os
 from pathlib import Path
+import tempfile
 import unittest
+from unittest.mock import patch
 
 
 class PromotionRuntimeTests(unittest.TestCase):
@@ -12,4 +15,29 @@ class PromotionRuntimeTests(unittest.TestCase):
         before = inventory(Path("/opt/promotion-base-app"))
         after = inventory(Path("/app"))
         differences = {key for key in before.keys() | after.keys() if before.get(key) != after.get(key)}
-        self.assertEqual(differences, {"map-platform/backend/map_platform/automatic_promotion.py"})
+        self.assertEqual(differences, set())
+
+    def test_real_converter_identity_verification_passes(self):
+        from map_platform.cli import _pipeline_producer_identity
+        build, image = _pipeline_producer_identity(
+            Path("/app"),
+            "ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8",
+            required=True,
+        )
+        self.assertEqual(len(build), 64)
+        self.assertEqual(image, "sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8")
+
+    def test_real_cli_reaches_promotion_with_isolated_data_root(self):
+        from map_platform.cli import main
+        with tempfile.TemporaryDirectory() as root, patch.dict(os.environ, {
+            "MAP_PLATFORM_CATALOG_URL": "https://maps-share.8o.vc",
+            "MAP_PLATFORM_CATALOG_CHANNEL": "production",
+            "MAP_PLATFORM_CATALOG_SERVICE_KEY_ID": "test-production",
+            "MAP_PLATFORM_CATALOG_SERVICE_SECRET": "s" * 48,
+            "MAP_PLATFORM_DEPLOYMENT_CHANNEL": "production",
+            "MAP_PLATFORM_WORKER_IMAGE_REFERENCE": "ghcr.io/seichris/open-bike-computer-map-platform@sha256:142957ae0d5f08d366b657f9bacb0ce17d85bfac9c5d98c644bc1b02188a59c8",
+        }), patch("map_platform.map_signing.load_map_artifact_signer_from_environment", return_value=object()), patch("map_platform.cli.create_artifact_store_from_environment", return_value=object()), patch("map_platform.catalog_promotion.promote_catalog_map", return_value={}) as promote:
+            with patch("sys.argv", ["map-platform", "--repo-root", "/app", "--data-root", root, "promote-catalog-map", "map_v1_" + "a" * 43]):
+                self.assertEqual(main(), 0)
+            promote.assert_called_once()
+            self.assertEqual(promote.call_args.kwargs["work_root"], Path(root) / "promotions")


### PR DESCRIPTION
Final preflight of the first scheduler image exposed a fail-closed identity mismatch: placing the scheduler in /app changed the qualified converter source hash. Move only the scheduling script to /opt with absolute imports; preserve every /app file. Add regression coverage that invokes the real identity verifier and real CLI initialization before mocking only the external promotion operation. Local exact-base image validation: 21 tests passed. No identity checks are disabled or hashes rewritten. PR 413 remains on hold until this fix is merged, republished and pinned.