### PR TITLE
Fix Watch Bluetooth shutdown, successor demand, and late readiness callbacks (R1–R3)

### DIFF
--- a/docs/plans/bluetooth-reliability-followups-2026-09-07.md
+++ b/docs/plans/bluetooth-reliability-followups-2026-09-07.md
@@ -1,0 +1,61 @@
+# Bluetooth reliability follow-ups (outside R1–R3 implementation)
+
+Status: proposed, not implemented or physically validated. This document does
+not authorize installation, flashing, production ride automation, or merging.
+See [the R1–R3 implementation record](bluetooth-reliability-reassessment-2026-09-06.md).
+
+## 1. Attempt-scoped callback and phone-coordinator review
+
+Review the iPhone BLEManager's actual lifecycle independently. Sharing a phase
+enum or an owner-phone reducer test does not prove runtime integration. Map its
+writer, capability, authentication, handoff and cancellation side effects before
+proposing a common adapter abstraction. Avoid replacing proven #366 delivery and
+#339 resource protections to achieve cosmetic symmetry.
+
+CoreBluetooth callbacks have no application attempt token. The R1–R3 cancellation
+barrier prevents normal old cancellation from racing a successor on the same
+peripheral; it is not a claim that arbitrary cross-attempt callback reuse has been
+eliminated. Evaluate scoped delegate ownership, explicit peripheral/session
+identity and generated traces before broadening this patch.
+
+## 2. Model-based and cross-language contract testing
+
+Extend deterministic adapter traces with generated permutations of authentication,
+CAP2, disconnect, radio state, revocation, selected-device changes, restoration,
+clock expiry and simultaneous navigation/workout boundaries. Shrink failing traces
+into named regression cases. Test against the real shared queue and session code;
+a copied policy or regex assertion is not adapter validation.
+
+Keep Swift/C++ golden vectors for authenticated framing, scoped permissions,
+lease generation, grouped RCM1/RAK1 delivery, stale/duplicate acknowledgements,
+terminal replay and malformed/rejected data. Existing generation, capacity and
+retry invariants remain hard requirements. Validate changed contracts jointly
+rather than editing generated output independently.
+
+## 3. Privacy-bounded observability
+
+Assess whether existing transition/timeout diagnostics adequately distinguish
+lease release, phone-outbox admission and peripheral cancellation. Add only
+bounded non-secret counters/IDs if evidence shows a gap. Never log credentials,
+nonces, protected payloads, route coordinates or workout values as a shortcut.
+Measure distributions of handoff, negotiation and cancellation latency before
+changing deadlines. Record explicit reasons for failed cancellation recovery.
+
+## 4. Authorized physical qualification
+
+First confirm the exact physical board and profile. Record exact app, Watch and
+firmware build/commit identities. Use repository build/boot tools and preserve the
+#339 DMA/crypto acceptance gates. No host or CI result substitutes for this step.
+
+Exercise repeated navigation-only, workout-only and simultaneous stop/start;
+phone nearby/absent/unreachable; WatchConnectivity activation and relaunch;
+Bluetooth-off/on and unexpected disconnect at every shutdown stage; foreground,
+background and wrist-down execution; preparation selection/revocation; terminal
+ACK loss/retry; and successor rides during release/cancellation. Verify exactly
+matched phone release, no unintended writer overlap, latest-state replay, and
+explicit bounded failure when cancellation never completes.
+
+Collect battery/thermal, latency and sustained-session measurements under the
+normal renderer workload. Preserve exact-head evidence and separate cold-start,
+warm-reset and radio recovery results. Obtain further authorization before any
+installation or flash operation.

--- a/docs/plans/bluetooth-reliability-reassessment-2026-09-06.md
+++ b/docs/plans/bluetooth-reliability-reassessment-2026-09-06.md
@@ -1,0 +1,203 @@
+# Bluetooth reliability reassessment — R1–R3 implementation record
+
+Updated: 2026-09-07. Scope: review and implementation, not merge, installation,
+flashing, or physical-device qualification.
+
+## Baseline and independent reassessment
+
+The analysis was read directly from unmerged PR [#418](https://github.com/seichris/open-bike-computer/pull/418),
+head `b263052c9f45231f2d98feaa70e4f3ec3b825c7b`, plan blob
+`d71f741e9d52fb739d830a24a342f1863cfdf9ae`. This document is the implementation
+record at that plan's path; the original proposal remains available at its pinned
+PR head. Broader work is separated into
+[the follow-up plan](bluetooth-reliability-followups-2026-09-07.md).
+
+Fresh GitHub main was checked before review and again before publication:
+`fe73e43431ed76c39159de7624c4cd9ede509434`. It still equals the reviewed baseline;
+there were no subsequent main fixes to subtract from R1–R3. PR #393's workout
+navigation/rerouting changes are already in this baseline. PRs #339 and #366 are
+merged; their existing code and validation history are not a validation result
+for this implementation.
+
+The reviewed production source blobs were independently hash-verified:
+
+- `WatchDeviceLink.swift`: `a3117e3fb4224c0a23cd427844c7d296109aa83d`.
+- `RideBLETransportStateMachine.swift`: `08b89bac91a3ec451c96e59c2f397f7d2a6d5154`.
+
+An isolated Git worktree and implementation branch were created from the exact
+main commit. Container DNS prevented ordinary Git clone/push. Source and Git
+objects were fetched through the GitHub connector; the local worktree is sparse,
+not a complete checkout. Publication uses a tree based on the original main tree,
+replacing only this implementation's explicitly listed paths. No existing user
+checkout or unrelated file is changed.
+
+### R1 — confirmed: shutdown can orphan a phone preparation
+
+At baseline, `stop()` retains the old preparation while waiting for
+`LEASE_RELEASED` or its deadline. `didDisconnectPeripheral` calls
+`resetTransport`, which cancels that deadline and clears `gracefulStopPending`
+without going through `completeStop()`'s phone release. The phone-side preparation
+can therefore remain active after the last Watch demand ended.
+
+This is not an assertion of permanent phone suppression: the existing phone
+policy expires it. The defect is loss of prompt, identity-matched release, not
+absence of all eventual expiry.
+
+### R2 — confirmed, with a path-specific qualification
+
+The baseline published state can remain `ready` while the reducer is `stopping`.
+A new navigation/workout demand is recorded but `beginIfNeeded()` returns because
+of that published readiness. ACK/deadline completion then resets to idle without
+reconciling the retained demand. A later unrelated update can mask the stall.
+
+The baseline ordinary-disconnect path already schedules reconnect when demand
+exists, and radio-on can restart it. Those paths must not be described as always
+permanently stranded. They still bypass the common shutdown/preparation boundary.
+Latest logical snapshots already survive the reset; the missing behavior is
+correct scheduling and replay on a fresh, admitted successor connection.
+
+### R3 — confirmed in the reducer and Watch adapter; phone claim narrowed
+
+At baseline, lease/capability acceptance does not require an appropriate phase.
+A same-generation writer-idle callback can also overwrite recovering writer
+state. Deterministic reducer sequences produce `becameReady` after stopping or
+recovery. Watch callback handling can consequently publish readiness, start a
+heartbeat, and replay data at the wrong lifecycle boundary.
+
+The reducer is parameterized for owner-phone and scoped-Watch roles, and the
+counterexample reproduces for both role values. Source search and inspection only
+identified a runtime reducer instance in `WatchDeviceLink`; `BLEManager` also uses
+shared phase types, but this is **not** evidence of a reproduced iPhone adapter
+failure. The implementation does not claim to repair or rewrite that separate
+phone coordinator.
+
+## Implemented lifecycle boundary
+
+`RideBLETransportStateMachineV1` is the authority for readiness, callback
+admission, recovery, and shutdown stage. Its stop stage is `releasingLease` then
+`awaitingDisconnect`. The redundant `gracefulStopPending` flag is removed.
+`WatchDeviceLinkState.stopping` is a UI projection, not a second state machine.
+Existing connection/write identities and logical demand retain their separate
+purposes; no wire generation or protocol schema was changed.
+
+1. All explicit stop completions (release ACK, release deadline, disconnect,
+   failed connection, radio loss, and defensive reset during stopping) handle the
+   old phone-preparation identity before cleanup can cancel its completion task.
+   Unavailable WatchConnectivity retains a persisted release intent. Successful
+   submission keeps the existing durable-outbox ownership semantics.
+2. Demand setters and snapshot updates keep the latest successor state but cannot
+   prepare or write it on a stopping lease. Shutdown clears only connection-scoped
+   bytes. Completion re-evaluates current demand and selection and starts a fresh
+   connection/preparation, then normal readiness performs full logical resync.
+3. Same-generation lease/capability/writer callbacks are phase-gated. Delegates
+   honor rejected reducer transitions before publishing state or performing
+   discovery. Late discovery errors cannot overwrite stopping/recovery. Duplicate
+   ready CAP2 refreshes do not repeat heartbeat startup or replay.
+4. The existing terminal-clear demand remains until the atomic group has both
+   physically completed and received its application acknowledgement. The stop
+   release is ordered behind already-admitted groups. No new ride groups enter
+   during stopping. Application ACK processing remains available while an old
+   admitted group is draining; it cannot restore readiness.
+
+### Cancellation boundary and bounded failure
+
+A lease ACK is not a CoreBluetooth disconnection callback. The successor cannot
+reuse the same peripheral until cancellation has completed. Otherwise an old
+cancellation callback, which has no logical attempt ID, can tear down its successor.
+
+The existing five-second lease-release wait is retained. Cancellation has a
+separate five-second bound. If that callback never arrives, the adapter preserves
+demand, reports an actionable Bluetooth-retry error, and does not start an
+unsafe overlapping connection. An actual disconnect or radio cycle can recover.
+This is an explicit failure state, not an idle-with-demand stall; the extra bound
+is not claimed to be physically tuned. Radio loss is itself a link-loss boundary.
+
+Normal active-ride disconnect/recovery retains phone preparation and demand.
+Credential revocation during a stop requests cancellation through the same stop
+boundary rather than reusing the peripheral early.
+
+## Regression tests and reproducibility
+
+`ios-app/scripts/run-watch-device-link-tests.sh` runs the reducer matrix and the
+complete production Watch adapter. `run-ride-shared-tests.sh` invokes it so the
+existing native shared-test CI entry point also exercises adapter coordination.
+The test files live under `ios-app/scripts/bluetooth-tests`, outside app targets.
+
+The native adapter runner substitutes only the CoreBluetooth radio boundary and
+an in-memory credential store; it compiles the real RideShared/WorkoutShared
+contracts, authentication/session implementation, packet encoding, bounded atomic
+queue, and application-ACK policy. Same-file test access is appended to a temporary
+copy of the **whole** adapter. No lifecycle model or extracted lifecycle method
+replaces production coordination. Authenticated ingress fixtures do not themselves
+prove cryptographic interoperability; the existing shared-contract suite supplies
+that separate coverage. Stop deadlines use an injected deterministic clock.
+
+Coverage includes ACK/deadline/disconnect/radio completion; navigation-only,
+workout-only and simultaneous successor demand; unavailable preparation submission
+and relaunch; stale preparation response/failure IDs; latest navigation/workout
+resync; independent demand withdrawal; late writer/CAP2/discovery callbacks;
+readiness refresh idempotence; terminal ATT versus application-ACK ordering; active
+ride recovery; and missing cancellation callback with radio-cycle recovery.
+
+Commands on macOS:
+
+```sh
+ios-app/scripts/run-watch-device-link-tests.sh
+ios-app/scripts/run-ride-shared-tests.sh
+ios-app/scripts/run-watch-source-typecheck.sh
+ios-app/scripts/run-navigation-tests.sh
+ios-app/scripts/run-workout-contract-tests.sh
+# Platform suites/builds must use repository scripts, including xcodebuild-cli.sh.
+```
+
+Portable reducer-only command:
+
+```sh
+ios-app/scripts/run-watch-device-link-tests.sh --reducer-only
+```
+
+### Local evidence — completed
+
+- Original hash-verified production reducer reproduced all four stop/recovery
+  counterexamples (two roles). Each incorrectly returned `becameReady`.
+- Initial actual-adapter lifecycle matrix: **115 assertions, 53 failures on the
+  baseline; 115 assertions, zero failures after the fixes**.
+- Expanded adapter matrix: **150 assertions, zero failures** after the fixes.
+- Production reducer permutation/identity matrix: **2,014 assertions passed**.
+- Shell syntax checks passed for the changed test runners.
+
+**Local limitation:** this Linux container lacks Xcode, Apple SDKs and CryptoKit.
+The local whole-adapter runs used explicitly local-only leaf stand-ins for SDK,
+wire and queue dependencies. They are useful counterexamples of the actual
+adapter's coordination but are **not** native integration, cryptographic, packet,
+or real-queue validation. Those stand-ins are not committed. The native runner
+uses the real shared contracts instead. No local iOS/watchOS build, full platform
+suite, firmware build or physical test is represented as passed.
+
+### CI evidence — publication gate
+
+The new native runner is wired into the existing shared-test script. Native
+compilation, real-contract adapter execution, existing shared/navigation/workout
+regressions, and the normal CI gate must be evaluated on the implementation PR's
+actual head. Pending or unavailable checks are not passes. Historical #339/#366
+CI results do not satisfy this gate. No manual 2.06-inch firmware job is requested.
+
+### Physical evidence — not run
+
+No iPhone, Watch or ESP32 was installed, flashed, or exercised. Before physical
+qualification, record the exact app/Watch/firmware commits, signed build identities,
+board/profile and OS versions. Run the separate follow-up matrix with explicit
+user authorization; do not infer radio, background execution, memory, power or
+battery behavior from host/CI results.
+
+## Preservation and review boundaries
+
+No firmware, generated BLE protocol, capability bit assignment, authentication
+cryptography, scoped-controller authorization, lease wire format, RCM1/RAK1
+format, retry budget, queue capacity, or acknowledgement identity policy changes.
+#339's DMA/crypto/TLS protections remain untouched. The Watch writer changes are
+limited to lifecycle admission and release ordering around the existing grouped
+writer. #366's durable preparation/outbox and terminal delivery contracts remain
+in place. Broader phone coordination, attempt-scoped delegate design, model-based
+fuzzing and physical qualification are tracked separately rather than implied to
+be solved by this patch.

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchDeviceLink.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchDeviceLink.swift
@@ -12,6 +12,7 @@ enum WatchDeviceLinkState: Equatable {
     case discovering
     case authenticating
     case claimingLease
+    case stopping
     case ready(deviceID: String)
     case busy
     case failed(String)
@@ -42,6 +43,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
 
     private let credentialStore: WatchControllerCredentialStore
     private let defaults: UserDefaults
+    private let stopDelay: @Sendable () async throws -> Void
     private let serviceUUID = CBUUID(
         string: WatchDirectBLEProtocolV1.serviceUUID
     )
@@ -121,7 +123,6 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     private var operationTimeoutTask: Task<Void, Never>?
     private var reconnectAttempt = 0
     private var disconnectingForBusyLease = false
-    private var gracefulStopPending = false
     private var leaseReleaseAckTask: Task<Void, Never>?
     private var latestWorkoutFrames: WorkoutDeviceFrames?
     private var latestWorkoutGPS: WorkoutDeviceGPSUpdate?
@@ -151,10 +152,14 @@ final class WatchDeviceLink: NSObject, ObservableObject {
 
     init(
         credentialStore: WatchControllerCredentialStore,
-        defaults: UserDefaults = .standard
+        defaults: UserDefaults = .standard,
+        stopDelay: @escaping @Sendable () async throws -> Void = {
+            try await Task.sleep(for: .seconds(5))
+        }
     ) {
         self.credentialStore = credentialStore
         self.defaults = defaults
+        self.stopDelay = stopDelay
         if let data = defaults.data(forKey: selectedBikeComputerKey) {
             selectedBikeComputerEnvelope = try?
                 WatchSelectedBikeComputerV1.decode(data)
@@ -200,10 +205,11 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         selectedBikeComputerEnvelope = incoming
         defaults.set(data, forKey: selectedBikeComputerKey)
         guard previousDeviceID != incoming.deviceID else { return }
+        guard !isStopping else { return }
 
         releasePhonePreparationIfNeeded()
 
-        let canRetainReadySession = state.isReady &&
+        let canRetainReadySession = isReady &&
             credential?.deviceID == incoming.deviceID
         if !canRetainReadySession {
             reconnectTask?.cancel()
@@ -212,7 +218,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             operationTimeoutTask = nil
             heartbeatTimer?.invalidate()
             heartbeatTimer = nil
-            if state.isReady {
+            if isReady {
                 writeProtectedAuth("LEASE_RELEASE")
             }
             if let peripheral {
@@ -291,6 +297,12 @@ final class WatchDeviceLink: NSObject, ObservableObject {
                 controllerID: active.controllerID
             ))
         } ?? false
+        if isStopping {
+            if activeWasRevoked {
+                beginStopDisconnection(generation: connectionGeneration)
+            }
+            return
+        }
         if activeWasRevoked {
             reconnectTask?.cancel()
             reconnectTask = nil
@@ -298,7 +310,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             operationTimeoutTask = nil
             heartbeatTimer?.invalidate()
             heartbeatTimer = nil
-            if state.isReady {
+            if isReady {
                 writeProtectedAuth("LEASE_RELEASE")
             }
             if let peripheral {
@@ -314,12 +326,15 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         guard hasDemand else { return }
         if credentials.isEmpty {
             state = .notEnrolled
-        } else if !state.isReady {
+        } else if !isReady {
             beginIfNeeded()
         }
     }
 
     private func reconcileDemand() {
+        // Setters still retain the successor's demand. Do not prepare it or
+        // write it on the lease whose shutdown is already in progress.
+        guard !isStopping else { return }
         guard hasDemand else {
             stop()
             return
@@ -332,7 +347,8 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         request: WatchDirectRidePreparationRequestV1,
         response: WatchDirectRidePreparationResponseV1
     ) {
-        guard request.operation == .prepare,
+        guard !isStopping, !phonePreparationReleasePending,
+              request.operation == .prepare,
               request.deviceID == preparedPhoneDeviceID,
               request.preparationID == preparedPhonePreparationID,
               request.deviceID == selectedBikeComputerEnvelope?.deviceID,
@@ -348,7 +364,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             return
         }
         phonePreparationAccepted = false
-        guard !state.isReady else { return }
+        guard !isReady else { return }
         if state == .scanning {
             central.stopScan()
         }
@@ -375,7 +391,8 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     func directRidePreparationSubmissionDidFail(
         request: WatchDirectRidePreparationRequestV1
     ) {
-        guard request.operation == .prepare,
+        guard !isStopping, !phonePreparationReleasePending,
+              request.operation == .prepare,
               request.deviceID == preparedPhoneDeviceID,
               request.preparationID == preparedPhonePreparationID,
               hasDemand else { return }
@@ -387,6 +404,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     func directRidePreparationAvailabilityDidChange() {
+        guard !isStopping else { return }
         if hasDemand {
             if phonePreparationReleasePending,
                preparedPhoneDeviceID ==
@@ -422,7 +440,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         latestLocation = location
         latestNavigationSnapshot = snapshot
         latestRouteWindow = snapshot.routeWindow
-        guard state.isReady else { return }
+        guard isReady else { return }
         enqueueLiveNavigation(
             location: location,
             snapshot: snapshot,
@@ -434,7 +452,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         latestLocation = nil
         latestNavigationSnapshot = nil
         latestRouteWindow = Data()
-        guard state.isReady else { return }
+        guard isReady else { return }
         _ = enqueueGroup(
             priority: .control,
             disposition: .critical,
@@ -465,7 +483,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     ) {
         latestWorkoutFrames = frames
         latestWorkoutGPS = gps
-        guard state.isReady else { return }
+        guard isReady else { return }
         enqueueWorkoutFrames(frames)
         enqueueWorkoutGPSIfNeeded()
         drainQueue()
@@ -474,14 +492,14 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     func clearWorkout(_ frames: WorkoutDeviceFrames) {
         latestWorkoutFrames = frames
         latestWorkoutGPS = nil
-        guard state.isReady else { return }
+        guard isReady else { return }
         enqueueWorkoutFrames(frames)
         drainQueue()
     }
 
     @discardableResult
     func sendRideAutomationFrame(_ frame: RideAutomationFrame) -> Bool {
-        guard state.isReady,
+        guard isReady,
               capabilities?.supportsRideAutomation == true,
               let payload = frame.encoded(),
               let transport = WatchRideAutomationTransportV1.outbound(
@@ -519,13 +537,17 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         demand.requiresConnection
     }
 
+    private var isReady: Bool { transportStateMachine.isReady }
+    private var isStopping: Bool { transportStateMachine.phase == .stopping }
+
     private struct CredentialIdentity: Hashable {
         let deviceID: String
         let controllerID: Data
     }
 
     private func beginIfNeeded() {
-        guard hasDemand, !state.isReady else { return }
+        guard hasDemand, !isReady, !isStopping,
+              transportStateMachine.phase != .recovering else { return }
         if state == .busy {
             requestPhonePreparationIfNeeded(force: true)
         } else {
@@ -591,7 +613,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func requestPhonePreparationIfNeeded(force: Bool = false) {
-        guard hasDemand,
+        guard hasDemand, !isStopping,
               let deviceID = selectedBikeComputerEnvelope?.deviceID else {
             return
         }
@@ -729,7 +751,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         heartbeatTimer?.invalidate()
         heartbeatTimer = nil
         if state == .scanning { central.stopScan() }
-        if state.isReady {
+        if isReady {
             writeProtectedAuth("LEASE_RELEASE")
         }
         if let peripheral {
@@ -756,6 +778,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         _ candidate: CBPeripheral,
         credential: WatchControllerCredentialV1
     ) {
+        guard !isStopping, transportStateMachine.phase != .recovering else { return }
         central.stopScan()
         resetTransport(keepingPeripheral: false)
         connectionGeneration &+= 1
@@ -771,7 +794,8 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func stop() {
-        if gracefulStopPending { return }
+        guard !isStopping, !hasDemand else { return }
+        let releaseLease = isReady && protectedSession != nil
         reconnectTask?.cancel()
         reconnectTask = nil
         operationTimeoutTask?.cancel()
@@ -779,48 +803,98 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         heartbeatTimer?.invalidate()
         heartbeatTimer = nil
         disconnectingForBusyLease = false
-        demand.reset()
-        if state.isReady, protectedSession != nil, !gracefulStopPending {
-            _ = reduceTransport(.stopRequested(
-                generation: transportStateMachine.generation
-            ))
-            gracefulStopPending = true
+        if state == .scanning { central.stopScan() }
+        _ = reduceTransport(.stopRequested(
+            generation: transportStateMachine.generation
+        ))
+        let generation = connectionGeneration
+        if releaseLease {
+            // Arm before writing: synchronous admission/write failure can
+            // complete shutdown and must not leave a newly armed stale timer.
+            armStopDeadline(generation: generation, disconnecting: false)
             writeProtectedAuth("LEASE_RELEASE")
-            leaseReleaseAckTask?.cancel()
-            let generation = connectionGeneration
-            leaseReleaseAckTask = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(5))
-                guard !Task.isCancelled, let self,
-                      self.gracefulStopPending,
-                      self.connectionGeneration == generation else { return }
-                self.leaseReleaseAckTask = nil
-                self.completeStop()
-            }
-            return
+        } else {
+            beginStopDisconnection(generation: generation)
         }
-        completeStop()
     }
 
-    private func completeStop() {
-        gracefulStopPending = false
+    private func armStopDeadline(generation: UInt64, disconnecting: Bool) {
         leaseReleaseAckTask?.cancel()
-        leaseReleaseAckTask = nil
-        if let peripheral {
-            central.cancelPeripheralConnection(peripheral)
+        leaseReleaseAckTask = Task { [weak self, stopDelay] in
+            try? await stopDelay()
+            guard !Task.isCancelled, let self,
+                  self.isStopping,
+                  self.connectionGeneration == generation else { return }
+            self.leaseReleaseAckTask = nil
+            if disconnecting {
+                guard self.transportStateMachine.stopStage ==
+                        .awaitingDisconnect else { return }
+                // Do not reuse a peripheral before CoreBluetooth confirms
+                // cancellation: its callbacks carry no connection-generation
+                // identifier. Demand survives; disconnect or a radio cycle
+                // can resume it. A missing callback is an actionable failure,
+                // not an idle-with-demand stall or a blind overlapping retry.
+                let message = "Bicino did not disconnect. Toggle Bluetooth to retry."
+                self.lastError = message
+                self.state = .failed(message)
+                _ = self.reduceTransport(.failed(
+                    generation: self.transportStateMachine.generation,
+                    reason: .connectionFailed
+                ))
+            } else {
+                guard self.transportStateMachine.stopStage ==
+                        .releasingLease else { return }
+                self.beginStopDisconnection(generation: generation)
+            }
         }
-        if transportStateMachine.phase != .idle {
-            _ = reduceTransport(.disconnected(
-                generation: transportStateMachine.generation
-            ))
+    }
+
+    private func beginStopDisconnection(generation: UInt64) {
+        guard isStopping, connectionGeneration == generation,
+              transportStateMachine.stopStage == .releasingLease else { return }
+        _ = reduceTransport(.disconnectRequested(
+            generation: transportStateMachine.generation
+        ))
+        // Persist/submit the old identity before any successor can prepare.
+        // A failed submission remains a durable release, not an orphan prepare.
+        releasePhonePreparationIfNeeded()
+        writerWatchdogTask?.cancel()
+        withoutResponseWatchdogTask?.cancel()
+        applicationAckWatchdogTask?.cancel()
+        queue.removeAll()
+        activeWriteGroup = nil
+        activeWriteIndex = 0
+        pendingATTWrite = nil
+        writeWithResponseInFlight = false
+        pendingApplicationAckGroup = nil
+        bufferedApplicationAcknowledgement = nil
+        guard let peripheral, central.state == .poweredOn else {
+            completeStop(generation: generation)
+            return
         }
+        armStopDeadline(generation: generation, disconnecting: true)
+        central.cancelPeripheralConnection(peripheral)
+    }
+
+    private func completeStop(generation: UInt64) {
+        guard isStopping, connectionGeneration == generation else { return }
+        // Keep stopping authoritative while calling the handoff boundary: a
+        // synchronous observer can add demand, but cannot prepare it early.
+        releasePhonePreparationIfNeeded()
         connectionGeneration &+= 1
         resetTransport(keepingPeripheral: false)
-        releasePhonePreparationIfNeeded()
         state = .idle
         lastError = nil
+        // Reset only connection-scoped bytes. The current demand and latest
+        // logical navigation/workout state belong to the successor ride.
+        if hasDemand { beginIfNeeded() }
     }
 
     private func resetTransport(keepingPeripheral: Bool) {
+        // Selection/revocation/fail-closed cleanup may also end a stop. Keep
+        // this invariant at the common reset boundary, before clearing phase
+        // or cancelling its deadline. Normal active-ride recovery retains prep.
+        if isStopping { releasePhonePreparationIfNeeded() }
         if transportStateMachine.phase != .idle {
             _ = reduceTransport(.disconnected(
                 generation: transportStateMachine.generation
@@ -830,7 +904,6 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         heartbeatTimer = nil
         leaseReleaseAckTask?.cancel()
         leaseReleaseAckTask = nil
-        gracefulStopPending = false
         operationTimeoutTask?.cancel()
         operationTimeoutTask = nil
         authentication = nil
@@ -865,8 +938,9 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func beginAuthentication() {
-        guard authentication == nil,
-              let credential,
+        guard transportStateMachine.phase == .authenticating,
+              authentication == nil else { return }
+        guard let credential,
               let nonce = Self.randomNonce() else {
             fail("Could not begin Watch authentication")
             return
@@ -886,6 +960,9 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func handleAuthNotification(_ raw: Data) {
+        guard transportStateMachine.phase != .idle,
+              transportStateMachine.phase != .recovering,
+              transportStateMachine.stopStage != .awaitingDisconnect else { return }
         if raw.prefix(2) == Data([0x52, 0x32]) {
             guard let protectedSession,
                   let payload = protectedSession.notificationPayload(
@@ -899,6 +976,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             handleProtectedAuthMessage(message)
             return
         }
+        guard transportStateMachine.phase == .authenticating else { return }
         guard let message = String(
             data: raw.trimmingTrailingTransportBytes(),
             encoding: .utf8
@@ -918,9 +996,9 @@ final class WatchDeviceLink: NSObject, ObservableObject {
                     message,
                     challenge: challenge
                 )
-                _ = reduceTransport(.authenticated(
+                guard reduceTransport(.authenticated(
                     generation: transportStateMachine.generation
-                ))
+                )) == .applied else { return }
                 state = .claimingLease
                 writeProtectedAuth("LEASE_CLAIM")
             } else if message.hasPrefix("DENIED|") {
@@ -934,21 +1012,25 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func handleProtectedAuthMessage(_ message: String) {
+        if isStopping {
+            guard message == "LEASE_RELEASED",
+                  transportStateMachine.stopStage == .releasingLease else { return }
+            _ = reduceTransport(.leaseReleased(
+                generation: transportStateMachine.generation
+            ))
+            beginStopDisconnection(generation: connectionGeneration)
+            return
+        }
+        guard transportStateMachine.phase != .idle,
+              transportStateMachine.phase != .recovering else { return }
         switch message {
         case "LEASE_OK":
             if state == .claimingLease {
-                _ = reduceTransport(.leaseAccepted(
+                guard reduceTransport(.leaseAccepted(
                     generation: transportStateMachine.generation,
                     leaseGeneration: 1
-                ))
+                )) == .applied else { return }
                 requestCapabilities()
-            }
-        case "LEASE_RELEASED":
-            if gracefulStopPending {
-                _ = reduceTransport(.leaseReleased(
-                    generation: transportStateMachine.generation
-                ))
-                completeStop()
             }
         case "ERROR|lease_busy":
             _ = reduceTransport(.failed(
@@ -984,6 +1066,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func handleNavigationNotification(_ raw: Data) {
+        guard transportStateMachine.acceptsWriterCallbacks else { return }
         guard let protectedSession,
               let payload = protectedSession.notificationPayload(
                 from: raw,
@@ -992,6 +1075,11 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             fail("Bike Computer sent invalid protected navigation data")
             return
         }
+        handleAuthenticatedNavigationPayload(payload)
+    }
+
+    private func handleAuthenticatedNavigationPayload(_ payload: Data) {
+        guard transportStateMachine.acceptsWriterCallbacks else { return }
         if payload.starts(with: RideBLEApplicationAcknowledgementV1.prefix) {
             guard let acknowledgement =
                     RideBLEApplicationAcknowledgementV1.decode(payload) else {
@@ -1004,8 +1092,11 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             handleApplicationAcknowledgement(acknowledgement)
             return
         }
+        // Terminal application ACKs above can still finish already-admitted
+        // work before LEASE_RELEASE. Capabilities/automation must not revive it.
+        guard transportStateMachine.acceptsReadinessCallbacks else { return }
         if payload.starts(with: WatchRideAutomationTransportV1.fallbackPrefix) {
-            guard state.isReady,
+            guard isReady,
                   capabilities?.supportsRideAutomation == true,
                   let framePayload = WatchRideAutomationTransportV1
                     .decodeNavigationFallback(payload),
@@ -1037,20 +1128,17 @@ final class WatchDeviceLink: NSObject, ObservableObject {
                 return
             }
         }
-        self.capabilities = capabilities
         let transportTransition = reduceTransport(.capabilitiesAccepted(
             generation: transportStateMachine.generation,
             schemaVersion: 1
         ))
         guard transportTransition == .becameReady ||
                 (transportTransition == .applied &&
-                 transportStateMachine.isReady) else {
-            fail(
-                "Watch transport could not establish authoritative readiness",
-                reason: .capabilityRejected
-            )
-            return
-        }
+                 transportStateMachine.isReady) else { return }
+        self.capabilities = capabilities
+        // A duplicate/refresh CAP2 is idempotent. Only the transition into
+        // readiness owns heartbeat startup and full-state replay.
+        guard transportTransition == .becameReady else { return }
         reconnectAttempt = 0
         lastError = nil
         state = .ready(deviceID: credential?.deviceID ?? "")
@@ -1063,8 +1151,8 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func handleRideAutomationNotification(_ raw: Data) {
-        guard state.isReady,
-              capabilities?.supportsRideAutomation == true,
+        guard isReady else { return }
+        guard capabilities?.supportsRideAutomation == true,
               let protectedSession,
               let payload = protectedSession.notificationPayload(
                 from: raw,
@@ -1267,6 +1355,13 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         coalescingKey: String? = nil,
         writes: [WatchBLEOutboundWriteV1]
     ) -> Bool {
+        guard transportStateMachine.acceptsWriterCallbacks else { return false }
+        if isStopping {
+            guard writes.count == 1,
+                  writes[0].target == .auth,
+                  writes[0].protection == .protected,
+                  writes[0].payload == Data("LEASE_RELEASE".utf8) else { return false }
+        }
         nextOutboundStateGeneration &+= 1
         if nextOutboundStateGeneration == 0 {
             nextOutboundStateGeneration = 1
@@ -1295,8 +1390,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
 
     private func drainQueue() {
         guard let peripheral,
-              transportStateMachine.phase != .idle,
-              transportStateMachine.phase != .recovering,
+              transportStateMachine.acceptsWriterCallbacks,
               !writeWithResponseInFlight,
               pendingApplicationAckGroup == nil else { return }
         while true {
@@ -1648,7 +1742,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
     }
 
     private func finishPendingReleasesIfPossible() {
-        guard state.isReady,
+        guard isReady,
               demand.hasPendingRelease,
               queue.isEmpty,
               activeWriteGroup == nil,
@@ -1698,7 +1792,9 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         let coalescingKey = message == "LEASE_HEARTBEAT"
             ? "lease-heartbeat" : nil
         guard enqueueGroup(
-            priority: .control,
+            // A stop is a barrier behind every already-admitted group, not a
+            // high-priority command that can overtake a terminal application ACK.
+            priority: isStopping ? .diagnostics : .control,
             disposition: .critical,
             coalescingKey: coalescingKey,
             writes: [.init(target: .auth, payload: data)]
@@ -1713,7 +1809,7 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             repeats: true
         ) { [weak self] _ in
             MainActor.assumeIsolated {
-                guard self?.state.isReady == true else { return }
+                guard self?.isReady == true else { return }
                 self?.writeProtectedAuth("LEASE_HEARTBEAT")
             }
         }
@@ -1726,6 +1822,11 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         let transition = transportStateMachine.reduce(event)
         transportPhase = transportStateMachine.phase
         transportFailureReason = transportStateMachine.lastFailure
+        if isStopping {
+            state = .stopping
+        } else if !isReady, state.isReady {
+            state = .idle
+        }
         recordTransportDiagnostic(kind: .transportTransition)
         return transition
     }
@@ -1779,6 +1880,10 @@ final class WatchDeviceLink: NSObject, ObservableObject {
         _ message: String,
         reason: RideBLETransportFailureReasonV1 = .connectionFailed
     ) {
+        if isStopping {
+            beginStopDisconnection(generation: connectionGeneration)
+            return
+        }
         guard transportStateMachine.phase != .recovering else { return }
         let wasScanning = state == .scanning
         lastError = message
@@ -1788,6 +1893,8 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             reason: reason
         ))
         recordTransportDiagnostic(kind: .recovery)
+        heartbeatTimer?.invalidate()
+        heartbeatTimer = nil
         operationTimeoutTask?.cancel()
         operationTimeoutTask = nil
         writerWatchdogTask?.cancel()
@@ -1819,14 +1926,14 @@ final class WatchDeviceLink: NSObject, ObservableObject {
             try? await Task.sleep(for: .seconds(20))
             guard !Task.isCancelled, let self,
                   self.connectionGeneration == generation,
-                  !self.state.isReady else { return }
+                  !self.isReady else { return }
             self.operationTimeoutTask = nil
             self.fail("Bike Computer connection timed out")
         }
     }
 
     private func scheduleReconnect() {
-        guard hasDemand, reconnectTask == nil else { return }
+        guard hasDemand, !isStopping, reconnectTask == nil else { return }
         reconnectAttempt = min(reconnectAttempt + 1, 6)
         let delay = min(pow(2, Double(reconnectAttempt - 1)), 30)
         let generation = connectionGeneration
@@ -1883,6 +1990,10 @@ final class WatchDeviceLink: NSObject, ObservableObject {
 
 extension WatchDeviceLink: @preconcurrency CBCentralManagerDelegate {
     func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        if central.state != .poweredOn, isStopping {
+            completeStop(generation: connectionGeneration)
+            return
+        }
         guard hasDemand else { return }
         if central.state == .poweredOn {
             beginIfNeeded()
@@ -1945,9 +2056,9 @@ extension WatchDeviceLink: @preconcurrency CBCentralManagerDelegate {
             central.cancelPeripheralConnection(connected)
             return
         }
-        _ = reduceTransport(.linkConnected(
+        guard reduceTransport(.linkConnected(
             generation: transportStateMachine.generation
-        ))
+        )) == .applied else { return }
         state = .discovering
         connected.discoverServices([serviceUUID])
     }
@@ -1958,6 +2069,10 @@ extension WatchDeviceLink: @preconcurrency CBCentralManagerDelegate {
         error: Error?
     ) {
         guard peripheral?.identifier == failed.identifier else { return }
+        if isStopping {
+            completeStop(generation: connectionGeneration)
+            return
+        }
         _ = reduceTransport(.failed(
             generation: transportStateMachine.generation,
             reason: .connectionFailed
@@ -1978,6 +2093,11 @@ extension WatchDeviceLink: @preconcurrency CBCentralManagerDelegate {
         error: Error?
     ) {
         guard peripheral?.identifier == disconnected.identifier else { return }
+        // Capture shutdown before reset consumes its phase and deadline.
+        if isStopping {
+            completeStop(generation: connectionGeneration)
+            return
+        }
         if transportStateMachine.phase != .idle {
             _ = reduceTransport(.disconnected(
                 generation: transportStateMachine.generation
@@ -2006,7 +2126,9 @@ extension WatchDeviceLink: @preconcurrency CBPeripheralDelegate {
         didDiscoverServices error: Error?
     ) {
         guard self.peripheral?.identifier == peripheral.identifier,
-              error == nil,
+              transportStateMachine.phase == .authenticating,
+              state == .discovering else { return }
+        guard error == nil,
               let service = peripheral.services?.first(where: {
                   $0.uuid == serviceUUID
               }) else {
@@ -2032,7 +2154,9 @@ extension WatchDeviceLink: @preconcurrency CBPeripheralDelegate {
         error: Error?
     ) {
         guard self.peripheral?.identifier == peripheral.identifier,
-              error == nil else {
+              transportStateMachine.phase == .authenticating,
+              state == .discovering else { return }
+        guard error == nil else {
             fail("Bike Computer characteristics are unavailable")
             return
         }
@@ -2067,9 +2191,9 @@ extension WatchDeviceLink: @preconcurrency CBPeripheralDelegate {
         didUpdateNotificationStateFor characteristic: CBCharacteristic,
         error: Error?
     ) {
-        guard self.peripheral?.identifier == peripheral.identifier else {
-            return
-        }
+        guard self.peripheral?.identifier == peripheral.identifier,
+              transportStateMachine.phase == .authenticating,
+              authentication == nil else { return }
         guard error == nil, characteristic.isNotifying else {
             fail("Bike Computer notifications could not be enabled")
             return
@@ -2105,6 +2229,7 @@ extension WatchDeviceLink: @preconcurrency CBPeripheralDelegate {
         error: Error?
     ) {
         guard self.peripheral?.identifier == peripheral.identifier,
+              transportStateMachine.acceptsWriterCallbacks,
               let pending = pendingATTWrite,
               pending.peripheralID == peripheral.identifier,
               pending.connectionGeneration == connectionGeneration,
@@ -2136,9 +2261,8 @@ extension WatchDeviceLink: @preconcurrency CBPeripheralDelegate {
     func peripheralIsReady(
         toSendWriteWithoutResponse peripheral: CBPeripheral
     ) {
-        guard self.peripheral?.identifier == peripheral.identifier else {
-            return
-        }
+        guard self.peripheral?.identifier == peripheral.identifier,
+              transportStateMachine.acceptsWriterCallbacks else { return }
         withoutResponseWatchdogTask?.cancel()
         withoutResponseWatchdogTask = nil
         _ = reduceTransport(.writerChanged(

--- a/ios-app/BikeComputer/BikeComputerWatch/Views/WatchNavigationStatusView.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Views/WatchNavigationStatusView.swift
@@ -146,7 +146,7 @@ struct WatchNavigationStatusView: View {
         case .failed:
             deviceLink.lastError ?? "Bicino connection failed"
         case .idle, .scanning, .connecting, .discovering, .authenticating,
-                .claimingLease, .ready:
+                .claimingLease, .ready, .stopping:
             nil
         }
     }

--- a/ios-app/BikeComputer/RideShared/RideBLETransportStateMachine.swift
+++ b/ios-app/BikeComputer/RideShared/RideBLETransportStateMachine.swift
@@ -60,6 +60,13 @@ enum RideBLETransportPhaseV1: String, Equatable, Sendable {
     case recovering
 }
 
+/// Shutdown is a connection-lifecycle boundary, not a second adapter Boolean.
+/// The old peripheral must finish cancellation before a successor can reuse it.
+enum RideBLEStopStageV1: Equatable, Sendable {
+    case releasingLease
+    case awaitingDisconnect
+}
+
 enum RideBLEWriterStateV1: Equatable, Sendable {
     case idle
     case waitingForWithoutResponseReadiness
@@ -92,6 +99,7 @@ enum RideBLETransportEventV1: Equatable, Sendable {
     case writerChanged(generation: UInt64, state: RideBLEWriterStateV1)
     case stopRequested(generation: UInt64)
     case leaseReleased(generation: UInt64)
+    case disconnectRequested(generation: UInt64)
     case failed(generation: UInt64, reason: RideBLETransportFailureReasonV1)
     case disconnected(generation: UInt64)
 }
@@ -112,6 +120,7 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
     let role: RideBLEControllerRoleV1
     private(set) var generation: UInt64 = 0
     private(set) var phase: RideBLETransportPhaseV1 = .idle
+    private(set) var stopStage: RideBLEStopStageV1?
     private(set) var isLinkConnected = false
     private(set) var isAuthenticated = false
     private(set) var leaseGeneration: UInt32?
@@ -123,6 +132,15 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
         phase == .ready && isLinkConnected && isAuthenticated &&
             leaseGeneration != nil && capabilitySchemaVersion != nil &&
             !writerIsRecovering
+    }
+
+    var acceptsReadinessCallbacks: Bool {
+        phase == .negotiating || phase == .ready
+    }
+
+    var acceptsWriterCallbacks: Bool {
+        phase != .idle && phase != .recovering &&
+            stopStage != .awaitingDisconnect
     }
 
     private var writerIsRecovering: Bool {
@@ -142,6 +160,9 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
         let applied: Bool
         switch event {
         case .beginConnection:
+            guard phase != .stopping else {
+                return .rejectedInvalidTransition
+            }
             generation &+= 1
             resetConnectionState(phase: .connecting)
             applied = true
@@ -173,7 +194,9 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
             guard eventGeneration == generation else {
                 return .ignoredStaleGeneration
             }
-            guard isAuthenticated, leaseGeneration != 0 else {
+            guard acceptsReadinessCallbacks,
+                  isAuthenticated, leaseGeneration != 0,
+                  phase != .ready || self.leaseGeneration == leaseGeneration else {
                 return .rejectedInvalidTransition
             }
             self.leaseGeneration = leaseGeneration
@@ -186,7 +209,8 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
             guard eventGeneration == generation else {
                 return .ignoredStaleGeneration
             }
-            guard isAuthenticated,
+            guard acceptsReadinessCallbacks,
+                  isAuthenticated,
                   leaseGeneration != nil,
                   schemaVersion != 0 else {
                 return .rejectedInvalidTransition
@@ -199,12 +223,13 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
             guard eventGeneration == generation else {
                 return .ignoredStaleGeneration
             }
-            guard phase != .idle else {
+            guard acceptsWriterCallbacks else {
                 return .rejectedInvalidTransition
             }
             writerState = state
             if case .recovering(let reason) = state {
                 phase = .recovering
+                stopStage = nil
                 lastFailure = reason
             }
             applied = true
@@ -213,20 +238,33 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
             guard eventGeneration == generation else {
                 return .ignoredStaleGeneration
             }
-            guard phase != .idle else {
-                return .rejectedInvalidTransition
+            // Phone preparation and scanning can need shutdown even before
+            // a BLE connection exists. Repeated stops must not rewind an
+            // in-progress peripheral cancellation.
+            if phase != .stopping {
+                phase = .stopping
+                stopStage = .releasingLease
             }
-            phase = .stopping
             applied = true
 
         case .leaseReleased(let eventGeneration):
             guard eventGeneration == generation else {
                 return .ignoredStaleGeneration
             }
-            guard phase == .stopping else {
+            guard phase == .stopping, stopStage == .releasingLease else {
                 return .rejectedInvalidTransition
             }
             leaseGeneration = nil
+            applied = true
+
+        case .disconnectRequested(let eventGeneration):
+            guard eventGeneration == generation else {
+                return .ignoredStaleGeneration
+            }
+            guard phase == .stopping else {
+                return .rejectedInvalidTransition
+            }
+            stopStage = .awaitingDisconnect
             applied = true
 
         case .failed(let eventGeneration, let reason):
@@ -237,6 +275,7 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
                 return .rejectedInvalidTransition
             }
             phase = .recovering
+            stopStage = nil
             writerState = .recovering(reason: reason)
             lastFailure = reason
             applied = true
@@ -259,6 +298,7 @@ struct RideBLETransportStateMachineV1: Equatable, Sendable {
         phase: RideBLETransportPhaseV1
     ) {
         self.phase = phase
+        stopStage = nil
         isLinkConnected = false
         isAuthenticated = false
         leaseGeneration = nil

--- a/ios-app/scripts/bluetooth-tests/RideBLELifecycleTests.swift
+++ b/ios-app/scripts/bluetooth-tests/RideBLELifecycleTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+@main
+struct RideBLELifecycleTests {
+    static var assertions = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        assertions += 1
+        guard condition() else { fatalError(message) }
+    }
+
+    static func ready(_ role: RideBLEControllerRoleV1) -> RideBLETransportStateMachineV1 {
+        var machine = RideBLETransportStateMachineV1(role: role)
+        expect(machine.reduce(.beginConnection) == .applied, "begin connection")
+        let generation = machine.generation
+        expect(machine.reduce(.linkConnected(generation: generation)) == .applied, "link")
+        expect(machine.reduce(.authenticated(generation: generation)) == .applied, "authentication")
+        expect(machine.reduce(.leaseAccepted(generation: generation, leaseGeneration: 7)) == .applied, "lease")
+        expect(machine.reduce(.capabilitiesAccepted(generation: generation, schemaVersion: 1)) == .becameReady, "capabilities")
+        return machine
+    }
+
+    static func permutations<T>(_ values: [T]) -> [[T]] {
+        guard !values.isEmpty else { return [[]] }
+        return values.indices.flatMap { index -> [[T]] in
+            var remaining = values
+            let first = remaining.remove(at: index)
+            return permutations(remaining).map { [first] + $0 }
+        }
+    }
+
+    static func main() {
+        for role: RideBLEControllerRoleV1 in [.ownerPhone, .scopedWatch] {
+            for phase in ["stopping", "disconnecting", "recovering"] {
+                let callbacks: [RideBLETransportEventV1] = [
+                    .leaseAccepted(generation: 1, leaseGeneration: 7),
+                    .capabilitiesAccepted(generation: 1, schemaVersion: 1),
+                    .writerChanged(generation: 1, state: .idle),
+                    .writerChanged(generation: 1, state: .waitingForATTResponse(writeID: 11)),
+                ]
+                for ordering in permutations(callbacks) {
+                    var machine = ready(role)
+                    if phase == "recovering" {
+                        _ = machine.reduce(.failed(generation: 1, reason: .attTimeout))
+                    } else {
+                        _ = machine.reduce(.stopRequested(generation: 1))
+                        if phase == "disconnecting" {
+                            _ = machine.reduce(.disconnectRequested(generation: 1))
+                        }
+                    }
+                    let expectedPhase = machine.phase
+                    for event in ordering {
+                        let before = machine
+                        let result = machine.reduce(event)
+                        expect(!machine.isReady && machine.phase == expectedPhase,
+                               "\(role) \(phase): late callback restored readiness")
+                        switch event {
+                        case .writerChanged where phase == "stopping":
+                            expect(result == .applied, "pre-release writer completion is allowed")
+                        default:
+                            expect(result == .rejectedInvalidTransition && machine == before,
+                                   "rejected same-generation callback must not mutate state")
+                        }
+                    }
+                    if phase != "recovering" {
+                        let before = machine
+                        expect(machine.reduce(.beginConnection) == .rejectedInvalidTransition &&
+                               machine == before, "successor waits for disconnect boundary")
+                    }
+                }
+            }
+
+            var machine = ready(role)
+            expect(machine.reduce(.capabilitiesAccepted(generation: 1, schemaVersion: 1)) == .applied,
+                   "ready capability refresh is idempotent")
+            expect(machine.reduce(.leaseAccepted(generation: 1, leaseGeneration: 7)) == .applied,
+                   "ready same-lease refresh is idempotent")
+            let beforeDifferentLease = machine
+            expect(machine.reduce(.leaseAccepted(generation: 1, leaseGeneration: 8)) == .rejectedInvalidTransition &&
+                   machine == beforeDifferentLease, "cannot replace a ready lease underneath delivery")
+            expect(machine.reduce(.stopRequested(generation: 1)) == .leftReady, "stop revokes readiness")
+            expect(machine.reduce(.leaseReleased(generation: 1)) == .applied && machine.leaseGeneration == nil,
+                   "release acknowledgement is recorded")
+            expect(machine.reduce(.disconnectRequested(generation: 1)) == .applied,
+                   "start cancellation barrier")
+            let awaitingDisconnect = machine
+            expect(machine.reduce(.stopRequested(generation: 1)) == .applied &&
+                   machine == awaitingDisconnect, "duplicate stop cannot rewind cancellation")
+            expect(machine.reduce(.leaseReleased(generation: 1)) == .rejectedInvalidTransition &&
+                   machine == awaitingDisconnect, "duplicate release cannot restart cancellation")
+            expect(machine.reduce(.disconnected(generation: 1)) == .applied &&
+                   machine.phase == .idle && machine.stopStage == nil, "disconnect completes stop")
+            let idle = machine
+            for event: RideBLETransportEventV1 in [
+                .leaseAccepted(generation: 1, leaseGeneration: 7),
+                .capabilitiesAccepted(generation: 1, schemaVersion: 1),
+                .writerChanged(generation: 1, state: .idle),
+                .disconnectRequested(generation: 1),
+                .disconnected(generation: 1),
+            ] {
+                expect(machine.reduce(event) == .ignoredStaleGeneration && machine == idle,
+                       "old callbacks cannot touch the next generation")
+            }
+            for event: RideBLETransportEventV1 in [
+                .leaseAccepted(generation: machine.generation, leaseGeneration: 7),
+                .capabilitiesAccepted(generation: machine.generation, schemaVersion: 1),
+                .writerChanged(generation: machine.generation, state: .idle),
+            ] {
+                expect(machine.reduce(event) == .rejectedInvalidTransition && machine == idle,
+                       "same-generation callbacks cannot revive idle")
+            }
+            expect(machine.reduce(.stopRequested(generation: machine.generation)) == .applied,
+                   "preparation-only/scanning shutdown has an authoritative stop phase")
+        }
+        print("RideBLE lifecycle: \(assertions) assertions passed")
+    }
+}

--- a/ios-app/scripts/bluetooth-tests/WatchBLETestCoreBluetooth.swift
+++ b/ios-app/scripts/bluetooth-tests/WatchBLETestCoreBluetooth.swift
@@ -1,0 +1,101 @@
+// Test-only CoreBluetooth module. The host runner puts this module ahead of
+// the SDK to drive real WatchDeviceLink delegate methods without a radio.
+// No lifecycle, authentication, queue or acknowledgement policy lives here.
+import Foundation
+@_exported import CoreFoundation
+
+public struct CBUUID: Hashable, Sendable {
+    public let uuidString: String
+    public init(string: String) { uuidString = string.uppercased() }
+}
+public struct CBCharacteristicProperties: OptionSet, Sendable {
+    public let rawValue: Int
+    public init(rawValue: Int) { self.rawValue = rawValue }
+    public static let write = Self(rawValue: 1)
+    public static let writeWithoutResponse = Self(rawValue: 2)
+    public static let notify = Self(rawValue: 4)
+}
+public enum CBCharacteristicWriteType { case withResponse, withoutResponse }
+public enum CBManagerState { case unknown, resetting, unsupported, unauthorized, poweredOff, poweredOn }
+public let CBCentralManagerOptionRestoreIdentifierKey = "restoreIdentifier"
+public let CBCentralManagerScanOptionAllowDuplicatesKey = "allowDuplicates"
+public let CBCentralManagerRestoredStatePeripheralsKey = "restoredPeripherals"
+public let CBAdvertisementDataManufacturerDataKey = "manufacturerData"
+
+public final class CBCharacteristic {
+    public let uuid: CBUUID
+    public let properties: CBCharacteristicProperties
+    public var isNotifying = false
+    public var value: Data?
+    public init(uuid: CBUUID, properties: CBCharacteristicProperties = [.write, .notify]) {
+        self.uuid = uuid
+        self.properties = properties
+    }
+}
+public final class CBService {
+    public let uuid: CBUUID
+    public var characteristics: [CBCharacteristic]?
+    public init(uuid: CBUUID, characteristics: [CBCharacteristic]) {
+        self.uuid = uuid
+        self.characteristics = characteristics
+    }
+}
+public protocol CBPeripheralDelegate: AnyObject {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?)
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?)
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?)
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?)
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?)
+    func peripheralIsReady(toSendWriteWithoutResponse peripheral: CBPeripheral)
+}
+public final class CBPeripheral {
+    public struct Write {
+        public let data: Data
+        public let characteristic: CBCharacteristic
+        public let type: CBCharacteristicWriteType
+    }
+    public let identifier: UUID
+    public weak var delegate: (any CBPeripheralDelegate)?
+    public var services: [CBService]?
+    public var canSendWriteWithoutResponse = true
+    public var maximumWriteLength = 576
+    public private(set) var writes: [Write] = []
+    public private(set) var serviceDiscoveryCount = 0
+    public private(set) var characteristicDiscoveryCount = 0
+    public init(identifier: UUID = UUID()) { self.identifier = identifier }
+    public func discoverServices(_ uuids: [CBUUID]?) { serviceDiscoveryCount += 1 }
+    public func discoverCharacteristics(_ uuids: [CBUUID]?, for service: CBService) { characteristicDiscoveryCount += 1 }
+    public func setNotifyValue(_ enabled: Bool, for characteristic: CBCharacteristic) { characteristic.isNotifying = enabled }
+    public func maximumWriteValueLength(for type: CBCharacteristicWriteType) -> Int { maximumWriteLength }
+    public func writeValue(_ data: Data, for characteristic: CBCharacteristic, type: CBCharacteristicWriteType) {
+        writes.append(Write(data: data, characteristic: characteristic, type: type))
+    }
+}
+public protocol CBCentralManagerDelegate: AnyObject {
+    func centralManagerDidUpdateState(_ central: CBCentralManager)
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String: Any])
+    func centralManager(_ central: CBCentralManager, didDiscover candidate: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber)
+    func centralManager(_ central: CBCentralManager, didConnect connected: CBPeripheral)
+    func centralManager(_ central: CBCentralManager, didFailToConnect failed: CBPeripheral, error: Error?)
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral disconnected: CBPeripheral, timestamp: CFAbsoluteTime, isReconnecting: Bool, error: Error?)
+}
+public final class CBCentralManager {
+    public static var latest: CBCentralManager?
+    public static var knownPeripherals: [CBPeripheral] = []
+    public weak var delegate: (any CBCentralManagerDelegate)?
+    public var state: CBManagerState = .poweredOn
+    public private(set) var isScanning = false
+    public private(set) var connections: [UUID] = []
+    public private(set) var cancellations: [UUID] = []
+    public init(delegate: (any CBCentralManagerDelegate)?, queue: DispatchQueue?, options: [String: Any]?) {
+        self.delegate = delegate
+        Self.latest = self
+    }
+    public func scanForPeripherals(withServices: [CBUUID]?, options: [String: Any]?) { isScanning = true }
+    public func stopScan() { isScanning = false }
+    public func retrievePeripherals(withIdentifiers ids: [UUID]) -> [CBPeripheral] {
+        Self.knownPeripherals.filter { ids.contains($0.identifier) }
+    }
+    public func connect(_ peripheral: CBPeripheral) { connections.append(peripheral.identifier) }
+    public func cancelPeripheralConnection(_ peripheral: CBPeripheral) { cancellations.append(peripheral.identifier) }
+}

--- a/ios-app/scripts/bluetooth-tests/WatchDeviceLinkLifecycleTests.swift
+++ b/ios-app/scripts/bluetooth-tests/WatchDeviceLinkLifecycleTests.swift
@@ -1,0 +1,456 @@
+import Foundation
+import CoreBluetooth
+
+private final class TestCancellation: @unchecked Sendable {
+    private let lock = NSLock()
+    private var cancelled = false
+    func cancel() { lock.lock(); cancelled = true; lock.unlock() }
+    var isCancelled: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return cancelled
+    }
+}
+
+actor WatchStopTestClock {
+    private var waits: [(UUID, CheckedContinuation<Void, Error>, TestCancellation)] = []
+
+    func sleep() async throws {
+        let id = UUID()
+        let cancellation = TestCancellation()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                if Task.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                } else {
+                    waits.append((id, continuation, cancellation))
+                }
+            }
+        } onCancel: {
+            cancellation.cancel()
+            Task { await self.cancel(id) }
+        }
+    }
+
+    private func cancel(_ id: UUID) {
+        guard let index = waits.firstIndex(where: { $0.0 == id }) else { return }
+        waits.remove(at: index).1.resume(throwing: CancellationError())
+    }
+
+    func fireNext() async {
+        for _ in 0..<10_000 {
+            if !waits.isEmpty {
+                let (_, continuation, cancellation) = waits.removeFirst()
+                if cancellation.isCancelled {
+                    continuation.resume(throwing: CancellationError())
+                    continue
+                }
+                continuation.resume()
+                return
+            }
+            await Task.yield()
+        }
+        fatalError("The production stop timer was not armed")
+    }
+}
+
+@MainActor
+private final class Fixture {
+    struct Preparation {
+        let operation: WatchDirectRidePreparationOperationV1
+        let deviceID: String
+        let preparationID: UUID
+        let persistedBeforeSubmission: Bool
+    }
+
+    let deviceID = String(repeating: "a", count: 32)
+    let preparationID = UUID()
+    let peripheral = CBPeripheral()
+    let defaults: UserDefaults
+    let suiteName = "WatchDeviceLinkLifecycleTests.\(UUID().uuidString)"
+    let clock = WatchStopTestClock()
+    let link: WatchDeviceLink
+    var preparations: [Preparation] = []
+    var disposition: WatchDirectRidePreparationSubmissionDispositionV1 = .activationPending
+
+    init(navigation: Bool = true, workout: Bool = false) throws {
+        defaults = UserDefaults(suiteName: suiteName)!
+        let credential = try WatchControllerCredentialV1(
+            deviceID: deviceID,
+            controllerID: Data(repeating: 1, count: 16),
+            key: Data(repeating: 2, count: 32)
+        )
+        let clock = self.clock
+        link = WatchDeviceLink(
+            credentialStore: WatchControllerCredentialStore(credentials: [credential]),
+            defaults: defaults,
+            stopDelay: { try await clock.sleep() }
+        )
+        try link.testSeedReady(
+            peripheral: peripheral,
+            credential: credential,
+            preparationID: preparationID,
+            navigation: navigation,
+            workout: workout
+        )
+        link.onDirectRidePreparationChange = { [weak self] operation, deviceID, id in
+            guard let self else { return .transportUnavailable }
+            let intent = self.intent
+            self.preparations.append(Preparation(
+                operation: operation, deviceID: deviceID, preparationID: id,
+                persistedBeforeSubmission: intent?.operation == operation &&
+                    intent?.preparationID == id && intent?.deviceID == deviceID
+            ))
+            return self.disposition
+        }
+    }
+
+    var central: CBCentralManager { CBCentralManager.latest! }
+    var intent: WatchDirectRidePreparationIntentV1? {
+        defaults.data(forKey: "watchDeviceLink.directRidePreparationIntent.v1")
+            .flatMap { try? WatchDirectRidePreparationIntentV1.decode($0) }
+    }
+
+    func stop() { link.setDemand(navigation: false, workout: false) }
+    func disconnect() {
+        link.centralManager(
+            central, didDisconnectPeripheral: peripheral,
+            timestamp: 0, isReconnecting: false, error: nil
+        )
+    }
+    func radio(_ poweredOn: Bool) {
+        central.state = poweredOn ? .poweredOn : .poweredOff
+        link.centralManagerDidUpdateState(central)
+    }
+    func dispose() {
+        link.testDispose()
+        defaults.removePersistentDomain(forName: suiteName)
+        CBCentralManager.knownPeripherals = []
+    }
+}
+
+@main
+@MainActor
+struct WatchDeviceLinkLifecycleTests {
+    static var failures: [String] = []
+    static var assertions = 0
+
+    static func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+        assertions += 1
+        if !condition() {
+            failures.append(message)
+            print("FAIL: \(message)")
+        }
+    }
+
+    static func flushActor() async {
+        for _ in 0..<20 { await Task.yield() }
+    }
+
+    static func main() async throws {
+        try await stopCompletionsReleasePreparation()
+        try await successorDemandRestarts()
+        try lateCallbacksDoNotRestoreReadiness()
+        try activeDisconnectRetainsPreparation()
+        try await missingDisconnectIsActionable()
+        try successorSnapshotsAndStalePreparationReplies()
+        try pendingReleaseSurvivesRelaunch()
+        try criticalClearsWaitForApplicationAcceptance()
+        try readyRefreshAndLateDiscoveryAreIdempotent()
+        try repeatedDemandDuringStop()
+        print("WatchDeviceLink lifecycle: \(assertions) assertions, \(failures.count) failures")
+        if !failures.isEmpty { exit(1) }
+    }
+
+    static func stopCompletionsReleasePreparation() async throws {
+        for completion in ["ack", "timeout", "disconnect", "radio"] {
+            let fixture = try Fixture()
+            defer { fixture.dispose() }
+            fixture.stop()
+            switch completion {
+            case "ack": fixture.link.testLeaseReleased()
+            case "timeout":
+                await fixture.clock.fireNext()
+                await flushActor()
+            case "disconnect": fixture.disconnect()
+            default: fixture.radio(false)
+            }
+            expect(fixture.intent?.operation == .release,
+                   "R1 \(completion): durable release, not orphaned prepare")
+            expect(fixture.intent?.preparationID == fixture.preparationID,
+                   "R1 \(completion): matching preparation identity")
+            expect(fixture.preparations.contains { $0.operation == .release },
+                   "R1 \(completion): release submitted to handoff boundary")
+            expect(fixture.preparations.allSatisfy(\.persistedBeforeSubmission),
+                   "R1 \(completion): persist intent before calling transport")
+            fixture.disconnect()
+            fixture.link.testLeaseReleased()
+            expect(!fixture.link.testHasDemand,
+                   "R1 \(completion): duplicate completion does not create demand")
+        }
+    }
+
+    static func successorDemandRestarts() async throws {
+        for completion in ["ack", "timeout", "disconnect", "radio"] {
+            for (navigation, workout) in [(true, false), (false, true), (true, true)] {
+                let fixture = try Fixture()
+                defer { fixture.dispose() }
+                fixture.disposition = .submitted
+                fixture.stop()
+                fixture.link.setDemand(navigation: navigation, workout: workout)
+                fixture.link.directRidePreparationAvailabilityDidChange()
+                expect(fixture.link.testHasDemand,
+                       "R2 \(completion): retain successor demand")
+                expect(!fixture.link.state.isReady,
+                       "R2 \(completion): readiness revoked while stopping")
+                expect(fixture.link.testPreparationID == fixture.preparationID,
+                       "R2 \(completion): do not replace stopping preparation early")
+                switch completion {
+                case "ack": fixture.link.testLeaseReleased()
+                case "timeout":
+                    await fixture.clock.fireNext()
+                    await flushActor()
+                case "disconnect": fixture.disconnect()
+                default: fixture.radio(false)
+                }
+                // Complete the old cancellation before allowing its peripheral
+                // to be reused. Radio loss is itself a link-loss boundary.
+                if completion == "ack" || completion == "timeout" {
+                    fixture.disconnect()
+                }
+                if completion == "radio" { fixture.radio(true) }
+                expect(fixture.central.connections.count == 1,
+                       "R2 \(completion) nav=\(navigation) workout=\(workout): successor connects once")
+                expect(fixture.link.testNavigationDemand == navigation &&
+                       fixture.link.testWorkoutDemand == workout,
+                       "R2 \(completion): preserve independent demand")
+                expect(fixture.link.testPreparationID != nil &&
+                       fixture.link.testPreparationID != fixture.preparationID,
+                       "R2 \(completion): fresh successor preparation identity")
+                expect(fixture.link.transportPhase == .connecting,
+                       "R2 \(completion): no idle-with-demand stall")
+            }
+        }
+    }
+
+    static func lateCallbacksDoNotRestoreReadiness() throws {
+        for stopping in [true, false] {
+            let fixture = try Fixture()
+            defer { fixture.dispose() }
+            if stopping { fixture.stop() } else { fixture.link.testFailWriter() }
+            fixture.link.peripheralIsReady(toSendWriteWithoutResponse: fixture.peripheral)
+            fixture.link.testCapabilities()
+            expect(!fixture.link.state.isReady,
+                   "R3 \(stopping ? "stopping" : "recovering"): published readiness stays false")
+            expect(fixture.link.transportPhase == (stopping ? .stopping : .recovering),
+                   "R3: late callbacks preserve authoritative phase")
+            expect(!fixture.link.testHasHeartbeat,
+                   "R3: late CAP2 does not start heartbeat")
+            if !stopping {
+                expect(fixture.link.testWriterState == .recovering(reason: .attTimeout),
+                       "R3: late writer callback does not erase recovery")
+            }
+        }
+    }
+
+    static func sample() -> NavigationLocationSampleV1 {
+        .init(coordinate: .init(latitude: 31, longitude: 121),
+              horizontalAccuracyMeters: 4, courseDegrees: 90,
+              speedMetersPerSecond: 5, altitudeMeters: 10,
+              timestamp: Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    static func snapshot(_ revision: UInt32) -> NavigationSnapshotV1 {
+        .init(navigationGeneration: 2, routeID: UUID(), revision: revision,
+              contentHash: nil, currentStepIndex: 0, maneuver: .straight,
+              instruction: "Successor \(revision)", distanceToManeuverMeters: 100,
+              routeRemainingDistanceMeters: 1_000, expectedArrival: nil,
+              offRouteDistanceMeters: nil, mode: .offline,
+              routeWindow: Data([1, 2, UInt8(revision)]))
+    }
+
+    static func workoutFrames(_ state: WorkoutDeviceSessionState) -> WorkoutDeviceFrames {
+        // Canonical-sized transport fixtures; lifecycle tests assert the
+        // adapter's group ordering, not the metric mapper's numeric values.
+        .init(core: Data(repeating: 1, count: 16),
+              extended: Data(repeating: 2, count: 16),
+              origin: Data(repeating: 3, count: 28), originAvailable: false,
+              identity: .init(state: state, sessionToken: state == .idle ? 0 : 7,
+                              hasLiveNumerics: false, isCurrentSnapshot: true))
+    }
+
+    static func missingDisconnectIsActionable() async throws {
+        let fixture = try Fixture()
+        defer { fixture.dispose() }
+        fixture.disposition = .submitted
+        fixture.stop()
+        fixture.link.setNavigationDemand(true)
+        fixture.link.testLeaseReleased()
+        expect(fixture.central.connections.isEmpty,
+               "Cancellation barrier prevents overlapping connect")
+        await fixture.clock.fireNext()
+        await flushActor()
+        expect(fixture.link.transportPhase == .recovering,
+               "Missing cancellation callback enters explicit recovery")
+        expect(fixture.link.lastError?.contains("Toggle Bluetooth") == true,
+               "Missing cancellation callback has actionable error")
+        expect(fixture.link.testHasDemand && fixture.central.connections.isEmpty,
+               "Missing cancellation callback retains demand without unsafe retry")
+        fixture.link.testCapabilities()
+        expect(!fixture.link.state.isReady, "Late CAP2 cannot bypass cancellation barrier")
+        fixture.radio(false)
+        fixture.radio(true)
+        expect(fixture.central.connections.count == 1,
+               "Radio cycle resumes demand after missing cancellation callback")
+    }
+
+    static func successorSnapshotsAndStalePreparationReplies() throws {
+        let fixture = try Fixture()
+        defer { fixture.dispose() }
+        fixture.disposition = .submitted
+        let oldRequest = try WatchDirectRidePreparationRequestV1(
+            preparationID: fixture.preparationID, operation: .prepare,
+            deviceID: fixture.deviceID
+        )
+        fixture.stop()
+        fixture.link.setDemand(navigation: true, workout: true)
+        let first = snapshot(1)
+        let latest = snapshot(2)
+        fixture.link.updateNavigation(location: sample(), snapshot: first)
+        fixture.link.updateNavigation(location: sample(), snapshot: latest)
+        fixture.link.updateWorkout(workoutFrames(.running), gps: nil)
+        expect(fixture.link.testLogicalWrites.allSatisfy { $0.target == .auth },
+               "Successor updates cannot write on the releasing lease")
+        fixture.link.testLeaseReleased()
+        fixture.disconnect()
+        let successorID = fixture.link.testPreparationID
+        fixture.link.directRidePreparationDidRespond(
+            request: oldRequest,
+            response: .init(requestID: oldRequest.requestID, accepted: true)
+        )
+        fixture.link.directRidePreparationSubmissionDidFail(request: oldRequest)
+        expect(!fixture.link.testPreparationAccepted &&
+               fixture.link.testPreparationID == successorID,
+               "Old prepare response/failure cannot alter successor preparation")
+        fixture.link.testNegotiateReady()
+        expect(fixture.link.state.isReady && fixture.link.testGeneration > 1,
+               "Successor reaches ready on a fresh generation")
+        expect(fixture.link.testLatestSnapshot == latest &&
+               fixture.link.testLatestWorkoutState == .running,
+               "Latest navigation/workout state survives shutdown")
+        let writes = fixture.link.testLogicalWrites
+        expect(writes.contains { $0.target == .route && $0.payload == latest.routeWindow },
+               "Successor full resync contains latest route")
+        expect(writes.contains {
+            $0.target == .navigation && $0.payload == WatchRidePacketEncoderV1.maneuver(latest)
+        }, "Successor full resync contains latest maneuver")
+        expect(writes.contains { $0.target == .workout },
+               "Successor full resync contains workout frames")
+        expect(!writes.contains { $0.target == .auth && $0.payload == Data("LEASE_RELEASE".utf8) },
+               "Old lease-release bytes do not enter successor connection")
+    }
+
+    static func pendingReleaseSurvivesRelaunch() throws {
+        for disposition in [WatchDirectRidePreparationSubmissionDispositionV1.activationPending,
+                            .counterpartUnreachable, .transportUnavailable] {
+            let fixture = try Fixture()
+            defer { fixture.dispose() }
+            fixture.disposition = disposition
+            fixture.stop()
+            fixture.disconnect()
+            let restored = WatchDeviceLink(
+                credentialStore: WatchControllerCredentialStore(credentials: []),
+                defaults: fixture.defaults
+            )
+            defer { restored.testDispose() }
+            var releases: [UUID] = []
+            restored.onDirectRidePreparationChange = { operation, _, id in
+                if operation == .release { releases.append(id) }
+                return .submitted
+            }
+            restored.completeInitialDemandRestoration()
+            restored.directRidePreparationAvailabilityDidChange()
+            restored.directRidePreparationAvailabilityDidChange()
+            expect(releases == [fixture.preparationID],
+                   "Relaunch submits exact durable release once after availability")
+            expect(fixture.intent == nil,
+                   "Accepted durable outbox submission removes local intent")
+        }
+    }
+
+    static func criticalClearsWaitForApplicationAcceptance() throws {
+        for navigation in [true, false] {
+            let fixture = try Fixture(navigation: navigation, workout: !navigation)
+            defer { fixture.dispose() }
+            if navigation {
+                fixture.link.endNavigationDemandAfterClearing()
+            } else {
+                fixture.link.endWorkoutDemandAfterClearing(workoutFrames(.ended))
+            }
+            expect(fixture.link.testHasDemand && fixture.link.state.isReady,
+                   "Terminal clear retains demand while ATT writes are pending")
+            for _ in 0..<16 where fixture.link.testHasATTWrite {
+                fixture.link.testATTCompletion()
+            }
+            expect(fixture.link.testHasApplicationAck && fixture.link.testHasDemand,
+                   "Physical group completion is not application acceptance")
+            expect(fixture.preparations.isEmpty,
+                   "No phone release before terminal application ACK")
+            fixture.link.testApplicationAcknowledgement()
+            expect(!fixture.link.testHasDemand && fixture.link.transportPhase == .stopping,
+                   "Terminal application ACK permits logical shutdown")
+            expect(fixture.link.testLogicalWrites.contains {
+                $0.target == .auth && $0.payload == Data("LEASE_RELEASE".utf8)
+            }, "Terminal acceptance precedes lease-release write")
+        }
+        // Releasing one channel must not terminate the independent other one.
+        let fixture = try Fixture(navigation: true, workout: true)
+        defer { fixture.dispose() }
+        fixture.link.endNavigationDemandAfterClearing()
+        for _ in 0..<16 where fixture.link.testHasATTWrite { fixture.link.testATTCompletion() }
+        fixture.link.testApplicationAcknowledgement()
+        expect(fixture.link.state.isReady && fixture.link.testWorkoutDemand,
+               "Navigation clear does not stop active workout")
+    }
+
+    static func readyRefreshAndLateDiscoveryAreIdempotent() throws {
+        let fixture = try Fixture()
+        defer { fixture.dispose() }
+        let writes = fixture.peripheral.writes.count
+        fixture.link.testCapabilities()
+        fixture.link.testCapabilities()
+        expect(fixture.peripheral.writes.count == writes,
+               "Ready CAP2 refresh does not enqueue duplicate replay")
+        fixture.stop()
+        let failed = NSError(domain: "Injected", code: 1)
+        fixture.link.peripheral(fixture.peripheral, didDiscoverServices: failed)
+        fixture.link.centralManager(fixture.central, didConnect: fixture.peripheral)
+        expect(fixture.link.transportPhase == .stopping && fixture.link.lastError == nil,
+               "Late discovery/connection callbacks cannot overwrite shutdown")
+    }
+
+    static func repeatedDemandDuringStop() throws {
+        let fixture = try Fixture()
+        defer { fixture.dispose() }
+        fixture.stop()
+        fixture.link.setNavigationDemand(true)
+        fixture.link.setNavigationDemand(false)
+        fixture.link.setWorkoutDemand(true)
+        fixture.link.setWorkoutDemand(false)
+        fixture.disconnect()
+        expect(!fixture.link.testHasDemand && fixture.central.connections.isEmpty,
+               "Withdrawn successor demand does not restart an unwanted ride")
+        expect(fixture.intent?.operation == .release,
+               "Repeated stop/start still releases the old preparation")
+    }
+
+    static func activeDisconnectRetainsPreparation() throws {
+        let fixture = try Fixture()
+        defer { fixture.dispose() }
+        fixture.disconnect()
+        expect(fixture.link.testHasDemand, "Active disconnect retains demand")
+        expect(fixture.intent?.operation == .prepare, "Active disconnect retains prepare")
+        expect(fixture.preparations.isEmpty, "Active disconnect does not release phone")
+        expect(fixture.link.testHasReconnect, "Active disconnect schedules recovery")
+    }
+}

--- a/ios-app/scripts/bluetooth-tests/WatchDeviceLinkTestAccess.swift
+++ b/ios-app/scripts/bluetooth-tests/WatchDeviceLinkTestAccess.swift
@@ -1,0 +1,132 @@
+// Appended to a temporary copy of the COMPLETE production WatchDeviceLink.swift
+// by the host runner. This file exposes fixtures/observations at the adapter's
+// authenticated ingress boundary; it does not implement lifecycle decisions.
+// No test-only access is compiled into the app target.
+
+extension WatchDeviceLink {
+    func testSeedReady(
+        peripheral: CBPeripheral,
+        credential: WatchControllerCredentialV1,
+        preparationID: UUID,
+        navigation: Bool = true,
+        workout: Bool = false
+    ) throws {
+        self.credential = credential
+        credentials = [credential]
+        selectedBikeComputerEnvelope = try WatchSelectedBikeComputerV1(
+            revision: 1, deviceID: credential.deviceID
+        )
+        defaults.set(
+            try selectedBikeComputerEnvelope!.encoded(),
+            forKey: selectedBikeComputerKey
+        )
+        self.peripheral = peripheral
+        peripheral.delegate = self
+        CBCentralManager.knownPeripherals = [peripheral]
+        _ = central
+        installTestCharacteristics()
+        demand.setNavigationActive(navigation)
+        demand.setWorkoutActive(workout)
+        connectionGeneration &+= 1
+        _ = reduceTransport(.beginConnection)
+        testNegotiateReady()
+        // The fixture starts after the initial resynchronization has drained.
+        queue.removeAll()
+        activeWriteGroup = nil
+        activeWriteIndex = 0
+        pendingATTWrite = nil
+        writeWithResponseInFlight = false
+        writerWatchdogTask?.cancel()
+        writerWatchdogTask = nil
+        preparedPhoneDeviceID = credential.deviceID
+        preparedPhonePreparationID = preparationID
+        phonePreparationAccepted = true
+        persistPhonePreparationIntent(operation: .prepare)
+    }
+
+    private func installTestCharacteristics() {
+        authCharacteristic = CBCharacteristic(uuid: authUUID)
+        navigationCharacteristic = CBCharacteristic(uuid: navigationUUID)
+        routeCharacteristic = CBCharacteristic(uuid: routeUUID)
+        gpsCharacteristic = CBCharacteristic(uuid: gpsUUID)
+        workoutCharacteristic = CBCharacteristic(uuid: workoutUUID)
+        rideAutomationCharacteristic = CBCharacteristic(uuid: rideAutomationUUID)
+    }
+
+    func testNegotiateReady() {
+        installTestCharacteristics()
+        let generation = transportStateMachine.generation
+        _ = reduceTransport(.linkConnected(generation: generation))
+        _ = reduceTransport(.authenticated(generation: generation))
+        _ = reduceTransport(.leaseAccepted(generation: generation, leaseGeneration: 7))
+        let credential = self.credential!
+        protectedSession = WatchAuthenticatedBLESessionV1(
+            controllerKey: credential.key,
+            deviceID: credential.deviceID,
+            controllerIDHex: credential.controllerIDHex,
+            clientNonceHex: String(format: "%032llx", connectionGeneration),
+            serverNonceHex: String(repeating: "2", count: 32)
+        )
+        testCapabilities()
+    }
+
+    func testCapabilities() {
+        // A valid, already-authenticated CAP2 payload with all optional flags.
+        // Authentication/encryption is independently covered by RideSharedTests.
+        handleAuthenticatedNavigationPayload(
+            Data("CAP2".utf8) + Data([1, 255, 255, 255, 255])
+        )
+    }
+
+    func testLeaseReleased() { handleProtectedAuthMessage("LEASE_RELEASED") }
+    func testFailWriter() { fail("Injected ATT timeout", reason: .attTimeout) }
+    var testGeneration: UInt64 { connectionGeneration }
+    var testHasDemand: Bool { hasDemand }
+    var testNavigationDemand: Bool { demand.navigationActive }
+    var testWorkoutDemand: Bool { demand.workoutActive }
+    var testHasReconnect: Bool { reconnectTask != nil }
+    var testPreparationID: UUID? { preparedPhonePreparationID }
+    var testPreparationAccepted: Bool { phonePreparationAccepted }
+    var testHasHeartbeat: Bool { heartbeatTimer != nil }
+    var testWriterState: RideBLEWriterStateV1 { transportStateMachine.writerState }
+    var testHasATTWrite: Bool { pendingATTWrite != nil }
+    var testHasApplicationAck: Bool { pendingApplicationAckGroup != nil }
+    var testLatestSnapshot: NavigationSnapshotV1? { latestNavigationSnapshot }
+    var testLatestWorkoutState: WorkoutDeviceSessionState? { latestWorkoutFrames?.identity.state }
+
+    var testLogicalWrites: [WatchBLEOutboundWriteV1] {
+        var result = activeWriteGroup?.writes ?? []
+        var copy = queue
+        while let group = copy.dequeueGroup() { result += group.writes }
+        return result
+    }
+
+    func testATTCompletion(error: Error? = nil) {
+        guard let peripheral, let pendingATTWrite,
+              let characteristic = [authCharacteristic, navigationCharacteristic,
+                  routeCharacteristic, gpsCharacteristic, workoutCharacteristic,
+                  rideAutomationCharacteristic].compactMap({ $0 }).first(where: {
+                      $0.uuid == pendingATTWrite.characteristicID
+                  }) else { return }
+        self.peripheral(peripheral, didWriteValueFor: characteristic, error: error)
+    }
+
+    func testApplicationAcknowledgement() {
+        guard let group = pendingApplicationAckGroup ?? activeWriteGroup,
+              let type = group.applicationCommandType else { return }
+        handleApplicationAcknowledgement(.init(
+            commandType: type,
+            result: .success,
+            commandID: group.commandID,
+            stateGeneration: group.stateGeneration,
+            leaseGeneration: 7
+        ))
+    }
+
+    func testDispose() {
+        reconnectTask?.cancel()
+        phonePreparationRetryTask?.cancel()
+        phonePreparationResponseTimeoutTask?.cancel()
+        resetTransport(keepingPeripheral: false)
+    }
+}

--- a/ios-app/scripts/bluetooth-tests/WatchDeviceLinkTestDependencies.swift
+++ b/ios-app/scripts/bluetooth-tests/WatchDeviceLinkTestDependencies.swift
@@ -1,0 +1,11 @@
+// No Keychain or navigation manager is instantiated by the adapter host tests.
+// The native runner compiles the real shared credentials, demand, queue,
+// authentication, packet and application-acknowledgement implementations.
+import Foundation
+
+final class WatchControllerCredentialStore {
+    var credentials: [WatchControllerCredentialV1]
+    init(credentials: [WatchControllerCredentialV1]) { self.credentials = credentials }
+    func allActiveCredentials() throws -> [WatchControllerCredentialV1] { credentials }
+}
+protocol WatchNavigationDeviceLinking: AnyObject {}

--- a/ios-app/scripts/run-ride-shared-tests.sh
+++ b/ios-app/scripts/run-ride-shared-tests.sh
@@ -30,3 +30,5 @@ xcrun swiftc \
   BikeComputerTests/RideSharedTests.swift
 
 "${OUT}"
+
+"${SCRIPT_DIR}/run-watch-device-link-tests.sh"

--- a/ios-app/scripts/run-watch-device-link-tests.sh
+++ b/ios-app/scripts/run-watch-device-link-tests.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+TEST_DIR="${SCRIPT_DIR}/bluetooth-tests"
+BUILD_DIR="$(mktemp -d "${TMPDIR:-/tmp}/obc-watch-link.XXXXXX")"
+trap 'rm -rf "${BUILD_DIR}"' EXIT
+
+if command -v xcrun >/dev/null 2>&1; then
+  SWIFTC=(xcrun swiftc)
+else
+  SWIFTC=(swiftc)
+fi
+
+"${SWIFTC[@]}" -parse-as-library \
+  "${IOS_DIR}/BikeComputer/RideShared/RideBLETransportStateMachine.swift" \
+  "${TEST_DIR}/RideBLELifecycleTests.swift" \
+  -o "${BUILD_DIR}/reducer-tests"
+"${BUILD_DIR}/reducer-tests"
+
+if [[ "${1:-}" == "--reducer-only" ]]; then
+  exit 0
+fi
+if [[ $# -ne 0 ]]; then
+  echo "Usage: $0 [--reducer-only]" >&2
+  exit 2
+fi
+if ! command -v xcrun >/dev/null 2>&1; then
+  echo "Adapter tests require macOS SDKs; use --reducer-only on other hosts." >&2
+  exit 2
+fi
+
+# Replace only the radio boundary. Shared authentication, demand, persistence
+# contracts, atomic groups, packet encoding and ACK policies remain production
+# code. The temporary module can never be included in an app build.
+"${SWIFTC[@]}" -swift-version 5 -emit-module -emit-library \
+  -module-name CoreBluetooth \
+  -emit-module-path "${BUILD_DIR}/CoreBluetooth.swiftmodule" \
+  "${TEST_DIR}/WatchBLETestCoreBluetooth.swift" \
+  -o "${BUILD_DIR}/libCoreBluetooth.dylib"
+
+# Same-file extension access avoids public/test-only mutation APIs in the app.
+# The entire adapter is compiled: there is no extracted/parallel lifecycle model.
+cat "${IOS_DIR}/BikeComputer/BikeComputerWatch/Managers/WatchDeviceLink.swift" \
+  "${TEST_DIR}/WatchDeviceLinkTestAccess.swift" \
+  > "${BUILD_DIR}/WatchDeviceLinkUnderTest.swift"
+
+cd "${IOS_DIR}"
+"${SWIFTC[@]}" -swift-version 5 -parse-as-library \
+  -I "${BUILD_DIR}" -L "${BUILD_DIR}" -lCoreBluetooth \
+  BikeComputer/RideShared/*.swift \
+  BikeComputer/WorkoutShared/RideAutomationContract.swift \
+  BikeComputer/WorkoutShared/RideAutomationRuntimeLogic.swift \
+  BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
+  BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
+  BikeComputer/WorkoutShared/WorkoutContract.swift \
+  BikeComputer/WorkoutShared/WorkoutDeviceFrames.swift \
+  BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
+  BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
+  BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \
+  "${TEST_DIR}/WatchDeviceLinkTestDependencies.swift" \
+  "${BUILD_DIR}/WatchDeviceLinkUnderTest.swift" \
+  "${TEST_DIR}/WatchDeviceLinkLifecycleTests.swift" \
+  -o "${BUILD_DIR}/adapter-tests"
+
+DYLD_LIBRARY_PATH="${BUILD_DIR}${DYLD_LIBRARY_PATH:+:${DYLD_LIBRARY_PATH}}" \
+  "${BUILD_DIR}/adapter-tests"


### PR DESCRIPTION
## Summary

Implements the confirmed R1–R3 findings from #418 on a new branch from freshly checked `main` at `fe73e43431ed76c39159de7624c4cd9ede509434`. #418 remains unmerged; its plan was reviewed directly at `b263052c9f45231f2d98feaa70e4f3ec3b825c7b`. Main still matched the reviewed baseline, so no newer-main fixes were subtracted.

- **R1:** release or durably retain the exact old phone-preparation release on every Watch shutdown exit, including disconnect and radio loss before the lease ACK/deadline.
- **R2:** preserve successor navigation/workout demand and latest logical state during stopping; reconnect/reprepare after the old peripheral's cancellation boundary and resynchronize on fresh readiness.
- **R3:** reject late lease, capabilities, writer and discovery callbacks in stopping/recovery before they can publish readiness, restart heartbeat or replay data.
- Make the existing transport reducer authoritative for readiness and shutdown stage; remove `gracefulStopPending`, add explicit release/cancellation stages and a non-authoritative UI stopping projection.
- Preserve terminal group ATT/application-ACK ordering. Do not admit new ride writes onto a stopping lease. No firmware, cryptographic framing, scoped authorization, generated protocol, queue capacity or ACK-identity-policy changes.

## Independent-review qualifications

R1 concerns loss of prompt identity-matched release, not permanent phone suppression: existing phone-side expiry still exists. R2's baseline ACK/deadline completion can strand demand; the ordinary-disconnect path already schedules reconnect when demand exists, and radio-on can also recover. R3 reproduces for both reducer role values, but the inspected runtime reducer consumer is WatchDeviceLink; this PR does **not** claim a reproduced or repaired iPhone BLEManager adapter failure.

A lease-release ACK is not a CoreBluetooth disconnect. The implementation waits for cancellation before reusing that peripheral, preventing the old cancellation from tearing down the successor. A missing cancellation callback produces a bounded, actionable recovery error with retained demand rather than an unsafe overlapping retry. The existing five-second lease wait is retained, with a separate five-second cancellation bound; these are not claimed to be physically tuned.

## Tests and evidence

The new native runner compiles the **complete production WatchDeviceLink**, not a parallel lifecycle model. A temporary fake CoreBluetooth module supplies only the radio boundary; native execution uses the real shared authentication/session, demand, persistence contracts, atomic queue and application-ACK code. Test files live outside app targets. `run-ride-shared-tests.sh` invokes the new runner.

**Completed locally:**
- Exact baseline reducer: four stop/recovery counterexamples reproduced (both roles incorrectly became ready).
- Initial whole-adapter matrix: **115 assertions / 53 baseline failures**, then **115 assertions / zero failures** with fixes.
- Expanded whole-adapter matrix: **150 assertions / zero failures**.
- Production reducer permutation/identity matrix: **2,014 assertions passed**.
- Changed runner shell syntax and explicit diff/whitespace review.
- All 12 published file blobs verified against the local manifest; resulting Git tree `23eb23a89afd68291b79dcc5319d3850580f9eb1` matches.

**Important local limitation:** this Linux environment has no Xcode/Apple SDKs/CryptoKit. The local whole-adapter tests used explicit local-only SDK/wire/queue leaf stand-ins. They exercise the actual adapter coordination but are **not** native integration, cryptographic, real-queue or platform-build validation. Those local-only stand-ins are not committed. The committed macOS runner uses the real shared implementations.

**CI:** native compilation/execution and the normal existing regressions must be evaluated on this PR's actual head. Pending/unavailable checks are not passes. Draft until native validation is reviewed.

**Physical devices:** not run. Nothing was merged, installed or flashed. #339/#366 historical CI or physical evidence is not acceptance evidence for this head. No manual 2.06-inch firmware job requested.

## Documentation and isolation

Updated `docs/plans/bluetooth-reliability-reassessment-2026-09-06.md` with findings, qualifications, implementation and evidence. Broader phone-coordinator, callback-identity, model-based testing, observability and authorized hardware work is separate in `docs/plans/bluetooth-reliability-followups-2026-09-07.md`.

Work used an isolated sparse Git worktree based on the exact main commit. Container DNS prevented normal clone/push; source/Git data and publication used the GitHub connector. The commit is based on the original main tree and replaces only the 12 listed implementation paths, preserving unrelated repository files and user checkouts.

No legal/CLA declarations are made on the user's behalf.