### PR TITLE
Fix environment secret public-key endpoint

### DIFF
--- a/.github/scripts/firmware_key_migration.py
+++ b/.github/scripts/firmware_key_migration.py
@@ -170,12 +170,12 @@ def prepare(value):
     if secret_metadata() is None:
         raise MigrationError("repository signing key is missing")
     key = signing_key(value)
-    recipient = api(environment_path("public-key"))
+    recipient = api(environment_path("secrets/public-key"))
     ciphertext = run_gh(["secret", "set", SECRET, "--repo", f"github.com/{REPOSITORY}",
                          "--env", ENVIRONMENT, "--no-store"], value).strip()
     if len(base64.b64decode(ciphertext, validate=True)) != len(value) + 48:
         raise MigrationError("invalid sealed-secret output")
-    if api(environment_path("public-key")) != recipient:
+    if api(environment_path("secrets/public-key")) != recipient:
         raise MigrationError("environment encryption key changed; prepare again")
     receipt.update(operation="prepare", keyId=recipient["key_id"],
                    recipientKeySha256=hashlib.sha256(base64.b64decode(recipient["key"], validate=True)).hexdigest(),
@@ -223,7 +223,7 @@ def install(document, expected_run, expected_sha):
     if comparison.get("status") not in ("ahead", "identical"):
         raise MigrationError("migration workflow commit is not on current main")
     validate_destination()
-    recipient = api(environment_path("public-key"))
+    recipient = api(environment_path("secrets/public-key"))
     if (recipient["key_id"] != receipt["keyId"] or
         hashlib.sha256(base64.b64decode(recipient["key"], validate=True)).hexdigest() != receipt["recipientKeySha256"] or
         len(base64.b64decode(receipt["encryptedValue"], validate=True)) != 92):

--- a/tools/tests/test_firmware_key_migration.py
+++ b/tools/tests/test_firmware_key_migration.py
@@ -95,6 +95,11 @@ class KeyMigrationTests(unittest.TestCase):
             command = gh.call_args.args[0]
             self.assertIn("--no-store", command)
             self.assertEqual(command[command.index("--env") + 1], migration.ENVIRONMENT)
+            self.assertEqual(
+                [call.args[0] for call in api.call_args_list
+                 if call.args[0].endswith("public-key")],
+                [migration.environment_path("secrets/public-key")] * 2,
+            )
             self.assertTrue(all(len(call.args) == 1 for call in api.call_args_list))
 
     def test_prepare_rejects_existing_or_shadowed_key_before_encryption(self):
@@ -144,7 +149,7 @@ class KeyMigrationTests(unittest.TestCase):
                 return None
             if "actions/runs" in path: return self.run
             if "compare/" in path: return {"status": "ahead"}
-            if path.endswith("public-key"): return self.recipient
+            if path.endswith("/secrets/public-key"): return self.recipient
             raise AssertionError(path)
         with patch.object(migration, "api", side_effect=api), \
              patch.object(migration, "validate_destination"), \


### PR DESCRIPTION
## Summary
- use GitHub's environment secret public-key endpoint for prepare and install
- add a regression assertion covering the endpoint path

The migration workflow previously requested `/environments/{environment}/public-key`, which GitHub returns as 404. The correct endpoint is `/environments/{environment}/secrets/public-key`.

## Validation
- `python3 -m unittest discover -s tools/tests -p 'test_firmware_key_migration.py'`
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_firmware_release_controls.py'`
- `python3 -m unittest discover -s .github/scripts/tests -p 'test_changed_components.py'`
- `git diff --check`

This is an administrative migration fix only; it does not build, release, flash, or alter secrets.
