### PR TITLE
feat(ios): show saved GPX and Strava routes on the main map

### DIFF
--- a/docs/plans/saved-route-map-preview-381.md
+++ b/docs/plans/saved-route-map-preview-381.md
@@ -1,0 +1,98 @@
+# Saved-route map preview (#381)
+
+## Scope and ownership
+
+Implemented from GitHub main `44e0df3bf87cce1aca0c4da9d5d7b776f1823c1b`.
+This is an iPhone-only presentation feature, not a navigation start, Watch
+transfer, new route import, or alternate persistent route cache.
+
+`SavedRoutesSettingsSection` exposes a local **Show on Map** action separately
+from rename, Watch sync, reload, and delete controls. The scoped
+`SavedRouteMapAction` environment value carries the Settings-to-ContentView
+callback. Navigation disables it; transfer and acknowledgement status do not.
+Expired Strava bookmark rows retain their existing reload/link actions only.
+Read or construction failure leaves Settings open with a localized error.
+
+`PhoneRouteLibrary.mapSelection(for:)` resolves the exact UUID, revision, and
+content hash through the existing archive store and revalidates retention after
+the read. A successful read has no write/Watch effects. Failure uses the normal
+library reload/pruning path rather than substituting another revision.
+
+`SavedRouteMapPreviewFactory` converts the verified canonical WGS-84 points at
+the iPhone display boundary using the existing China coordinate policy. It
+validates point count, finite coordinates, distinct geometry, map bounds, and
+expiry before and after construction. Only the finished polyline and display
+metadata survive construction; no archive/coordinate array is persisted.
+
+`ContentView` owns ephemeral presentation state. Library changes reconcile the
+full immutable identity; deletion, pruning, expiry, replacement, and foreground
+reload invalidate old geometry. The library's existing expiry scheduling remains
+authoritative. Starting route planning, navigation, or offline-area selection
+clears the saved preview. An explicit attempt during an existing plan is rejected
+without cancelling that plan. Hide affects presentation only.
+
+The MapKit coordinator owns separate arrays/references for calculated/navigation
+polylines and the saved polyline. It never clears all overlays. Precedence is
+navigation, calculated route/alternatives/in-flight calculation, saved preview,
+then no route. Saved styling is thinner and translucent with rounded caps/joins.
+The camera waits for the bottom card's measured layout, keyed by full identity,
+then fits once; location/appearance/layout updates cannot repeatedly refit it.
+Hide restores authorized follow unless another interaction owns free pan.
+
+An active workout continues normally, but its automatic metrics-sheet restoration
+is suspended during preview so that closing Settings reveals the map. Hiding the
+preview restores normal ride-sheet behavior. Nearby-device automatic sheets are
+also deferred while the preview is present.
+
+## Automated verification
+
+Run the focused suite with:
+
+```sh
+bash ios-app/scripts/run-saved-route-map-tests.sh
+```
+
+The portable Swift policy suite covers all precedence combinations, full-identity
+camera changes, repeated updates, reopening, deletion/replacement, and the exact
+expiry boundary. It was compiled and executed with Swift 6.2.1 on Linux: **178
+checks passed**.
+
+On macOS the same script also compiles a focused Mac Catalyst executable against
+the production archive store, PhoneRouteLibrary, preview factory, and MapView
+coordinator. Only the Watch-connectivity and map-system boundaries are doubled.
+It covers both providers/local aliases; archive bytes, modification time,
+preferences and Watch effects; stale/missing/corrupt archives; expiry/deletion;
+China/non-China conversion; 50,000-point reuse; overlay ownership and styling;
+one-time layout-aware fitting; free-pan preservation; priority transitions; and
+successful/failed Settings callbacks.
+
+The focused runner is included in `run-navigation-tests.sh`. Existing MapView
+Catalyst suites also compile the new shared presentation policy.
+
+**Environment limit:** the implementation environment has no Apple SDK or Xcode.
+The Mac Catalyst suite, full iOS build, and interactive UI checks were not run
+locally. CI/build results must be checked separately; adding a test is not proof
+that it has passed.
+
+## Interactive acceptance checks (not performed locally)
+
+1. Import a GPX and a currently valid Strava route; rename each and show it from
+   Settings. Confirm Settings dismisses only after success and the main map/card
+   shows the selected alias, labels, distance, attribution, and Strava expiry.
+2. Repeat while a Watch transfer is pending or rejected. Preview still works and
+   does not send a route. During navigation it is disabled. Expired Strava rows
+   offer reload/link but no preview.
+3. Pan/zoom, change Layers, toggle 2D/3D, rotate the phone, and receive location
+   updates. Verify the preview remains and no update repeatedly snaps the camera.
+   Hide and reopen; the new presentation should fit again.
+4. Preview a China route and a non-China route. Confirm alignment without changing
+   the archive. Exercise deletion, a newer imported revision, provider expiry,
+   and foreground return: old geometry must disappear.
+5. Start search/planning, select alternatives, start/stop navigation, and choose
+   an offline map area. Confirm route priority, destination callouts, unrelated
+   overlays, and existing map controls are preserved.
+6. Preview during an active workout, hide it, and reopen Settings. The workout
+   must keep running and its metrics sheet must not cover the preview immediately.
+7. Check VoiceOver names/hints, 44-point preview/close targets, long route names,
+   large accessibility text, landscape and a small iPhone screen. Capture UI
+   screenshots during this device/simulator verification.

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -78,6 +78,8 @@ struct ContentView: View {
     
     @State private var sourceAddress = ""
     @State private var destinationAddress = ""
+    @State private var savedRouteMapPreview: SavedRouteMapPreview?
+    @State private var savedRoutePreviewBottomHeight: CGFloat?
     @State private var presentedSheet: ContentSheetDestination?
     @State private var queuedSheetAfterDismiss:
         ContentSheetDestination?
@@ -232,7 +234,11 @@ struct ContentView: View {
                         ? selectionFrame
                         : nil,
                     routePlanningBottomPadding:
-                        mapRoutePlanningBottomPadding(in: proxy)
+                        mapRoutePlanningBottomPadding(in: proxy),
+                    savedRoutePreviewBottomPadding:
+                        savedRoutePreviewBottomHeight.map {
+                            $0 + proxy.safeAreaInsets.bottom + 12
+                        }
                 )
                     .ignoresSafeArea()
 
@@ -313,6 +319,19 @@ struct ContentView: View {
                         maxHeight: proxy.size.height * 0.68,
                         isCompactHeight: isCompactHeight
                     )
+                    .background {
+                        GeometryReader { layout in
+                            Color.clear.preference(
+                                key: SavedRoutePreviewLayoutKey.self,
+                                value: visibleSavedRouteMapPreview.map {
+                                    SavedRoutePreviewLayout(
+                                        identity: $0.layoutIdentity,
+                                        height: layout.size.height
+                                    )
+                                }
+                            )
+                        }
+                    }
                 }
                 .ignoresSafeArea(.container, edges: .bottom)
 
@@ -371,6 +390,21 @@ struct ContentView: View {
                 presentedSheetContent(for: destination)
             }
         }
+        .onPreferenceChange(SavedRoutePreviewLayoutKey.self) { layout in
+            Task { @MainActor in updateSavedRoutePreviewLayout(layout) }
+        }
+        .onReceive(routeLibrary.$routes) { routes in
+            reconcileSavedRoutePreview(with: routes)
+        }
+        .onChange(of: savedRoutePreviewIsBlocked) { isBlocked in
+            if isBlocked { clearSavedRoutePreview() }
+        }
+        .onChange(of: isSearchPanelExpanded) { isExpanded in
+            if isExpanded { clearSavedRoutePreview() }
+        }
+        .onChange(of: savedRouteMapPreview?.identity) { identity in
+            if identity == nil { synchronizeRideMetricsSheet() }
+        }
         .onAppear {
             onApplicationActiveChange(scenePhase == .active)
             migrateExistingInstallOnboardingIfNeeded()
@@ -382,6 +416,7 @@ struct ContentView: View {
             workoutMirrorManager.refreshFreshness()
             observedWorkoutSegmentIndex = currentWorkoutSegment?.index
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
+            routeLibrary.reload()
             stravaIntegrationCoordinator.activate()
             synchronizeRideMetricsSheet()
             presentNearbyBicinoIfEligible()
@@ -440,6 +475,7 @@ struct ContentView: View {
             coordinator.applicationDidBecomeActive()
             workoutMirrorManager.refreshFreshness()
             offlineMapManager.resumePendingMapJobIfNeeded(bleManager: coordinator.bleManager)
+            routeLibrary.reload()
             stravaIntegrationCoordinator.activate()
             presentNearbyBicinoIfEligible()
         }
@@ -547,6 +583,67 @@ struct ContentView: View {
         }
     }
 
+    private var savedRoutePreviewIsBlocked: Bool {
+        SavedRouteMapPolicy.content(
+            isNavigating: coordinator.isNavigating,
+            hasCalculatedRoute: coordinator.currentRoute != nil,
+            hasRouteAlternatives: !coordinator.routeAlternatives.isEmpty,
+            isCalculating: coordinator.routeCalculation.isCalculating,
+            hasSavedRoute: true,
+            isOfflineMapSelectionActive: offlineMapManager.isMapAreaSelectionActive
+        ) != .savedRoute
+    }
+
+    private var visibleSavedRouteMapPreview: SavedRouteMapPreview? {
+        guard !savedRoutePreviewIsBlocked,
+              let preview = savedRouteMapPreview,
+              preview.deleteAfter.map({ Date() < $0 }) ?? true else { return nil }
+        return preview
+    }
+
+    private func showSavedRouteMapPreview(_ selection: SavedRouteMapSelection) throws {
+        guard !coordinator.isNavigating else { throw SavedRouteMapError.navigationActive }
+        guard !savedRoutePreviewIsBlocked else { throw SavedRouteMapError.planningActive }
+        let preview = try SavedRouteMapPreviewFactory.make(selection)
+        if savedRouteMapPreview?.identity != preview.identity {
+            savedRoutePreviewBottomHeight = nil
+        }
+        savedRouteMapPreview = preview
+        isSearchPanelExpanded = false
+        // This is deliberately after both the validated read and factory. A
+        // failure is shown by the Settings row, without dismissing its sheet.
+        presentedSheet = nil
+    }
+
+    private func clearSavedRoutePreview() {
+        savedRouteMapPreview = nil
+        savedRoutePreviewBottomHeight = nil
+    }
+
+    private func updateSavedRoutePreviewLayout(_ layout: SavedRoutePreviewLayout?) {
+        guard let layout,
+              layout.identity == visibleSavedRouteMapPreview?.layoutIdentity,
+              layout.height > 0,
+              savedRoutePreviewBottomHeight != layout.height else { return }
+        savedRoutePreviewBottomHeight = layout.height
+    }
+
+    private func reconcileSavedRoutePreview(with routes: [PlannedRouteSummaryV1]) {
+        guard let preview = savedRouteMapPreview else { return }
+        let identities = routes.map {
+            WatchRouteIdentityV1(routeID: $0.id, revision: $0.revision, contentHash: $0.contentHash)
+        }
+        guard SavedRouteMapPolicy.shouldRetain(
+            preview.identity,
+            installedIdentities: identities,
+            deleteAfter: preview.deleteAfter,
+            now: Date()
+        ) else {
+            clearSavedRoutePreview()
+            return
+        }
+    }
+
     private func liveActivityDiagnosticBanner(
         _ message: String
     ) -> some View {
@@ -576,7 +673,6 @@ struct ContentView: View {
                 "Times out in \(rideAutomationCoordinator.promptSecondsRemaining)s"
             )
             .font(.caption.monospacedDigit())
-            .foregroundStyle(.secondary)
             HStack {
                 Button("Not Now", role: .cancel) {
                     rideAutomationCoordinator.dismissStartPrompt()
@@ -658,6 +754,7 @@ struct ContentView: View {
                     coordinator.requestLocationAuthorization()
                 },
                 onStartTestNavigation: { destination in
+                    clearSavedRoutePreview()
                     coordinator.startNavigation(
                         from: .currentLocation,
                         to: .query(destination),
@@ -666,6 +763,10 @@ struct ContentView: View {
                     )
                 }
             )
+            .environment(\.savedRouteMapAction, SavedRouteMapAction(
+                isNavigationActive: coordinator.isNavigating,
+                show: { selection in try showSavedRouteMapPreview(selection) }
+            ))
             .environmentObject(coordinator.bleManager)
             .presentationDetents([.large])
             .presentationBackgroundInteraction(.disabled)
@@ -768,7 +869,8 @@ struct ContentView: View {
 
     private func synchronizeRideMetricsSheet() {
         if workoutStore.presentation.isWorkoutActive {
-            guard presentedSheet == nil else { return }
+            guard presentedSheet == nil,
+                  savedRouteMapPreview == nil else { return }
             rideMetricsDetent = .rideMetricsCompact
             presentedSheet = .rideMetrics
         } else if presentedSheet == .rideMetrics {
@@ -777,7 +879,8 @@ struct ContentView: View {
     }
 
     private func restoreRideMetricsSheetIfNeeded() {
-        guard workoutStore.presentation.isWorkoutActive else {
+        guard workoutStore.presentation.isWorkoutActive,
+              savedRouteMapPreview == nil else {
             isSheetDismissalInFlight = false
             presentNearbyBicinoIfEligible()
             return
@@ -785,6 +888,7 @@ struct ContentView: View {
         Task { @MainActor in
             await Task.yield()
             guard presentedSheet == nil,
+                  savedRouteMapPreview == nil,
                   workoutStore.presentation.isWorkoutActive else {
                 isSheetDismissalInFlight = false
                 presentNearbyBicinoIfEligible()
@@ -848,6 +952,7 @@ struct ContentView: View {
                     activeSheetDestination != nil ||
                     isSheetDismissalInFlight ||
                     queuedSheetAfterDismiss != nil ||
+                    savedRouteMapPreview != nil ||
                     visibleOfflineMapOnboardingStep != nil,
                 isMapAreaSelectionActive:
                     offlineMapManager.isMapAreaSelectionActive,
@@ -1145,6 +1250,15 @@ struct ContentView: View {
         isCompactHeight: Bool
     ) -> some View {
         VStack(spacing: 12) {
+            if let preview = visibleSavedRouteMapPreview {
+                SavedRouteMapPreviewCard(
+                    preview: preview,
+                    maximumHeight: min(220, maxHeight * 0.45),
+                    onHide: clearSavedRoutePreview
+                )
+                .padding(.horizontal, 12)
+            }
+
             if coordinator.routeCalculation.isCalculating {
                 CalculationStatusView(status: coordinator.routeCalculation.status)
                     .padding(.horizontal, 18)
@@ -1266,6 +1380,7 @@ struct ContentView: View {
                 currentLocation: coordinator.currentLocation,
                 maxExpandedHeight: maxHeight,
                 onStartNavigation: { source, destination, transport in
+                    clearSavedRoutePreview()
                     isSearchPanelExpanded = false
                     coordinator.planNavigation(
                         from: source,
@@ -1499,7 +1614,8 @@ struct ContentView: View {
     
     private func mapView(
         selectionFrame: CGRect?,
-        routePlanningBottomPadding: CGFloat
+        routePlanningBottomPadding: CGFloat,
+        savedRoutePreviewBottomPadding: CGFloat?
     ) -> some View {
         let canSelectDestination = !coordinator.isNavigating && !offlineMapManager.isMapAreaSelectionActive
 
@@ -1533,9 +1649,13 @@ struct ContentView: View {
             onDestinationSelected: canSelectDestination ? MapDestinationSelection.handler(
                 store: coordinator.destinationStore,
                 navigate: { destination, mapLocation in
+                    clearSavedRoutePreview()
                     coordinator.handleDestinationSelection(destination: destination, mapLocation: mapLocation)
                 }
-            ) : nil
+            ) : nil,
+            savedRoutePreview: visibleSavedRouteMapPreview?.overlay,
+            savedRoutePreviewBottomPadding: savedRoutePreviewBottomPadding,
+            isRouteCalculationActive: coordinator.routeCalculation.isCalculating
         )
     }
 

--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -673,6 +673,7 @@ struct ContentView: View {
                 "Times out in \(rideAutomationCoordinator.promptSecondsRemaining)s"
             )
             .font(.caption.monospacedDigit())
+            .foregroundStyle(.secondary)
             HStack {
                 Button("Not Now", role: .cancel) {
                     rideAutomationCoordinator.dismissStartPrompt()

--- a/ios-app/BikeComputer/BikeComputer/Managers/PhoneRouteLibrary.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/PhoneRouteLibrary.swift
@@ -317,6 +317,38 @@ final class PhoneRouteLibrary: ObservableObject {
         )
     }
 
+    /// Resolve only the selected immutable identity through normal archive
+    /// validation and retention. A successful preview read has no write or
+    /// Watch-transfer side effects and never falls back to another revision.
+    func mapSelection(
+        for summary: PlannedRouteSummaryV1
+    ) throws -> SavedRouteMapSelection {
+        let name = displayName(for: summary)
+        do {
+            let record = try store.record(
+                matching: identity(for: summary),
+                now: now()
+            )
+            // The clock may have crossed the retention deadline while reading.
+            try record.archive.validate(purpose: .offlineNavigation, now: now())
+            return SavedRouteMapSelection(
+                identity: WatchRouteIdentityV1(archive: record.archive),
+                displayName: displayName(for: record.summary),
+                route: record.archive.route,
+                createdAt: record.archive.createdAt,
+                deleteAfter: record.archive.deleteAfter
+            )
+        } catch {
+            // Publish deletion, corruption, or replacement to any open preview
+            // using the same cleanup and Watch-retention path as the library.
+            reload()
+            if let deadline = summary.deleteAfter, now() >= deadline {
+                throw SavedRouteMapError.expired(name)
+            }
+            throw SavedRouteMapError.unavailable(name)
+        }
+    }
+
     @discardableResult
     func rename(
         _ summary: PlannedRouteSummaryV1,

--- a/ios-app/BikeComputer/BikeComputer/Models/SavedRouteMapSelection.swift
+++ b/ios-app/BikeComputer/BikeComputer/Models/SavedRouteMapSelection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// An exact, verified archive read. This value is never written as a second
+/// persistent route and its geometry remains canonical WGS-84.
+struct SavedRouteMapSelection {
+    let identity: WatchRouteIdentityV1
+    let displayName: String
+    let route: NavigationRouteV1
+    let createdAt: Date
+    let deleteAfter: Date?
+}
+
+nonisolated enum SavedRouteMapError: LocalizedError {
+    case unavailable(String)
+    case expired(String)
+    case invalidGeometry(String)
+    case navigationActive
+    case planningActive
+
+    var errorDescription: String? {
+        switch self {
+        case .unavailable(let name):
+            return String(format: NSLocalizedString(
+                "“%@” is no longer available in this version or could not be verified. Select the current route, or import it again.",
+                comment: "Saved route map preview load failure"
+            ), name)
+        case .expired(let name):
+            return String(format: NSLocalizedString(
+                "“%@” has expired. Reload it from Strava before showing it on the map.",
+                comment: "Saved Strava route map preview expired"
+            ), name)
+        case .invalidGeometry(let name):
+            return String(format: NSLocalizedString(
+                "“%@” does not contain valid map geometry. Import the route again.",
+                comment: "Saved route map preview invalid coordinates"
+            ), name)
+        case .navigationActive:
+            return NSLocalizedString(
+                "Stop navigation before showing a saved route on the map.",
+                comment: "Saved route preview cannot replace active navigation"
+            )
+        case .planningActive:
+            return NSLocalizedString(
+                "Finish or cancel the current route or map-area selection before showing a saved route.",
+                comment: "Saved route preview must not replace an existing map interaction"
+            )
+        }
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift
+++ b/ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Presentation precedence only. A saved-route preview never owns navigation.
+nonisolated enum SavedRouteMapPolicy {
+    enum Content: Equatable {
+        case navigation
+        case calculatedRoute
+        case savedRoute
+        case none
+    }
+
+    static func content(
+        isNavigating: Bool,
+        hasCalculatedRoute: Bool,
+        hasRouteAlternatives: Bool,
+        isCalculating: Bool,
+        hasSavedRoute: Bool,
+        isOfflineMapSelectionActive: Bool
+    ) -> Content {
+        if isNavigating { return .navigation }
+        if isCalculating || hasCalculatedRoute || hasRouteAlternatives {
+            return .calculatedRoute
+        }
+        if hasSavedRoute && !isOfflineMapSelectionActive { return .savedRoute }
+        return .none
+    }
+
+    /// Compare the entire immutable identity, never just its route UUID.
+    static func shouldRetain<Identity: Equatable>(
+        _ identity: Identity,
+        installedIdentities: [Identity],
+        deleteAfter: Date?,
+        now: Date
+    ) -> Bool {
+        (deleteAfter.map { now < $0 } ?? true) &&
+            installedIdentities.contains(identity)
+    }
+}
+
+/// A camera fit belongs to one presentation, not to an ordinary view update.
+/// Clearing the presentation allows the same route to be fitted on reopening.
+nonisolated struct SavedRouteMapCameraState<Identity: Equatable> {
+    private(set) var displayedIdentity: Identity?
+
+    @discardableResult
+    mutating func select(_ identity: Identity?) -> Bool {
+        guard displayedIdentity != identity else { return false }
+        displayedIdentity = identity
+        return identity != nil
+    }
+}

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -118,6 +118,13 @@ struct MapCompassControl: UIViewRepresentable {
     }
 }
 
+/// Render input only; identity wraps the full UUID/revision/content-hash value.
+/// The map does not load archives, convert coordinates, or own navigation.
+struct MapSavedRouteOverlay {
+    let identity: AnyHashable
+    let polyline: MKPolyline
+}
+
 struct MapRouteAlternative: Identifiable, Equatable {
     let id: UUID
     let route: MKRoute
@@ -234,6 +241,21 @@ struct MapViewContainer: UIViewRepresentable {
     let onRouteAlternativeSelected: ((UUID) -> Void)?
     let onOfflineMapSelectionBoundsChanged: ((OfflineMapBounds) -> Void)?
     let onDestinationSelected: ((SavedDestination, CLLocation?) -> Void)?
+    var savedRoutePreview: MapSavedRouteOverlay? = nil
+    var savedRoutePreviewBottomPadding: CGFloat? = 220
+    var isRouteCalculationActive = false
+
+    private var visibleSavedRoutePreview: MapSavedRouteOverlay? {
+        let content = SavedRouteMapPolicy.content(
+            isNavigating: isNavigating,
+            hasCalculatedRoute: route != nil,
+            hasRouteAlternatives: !routeAlternatives.isEmpty,
+            isCalculating: isRouteCalculationActive,
+            hasSavedRoute: savedRoutePreview != nil,
+            isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+        )
+        return content == .savedRoute ? savedRoutePreview : nil
+    }
     
     func makeUIView(context: Context) -> MKMapView {
         let mapView = MKMapView()
@@ -247,7 +269,8 @@ struct MapViewContainer: UIViewRepresentable {
         )
         mapView.delegate = context.coordinator
         mapView.showsUserLocation = isUserLocationAuthorized
-        mapView.userTrackingMode = isUserLocationAuthorized ? .follow : .none
+        mapView.userTrackingMode = isUserLocationAuthorized &&
+            visibleSavedRoutePreview == nil ? .follow : .none
         
         // Configure map appearance
         mapView.showsCompass = false
@@ -295,10 +318,16 @@ struct MapViewContainer: UIViewRepresentable {
             to: uiView
         )
         let isOfflineMapSelectionActive = offlineMapSelectionFrame != nil
-        let isFreePanActive = context.coordinator.isFreePanActive(
+        // Use the incoming preview, not the old coordinator state: clearing a
+        // preview must restore tracking, while showing one must block an
+        // initial-location update before the overlay has been installed.
+        let otherFreePanActive = context.coordinator.isFreePanActive(
             mapView: uiView,
-            isOfflineMapSelectionActive: isOfflineMapSelectionActive
+            isOfflineMapSelectionActive: isOfflineMapSelectionActive,
+            includesSavedRoutePreview: false
         )
+        let preview = visibleSavedRoutePreview
+        let isFreePanActive = otherFreePanActive || preview != nil
 
         // Store reference to map view in coordinator
         context.coordinator.mapView = uiView
@@ -340,7 +369,10 @@ struct MapViewContainer: UIViewRepresentable {
             isSimulationMode: isSimulationMode,
             isNavigating: isNavigating,
             isUserLocationAuthorized: isUserLocationAuthorized,
-            isFreePanActive: isFreePanActive
+            isFreePanActive: otherFreePanActive,
+            savedRoutePreview: preview,
+            savedRoutePreviewBottomPadding: savedRoutePreviewBottomPadding,
+            isRouteCalculationActive: isRouteCalculationActive
         )
         
         // Update simulated position
@@ -404,6 +436,7 @@ struct MapViewContainer: UIViewRepresentable {
         _ uiView: MKMapView,
         coordinator: Coordinator
     ) {
+        coordinator.removeSavedRouteOverlay(from: uiView)
         coordinator.controlState?.disconnect(from: uiView)
     }
     
@@ -426,6 +459,10 @@ struct MapViewContainer: UIViewRepresentable {
         var simulatedPosition: CLLocationCoordinate2D?
         var hasSetInitialRegion = false
         private(set) var lastAppliedAppearance: IPhoneMapAppearance?
+        private(set) var displayedSavedRouteIdentity: AnyHashable?
+        private(set) var displayedSavedRouteOverlay: MKPolyline?
+        private var savedRouteCamera = SavedRouteMapCameraState<AnyHashable>()
+        private var routeOverlays: [MKPolyline] = []
         private var trackingButton: MKUserTrackingButton?
         private var lastNavigationCoordinate: CLLocationCoordinate2D?
         private var lastNavigationHeading: CLLocationDirection = 0
@@ -487,7 +524,8 @@ struct MapViewContainer: UIViewRepresentable {
             }
             let desiredTrackingBehavior = MapTrackingPolicy.desiredMode(
                 isNavigating: isNavigating,
-                isOfflineMapSelectionActive: isOfflineMapSelectionActive,
+                isOfflineMapSelectionActive: isOfflineMapSelectionActive ||
+                    displayedSavedRouteOverlay != nil,
                 isDestinationSelectionActive: isDestinationSelectionActive
             )
 
@@ -524,11 +562,13 @@ struct MapViewContainer: UIViewRepresentable {
 
         func isFreePanActive(
             mapView: MKMapView,
-            isOfflineMapSelectionActive: Bool
+            isOfflineMapSelectionActive: Bool,
+            includesSavedRoutePreview: Bool = true
         ) -> Bool {
-            isOfflineMapSelectionActive || mapView.selectedAnnotations.contains {
-                $0 is DestinationAnnotation
-            }
+            (includesSavedRoutePreview && displayedSavedRouteOverlay != nil) ||
+                isOfflineMapSelectionActive || mapView.selectedAnnotations.contains {
+                    $0 is DestinationAnnotation
+                }
         }
 
         func updateInitialRegionIfNeeded(
@@ -615,29 +655,63 @@ struct MapViewContainer: UIViewRepresentable {
             isSimulationMode: Bool,
             isNavigating: Bool,
             isUserLocationAuthorized: Bool,
-            isFreePanActive: Bool
+            isFreePanActive: Bool,
+            savedRoutePreview: MapSavedRouteOverlay? = nil,
+            savedRoutePreviewBottomPadding: CGFloat? = 220,
+            isRouteCalculationActive: Bool = false
         ) {
+            // Navigation wins even if an alternatives callback arrives late.
+            let alternatives = isNavigating ? [] : alternatives
+            let content = SavedRouteMapPolicy.content(
+                isNavigating: isNavigating,
+                hasCalculatedRoute: route != nil,
+                hasRouteAlternatives: !alternatives.isEmpty,
+                isCalculating: isRouteCalculationActive,
+                hasSavedRoute: savedRoutePreview != nil,
+                isOfflineMapSelectionActive: offlineMapSelectionFrame != nil
+            )
+            let preview = content == .savedRoute ? savedRoutePreview : nil
+            let removedSavedRoute = preview == nil
+                ? removeSavedRouteOverlay(from: mapView) : false
             let activeRouteMatches =
                 (lastRoute == nil && route == nil) || lastRoute === route
             let routeContentChanged =
                 !activeRouteMatches || lastRouteAlternatives != alternatives
+            let hadRouteContent = lastRoute != nil ||
+                !lastRouteAlternatives.isEmpty
+
+            if routeContentChanged {
+                installRouteOverlays(
+                    route: route,
+                    alternatives: alternatives,
+                    selectedAlternativeID: selectedAlternativeID,
+                    on: mapView
+                )
+            }
+
+            if let preview {
+                updateSavedRouteOverlay(
+                    preview,
+                    on: mapView,
+                    bottomPadding: savedRoutePreviewBottomPadding
+                )
+                return
+            }
 
             if !routeContentChanged {
                 updateSelectedRouteAlternative(
                     selectedAlternativeID,
                     on: mapView
                 )
+                if removedSavedRoute {
+                    finishNavigationTracking(
+                        mapView: mapView,
+                        isUserLocationAuthorized: isUserLocationAuthorized,
+                        isFreePanActive: isFreePanActive
+                    )
+                }
                 return
             }
-
-            let hadRouteContent = lastRoute != nil ||
-                !lastRouteAlternatives.isEmpty
-            installRouteOverlays(
-                route: route,
-                alternatives: alternatives,
-                selectedAlternativeID: selectedAlternativeID,
-                on: mapView
-            )
 
             if !alternatives.isEmpty {
                 configureRouteAlternativesCamera(
@@ -678,7 +752,10 @@ struct MapViewContainer: UIViewRepresentable {
             selectedAlternativeID: UUID?,
             on mapView: MKMapView
         ) {
-            mapView.removeOverlays(mapView.overlays)
+            // Only these polylines belong to the calculated/navigation layer.
+            // In particular, never remove every overlay from the shared map.
+            mapView.removeOverlays(routeOverlays)
+            routeOverlays.removeAll(keepingCapacity: true)
             lastRoute = route
             lastRouteAlternatives = alternatives
             self.selectedRouteAlternativeID = selectedAlternativeID
@@ -686,6 +763,7 @@ struct MapViewContainer: UIViewRepresentable {
 
             guard !alternatives.isEmpty else {
                 if let route {
+                    routeOverlays = [route.polyline]
                     mapView.addOverlay(route.polyline, level: .aboveRoads)
                 }
                 return
@@ -701,10 +779,60 @@ struct MapViewContainer: UIViewRepresentable {
             } + alternatives.filter {
                 $0.id == selectedAlternativeID
             }
-            mapView.addOverlays(
-                orderedAlternatives.map(\.route.polyline),
-                level: .aboveRoads
+            routeOverlays = orderedAlternatives.map(\.route.polyline)
+            mapView.addOverlays(routeOverlays, level: .aboveRoads)
+        }
+
+        @discardableResult
+        func removeSavedRouteOverlay(from mapView: MKMapView) -> Bool {
+            let overlay = displayedSavedRouteOverlay
+            if let overlay { mapView.removeOverlay(overlay) }
+            displayedSavedRouteOverlay = nil
+            displayedSavedRouteIdentity = nil
+            savedRouteCamera.select(nil)
+            return overlay != nil
+        }
+
+        private func updateSavedRouteOverlay(
+            _ preview: MapSavedRouteOverlay,
+            on mapView: MKMapView,
+            bottomPadding: CGFloat?
+        ) {
+            if displayedSavedRouteIdentity != preview.identity {
+                removeSavedRouteOverlay(from: mapView)
+                displayedSavedRouteIdentity = preview.identity
+                displayedSavedRouteOverlay = preview.polyline
+                mapView.addOverlay(preview.polyline, level: .aboveRoads)
+            }
+            if mapView.userTrackingMode != .none {
+                mapView.setUserTrackingMode(.none, animated: false)
+            }
+            // Wait for the card's actual layout before the one camera fit.
+            // Subsequent location, appearance, pitch, and layout updates do not
+            // refit, so manual pan/zoom remains under the user's control.
+            guard let bottomPadding, bottomPadding.isFinite,
+                  mapView.bounds.width > 0, mapView.bounds.height > 0,
+                  savedRouteCamera.select(preview.identity) else { return }
+            let bounds = preview.polyline.boundingMapRect
+            let width = max(bounds.width, 100)
+            let height = max(bounds.height, 100)
+            let fittingBounds = MKMapRect(
+                x: bounds.midX - width / 2,
+                y: bounds.midY - height / 2,
+                width: width,
+                height: height
             )
+            mapView.setVisibleMapRect(
+                fittingBounds,
+                edgePadding: UIEdgeInsets(
+                    top: 140,
+                    left: 32,
+                    bottom: min(max(bottomPadding, 100), max(mapView.bounds.height - 180, 100)),
+                    right: 80
+                ),
+                animated: true
+            )
+            hasSetInitialRegion = true
         }
 
         func updateSelectedRouteAlternative(
@@ -717,14 +845,14 @@ struct MapViewContainer: UIViewRepresentable {
             self.selectedRouteAlternativeID = selectedAlternativeID
 
             if let selectedAlternativeID,
-               let selectedOverlay = mapView.overlays.first(where: {
+               let selectedOverlay = routeOverlays.first(where: {
                    routeAlternativeID(for: $0) == selectedAlternativeID
                }) {
                 mapView.removeOverlay(selectedOverlay)
                 mapView.addOverlay(selectedOverlay, level: .aboveRoads)
             }
 
-            for overlay in mapView.overlays {
+            for overlay in routeOverlays {
                 guard let renderer = mapView.renderer(for: overlay)
                     as? MKPolylineRenderer else {
                     continue
@@ -1125,6 +1253,12 @@ struct MapViewContainer: UIViewRepresentable {
             _ renderer: MKPolylineRenderer,
             for overlay: MKOverlay
         ) {
+            if let saved = displayedSavedRouteOverlay, overlay === saved {
+                renderer.strokeColor = .systemBlue
+                renderer.lineWidth = 4
+                renderer.alpha = 0.65
+                return
+            }
             guard let alternativeID = routeAlternativeID(for: overlay) else {
                 renderer.strokeColor = .systemBlue
                 renderer.lineWidth = 6

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -43,6 +43,10 @@ enum DestinationCalloutLabel {
 
 class SimulatedPositionAnnotation: MKPointAnnotation {}
 
+// MARK: - Saved Route Finish Annotation
+
+final class SavedRouteFinishAnnotation: MKPointAnnotation {}
+
 // MARK: - Map View Container
 
 @MainActor
@@ -123,6 +127,17 @@ struct MapCompassControl: UIViewRepresentable {
 struct MapSavedRouteOverlay {
     let identity: AnyHashable
     let polyline: MKPolyline
+
+    var finishCoordinate: CLLocationCoordinate2D {
+        guard polyline.pointCount > 0 else { return polyline.coordinate }
+
+        var coordinate = CLLocationCoordinate2D()
+        polyline.getCoordinates(
+            &coordinate,
+            range: NSRange(location: polyline.pointCount - 1, length: 1)
+        )
+        return coordinate
+    }
 }
 
 struct MapRouteAlternative: Identifiable, Equatable {
@@ -461,6 +476,7 @@ struct MapViewContainer: UIViewRepresentable {
         private(set) var lastAppliedAppearance: IPhoneMapAppearance?
         private(set) var displayedSavedRouteIdentity: AnyHashable?
         private(set) var displayedSavedRouteOverlay: MKPolyline?
+        private(set) var displayedSavedRouteFinishAnnotation: SavedRouteFinishAnnotation?
         private var savedRouteCamera = SavedRouteMapCameraState<AnyHashable>()
         private var routeOverlays: [MKPolyline] = []
         private var trackingButton: MKUserTrackingButton?
@@ -787,10 +803,13 @@ struct MapViewContainer: UIViewRepresentable {
         func removeSavedRouteOverlay(from mapView: MKMapView) -> Bool {
             let overlay = displayedSavedRouteOverlay
             if let overlay { mapView.removeOverlay(overlay) }
+            let finishAnnotation = displayedSavedRouteFinishAnnotation
+            if let finishAnnotation { mapView.removeAnnotation(finishAnnotation) }
             displayedSavedRouteOverlay = nil
+            displayedSavedRouteFinishAnnotation = nil
             displayedSavedRouteIdentity = nil
             savedRouteCamera.select(nil)
-            return overlay != nil
+            return overlay != nil || finishAnnotation != nil
         }
 
         private func updateSavedRouteOverlay(
@@ -803,6 +822,12 @@ struct MapViewContainer: UIViewRepresentable {
                 displayedSavedRouteIdentity = preview.identity
                 displayedSavedRouteOverlay = preview.polyline
                 mapView.addOverlay(preview.polyline, level: .aboveRoads)
+
+                let finishAnnotation = SavedRouteFinishAnnotation()
+                finishAnnotation.coordinate = preview.finishCoordinate
+                finishAnnotation.title = "Finish"
+                displayedSavedRouteFinishAnnotation = finishAnnotation
+                mapView.addAnnotation(finishAnnotation)
             }
             if mapView.userTrackingMode != .none {
                 mapView.setUserTrackingMode(.none, animated: false)
@@ -1278,6 +1303,26 @@ struct MapViewContainer: UIViewRepresentable {
             // Use default view for user location
             if annotation is MKUserLocation {
                 return nil
+            }
+
+            // Mark the endpoint of a saved route with the native checkered-flag
+            // SF Symbol when available, falling back to the standard flag.
+            if let _ = annotation as? SavedRouteFinishAnnotation {
+                let identifier = "SavedRouteFinish"
+                var annotationView = mapView.dequeueReusableAnnotationView(withIdentifier: identifier) as? MKMarkerAnnotationView
+
+                if annotationView == nil {
+                    annotationView = MKMarkerAnnotationView(annotation: annotation, reuseIdentifier: identifier)
+                    annotationView?.canShowCallout = false
+                    annotationView?.markerTintColor = .systemGreen
+                    annotationView?.glyphImage = UIImage(systemName: "flag.checkered")
+                        ?? UIImage(systemName: "flag.fill")
+                    annotationView?.displayPriority = .required
+                    annotationView?.accessibilityLabel = "Route finish"
+                } else {
+                    annotationView?.annotation = annotation
+                }
+                return annotationView
             }
             
             // Handle simulated position annotation

--- a/ios-app/BikeComputer/BikeComputer/Views/PlannedRoutesView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/PlannedRoutesView.swift
@@ -4,6 +4,7 @@ import UniformTypeIdentifiers
 struct SavedRoutesSettingsSection: View {
     @ObservedObject var routeLibrary: PhoneRouteLibrary
     @ObservedObject var stravaCoordinator: StravaIntegrationCoordinator
+    @Environment(\.savedRouteMapAction) private var mapAction
     let onImportFromStrava: () -> Void
     @FocusState private var focusedRouteID: UUID?
     @State private var renameInteraction = SavedRouteRenameInteraction()
@@ -60,11 +61,11 @@ struct SavedRoutesSettingsSection: View {
             Text("Saved Routes")
         } footer: {
             Text(
-                "Save GPX route files to your Apple watch for offline navigation"
+                "Preview saved routes on the map, or send them to Apple Watch for offline navigation."
             )
         }
         .alert(
-            "Route Sync Error",
+            "Saved Route Error",
             isPresented: Binding(
                 get: { errorMessage != nil },
                 set: { if !$0 { errorMessage = nil } }
@@ -174,6 +175,33 @@ struct SavedRoutesSettingsSection: View {
                     deleteAfter: route.deleteAfter
                 )
             }
+
+            // This is a local read, independent of Watch transfer state. Keep
+            // it separate from the already crowded rename/Watch/delete row.
+            Button {
+                finishRenaming()
+                focusedRouteID = nil
+                guard let mapAction else { return }
+                do {
+                    try mapAction.perform {
+                        try routeLibrary.mapSelection(for: route)
+                    }
+                } catch {
+                    errorMessage = error.localizedDescription
+                }
+            } label: {
+                Label("Show on Map", systemImage: "map")
+                    .frame(minHeight: 44)
+            }
+            .buttonStyle(.borderless)
+            .disabled(mapAction == nil || mapAction?.isNavigationActive == true)
+            .accessibilityLabel("Show \(displayName) on map")
+            .accessibilityHint(
+                mapAction?.isNavigationActive == true
+                    ? "Available after navigation stops"
+                    : "Previews the saved route without starting navigation"
+            )
+            .accessibilityIdentifier("showSavedRouteOnMap-\(route.id.uuidString)")
 
             if let transientStatus = transientStatus(status) {
                 Label(transientStatus.label, systemImage: transientStatus.icon)

--- a/ios-app/BikeComputer/BikeComputer/Views/PlannedRoutesView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/PlannedRoutesView.swift
@@ -130,6 +130,11 @@ struct SavedRoutesSettingsSection: View {
                     .contentShape(Rectangle())
                     .onTapGesture { focusedRouteID = nil }
 
+                mapPreviewButton(
+                    route: route,
+                    displayName: displayName
+                )
+
                 watchStatusControl(
                     status,
                     route: route,
@@ -164,44 +169,12 @@ struct SavedRoutesSettingsSection: View {
                 .accessibilityLabel("Delete \(displayName)")
             }
 
-            Text("\(route.source.label) → \(route.destination.label)")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .lineLimit(2)
-
             if route.providerID == RouteProviderPolicyV1.strava.providerID {
                 stravaAttribution(
                     sourceReference: route.sourceReference,
                     deleteAfter: route.deleteAfter
                 )
             }
-
-            // This is a local read, independent of Watch transfer state. Keep
-            // it separate from the already crowded rename/Watch/delete row.
-            Button {
-                finishRenaming()
-                focusedRouteID = nil
-                guard let mapAction else { return }
-                do {
-                    try mapAction.perform {
-                        try routeLibrary.mapSelection(for: route)
-                    }
-                } catch {
-                    errorMessage = error.localizedDescription
-                }
-            } label: {
-                Label("Show on Map", systemImage: "map")
-                    .frame(minHeight: 44)
-            }
-            .buttonStyle(.borderless)
-            .disabled(mapAction == nil || mapAction?.isNavigationActive == true)
-            .accessibilityLabel("Show \(displayName) on map")
-            .accessibilityHint(
-                mapAction?.isNavigationActive == true
-                    ? "Available after navigation stops"
-                    : "Previews the saved route without starting navigation"
-            )
-            .accessibilityIdentifier("showSavedRouteOnMap-\(route.id.uuidString)")
 
             if let transientStatus = transientStatus(status) {
                 Label(transientStatus.label, systemImage: transientStatus.icon)
@@ -210,6 +183,38 @@ struct SavedRoutesSettingsSection: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func mapPreviewButton(
+        route: PlannedRouteSummaryV1,
+        displayName: String
+    ) -> some View {
+        // This is a local read, independent of Watch transfer state. Keep it
+        // beside the Watch upload action so each route's controls stay together.
+        Button {
+            finishRenaming()
+            focusedRouteID = nil
+            guard let mapAction else { return }
+            do {
+                try mapAction.perform {
+                    try routeLibrary.mapSelection(for: route)
+                }
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        } label: {
+            Image(systemName: "map")
+                .frame(width: 32, height: 32)
+        }
+        .buttonStyle(.borderless)
+        .disabled(mapAction == nil || mapAction?.isNavigationActive == true)
+        .accessibilityLabel("Show \(displayName) on map")
+        .accessibilityHint(
+            mapAction?.isNavigationActive == true
+                ? "Available after navigation stops"
+                : "Previews the saved route without starting navigation"
+        )
+        .accessibilityIdentifier("showSavedRouteOnMap-\(route.id.uuidString)")
     }
 
     private func expiredStravaRow(
@@ -223,6 +228,11 @@ struct SavedRoutesSettingsSection: View {
                     .lineLimit(2)
 
                 Spacer()
+
+                Image(systemName: "clock.badge.exclamationmark")
+                    .foregroundStyle(.secondary)
+                    .frame(width: 32, height: 32)
+                    .accessibilityLabel("Expired")
 
                 stravaReloadButton(
                     routeID: bookmark.routeID,
@@ -245,10 +255,6 @@ struct SavedRoutesSettingsSection: View {
                 .buttonStyle(.borderless)
                 .accessibilityLabel("Delete \(displayName)")
             }
-
-            Label("Expired", systemImage: "clock.badge.exclamationmark")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
 
             HStack(spacing: 10) {
                 if let url = URL(string: bookmark.canonicalURL) {

--- a/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
@@ -28,7 +28,7 @@ enum SavedRouteMapPreviewFactory {
     static func make(
         _ selection: SavedRouteMapSelection,
         now: () -> Date = Date.init,
-        convert: (CLLocationCoordinate2D) -> CLLocationCoordinate2D =
+        convert: @MainActor (CLLocationCoordinate2D) -> CLLocationCoordinate2D =
             displayCoordinate
     ) throws -> SavedRouteMapPreview {
         try checkExpiry(selection, now: now())

--- a/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
@@ -151,9 +151,11 @@ struct SavedRouteMapPreviewCard: View {
     var body: some View {
         ViewThatFits(in: .vertical) {
             contents
+                .fixedSize(horizontal: false, vertical: true)
             ScrollView { contents }
+                .frame(maxHeight: maximumHeight, alignment: .top)
         }
-        .frame(maxHeight: maximumHeight)
+        .fixedSize(horizontal: false, vertical: true)
         .padding(14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
@@ -165,9 +167,6 @@ struct SavedRouteMapPreviewCard: View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(alignment: .top, spacing: 8) {
                 VStack(alignment: .leading, spacing: 3) {
-                    Text("Route preview")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
                     Text(preview.displayName)
                         .font(.headline)
                         .fixedSize(horizontal: false, vertical: true)
@@ -183,15 +182,8 @@ struct SavedRouteMapPreviewCard: View {
                 .accessibilityHint("Closes the preview without deleting the saved route")
                 .accessibilityIdentifier("hideSavedRouteMapPreview")
             }
-            Text("\(preview.sourceLabel) → \(preview.destinationLabel)")
-                .font(.subheadline)
-                .fixedSize(horizontal: false, vertical: true)
             Text(distance)
                 .font(.subheadline)
-            Text(preview.attribution)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
             if preview.providerID == RouteProviderPolicyV1.strava.providerID,
                let url = preview.sourceURL {
                 Link("View on Strava", destination: url)

--- a/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift
@@ -1,0 +1,213 @@
+import CoreLocation
+import Foundation
+import MapKit
+import SwiftUI
+
+/// Display-only data. In particular, no archive or second coordinate cache is
+/// retained after construction of the MapKit overlay.
+struct SavedRouteMapPreview {
+    let identity: WatchRouteIdentityV1
+    let displayName: String
+    let sourceLabel: String
+    let destinationLabel: String
+    let distanceMeters: CLLocationDistance
+    let providerID: String
+    let attribution: String
+    let sourceURL: URL?
+    let createdAt: Date
+    let deleteAfter: Date?
+    let overlay: MapSavedRouteOverlay
+
+    var layoutIdentity: String {
+        "\(identity.routeID.uuidString)|\(identity.revision)|\(identity.contentHash)"
+    }
+}
+
+@MainActor
+enum SavedRouteMapPreviewFactory {
+    static func make(
+        _ selection: SavedRouteMapSelection,
+        now: () -> Date = Date.init,
+        convert: (CLLocationCoordinate2D) -> CLLocationCoordinate2D =
+            displayCoordinate
+    ) throws -> SavedRouteMapPreview {
+        try checkExpiry(selection, now: now())
+        let route = selection.route
+        guard selection.identity.routeID == route.id,
+              selection.identity.revision == route.revision,
+              (2...NavigationRouteLimitsV1.production.maximumPoints)
+                .contains(route.points.count) else {
+            throw SavedRouteMapError.invalidGeometry(selection.displayName)
+        }
+
+        // Convert once, at the iPhone presentation boundary. Never mutate the
+        // archive, request directions, reparse GPX, or contact the provider.
+        let coordinates = try route.points.map { point in
+            guard point.isValid else {
+                throw SavedRouteMapError.invalidGeometry(selection.displayName)
+            }
+            let coordinate = convert(CLLocationCoordinate2D(
+                latitude: point.latitude,
+                longitude: point.longitude
+            ))
+            guard CLLocationCoordinate2DIsValid(coordinate),
+                  coordinate.latitude.isFinite,
+                  coordinate.longitude.isFinite else {
+                throw SavedRouteMapError.invalidGeometry(selection.displayName)
+            }
+            return coordinate
+        }
+        guard let first = coordinates.first,
+              coordinates.contains(where: {
+                  $0.latitude != first.latitude || $0.longitude != first.longitude
+              }) else {
+            throw SavedRouteMapError.invalidGeometry(selection.displayName)
+        }
+        let polyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
+        let bounds = polyline.boundingMapRect
+        guard !bounds.isNull,
+              [bounds.origin.x, bounds.origin.y, bounds.width, bounds.height]
+                .allSatisfy(\.isFinite) else {
+            throw SavedRouteMapError.invalidGeometry(selection.displayName)
+        }
+        try checkExpiry(selection, now: now())
+        return SavedRouteMapPreview(
+            identity: selection.identity,
+            displayName: selection.displayName,
+            sourceLabel: route.source.label,
+            destinationLabel: route.destination.label,
+            distanceMeters: route.distanceMeters,
+            providerID: route.provider.providerID,
+            attribution: route.provider.attribution,
+            sourceURL: route.sourceReference.flatMap { URL(string: $0.canonicalURL) },
+            createdAt: selection.createdAt,
+            deleteAfter: selection.deleteAfter,
+            overlay: MapSavedRouteOverlay(identity: selection.identity, polyline: polyline)
+        )
+    }
+
+    static func displayCoordinate(
+        _ coordinate: CLLocationCoordinate2D
+    ) -> CLLocationCoordinate2D {
+        guard CoordinateConverter.isInChina(
+            lat: coordinate.latitude,
+            lon: coordinate.longitude
+        ) else { return coordinate }
+        return CoordinateConverter.wgs84ToGCJ02(coordinate: coordinate)
+    }
+
+    private static func checkExpiry(_ selection: SavedRouteMapSelection, now: Date) throws {
+        if let deadline = selection.deleteAfter, now >= deadline {
+            throw SavedRouteMapError.expired(selection.displayName)
+        }
+    }
+}
+
+/// A scoped Settings-to-main-map callback. The default does not silently accept
+/// selections. Both the exact archive read and the presentation callback must
+/// succeed before ContentView dismisses Settings.
+nonisolated struct SavedRouteMapAction: Sendable {
+    let isNavigationActive: Bool
+    let show: @MainActor @Sendable (SavedRouteMapSelection) throws -> Void
+
+    @MainActor
+    func perform(load: () throws -> SavedRouteMapSelection) throws {
+        guard !isNavigationActive else { throw SavedRouteMapError.navigationActive }
+        try show(try load())
+    }
+}
+
+private nonisolated struct SavedRouteMapActionKey: EnvironmentKey {
+    static let defaultValue: SavedRouteMapAction? = nil
+}
+
+extension EnvironmentValues {
+    var savedRouteMapAction: SavedRouteMapAction? {
+        get { self[SavedRouteMapActionKey.self] }
+        set { self[SavedRouteMapActionKey.self] = newValue }
+    }
+}
+
+/// Include identity so equally tall successive route cards still publish their
+/// first layout. A delayed layout from a previous preview cannot fit a new one.
+nonisolated struct SavedRoutePreviewLayout: Equatable, Sendable {
+    let identity: String
+    let height: CGFloat
+}
+
+nonisolated struct SavedRoutePreviewLayoutKey: PreferenceKey {
+    static let defaultValue: SavedRoutePreviewLayout? = nil
+
+    static func reduce(value: inout SavedRoutePreviewLayout?, nextValue: () -> SavedRoutePreviewLayout?) {
+        value = nextValue() ?? value
+    }
+}
+
+struct SavedRouteMapPreviewCard: View {
+    let preview: SavedRouteMapPreview
+    let maximumHeight: CGFloat
+    let onHide: () -> Void
+
+    var body: some View {
+        ViewThatFits(in: .vertical) {
+            contents
+            ScrollView { contents }
+        }
+        .frame(maxHeight: maximumHeight)
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 20))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("savedRouteMapPreview")
+    }
+
+    private var contents: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .top, spacing: 8) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text("Route preview")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text(preview.displayName)
+                        .font(.headline)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                Spacer(minLength: 0)
+                Button(action: onHide) {
+                    Image(systemName: "xmark")
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Hide \(preview.displayName) from map")
+                .accessibilityHint("Closes the preview without deleting the saved route")
+                .accessibilityIdentifier("hideSavedRouteMapPreview")
+            }
+            Text("\(preview.sourceLabel) → \(preview.destinationLabel)")
+                .font(.subheadline)
+                .fixedSize(horizontal: false, vertical: true)
+            Text(distance)
+                .font(.subheadline)
+            Text(preview.attribution)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if preview.providerID == RouteProviderPolicyV1.strava.providerID,
+               let url = preview.sourceURL {
+                Link("View on Strava", destination: url)
+                    .font(.caption)
+            }
+            if let deadline = preview.deleteAfter {
+                Text("Expires \(deadline.formatted(date: .abbreviated, time: .shortened))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private var distance: String {
+        let formatter = MKDistanceFormatter()
+        return formatter.string(fromDistance: preview.distanceMeters)
+    }
+}

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -12082,7 +12082,7 @@ struct NavigationProtocolTests {
         assert(
             source.contains("Text(\"Saved Routes\")") &&
                 source.contains(
-                    "Save GPX route files to your Apple watch for offline navigation"
+                    "Preview saved routes on the map, or send them to Apple Watch for offline navigation."
                 ),
             "Saved Routes uses the requested title and explanatory copy"
         )

--- a/ios-app/BikeComputerTests/SavedRouteMapPolicyTests.swift
+++ b/ios-app/BikeComputerTests/SavedRouteMapPolicyTests.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+@main
+struct SavedRouteMapPolicyTests {
+    struct Identity: Equatable {
+        let routeID: UUID
+        let revision: UInt32
+        let contentHash: String
+    }
+
+    static func main() {
+        var checks = 0
+        func check(_ value: Bool, _ message: String) {
+            precondition(value, message)
+            checks += 1
+        }
+        for mask in 0..<64 {
+            let navigating = mask & 1 != 0
+            let calculated = mask & 2 != 0
+            let alternatives = mask & 4 != 0
+            let calculating = mask & 8 != 0
+            let saved = mask & 16 != 0
+            let offlineSelection = mask & 32 != 0
+            let actual = SavedRouteMapPolicy.content(
+                isNavigating: navigating,
+                hasCalculatedRoute: calculated,
+                hasRouteAlternatives: alternatives,
+                isCalculating: calculating,
+                hasSavedRoute: saved,
+                isOfflineMapSelectionActive: offlineSelection
+            )
+            let expected: SavedRouteMapPolicy.Content
+            if navigating { expected = .navigation }
+            else if calculated || alternatives || calculating {
+                expected = .calculatedRoute
+            } else if saved && !offlineSelection { expected = .savedRoute }
+            else { expected = .none }
+            check(actual == expected, "Precedence combination \(mask)")
+        }
+
+        let routeID = UUID()
+        let first = Identity(routeID: routeID, revision: 1, contentHash: "a")
+        let revision = Identity(routeID: routeID, revision: 2, contentHash: "a")
+        let hash = Identity(routeID: routeID, revision: 1, contentHash: "b")
+        let second = Identity(routeID: UUID(), revision: 1, contentHash: "a")
+        var camera = SavedRouteMapCameraState<Identity>()
+        check(!camera.select(nil), "Empty map must not fit")
+        check(camera.select(first), "First selection must fit")
+        for _ in 0..<100 {
+            check(!camera.select(first), "Unrelated view/location updates must not refit")
+        }
+        check(camera.select(second), "A different route must fit")
+        check(camera.select(revision), "A new revision must fit")
+        check(camera.select(hash), "A different hash must fit")
+        check(!camera.select(nil), "Clearing must not fit")
+        check(camera.displayedIdentity == nil, "Clearing releases identity")
+        check(camera.select(hash), "Reopening after hiding must fit")
+
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        check(SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [first], deleteAfter: nil, now: now), "GPX remains available")
+        check(SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [first], deleteAfter: now.addingTimeInterval(1), now: now), "Active Strava remains available")
+        check(!SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [first], deleteAfter: now, now: now), "Expiry boundary is exclusive")
+        check(!SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [], deleteAfter: nil, now: now), "Deletion/pruning/corruption clears preview")
+        check(!SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [revision], deleteAfter: nil, now: now), "Revision replacement clears old geometry")
+        check(!SavedRouteMapPolicy.shouldRetain(first, installedIdentities: [hash], deleteAfter: nil, now: now), "Hash replacement clears old geometry")
+        print("Saved route map policy: \(checks) checks passed")
+    }
+}

--- a/ios-app/BikeComputerTests/SavedRouteMapPreviewTests.swift
+++ b/ios-app/BikeComputerTests/SavedRouteMapPreviewTests.swift
@@ -1,0 +1,472 @@
+import Combine
+import Foundation
+import MapKit
+import SwiftUI
+import UIKit
+
+// Boundary doubles only: compile the production library, archive store,
+// preview factory, and MapView coordinator in this executable.
+@MainActor
+final class PhoneWatchConnectivityCoordinator: ObservableObject {
+    struct State { var isReachable = false }
+    @Published var state = State()
+    var onRouteAcknowledgement: ((WatchRouteSyncMessageV1) -> Void)?
+    private(set) var sideEffects = 0
+    func transferRoute(_ record: InstalledNavigationRouteV1) -> UUID? {
+        sideEffects += 1
+        return UUID()
+    }
+    func sendRouteImmediately(_ record: InstalledNavigationRouteV1) {
+        sideEffects += 1
+    }
+    func cancelRouteTransfers(_ identity: WatchRouteIdentityV1) -> Int {
+        sideEffects += 1
+        return 1
+    }
+    func requestRouteDeletion(_ identity: WatchRouteIdentityV1) -> UUID? {
+        sideEffects += 1
+        return UUID()
+    }
+    func updateRouteDisplayNames(_ entries: [WatchRouteDisplayNameV1]) throws {
+        sideEffects += 1
+    }
+}
+
+struct OfflineMapBounds {
+    let minLon: Double
+    let minLat: Double
+    let maxLon: Double
+    let maxLat: Double
+}
+
+@MainActor
+private final class PreviewClock {
+    var now = Date(timeIntervalSince1970: 1_800_000_000)
+}
+
+@MainActor
+private final class LibraryFixture {
+    let clock = PreviewClock()
+    let root = FileManager.default.temporaryDirectory
+        .appendingPathComponent("saved-route-preview-\(UUID().uuidString)")
+    let suite = "saved-route-preview.\(UUID().uuidString)"
+    let defaults: UserDefaults
+    let store: NavigationRouteFileStoreV1
+    let connectivity = PhoneWatchConnectivityCoordinator()
+    let library: PhoneRouteLibrary
+
+    init() {
+        defaults = UserDefaults(suiteName: suite)!
+        store = NavigationRouteFileStoreV1(rootDirectory: root)
+        let clock = self.clock
+        library = PhoneRouteLibrary(
+            store: store,
+            connectivity: connectivity,
+            defaults: defaults,
+            now: { clock.now }
+        )
+    }
+
+    func install(_ archive: NavigationRouteArchiveV1) throws -> PlannedRouteSummaryV1 {
+        try library.importArchive(archive.encoded(purpose: .offlineNavigation, now: clock.now))
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: root)
+        defaults.removePersistentDomain(forName: suite)
+    }
+}
+
+@MainActor
+private final class PreviewRecordingMap: MKMapView {
+    private var items: [MKOverlay] = []
+    private var mode: MKUserTrackingMode = .none
+    private var selection: [MKAnnotation] = []
+    private var renderers: [ObjectIdentifier: MKOverlayRenderer] = [:]
+    private(set) var additions = 0
+    private(set) var removals = 0
+    private(set) var fits: [(MKMapRect, UIEdgeInsets)] = []
+    private(set) var regionUpdates = 0
+    private(set) var cameraUpdates = 0
+    private(set) var levels: [MKOverlayLevel] = []
+
+    override var overlays: [MKOverlay] { items }
+    override var userTrackingMode: MKUserTrackingMode {
+        get { mode }
+        set { mode = newValue }
+    }
+    override var selectedAnnotations: [MKAnnotation] {
+        get { selection }
+        set { selection = newValue }
+    }
+    override func setUserTrackingMode(_ mode: MKUserTrackingMode, animated: Bool) {
+        self.mode = mode
+    }
+    override func addOverlay(_ overlay: MKOverlay, level: MKOverlayLevel) {
+        additions += 1
+        items.append(overlay)
+        levels.append(level)
+    }
+    override func addOverlays(_ overlays: [MKOverlay], level: MKOverlayLevel) {
+        for overlay in overlays { addOverlay(overlay, level: level) }
+    }
+    override func removeOverlay(_ overlay: MKOverlay) {
+        if items.contains(where: { $0 === overlay }) { removals += 1 }
+        items.removeAll { $0 === overlay }
+        renderers.removeValue(forKey: ObjectIdentifier(overlay as AnyObject))
+    }
+    override func removeOverlays(_ overlays: [MKOverlay]) {
+        for overlay in overlays { removeOverlay(overlay) }
+    }
+    override func renderer(for overlay: MKOverlay) -> MKOverlayRenderer? {
+        let key = ObjectIdentifier(overlay as AnyObject)
+        if let renderer = renderers[key] { return renderer }
+        guard let renderer = delegate?.mapView?(self, rendererFor: overlay) else { return nil }
+        renderers[key] = renderer
+        return renderer
+    }
+    override func setVisibleMapRect(_ mapRect: MKMapRect, edgePadding insets: UIEdgeInsets, animated: Bool) {
+        fits.append((mapRect, insets))
+    }
+    override func setRegion(_ region: MKCoordinateRegion, animated: Bool) {
+        regionUpdates += 1
+    }
+    override func setCamera(_ camera: MKMapCamera, animated: Bool) {
+        cameraUpdates += 1
+    }
+}
+
+private final class PreviewRecordingRoute: MKRoute {
+    private let line: MKPolyline
+    init(_ line: MKPolyline) {
+        self.line = line
+        super.init()
+    }
+    override var polyline: MKPolyline { line }
+}
+
+@main
+@MainActor
+struct SavedRouteMapPreviewTests {
+    private static var checks = 0
+    private static let timestamp = Date(timeIntervalSince1970: 1_800_000_000)
+
+    static func main() async throws {
+        try testLibraryReadsAndWatchIndependence()
+        try testMissingReplacedAndCorruptArchives()
+        try testExpiryAndDeletion()
+        try testFactoryAndCoordinateBoundary()
+        try testOverlayOwnershipAndCamera()
+        try testSettingsAction()
+        print("Saved route map integration: \(checks) checks passed")
+    }
+
+    private static func check(_ condition: Bool, _ message: String) {
+        precondition(condition, message)
+        checks += 1
+    }
+
+    @discardableResult
+    private static func failure(_ body: () throws -> Void) -> String {
+        do {
+            try body()
+            preconditionFailure("Expected operation to fail")
+        } catch {
+            checks += 1
+            return error.localizedDescription
+        }
+    }
+
+    private static func route(
+        id: UUID = UUID(), revision: UInt32 = 1,
+        provider: RouteProviderMetadataV1 = RouteProviderPolicyV1.importedGPX,
+        name: String = "Canal ride", points: [RouteCoordinateV1]? = nil
+    ) -> NavigationRouteV1 {
+        let points = points ?? [
+            RouteCoordinateV1(latitude: 51.5, longitude: -0.1),
+            RouteCoordinateV1(latitude: 51.501, longitude: -0.099),
+            RouteCoordinateV1(latitude: 51.502, longitude: -0.098)
+        ]
+        return NavigationRouteV1(
+            id: id, revision: revision, provider: provider,
+            sourceReference: provider == RouteProviderPolicyV1.strava ?
+                RouteSourceReferenceV1(providerID: provider.providerID,
+                    externalRouteID: "123456", canonicalURL: "https://www.strava.com/routes/123456") : nil,
+            localeIdentifier: "en_US", transportType: .cycling,
+            source: RouteEndpointV1(coordinate: points[0], label: "Start"),
+            destination: RouteEndpointV1(coordinate: points[points.count - 1], label: "Finish"),
+            bounds: RouteBoundsV1.enclosing(points)!, distanceMeters: 300,
+            expectedTravelTimeSeconds: 90, name: name, points: points,
+            steps: [NavigationRouteStepV1(id: 1, geometryStartIndex: 0,
+                geometryEndIndex: points.count - 1, instruction: "Continue",
+                maneuver: .straight, distanceMeters: 300)],
+            normalizationVersion: 1
+        )
+    }
+
+    private static func archive(_ route: NavigationRouteV1, deadline: Date? = nil) throws -> NavigationRouteArchiveV1 {
+        try NavigationRouteArchiveV1.create(route: route, createdAt: timestamp,
+            deleteAfter: deadline, purpose: .offlineNavigation)
+    }
+
+    private static func selection(_ archive: NavigationRouteArchiveV1, name: String = "Local alias") -> SavedRouteMapSelection {
+        SavedRouteMapSelection(identity: WatchRouteIdentityV1(archive: archive),
+            displayName: name, route: archive.route, createdAt: archive.createdAt,
+            deleteAfter: archive.deleteAfter)
+    }
+
+    private static func testLibraryReadsAndWatchIndependence() throws {
+        for provider in [RouteProviderPolicyV1.importedGPX, RouteProviderPolicyV1.strava] {
+            let fixture = LibraryFixture()
+            defer { fixture.cleanup() }
+            let saved = try archive(route(provider: provider),
+                deadline: provider == RouteProviderPolicyV1.strava ? timestamp.addingTimeInterval(600) : nil)
+            let summary = try fixture.install(saved)
+            _ = fixture.library.rename(summary, to: "My renamed ride")
+            let record = try fixture.store.record(matching: WatchRouteIdentityV1(archive: saved), now: fixture.clock.now)
+            let data = try Data(contentsOf: record.fileURL)
+            let attributes = try FileManager.default.attributesOfItem(atPath: record.fileURL.path)
+            let beforeDefaults = fixture.defaults.dictionaryRepresentation()
+            let beforeWatch = fixture.connectivity.sideEffects
+            let loaded = try fixture.library.mapSelection(for: summary)
+            check(loaded.displayName == "My renamed ride", "Preview uses the local alias")
+            check(loaded.identity == WatchRouteIdentityV1(archive: saved), "Preview reads the exact identity")
+            check(loaded.route == saved.route, "Preview keeps canonical archive geometry and metadata")
+            check(loaded.createdAt == saved.createdAt && loaded.deleteAfter == saved.deleteAfter, "Preview keeps retention metadata")
+            check(try Data(contentsOf: record.fileURL) == data, "Preview does not rewrite the archive")
+            let afterAttributes = try FileManager.default.attributesOfItem(atPath: record.fileURL.path)
+            check(attributes[.modificationDate] as? Date == afterAttributes[.modificationDate] as? Date, "Preview does not touch the archive")
+            check(NSDictionary(dictionary: beforeDefaults).isEqual(to: fixture.defaults.dictionaryRepresentation()), "Preview does not write preferences")
+            check(fixture.connectivity.sideEffects == beforeWatch, "Preview has no Watch side effects")
+
+            let identity = loaded.identity
+            fixture.connectivity.onRouteAcknowledgement?(WatchRouteSyncMessageV1(
+                operation: .acknowledge, identity: identity, status: .rejected, errorCode: "test_rejection"))
+            let rejectedEffects = fixture.connectivity.sideEffects
+            _ = try fixture.library.mapSelection(for: summary)
+            check(fixture.connectivity.sideEffects == rejectedEffects, "Rejected Watch sync does not block local preview")
+            try fixture.library.sendToWatch(summary)
+            for status in [WatchRouteSyncStatusV1.ready, .rejected] {
+                let effects = fixture.connectivity.sideEffects
+                _ = try fixture.library.mapSelection(for: summary)
+                check(fixture.connectivity.sideEffects == effects, "Transferring/ready reads have no Watch effects")
+                fixture.connectivity.onRouteAcknowledgement?(WatchRouteSyncMessageV1(
+                    operation: .acknowledge, identity: identity, status: status,
+                    errorCode: status == .rejected ? "test_rejection" : nil))
+            }
+        }
+    }
+
+    private static func testMissingReplacedAndCorruptArchives() throws {
+        let fixture = LibraryFixture()
+        defer { fixture.cleanup() }
+        let first = try archive(route())
+        let summary = try fixture.install(first)
+        let missing = PlannedRouteSummaryV1(archive: try archive(route()))
+        failure { _ = try fixture.library.mapSelection(for: missing) }
+        let otherHash = PlannedRouteSummaryV1(archive: try archive(route(id: first.routeID, name: "Other content")))
+        failure { _ = try fixture.library.mapSelection(for: otherHash) }
+        let newArchive = try archive(route(id: first.routeID, revision: 2))
+        let newest = try fixture.install(newArchive)
+        failure { _ = try fixture.library.mapSelection(for: summary) }
+        check(try fixture.library.mapSelection(for: newest).identity == WatchRouteIdentityV1(archive: newArchive), "Stale read never silently substitutes the new revision")
+        let record = try fixture.store.record(matching: WatchRouteIdentityV1(archive: newArchive), now: timestamp)
+        try Data("corrupt archive".utf8).write(to: record.fileURL)
+        let message = failure { _ = try fixture.library.mapSelection(for: newest) }
+        check(!message.isEmpty, "Corruption returns a user-visible explanation")
+        check(fixture.library.routes.isEmpty, "Corrupt archive is pruned through normal library reload")
+    }
+
+    private static func testExpiryAndDeletion() throws {
+        let fixture = LibraryFixture()
+        defer { fixture.cleanup() }
+        let deadline = timestamp.addingTimeInterval(60)
+        let saved = try archive(route(provider: RouteProviderPolicyV1.strava), deadline: deadline)
+        let summary = try fixture.install(saved)
+        fixture.clock.now = deadline.addingTimeInterval(-0.001)
+        _ = try fixture.library.mapSelection(for: summary)
+        fixture.clock.now = deadline
+        let message = failure { _ = try fixture.library.mapSelection(for: summary) }
+        check(message == SavedRouteMapError.expired(fixture.library.displayName(for: summary)).localizedDescription, "Exact deadline returns an expiry error")
+        check(fixture.library.routes.isEmpty, "Expiry publishes removal to existing previews")
+        let gpx = try archive(route())
+        let local = try fixture.install(gpx)
+        try fixture.library.delete(local)
+        failure { _ = try fixture.library.mapSelection(for: local) }
+        check(fixture.library.routes.isEmpty, "Deleted routes cannot remain selected")
+    }
+
+    private static func testFactoryAndCoordinateBoundary() throws {
+        for points in [
+            [RouteCoordinateV1(latitude: 51.5, longitude: -0.1), RouteCoordinateV1(latitude: 51.501, longitude: -0.099)],
+            [RouteCoordinateV1(latitude: 31.23, longitude: 121.47), RouteCoordinateV1(latitude: 31.231, longitude: 121.471)]
+        ] {
+            let saved = try archive(route(points: points))
+            let preview = try SavedRouteMapPreviewFactory.make(selection(saved), now: { timestamp })
+            var actual = Array(repeating: CLLocationCoordinate2D(), count: points.count)
+            preview.overlay.polyline.getCoordinates(&actual, range: NSRange(location: 0, length: actual.count))
+            for index in points.indices {
+                let expected = SavedRouteMapPreviewFactory.displayCoordinate(CLLocationCoordinate2D(latitude: points[index].latitude, longitude: points[index].longitude))
+                check(abs(actual[index].latitude - expected.latitude) < 1e-7 && abs(actual[index].longitude - expected.longitude) < 1e-7, "Ordered coordinates convert exactly once at display boundary")
+            }
+            check(saved.route.points == points, "Factory leaves WGS-84 archive points unchanged")
+            check(preview.displayName == "Local alias" && preview.sourceLabel == "Start" && preview.attribution == saved.route.provider.attribution, "Factory preserves display metadata")
+            failure {
+                _ = try SavedRouteMapPreviewFactory.make(selection(saved), now: { timestamp }, convert: { _ in
+                    CLLocationCoordinate2D(latitude: .nan, longitude: 0)
+                })
+            }
+        }
+        let deadline = timestamp.addingTimeInterval(10)
+        let strava = try archive(route(provider: RouteProviderPolicyV1.strava), deadline: deadline)
+        failure { _ = try SavedRouteMapPreviewFactory.make(selection(strava), now: { deadline }) }
+        var time = timestamp
+        failure {
+            _ = try SavedRouteMapPreviewFactory.make(selection(strava), now: { time }, convert: { coordinate in
+                time = deadline
+                return coordinate
+            })
+        }
+        let largePoints = (0..<50_000).map {
+            RouteCoordinateV1(latitude: 51.5 + Double($0) * 0.0000001, longitude: -0.1)
+        }
+        let largeRoute = route(points: largePoints)
+        let large = SavedRouteMapSelection(identity: WatchRouteIdentityV1(routeID: largeRoute.id, revision: 1, contentHash: String(repeating: "a", count: 64)), displayName: "Large GPX", route: largeRoute, createdAt: timestamp, deleteAfter: nil)
+        var conversions = 0
+        let preview = try SavedRouteMapPreviewFactory.make(large, now: { timestamp }, convert: {
+            conversions += 1
+            return $0
+        })
+        let map = PreviewRecordingMap(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let coordinator = MapViewContainer.Coordinator()
+        for _ in 0..<100 { update(coordinator, map: map, preview: preview.overlay) }
+        check(conversions == 50_000, "Maximum-size GPX converts once, not on view updates")
+        check(map.additions == 1 && map.fits.count == 1, "Maximum-size GPX reuses one overlay and one fit")
+        let tooLargeRoute = route(points: largePoints + [largePoints.last!])
+        let tooLarge = SavedRouteMapSelection(identity: WatchRouteIdentityV1(routeID: tooLargeRoute.id, revision: 1, contentHash: large.identity.contentHash), displayName: "Too large", route: tooLargeRoute, createdAt: timestamp, deleteAfter: nil)
+        failure { _ = try SavedRouteMapPreviewFactory.make(tooLarge, now: { timestamp }) }
+    }
+
+    private static func update(
+        _ coordinator: MapViewContainer.Coordinator, map: PreviewRecordingMap,
+        preview: MapSavedRouteOverlay? = nil, route: MKRoute? = nil,
+        alternatives: [MapRouteAlternative] = [], selected: UUID? = nil,
+        navigating: Bool = false, calculating: Bool = false,
+        authorized: Bool = true, padding: CGFloat? = 300
+    ) {
+        coordinator.mapView = map
+        coordinator.isNavigating = navigating
+        coordinator.isUserLocationAuthorized = authorized
+        map.delegate = coordinator
+        coordinator.updateRouteOverlays(on: map, route: route, alternatives: alternatives,
+            selectedAlternativeID: selected, routePlanningBottomPadding: 300,
+            location: nil, simulatedPosition: nil, isSimulationMode: false,
+            isNavigating: navigating, isUserLocationAuthorized: authorized,
+            isFreePanActive: coordinator.isFreePanActive(mapView: map,
+                isOfflineMapSelectionActive: coordinator.offlineMapSelectionFrame != nil,
+                includesSavedRoutePreview: false),
+            savedRoutePreview: preview, savedRoutePreviewBottomPadding: padding,
+            isRouteCalculationActive: calculating)
+    }
+
+    private static func testOverlayOwnershipAndCamera() throws {
+        let saved = try archive(route())
+        let preview = try SavedRouteMapPreviewFactory.make(selection(saved), now: { timestamp })
+        let map = PreviewRecordingMap(frame: CGRect(x: 0, y: 0, width: 390, height: 844))
+        let coordinator = MapViewContainer.Coordinator()
+        let unrelated = MKPolyline(coordinates: [CLLocationCoordinate2D(latitude: 0, longitude: 0), CLLocationCoordinate2D(latitude: 0.1, longitude: 0.1)], count: 2)
+        map.addOverlay(unrelated, level: .aboveLabels)
+        update(coordinator, map: map, preview: preview.overlay, padding: nil)
+        check(map.fits.isEmpty && map.userTrackingMode == .none, "Wait for measured layout without following location")
+        update(coordinator, map: map, preview: preview.overlay)
+        check(map.fits.count == 1 && map.fits[0].1.bottom == 300, "Fit once using actual card padding")
+        let owned = coordinator.displayedSavedRouteOverlay
+        let beforeAdds = map.additions
+        let beforeRemoves = map.removals
+        update(coordinator, map: map, preview: preview.overlay, padding: 330)
+        check(map.additions == beforeAdds && map.removals == beforeRemoves && map.fits.count == 1, "Ordinary layout update does not rebuild or refit")
+        check(coordinator.displayedSavedRouteOverlay === owned, "Unchanged immutable identity reuses polyline")
+        coordinator.updateUserTrackingMode(mapView: map, isNavigating: false, isOfflineMapSelectionActive: false)
+        coordinator.updateInitialRegionIfNeeded(mapView: map, location: CLLocation(latitude: 40, longitude: 0), simulatedPosition: nil, isSimulationMode: false,
+            isFreePanActive: coordinator.isFreePanActive(mapView: map, isOfflineMapSelectionActive: false))
+        check(map.userTrackingMode == .none && map.regionUpdates == 0, "Location changes cannot steal preview camera")
+        let renderer = coordinator.mapView(map, rendererFor: preview.overlay.polyline) as! MKPolylineRenderer
+        check(renderer.lineWidth == 4 && abs(renderer.alpha - 0.65) < 0.001 && renderer.lineCap == .round && renderer.lineJoin == .round, "Saved route has distinct rounded thinner styling")
+        check(map.levels.last == .aboveRoads, "Saved route is above roads")
+
+        let revision = MapSavedRouteOverlay(identity: WatchRouteIdentityV1(routeID: saved.routeID, revision: 2, contentHash: saved.contentHash), polyline: preview.overlay.polyline)
+        update(coordinator, map: map, preview: revision)
+        check(map.fits.count == 2, "Same UUID with a new revision fits anew")
+        let changedHash = MapSavedRouteOverlay(identity: WatchRouteIdentityV1(routeID: saved.routeID, revision: 2, contentHash: String(repeating: "b", count: 64)), polyline: preview.overlay.polyline)
+        update(coordinator, map: map, preview: changedHash)
+        check(map.fits.count == 3, "Same UUID and revision with changed hash is a new preview")
+        update(coordinator, map: map)
+        check(map.overlays.count == 1 && map.overlays[0] === unrelated, "Hide removes only the saved overlay")
+        check(map.userTrackingMode == .follow && coordinator.displayedSavedRouteIdentity == nil, "Hide releases identity and restores permitted follow")
+        update(coordinator, map: map, preview: preview.overlay)
+        map.selectedAnnotations = [DestinationAnnotation()]
+        update(coordinator, map: map)
+        check(map.userTrackingMode == .none, "Hide preserves destination free pan")
+        map.selectedAnnotations = []
+        update(coordinator, map: map, preview: preview.overlay)
+        update(coordinator, map: map, authorized: false)
+        check(map.userTrackingMode == .none, "Hide does not follow without location authorization")
+        update(coordinator, map: map, preview: preview.overlay)
+        coordinator.offlineMapSelectionFrame = CGRect(x: 0, y: 0, width: 100, height: 100)
+        update(coordinator, map: map, preview: preview.overlay)
+        check(coordinator.displayedSavedRouteOverlay == nil && map.userTrackingMode == .none, "Offline-area selection takes control without destroying unrelated overlays")
+        coordinator.offlineMapSelectionFrame = nil
+
+        let navigation = PreviewRecordingRoute(preview.overlay.polyline)
+        let alternativeID = UUID()
+        let alternatives = [MapRouteAlternative(id: alternativeID, route: navigation)]
+        update(coordinator, map: map, preview: preview.overlay, alternatives: alternatives)
+        check(coordinator.displayedSavedRouteOverlay == nil && coordinator.lastRouteAlternatives == alternatives, "Calculated alternatives outrank saved previews")
+        let foreignRenderer = map.renderer(for: unrelated) as! MKPolylineRenderer
+        foreignRenderer.lineWidth = 17
+        coordinator.updateSelectedRouteAlternative(alternativeID, on: map)
+        check(foreignRenderer.lineWidth == 17, "Alternative selection does not restyle foreign polylines")
+        update(coordinator, map: map, preview: preview.overlay, route: navigation, alternatives: alternatives, navigating: true)
+        check(coordinator.lastRoute === navigation && coordinator.lastRouteAlternatives.isEmpty && coordinator.displayedSavedRouteOverlay == nil, "Active navigation beats even late alternatives")
+        let navigationAdds = map.additions
+        let navigationRemoves = map.removals
+        update(coordinator, map: map, route: navigation, navigating: true)
+        check(map.additions == navigationAdds && map.removals == navigationRemoves, "Clearing a suppressed preview does not reinstall unchanged navigation")
+        update(coordinator, map: map, preview: preview.overlay, calculating: true)
+        check(coordinator.displayedSavedRouteOverlay == nil, "In-flight directions calculations suppress stale saved previews")
+        check(map.overlays.contains(where: { $0 === unrelated }), "All transitions preserve unrelated overlays")
+    }
+
+    private static func testSettingsAction() throws {
+        let fixture = LibraryFixture()
+        defer { fixture.cleanup() }
+        let saved = try archive(route())
+        let summary = try fixture.install(saved)
+        var settingsPresented = true
+        var accepted: SavedRouteMapPreview?
+        let action = SavedRouteMapAction(isNavigationActive: false, show: { value in
+            accepted = try SavedRouteMapPreviewFactory.make(value, now: { timestamp })
+            settingsPresented = false
+        })
+        failure { try action.perform { throw SavedRouteMapError.unavailable("Missing") } }
+        check(settingsPresented && accepted == nil, "Read failure leaves Settings presented")
+        let expired = try archive(route(provider: RouteProviderPolicyV1.strava), deadline: timestamp.addingTimeInterval(1))
+        let expiredAction = SavedRouteMapAction(isNavigationActive: false, show: { value in
+            accepted = try SavedRouteMapPreviewFactory.make(value, now: { timestamp.addingTimeInterval(1) })
+            settingsPresented = false
+        })
+        failure { try expiredAction.perform { selection(expired) } }
+        check(settingsPresented && accepted == nil, "Expiry during presentation also leaves Settings presented")
+        var loadedWhileNavigating = false
+        let blocked = SavedRouteMapAction(isNavigationActive: true, show: action.show)
+        failure {
+            try blocked.perform {
+                loadedWhileNavigating = true
+                return try fixture.library.mapSelection(for: summary)
+            }
+        }
+        check(!loadedWhileNavigating && settingsPresented, "Disabled navigation action cannot even load a route")
+        try action.perform { try fixture.library.mapSelection(for: summary) }
+        check(!settingsPresented && accepted?.identity == WatchRouteIdentityV1(archive: saved), "Validated success accepts the exact preview before dismissing Settings")
+    }
+}

--- a/ios-app/BikeComputerTests/SavedRouteMapPreviewTests.swift
+++ b/ios-app/BikeComputerTests/SavedRouteMapPreviewTests.swift
@@ -313,6 +313,9 @@ struct SavedRouteMapPreviewTests {
                 let expected = SavedRouteMapPreviewFactory.displayCoordinate(CLLocationCoordinate2D(latitude: points[index].latitude, longitude: points[index].longitude))
                 check(abs(actual[index].latitude - expected.latitude) < 1e-7 && abs(actual[index].longitude - expected.longitude) < 1e-7, "Ordered coordinates convert exactly once at display boundary")
             }
+            let expectedFinish = actual[actual.count - 1]
+            let finish = preview.overlay.finishCoordinate
+            check(abs(finish.latitude - expectedFinish.latitude) < 1e-7 && abs(finish.longitude - expectedFinish.longitude) < 1e-7, "Finish marker uses the final converted route coordinate")
             check(saved.route.points == points, "Factory leaves WGS-84 archive points unchanged")
             check(preview.displayName == "Local alias" && preview.sourceLabel == "Start" && preview.attribution == saved.route.provider.attribution, "Factory preserves display metadata")
             failure {
@@ -383,6 +386,9 @@ struct SavedRouteMapPreviewTests {
         map.addOverlay(unrelated, level: .aboveLabels)
         update(coordinator, map: map, preview: preview.overlay, padding: nil)
         check(map.fits.isEmpty && map.userTrackingMode == .none, "Wait for measured layout without following location")
+        check(coordinator.displayedSavedRouteFinishAnnotation?.title == "Finish" && coordinator.displayedSavedRouteFinishAnnotation?.coordinate.latitude == preview.overlay.finishCoordinate.latitude && coordinator.displayedSavedRouteFinishAnnotation?.coordinate.longitude == preview.overlay.finishCoordinate.longitude, "Saved preview installs a finish annotation at the route endpoint")
+        let finishView = coordinator.mapView(map, viewFor: SavedRouteFinishAnnotation()) as? MKMarkerAnnotationView
+        check(finishView?.glyphImage != nil && finishView?.markerTintColor == .systemGreen, "Finish annotation uses a native flag marker")
         update(coordinator, map: map, preview: preview.overlay)
         check(map.fits.count == 1 && map.fits[0].1.bottom == 300, "Fit once using actual card padding")
         let owned = coordinator.displayedSavedRouteOverlay
@@ -406,7 +412,7 @@ struct SavedRouteMapPreviewTests {
         update(coordinator, map: map, preview: changedHash)
         check(map.fits.count == 3, "Same UUID and revision with changed hash is a new preview")
         update(coordinator, map: map)
-        check(map.overlays.count == 1 && map.overlays[0] === unrelated, "Hide removes only the saved overlay")
+        check(map.overlays.count == 1 && map.overlays[0] === unrelated && coordinator.displayedSavedRouteFinishAnnotation == nil, "Hide removes only the saved overlay and its finish marker")
         check(map.userTrackingMode == .follow && coordinator.displayedSavedRouteIdentity == nil, "Hide releases identity and restores permitted follow")
         update(coordinator, map: map, preview: preview.overlay)
         map.selectedAnnotations = [DestinationAnnotation()]

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -8,6 +8,8 @@ OUT="${TMPDIR:-/tmp}/open-bike-navigation-tests"
 
 cd "${REPO_DIR}"
 
+bash "${SCRIPT_DIR}/run-saved-route-map-tests.sh"
+
 RENDERER_SCHEDULER_OUT="${TMPDIR:-/tmp}/open-bike-renderer-scheduler-tests"
 xcrun swiftc -D HOST_TESTING -parse-as-library \
   -o "${RENDERER_SCHEDULER_OUT}" \
@@ -78,7 +80,6 @@ xcrun swiftc \
   ios-app/BikeComputer/RideShared/WatchDirectBLEContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
-  ios-app/BikeComputer/WorkoutShared/RideAutomationSourceHealth.generated.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutDeviceFrames.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \
@@ -128,6 +129,7 @@ xcrun swiftc \
   ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
   ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
 
@@ -148,6 +150,7 @@ xcrun swiftc \
   ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift \
   ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
   ios-app/BikeComputerTests/MapAppearanceTests.swift
 

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -80,6 +80,7 @@ xcrun swiftc \
   ios-app/BikeComputer/RideShared/WatchDirectBLEContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutHeartRateZones.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutValueFormatter.swift \
+  ios-app/BikeComputer/WorkoutShared/RideAutomationSourceHealth.generated.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutDeviceFrames.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMetricUnits.swift \

--- a/ios-app/scripts/run-saved-route-map-tests.sh
+++ b/ios-app/scripts/run-saved-route-map-tests.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/saved-route-map-tests.XXXXXX")"
+trap 'rm -rf "${OUT_DIR}"' EXIT
+cd "${REPO_DIR}"
+
+if command -v xcrun >/dev/null 2>&1; then
+  SWIFTC=(xcrun swiftc)
+else
+  SWIFTC=(swiftc)
+fi
+
+"${SWIFTC[@]}" -parse-as-library -o "${OUT_DIR}/policy" \
+  ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift \
+  ios-app/BikeComputerTests/SavedRouteMapPolicyTests.swift
+"${OUT_DIR}/policy"
+
+if [[ "$(uname -s)" != Darwin ]]; then
+  echo "Native saved-route map integration tests skipped: macOS and an Apple SDK are required."
+  exit 0
+fi
+
+MACOS_SDK="$(xcrun --sdk macosx --show-sdk-path)"
+IOS_SUPPORT="${MACOS_SDK}/System/iOSSupport"
+xcrun swiftc -D HOST_TESTING -parse-as-library \
+  -target "$(uname -m)-apple-ios16.4-macabi" \
+  -sdk "${MACOS_SDK}" \
+  -F "${IOS_SUPPORT}/System/Library/Frameworks" \
+  -I "${IOS_SUPPORT}/usr/lib/swift" \
+  -L "${IOS_SUPPORT}/usr/lib/swift" \
+  -o "${OUT_DIR}/integration" \
+  ios-app/BikeComputer/RideShared/NavigationRouteContract.swift \
+  ios-app/BikeComputer/RideShared/RouteCoordinateNormalization.swift \
+  ios-app/BikeComputer/RideShared/SavedDestinationContract.swift \
+  ios-app/BikeComputer/RideShared/RouteProviderContract.swift \
+  ios-app/BikeComputer/RideShared/StravaAthleteRoutes.swift \
+  ios-app/BikeComputer/RideShared/StravaRouteURL.swift \
+  ios-app/BikeComputer/RideShared/StravaRouteReloadBookmark.swift \
+  ios-app/BikeComputer/RideShared/NavigationRouteArchive.swift \
+  ios-app/BikeComputer/RideShared/NavigationGeometry.swift \
+  ios-app/BikeComputer/RideShared/NavigationRuntime.swift \
+  ios-app/BikeComputer/RideShared/WatchRouteSyncContract.swift \
+  ios-app/BikeComputer/RideShared/WatchControllerContract.swift \
+  ios-app/BikeComputer/RideShared/RideBLEProtocol.generated.swift \
+  ios-app/BikeComputer/RideShared/RideBLETransportStateMachine.swift \
+  ios-app/BikeComputer/RideShared/WatchDirectBLEContract.swift \
+  ios-app/BikeComputer/RideShared/NavigationRouteFileStore.swift \
+  ios-app/BikeComputer/RideShared/GPXRouteImporter.swift \
+  ios-app/BikeComputer/BikeComputer/Models/AppModels.swift \
+  ios-app/BikeComputer/BikeComputer/Models/IPhoneMapAppearance.swift \
+  ios-app/BikeComputer/BikeComputer/Models/SavedRouteNaming.swift \
+  ios-app/BikeComputer/BikeComputer/Models/SavedRouteMapSelection.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/CoordinateConverter.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/MapTrackingPolicy.swift \
+  ios-app/BikeComputer/BikeComputer/Utilities/SavedRouteMapPolicy.swift \
+  ios-app/BikeComputer/BikeComputer/Managers/PhoneRouteLibrary.swift \
+  ios-app/BikeComputer/BikeComputer/Views/MapView.swift \
+  ios-app/BikeComputer/BikeComputer/Views/SavedRouteMapPreview.swift \
+  ios-app/BikeComputerTests/SavedRouteMapPreviewTests.swift
+"${OUT_DIR}/integration"


### PR DESCRIPTION
## Summary

Closes #381.

Branched directly from GitHub `main` at `44e0df3bf87cce1aca0c4da9d5d7b776f1823c1b`, not from another PR.

- Add an accessible **Show on Map** action for installed saved GPX and active Strava routes, independent of Watch synchronization status. Disable it during navigation and retain the existing expired-Strava reload/link UI.
- Read the exact UUID/revision/content-hash identity through `PhoneRouteLibrary` and its validated archive store. Dismiss Settings only after a successful read and preview construction; report localized failures without substituting another revision.
- Build an ephemeral display-only polyline once, preserving canonical WGS-84 archive geometry and converting China coordinates only at the iPhone MapKit boundary. Show alias, endpoints, distance, provider attribution and Strava link/expiry in a dismissible card.
- Give navigation and calculated routes priority. Use separately owned overlays instead of removing every map overlay, preserve alternative selection, fit once after measuring card layout, and preserve subsequent pan/zoom/pitch.
- Clear stale preview identities on library deletion/pruning/replacement/expiry and foreground reload. Preserve the active workout while preventing automatic ride-sheet restoration from covering the preview.

No navigation start, Watch/ESP32 protocol change, provider fetch, GPX reparsing, or new persistent route cache is introduced by previewing.

## Tests

**Executed locally:** Swift 6.2.1 portable production-policy suite — **178 checks passed**, covering all precedence combinations, full-identity camera changes, repeated updates, reopening, deletion/replacement and the exact expiry boundary.

**Added, not executed locally:** a focused Mac Catalyst integration suite compiling the actual archive store, `PhoneRouteLibrary`, preview factory and `MapView` coordinator with narrow Watch/MapKit boundary doubles. It covers successful read side effects, aliases and both providers, stale/missing/corrupt archives, retention, China conversion, 50,000-point reuse, overlay ownership/styles, camera fitting, priority and Settings callback success/failure.

Run:
```sh
bash ios-app/scripts/run-saved-route-map-tests.sh
bash ios-app/scripts/run-navigation-tests.sh
```

The focused suite is wired into the existing navigation runner; existing MapView Catalyst suites receive the new policy dependency.

**Validation limitation:** this environment has Swift on Linux but no Apple SDK/Xcode. Native integration tests, the full iOS build and device/simulator UI checks have not been run locally. CI results and the manual accessibility/layout checklist must be reviewed before merging; no passing Apple-platform result is claimed.

Implementation notes and the interactive acceptance checklist: `docs/plans/saved-route-map-preview-381.md`.