### PR TITLE
Fix Watch-owned sensor discovery independently of workout mirroring

### DIFF
--- a/docs/watch-cycling-sensor-observations.md
+++ b/docs/watch-cycling-sensor-observations.md
@@ -1,0 +1,121 @@
+# Watch-owned cycling sensor discovery
+
+Issue: #383. Implementation baseline: `44e0df3bf87cce1aca0c4da9d5d7b776f1823c1b`.
+
+## Ownership and data flow
+
+The accessory remains paired to Apple Watch. HealthKit workout snapshots remain
+its observation source. Watch-to-ESP32 workout delivery and mirrored numeric
+metrics are unchanged. Nothing in this change scans for or connects an iPhone
+Bluetooth peripheral, invents a physical accessory identity, or enrolls a sensor
+automatically.
+
+`WatchAppDelegate` observes the local workout envelope independently of mirror
+transport success. It derives a `WatchCyclingSensorObservationV1` containing only
+schema version, workout identity/start/capture dates, active state, and the
+original cadence/power sample timestamps. The original sample values, names,
+peripheral identifiers, heart rate, and route data are not copied into this
+channel. Cadence and power remain separate logical capabilities unless the user
+explicitly configures otherwise.
+
+The existing `WatchConnectivityCoordinator` is still the sole Watch WCSession
+owner. Its bounded publisher merges the observation under
+`watchCyclingSensorObservation.v1` into `session.applicationContext`. Existing
+metadata and HealthKit-setup fields survive both directions of the merge.
+Activation, not reachability, gates submission. First observations and lifecycle
+or capability changes are immediate when the transport permits; timestamp-only
+refreshes are coalesced to one every two seconds, including a trailing flush.
+A failed submission retains only the newest pending value and retries with
+2–30-second backoff. It is never marked published on failure. New offers do not
+reset the retry deadline. The in-memory pending value is reconstructed from the
+workout after process recovery; raw workout metrics are not persisted here.
+
+`PhoneWatchConnectivityCoordinator.refreshState` reads the latest
+`receivedApplicationContext` on activation as well as delivery. Its current-value
+publisher is bound alongside `WorkoutMetricsStore` before the iPhone UI starts.
+Opening the iPhone after a sensor began reporting therefore consumes fresh
+cached evidence without needing a mirrored workout or a subsequent callback.
+Missing/invalid context or an unavailable paired app withdraws only the Watch
+source. The original mirrored observation path remains compatible with an older
+Watch app that does not publish the new key.
+
+## Freshness and lifecycle invariants
+
+`CyclingSensorObservationReducer` is the single source-independent admission and
+lifecycle policy. Discovery requires both a capture and a sample no older than
+five seconds, with no future timestamps. Accepted samples may report for ten
+seconds from their **original sample time**, not their delivery time. An expiry
+task clears published reporting and prompts even when no more callbacks arrive.
+Recently observed enrollment candidates retain the existing 30-minute grace
+period; that is not permission to label them as currently Reporting.
+
+Mirror idle, stale, or disconnected means that one transport is unavailable. It
+is not a Watch workout-end event. Losing that source neither clears independent
+Watch evidence nor resets the workout-scoped prompt dismissal. Observations from
+both paths update one candidate per capability; enrollment remains explicit.
+
+An explicit ended/failed workout observation retires its session and removes
+both sources' reporting immediately. The publisher uses the same lifecycle gate
+so a late active callback cannot overwrite a not-yet-delivered end context. Late packets cannot reopen that same
+session. A newer session is identified by a later workout start, and each source
+also has a capture-time watermark. Rejected out-of-order packets do not mutate
+the selected session. A confirmed Watch idle state publishes an inactive
+tombstone; the initial idle value is deliberately suppressed while HealthKit
+recovery is unresolved. Clock skew or stale delivery fails closed rather than
+extending freshness.
+
+WatchConnectivity application context is best-effort latest-state delivery, not
+a guaranteed low-latency stream. A delayed packet may be rejected and discovery
+may wait for another fresh observation. If an end cannot be delivered, the phone
+still expires the previously admitted evidence; it does not keep Reporting
+indefinitely. Test this delivery behavior on real paired devices before release.
+
+## Regression tests
+
+Run the Foundation-only contract, reducer, and actual publication-adapter tests
+on Swift 6.2 or newer (Linux or macOS):
+
+```sh
+ios-app/scripts/run-cycling-sensor-observation-tests.sh
+```
+
+The suite covers codec bounds/version/date validation, context merging, original
+timestamps, cold-cache staleness, both source lifecycles, terminal/replay ordering,
+atomic rejection, sender-side terminal replay protection, publication before
+activation, coalescing, retry backoff,
+latest-only retention, and a real trailing publication timer.
+
+On macOS, run the existing full host suite:
+
+```sh
+ios-app/scripts/run-navigation-tests.sh
+```
+
+It also runs `CyclingSensorObservationIntegrationTests` against the production
+sensor coordinator/store, actual `WorkoutMetricsStore` publication, and a
+current-value Watch-observation publisher. These cover cached launch, all three
+unavailable mirror states, dual-source deduplication, explicit logical enrollment,
+persisted dismissal, terminal retirement, stale/future/replayed data, and actual
+silent-source expiry. This boundary test does not pretend to simulate WCSession
+OS delivery or Bluetooth hardware.
+
+Build the app using `ios-app/scripts/xcodebuild-cli.sh`, as required by AGENTS.md.
+The new WorkoutShared files use the existing synchronized Xcode groups.
+
+## Paired-device acceptance before release
+
+1. Pair a cadence sensor on Watch, start a cycling workout there, and confirm
+   cadence still appears on Watch and ESP32 with the iPhone mirror unavailable.
+2. Open iPhone My Sensors / Connect new. A fresh logical cadence candidate must
+   appear. Repeat with iPhone launched after cadence was already being received.
+3. Connect it explicitly once, restore/disconnect the mirror, and confirm there
+   remains one enabled logical profile with no duplicate prompt/candidate.
+4. Stop sensor reports. Reporting and its prompt must clear without navigating
+   away. A recently seen enrollment candidate may remain during its grace period.
+5. End/discard the workout on Watch. Reporting clears on receipt of the tombstone;
+   if delivery is unavailable it expires locally. Reopening the phone or receiving
+   an older mirror packet must not bring that workout's Reporting state back.
+6. Verify metadata/setup/route synchronization and Watch-direct ESP32 cadence
+   continue to work. Exercise Watch recovery and a new workout after a previous
+   prompt was dismissed. No hardware flashing or production ride automation is
+   required or authorized by this PR.

--- a/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
+++ b/ios-app/BikeComputer/BikeComputer/BikeComputerApp.swift
@@ -150,7 +150,9 @@ class AppDelegate: NSObject, UIApplicationDelegate {
             }
             .store(in: &cancellables)
         cyclingSensorDetectionCoordinator.bind(
-            to: workoutMirrorManager.store
+            to: workoutMirrorManager.store,
+            watchObservations: watchConnectivityCoordinator
+                .$cyclingSensorObservation.eraseToAnyPublisher()
         )
         locationManager.bindWorkoutMetricsStore(
             workoutMirrorManager.store

--- a/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift
@@ -12,7 +12,8 @@ private struct CyclingSensorPromptDismissalEnvelope: Codable {
 @MainActor
 final class CyclingSensorDetectionCoordinator: ObservableObject {
     nonisolated static let candidateGracePeriod: TimeInterval = 30 * 60
-    nonisolated static let reportingFreshness: TimeInterval = 10
+    nonisolated static let reportingFreshness =
+        WatchCyclingSensorObservationV1.reportingFreshness
     nonisolated static let defaultDismissalStorageKey =
         "cyclingSensors.promptDismissal.v1"
 
@@ -29,6 +30,8 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
     private let candidateGracePeriod: TimeInterval
     private let dismissalDefaults: UserDefaults
     private let dismissalStorageKey: String
+    private var observationReducer = CyclingSensorObservationReducer()
+    private var watchObservationCancellable: AnyCancellable?
     private var presentationCancellable: AnyCancellable?
     private var profileCancellable: AnyCancellable?
     private var candidateExpiryTask: Task<Void, Never>?
@@ -62,18 +65,32 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         candidateExpiryTask?.cancel()
     }
 
-    func bind(to workoutStore: WorkoutMetricsStore) {
-        guard presentationCancellable == nil else { return }
-        presentationCancellable = workoutStore.$presentation.sink {
-            [weak self] presentation in
-            self?.ingest(presentation, at: self?.now() ?? Date())
+    func bind(
+        to workoutStore: WorkoutMetricsStore,
+        watchObservations:
+            AnyPublisher<WatchCyclingSensorObservationV1?, Never>? = nil
+    ) {
+        if presentationCancellable == nil {
+            presentationCancellable = workoutStore.$presentation.sink {
+                [weak self] presentation in
+                guard let self else { return }
+                self.ingest(presentation, at: self.now())
+            }
         }
-        ingest(workoutStore.presentation, at: now())
+        if watchObservationCancellable == nil, let watchObservations {
+            // Published/CurrentValueSubject replays the latest received
+            // context on binding, including a cold-start cached observation.
+            watchObservationCancellable = watchObservations.sink {
+                [weak self] observation in
+                guard let self else { return }
+                self.ingestWatchObservation(observation, at: self.now())
+            }
+        }
     }
 
     func beginLooking() {
         isLooking = true
-        pruneCandidates(at: now())
+        refresh(at: now())
     }
 
     func stopLooking() {
@@ -126,7 +143,8 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         capabilities: CyclingSensorCapabilities,
         at date: Date = Date()
     ) -> Bool {
-        guard let lastObservedAt = lastObservedAt(for: capabilities) else {
+        guard hasActiveWorkout,
+              let lastObservedAt = lastObservedAt(for: capabilities) else {
             return false
         }
         let age = date.timeIntervalSince(lastObservedAt)
@@ -137,37 +155,81 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         _ presentation: WorkoutMirrorPresentationV1,
         at date: Date
     ) {
-        hasActiveWorkout = presentation.isWorkoutActive
-
-        guard presentation.isWorkoutActive,
-              presentation.connectionState == .connected,
-              let sessionID = presentation.sessionID else {
-            if !presentation.isWorkoutActive {
-                currentSessionID = nil
-                dismissedCapabilities = []
-            }
-            pruneCandidates(at: date)
-            reconcileCandidatesAndPrompt(at: date)
-            return
+        // snapshot.state comes from the Watch envelope. sessionState can
+        // instead reflect a local mirror failure and must not retire Watch.
+        let isTerminal = presentation.snapshot.state == .ended ||
+            presentation.snapshot.state == .failed
+        let accepted: Bool
+        let hasActiveMirror = presentation.connectionState == .connected &&
+            presentation.isWorkoutActive &&
+            presentation.snapshot.state.isActive
+        if (hasActiveMirror || isTerminal),
+           let sessionID = presentation.sessionID,
+           let capturedAt = presentation.capturedAt,
+           let observation = WatchCyclingSensorObservationV1(
+               sessionID: sessionID,
+               snapshot: presentation.snapshot,
+               capturedAt: capturedAt
+           ) {
+            accepted = observationReducer.ingest(
+                observation, from: .mirror, at: date
+            )
+        } else {
+            // Idle/stale/disconnected describes the mirror, not the Watch
+            // workout. It must not clear Watch evidence or prompt dismissal.
+            observationReducer.setUnavailable(.mirror)
+            accepted = false
         }
+        refresh(at: date, admittingCandidates: accepted)
+    }
 
-        if currentSessionID != sessionID {
+    func ingestWatchObservation(
+        _ observation: WatchCyclingSensorObservationV1?,
+        at date: Date
+    ) {
+        let accepted: Bool
+        if let observation {
+            accepted = observationReducer.ingest(
+                observation, from: .watch, at: date
+            )
+        } else {
+            observationReducer.setUnavailable(.watch)
+            accepted = false
+        }
+        refresh(at: date, admittingCandidates: accepted)
+    }
+
+    /// Refreshes time-dependent presentation without manufacturing another
+    /// observation. Expiry must work even with no further mirror/WC callbacks.
+    func refresh(
+        at date: Date,
+        admittingCandidates: Bool = false
+    ) {
+        if let sessionID = observationReducer.sessionID,
+           sessionID != currentSessionID {
             currentSessionID = sessionID
             dismissedCapabilities = restoredDismissedCapabilities(
                 for: sessionID
             )
             candidates.removeAll()
-            lastObservedAtByCapability = [:]
         }
-
-        let snapshot = presentation.snapshot
-        if isFresh(snapshot.cyclingCadence, at: date) {
-            observe(.cadence, at: date)
+        hasActiveWorkout = observationReducer.hasActiveWorkout(at: date)
+        var observed: [CyclingSensorCapabilities: Date] = [:]
+        observed[.cadence] = observationReducer.cadenceObservedAt(at: date)
+        observed[.power] = observationReducer.powerObservedAt(at: date)
+        lastObservedAtByCapability = observed
+        if admittingCandidates {
+            for capability in CyclingSensorCapabilities.supported
+                .individualCapabilities {
+                guard let sampleDate = observed[capability],
+                      WatchCyclingSensorObservationV1.isFresh(
+                          sampleDate, at: date,
+                          maximumAge:
+                            WatchCyclingSensorObservationV1.discoveryFreshness
+                      ) else { continue }
+                observe(capability, at: sampleDate)
+            }
         }
-        if isFresh(snapshot.cyclingPower, at: date) {
-            observe(.power, at: date)
-        }
-
         pruneCandidates(at: date)
         reconcileCandidatesAndPrompt(at: date)
     }
@@ -186,7 +248,9 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
         if let index = candidates.firstIndex(where: {
             $0.capabilities == capability
         }) {
-            candidates[index].lastObservedAt = date
+            candidates[index].lastObservedAt = max(
+                candidates[index].lastObservedAt, date
+            )
         } else {
             candidates.append(
                 CyclingSensorCandidate(
@@ -198,19 +262,6 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
             )
         }
         scheduleCandidateExpiry()
-    }
-
-    private func isFresh(
-        _ metric: WorkoutMetricV1?,
-        at date: Date
-    ) -> Bool {
-        guard let metric else { return false }
-        return WorkoutMetricFreshness.isFresh(
-            capturedAt: metric.capturedAt,
-            now: date,
-            maximumAge:
-                WorkoutMetricFreshness.pairedCyclingSensorMaximumAge
-        )
     }
 
     private func pruneCandidates(at date: Date) {
@@ -293,13 +344,15 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
     private func scheduleCandidateExpiry() {
         candidateExpiryTask?.cancel()
         candidateExpiryTask = nil
-        guard let nextExpiry = candidates.map({
+        let referenceDate = now()
+        let deadlines = candidates.map {
             $0.lastObservedAt.addingTimeInterval(candidateGracePeriod)
-        }).min() else {
+        } + [observationReducer.nextExpiry(after: referenceDate)].compactMap { $0 }
+        guard let nextExpiry = deadlines.min() else {
             return
         }
 
-        let delay = max(0, nextExpiry.timeIntervalSince(now()))
+        let delay = max(0, nextExpiry.timeIntervalSince(referenceDate))
         let nanoseconds = UInt64(
             min(delay, Double(UInt64.max) / 1_000_000_000)
                 * 1_000_000_000
@@ -312,9 +365,7 @@ final class CyclingSensorDetectionCoordinator: ObservableObject {
             }
             guard !Task.isCancelled, let self else { return }
             self.candidateExpiryTask = nil
-            let date = self.now()
-            self.pruneCandidates(at: date)
-            self.reconcileCandidatesAndPrompt(at: date)
+            self.refresh(at: self.now())
         }
     }
 

--- a/ios-app/BikeComputer/BikeComputer/Managers/PhoneWatchConnectivityCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/PhoneWatchConnectivityCoordinator.swift
@@ -14,6 +14,9 @@ final class PhoneWatchConnectivityCoordinator: NSObject, ObservableObject,
     @Published private(set) var workoutHealthSetupSnapshot:
         WorkoutHealthSetupSnapshotV1?
 
+    @Published private(set) var cyclingSensorObservation:
+        WatchCyclingSensorObservationV1?
+
     var onRouteAcknowledgement: ((WatchRouteSyncMessageV1) -> Void)?
     var onDirectRidePreparationRequest:
         ((WatchDirectRidePreparationRequestV1) ->
@@ -574,12 +577,24 @@ final class PhoneWatchConnectivityCoordinator: NSObject, ObservableObject,
     fileprivate func refreshState(activationFailed: Bool? = nil) {
         guard let session else {
             workoutHealthSetupSnapshot = nil
+            cyclingSensorObservation = nil
             state = PhoneWatchConnectivityStateV1()
             return
         }
         let activated = session.activationState == .activated
         let paired = activated && session.isPaired
         let watchAppInstalled = paired && session.isWatchAppInstalled
+        // Read the latest context on activation as well as delivery. A phone
+        // launched after the sensor started must not wait for another packet.
+        if watchAppInstalled,
+           let data = session.receivedApplicationContext[
+               WatchCyclingSensorObservationV1.applicationContextKey
+           ] as? Data {
+            cyclingSensorObservation = try?
+                WatchCyclingSensorObservationV1.decode(data)
+        } else {
+            cyclingSensorObservation = nil
+        }
         let watchMetadata: WatchDeviceMetadataV1?
         if watchAppInstalled,
            let data = session.receivedApplicationContext[

--- a/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchConnectivityCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/Managers/WatchConnectivityCoordinator.swift
@@ -26,6 +26,33 @@ final class WatchConnectivityCoordinator: NSObject {
     private let inFlightTransportDiagnosticsKey =
         "watchConnectivity.inFlightBLETransportDiagnostics.v1"
 
+    private lazy var cyclingSensorPublisher =
+        WatchCyclingSensorObservationPublisher(
+            isActivated: { [weak self] in
+                self?.session?.activationState == .activated
+            },
+            publish: { [weak self] observation in
+                guard let session = self?.session,
+                      session.activationState == .activated else {
+                    return false
+                }
+                do {
+                    try session.updateApplicationContext(
+                        observation.merging(into: session.applicationContext)
+                    )
+                    return true
+                } catch {
+                    return false
+                }
+            }
+        )
+
+    func publishCyclingSensorObservation(
+        _ observation: WatchCyclingSensorObservationV1
+    ) {
+        cyclingSensorPublisher.offer(observation)
+    }
+
     init(
         routeLibrary: WatchRouteLibrary,
         controllerCredentialStore: WatchControllerCredentialStore,
@@ -45,6 +72,7 @@ final class WatchConnectivityCoordinator: NSObject {
             if session.activationState == .activated {
                 flushPendingTransportDiagnostics(using: session)
                 publishDeviceMetadata(using: session)
+                cyclingSensorPublisher.flush()
             }
             return
         }
@@ -57,6 +85,7 @@ final class WatchConnectivityCoordinator: NSObject {
         guard let session,
               session.activationState == .activated else { return }
         publishDeviceMetadata(using: session)
+        cyclingSensorPublisher.flush()
     }
 
     func publishWorkoutHealthSetup(
@@ -142,11 +171,13 @@ final class WatchConnectivityCoordinator: NSObject {
         flushPendingDirectRideReleases(using: session)
         flushPendingTransportDiagnostics(using: session)
         publishDeviceMetadata(using: session)
+        cyclingSensorPublisher.flush()
         onApplicationContext?(session.receivedApplicationContext)
     }
 
     fileprivate func reachabilityDidChange() {
         onDirectRidePreparationAvailabilityChanged?()
+        cyclingSensorPublisher.flush()
         if let session {
             flushPendingTransportDiagnostics(using: session)
         }

--- a/ios-app/BikeComputer/BikeComputerWatch/WatchAppDelegate.swift
+++ b/ios-app/BikeComputer/BikeComputerWatch/WatchAppDelegate.swift
@@ -137,6 +137,30 @@ final class WatchAppDelegate: NSObject, WKApplicationDelegate {
                 )
             }
             .store(in: &cancellables)
+        Publishers.CombineLatest3(
+            workoutManager.$latestEnvelope,
+            workoutManager.$snapshot,
+            workoutManager.$isRecovering
+        )
+            .sink { [weak connectivityCoordinator]
+                envelope, snapshot, recovering in
+                // The initial idle value is not an authoritative tombstone
+                // while HealthKit recovery is still resolving the workout.
+                guard !recovering else { return }
+                if let envelope,
+                   let observation = WatchCyclingSensorObservationV1(
+                       envelope: envelope
+                   ) {
+                    connectivityCoordinator?.publishCyclingSensorObservation(
+                        observation
+                    )
+                } else if envelope == nil && !snapshot.state.isActive {
+                    connectivityCoordinator?.publishCyclingSensorObservation(
+                        .inactive(at: Date())
+                    )
+                }
+            }
+            .store(in: &cancellables)
         connectivityCoordinator.activate()
         navigationManager.recoverIfNeeded()
         workoutManager.$isRecovering

--- a/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation+Workout.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation+Workout.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension WatchCyclingSensorObservationV1 {
+    init?(envelope: WorkoutEnvelopeV1) {
+        guard let snapshot = envelope.snapshot else { return nil }
+        self.init(
+            sessionID: envelope.sessionID,
+            snapshot: snapshot,
+            capturedAt: envelope.capturedAt
+        )
+    }
+
+    init?(
+        sessionID: UUID,
+        snapshot: WorkoutSnapshotV1,
+        capturedAt: Date
+    ) {
+        // An idle envelope may precede a real workout identity. Only an
+        // ended/failed snapshot (or confirmed recovery with no envelope) is
+        // an authoritative inactivity event.
+        guard snapshot.state != .idle else { return nil }
+        func observedAt(_ metric: WorkoutMetricV1?) -> Date? {
+            guard snapshot.state.isActive, let metric,
+                Self.isFresh(
+                    metric.capturedAt, at: capturedAt,
+                    maximumAge: Self.discoveryFreshness
+                )
+            else { return nil }
+            return metric.capturedAt
+        }
+        self.init(
+            sessionID: sessionID,
+            sessionStartedAt: snapshot.startDate,
+            capturedAt: capturedAt,
+            isWorkoutActive: snapshot.state.isActive,
+            cadenceObservedAt: observedAt(snapshot.cyclingCadence),
+            powerObservedAt: observedAt(snapshot.cyclingPower)
+        )
+        guard isValid else { return nil }
+    }
+}

--- a/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation.swift
@@ -1,0 +1,317 @@
+import Foundation
+
+/// Discovery evidence only. The Watch owns the accessory; this is neither an
+/// accessory identity nor another transport for numeric workout metrics.
+nonisolated struct WatchCyclingSensorObservationV1: Codable, Equatable, Sendable
+{
+    static let applicationContextKey = "watchCyclingSensorObservation.v1"
+    static let maximumEncodedBytes = 2_048
+    static let discoveryFreshness: TimeInterval = 5
+    static let reportingFreshness: TimeInterval = 10
+
+    let version: Int
+    let sessionID: UUID?
+    let sessionStartedAt: Date?
+    let capturedAt: Date
+    let isWorkoutActive: Bool
+    let cadenceObservedAt: Date?
+    let powerObservedAt: Date?
+
+    init(
+        version: Int = 1,
+        sessionID: UUID?,
+        sessionStartedAt: Date?,
+        capturedAt: Date,
+        isWorkoutActive: Bool,
+        cadenceObservedAt: Date? = nil,
+        powerObservedAt: Date? = nil
+    ) {
+        self.version = version
+        self.sessionID = sessionID
+        self.sessionStartedAt = sessionStartedAt
+        self.capturedAt = capturedAt
+        self.isWorkoutActive = isWorkoutActive
+        self.cadenceObservedAt = cadenceObservedAt
+        self.powerObservedAt = powerObservedAt
+    }
+
+    static func inactive(at date: Date) -> Self {
+        Self(
+            sessionID: nil, sessionStartedAt: nil,
+            capturedAt: date, isWorkoutActive: false
+        )
+    }
+
+    var isValid: Bool {
+        guard version == 1, capturedAt.timeIntervalSinceReferenceDate.isFinite,
+            sessionID != nil || sessionStartedAt == nil
+        else { return false }
+        if isWorkoutActive && (sessionID == nil || sessionStartedAt == nil) {
+            return false
+        }
+        if !isWorkoutActive
+            && (cadenceObservedAt != nil || powerObservedAt != nil)
+        {
+            return false
+        }
+        if let start = sessionStartedAt {
+            guard start.timeIntervalSinceReferenceDate.isFinite,
+                start <= capturedAt
+            else { return false }
+        }
+        return [cadenceObservedAt, powerObservedAt].compactMap { $0 }.allSatisfy
+        { date in
+            date.timeIntervalSinceReferenceDate.isFinite && date <= capturedAt
+                && (sessionStartedAt.map { date >= $0 } ?? false)
+        }
+    }
+
+    func encoded() throws -> Data {
+        guard isValid else { throw CodingError.invalidObservation }
+        let encoder = PropertyListEncoder()
+        encoder.outputFormat = .binary
+        let data = try encoder.encode(self)
+        guard data.count <= Self.maximumEncodedBytes else {
+            throw CodingError.invalidObservation
+        }
+        return data
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        guard !data.isEmpty, data.count <= maximumEncodedBytes else {
+            throw CodingError.invalidObservation
+        }
+        let value = try PropertyListDecoder().decode(Self.self, from: data)
+        guard value.isValid else { throw CodingError.invalidObservation }
+        return value
+    }
+
+    func merging(into context: [String: Any]) throws -> [String: Any] {
+        var merged = context
+        merged[Self.applicationContextKey] = try encoded()
+        return merged
+    }
+
+    static func isFresh(_ date: Date?, at now: Date, maximumAge: TimeInterval)
+        -> Bool
+    {
+        guard let date else { return false }
+        let age = now.timeIntervalSince(date)
+        return age.isFinite && age >= 0 && age <= maximumAge
+    }
+
+    enum CodingError: Error { case invalidObservation }
+}
+
+/// Source-independent session/replay policy shared by discovery and its host
+/// tests. Losing the mirror is not a workout-end event. Only an explicit
+/// Watch/HealthKit terminal observation closes the selected session.
+nonisolated struct CyclingSensorObservationReducer {
+    enum Source: Hashable { case mirror, watch }
+
+    private(set) var sessionID: UUID?
+    private var sessionStartedAt: Date?
+    private var isClosed = false
+    private var inactiveBarrier: Date?
+    private var latestCapturedAt: Date?
+    private var watermarks: [Source: Date] = [:]
+    private var observations: [Source: WatchCyclingSensorObservationV1] = [:]
+
+    mutating func setUnavailable(_ source: Source) {
+        observations.removeValue(forKey: source)
+    }
+
+    @discardableResult
+    mutating func ingest(
+        _ observation: WatchCyclingSensorObservationV1,
+        from source: Source,
+        at now: Date
+    ) -> Bool {
+        guard observation.isValid, now.timeIntervalSinceReferenceDate.isFinite,
+            observation.capturedAt <= now
+        else { return false }
+        // Old cached activity is not evidence of a currently running workout.
+        if observation.isWorkoutActive
+            && !WatchCyclingSensorObservationV1.isFresh(
+                observation.capturedAt, at: now,
+                maximumAge: WatchCyclingSensorObservationV1.discoveryFreshness
+            )
+        {
+            return false
+        }
+
+        guard let incomingID = observation.sessionID else {
+            // Only Watch can assert that recovery completed with no workout.
+            guard source == .watch,
+                latestCapturedAt.map({ observation.capturedAt >= $0 }) ?? true,
+                inactiveBarrier.map({ observation.capturedAt >= $0 }) ?? true
+            else {
+                return false
+            }
+            inactiveBarrier = observation.capturedAt
+            latestCapturedAt = observation.capturedAt
+            isClosed = true
+            observations.removeAll()
+            return true
+        }
+        if let inactiveBarrier, observation.capturedAt <= inactiveBarrier {
+            return false
+        }
+        // Check ordering before mutating the selected session. A rejected
+        // packet must not clear another source's live observations.
+        if !observation.isWorkoutActive || incomingID != sessionID {
+            if let latestCapturedAt, observation.capturedAt < latestCapturedAt {
+                return false
+            }
+        }
+        if incomingID != sessionID {
+            if let currentStart = sessionStartedAt {
+                guard let incomingStart = observation.sessionStartedAt,
+                    incomingStart > currentStart
+                else { return false }
+            } else if let latestCapturedAt,
+                observation.capturedAt <= latestCapturedAt
+            {
+                return false
+            }
+            sessionID = incomingID
+            sessionStartedAt = observation.sessionStartedAt
+            isClosed = false
+            watermarks.removeAll()
+            observations.removeAll()
+        } else if isClosed {
+            return false
+        }
+        if let previous = watermarks[source], observation.capturedAt < previous
+        {
+            return false
+        }
+        watermarks[source] = observation.capturedAt
+        latestCapturedAt = max(
+            latestCapturedAt ?? observation.capturedAt, observation.capturedAt)
+        if observation.isWorkoutActive {
+            // Freshness is based on the original HealthKit sample, never the
+            // context delivery time. Newly delivered stale samples cannot make
+            // an enrolled profile report; previously admitted evidence gets
+            // the reporting grace period without being re-dated.
+            observations[source] = WatchCyclingSensorObservationV1(
+                sessionID: incomingID,
+                sessionStartedAt: observation.sessionStartedAt,
+                capturedAt: observation.capturedAt,
+                isWorkoutActive: true,
+                cadenceObservedAt: admitted(
+                    observation.cadenceObservedAt, at: now),
+                powerObservedAt: admitted(observation.powerObservedAt, at: now)
+            )
+        } else {
+            isClosed = true
+            observations.removeAll()
+        }
+        return true
+    }
+
+    func hasActiveWorkout(at now: Date) -> Bool {
+        !activeObservations(at: now).isEmpty
+    }
+
+    func cadenceObservedAt(at now: Date) -> Date? {
+        freshMaximum(
+            activeObservations(at: now).compactMap(\.cadenceObservedAt), at: now
+        )
+    }
+
+    func powerObservedAt(at now: Date) -> Date? {
+        freshMaximum(
+            activeObservations(at: now).compactMap(\.powerObservedAt), at: now)
+    }
+
+    func nextExpiry(after now: Date) -> Date? {
+        observations.values.flatMap { observation in
+            [
+                observation.capturedAt, observation.cadenceObservedAt,
+                observation.powerObservedAt,
+            ]
+            .compactMap { $0 }
+            .map {
+                $0.addingTimeInterval(
+                    WatchCyclingSensorObservationV1.reportingFreshness + 0.001)
+            }
+        }.filter { $0 > now }.min()
+    }
+
+    private func activeObservations(at now: Date)
+        -> [WatchCyclingSensorObservationV1]
+    {
+        guard !isClosed else { return [] }
+        return observations.values.filter {
+            $0.isWorkoutActive
+                && WatchCyclingSensorObservationV1.isFresh(
+                    $0.capturedAt, at: now,
+                    maximumAge: WatchCyclingSensorObservationV1
+                        .reportingFreshness
+                )
+        }
+    }
+
+    private func admitted(_ date: Date?, at now: Date) -> Date? {
+        WatchCyclingSensorObservationV1.isFresh(
+            date, at: now,
+            maximumAge: WatchCyclingSensorObservationV1.discoveryFreshness
+        ) ? date : nil
+    }
+
+    private func freshMaximum(_ dates: [Date], at now: Date) -> Date? {
+        dates.filter {
+            WatchCyclingSensorObservationV1.isFresh(
+                $0, at: now,
+                maximumAge: WatchCyclingSensorObservationV1.reportingFreshness
+            )
+        }.max()
+    }
+}
+
+/// A one-slot outbox: lifecycle/capability changes are immediate, timestamp
+/// refreshes are coalesced, and failed submissions never advance the watermark.
+nonisolated struct WatchCyclingSensorPublicationV1 {
+    static let minimumInterval: TimeInterval = 2
+    private(set) var latest: WatchCyclingSensorObservationV1?
+    private var lifecycle = CyclingSensorObservationReducer()
+    private var published: WatchCyclingSensorObservationV1?
+    private var publishedAt: Date?
+
+    mutating func offer(_ observation: WatchCyclingSensorObservationV1) {
+        // Apply the same lifecycle gate at the sender. Otherwise a late
+        // active callback could overwrite an undelivered terminal context
+        // before a cold-started phone had an opportunity to see it.
+        guard
+            lifecycle.ingest(
+                observation, from: .watch, at: observation.capturedAt
+            )
+        else { return }
+        latest = observation
+    }
+
+    func publicationDelay(at now: Date) -> TimeInterval? {
+        guard let latest else { return nil }
+        guard let published, let publishedAt else { return 0 }
+        if latest.sessionID != published.sessionID
+            || latest.isWorkoutActive != published.isWorkoutActive
+            || (latest.cadenceObservedAt != nil)
+                != (published.cadenceObservedAt != nil)
+            || (latest.powerObservedAt != nil)
+                != (published.powerObservedAt != nil)
+        {
+            return 0
+        }
+        guard
+            latest.cadenceObservedAt != published.cadenceObservedAt
+                || latest.powerObservedAt != published.powerObservedAt
+        else { return nil }
+        return max(0, Self.minimumInterval - now.timeIntervalSince(publishedAt))
+    }
+
+    mutating func didPublish(at now: Date) {
+        published = latest
+        publishedAt = now
+    }
+}

--- a/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservationPublisher.swift
+++ b/ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservationPublisher.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Owns the bounded publication lifecycle, not WCSession. The existing Watch
+/// connectivity coordinator supplies the activated session and merged write.
+@MainActor
+final class WatchCyclingSensorObservationPublisher {
+    private let isActivated: () -> Bool
+    private let publish: (WatchCyclingSensorObservationV1) -> Bool
+    private let now: () -> Date
+    private var publication = WatchCyclingSensorPublicationV1()
+    private var pendingTask: Task<Void, Never>?
+    private var retryNotBefore: Date?
+    private var retryDelay: TimeInterval = 2
+
+    init(
+        isActivated: @escaping () -> Bool,
+        publish: @escaping (WatchCyclingSensorObservationV1) -> Bool,
+        now: @escaping () -> Date = Date.init
+    ) {
+        self.isActivated = isActivated
+        self.publish = publish
+        self.now = now
+    }
+
+    deinit {
+        pendingTask?.cancel()
+    }
+
+    func offer(_ observation: WatchCyclingSensorObservationV1) {
+        publication.offer(observation)
+        flush()
+    }
+
+    /// Also called after activation/foregrounding. Context delivery does not
+    /// require reachability; a failed write keeps the latest pending value.
+    func flush() {
+        pendingTask?.cancel()
+        pendingTask = nil
+        guard isActivated(), let latest = publication.latest,
+            let publicationDelay = publication.publicationDelay(at: now())
+        else { return }
+        let date = now()
+        let delay = max(
+            publicationDelay,
+            retryNotBefore?.timeIntervalSince(date) ?? 0
+        )
+        if delay > 0 {
+            schedule(after: delay)
+            return
+        }
+        if publish(latest) {
+            publication.didPublish(at: date)
+            retryNotBefore = nil
+            retryDelay = 2
+        } else {
+            // New samples cannot defeat the retry deadline or create an
+            // unbounded queue. Persistent transport errors back off to 30s.
+            retryNotBefore = date.addingTimeInterval(retryDelay)
+            schedule(after: retryDelay)
+            retryDelay = min(30, retryDelay * 2)
+        }
+    }
+
+    private func schedule(after delay: TimeInterval) {
+        let nanoseconds = UInt64(min(max(0, delay), 30) * 1_000_000_000)
+        pendingTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(nanoseconds: nanoseconds)
+            } catch {
+                return
+            }
+            guard !Task.isCancelled else { return }
+            self?.flush()
+        }
+    }
+}

--- a/ios-app/BikeComputerTests/CyclingSensorObservationIntegrationTests.swift
+++ b/ios-app/BikeComputerTests/CyclingSensorObservationIntegrationTests.swift
@@ -1,0 +1,294 @@
+import Combine
+import Foundation
+
+private func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() { fatalError(message) }
+}
+
+@MainActor
+private final class SensorObservationClock {
+    var date = Date(timeIntervalSinceReferenceDate: 800_100_000)
+}
+
+@MainActor
+private final class SensorObservationFixture {
+    let suiteName = "SensorObservationIntegration.\(UUID().uuidString)"
+    let defaults: UserDefaults
+    let clock = SensorObservationClock()
+    let sessionID = UUID()
+    let store: CyclingSensorStore
+    let mirror: WorkoutMetricsStore
+    let coordinator: CyclingSensorDetectionCoordinator
+    let watch: CurrentValueSubject<WatchCyclingSensorObservationV1?, Never>
+
+    init(cachedSampleAge: TimeInterval = 0) throws {
+        defaults = UserDefaults(suiteName: suiteName)!
+        let clock = self.clock
+        store = CyclingSensorStore(defaults: defaults, now: { clock.date })
+        mirror = WorkoutMetricsStore(now: { clock.date })
+        coordinator = CyclingSensorDetectionCoordinator(
+            sensorStore: store, now: { clock.date },
+            dismissalDefaults: defaults
+        )
+        let cached = WatchCyclingSensorObservationV1(
+            sessionID: sessionID,
+            sessionStartedAt: clock.date.addingTimeInterval(-60),
+            capturedAt: clock.date,
+            isWorkoutActive: true,
+            cadenceObservedAt: clock.date.addingTimeInterval(-cachedSampleAge)
+        )
+        // This is the same codec and current-value publication boundary used
+        // after PhoneWatchConnectivityCoordinator reads receivedApplicationContext.
+        let decoded = try WatchCyclingSensorObservationV1.decode(
+            cached.encoded())
+        watch = CurrentValueSubject<WatchCyclingSensorObservationV1?, Never>(
+            decoded)
+        coordinator.bind(
+            to: mirror, watchObservations: watch.eraseToAnyPublisher())
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func presentation(
+        connection: WorkoutMirrorConnectionStateV1 = .connected,
+        state: WorkoutSessionStateV1 = .running,
+        at date: Date? = nil
+    ) -> WorkoutMirrorPresentationV1 {
+        let date = date ?? clock.date
+        return WorkoutMirrorPresentationV1(
+            connectionState: connection,
+            snapshot: WorkoutSnapshotV1(
+                state: state,
+                startDate: clock.date.addingTimeInterval(-60),
+                cyclingCadence: WorkoutMetricV1(
+                    value: 82, unit: .revolutionsPerMinute,
+                    capturedAt: date, source: .healthKit
+                ),
+                availability: .cyclingCadence
+            ),
+            sessionID: sessionID, capturedAt: date, receivedAt: date,
+            confirmedSessionState: state, errorCode: nil,
+            pendingControl: nil, finalSnapshot: nil, navigation: .empty
+        )
+    }
+}
+
+@main
+private enum CyclingSensorObservationIntegrationTests {
+    @MainActor
+    static func main() async throws {
+        require(
+            WatchCyclingSensorObservationV1(
+                sessionID: UUID(), snapshot: WorkoutSnapshotV1(state: .idle),
+                capturedAt: Date()
+            ) == nil,
+            "idle envelope cannot permanently retire a future workout identity")
+        let fixture = try SensorObservationFixture(cachedSampleAge: 2)
+        let originalSample = fixture.clock.date.addingTimeInterval(-2)
+        require(
+            fixture.mirror.presentation.connectionState == .idle,
+            "fixture has no mirror")
+        require(
+            fixture.coordinator.candidates.count == 1,
+            "cold-start cached Watch evidence discovers cadence")
+        require(
+            fixture.coordinator.candidates[0].lastObservedAt == originalSample,
+            "candidate uses sample time, not receipt time")
+        require(fixture.store.profiles.isEmpty, "discovery never auto-enrolls")
+        let candidateID = fixture.coordinator.candidates[0].id
+        for connection in [
+            WorkoutMirrorConnectionStateV1.idle, .stale, .disconnected, .failed,
+        ] {
+            fixture.coordinator.ingest(
+                fixture.presentation(connection: connection),
+                at: fixture.clock.date)
+            require(
+                fixture.coordinator.hasActiveWorkout,
+                "mirror availability cannot end Watch activity")
+            require(
+                fixture.coordinator.isReporting(
+                    capabilities: .cadence, at: fixture.clock.date),
+                "Watch reporting survives idle/stale/disconnected mirror")
+            require(
+                fixture.coordinator.candidates.first?.id == candidateID,
+                "mirror loss cannot duplicate candidates")
+        }
+        fixture.mirror.disconnect(error: nil)
+        fixture.mirror.failSession(error: .watchUnavailable)
+        require(
+            fixture.coordinator.hasActiveWorkout,
+            "actual mirror-store publication preserves Watch evidence")
+        fixture.coordinator.ingest(
+            fixture.presentation(), at: fixture.clock.date)
+        require(
+            fixture.coordinator.candidates.count == 1,
+            "dual-source observations deduplicate")
+        let profile = fixture.store.enroll(
+            name: "Crank", capabilities: .cadence)!
+        fixture.coordinator.didEnroll(capabilities: .cadence)
+        fixture.coordinator.ingest(
+            fixture.presentation(), at: fixture.clock.date)
+        fixture.watch.send(fixture.watch.value)
+        require(
+            fixture.store.profiles.count == 1
+                && profile.identityKind == .logical,
+            "explicit connection creates exactly one logical profile")
+        require(
+            fixture.coordinator.candidates.isEmpty
+                && fixture.coordinator.activePrompt == nil,
+            "enrollment suppresses duplicate candidates and prompts from both paths"
+        )
+
+        let endedAt = fixture.clock.date.addingTimeInterval(1)
+        fixture.clock.date = endedAt
+        fixture.watch.send(
+            WatchCyclingSensorObservationV1(
+                sessionID: fixture.sessionID,
+                sessionStartedAt: endedAt.addingTimeInterval(-61),
+                capturedAt: endedAt, isWorkoutActive: false
+            ))
+        require(
+            !fixture.coordinator.hasActiveWorkout,
+            "Watch end clears active status immediately")
+        require(
+            !fixture.coordinator.isReporting(
+                capabilities: .cadence, at: endedAt),
+            "Watch end immediately clears enrolled reporting")
+        fixture.coordinator.ingest(
+            fixture.presentation(at: endedAt.addingTimeInterval(-1)),
+            at: endedAt)
+        require(
+            !fixture.coordinator.hasActiveWorkout,
+            "late mirrored snapshot cannot revive an ended session")
+
+        let dismissed = try SensorObservationFixture()
+        dismissed.coordinator.dismissPrompt()
+        dismissed.mirror.disconnect(error: nil)
+        dismissed.watch.send(dismissed.watch.value)
+        require(
+            dismissed.coordinator.activePrompt == nil,
+            "mirror outage does not reset same-workout dismissal")
+        let restored = CyclingSensorDetectionCoordinator(
+            sensorStore: dismissed.store, now: { dismissed.clock.date },
+            dismissalDefaults: dismissed.defaults
+        )
+        restored.bind(
+            to: dismissed.mirror,
+            watchObservations: dismissed.watch.eraseToAnyPublisher())
+        require(
+            restored.activePrompt == nil,
+            "Watch-only dismissal survives phone coordinator recreation")
+        dismissed.clock.date.addTimeInterval(1)
+        dismissed.watch.send(
+            WatchCyclingSensorObservationV1(
+                sessionID: UUID(), sessionStartedAt: dismissed.clock.date,
+                capturedAt: dismissed.clock.date, isWorkoutActive: true,
+                cadenceObservedAt: dismissed.clock.date
+            ))
+        require(
+            restored.activePrompt?.capabilities == .cadence,
+            "successor workout may prompt again")
+
+        let stale = try SensorObservationFixture(cachedSampleAge: 6)
+        require(
+            stale.coordinator.candidates.isEmpty,
+            "fresh context cannot rejuvenate stale sensor sample")
+        require(
+            !stale.coordinator.isReporting(
+                capabilities: .cadence, at: stale.clock.date),
+            "stale sample is not Reporting")
+        stale.watch.send(
+            WatchCyclingSensorObservationV1(
+                sessionID: stale.sessionID,
+                sessionStartedAt: stale.clock.date.addingTimeInterval(-60),
+                capturedAt: stale.clock.date.addingTimeInterval(1),
+                isWorkoutActive: true,
+                cadenceObservedAt: stale.clock.date.addingTimeInterval(1)
+            ))
+        require(
+            stale.coordinator.candidates.isEmpty,
+            "future Watch context does not create candidates")
+
+        let replay = try SensorObservationFixture(cachedSampleAge: 2)
+        let cached = replay.watch.value
+        let timestamp = replay.coordinator.lastObservedAt(for: .cadence)
+        replay.clock.date.addTimeInterval(1)
+        replay.watch.send(cached)
+        require(
+            replay.coordinator.lastObservedAt(for: .cadence) == timestamp,
+            "cache replay never extends last-seen time")
+        replay.clock.date.addTimeInterval(8)
+        replay.coordinator.refresh(at: replay.clock.date)
+        require(
+            replay.coordinator.activePrompt == nil,
+            "silent source stops prompting after original sample expires")
+        require(
+            !replay.coordinator.isReporting(
+                capabilities: .cadence, at: replay.clock.date),
+            "silent source cannot report indefinitely")
+
+        let mirrorEnd = try SensorObservationFixture()
+        mirrorEnd.coordinator.ingest(
+            mirrorEnd.presentation(connection: .ended, state: .ended),
+            at: mirrorEnd.clock.date
+        )
+        require(
+            !mirrorEnd.coordinator.hasActiveWorkout,
+            "explicit HealthKit end also retires Watch evidence")
+        mirrorEnd.watch.send(mirrorEnd.watch.value)
+        require(
+            !mirrorEnd.coordinator.hasActiveWorkout,
+            "cached Watch packet cannot revive mirrored end")
+
+        let removed = try SensorObservationFixture()
+        removed.watch.send(nil)
+        require(
+            !removed.coordinator.hasActiveWorkout,
+            "counterpart removal clears Watch-only reporting")
+        let combined = WatchCyclingSensorObservationV1(
+            sessionID: removed.sessionID,
+            sessionStartedAt: removed.clock.date.addingTimeInterval(-60),
+            capturedAt: removed.clock.date, isWorkoutActive: true,
+            cadenceObservedAt: removed.clock.date,
+            powerObservedAt: removed.clock.date
+        )
+        removed.watch.send(combined)
+        require(
+            Set(removed.coordinator.candidates.map(\.capabilities))
+                == Set([.cadence, .power]),
+            "unidentified cadence and power remain separate logical candidates")
+
+        // Actual timer integration: no refresh(), new presentation, or Watch
+        // event is supplied after admission. The first sample expires in ~5s.
+        let timerSuite = "SensorObservationTimer.\(UUID().uuidString)"
+        let timerDefaults = UserDefaults(suiteName: timerSuite)!
+        defer { timerDefaults.removePersistentDomain(forName: timerSuite) }
+        let timerStore = CyclingSensorStore(defaults: timerDefaults)
+        let timerCoordinator = CyclingSensorDetectionCoordinator(
+            sensorStore: timerStore, dismissalDefaults: timerDefaults
+        )
+        let timerNow = Date()
+        timerCoordinator.ingestWatchObservation(
+            WatchCyclingSensorObservationV1(
+                sessionID: UUID(),
+                sessionStartedAt: timerNow.addingTimeInterval(-60),
+                capturedAt: timerNow, isWorkoutActive: true,
+                cadenceObservedAt: timerNow.addingTimeInterval(-4.9)
+            ), at: timerNow)
+        require(
+            timerCoordinator.activePrompt != nil,
+            "timer fixture starts with a fresh prompt")
+        let timerDeadline = Date().addingTimeInterval(15)
+        while timerCoordinator.activePrompt != nil && Date() < timerDeadline {
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        require(
+            timerCoordinator.activePrompt == nil
+                && timerCoordinator.lastObservedAt(for: .cadence) == nil,
+            "expiry task clears published reporting and prompt without another callback"
+        )
+        print("Cycling sensor observation integration tests passed")
+    }
+}

--- a/ios-app/BikeComputerTests/WatchCyclingSensorObservationTests.swift
+++ b/ios-app/BikeComputerTests/WatchCyclingSensorObservationTests.swift
@@ -1,0 +1,323 @@
+import Foundation
+
+private func check(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() { fatalError(message) }
+}
+
+@main
+private enum WatchCyclingSensorObservationTests {
+    @MainActor
+    static func main() async throws {
+        let now = Date(timeIntervalSinceReferenceDate: 800_000_000)
+        let id = UUID()
+        func observation(
+            id: UUID = id, start: Date = now.addingTimeInterval(-60),
+            at: Date = now, active: Bool = true,
+            cadence: Date? = now, power: Date? = nil
+        ) -> WatchCyclingSensorObservationV1 {
+            WatchCyclingSensorObservationV1(
+                sessionID: id, sessionStartedAt: start, capturedAt: at,
+                isWorkoutActive: active,
+                cadenceObservedAt: active ? cadence : nil,
+                powerObservedAt: active ? power : nil
+            )
+        }
+        let live = observation()
+        let decoded = try WatchCyclingSensorObservationV1.decode(live.encoded())
+        check(
+            decoded == live,
+            "binary property-list round trip")
+        let context = try live.merging(into: [
+            "metadata": Data([1]), "health": "ready",
+        ])
+        check(
+            context["metadata"] as? Data == Data([1]), "metadata survives merge"
+        )
+        check(
+            context["health"] as? String == "ready",
+            "health state survives merge")
+        let wire =
+            try PropertyListSerialization.propertyList(
+                from: live.encoded(), options: [], format: nil
+            ) as! [String: Any]
+        check(
+            Set(wire.keys)
+                == Set([
+                    "version", "sessionID", "sessionStartedAt", "capturedAt",
+                    "isWorkoutActive", "cadenceObservedAt",
+                ]),
+            "wire carries only lifecycle and timestamps, no numeric metrics")
+        for bad in [
+            Data(), Data("invalid".utf8), Data(repeating: 0, count: 2_049),
+        ] {
+            check(
+                (try? WatchCyclingSensorObservationV1.decode(bad)) == nil,
+                "malformed and oversized input fails closed")
+        }
+        var futureWire = wire
+        futureWire["version"] = 2
+        let futureData = try PropertyListSerialization.data(
+            fromPropertyList: futureWire, format: .binary, options: 0
+        )
+        check(
+            (try? WatchCyclingSensorObservationV1.decode(futureData)) == nil,
+            "unsupported version is not accepted")
+        check(
+            !observation(cadence: now.addingTimeInterval(1)).isValid,
+            "a sample cannot be newer than its snapshot")
+        check(
+            !observation(cadence: now.addingTimeInterval(-61)).isValid,
+            "a sample cannot predate its session")
+        check(
+            !observation(at: Date(timeIntervalSinceReferenceDate: .nan))
+                .isValid,
+            "nonfinite capture time rejected")
+        let end = observation(at: now.addingTimeInterval(2), active: false)
+        check(end.isValid, "terminal snapshot strips sensor evidence")
+
+        var reducer = CyclingSensorObservationReducer()
+        check(
+            reducer.ingest(live, from: .watch, at: now), "Watch-only admission")
+        check(
+            reducer.hasActiveWorkout(at: now),
+            "idle mirror does not gate Watch activity")
+        check(
+            reducer.cadenceObservedAt(at: now) == now,
+            "original sample timestamp")
+        check(
+            reducer.ingest(live, from: .mirror, at: now),
+            "parallel mirror admission")
+        reducer.setUnavailable(.mirror)
+        check(
+            reducer.cadenceObservedAt(at: now) == now,
+            "mirror loss keeps Watch evidence")
+        check(
+            reducer.ingest(end, from: .watch, at: end.capturedAt),
+            "end accepted")
+        check(
+            !reducer.hasActiveWorkout(at: end.capturedAt),
+            "end clears reporting immediately")
+        check(
+            reducer.cadenceObservedAt(at: end.capturedAt) == nil,
+            "end clears cadence")
+        check(
+            !reducer.ingest(live, from: .mirror, at: end.capturedAt),
+            "late mirror cannot revive end")
+        check(
+            !reducer.ingest(
+                observation(at: end.capturedAt), from: .watch,
+                at: end.capturedAt),
+            "even a higher timestamp cannot reopen the same ended session")
+
+        let nextID = UUID()
+        let next = observation(
+            id: nextID, start: now.addingTimeInterval(3),
+            at: now.addingTimeInterval(4), cadence: now.addingTimeInterval(4))
+        check(
+            reducer.ingest(next, from: .watch, at: next.capturedAt),
+            "successor session accepted")
+        check(
+            !reducer.ingest(end, from: .mirror, at: next.capturedAt),
+            "old end rejected")
+        check(
+            reducer.sessionID == nextID
+                && reducer.hasActiveWorkout(at: next.capturedAt),
+            "rejecting old end is atomic")
+        let invalidSuccessor = observation(
+            id: UUID(), start: now.addingTimeInterval(3.5),
+            at: now.addingTimeInterval(3.9), active: false)
+        check(
+            !reducer.ingest(
+                invalidSuccessor, from: .watch, at: next.capturedAt),
+            "older capture rejected before replacing session")
+        check(
+            reducer.sessionID == nextID
+                && reducer.cadenceObservedAt(at: next.capturedAt) != nil,
+            "rejected packet leaves existing evidence unchanged")
+
+        var expired = CyclingSensorObservationReducer()
+        check(
+            !expired.ingest(
+                live, from: .watch, at: now.addingTimeInterval(5.001)),
+            "stale cached context cannot discover or report on launch")
+        check(
+            !expired.hasActiveWorkout(at: now.addingTimeInterval(5.001)),
+            "no stale activity")
+        check(
+            !expired.ingest(
+                live, from: .watch, at: now.addingTimeInterval(-0.001)),
+            "future capture rejected")
+        let oldSample = observation(cadence: now.addingTimeInterval(-6))
+        check(
+            expired.ingest(oldSample, from: .watch, at: now),
+            "fresh lifecycle still accepted")
+        check(
+            expired.cadenceObservedAt(at: now) == nil,
+            "fresh context does not rejuvenate old sample")
+        var grace = CyclingSensorObservationReducer()
+        check(
+            grace.ingest(live, from: .watch, at: now.addingTimeInterval(5)),
+            "inclusive discovery boundary")
+        check(
+            grace.cadenceObservedAt(at: now.addingTimeInterval(10)) == now,
+            "inclusive reporting boundary")
+        check(
+            grace.cadenceObservedAt(at: now.addingTimeInterval(10.001)) == nil,
+            "silent source expires")
+        check(
+            grace.nextExpiry(after: now) == now.addingTimeInterval(10.001),
+            "expiry deadline uses sample time")
+        check(
+            !grace.ingest(live, from: .watch, at: now.addingTimeInterval(6)),
+            "cache replay is stale")
+        check(
+            grace.cadenceObservedAt(at: now.addingTimeInterval(9)) == now,
+            "replay does not re-date accepted sample")
+        grace.setUnavailable(.watch)
+        check(
+            !grace.hasActiveWorkout(at: now),
+            "unpair/removal clears only available evidence")
+
+        var idle = CyclingSensorObservationReducer()
+        let tombstone = WatchCyclingSensorObservationV1.inactive(at: now)
+        check(
+            !idle.ingest(tombstone, from: .mirror, at: now),
+            "idle phone cannot end Watch workout")
+        check(
+            idle.ingest(tombstone, from: .watch, at: now),
+            "confirmed Watch idle tombstone")
+        check(
+            !idle.ingest(live, from: .mirror, at: now),
+            "idle barrier rejects prior context")
+        check(
+            idle.ingest(next, from: .watch, at: next.capturedAt),
+            "new workout after idle accepted")
+
+        var publication = WatchCyclingSensorPublicationV1()
+        publication.offer(live)
+        check(
+            publication.publicationDelay(at: now) == 0, "first sensor immediate"
+        )
+        check(
+            publication.publicationDelay(at: now.addingTimeInterval(1)) == 0,
+            "failed submission remains pending")
+        publication.didPublish(at: now)
+        check(
+            publication.publicationDelay(at: now) == nil,
+            "successful identical context is not resent")
+        let refresh = observation(
+            at: now.addingTimeInterval(1), cadence: now.addingTimeInterval(1))
+        publication.offer(refresh)
+        check(
+            publication.publicationDelay(at: refresh.capturedAt) == 1,
+            "refresh coalesced to two seconds")
+        let newest = observation(
+            at: now.addingTimeInterval(1.5),
+            cadence: now.addingTimeInterval(1.5))
+        publication.offer(newest)
+        publication.offer(live)
+        check(
+            publication.latest == newest,
+            "one-slot queue keeps newest and rejects late offer")
+        check(
+            publication.publicationDelay(at: now.addingTimeInterval(2)) == 0,
+            "trailing refresh eventually due")
+        publication.offer(end)
+        check(
+            publication.publicationDelay(at: end.capturedAt) == 0,
+            "terminal state bypasses refresh throttle")
+        publication.offer(
+            observation(
+                at: now.addingTimeInterval(3),
+                cadence: now.addingTimeInterval(3)
+            ))
+        check(
+            publication.latest == end,
+            "late active callback cannot overwrite an undelivered tombstone")
+        publication.didPublish(at: end.capturedAt)
+        publication.offer(next)
+        check(
+            publication.publicationDelay(at: next.capturedAt) == 0,
+            "successor session immediate")
+        // Exercise the actual publisher adapter, including pre-activation,
+        // coalescing, failed submission, bounded retry, and trailing delivery.
+        var activated = false
+        var clock = now
+        var attempts = 0
+        var fails = false
+        var sent: [WatchCyclingSensorObservationV1] = []
+        let publisher = WatchCyclingSensorObservationPublisher(
+            isActivated: { activated },
+            publish: { observation in
+                attempts += 1
+                if fails { return false }
+                sent.append(observation)
+                return true
+            },
+            now: { clock }
+        )
+        publisher.offer(live)
+        publisher.offer(refresh)
+        check(attempts == 0, "no writes before session activation")
+        activated = true
+        clock = refresh.capturedAt
+        publisher.flush()
+        check(
+            sent == [refresh],
+            "activation flushes only latest pending observation")
+        publisher.flush()
+        check(
+            attempts == 1,
+            "activation/metadata replay does not resend unchanged state")
+        clock = newest.capturedAt
+        publisher.offer(newest)
+        check(attempts == 1, "actual publisher throttles timestamp refresh")
+        clock = now.addingTimeInterval(3)
+        fails = true
+        publisher.flush()
+        check(attempts == 2, "due refresh attempts submission")
+        publisher.offer(end)
+        publisher.flush()
+        check(
+            attempts == 2, "new envelopes cannot defeat a failed-write deadline"
+        )
+        clock = now.addingTimeInterval(5)
+        publisher.flush()
+        check(attempts == 3, "failed publication retries at deadline")
+        fails = false
+        clock = now.addingTimeInterval(9)
+        publisher.flush()
+        check(
+            sent == [refresh, end],
+            "retry retains terminal rather than older numeric evidence")
+
+        var trailing: [WatchCyclingSensorObservationV1] = []
+        let liveClock = Date()
+        let livePublisher = WatchCyclingSensorObservationPublisher(
+            isActivated: { true },
+            publish: {
+                trailing.append($0)
+                return true
+            }
+        )
+        livePublisher.offer(
+            observation(
+                start: liveClock.addingTimeInterval(-60),
+                at: liveClock, cadence: liveClock))
+        try await Task.sleep(nanoseconds: 50_000_000)
+        let lastSample = Date()
+        livePublisher.offer(
+            observation(
+                start: liveClock.addingTimeInterval(-60),
+                at: lastSample, cadence: lastSample))
+        let deadline = Date().addingTimeInterval(3)
+        while trailing.count < 2 && Date() < deadline {
+            try await Task.sleep(nanoseconds: 25_000_000)
+        }
+        check(
+            trailing.count == 2
+                && trailing.last?.cadenceObservedAt == lastSample,
+            "trailing timer flushes the last sample without another offer")
+        print("Watch cycling sensor observation tests passed")
+    }
+}

--- a/ios-app/scripts/run-cycling-sensor-observation-tests.sh
+++ b/ios-app/scripts/run-cycling-sensor-observation-tests.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IOS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+OUT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/cycling-sensor-observations.XXXXXX")"
+trap 'rm -rf "${OUT_DIR}"' EXIT
+
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  SWIFTC=(xcrun swiftc)
+else
+  SWIFTC=(swiftc)
+fi
+
+"${SWIFTC[@]}" -parse-as-library -default-isolation MainActor \
+  -o "${OUT_DIR}/tests" \
+  "${IOS_DIR}/BikeComputer/WorkoutShared/WatchCyclingSensorObservation.swift" \
+  "${IOS_DIR}/BikeComputer/WorkoutShared/WatchCyclingSensorObservationPublisher.swift" \
+  "${IOS_DIR}/BikeComputerTests/WatchCyclingSensorObservationTests.swift"
+"${OUT_DIR}/tests"

--- a/ios-app/scripts/run-navigation-tests.sh
+++ b/ios-app/scripts/run-navigation-tests.sh
@@ -8,6 +8,8 @@ OUT="${TMPDIR:-/tmp}/open-bike-navigation-tests"
 
 cd "${REPO_DIR}"
 
+"${SCRIPT_DIR}/run-cycling-sensor-observation-tests.sh"
+
 RENDERER_SCHEDULER_OUT="${TMPDIR:-/tmp}/open-bike-renderer-scheduler-tests"
 xcrun swiftc -D HOST_TESTING -parse-as-library \
   -o "${RENDERER_SCHEDULER_OUT}" \
@@ -90,6 +92,7 @@ xcrun swiftc \
 
 CYCLING_SENSOR_OUT="${TMPDIR:-/tmp}/open-bike-cycling-sensor-tests"
 
+for CYCLING_SENSOR_TEST in CyclingSensorTests CyclingSensorObservationIntegrationTests; do
 xcrun swiftc \
   -parse-as-library \
   -default-isolation MainActor \
@@ -102,14 +105,17 @@ xcrun swiftc \
   ios-app/BikeComputer/WorkoutShared/WorkoutContract.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutMirrorRuntimeLogic.swift \
   ios-app/BikeComputer/WorkoutShared/WorkoutRuntimeLogic.swift \
+  ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation.swift \
+  ios-app/BikeComputer/WorkoutShared/WatchCyclingSensorObservation+Workout.swift \
   ios-app/BikeComputer/BikeComputer/Utilities/RideDiagnostics.swift \
   ios-app/BikeComputer/BikeComputer/Managers/WorkoutMetricsStore.swift \
   ios-app/BikeComputer/BikeComputer/Models/CyclingSensorProfile.swift \
   ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorStore.swift \
   ios-app/BikeComputer/BikeComputer/Managers/CyclingSensorDetectionCoordinator.swift \
-  ios-app/BikeComputerTests/CyclingSensorTests.swift
+  "ios-app/BikeComputerTests/${CYCLING_SENSOR_TEST}.swift"
 
 "${CYCLING_SENSOR_OUT}"
+done
 
 CATALYST_OUT="${TMPDIR:-/tmp}/open-bike-destination-callout-tests"
 MACOS_SDK="$(xcrun --sdk macosx --show-sdk-path)"


### PR DESCRIPTION
## Summary

Fixes #383.

Branched from verified `main` at `44e0df3bf87cce1aca0c4da9d5d7b776f1823c1b`.

The iPhone detector previously required a connected workout mirror even when Watch HealthKit and Watch-direct ESP32 cadence were working. This removes that architectural dependency rather than increasing timeouts or adding a competing iPhone Bluetooth connection.

- Publish a bounded, versioned, capability-only WatchConnectivity application context through the existing sole Watch WCSession owner. Carry workout lifecycle and original cadence/power sample timestamps, not numeric measurements, accessory identifiers, names, heart rate, or routes. Consume fresh cached context during iPhone activation.
- Use one shared lifecycle/admission policy for Watch observations and the existing mirror. Mirror idle/stale/disconnected/local failure withdraws only that source. Explicit Watch-ended state retires reporting; sender-side and receiver-side replay guards prevent late activity from reviving an ended workout or replacing an undelivered tombstone. Reporting and prompts expire even without another callback.
- Preserve explicit logical enrollment, one candidate per capability, existing candidate grace, and persisted workout-scoped prompt dismissal. Keep the existing Watch-to-ESP32/numeric workout transport and firmware unchanged.
- Coalesce timestamp refreshes with a trailing flush, keep one pending value, and retry failed context submissions with bounded backoff. Merge with existing metadata and HealthKit setup fields.

Implementation and paired-device acceptance checklist: [`docs/watch-cycling-sensor-observations.md`](../blob/fix/383-watch-sensor-discovery/docs/watch-cycling-sensor-observations.md).

## Validation

Executed on Linux with Swift 6.2.1:

- [x] `ios-app/scripts/run-cycling-sensor-observation-tests.sh` — passed, including codec bounds, freshness, dual-source lifecycle, terminal replay protection, context merging, actual publisher activation/coalescing/retry behavior, and a real trailing timer.
- [x] Same production shared sources and tests compiled and passed with `-swift-version 6 -strict-concurrency=complete -default-isolation MainActor -O`.
- [x] Swift syntax parsing of all changed Swift files; `bash -n` on both changed scripts; `git diff --check`.
- [x] All 13 uploaded file blob hashes match the reviewed local files; original files were pinned and hash-verified against the main baseline.
- [ ] Full macOS host suite: `ios-app/scripts/run-navigation-tests.sh`. It now includes new integration coverage against the production sensor coordinator/store, actual WorkoutMetricsStore publication, and the current-value Watch-observation boundary: cached launch, unavailable/failed mirror, explicit enrollment, deduplication, dismissal/recreation, stale/future/replayed packets, end handling, and real silent-source expiry.
- [ ] Native iOS/watchOS build using `ios-app/scripts/xcodebuild-cli.sh`.
- [ ] Paired Watch/iPhone/sensor/ESP32 acceptance checklist in the documentation.

This runner has no Xcode/Apple SDK/Combine, so native integration tests and device behavior are **not claimed as passed**. WatchConnectivity application context is best-effort latest-state delivery, not guaranteed low-latency telemetry; stale/future observations fail closed. No hardware was flashed and no ride automation was enabled.

## Contributor License Agreement

Owner to complete the applicable attestation:

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the [Open Bike Computer Contributor License Agreement](https://github.com/seichris/open-bike-computer/blob/main/CLA.md). By checking this box and submitting the pull request, I adopt my GitHub account as my electronic signature.

Legal entity represented, if any: <!-- owner to complete -->

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
