### PR TITLE
Improve route selection flow and ordering

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -1223,9 +1223,6 @@ struct ContentView: View {
                 routeAlternativePicker
                 selectedRouteAdvisory
 
-                Text("Tap a route on the map, or choose below. Your workout keeps running.")
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
             }
             .padding(.horizontal, 20)
             .padding(.top, 24)
@@ -1320,10 +1317,6 @@ struct ContentView: View {
                 .font(.subheadline)
             }
 
-            Text("Tap a route on the map, or choose below.")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-
             routeAlternativePicker
 
             HStack(spacing: 8) {
@@ -1375,7 +1368,7 @@ struct ContentView: View {
                                 .lineLimit(1)
                             Text(routeAlternativeDetails(alternative))
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(.white)
                         }
                         .padding(.horizontal, 12)
                         .padding(.vertical, 9)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BikeComputerCoordinator.swift
@@ -1299,8 +1299,8 @@ extension BikeComputerCoordinator {
                 }
 
                 if presentsAlternatives {
-                    let alternatives = routes.compactMap { candidate ->
-                        NavigationRouteAlternativeV1? in
+                    let alternatives = routes.enumerated().compactMap {
+                        index, candidate -> (index: Int, candidate: MKRoute, name: String)? in
                         do {
                             let normalizedInitialLocation =
                                 MapKitRouteAdapter.normalizedLocation(
@@ -1320,15 +1320,34 @@ extension BikeComputerCoordinator {
                             print("Ignoring invalid route alternative: \(error)")
                             return nil
                         }
-                        return NavigationRouteAlternativeV1(
+                        return (
+                            index: index,
+                            candidate: candidate,
+                            name: candidate.name
+                        )
+                    }
+                    .sorted { lhs, rhs in
+                        if lhs.candidate.expectedTravelTime !=
+                            rhs.candidate.expectedTravelTime {
+                            return lhs.candidate.expectedTravelTime <
+                                rhs.candidate.expectedTravelTime
+                        }
+                        if lhs.candidate.distance != rhs.candidate.distance {
+                            return lhs.candidate.distance < rhs.candidate.distance
+                        }
+                        return lhs.index < rhs.index
+                    }
+                    .enumerated()
+                    .map { displayIndex, entry in
+                        NavigationRouteAlternativeV1(
                             id: UUID(),
-                            route: candidate,
-                            title: candidate.name.isEmpty
-                                ? "Route \(routes.firstIndex(where: { $0 === candidate }).map { $0 + 1 } ?? 1)"
-                                : candidate.name,
-                            distanceMeters: candidate.distance,
-                            expectedTravelTime: candidate.expectedTravelTime,
-                            advisoryNotices: candidate.advisoryNotices
+                            route: entry.candidate,
+                            title: entry.name.isEmpty
+                                ? "Route \(displayIndex + 1)"
+                                : entry.name,
+                            distanceMeters: entry.candidate.distance,
+                            expectedTravelTime: entry.candidate.expectedTravelTime,
+                            advisoryNotices: entry.candidate.advisoryNotices
                         )
                     }
                     guard let selected = alternatives.first else {
@@ -1338,6 +1357,30 @@ extension BikeComputerCoordinator {
                         self.alert.isShowing = true
                         return
                     }
+
+                    if alternatives.count == 1 {
+                        print("Route calculated successfully!")
+                        print("Distance: \(selected.distanceMeters)m, ETA: \(selected.expectedTravelTime)s")
+                        print("Steps: \(selected.route.steps.count)")
+
+                        self.routeCalculation.status = "Starting navigation..."
+                        self.beginNavigation(
+                            with: selected.route,
+                            destination: destinationItem,
+                            transportType: requestedTransportType,
+                            isTestMode: isTestMode,
+                            initialLocation: initialLocation
+                        )
+                        self.completeNavigationStart(.started, generation: generation)
+
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                            guard self.routeCalculationGeneration == generation else { return }
+                            self.routeCalculation.isCalculating = false
+                            self.routeCalculation.status = ""
+                        }
+                        return
+                    }
+
                     self.pendingRoutePlan = PendingRoutePlan(
                         alternatives: alternatives,
                         destination: destinationItem,

--- a/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/MapView.swift
@@ -1133,9 +1133,9 @@ struct MapViewContainer: UIViewRepresentable {
             }
 
             let isSelected = alternativeID == selectedRouteAlternativeID
-            renderer.strokeColor = isSelected ? .systemBlue : .systemGray
+            renderer.strokeColor = .systemBlue
             renderer.lineWidth = isSelected ? 8 : 5
-            renderer.alpha = isSelected ? 1 : 0.72
+            renderer.alpha = 1
         }
         
 

--- a/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
+++ b/ios-app/BikeComputerTests/DestinationCalloutLayoutTests.swift
@@ -244,10 +244,10 @@ struct DestinationCalloutLayoutTests {
             "the selected route should be prominent and blue"
         )
         precondition(
-            unselectedRenderer.strokeColor == .systemGray &&
+            unselectedRenderer.strokeColor == .systemBlue &&
                 unselectedRenderer.lineWidth == 5 &&
-                unselectedRenderer.alpha == 0.72,
-            "unselected routes should remain visible but visually secondary"
+                unselectedRenderer.alpha == 1,
+            "unselected routes should remain blue and use a narrower line"
         )
 
         selectedRouteID = nil

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -594,21 +594,32 @@ final class TestRoute: MKRoute {
     private let storedSteps: [MKRoute.Step]
     private let storedPolyline: MKPolyline
     private let storedDistance: CLLocationDistance
+    private let storedExpectedTravelTime: TimeInterval
 
-    init(instructions: String, coordinates: [CLLocationCoordinate2D]) {
+    init(
+        instructions: String,
+        coordinates: [CLLocationCoordinate2D],
+        expectedTravelTime: TimeInterval = 0
+    ) {
         self.storedSteps = [TestRouteStep(instructions: instructions, coordinates: coordinates)]
         self.storedPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
         self.storedDistance = zip(coordinates, coordinates.dropFirst()).reduce(0) { distance, pair in
             distance + CLLocation(latitude: pair.0.latitude, longitude: pair.0.longitude)
                 .distance(from: CLLocation(latitude: pair.1.latitude, longitude: pair.1.longitude))
         }
+        self.storedExpectedTravelTime = expectedTravelTime
         super.init()
     }
 
-    init(steps: [TestRouteStep], coordinates: [CLLocationCoordinate2D]) {
+    init(
+        steps: [TestRouteStep],
+        coordinates: [CLLocationCoordinate2D],
+        expectedTravelTime: TimeInterval = 0
+    ) {
         self.storedSteps = steps
         self.storedPolyline = MKPolyline(coordinates: coordinates, count: coordinates.count)
         self.storedDistance = steps.reduce(0) { $0 + $1.distance }
+        self.storedExpectedTravelTime = expectedTravelTime
         super.init()
     }
 
@@ -622,6 +633,10 @@ final class TestRoute: MKRoute {
 
     override var distance: CLLocationDistance {
         storedDistance
+    }
+
+    override var expectedTravelTime: TimeInterval {
+        storedExpectedTravelTime
     }
 }
 
@@ -697,6 +712,7 @@ struct NavigationProtocolTests {
         testRouteDeviationDetection()
         testReplacementStepSelectionUsesUnambiguousGeometry()
         testCoordinatorPreviewsAndSelectsAlternateRoutes()
+        testCoordinatorStartsSingleRouteWithoutPicker()
         testCoordinatorReroutesAndAppliesLatestRoute()
         testCoordinatorReroutesWhenProgressRejectsFarLocation()
         testWorkoutAndNavigationLifecyclesStayIndependent()
@@ -3716,7 +3732,8 @@ struct NavigationProtocolTests {
         destination.name = "Finish"
         let direct = TestRoute(
             instructions: "Continue",
-            coordinates: [sourceCoordinate, destinationCoordinate]
+            coordinates: [sourceCoordinate, destinationCoordinate],
+            expectedTravelTime: 300
         )
         let scenic = TestRoute(
             instructions: "Bear right",
@@ -3727,7 +3744,8 @@ struct NavigationProtocolTests {
                     longitude: -122.001
                 ),
                 destinationCoordinate
-            ]
+            ],
+            expectedTravelTime: 120
         )
 
         coordinator.planNavigation(
@@ -3748,13 +3766,17 @@ struct NavigationProtocolTests {
             "all valid alternatives are presented before navigation"
         )
         assert(!coordinator.isNavigating, "route preview does not start navigation")
-        assert(coordinator.routePreview === direct, "first alternative is previewed")
+        assert(
+            coordinator.routeAlternatives[0].route === scenic,
+            "fastest alternative is listed first"
+        )
+        assert(coordinator.routePreview === scenic, "fastest alternative is previewed")
         assert(
             coordinator.selectedRouteAlternativeID == nil,
             "the rider must explicitly select an alternative"
         )
 
-        let scenicID = coordinator.routeAlternatives[1].id
+        let scenicID = coordinator.routeAlternatives[0].id
         coordinator.selectRouteAlternative(scenicID)
         assert(coordinator.routePreview === scenic, "selection updates map preview")
         coordinator.startSelectedRoute()
@@ -3773,6 +3795,60 @@ struct NavigationProtocolTests {
         assert(
             !factory.tasks[1].request.requestsAlternateRoutes,
             "immediate/device starts retain a single-route request"
+        )
+    }
+
+    @MainActor
+    static func testCoordinatorStartsSingleRouteWithoutPicker() {
+        let suite = "CoordinatorSingleRoute.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        let factory = TestNavigationDirectionsFactory()
+        let coordinator = BikeComputerCoordinator(
+            destinationStore: SavedDestinationStore(defaults: defaults),
+            directionsFactory: factory.makeTask,
+            startServices: false
+        )
+        let sourceCoordinate = CLLocationCoordinate2D(
+            latitude: 37.0,
+            longitude: -122.0
+        )
+        let destinationCoordinate = CLLocationCoordinate2D(
+            latitude: 37.004,
+            longitude: -122.0
+        )
+        let source = MKMapItem(
+            placemark: MKPlacemark(coordinate: sourceCoordinate)
+        )
+        source.name = "Start"
+        let destination = MKMapItem(
+            placemark: MKPlacemark(coordinate: destinationCoordinate)
+        )
+        destination.name = "Finish"
+        let route = TestRoute(
+            instructions: "Continue",
+            coordinates: [sourceCoordinate, destinationCoordinate]
+        )
+
+        coordinator.planNavigation(
+            from: .mapItem(source),
+            to: .mapItem(destination),
+            transportType: RouteTransportTypes.cycling,
+            isTestMode: true
+        )
+        assertEqual(factory.tasks.count, 1, "single-route planning creates one request")
+        assert(
+            factory.tasks[0].request.requestsAlternateRoutes,
+            "single-route planning still asks MapKit for alternatives"
+        )
+        factory.tasks[0].succeed(with: [route])
+
+        assert(coordinator.isNavigating, "one returned route starts navigation immediately")
+        assert(coordinator.currentRoute === route, "the only route becomes the active route")
+        assert(coordinator.routeAlternatives.isEmpty, "single-route planning skips the picker")
+        assert(
+            coordinator.selectedRouteAlternativeID == nil,
+            "single-route planning does not require an explicit selection"
         )
     }
 

--- a/ios-app/BikeComputerTests/WorkoutContractTests.swift
+++ b/ios-app/BikeComputerTests/WorkoutContractTests.swift
@@ -8195,10 +8195,10 @@ private struct WorkoutContractTestSuite {
                 && compactContent.contains(
                     "onRouteAlternativeSelected:{coordinator.selectRouteAlternative($0)}"
                 )
-                && compactContent.contains(
+                && !compactContent.contains(
                     "Taparouteonthemap,orchoosebelow.Yourworkoutkeepsrunning."
                 ),
-            "route alternatives must render and remain selectable on the map while the buttons stay available"
+            "route alternatives must render and remain selectable on the map while the buttons stay available without redundant helper copy"
         )
         expect(
             compactContent.contains("mapControlsBottomPadding(in:proxy)")


### PR DESCRIPTION
## Summary
- Start navigation immediately when a destination returns one usable route.
- Keep the multi-route picker explicit, with fastest route first.
- Make route alternatives uniformly blue, emphasize the selected line by width, remove redundant helper text, and use white distance/time details.

## Verification
- `./scripts/run-navigation-tests.sh`
- iOS build via `scripts/xcodebuild-cli.sh`
- Signed Debug app installed and launched on the connected iPhone 16 Pro Max.