### PR TITLE
Refresh GitHub Actions and align Pages recovery policy

### DIFF
--- a/.github/scripts/tests/test_workflow_policy.py
+++ b/.github/scripts/tests/test_workflow_policy.py
@@ -581,11 +581,11 @@ class WorkflowPolicyTests(unittest.TestCase):
         self.assertIn('gh release verify "${RELEASE_TAG}"', recovery)
         self.assertIn('gh release verify-asset "${RELEASE_TAG}"', recovery)
         self.assertIn(
-            "actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3",
+            "actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0",
             recovery,
         )
         self.assertIn(
-            "actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4",
+            "actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1",
             recovery,
         )
         self.assertNotIn("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY", recovery)

--- a/.github/workflows/firmware-release-candidate.yml
+++ b/.github/workflows/firmware-release-candidate.yml
@@ -71,7 +71,7 @@ jobs:
             --tag "${RELEASE_TAG}" \
             --git-sha "${RELEASE_GIT_SHA}"
           shasum -a 256 dist/*
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-${{ matrix.target }}
           path: esp32/dist/

--- a/.github/workflows/firmware-release.yml
+++ b/.github/workflows/firmware-release.yml
@@ -101,7 +101,7 @@ jobs:
             echo "Unable to prove that release ${RELEASE_TAG} does not exist" >&2
             exit 1
           fi
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-release-gate-${{ github.event.workflow_run.id }}
           path: ${{ runner.temp }}/firmware-release-gate.json
@@ -150,7 +150,7 @@ jobs:
             --expected-workflow-path .github/workflows/firmware-release-candidate.yml \
             --github-output "${GITHUB_OUTPUT}" \
             --output-receipt "${RUNNER_TEMP}/firmware-release-gate-revalidated.json"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: firmware-release-gate-${{ needs.gate.outputs.candidate_run_id }}
           path: ${{ runner.temp }}/release-gate
@@ -328,7 +328,7 @@ jobs:
             --asset-dir "${release_assets}" \
             --require-immutable \
             --output "${RUNNER_TEMP}/publication-receipt.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-release-publication-receipts
           path: |
@@ -337,7 +337,7 @@ jobs:
             ${{ runner.temp }}/publication-receipt.json
           if-no-files-found: error
           retention-days: 90
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
 
@@ -357,7 +357,7 @@ jobs:
       pages: write
     steps:
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1
 
   recover-pages:
     name: Recover Firmware OTA Pages
@@ -433,14 +433,14 @@ jobs:
             --repository "${GITHUB_REPOSITORY}" \
             --recovery-assets release-assets "${options[@]}"
           echo "Older channel explicitly authorized: ${ALLOW_OLDER}" >> "${GITHUB_STEP_SUMMARY}"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-release-recovery-receipt-${{ inputs.release_tag }}
           path: ${{ runner.temp }}/recovery-receipt.json
           if-no-files-found: error
           retention-days: 90
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: public
       - id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1

--- a/.github/workflows/firmware-runtime-performance.yml
+++ b/.github/workflows/firmware-runtime-performance.yml
@@ -56,7 +56,7 @@ jobs:
             --samples "$samples" \
             --target "${{ matrix.target }}" \
             --output "$RUNNER_TEMP/runtime-performance-${{ matrix.target }}.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-runtime-performance-${{ matrix.target }}
           path: ${{ runner.temp }}/runtime-performance-${{ matrix.target }}.json

--- a/.github/workflows/firmware-runtime-publish.yml
+++ b/.github/workflows/firmware-runtime-publish.yml
@@ -78,13 +78,13 @@ jobs:
           ):
               raise SystemExit("firmware-runtime-publication requires human reviewers")
           PY
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           run-id: ${{ inputs.candidate_run_id }}
           github-token: ${{ github.token }}
           pattern: firmware-runtime-candidate-*
           path: ${{ runner.temp }}/runtime-candidates
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           run-id: ${{ inputs.candidate_run_id }}
           github-token: ${{ github.token }}
@@ -110,7 +110,7 @@ jobs:
             tools/firmware_runtime_publication.py verify-staged \
             --asset-dir "${RUNNER_TEMP}/runtime-publication/assets" \
             --manifest "${RUNNER_TEMP}/runtime-publication/publication-manifest.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: reviewed-firmware-runtime-publication
           path: ${{ runner.temp }}/runtime-publication
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.sha }}
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: reviewed-firmware-runtime-publication
           path: ${{ runner.temp }}/runtime-publication
@@ -203,7 +203,7 @@ jobs:
             --asset-dir "${RUNNER_TEMP}/runtime-publication/assets" \
             --require-immutable \
             --output "${RUNNER_TEMP}/runtime-publication-receipt.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-runtime-publication-receipt
           path: ${{ runner.temp }}/runtime-publication-receipt.json

--- a/.github/workflows/firmware-runtime-refresh.yml
+++ b/.github/workflows/firmware-runtime-refresh.yml
@@ -83,7 +83,7 @@ jobs:
             --target "${{ matrix.target }}" \
             --output-dir runtime-candidate-a \
             > "runtime-candidate-a/offline-replay-${{ matrix.target }}.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: firmware-runtime-candidate-${{ matrix.target }}
@@ -126,7 +126,7 @@ jobs:
           echo "RUNTIME_RELEASE_TAG=$(python -c 'import json,sys; print(json.loads(sys.argv[1])["releaseTag"])' "$publication")" >> "$GITHUB_ENV"
       - name: Configure the isolated runtime cache
         run: echo "OPEN_BIKE_FIRMWARE_RUNTIME_CACHE=$RUNNER_TEMP/firmware-runtime-cache" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: firmware-runtime-candidate-*
           path: ${{ runner.temp }}/runtime-candidates
@@ -256,7 +256,7 @@ jobs:
             echo "tampered runtime reached PlatformIO" >&2
             exit 1
           fi
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: firmware-build-validation-${{ matrix.target }}
@@ -279,11 +279,11 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.13"
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: firmware-runtime-candidate-*
           path: ${{ runner.temp }}/runtime-candidates
-      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: firmware-build-validation-*
           path: ${{ runner.temp }}/firmware-validation
@@ -315,7 +315,7 @@ jobs:
             --candidate-root "$RUNNER_TEMP/runtime-candidates" \
             --validation-root "$RUNNER_TEMP/firmware-validation" \
             --output "$RUNNER_TEMP/firmware-runtime-review-summary.json"
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: firmware-runtime-review-summary
           path: ${{ runner.temp }}/firmware-runtime-review-summary.json

--- a/.github/workflows/map-platform-ci.yml
+++ b/.github/workflows/map-platform-ci.yml
@@ -37,7 +37,7 @@ jobs:
         working-directory: map-platform/catalog
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+      - uses: pnpm/action-setup@ea17c68df8912ef543352723c149a84f56e3d413 # v6.1.0
         with:
           version: 11.19.0
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7
         with:
           python-version: "3.12"
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Install backend test dependencies
         run: python -m pip install -e '.[test,object-storage]'
       - name: Python syntax

--- a/.github/workflows/map-platform-image.yml
+++ b/.github/workflows/map-platform-image.yml
@@ -64,9 +64,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -100,7 +100,7 @@ jobs:
 
       - id: image
         name: Build and publish image
-        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           file: ${{ inputs.release_profile == 'production-auth-compatibility' && 'map-platform/deploy/compatibility/Dockerfile' || inputs.release_profile == 'production-map-promotion' && 'map-platform/deploy/promotion/Dockerfile' || 'map-platform/backend/Dockerfile' }}
@@ -112,7 +112,7 @@ jobs:
           sbom: true
 
       - name: Attest image provenance
-        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
         with:
           subject-name: ghcr.io/${{ github.repository_owner }}/open-bike-computer-map-platform
           subject-digest: ${{ steps.image.outputs.digest }}
@@ -163,7 +163,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - id: base
         name: Reconcile with the live default branch
@@ -470,7 +470,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
 
       - id: base
         name: Reconcile with the live default branch


### PR DESCRIPTION
## Summary

Replaces #343 with the nine GitHub Actions dependency updates rebased onto current main. Refreshes pnpm/action-setup to v6.1.0 and updates the Pages recovery policy assertions to the new immutable upload/deploy action SHAs, resolving the required CI failure in #343.

All actions remain pinned to full commit SHAs. Artifact upload options, workflow permissions, release verification, and deployment approval gates are unchanged. Broader application dependency updates are outside this PR.

## Validation

- `python3 -m unittest discover -s .github/scripts/tests`: all 78 tests passed.
- `git diff --check`: passed.
- GitHub CI will validate workflow syntax and applicable checks. Release and deployment workflows were not dispatched.

## Contributor License Agreement

- [x] I am the repository owner submitting my own work.
- [x] I have read and agree to the Contributor License Agreement.

Legal entity represented, if any: none

- [x] I have the right to submit this contribution and have identified all third-party material and applicable license notices.
