### PR TITLE
Add device sounds visibility toggle

### DIFF
--- a/ios-app/BikeComputer/BikeComputer/ContentView.swift
+++ b/ios-app/BikeComputer/BikeComputer/ContentView.swift
@@ -335,7 +335,8 @@ struct ContentView: View {
                 }
                 .ignoresSafeArea(.container, edges: .bottom)
 
-                if coordinator.bleManager.supportsDeviceSounds &&
+                if coordinator.bleManager.deviceSoundsEnabled &&
+                    coordinator.bleManager.supportsDeviceSounds &&
                     !offlineMapManager.isMapAreaSelectionActive &&
                     visibleOfflineMapOnboardingStep == nil {
                     DeviceSoundMapButton(bleManager: coordinator.bleManager)

--- a/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
+++ b/ios-app/BikeComputer/BikeComputer/Managers/BLEManager.swift
@@ -1068,6 +1068,7 @@ class BLEManager: NSObject, ObservableObject {
     @Published var deviceBrightnessPercent: Double = 100
     @Published var automaticDisplayOffEnabled: Bool = true
     @Published var disconnectedSleepTimeout: DisconnectedSleepTimeout = .twoMinutes
+    @Published var deviceSoundsEnabled: Bool = false
     @Published var selectedDeviceSound: DeviceSound = .defaultSelection
     @Published var deviceSoundVolumePercent: Double = DeviceSound.defaultVolumePercent
     @Published var isPowerButtonHonkEnabled: Bool = false
@@ -1404,6 +1405,7 @@ class BLEManager: NSObject, ObservableObject {
         static let deviceBrightnessPercent = "deviceSettings.brightnessPercent"
         static let automaticDisplayOffEnabled = "deviceSettings.automaticDisplayOffEnabled"
         static let disconnectedSleepTimeoutSeconds = "deviceSettings.disconnectedSleepTimeoutSeconds"
+        static let deviceSoundsEnabled = "deviceSettings.deviceSoundsEnabled"
         static let watchControllerIDsByDevice =
             "deviceSettings.watchControllerIDsByDevice.v1"
         static let selectedDeviceSound = "deviceSettings.selectedSound"
@@ -1639,6 +1641,9 @@ class BLEManager: NSObject, ObservableObject {
         disconnectedSleepTimeout = DisconnectedSleepTimeout.normalized(
             rawValue: defaults.object(forKey: SettingsKeys.disconnectedSleepTimeoutSeconds) as? Int ?? DisconnectedSleepTimeout.twoMinutes.rawValue
         )
+        deviceSoundsEnabled = defaults.object(
+            forKey: SettingsKeys.deviceSoundsEnabled
+        ) as? Bool ?? false
         let storedSoundID = defaults.object(forKey: SettingsKeys.selectedDeviceSound) as? Int
             ?? Int(DeviceSound.defaultSelection.rawValue)
         selectedDeviceSound = UInt8(exactly: storedSoundID)
@@ -1925,6 +1930,7 @@ class BLEManager: NSObject, ObservableObject {
         defaults.set(deviceBrightnessPercent, forKey: SettingsKeys.deviceBrightnessPercent)
         defaults.set(automaticDisplayOffEnabled, forKey: SettingsKeys.automaticDisplayOffEnabled)
         defaults.set(disconnectedSleepTimeout.rawValue, forKey: SettingsKeys.disconnectedSleepTimeoutSeconds)
+        defaults.set(deviceSoundsEnabled, forKey: SettingsKeys.deviceSoundsEnabled)
         defaults.set(Int(selectedDeviceSound.rawValue), forKey: SettingsKeys.selectedDeviceSound)
         deviceSoundVolumePercent = DeviceSound.normalizedVolumePercent(deviceSoundVolumePercent)
         defaults.set(deviceSoundVolumePercent, forKey: SettingsKeys.deviceSoundVolumePercent)

--- a/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
+++ b/ios-app/BikeComputer/BikeComputer/Views/SettingsView.swift
@@ -665,39 +665,52 @@ private struct DeviceSoundsSettingsSection: View {
     }
 
     var body: some View {
-        Section(header: Text("Device Sounds")) {
-            Picker("Sound", selection: soundSelection) {
-                ForEach(DeviceSound.allCases) { sound in
-                    Label(sound.title, systemImage: sound.systemImage)
-                        .tag(sound)
+        Section(
+            header: Text("Device Sounds"),
+            footer: Text("Enable this when a speaker is connected to show the sound controls and honk button.")
+        ) {
+            Toggle("Enable Device Sounds", isOn: $bleManager.deviceSoundsEnabled)
+                .onChange(of: bleManager.deviceSoundsEnabled) { _ in
+                    bleManager.saveSettings()
                 }
-            }
-            .pickerStyle(.inline)
 
-            VStack(alignment: .leading) {
-                HStack {
-                    Text("Volume")
-                    Spacer()
-                    Text("\(Int(bleManager.deviceSoundVolumePercent))%")
-                        .foregroundColor(.secondary)
-                }
-                Slider(
-                    value: volumeSelection,
-                    in: 0...100,
-                    step: 5,
-                    onEditingChanged: { isEditing in
-                        bleManager.deviceSoundVolumeEditingChanged(isEditing)
+            if bleManager.deviceSoundsEnabled {
+                Group {
+                    Picker("Sound", selection: soundSelection) {
+                        ForEach(DeviceSound.allCases) { sound in
+                            Label(sound.title, systemImage: sound.systemImage)
+                                .tag(sound)
+                        }
                     }
-                )
-            }
+                    .pickerStyle(.inline)
 
-            Toggle("Use PWR Button as Honk", isOn: powerButtonHonkSelection)
-                .disabled(!bleManager.supportsPowerButtonHonk)
+                    VStack(alignment: .leading) {
+                        HStack {
+                            Text("Volume")
+                            Spacer()
+                            Text("\(Int(bleManager.deviceSoundVolumePercent))%")
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(
+                            value: volumeSelection,
+                            in: 0...100,
+                            step: 5,
+                            onEditingChanged: { isEditing in
+                                bleManager.deviceSoundVolumeEditingChanged(isEditing)
+                            }
+                        )
+                    }
 
-            if let error = bleManager.powerButtonHonkConfigurationError {
-                Label(error, systemImage: "exclamationmark.triangle.fill")
-                    .font(.caption)
-                    .foregroundColor(.red)
+                    Toggle("Use PWR Button as Honk", isOn: powerButtonHonkSelection)
+                        .disabled(!bleManager.supportsPowerButtonHonk)
+
+                    if let error = bleManager.powerButtonHonkConfigurationError {
+                        Label(error, systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption)
+                            .foregroundColor(.red)
+                    }
+                }
+                .disabled(!bleManager.supportsDeviceSounds)
             }
         }
     }
@@ -2500,9 +2513,6 @@ private struct HardwareCustomizationSettingsView: View {
             }
             .disabled(!bleManager.supportsDeviceSettings)
 
-            DeviceSoundsSettingsSection()
-                .disabled(!bleManager.supportsDeviceSounds)
-
             Section(header: Text("Power")) {
                 Picker("Disconnected Sleep After", selection: $bleManager.disconnectedSleepTimeout) {
                     ForEach(DisconnectedSleepTimeout.allCases) { timeout in
@@ -2525,6 +2535,8 @@ private struct HardwareCustomizationSettingsView: View {
                     }
             }
             .disabled(!bleManager.supportsDeviceSettings)
+
+            DeviceSoundsSettingsSection()
         }
         .navigationTitle("Hardware Customization")
         .navigationBarTitleDisplayMode(.inline)

--- a/ios-app/BikeComputerTests/NavigationProtocolTests.swift
+++ b/ios-app/BikeComputerTests/NavigationProtocolTests.swift
@@ -23164,24 +23164,29 @@ struct NavigationProtocolTests {
 
     static func testBLEManagerPersistsDeviceSoundSettings() {
         let defaults = UserDefaults.standard
+        let deviceSoundsEnabledKey = "deviceSettings.deviceSoundsEnabled"
         let soundKey = "deviceSettings.selectedSound"
         let volumeKey = "deviceSettings.soundVolumePercent"
         let powerButtonHonkKey = "deviceSettings.powerButtonHonkEnabled"
+        defaults.removeObject(forKey: deviceSoundsEnabledKey)
         defaults.removeObject(forKey: soundKey)
         defaults.removeObject(forKey: volumeKey)
         defaults.removeObject(forKey: powerButtonHonkKey)
 
         let freshManager = BLEManager()
+        assert(!freshManager.deviceSoundsEnabled, "fresh installs leave device sounds disabled")
         assertEqual(freshManager.selectedDeviceSound, .plasticBicycleHorn, "fresh installs use the bicycle horn")
         assertEqual(freshManager.deviceSoundVolumePercent, 70, "fresh installs use 70 percent sound volume")
         assert(!freshManager.isPowerButtonHonkEnabled, "fresh installs leave PWR honk disabled")
 
+        freshManager.deviceSoundsEnabled = true
         freshManager.selectedDeviceSound = .rotatingBicycleBell
         freshManager.deviceSoundVolumePercent = 65
         freshManager.isPowerButtonHonkEnabled = true
         freshManager.saveSettings()
 
         let reloaded = BLEManager()
+        assert(reloaded.deviceSoundsEnabled, "device sounds enabled state persists")
         assertEqual(reloaded.selectedDeviceSound, .rotatingBicycleBell, "selected sound persists")
         assertEqual(reloaded.deviceSoundVolumePercent, 65, "sound volume persists")
         assert(reloaded.isPowerButtonHonkEnabled, "PWR honk enabled state persists")
@@ -23192,6 +23197,7 @@ struct NavigationProtocolTests {
         assertEqual(invalidValues.selectedDeviceSound, .plasticBicycleHorn, "unknown sound IDs fall back safely")
         assertEqual(invalidValues.deviceSoundVolumePercent, 70, "non-finite persisted volume falls back safely")
 
+        defaults.removeObject(forKey: deviceSoundsEnabledKey)
         defaults.removeObject(forKey: soundKey)
         defaults.removeObject(forKey: volumeKey)
         defaults.removeObject(forKey: powerButtonHonkKey)


### PR DESCRIPTION
## Summary
- Add a persisted Device Sounds toggle in Hardware Customization, defaulting off.
- Move Device Sounds to the end of Hardware Customization.
- Hide sound controls and the map honk button until enabled.
- Keep sound controls gated by the connected board capability.

## Validation
- `bash ios-app/scripts/run-navigation-tests.sh`
- Unsigned generic iOS build
- `git diff --check`