### PR TITLE
Fix firmware release ruleset preflight scope

### DIFF
--- a/.github/actions/require-firmware-release-controls/action.yml
+++ b/.github/actions/require-firmware-release-controls/action.yml
@@ -3,7 +3,7 @@ description: Fail before signing unless the explicit review policy, environment 
 inputs:
   app-id:
     required: true
-    description: Repository-scoped read-only preflight App ID
+    description: Repository-scoped preflight App ID (Administration write is required for ruleset actor read-back)
   private-key:
     required: true
     description: Environment-scoped preflight App private key
@@ -17,7 +17,11 @@ runs:
         private-key: ${{ inputs.private-key }}
         owner: ${{ github.repository_owner }}
         repositories: ${{ github.event.repository.name }}
-        permission-administration: read
+        # GitHub redacts ruleset bypass_actors unless the caller has write
+        # access to the ruleset. The script only reads metadata and has no
+        # mutation endpoint; this is the minimum permission that exposes the
+        # configured actor for the fail-closed check.
+        permission-administration: write
         permission-environments: read
         permission-secrets: read
         permission-contents: read

--- a/.github/scripts/tests/test_firmware_release_controls.py
+++ b/.github/scripts/tests/test_firmware_release_controls.py
@@ -74,6 +74,12 @@ class ReleaseControlsTests(unittest.TestCase):
         self.assertLess(workflow.index("uses: ./.github/actions/require-firmware-release-controls"),
                         workflow.index("FIRMWARE_MANIFEST_SIGNING_PRIVATE_KEY: ${{ secrets."))
 
+    def test_ruleset_actor_readback_requests_required_administration_scope(self):
+        action = (Path(__file__).resolve().parents[2] /
+                  "actions/require-firmware-release-controls/action.yml").read_text()
+        self.assertIn("permission-administration: write", action)
+        self.assertNotIn("permission-administration: read", action)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/docs/firmware-factory-release.md
+++ b/docs/firmware-factory-release.md
@@ -68,8 +68,11 @@ Source changes alone do not prove those live controls are configured. Do not
 push the first release tag until their read-back has been reviewed.
 
 The publisher now runs `firmware_release_controls.py` before exposing the
-firmware scalar to the signing command. Its read-only App token needs
-Administration, Actions, Contents, Environments and Secrets **read** permissions.
+firmware scalar to the signing command. Its repository-scoped preflight App
+needs Administration **write** plus Actions, Contents, Environments and Secrets
+**read** permissions: GitHub only returns a ruleset's `bypass_actors` to a caller
+with write access. The preflight script only reads metadata and has no GitHub
+settings mutation path.
 It reads secret names only, requires both private keys in `firmware-release`,
 rejects repository/organization copies, requires the checked-in environment-review policy,
 an exact default-branch-only deployment policy, strict admin-enforced `CI Gate`,
@@ -104,7 +107,8 @@ Prerequisites:
 - Keep both repository-level private keys until verification completes.
 - Add the existing/new preflight App private key to `firmware-release` and
   `firmware-runtime-publication`. It must be for App ID 4579522, with repository
-  Administration, Environments, Secrets, Contents and Actions read access. No
+  Administration write access (needed only to read ruleset bypass actors), and
+  Environments, Secrets, Contents and Actions read access. No
   secret-write permission or replacement App is needed.
 - Both environments require the named maintainer reviewer. Only `main` may
   deploy to `firmware-release`; the workflow also rejects non-main dispatches,

--- a/docs/firmware-signing-key-migration.md
+++ b/docs/firmware-signing-key-migration.md
@@ -9,8 +9,11 @@ been retired through a reviewed change; the procedure below is retained as an
 audit record and is not an instruction to dispatch a removed workflow.
 
 The publisher now runs `firmware_release_controls.py` before exposing the
-firmware scalar to the signing command. Its read-only App token needs
-Administration, Actions, Contents, Environments and Secrets **read** permissions.
+firmware scalar to the signing command. Its repository-scoped preflight App
+needs Administration **write** plus Actions, Contents, Environments and Secrets
+**read** permissions: GitHub only returns a ruleset's `bypass_actors` to a caller
+with write access. The preflight script only reads metadata and has no GitHub
+settings mutation path.
 It reads secret names only, requires both private keys in `firmware-release`,
 rejects repository/organization copies, requires the checked-in environment-review policy,
 an exact default-branch-only deployment policy, strict admin-enforced `CI Gate`,
@@ -45,7 +48,8 @@ Prerequisites:
 - Keep both repository-level private keys until verification completes.
 - Add the existing/new preflight App private key to `firmware-release` and
   `firmware-runtime-publication`. It must be for App ID 4579522, with repository
-  Administration, Environments, Secrets, Contents and Actions read access. No
+  Administration write access (needed only to read ruleset bypass actors), and
+  Environments, Secrets, Contents and Actions read access. No
   secret-write permission or replacement App is needed.
 - Both environments require the named maintainer reviewer. Only `main` may
   deploy to `firmware-release`; the workflow also rejects non-main dispatches,


### PR DESCRIPTION
## Summary
- request Administration write on the repository-scoped preflight App because GitHub redacts `bypass_actors` from ruleset reads without ruleset write access
- keep the preflight script read-only and document the exact permission rationale
- add a regression test for the action scope

## Validation
- `python3 .github/scripts/tests/test_firmware_release_controls.py`
- `python3 .github/scripts/tests/test_workflow_policy.py`
- `git diff --check`

The action does not call any GitHub settings mutation endpoint; the extra scope is required only for the ruleset actor read-back.
